### PR TITLE
chore: add PlaidBar goal command

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -1,0 +1,17 @@
+# Codex Skills For PlaidBar
+
+Repo-local Codex skills keep PlaidBar work focused on production readiness.
+
+- `plaidbar-production-loop` — multi-hour improvement loop.
+- `commit` — create one focused commit with validation evidence.
+- `push` — publish a branch and open/update a PR after approval.
+- `review` — review PRs/local diffs for production-readiness risks.
+
+The main user-facing command is:
+
+```bash
+/goal
+```
+
+Its entrypoint lives in `commands/goal.md`; detailed loop instructions live in
+`commands/plaidbar-prod-loop.md`.

--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: commit
+description: Create one focused PlaidBar commit with validation evidence.
+---
+
+# Commit
+
+1. Inspect `git status --short`, `git diff`, and `git diff --staged`.
+2. Stage only files that belong to the current PlaidBar slice.
+3. Do not stage screenshots, logs, `.build`, derived data, local databases, or
+   credentials.
+4. Use a conventional commit subject under 72 characters.
+5. Include a concise body with summary and validation commands.
+6. Never commit secrets or real financial data.

--- a/.codex/skills/plaidbar-production-loop/SKILL.md
+++ b/.codex/skills/plaidbar-production-loop/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: plaidbar-production-loop
+description: Keep PlaidBar moving through multi-hour production-readiness improvement loops.
+---
+
+# PlaidBar Production Loop
+
+Use this skill when Felipe asks to keep improving PlaidBar, make it production
+ready, or run the repo-local `/goal` command.
+
+## Goal
+
+PlaidBar should become a local-first macOS menu bar dashboard for Plaid data:
+CodexBar for personal finance. Favor trustworthy real-data readiness over new
+feature breadth.
+
+## Rules
+
+- Work locally unless Felipe explicitly approves push or PR creation.
+- Never merge from this skill.
+- Do not add hosted backend, telemetry, cloud sync, multi-user support, or
+  budgeting workflows.
+- Do not overclaim security. If tokens are stored in SQLite, say that plainly.
+- Keep changes small, reviewable, and backed by verification evidence.
+
+## Loop
+
+1. Inspect `git status --short --branch`, `GOAL.md`, `README.md`,
+   `DESIGN.md`, and the files likely to change.
+2. Choose one production-readiness slice:
+   - local data controls,
+   - empty/error states,
+   - server/config preflight,
+   - reconnect and degraded item handling,
+   - demo/screenshot polish.
+3. Implement using existing SwiftUI, `AppState`, `ServerClient`, settings,
+   status, and `PlaidBarCore` patterns.
+4. Run:
+   - `git diff --check`
+   - `swift build --target PlaidBar --skip-update --disable-keychain`
+   - focused Swift tests when logic changed and the local toolchain supports it
+   - a secret scan over docs, sources, tests, `commands`, and `.codex`
+5. Commit only one coherent slice at a time.
+6. Report progress with branch, changed files, validation, warnings, and next
+   slice.
+
+## Preferred Next Slice
+
+When no focus is supplied, implement trust-first local data controls:
+
+- show `~/.plaidbar/` in Settings,
+- add copy/reveal actions if practical,
+- add confirmation-gated reset/delete local data,
+- explain what local reset does and does not remove.

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: push
+description: Publish a PlaidBar branch and open a PR after approval.
+---
+
+# Push
+
+Use only after Felipe explicitly approves pushing/opening a PR.
+
+1. Confirm the branch and latest validation.
+2. Push the branch with tracking.
+3. Open or update a PR against `main`.
+4. PR body must include:
+   - summary,
+   - product impact,
+   - validation commands and results,
+   - known warnings or blockers.
+5. Do not merge from this skill.

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: review
+description: Review PlaidBar PRs and local changes for production-readiness risks.
+---
+
+# Review
+
+Focus review on:
+
+- misleading security or production claims,
+- Plaid environment mismatch bugs,
+- local data loss risks,
+- SwiftUI state bugs,
+- broken demo/sandbox/production onboarding,
+- untested finance calculations,
+- confusing empty/error states,
+- docs that no longer match behavior.
+
+Check:
+
+```bash
+git diff --check
+swift build --target PlaidBar --skip-update --disable-keychain
+```
+
+For PRs, inspect CI, Claude/Codex review comments, and mergeability before
+recommending merge.

--- a/GOAL.md
+++ b/GOAL.md
@@ -83,6 +83,11 @@ Prioritize these before adding new finance features:
    - Add a local data section with `~/.plaidbar/` storage path, reset/delete options, and clear warnings.
    - Keep dangerous actions explicit and confirmation-gated.
 
