### PR TITLE
docs: add accessibility guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -1,0 +1,34 @@
+name: Accessibility issue
+description: Report a barrier in the macOS app, menu bar UI, docs, or screenshots.
+title: "[Accessibility]: "
+labels: ["accessibility"]
+body:
+  - type: textarea
+    id: barrier
+    attributes:
+      label: Accessibility barrier
+      description: What was difficult or impossible to use?
+    validations:
+      required: true
+  - type: textarea
+    id: surface
+    attributes:
+      label: Surface
+      description: Menu bar, account view, transactions, spending, credit, settings, local server, or docs.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: macOS version, PlaidBar version or commit, VoiceOver, keyboard-only use, display settings, or other setup.
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps using sandbox or synthetic data only.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What would make this accessible?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## Checks
+
+- [ ] I ran `swift test` or documented why not.
+- [ ] I used sandbox or synthetic financial data in tests, screenshots, and examples.
+- [ ] I checked keyboard access and visible focus for UI changes.
+- [ ] I spot-checked VoiceOver labels or announcements for UI changes.
+- [ ] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
+- [ ] I updated docs or screenshots if user-facing behavior changed.

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,38 @@
+# Accessibility
+
+PlaidBar is a native macOS menu bar app. Accessibility work in this repo focuses
+on VoiceOver, keyboard navigation, readable finance data, color-independent
+status, and clear local-server errors.
+
+## What we aim for
+
+- Menu bar and popover controls are reachable by keyboard.
+- Interactive controls have useful labels for VoiceOver.
+- Focus states are visible.
+- Account, transaction, spending, and credit-utilization states do not rely on
+  color alone.
+- Charts and gauges have text equivalents or summaries.
+- Alerts and errors are written clearly and announced through standard macOS UI
+  patterns where practical.
+- Motion and loading states do not create barriers.
+- Screenshots and docs include meaningful alt text.
+
+## Reporting accessibility issues
+
+Please open an accessibility issue if you find:
+
+- unlabeled controls or confusing VoiceOver announcements
+- keyboard traps or unreachable actions
+- charts, gauges, or status indicators without text equivalents
+- color-only balance, risk, or utilization meaning
+- confusing focus order, loading, alert, or error behavior
+
+Include macOS version, PlaidBar version or commit, VoiceOver/keyboard setup,
+display settings, and steps to reproduce. Do not include real financial data,
+access tokens, account numbers, or private transaction details.
+
+## Contribution expectations
+
+UI changes should include a keyboard pass, VoiceOver spot check, visible-focus
+check, and color-independent review of balances, charts, warnings, and errors.
+Use synthetic or sandbox financial data in screenshots, tests, and examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,22 @@ Configuration files: `.swiftformat` and `.swiftlint.yml` in the repo root.
 
 - Use the [bug report template](https://github.com/ftchvs/PlaidBar/issues/new?template=bug_report.yml) for bugs
 - Use the [feature request template](https://github.com/ftchvs/PlaidBar/issues/new?template=feature_request.yml) for ideas
+- Use the accessibility issue template for VoiceOver, keyboard, chart, contrast, or reduced-motion barriers
+
+## Accessibility Expectations
+
+- Keep controls reachable by keyboard.
+- Add useful labels for VoiceOver.
+- Preserve visible focus states.
+- Do not communicate balance, risk, utilization, errors, or chart meaning through color alone.
+- Use sandbox or synthetic financial data in screenshots, tests, and examples.
+
+## Pull Request Checklist
+
+- [ ] I ran `swift test` or documented why not.
+- [ ] I checked relevant accessibility expectations from [ACCESSIBILITY.md](ACCESSIBILITY.md).
+- [ ] I used sandbox or synthetic financial data in screenshots, tests, and examples.
+- [ ] I updated docs if user-facing behavior changed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sand
 | `Cmd+R` | Refresh balances |
 | `Cmd+N` | Add account |
 
+## Accessibility
+
+Accessibility expectations for keyboard navigation, VoiceOver labels, charts,
+status indicators, and screenshots are in [ACCESSIBILITY.md](ACCESSIBILITY.md).
+
 ## Requirements
 
 | Requirement | Version |


### PR DESCRIPTION
## Summary
- Add repo-specific accessibility guidance.
- Add an accessibility issue template.
- Add a pull request checklist with accessibility checks.

## Motivation
This aligns the project with GitHub/Open Source Guide accessibility practices by making accessibility expectations visible to contributors and giving users a clear path to report barriers.

## Test plan
- [x] Ran `git diff --check` before commit.
- [ ] No runtime tests run; documentation and GitHub template changes only.
