### PR TITLE
feat: add spending heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to PlaidBar.
 
 ---
 
+## [Unreleased] — Feature
+
+- Add a GitHub-style spending heatmap to the Spending tab, with daily intensity cells for spend and net cashflow modes.
+- Add core heatmap bucketing tests for date ranges, transfer/income exclusions, and net cashflow signs.
+- Add a `Last 90 Days` spending period so the heatmap has enough history to be useful.
+
+---
+
 ## [2026-05-26 21:42 UTC] — Feature
 
 add PlaidBar trust goal and status strip (#22)

--- a/GOAL.md
+++ b/GOAL.md
@@ -57,21 +57,26 @@ Prioritize these before adding new finance features:
    - Let users choose the menu bar label: Net cash, total cash, credit utilization, recent spend, or compact icon-only.
    - Keep the default conservative: net cash or account health, not noisy transaction counts.
 
-3. **CodexBar-style health panel**
+3. **Spending heatmap**
+   - Add a GitHub-style daily grid for recent spending intensity.
+   - Support both total spend and net cashflow so income/refunds do not disappear from the story.
+   - Keep day details local and glanceable: amount, transaction count, and date.
+
+4. **CodexBar-style health panel**
    - Add a small diagnostics/settings surface for local server URL, Plaid environment, item count, last sync, and refresh cadence.
    - Make failures actionable: missing credentials, server offline, token expired, Plaid error.
 
-4. **Cleaner onboarding**
+5. **Cleaner onboarding**
    - Separate "View Demo", "Connect Sandbox", and "Use Production Credentials".
    - Never imply sandbox works without credentials unless the app can actually do that.
    - Explain what data is stored before the user links an account.
 
-5. **Sharper empty and error states**
+6. **Sharper empty and error states**
    - Accounts: explain whether there is no data, no server, or no linked institution.
    - Transactions: distinguish no synced history from filters returning zero results.
    - Credit: explain if no credit accounts are linked.
 
-6. **Trust-first settings**
+7. **Trust-first settings**
    - Add a local data section with `~/.plaidbar/` storage path, reset/delete options, and clear warnings.
    - Keep dangerous actions explicit and confirmation-gated.
 
@@ -81,6 +86,7 @@ Prioritize these before adding new finance features:
 - Real production credential setup documentation.
 - Local server health/status visibility.
 - Manual refresh plus background refresh with visible stale-data state.
+- GitHub-style spending heatmap for daily spend intensity and net cashflow.
 - Account reconnect/token-expired handling.
 - Polished demo fixtures and screenshots.
 - Security and privacy docs that match actual implementation.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Personal finance data lives behind bank website logins. The closest thing to a m
 - **Transaction Detail** — Tap any transaction for merchant, category, account, and status details
 - **Transaction Filtering** — Filter by category, account, or date range with chip controls
 - **Recurring Detection** — Automatic identification of subscriptions and recurring charges with monthly total
-- **Spending Breakdown** — Donut chart, trend line, income vs expense views, and month-over-month comparison
+- **Spending Breakdown** — Donut chart, GitHub-style daily spending heatmap, trend line, income vs expense views, and month-over-month comparison
 - **Credit Utilization** — Progress bars with configurable warning thresholds and gauge
 - **Smart Notifications** — Alerts for large transactions, low balances, and high credit utilization
 - **Balance History** — Sparkline showing net balance trend over time
@@ -184,7 +184,7 @@ PlaidBar/
 │   │   ├── Views/                   # SwiftUI views (4 tabs)
 │   │   │   ├── AccountsView.swift   # Balance list by account type
 │   │   │   ├── TransactionsView.swift # Searchable grouped list
-│   │   │   ├── SpendingView.swift   # Donut/trend/bar charts
+│   │   │   ├── SpendingView.swift   # Donut/heatmap/trend/bar charts
 │   │   │   ├── CreditView.swift     # Utilization bars + gauge
 │   │   │   ├── SetupView.swift      # Onboarding flow
 │   │   │   └── Charts/             # Chart components

--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import PlaidBarCore
+
+struct SpendingHeatmapView: View {
+    let transactions: [TransactionDTO]
+    let startDate: Date
+    let endDate: Date
+
+    @State private var mode: SpendingHeatmapMode = .spending
+    @State private var selectedDate: String?
+
+    private let calendar = Calendar.current
+
+    private var days: [SpendingHeatmapDay] {
+        SpendingHeatmap.days(
+            from: transactions,
+            startDate: startDate,
+            endDate: endDate,
+            mode: mode,
+            calendar: calendar
+        )
+    }
+
+    private var peakValue: Double {
+        max(days.map { abs($0.value) }.max() ?? 0, 1)
+    }
+
+    private var totalValue: Double {
+        days.reduce(0) { $0 + $1.value }
+    }
+
+    private var totalLabel: String {
+        guard mode == .netCashflow else {
+            return Formatters.currency(totalValue, format: .compact)
+        }
+        let prefix = totalValue > 0 ? "+" : totalValue < 0 ? "-" : ""
+        return "\(prefix)\(Formatters.currency(abs(totalValue), format: .compact))"
+    }
+
+    private var selectedDay: SpendingHeatmapDay? {
+        guard let selectedDate else { return nil }
+        return days.first { $0.date == selectedDate }
+    }
+
+    private var weekColumns: [[SpendingHeatmapDay?]] {
+        guard let firstDay = days.first,
+              let firstDate = Formatters.parseTransactionDate(firstDay.date) else {
+            return []
+        }
+
+        let weekday = calendar.component(.weekday, from: firstDate)
+        let leadingEmptyDays = (weekday - calendar.firstWeekday + 7) % 7
+        let padded: [SpendingHeatmapDay?] = Array(repeating: nil, count: leadingEmptyDays) + days.map(Optional.some)
+        return stride(from: 0, to: padded.count, by: 7).map { start in
+            let week = Array(padded[start..<min(start + 7, padded.count)])
+            return week + Array(repeating: nil, count: max(0, 7 - week.count))
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            header
+
+            Picker("Heatmap metric", selection: $mode) {
+                Text("Spend").tag(SpendingHeatmapMode.spending)
+                Text("Net").tag(SpendingHeatmapMode.netCashflow)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .onChange(of: mode) { _, _ in
+                selectedDate = nil
+            }
+
+            if days.allSatisfy({ $0.transactionCount == 0 }) {
+                emptyState
+            } else {
+                heatmapGrid
+                legend
+                selectedDaySummary
+            }
+        }
+        .padding(.horizontal, Spacing.lg)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Spending heatmap")
+                    .sectionTitle()
+                Text(mode == .spending ? "Daily outflow intensity" : "Money out minus money in")
+                    .detailText()
+            }
+
+            Spacer()
+
+            Text(totalLabel)
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(mode == .netCashflow && totalValue < 0 ? SemanticColors.positive : .primary)
+        }
+    }
+
+    private var heatmapGrid: some View {
+        HStack(alignment: .top, spacing: Spacing.xs) {
+            ForEach(Array(weekColumns.enumerated()), id: \.offset) { _, week in
+                VStack(spacing: Spacing.xs) {
+                    ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                        if let day {
+                            HeatmapCell(
+                                day: day,
+                                peakValue: peakValue,
+                                mode: mode,
+                                isSelected: selectedDate == day.date
+                            )
+                            .onTapGesture {
+                                selectedDate = selectedDate == day.date ? nil : day.date
+                            }
+                        } else {
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(.clear)
+                                .frame(width: 13, height: 13)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var legend: some View {
+        HStack(spacing: Spacing.xs) {
+            Text("Less")
+                .microText()
+                .foregroundStyle(.secondary)
+
+            ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(HeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
+                    .frame(width: 13, height: 13)
+            }
+
+            Text("More")
+                .microText()
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var selectedDaySummary: some View {
+        if let selectedDay {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: mode == .spending ? "calendar" : "arrow.left.arrow.right")
+                    .foregroundStyle(SemanticColors.brand)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text(Formatters.displayTransactionDate(selectedDay.date))
+                        .font(.caption.weight(.semibold))
+                    Text("\(dayValueText(selectedDay)) across \(selectedDay.transactionCount) transaction\(selectedDay.transactionCount == 1 ? "" : "s")")
+                        .detailText()
+                }
+
+                Spacer()
+            }
+            .padding(Spacing.sm)
+            .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Heatmap Data", systemImage: "calendar.badge.exclamationmark")
+        } description: {
+            Text("Daily spending intensity will appear after syncing transactions.")
+        }
+        .frame(height: 150)
+    }
+
+    private var accessibilitySummary: String {
+        let activeDays = days.filter { $0.transactionCount > 0 }.count
+        return "Spending heatmap with \(activeDays) active days. Peak day \(Formatters.currency(peakValue, format: .full))."
+    }
+
+    private func dayValueText(_ day: SpendingHeatmapDay) -> String {
+        guard mode == .netCashflow else {
+            return Formatters.currency(day.value, format: .full)
+        }
+        let prefix = day.value > 0 ? "+" : day.value < 0 ? "-" : ""
+        return "\(prefix)\(Formatters.currency(abs(day.value), format: .full))"
+    }
+}
+
+private struct HeatmapCell: View {
+    let day: SpendingHeatmapDay
+    let peakValue: Double
+    let mode: SpendingHeatmapMode
+    let isSelected: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 3)
+            .fill(Self.fillColor(intensity: intensity, value: day.value, mode: mode))
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(.primary, lineWidth: 1.5)
+                }
+            }
+            .frame(width: 13, height: 13)
+            .contentShape(Rectangle())
+            .help(helpText)
+            .accessibilityLabel(helpText)
+    }
+
+    private var intensity: Double {
+        guard day.transactionCount > 0 else { return 0 }
+        return min(max(abs(day.value) / peakValue, 0), 1)
+    }
+
+    private var helpText: String {
+        let amount: String
+        if mode == .netCashflow {
+            let prefix = day.value > 0 ? "+" : day.value < 0 ? "-" : ""
+            amount = "\(prefix)\(Formatters.currency(abs(day.value), format: .full))"
+        } else {
+            amount = Formatters.currency(day.value, format: .full)
+        }
+        return "\(Formatters.displayTransactionDate(day.date)): \(amount), \(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
+    }
+
+    static func fillColor(intensity: Double, value: Double, mode: SpendingHeatmapMode) -> Color {
+        guard intensity > 0 else { return Color.primary.opacity(0.08) }
+
+        let base: Color
+        if mode == .netCashflow && value < 0 {
+            base = SemanticColors.positive
+        } else {
+            base = SemanticColors.brand
+        }
+
+        return base.opacity(0.18 + (0.72 * intensity))
+    }
+}

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -11,17 +11,19 @@ struct SpendingView: View {
         case thisWeek = "This Week"
         case thisMonth = "This Month"
         case last30Days = "Last 30 Days"
+        case last90Days = "Last 90 Days"
     }
 
     enum ChartType: String, CaseIterable, Sendable {
         case donut = "Categories"
+        case heatmap = "Heatmap"
         case trend = "Trend"
         case incomeExpense = "In vs Out"
     }
 
