### PR TITLE
feat: add menu bar summary modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to PlaidBar.
 
 ## [Unreleased] — Feature
 
+- Add CodexBar-style menu bar summary modes for net cash, total cash, credit utilization, recent spend, and icon-only.
 - Add a GitHub-style spending heatmap to the Spending tab, with daily intensity cells for spend and net cashflow modes.
 - Add core heatmap bucketing tests for date ranges, transfer/income exclusions, and net cashflow signs.
 - Add a `Last 90 Days` spending period so the heatmap has enough history to be useful.

--- a/GOAL.md
+++ b/GOAL.md
@@ -56,6 +56,7 @@ Prioritize these before adding new finance features:
 2. **Menu bar summary modes**
    - Let users choose the menu bar label: Net cash, total cash, credit utilization, recent spend, or compact icon-only.
    - Keep the default conservative: net cash or account health, not noisy transaction counts.
+   - Implemented local slice: settings picker, persisted mode, shared summary calculator, and focused tests.
 
 3. **Spending heatmap**
    - Add a GitHub-style daily grid for recent spending intensity.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PlaidBar is an open-source macOS menu bar dashboard for [Plaid](https://plaid.co
 
 Personal finance data lives behind bank website logins. The closest thing to a menu bar finance app was [Balance](https://balancemy.money/) — commercial and now defunct. PlaidBar fills that gap as an open-source, privacy-first alternative.
 
-- **Glanceable** — Net balance visible right in the menu bar
+- **Glanceable** — Choose whether the menu bar shows net cash, total cash, credit utilization, recent spend, or icon-only
 - **Account Balances** — All bank accounts and credit cards at a glance
 - **Recent Transactions** — Searchable, filterable list grouped by day with category icons
 - **Transaction Detail** — Tap any transaction for merchant, category, account, and status details

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -8,6 +8,7 @@ final class AppState {
     // MARK: - UserDefaults Keys
     private enum Keys {
         static let showBalanceInMenuBar = "showBalanceInMenuBar"
+        static let menuBarSummaryMode = "menuBarSummaryMode"
         static let balanceFormat = "balanceFormat"
         static let creditUtilizationThreshold = "creditUtilizationThreshold"
         static let refreshInterval = "refreshInterval"
@@ -38,10 +39,10 @@ final class AppState {
     var balanceHistory: [BalanceSnapshot] = []
 
     // MARK: - Settings (persisted to UserDefaults)
-    var showBalanceInMenuBar: Bool = true {
+    var menuBarSummaryMode: MenuBarSummaryMode = .netCash {
         didSet {
-            guard showBalanceInMenuBar != oldValue else { return }
-            UserDefaults.standard.set(showBalanceInMenuBar, forKey: Keys.showBalanceInMenuBar)
+            guard menuBarSummaryMode != oldValue else { return }
+            UserDefaults.standard.set(menuBarSummaryMode.rawValue, forKey: Keys.menuBarSummaryMode)
         }
     }
     var balanceFormat: CurrencyFormat = .abbreviated {
@@ -127,8 +128,12 @@ final class AppState {
 
     private func loadSettings() {
         let defaults = UserDefaults.standard
-        if defaults.object(forKey: Keys.showBalanceInMenuBar) != nil {
-            showBalanceInMenuBar = defaults.bool(forKey: Keys.showBalanceInMenuBar)
+        if let mode = defaults.string(forKey: Keys.menuBarSummaryMode),
+           let summaryMode = MenuBarSummaryMode(rawValue: mode) {
+            menuBarSummaryMode = summaryMode
+        } else if defaults.object(forKey: Keys.showBalanceInMenuBar) != nil,
+                  !defaults.bool(forKey: Keys.showBalanceInMenuBar) {
+            menuBarSummaryMode = .iconOnly
         }
         if let format = defaults.string(forKey: Keys.balanceFormat),
            let f = CurrencyFormat(rawValue: format) {
@@ -171,22 +176,58 @@ final class AppState {
     // MARK: - Computed
 
     var netBalance: Double {
-        accounts.reduce(0) { total, account in
-            switch account.type {
-            case .depository, .investment:
-                return total + account.balances.effectiveBalance
-            case .credit, .loan:
-                return total - abs(account.balances.current ?? 0)
-            case .other:
-                return total + account.balances.effectiveBalance
-            }
-        }
+        MenuBarSummary.netCash(from: accounts)
+    }
+
+    var totalCash: Double {
+        MenuBarSummary.totalCash(from: accounts)
+    }
+
+    var totalCreditUtilization: Double? {
+        MenuBarSummary.creditUtilization(from: accounts)
+    }
+
+    var recentSpend: Double {
+        MenuBarSummary.recentSpend(from: transactions)
     }
 
     var menuBarText: String {
-        guard !accounts.isEmpty else { return "PlaidBar" }
-        guard showBalanceInMenuBar else { return "\u{1F4B0}" }
-        return Formatters.currency(netBalance, format: balanceFormat)
+        MenuBarSummary.text(
+            mode: menuBarSummaryMode,
+            accounts: accounts,
+            transactions: transactions,
+            currencyFormat: balanceFormat
+        )
+    }
+
+    var menuBarHelpText: String {
+        switch menuBarSummaryMode {
+        case .netCash:
+            return "PlaidBar - Net cash: \(menuBarText)"
+        case .totalCash:
+            return "PlaidBar - Total cash: \(menuBarText)"
+        case .creditUtilization:
+            return "PlaidBar - Credit utilization: \(menuBarText)"
+        case .recentSpend:
+            return "PlaidBar - Recent spend: \(menuBarText)"
+        case .iconOnly:
+            return "PlaidBar"
+        }
+    }
+
+    var menuBarAccessibilityLabel: String {
+        switch menuBarSummaryMode {
+        case .netCash:
+            return "PlaidBar net cash \(menuBarText)"
+        case .totalCash:
+            return "PlaidBar total cash \(menuBarText)"
+        case .creditUtilization:
+            return "PlaidBar credit utilization \(menuBarText)"
+        case .recentSpend:
+            return "PlaidBar recent spend \(menuBarText)"
+        case .iconOnly:
+            return "PlaidBar"
+        }
     }
 
     var lastSyncRelative: String? {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -42,14 +42,18 @@ struct GeneralSettingsView: View {
         @Bindable var state = appState
 
         Form {
-            Toggle("Show balance in menu bar", isOn: $state.showBalanceInMenuBar)
+            Picker("Menu bar shows", selection: $state.menuBarSummaryMode) {
+                ForEach(MenuBarSummaryMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
 
             Picker("Balance format", selection: $state.balanceFormat) {
                 Text("$12,450.32").tag(CurrencyFormat.full)
                 Text("$12.4K").tag(CurrencyFormat.abbreviated)
                 Text("$12,450").tag(CurrencyFormat.compact)
             }
-            .disabled(!appState.showBalanceInMenuBar)
+            .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
 
             Picker("Refresh interval", selection: $state.refreshInterval) {
                 Text("5 minutes").tag(TimeInterval(5 * 60))

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -7,10 +7,12 @@ struct MenuBarLabel: View {
         HStack(spacing: Spacing.xs) {
             Image(systemName: "dollarsign.circle.fill")
                 .foregroundStyle(SemanticColors.income)
-            Text(appState.menuBarText)
-                .monospacedDigit()
+            if !appState.menuBarText.isEmpty {
+                Text(appState.menuBarText)
+                    .monospacedDigit()
+            }
         }
-        .help("PlaidBar \u{2014} Net: \(appState.menuBarText)")
-        .accessibilityLabel("PlaidBar net balance \(appState.menuBarText)")
+        .help(appState.menuBarHelpText)
+        .accessibilityLabel(appState.menuBarAccessibilityLabel)
     }
 }

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
+    case netCash
+    case totalCash
+    case creditUtilization
+    case recentSpend
+    case iconOnly
+
+    public var displayName: String {
+        switch self {
+        case .netCash: return "Net cash"
+        case .totalCash: return "Total cash"
+        case .creditUtilization: return "Credit utilization"
+        case .recentSpend: return "Recent spend"
+        case .iconOnly: return "Icon only"
+        }
+    }
+}
+
+public enum MenuBarSummary {
+    public static func netCash(from accounts: [AccountDTO]) -> Double {
+        accounts.reduce(0) { total, account in
+            switch account.type {
+            case .depository, .investment:
+                return total + account.balances.effectiveBalance
+            case .credit, .loan:
+                return total - abs(account.balances.current ?? 0)
+            case .other:
+                return total + account.balances.effectiveBalance
+            }
+        }
+    }
+
+    public static func totalCash(from accounts: [AccountDTO]) -> Double {
+        accounts
+            .filter { $0.type == .depository }
+            .reduce(0) { $0 + $1.balances.effectiveBalance }
+    }
+
+    public static func creditUtilization(from accounts: [AccountDTO]) -> Double? {
+        let creditBalances = accounts
+            .filter { $0.type == .credit }
+            .map(\.balances)
+
+        let totalLimit = creditBalances.reduce(0) { $0 + ($1.limit ?? 0) }
+        guard totalLimit > 0 else { return nil }
+
+        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
+        return (usedCredit / totalLimit) * 100
+    }
+
+    public static func recentSpend(
+        from transactions: [TransactionDTO],
+        now: Date = Date(),
+        calendar: Calendar = .current,
+        days: Int = 7
+    ) -> Double {
+        let startDate = calendar.startOfDay(
+            for: calendar.date(byAdding: .day, value: -(days - 1), to: now) ?? now
+        )
+
+        return transactions.reduce(0) { total, transaction in
+            guard !transaction.isIncome,
+                  transaction.category != .transfer,
+                  transaction.category != .transferOut,
+                  let date = Formatters.parseTransactionDate(transaction.date),
+                  date >= startDate,
+                  date <= now
+            else {
+                return total
+            }
+            return total + transaction.displayAmount
+        }
+    }
+
+    public static func text(
+        mode: MenuBarSummaryMode,
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        currencyFormat: CurrencyFormat
+    ) -> String {
+        switch mode {
+        case .netCash:
+            guard !accounts.isEmpty else { return "PlaidBar" }
+            return Formatters.currency(netCash(from: accounts), format: currencyFormat)
+        case .totalCash:
+            guard !accounts.isEmpty else { return "PlaidBar" }
+            return Formatters.currency(totalCash(from: accounts), format: currencyFormat)
+        case .creditUtilization:
+            guard !accounts.isEmpty else { return "PlaidBar" }
+            guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
+            return Formatters.percent(utilization, decimals: 0)
+        case .recentSpend:
+            guard !transactions.isEmpty else { return "No spend" }
+            return Formatters.currency(recentSpend(from: transactions), format: currencyFormat)
+        case .iconOnly:
+            return ""
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -123,6 +123,72 @@ struct PlaidBarCoreTests {
         #expect(days.first?.transactionCount == 1)
     }
 
+    // MARK: - Menu Bar Summary Tests
+
+    @Test("Menu bar summary calculates net cash")
+    func menuBarSummaryNetCash() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Savings", type: .depository, balances: BalanceDTO(available: 5_100)),
+            AccountDTO(id: "3", itemId: "i", name: "Amex", type: .credit, balances: BalanceDTO(current: -850.68)),
+        ]
+
+        #expect(abs(MenuBarSummary.netCash(from: accounts) - 12_449.32) < 0.01)
+    }
+
+    @Test("Menu bar summary total cash uses depository accounts only")
+    func menuBarSummaryTotalCash() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 50_000)),
+            AccountDTO(id: "3", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -1_500, limit: 10_000)),
+        ]
+
+        #expect(MenuBarSummary.totalCash(from: accounts) == 8_200)
+    }
+
+    @Test("Menu bar summary aggregates credit utilization")
+    func menuBarSummaryCreditUtilization() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Amex", type: .credit, balances: BalanceDTO(current: -1_000, limit: 10_000)),
+            AccountDTO(id: "3", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -2_000, limit: 5_000)),
+        ]
+
+        #expect(MenuBarSummary.creditUtilization(from: accounts) == 20)
+    }
+
+    @Test("Menu bar summary recent spend excludes income and transfers")
+    func menuBarSummaryRecentSpend() {
+        let now = Formatters.parseTransactionDate("2026-01-15")!
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 25, date: "2026-01-15", name: "Coffee"),
+            TransactionDTO(id: "2", accountId: "a", amount: 75, date: "2026-01-10", name: "Groceries"),
+            TransactionDTO(id: "3", accountId: "a", amount: -200, date: "2026-01-15", name: "Refund"),
+            TransactionDTO(id: "4", accountId: "a", amount: 500, date: "2026-01-15", name: "Transfer", category: .transfer),
+            TransactionDTO(id: "5", accountId: "a", amount: 40, date: "2026-01-01", name: "Old")
+        ]
+
+        #expect(MenuBarSummary.recentSpend(from: transactions, now: now) == 100)
+    }
+
+    @Test("Menu bar summary text supports every mode")
+    func menuBarSummaryTextModes() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -1_500, limit: 10_000)),
+        ]
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 25, date: Formatters.transactionDateString(Date()), name: "Coffee")
+        ]
+
+        #expect(!MenuBarSummary.text(mode: .netCash, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
+        #expect(!MenuBarSummary.text(mode: .totalCash, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
+        #expect(MenuBarSummary.text(mode: .creditUtilization, accounts: accounts, transactions: transactions, currencyFormat: .compact) == "15%")
+        #expect(!MenuBarSummary.text(mode: .recentSpend, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
+        #expect(MenuBarSummary.text(mode: .iconOnly, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
+    }
+
     @Test("Net cashflow heatmap keeps Plaid amount signs")
     func netCashflowHeatmapKeepsSigns() {
         let day = Formatters.parseTransactionDate("2026-01-02")!


### PR DESCRIPTION
## Summary
- Add persisted menu bar summary modes for net cash, total cash, credit utilization, recent spend, and icon-only.
- Add a Settings picker for choosing the active menu bar signal.
- Extract the summary calculations into shared core code with focused tests.
- Refresh menu bar help/accessibility text and update README, GOAL, and CHANGELOG.

## Verification
- `git diff --check`
- `swiftc -typecheck Sources/PlaidBarCore/Exports.swift Sources/PlaidBarCore/Utilities/Formatters.swift Sources/PlaidBarCore/Utilities/MenuBarSummary.swift Sources/PlaidBarCore/Models/BalanceDTO.swift Sources/PlaidBarCore/Models/AccountDTO.swift Sources/PlaidBarCore/Models/TransactionDTO.swift Sources/PlaidBarCore/Models/SpendingCategory.swift`

## Notes
- Full local SwiftPM build/test is still blocked in this environment by the existing Sparkle artifact download/keychain friction. CI should be the canonical SwiftPM gate.