+8. **Long-running production loop**
+   - Use `/goal` for multi-hour, Codex-assisted production-readiness work.
+   - Keep each run focused on one reviewable slice with verification evidence.
+   - Stop before push, PR, or merge unless explicitly approved.
+
 ## Worth Implementing
 
 - Reliable Plaid sandbox onboarding.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for code style, PR process, and architect
 
 See [GOAL.md](GOAL.md) for the CodexBar-style product direction, design principles, and implementation priorities.
 
+### Agentic Development Loop
+
+This repo includes a local slash-command style runbook for long-running
+production-readiness work:
+
+```bash
+/goal
+```
+
+The entrypoint lives in [`commands/goal.md`](commands/goal.md) and delegates to
+[`commands/plaidbar-prod-loop.md`](commands/plaidbar-prod-loop.md) for the full
+multi-hour loop. It is designed for focused production-readiness work around
+trust, onboarding, local data controls, diagnostics, and empty/error states.
+Repo-local Codex skills in `.codex/skills/` provide companion instructions for
+commit, push, review, and production-readiness work.
+
 ## Server API Reference
 
 The companion server exposes these localhost endpoints:

--- a/commands/goal.md
+++ b/commands/goal.md
@@ -1,0 +1,51 @@
+---
+description: Continue PlaidBar production-readiness work for multiple hours.
+argument-hint: "[focus area] [--hours=2-4] [--no-commit]"
+---
+
+# /goal
+
+Run the PlaidBar production-readiness loop for a multi-hour work session.
+
+Default goal:
+
+> Make PlaidBar trustworthy and useful with real Plaid data: clear local data
+> controls, reliable sandbox/production setup, actionable diagnostics, and
+> polished empty/error states.
+
+## How To Use
+
+```bash
+/goal
+/goal "trust-first local data controls" --hours=2
+/goal "empty states and error recovery" --hours=3
+```
+
+This command intentionally delegates the detailed operating loop to:
+
+```text
+commands/plaidbar-prod-loop.md
+```
+
+Read that file first, then execute the same loop with the `/goal` arguments as
+the requested focus/timebox.
+
+## Priority Order
+
+1. Trust-first local data controls in Settings.
+2. Sharper empty and error states across Accounts, Transactions, and Credit.
+3. Server/config preflight for environment and credential readiness.
+4. Reconnect/degraded-item handling.
+5. Demo and screenshot polish.
+6. Distribution readiness only after the real Plaid flow is reliable.
+
+## Stop Conditions
+
+Stop and report when:
+
+- the requested timebox ends,
+- a coherent slice is committed and ready for push/PR approval,
+- verification fails on a real regression,
+- a product/security decision needs Felipe.
+
+Never push, open PRs, or merge from `/goal` without explicit approval.

