### PR TITLE
feat: clarify production onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ add spending heatmap (#23)
 
 ## [Unreleased] — Feature
 
+- Add cleaner first-run onboarding that separates View Demo, Connect Sandbox, and Use Production Credentials, with local storage disclosure and server environment checks before Plaid Link.
 - Add a Status tab with CodexBar-style diagnostics for server health, sync recency, account/transaction counts, Plaid item state, and recovery actions.
 - Add CodexBar-style menu bar summary modes for net cash, total cash, credit utilization, recent spend, and icon-only.
 - Add a GitHub-style spending heatmap to the Spending tab, with daily intensity cells for spend and net cashflow modes.

--- a/GOAL.md
+++ b/GOAL.md
@@ -72,6 +72,7 @@ Prioritize these before adding new finance features:
    - Separate "View Demo", "Connect Sandbox", and "Use Production Credentials".
    - Never imply sandbox works without credentials unless the app can actually do that.
    - Explain what data is stored before the user links an account.
+   - Implemented local slice: first-run chooser with Demo, Sandbox, and Production paths; server environment checks before Plaid Link; local storage disclosure before linking.
 
 6. **Sharper empty and error states**
    - Accounts: explain whether there is no data, no server, or no linked institution.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ swift run PlaidBar --demo
 
 ### 3. Click the PlaidBar icon in your menu bar
 
-Select **"Try with sandbox"** -> **Add Account** -> complete the Plaid sandbox login in your browser -> data appears after the account sync.
+First run now asks you to choose a data source:
+
+- **View Demo** loads local fixture accounts and transactions. It does not call Plaid and does not require credentials.
+- **Connect Sandbox** opens Plaid Link only when the local server is running in sandbox mode with sandbox credentials.
+- **Use Production Credentials** opens the same connect flow only when the local server reports production mode. Production uses real account data and requires Plaid approval.
+
+Before Plaid Link opens, the app explains that Plaid access tokens and synced account data are stored locally under `~/.plaidbar/`, while Plaid credentials remain in the local server environment.
 
 ### 4. Use with real bank data (optional)
 
@@ -96,7 +102,7 @@ export PLAID_SECRET=your_secret
 ./Scripts/run.sh
 ```
 
-Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sandbox works immediately; production requires Plaid approval.
+Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sandbox credentials can be used immediately; production requires Plaid approval.
 
 ## Data Modes
 

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -451,6 +451,40 @@ final class AppState {
         }
     }
 
+    func startDemoMode() {
+        isDemoMode = true
+        loadDemoData()
+    }
+
+    func connectForOnboarding(expectedEnvironment: PlaidEnvironment) async -> Bool {
+        error = nil
+        await checkServerConnection()
+
+        guard serverConnected else {
+            switch expectedEnvironment {
+            case .sandbox:
+                error = "Start PlaidBarServer with --sandbox and sandbox credentials before connecting."
+            case .production:
+                error = "Start PlaidBarServer with production credentials before connecting real accounts."
+            }
+            return false
+        }
+
+        guard serverEnvironment == expectedEnvironment else {
+            let currentMode = statusModeText.lowercased()
+            switch expectedEnvironment {
+            case .sandbox:
+                error = "Server is running in \(currentMode), not sandbox. Restart with ./Scripts/run.sh --sandbox."
+            case .production:
+                error = "Server is running in \(currentMode), not production. Restart with ./Scripts/run.sh after Plaid production approval."
+            }
+            return false
+        }
+
+        await addAccount()
+        return error == nil
+    }
+
     func removeAccount(itemId: String) async {
         do {
             try await serverClient.removeItem(itemId: itemId)
@@ -652,6 +686,7 @@ final class AppState {
         }
 
         isSetupComplete = true
+        isDemoMode = true
         serverConnected = true
         serverEnvironment = .sandbox
         serverVersion = PlaidBarConstants.appVersion

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -3,33 +3,38 @@ import PlaidBarCore
 
 struct SetupView: View {
     @Environment(AppState.self) private var appState
-    @State private var setupMode: SetupMode = .welcome
+    @State private var setupMode: SetupMode = .choose
 
-    enum SetupMode: Sendable {
-        case welcome
+    enum SetupMode: Sendable, Equatable {
+        case choose
         case sandbox
-        case connecting
+        case production
+        case connecting(PlaidEnvironment)
     }
 
     var body: some View {
         VStack(spacing: Spacing.lg) {
-            // Step indicator
-            HStack(spacing: Spacing.sm) {
-                ForEach(0..<2) { step in
-                    Circle()
-                        .fill(stepIndex >= step ? SemanticColors.brand : Color.gray.opacity(0.3))
-                        .frame(width: 6, height: 6)
-                }
-            }
-            .padding(.top, Spacing.sm)
-
             switch setupMode {
-            case .welcome:
-                welcomeView
+            case .choose:
+                choiceView
             case .sandbox:
-                sandboxView
-            case .connecting:
-                connectingView
+                linkPrepView(
+                    environment: .sandbox,
+                    icon: "testtube.2",
+                    title: "Connect Sandbox",
+                    summary: "Uses Plaid's sandbox API with Plaid-hosted test institutions. This still requires your sandbox client ID and secret on the local server.",
+                    primaryTitle: "Open Sandbox Link"
+                )
+            case .production:
+                linkPrepView(
+                    environment: .production,
+                    icon: "lock.shield",
+                    title: "Use Production Credentials",
+                    summary: "Uses real Plaid production access. Production requires Plaid approval and will connect accounts with real financial data.",
+                    primaryTitle: "Open Production Link"
+                )
+            case .connecting(let environment):
+                connectingView(environment: environment)
             }
         }
         .padding()
@@ -37,99 +42,204 @@ struct SetupView: View {
         .animation(.easeInOut(duration: 0.25), value: setupMode)
     }
 
-    private var stepIndex: Int {
-        switch setupMode {
-        case .welcome: return 0
-        case .sandbox: return 1
-        case .connecting: return 1
-        }
-    }
-
-    private var welcomeView: some View {
+    private var choiceView: some View {
         VStack(spacing: Spacing.lg) {
             Image(systemName: "dollarsign.circle.fill")
-                .font(.system(size: 48))
+                .font(.system(size: 44))
                 .foregroundStyle(SemanticColors.brand)
 
-            Text("Welcome to PlaidBar")
-                .font(.title2)
-                .fontWeight(.bold)
+            VStack(spacing: Spacing.xs) {
+                Text("Welcome to PlaidBar")
+                    .font(.title2)
+                    .fontWeight(.bold)
 
-            Text("Connect your bank accounts to see\nbalances and spending in your menu bar.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
+                Text("Choose exactly what data source to use before anything connects.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
 
-            VStack(spacing: Spacing.md) {
-                Button {
-                    setupMode = .sandbox
-                } label: {
-                    HStack {
-                        Image(systemName: "play.circle")
-                        Text("Connect sandbox")
-                    }
-                    .frame(maxWidth: .infinity)
+            VStack(spacing: Spacing.sm) {
+                OnboardingChoiceButton(
+                    title: "View Demo",
+                    subtitle: "Local fixture data. No Plaid credentials or network calls.",
+                    icon: "play.circle",
+                    color: SemanticColors.brandSecondary
+                ) {
+                    appState.startDemoMode()
                 }
-                .buttonStyle(.borderedProminent)
 
+                OnboardingChoiceButton(
+                    title: "Connect Sandbox",
+                    subtitle: "Requires sandbox credentials on PlaidBarServer.",
+                    icon: "testtube.2",
+                    color: SemanticColors.brand
+                ) {
+                    setupMode = .sandbox
+                }
+
+                OnboardingChoiceButton(
+                    title: "Use Production Credentials",
+                    subtitle: "Requires Plaid approval. Connects real accounts.",
+                    icon: "lock.shield",
+                    color: SemanticColors.positive
+                ) {
+                    setupMode = .production
+                }
             }
         }
     }
 
-    private var sandboxView: some View {
+    private func linkPrepView(
+        environment: PlaidEnvironment,
+        icon: String,
+        title: String,
+        summary: String,
+        primaryTitle: String
+    ) -> some View {
         VStack(spacing: Spacing.lg) {
-            Image(systemName: "testtube.2")
+            Image(systemName: icon)
                 .font(.system(size: 36))
-                .foregroundStyle(SemanticColors.brandSecondary)
+                .foregroundStyle(environment == .production ? SemanticColors.positive : SemanticColors.brand)
 
-            Text("Sandbox Mode")
-                .font(.title3)
-                .fontWeight(.semibold)
+            VStack(spacing: Spacing.xs) {
+                Text(title)
+                    .font(.title3)
+                    .fontWeight(.semibold)
 
-            Text("This will connect to Plaid's sandbox with demo bank data. No real financial data is used.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .font(.callout)
+                Text(summary)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
 
-            Button("Add Demo Account") {
-                setupMode = .connecting
-                Task { await appState.addAccount() }
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                StorageDisclosureRow(
+                    icon: "externaldrive",
+                    text: "PlaidBar stores access tokens and synced account data locally under \(appState.localStoragePathText)."
+                )
+                StorageDisclosureRow(
+                    icon: "server.rack",
+                    text: "Plaid credentials stay in the local server environment, not in the menu bar app."
+                )
+                StorageDisclosureRow(
+                    icon: "eye.slash",
+                    text: "There is no PlaidBar cloud backend, analytics, or telemetry."
+                )
+            }
+            .padding(Spacing.md)
+            .background(.quaternary.opacity(0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            Button {
+                setupMode = .connecting(environment)
+                Task {
+                    let opened = await appState.connectForOnboarding(expectedEnvironment: environment)
+                    if !opened {
+                        setupMode = environment == .production ? .production : .sandbox
+                    }
+                }
+            } label: {
+                Label(primaryTitle, systemImage: "link")
+                    .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .disabled(appState.isLoading)
 
             Button("Back") {
-                setupMode = .welcome
+                setupMode = .choose
             }
             .buttonStyle(.borderless)
         }
     }
 
-    private var connectingView: some View {
+    private func connectingView(environment: PlaidEnvironment) -> some View {
         VStack(spacing: Spacing.lg) {
             ProgressView()
                 .scaleEffect(1.5)
 
-            Text("Connecting...")
+            Text("Opening Plaid Link...")
                 .font(.title3)
 
-            Text("Complete the bank login in your browser, then return here.")
+            Text("Complete the \(environment.rawValue) login in your browser, then return here.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .font(.callout)
 
-            Button("Check Connection") {
+            Button {
                 Task {
                     await appState.refreshAccounts()
                     if appState.isSetupComplete {
                         await appState.syncTransactions()
                     }
                 }
+            } label: {
+                Label("Check Connection", systemImage: "arrow.clockwise")
             }
             .buttonStyle(.bordered)
 
             Button("Cancel") {
-                setupMode = .welcome
+                setupMode = environment == .production ? .production : .sandbox
             }
             .buttonStyle(.borderless)
+        }
+    }
+}
+
+private struct OnboardingChoiceButton: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let color: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.md) {
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundStyle(color)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(Spacing.md)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(.quaternary.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct StorageDisclosureRow: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }


### PR DESCRIPTION
## Summary
- adds an explicit first-run choice between demo mode, Plaid sandbox, and Plaid production
- discloses local storage boundaries before opening Plaid Link
- guards sandbox/production connect flows against local server environment mismatches
- updates README, GOAL, and CHANGELOG for the production-readiness path

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan for token/key patterns only found documented placeholders and schema field names

## Known local test gap
- swift test --enable-swift-testing still fails locally with the existing no such module 'Testing' toolchain issue