### PR TITLE
fix: resolve all 9 open issues for v0.4

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -55,6 +55,7 @@ final class AppState {
     }
     var refreshInterval: TimeInterval = PlaidBarConstants.backgroundRefreshInterval {
         didSet {
+            guard refreshInterval != oldValue else { return }
             UserDefaults.standard.set(refreshInterval, forKey: Keys.refreshInterval)
             // Restart background refresh with new interval
             if refreshTask != nil { startBackgroundRefresh() }
@@ -67,19 +68,34 @@ final class AppState {
         }
     }
     var largeTransactionThreshold: Double = 500.0 {
-        didSet { UserDefaults.standard.set(largeTransactionThreshold, forKey: Keys.largeTransactionThreshold) }
+        didSet {
+            guard largeTransactionThreshold != oldValue else { return }
+            UserDefaults.standard.set(largeTransactionThreshold, forKey: Keys.largeTransactionThreshold)
+        }
     }
     var lowBalanceThreshold: Double = 100.0 {
-        didSet { UserDefaults.standard.set(lowBalanceThreshold, forKey: Keys.lowBalanceThreshold) }
+        didSet {
+            guard lowBalanceThreshold != oldValue else { return }
+            UserDefaults.standard.set(lowBalanceThreshold, forKey: Keys.lowBalanceThreshold)
+        }
     }
     var notifyLargeTransaction: Bool = true {
-        didSet { UserDefaults.standard.set(notifyLargeTransaction, forKey: Keys.notifyLargeTransaction) }
+        didSet {
+            guard notifyLargeTransaction != oldValue else { return }
+            UserDefaults.standard.set(notifyLargeTransaction, forKey: Keys.notifyLargeTransaction)
+        }
     }
     var notifyLowBalance: Bool = true {
-        didSet { UserDefaults.standard.set(notifyLowBalance, forKey: Keys.notifyLowBalance) }
+        didSet {
+            guard notifyLowBalance != oldValue else { return }
+            UserDefaults.standard.set(notifyLowBalance, forKey: Keys.notifyLowBalance)
+        }
     }
     var notifyHighUtilization: Bool = true {
-        didSet { UserDefaults.standard.set(notifyHighUtilization, forKey: Keys.notifyHighUtilization) }
+        didSet {
+            guard notifyHighUtilization != oldValue else { return }
+            UserDefaults.standard.set(notifyHighUtilization, forKey: Keys.notifyHighUtilization)
+        }
     }
 
     var launchAtLogin: Bool = false {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -36,13 +36,22 @@ final class AppState {
 
     // MARK: - Settings (persisted to UserDefaults)
     var showBalanceInMenuBar: Bool = true {
-        didSet { UserDefaults.standard.set(showBalanceInMenuBar, forKey: Keys.showBalanceInMenuBar) }
+        didSet {
+            guard showBalanceInMenuBar != oldValue else { return }
+            UserDefaults.standard.set(showBalanceInMenuBar, forKey: Keys.showBalanceInMenuBar)
+        }
     }
     var balanceFormat: CurrencyFormat = .abbreviated {
-        didSet { UserDefaults.standard.set(balanceFormat.rawValue, forKey: Keys.balanceFormat) }
+        didSet {
+            guard balanceFormat != oldValue else { return }
+            UserDefaults.standard.set(balanceFormat.rawValue, forKey: Keys.balanceFormat)
+        }
     }
     var creditUtilizationThreshold: Double = 30.0 {
-        didSet { UserDefaults.standard.set(creditUtilizationThreshold, forKey: Keys.creditUtilizationThreshold) }
+        didSet {
+            guard creditUtilizationThreshold != oldValue else { return }
+            UserDefaults.standard.set(creditUtilizationThreshold, forKey: Keys.creditUtilizationThreshold)
+        }
     }
     var refreshInterval: TimeInterval = PlaidBarConstants.backgroundRefreshInterval {
         didSet {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -112,11 +112,13 @@ final class AppState {
 
     // MARK: - Services
     private let serverClient = ServerClient()
+    private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
 
     // MARK: - Init
 
-    init() {
+    init(notificationService: any NotificationServiceProtocol = NotificationService.shared) {
+        self.notificationService = notificationService
         loadSettings()
     }
 
@@ -355,11 +357,15 @@ final class AppState {
             lowBalanceThreshold: lowBalanceThreshold,
             creditUtilizationThreshold: creditUtilizationThreshold
         )
-        await NotificationService.shared.evaluateTriggers(
+        await notificationService.evaluateTriggers(
             transactions: transactions,
             accounts: accounts,
             config: config
         )
+    }
+
+    func requestNotificationPermission() async -> Bool {
+        await notificationService.requestPermission()
     }
 
     func stopBackgroundRefresh() {
@@ -370,7 +376,7 @@ final class AppState {
     func loadInitialData() async {
         // Recheck notification permission at startup (user may have revoked in System Settings)
         if notificationsEnabled {
-            let status = await NotificationService.shared.checkPermissionStatus()
+            let status = await notificationService.checkPermissionStatus()
             if status == .denied || status == .notDetermined {
                 notificationsEnabled = false
             }

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -3,7 +3,18 @@ import UserNotifications
 import PlaidBarCore
 
 @MainActor
-final class NotificationService {
+protocol NotificationServiceProtocol {
+    func requestPermission() async -> Bool
+    func checkPermissionStatus() async -> UNAuthorizationStatus
+    func evaluateTriggers(
+        transactions: [TransactionDTO],
+        accounts: [AccountDTO],
+        config: NotificationTriggers
+    ) async
+}
+
+@MainActor
+final class NotificationService: NotificationServiceProtocol {
     static let shared = NotificationService()
 
     private static let notifiedTxKey = "notifiedTransactionIds"

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -128,7 +128,7 @@ struct NotificationSettingsView: View {
                 .onChange(of: appState.notificationsEnabled) { _, enabled in
                     if enabled {
                         Task {
-                            let granted = await NotificationService.shared.requestPermission()
+                            let granted = await appState.requestNotificationPermission()
                             if !granted {
                                 permissionDenied = true
                                 appState.notificationsEnabled = false

--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -3,26 +3,56 @@ import SwiftUI
 // MARK: - Semantic Colors
 
 enum SemanticColors {
-    // Financial meaning
+
+    // MARK: - Financial Meaning
+
+    /// Money received — paycheck deposits, refunds, Venmo inflows.
+    /// Used in transaction rows and Income vs Expense chart bars.
     static let income = Color.green
+
+    /// Default text color for outgoing transactions
+    /// (uses `.primary` to follow system appearance).
     static let expense = Color.primary
+
+    /// Outstanding credit card balance shown in account rows
+    /// and credit utilization display.
     static let creditDebt = Color.red
+
+    /// Available/spendable balance in depository account rows.
     static let available = Color.green
 
-    // Status
+    // MARK: - Status Indicators
+
+    /// General caution indicator — moderate credit utilization (30-50%),
+    /// stale sync badge.
     static let warning = Color.orange
+
+    /// Favorable delta — spending decreased vs. prior period, balance increased.
     static let positive = Color.green
+
+    /// Unfavorable delta — spending increased vs. prior period,
+    /// "Remove" destructive actions.
     static let negative = Color.red
+
+    /// Uncommitted transactions that haven't cleared yet.
     static let pending = Color.orange
 
-    // Charts
+    // MARK: - Charts
+
+    /// Balance history mini-chart and spending trend line/area fill.
     static let sparkline = Color.blue
 
-    // Brand
+    // MARK: - Brand Identity
+
+    /// Primary app accent — hero icons, step dots, active controls.
     static let brand = Color.blue
+
+    /// Secondary accent — sandbox mode icon, complementary highlights.
     static let brandSecondary = Color.orange
 
-    // Recurring
+    // MARK: - Recurring
+
+    /// Detected recurring charges badge and recurring transaction section header.
     static let recurring = Color.indigo
 
     // Utilization thresholds

--- a/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
+++ b/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
@@ -44,7 +44,8 @@ struct IncomeExpenseChart: View {
     }
 
     var body: some View {
-        if monthlyData.isEmpty {
+        let data = monthlyData
+        if data.isEmpty {
             ContentUnavailableView {
                 Label("No Data", systemImage: "chart.bar")
             } description: {
@@ -52,7 +53,7 @@ struct IncomeExpenseChart: View {
             }
             .padding()
         } else {
-            Chart(monthlyData) { data in
+            Chart(data) { data in
                 BarMark(
                     x: .value("Month", data.label),
                     y: .value("Amount", data.income)

--- a/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
@@ -20,7 +20,8 @@ struct SpendingTrendChart: View {
     }
 
     var body: some View {
-        if dailySpending.isEmpty {
+        let data = dailySpending
+        if data.isEmpty {
             ContentUnavailableView {
                 Label("No Spending Data", systemImage: "chart.line.downtrend.xyaxis")
             } description: {
@@ -28,7 +29,7 @@ struct SpendingTrendChart: View {
             }
             .padding()
         } else {
-            Chart(dailySpending, id: \.0) { date, amount in
+            Chart(data, id: \.0) { date, amount in
                 LineMark(
                     x: .value("Date", date, unit: .day),
                     y: .value("Amount", amount)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -109,12 +109,28 @@ struct MainPopover: View {
 
                     Button {
                         openSettings()
-                        // Menu bar apps need activation policy switch to bring Settings to front
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                             NSApp.setActivationPolicy(.regular)
                             NSApp.activate(ignoringOtherApps: true)
-                            for window in NSApp.windows where window.title == "General" || window.title == "Settings" {
-                                window.orderFrontRegardless()
+                            if let settingsWindow = NSApp.keyWindow ?? NSApp.windows.first(where: {
+                                $0.canBecomeKey && $0.isVisible && $0.level == .normal
+                            }) {
+                                settingsWindow.orderFrontRegardless()
+                                // Remove previous observer to prevent stacking
+                                if let existing = settingsCloseObserver {
+                                    NotificationCenter.default.removeObserver(existing)
+                                }
+                                settingsCloseObserver = NotificationCenter.default.addObserver(
+                                    forName: NSWindow.willCloseNotification,
+                                    object: settingsWindow,
+                                    queue: .main
+                                ) { _ in
+                                    NSApp.setActivationPolicy(.accessory)
+                                    if let observer = settingsCloseObserver {
+                                        NotificationCenter.default.removeObserver(observer)
+                                    }
+                                    settingsCloseObserver = nil
+                                }
                             }
                         }
                     } label: {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -5,6 +5,7 @@ import PlaidBarCore
 struct MainPopover: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    @State private var settingsCloseObserver: NSObjectProtocol?
 
     var body: some View {
         @Bindable var state = appState

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -4,13 +4,10 @@ import PlaidBarCore
 struct SetupView: View {
     @Environment(AppState.self) private var appState
     @State private var setupMode: SetupMode = .welcome
-    @State private var clientId = ""
-    @State private var secret = ""
 
     enum SetupMode: Sendable {
         case welcome
         case sandbox
-        case credentials
         case connecting
     }
 
@@ -18,7 +15,7 @@ struct SetupView: View {
         VStack(spacing: Spacing.lg) {
             // Step indicator
             HStack(spacing: Spacing.sm) {
-                ForEach(0..<3) { step in
+                ForEach(0..<2) { step in
                     Circle()
                         .fill(stepIndex >= step ? SemanticColors.brand : Color.gray.opacity(0.3))
                         .frame(width: 6, height: 6)
@@ -31,8 +28,6 @@ struct SetupView: View {
                 welcomeView
             case .sandbox:
                 sandboxView
-            case .credentials:
-                credentialsView
             case .connecting:
                 connectingView
             }
@@ -45,8 +40,8 @@ struct SetupView: View {
     private var stepIndex: Int {
         switch setupMode {
         case .welcome: return 0
-        case .sandbox, .credentials: return 1
-        case .connecting: return 2
+        case .sandbox: return 1
+        case .connecting: return 1
         }
     }
 
@@ -76,16 +71,6 @@ struct SetupView: View {
                 }
                 .buttonStyle(.borderedProminent)
 
-                Button {
-                    setupMode = .credentials
-                } label: {
-                    HStack {
-                        Image(systemName: "key")
-                        Text("Use my Plaid credentials")
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
             }
         }
     }
@@ -110,42 +95,6 @@ struct SetupView: View {
                 Task { await appState.addAccount() }
             }
             .buttonStyle(.borderedProminent)
-
-            Button("Back") {
-                setupMode = .welcome
-            }
-            .buttonStyle(.borderless)
-        }
-    }
-
-    private var credentialsView: some View {
-        VStack(spacing: Spacing.lg) {
-            Image(systemName: "key.fill")
-                .font(.system(size: 36))
-                .foregroundStyle(SemanticColors.brand)
-
-            Text("Plaid Credentials")
-                .font(.title3)
-                .fontWeight(.semibold)
-
-            Text("Enter your Plaid API credentials. Get them at dashboard.plaid.com")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .font(.callout)
-
-            VStack(alignment: .leading, spacing: Spacing.sm) {
-                TextField("Client ID", text: $clientId)
-                    .textFieldStyle(.roundedBorder)
-                SecureField("Secret", text: $secret)
-                    .textFieldStyle(.roundedBorder)
-            }
-
-            Button("Connect") {
-                setupMode = .connecting
-                Task { await appState.addAccount() }
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(clientId.isEmpty || secret.isEmpty)
 
             Button("Back") {
                 setupMode = .welcome

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -92,6 +92,9 @@ struct SpendingView: View {
     var body: some View {
         let categories = chartCategories
         let total = totalFiltered
+        let prevSpending = previousPeriodSpending
+        let delta = spendingDelta
+        let deltaPercent = spendingDeltaPercent
 
         VStack(spacing: Spacing.md) {
             // Period picker
@@ -112,24 +115,24 @@ struct SpendingView: View {
                 .animation(.default, value: total)
 
             // Month-over-month comparison
-            if previousPeriodSpending > 0 {
+            if prevSpending > 0 {
                 VStack(spacing: Spacing.xxs) {
                     HStack(spacing: Spacing.xs) {
-                        Image(systemName: spendingDelta >= 0 ? "arrow.up.right" : "arrow.down.right")
+                        Image(systemName: delta >= 0 ? "arrow.up.right" : "arrow.down.right")
                             .font(.caption)
-                        Text("\(spendingDelta >= 0 ? "+" : "")\(Formatters.currency(abs(spendingDelta), format: .full)) (\(Formatters.percent(abs(spendingDeltaPercent), decimals: 1)))")
+                        Text("\(delta >= 0 ? "+" : "")\(Formatters.currency(abs(delta), format: .full)) (\(Formatters.percent(abs(deltaPercent), decimals: 1)))")
                             .font(.callout.weight(.medium))
                     }
-                    .foregroundStyle(spendingDelta >= 0 ? SemanticColors.negative : SemanticColors.positive)
+                    .foregroundStyle(delta >= 0 ? SemanticColors.negative : SemanticColors.positive)
                     .contentTransition(.numericText())
-                    .animation(.default, value: spendingDelta)
+                    .animation(.default, value: delta)
 
                     Text("vs. last period")
                         .microText()
                         .foregroundStyle(.secondary)
                 }
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel("Spending \(spendingDelta >= 0 ? "increased" : "decreased") by \(Formatters.currency(abs(spendingDelta), format: .full)), \(Formatters.percent(abs(spendingDeltaPercent), decimals: 1)) \(spendingDelta >= 0 ? "more" : "less") than last period")
+                .accessibilityLabel("Spending \(delta >= 0 ? "increased" : "decreased") by \(Formatters.currency(abs(delta), format: .full)), \(Formatters.percent(abs(deltaPercent), decimals: 1)) \(delta >= 0 ? "more" : "less") than last period")
             }
 
             // Chart type picker

--- a/Sources/PlaidBarCore/Utilities/Formatters.swift
+++ b/Sources/PlaidBarCore/Utilities/Formatters.swift
@@ -30,12 +30,18 @@ public enum Formatters {
     public static func currency(_ amount: Double, format: CurrencyFormat = .full, currencyCode: String = "USD") -> String {
         switch format {
         case .full:
+            if currencyCode == "USD" {
+                return fullFormatter.string(from: NSNumber(value: amount)) ?? "$\(amount)"
+            }
             guard let formatter = fullFormatter.copy() as? NumberFormatter else { return "$\(amount)" }
             formatter.currencyCode = currencyCode
             return formatter.string(from: NSNumber(value: amount)) ?? "$\(amount)"
         case .abbreviated:
             return abbreviatedCurrency(amount, currencyCode: currencyCode)
         case .compact:
+            if currencyCode == "USD" {
+                return compactFormatter.string(from: NSNumber(value: amount)) ?? "$\(amount)"
+            }
             guard let formatter = compactFormatter.copy() as? NumberFormatter else { return "$\(amount)" }
             formatter.currencyCode = currencyCode
             return formatter.string(from: NSNumber(value: amount)) ?? "$\(amount)"


### PR DESCRIPTION
## Summary

Resolves all 9 open issues in a single branch, organized by wave to avoid file conflicts.

- **#7** — Remove unused credential fields from SetupView (server handles its own credentials)
- **#8** — Add semantic purpose doc comments to all 12 DesignTokens colors
- **#9, #15** — Cache computed properties in chart and spending views to prevent redundant recomputation
- **#10** — Skip NumberFormatter `.copy()` for USD (the default), eliminating allocation on 34+ call sites
- **#12** — Extract `NotificationServiceProtocol` and inject into AppState for testability
- **#13, #17** — Replace fragile Settings window title matching with `keyWindow` detection; restore `.accessory` activation policy on close
- **#14** — Add `didSet` guards to all 9 UserDefaults-backed properties (critical for `refreshInterval` which restarts background refresh)

## Test plan

- [ ] `swift build` passes for both PlaidBar and PlaidBarServer targets
- [ ] Verify SetupView shows 2 step dots and no credential input flow
- [ ] Verify Settings window opens/closes correctly and Dock icon disappears on close
- [ ] Verify currency formatting still works for USD amounts
- [ ] Verify spending view month-over-month comparison renders correctly
- [ ] Verify notification toggle still requests permission in Settings
- [ ] Run full test suite via Xcode (`swift test` requires Xcode for Swift Testing framework)

Closes #7, #8, #9, #10, #12, #13, #14, #15, #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)