--- a/commands/plaidbar-prod-loop.md
+++ b/commands/plaidbar-prod-loop.md
@@ -1,0 +1,161 @@
+---
+description: Run a multi-hour PlaidBar production-readiness loop with focused implementation, verification, and handoff.
+argument-hint: "[focus area] [--hours=2-4] [--no-commit]"
+---
+
+# /plaidbar-prod-loop
+
+Use this command to keep improving PlaidBar toward a production-ready,
+local-first macOS finance utility.
+
+The default goal is:
+
+> Make PlaidBar feel trustworthy and useful with real Plaid data before
+> optimizing for packaging, distribution, or new finance verticals.
+
+## Usage
+
+```bash
+/plaidbar-prod-loop
+/plaidbar-prod-loop "local data controls" --hours=2
+/plaidbar-prod-loop "empty states and error recovery" --hours=3 --no-commit
+```
+
+For Codex CLI non-interactive runs:
+
+```bash
+codex exec --cd /Users/otto/.openclaw/workspace/repos/PlaidBar \
+  "$(cat commands/plaidbar-prod-loop.md)"
+```
+
+## Operating Boundaries
+
+- Work locally unless Felipe explicitly approves pushing or opening a PR.
+- Do not merge PRs from this command.
+- Do not add telemetry, cloud sync, hosted backend, or multi-user features.
+- Do not claim token encryption, notarization, or production security properties
+  unless the implementation actually provides them.
+- Do not commit screenshots, logs, build products, local databases, or secrets.
+- Keep every slice reviewable: one coherent product improvement at a time.
+
+## Long-Run Loop
+
+Run for the requested timebox, defaulting to 2 hours and stopping at 4 hours.
+Repeat these phases until the timebox ends or a blocker appears:
+
+1. Sync and inspect:
+   - `git status --short --branch`
+   - `git fetch origin main`
+   - If on `main`, create a feature branch named
+     `feature/<short-production-readiness-topic>`.
+   - Read `GOAL.md`, `README.md`, `DESIGN.md`, `ARCHITECTURE.md`, and recent
+     changed files before editing.
+
+2. Pick the highest-leverage next slice:
+   - Prefer the explicit focus area in `$ARGUMENTS`.
+   - Otherwise use the production-readiness backlog below.
+   - Keep the slice small enough to finish with verification evidence.
+
+3. Implement:
+   - Follow the app's existing SwiftUI, theme, and local-server patterns.
+   - Put finance calculations in `PlaidBarCore` when they are testable logic.
+   - Keep UI dense, native, status-rich, and non-marketing.
+   - Update docs only when behavior or setup changes.
+
+4. Verify:
+   - Always run `git diff --check`.
+   - Run the smallest meaningful Swift gate:
+     `swift build --target PlaidBar --skip-update --disable-keychain`.
+   - Run focused tests when core/server logic changes.
+   - Run the secret scan in this command before reporting success.
+   - Note known baseline warnings instead of hiding them.
+
+5. Commit or stage:
+   - If `--no-commit` is absent and verification passes, create one focused
+     conventional commit.
+   - If verification fails from a pre-existing baseline issue, document it and
+     keep the branch reviewable.
+
+6. Report progress:
+   - Every 30-45 minutes, summarize changed files, validation, and next slice.
+   - End with branch name, commit SHA(s), checks, and whether it is ready for
+     Felipe to approve push/PR.
+
+## Production-Readiness Backlog
+
+Work in this order unless Felipe gives a better focus:
+
+1. **Trust-first local data controls**
+   - Show the local storage path (`~/.plaidbar/`) in Settings.
+   - Add copy/reveal actions for the storage directory when practical.
+   - Add confirmation-gated reset/delete local data flow.
+   - Keep language explicit about what is removed and what remains in Plaid.
+
+2. **Sharper empty and error states**
+   - Accounts: no server, no linked institution, no synced account data.
+   - Transactions: no synced history vs filters returning zero results.
+   - Credit: no linked credit accounts vs data unavailable.
+   - Include one clear recovery action per state.
+
+3. **Server/config preflight**
+   - Add a server endpoint or client helper that reports environment,
+     credential readiness, storage path, item count, and sync readiness.
+   - Use it before Plaid Link and in the Status tab.
+   - Avoid exposing secrets or raw tokens.
+
+4. **Reconnect and degraded-item handling**
+   - Surface item errors and token-expired states in the Status tab.
+   - Provide a clear reconnect/add-account path.
+
+5. **Demo and screenshot polish**
+   - Keep demo data realistic but synthetic.
+   - Ensure screenshots show the current product story:
+     menu summary, status, spending heatmap, onboarding, and settings.
+
+6. **Distribution readiness, later**
+   - Only after sandbox and production setup are reliable.
+   - Focus on packaging docs, signing assumptions, and release checklist.
+   - Do not implement notarization prematurely.
+
+## Design Standard
+
+PlaidBar should feel like a compact financial instrument:
+
+- At-a-glance status first.
+- Dense but calm layout.
+- Finance colors carry meaning, not decoration.
+- Every risky action has explicit copy and confirmation.
+- Every error state says what happened and what to do next.
+- Keyboard and accessibility behavior must not regress.
+
+## Verification Commands
+
+Run from the repository root:
+
+```bash
+git diff --check
+swift build --target PlaidBar --skip-update --disable-keychain
+rg -n "(PLAID_SECRET|client_secret|access_token|sk-|ghp_|github_pat_|BEGIN (RSA|OPENSSH|EC) PRIVATE KEY|api[_-]?key)" \
+  README.md GOAL.md CHANGELOG.md SECURITY.md ARCHITECTURE.md DESIGN.md PRD.md Sources Tests commands .codex
+```
+
+For core logic changes, also run focused tests where the local Swift toolchain
+supports them. If `swift test --enable-swift-testing` fails with the known
+`no such module 'Testing'` baseline issue, record that explicitly.
+
+## Done Criteria
+
+A run is complete only when it leaves the repo in one of these states:
+
+- clean branch with one or more focused commits and passing local gates, or
+- documented blocker with no half-finished edits.
+
+Final report must include:
+
+- branch name
+- commit SHA(s), if any
+- changed files
+- validation commands and results
+- known warnings or blockers
+- recommended next slice
+- whether push/PR approval is needed


### PR DESCRIPTION
## Summary
- adds `commands/goal.md` as the user-facing `/goal` command for multi-hour PlaidBar production-readiness work
- adds `commands/plaidbar-prod-loop.md` as the detailed backing runbook
- adds repo-local Codex skills for production loop, commit, push, and review behavior
- documents the agentic development loop in README and GOAL

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan over docs, sources, tests, commands, and .codex only found documented Plaid placeholders/schema field names

## Notes
- This is a workflow/docs-only change; no app runtime behavior changed.