-    /// Returns (currentPeriodStart, previousPeriodStart) as formatted date strings.
+    /// Returns current/previous period starts for filtering and comparisons.
     /// Computed once per render — both `filteredTransactions` and `previousPeriodSpending` use this.
-    private var periodInterval: (current: String, previous: String) {
+    private var periodInterval: (currentDate: Date, previousDate: Date, current: String, previous: String) {
         let calendar = Calendar.current
         let now = Date()
 
@@ -37,8 +39,11 @@ struct SpendingView: View {
         case .last30Days:
             startDate = calendar.date(byAdding: .day, value: -30, to: now) ?? now
             previousStart = calendar.date(byAdding: .day, value: -30, to: startDate) ?? now
+        case .last90Days:
+            startDate = calendar.date(byAdding: .day, value: -90, to: now) ?? now
+            previousStart = calendar.date(byAdding: .day, value: -90, to: startDate) ?? now
         }
-        return (Self.formatDate(startDate), Self.formatDate(previousStart))
+        return (startDate, previousStart, Self.formatDate(startDate), Self.formatDate(previousStart))
     }
 
     private var filteredTransactions: [TransactionDTO] {
@@ -149,6 +154,12 @@ struct SpendingView: View {
             switch chartType {
             case .donut:
                 donutChart(categories: categories, total: total)
+            case .heatmap:
+                SpendingHeatmapView(
+                    transactions: filteredTransactions,
+                    startDate: periodInterval.currentDate,
+                    endDate: Date()
+                )
             case .trend:
                 SpendingTrendChart(transactions: filteredTransactions)
             case .incomeExpense:

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum SpendingHeatmapMode: String, Codable, CaseIterable, Sendable {
+    case spending
+    case netCashflow
+}
+
+public struct SpendingHeatmapDay: Identifiable, Sendable, Hashable {
+    public let date: String
+    public let value: Double
+    public let transactionCount: Int
+
+    public var id: String { date }
+
+    public init(date: String, value: Double, transactionCount: Int) {
+        self.date = date
+        self.value = value
+        self.transactionCount = transactionCount
+    }
+}
+
+public enum SpendingHeatmap {
+    public static func days(
+        from transactions: [TransactionDTO],
+        startDate: Date,
+        endDate: Date,
+        mode: SpendingHeatmapMode,
+        calendar: Calendar = .current
+    ) -> [SpendingHeatmapDay] {
+        let start = calendar.startOfDay(for: startDate)
+        let end = calendar.startOfDay(for: endDate)
+        guard start <= end else { return [] }
+
+        let relevant = transactions.compactMap { transaction -> (String, Double)? in
+            guard let date = Formatters.parseTransactionDate(transaction.date) else { return nil }
+            let day = calendar.startOfDay(for: date)
+            guard day >= start && day <= end else { return nil }
+            guard !isTransfer(transaction) else { return nil }
+
+            switch mode {
+            case .spending:
+                guard !transaction.isIncome else { return nil }
+                return (transaction.date, transaction.displayAmount)
+            case .netCashflow:
+                return (transaction.date, transaction.amount)
+            }
+        }
+
+        let grouped = Dictionary(grouping: relevant) { $0.0 }
+        let dayCount = calendar.dateComponents([.day], from: start, to: end).day ?? 0
+
+        return (0...dayCount).compactMap { offset in
+            guard let day = calendar.date(byAdding: .day, value: offset, to: start) else { return nil }
+            let dateString = Formatters.transactionDateString(day)
+            let entries = grouped[dateString] ?? []
+            return SpendingHeatmapDay(
+                date: dateString,
+                value: entries.reduce(0) { $0 + $1.1 },
+                transactionCount: entries.count
+            )
+        }
+    }
+
+    private static func isTransfer(_ transaction: TransactionDTO) -> Bool {
+        transaction.category == .transfer || transaction.category == .transferOut
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -84,6 +84,63 @@ struct PlaidBarCoreTests {
         #expect(tx.displayAmount == 0)
     }
 
+    @Test("Spending heatmap fills every day in range")
+    func spendingHeatmapFillsDateRange() {
+        let start = Formatters.parseTransactionDate("2026-01-01")!
+        let end = Formatters.parseTransactionDate("2026-01-03")!
+
+        let days = SpendingHeatmap.days(
+            from: [
+                TransactionDTO(id: "1", accountId: "a", amount: 25, date: "2026-01-02", name: "Coffee")
+            ],
+            startDate: start,
+            endDate: end,
+            mode: .spending
+        )
+
+        #expect(days.map(\.date) == ["2026-01-01", "2026-01-02", "2026-01-03"])
+        #expect(days[0].value == 0)
+        #expect(days[1].value == 25)
+        #expect(days[1].transactionCount == 1)
+    }
+
+    @Test("Spending heatmap excludes income and transfers")
+    func spendingHeatmapExcludesIncomeAndTransfers() {
+        let day = Formatters.parseTransactionDate("2026-01-02")!
+
+        let days = SpendingHeatmap.days(
+            from: [
+                TransactionDTO(id: "1", accountId: "a", amount: 25, date: "2026-01-02", name: "Coffee"),
+                TransactionDTO(id: "2", accountId: "a", amount: -100, date: "2026-01-02", name: "Refund"),
+                TransactionDTO(id: "3", accountId: "a", amount: 200, date: "2026-01-02", name: "Transfer", category: .transfer)
+            ],
+            startDate: day,
+            endDate: day,
+            mode: .spending
+        )
+
+        #expect(days.first?.value == 25)
+        #expect(days.first?.transactionCount == 1)
+    }
+
+    @Test("Net cashflow heatmap keeps Plaid amount signs")
+    func netCashflowHeatmapKeepsSigns() {
+        let day = Formatters.parseTransactionDate("2026-01-02")!
+
+        let days = SpendingHeatmap.days(
+            from: [
+                TransactionDTO(id: "1", accountId: "a", amount: 75, date: "2026-01-02", name: "Groceries"),
+                TransactionDTO(id: "2", accountId: "a", amount: -250, date: "2026-01-02", name: "Payroll")
+            ],
+            startDate: day,
+            endDate: day,
+            mode: .netCashflow
+        )
+
+        #expect(days.first?.value == -175)
+        #expect(days.first?.transactionCount == 2)
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")


### PR DESCRIPTION
## Summary
- Add a GitHub-style spending heatmap to the Spending tab.
- Support Spend and Net modes so users can scan both daily outflow intensity and net cashflow.
- Add a Last 90 Days period plus core heatmap bucketing tests.

## Test plan
- [x] `git diff --check`
- [x] Core heatmap model typecheck with `xcrun swiftc`
- [x] Heatmap SwiftUI view typecheck with `xcrun swiftc`
- [ ] GitHub Actions CI

## Local note
`swift test --filter SpendingHeatmap` still blocks locally before compilation while downloading Sparkle's binary artifact due local GitHub keychain/artifact friction. This is the same local environment issue seen on the previous PlaidBar PR, so CI is the final Swift package gate.