### PR TITLE
feat: add diagnostics status panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ add spending heatmap (#23)
 
 ## [Unreleased] — Feature
 
+- Add a Status tab with CodexBar-style diagnostics for server health, sync recency, account/transaction counts, Plaid item state, and recovery actions.
 - Add CodexBar-style menu bar summary modes for net cash, total cash, credit utilization, recent spend, and icon-only.
 - Add a GitHub-style spending heatmap to the Spending tab, with daily intensity cells for spend and net cashflow modes.
 - Add core heatmap bucketing tests for date ranges, transfer/income exclusions, and net cashflow signs.

--- a/GOAL.md
+++ b/GOAL.md
@@ -66,6 +66,7 @@ Prioritize these before adding new finance features:
 4. **CodexBar-style health panel**
    - Add a small diagnostics/settings surface for local server URL, Plaid environment, item count, last sync, and refresh cadence.
    - Make failures actionable: missing credentials, server offline, token expired, Plaid error.
+   - Implemented local slice: Status tab with server/sync/data/item diagnostics and refresh/connect/settings recovery actions.
 
 5. **Cleaner onboarding**
    - Separate "View Demo", "Connect Sandbox", and "Use Production Credentials".

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Personal finance data lives behind bank website logins. The closest thing to a m
 - **Credit Utilization** — Progress bars with configurable warning thresholds and gauge
 - **Smart Notifications** — Alerts for large transactions, low balances, and high credit utilization
 - **Balance History** — Sparkline showing net balance trend over time
-- **Keyboard Shortcuts** — Cmd+1-4 to switch tabs, Cmd+R to refresh, Cmd+N to add account
+- **Diagnostics** — Status tab for server health, sync recency, item state, data counts, and recovery actions
+- **Keyboard Shortcuts** — Cmd+1-5 to switch tabs, Cmd+R to refresh, Cmd+N to add account
 - **Settings Persistence** — Preferences saved across launches
 - **Launch at Login** — Optional auto-start via macOS Login Items
 - **Auto-Updates** — Sparkle integration for seamless updates
@@ -113,6 +114,7 @@ Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sand
 | `Cmd+2` | Transactions tab |
 | `Cmd+3` | Spending tab |
 | `Cmd+4` | Credit tab |
+| `Cmd+5` | Status tab |
 | `Cmd+R` | Refresh balances |
 | `Cmd+N` | Add account |
 
@@ -181,11 +183,12 @@ PlaidBar/
 │   ├── PlaidBar/                    # macOS menu bar app
 │   │   ├── App/                     # @main entry, AppState
 │   │   ├── Theme/                   # Design tokens, typography
-│   │   ├── Views/                   # SwiftUI views (4 tabs)
+│   │   ├── Views/                   # SwiftUI views (5 tabs)
 │   │   │   ├── AccountsView.swift   # Balance list by account type
 │   │   │   ├── TransactionsView.swift # Searchable grouped list
 │   │   │   ├── SpendingView.swift   # Donut/heatmap/trend/bar charts
 │   │   │   ├── CreditView.swift     # Utilization bars + gauge
+│   │   │   ├── StatusView.swift     # Diagnostics and recovery actions
 │   │   │   ├── SetupView.swift      # Onboarding flow
 │   │   │   └── Charts/             # Chart components
 │   │   ├── Models/                  # Local cache models

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -33,7 +33,9 @@ final class AppState {
     var isSetupComplete = false
     var serverConnected = false
     var serverEnvironment: PlaidEnvironment?
+    var serverVersion: String?
     var serverItemCount: Int?
+    var itemStatuses: [ItemStatus] = []
     var isDemoMode = false
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
@@ -255,6 +257,47 @@ final class AppState {
         return Set(accounts.map(\.itemId)).count
     }
 
+    var accountCount: Int {
+        accounts.count
+    }
+
+    var transactionCount: Int {
+        transactions.count
+    }
+
+    var localServerURLText: String {
+        PlaidBarConstants.serverBaseURL
+    }
+
+    var localStoragePathText: String {
+        "~/.plaidbar/"
+    }
+
+    var refreshCadenceText: String {
+        "\(Int(refreshInterval / 60)) min"
+    }
+
+    var connectedItemCount: Int {
+        itemStatuses.filter { $0.status == .connected }.count
+    }
+
+    var needsLoginItemCount: Int {
+        itemStatuses.filter { $0.status == .loginRequired }.count
+    }
+
+    var erroredItemCount: Int {
+        itemStatuses.filter { $0.status == .error }.count
+    }
+
+    var diagnosticsSummary: String {
+        if isDemoMode { return "Demo data loaded" }
+        if !serverConnected { return "Server offline" }
+        if statusItemCount == 0 { return "No Plaid items connected" }
+        if erroredItemCount > 0 { return "\(erroredItemCount) item\(erroredItemCount == 1 ? "" : "s") need attention" }
+        if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(needsLoginItemCount == 1 ? "" : "s") need login" }
+        return "Plaid connection healthy"
+    }
+
     var isSyncStale: Bool {
         guard let lastSyncDate else { return true }
         let staleAfter = max(refreshInterval * 2, PlaidBarConstants.transactionSyncInterval * 2)
@@ -329,13 +372,17 @@ final class AppState {
             let status = try await serverClient.getStatus()
             serverConnected = true
             serverEnvironment = status.environment
+            serverVersion = status.version
             serverItemCount = status.itemCount
             lastSyncDate = status.lastSync
             isSetupComplete = status.itemCount > 0
+            itemStatuses = (try? await serverClient.getItems()) ?? []
         } catch {
             serverConnected = false
             serverEnvironment = nil
+            serverVersion = nil
             serverItemCount = nil
+            itemStatuses = []
             isSetupComplete = false
         }
     }
@@ -347,6 +394,7 @@ final class AppState {
             accounts = try await serverClient.getAccounts()
             serverItemCount = Set(accounts.map(\.itemId)).count
             isSetupComplete = !accounts.isEmpty
+            itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
         } catch {
             self.error = error.localizedDescription
         }
@@ -385,6 +433,7 @@ final class AppState {
                 hasMore = response.hasMore
             }
             lastSyncDate = Date()
+            itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
         } catch {
             self.error = error.localizedDescription
         }
@@ -605,7 +654,12 @@ final class AppState {
         isSetupComplete = true
         serverConnected = true
         serverEnvironment = .sandbox
+        serverVersion = PlaidBarConstants.appVersion
         serverItemCount = Set(accounts.map(\.itemId)).count
+        itemStatuses = [
+            ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: Date()),
+            ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),
+        ]
         lastSyncDate = Date()
     }
 
