### PR TITLE
docs: add repo health baseline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our pledge
+
+PlaidBar should be a practical and respectful project for people improving
+privacy-first personal finance tools on macOS.
+
+## Expected behavior
+
+- Use welcoming and inclusive language.
+- Give specific, constructive feedback.
+- Respect user privacy and financial-data sensitivity.
+- Use sandbox or synthetic financial data in public examples.
+- Avoid publishing private data, credentials, tokens, or account details.
+
+## Unacceptable behavior
+
+- Harassment, threats, insults, or discriminatory language.
+- Publishing someone else's private information.
+- Submitting real financial data, Plaid secrets, access tokens, account numbers,
+  or private transaction details.
+- Repeatedly derailing issues or reviews.
+
+## Enforcement
+
+Maintainers may remove comments, close issues or pull requests, or block
+contributors whose behavior is harmful to the project or community.
+
+For sensitive concerns, contact the maintainer privately through the repository
+owner profile or GitHub private vulnerability reporting if available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security
+
+PlaidBar handles sensitive financial metadata locally. Please report security or
+privacy issues responsibly.
+
+## Supported versions
+
+The `main` branch is the supported development line before stable releases are
+published.
+
+## Reporting a vulnerability
+
+Use GitHub private vulnerability reporting if available, or contact the
+repository owner through the GitHub profile. Do not open a public issue for
+secrets, token handling bugs, private financial data exposure, or exploitable
+vulnerabilities.
+
+Please include:
+
+- affected commit or version
+- steps to reproduce
+- impact
+- whether Plaid tokens, account metadata, transaction data, or local database
+  contents may be exposed
+- suggested remediation, if known
+
+## Security model
+
+- The companion server should bind to `127.0.0.1` only.
+- Plaid secrets and access tokens must not be embedded in the app binary.
+- Screenshots, tests, and examples must use sandbox or synthetic financial data.
+- Logs should not include real account numbers, access tokens, raw transaction
+  details, or secrets.
+- App-server communication should preserve local-only assumptions unless a
+  future change explicitly documents otherwise.
+
+## Maintainer response
+
+Maintainers will acknowledge credible reports, investigate the scope, and fix or
+document mitigations before public disclosure when appropriate.


### PR DESCRIPTION
## Summary
- Add finance-data-specific security policy.
- Add code of conduct with privacy and sandbox-data expectations. $-

## Validation
[x]