@@ -620,4 +674,5 @@ enum PopoverTab: String, CaseIterable, Sendable {
     case transactions = "Transactions"
     case spending = "Spending"
     case credit = "Credit"
+    case status = "Status"
 }

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -18,6 +18,10 @@ actor ServerClient {
         try await get("/api/status")
     }
 
+    func getItems() async throws -> [ItemStatus] {
+        try await get("/api/items")
+    }
+
     func getAccounts() async throws -> [AccountDTO] {
         try await get("/api/accounts")
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -77,6 +77,8 @@ struct MainPopover: View {
                             SpendingView()
                         case .credit:
                             CreditView()
+                        case .status:
+                            StatusView()
                         }
                     }
                     .animation(.easeInOut(duration: 0.2), value: appState.selectedTab)
@@ -184,6 +186,8 @@ struct MainPopover: View {
                     .keyboardShortcut("3", modifiers: .command)
                 Button("") { appState.selectedTab = .credit }
                     .keyboardShortcut("4", modifiers: .command)
+                Button("") { appState.selectedTab = .status }
+                    .keyboardShortcut("5", modifiers: .command)
             }
             .frame(width: 0, height: 0)
             .opacity(0)

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+import PlaidBarCore
+
+struct StatusView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.lg) {
+            statusHeader
+
+            diagnosticsGrid
+
+            if !appState.itemStatuses.isEmpty {
+                itemSection
+            }
+
+            recoveryActions
+        }
+        .padding(Spacing.lg)
+    }
+
+    private var statusHeader: some View {
+        HStack(spacing: Spacing.md) {
+            Image(systemName: statusIcon)
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(statusColor)
+                .frame(width: 36)
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(appState.diagnosticsSummary)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+
+                Text("Mode: \(appState.statusModeText)")
+                    .detailText()
+            }
+
+            Spacer()
+        }
+        .padding(Spacing.md)
+        .background(.quaternary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var diagnosticsGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: Spacing.sm),
+                GridItem(.flexible(), spacing: Spacing.sm),
+            ],
+            spacing: Spacing.sm
+        ) {
+            DiagnosticTile(
+                title: "Server",
+                value: appState.statusServerText,
+                icon: "server.rack",
+                color: appState.serverConnected ? SemanticColors.positive : SemanticColors.negative
+            )
+            DiagnosticTile(
+                title: "Sync",
+                value: appState.statusSyncText,
+                icon: "arrow.triangle.2.circlepath",
+                color: appState.isSyncStale ? SemanticColors.warning : SemanticColors.positive
+            )
+            DiagnosticTile(
+                title: "Accounts",
+                value: "\(appState.accountCount)",
+                icon: "creditcard",
+                color: SemanticColors.brand
+            )
+            DiagnosticTile(
+                title: "Transactions",
+                value: "\(appState.transactionCount)",
+                icon: "list.bullet.rectangle",
+                color: SemanticColors.brandSecondary
+            )
+            DiagnosticTile(
+                title: "Plaid items",
+                value: "\(appState.connectedItemCount)/\(appState.statusItemCount)",
+                icon: "link",
+                color: itemHealthColor
+            )
+            DiagnosticTile(
+                title: "Version",
+                value: appState.serverVersion ?? PlaidBarConstants.appVersion,
+                icon: "number",
+                color: .secondary
+            )
+            DiagnosticTile(
+                title: "Endpoint",
+                value: appState.localServerURLText.replacingOccurrences(of: "http://", with: ""),
+                icon: "network",
+                color: .secondary
+            )
+            DiagnosticTile(
+                title: "Refresh",
+                value: appState.refreshCadenceText,
+                icon: "timer",
+                color: .secondary
+            )
+        }
+    }
+
+    private var itemSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("PLAID ITEMS")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: Spacing.xs) {
+                ForEach(appState.itemStatuses) { item in
+                    HStack(spacing: Spacing.sm) {
+                        Image(systemName: icon(for: item.status))
+                            .foregroundStyle(color(for: item.status))
+                            .frame(width: 18)
+
+                        VStack(alignment: .leading, spacing: Spacing.xxs) {
+                            Text(item.institutionName ?? "Plaid item")
+                                .font(.callout.weight(.medium))
+                                .lineLimit(1)
+
+                            Text(item.lastSync.map { "Updated \(Formatters.relativeDate($0))" } ?? "No sync recorded")
+                                .detailText()
+                        }
+
+                        Spacer()
+
+                        Text(label(for: item.status))
+                            .microText()
+                            .foregroundStyle(color(for: item.status))
+                    }
+                    .padding(.vertical, Spacing.xs)
+                }
+            }
+        }
+    }
+
+    private var recoveryActions: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "lock.doc")
+                Text("Local data path: \(appState.localStoragePathText)")
+            }
+            .detailText()
+
+            Text("RECOVERY")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: Spacing.sm) {
+                Button {
+                    Task {
+                        await appState.checkServerConnection()
+                        if appState.serverConnected {
+                            await appState.refreshAccounts()
+                            await appState.syncTransactions()
+                        }
+                    }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Connect", systemImage: "plus.circle")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    openSettings()
+                } label: {
+                    Label("Settings", systemImage: "gear")
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    private var statusIcon: String {
+        if appState.isDemoMode { return "play.circle.fill" }
+        if !appState.serverConnected { return "xmark.octagon.fill" }
+        if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return "exclamationmark.triangle.fill" }
+        return "checkmark.seal.fill"
+    }
+
+    private var statusColor: Color {
+        if appState.isDemoMode { return SemanticColors.brandSecondary }
+        if !appState.serverConnected { return SemanticColors.negative }
+        if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return SemanticColors.warning }
+        return SemanticColors.positive
+    }
+
+    private var itemHealthColor: Color {
+        if appState.statusItemCount == 0 { return .secondary }
+        if appState.connectedItemCount < appState.statusItemCount { return SemanticColors.warning }
+        if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return SemanticColors.warning }
+        return SemanticColors.positive
+    }
+
+    private func icon(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .connected: "checkmark.circle.fill"
+        case .loginRequired: "person.crop.circle.badge.exclamationmark"
+        case .error: "xmark.octagon.fill"
+        }
+    }
+
+    private func color(for status: ItemConnectionStatus) -> Color {
+        switch status {
+        case .connected: SemanticColors.positive
+        case .loginRequired: SemanticColors.warning
+        case .error: SemanticColors.negative
+        }
+    }
+
+    private func label(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .connected: "Connected"
+        case .loginRequired: "Login"
+        case .error: "Error"
+        }
+    }
+}
+
+private struct DiagnosticTile: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                Spacer()
+            }
+
+            Text(value)
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            Text(title)
+                .detailText()
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 78, alignment: .topLeading)
+        .padding(Spacing.sm)
+        .background(.quaternary.opacity(0.35))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Status tab with CodexBar-style diagnostics for server health, sync recency, account and transaction counts, Plaid item state, endpoint, refresh cadence, and local storage path.
- Add recovery actions for refresh, connecting an account, and opening settings.
- Add `ServerClient.getItems()` plus AppState diagnostics fields for item and server version health.
- Add `Cmd+5` Status tab shortcut and update README, GOAL, and CHANGELOG.

## Verification
- `git diff --check`
- `swiftc -typecheck Sources/PlaidBarCore/Exports.swift Sources/PlaidBarCore/Utilities/Formatters.swift Sources/PlaidBarCore/Utilities/MenuBarSummary.swift Sources/PlaidBarCore/Models/BalanceDTO.swift Sources/PlaidBarCore/Models/AccountDTO.swift Sources/PlaidBarCore/Models/TransactionDTO.swift Sources/PlaidBarCore/Models/SpendingCategory.swift Sources/PlaidBarCore/Models/LinkResponse.swift Sources/PlaidBarCore/Models/ServerStatus.swift Sources/PlaidBarCore/Utilities/Constants.swift`
- `swift build --target PlaidBar`

## Notes
- `swift build --target PlaidBar` passes with the existing `NotificationService.shared` actor-isolation warning.
- `swift test` still fails locally with the existing `no such module 'Testing'` issue in test targets; CI is the canonical test gate.
