### PR TITLE
feat: add local data controls

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -270,7 +270,15 @@ final class AppState {
     }
 
     var localStoragePathText: String {
-        "~/.plaidbar/"
+        LocalDataStore.displayPath
+    }
+
+    var localStorageDirectoryURL: URL {
+        LocalDataStore.storageDirectoryURL()
+    }
+
+    var localStorageResolvedPathText: String {
+        localStorageDirectoryURL.path
     }
 
     var refreshCadenceText: String {
@@ -498,6 +506,27 @@ final class AppState {
         } catch {
             self.error = error.localizedDescription
         }
+    }
+
+    @discardableResult
+    func resetLocalData() throws -> LocalDataResetResult {
+        stopBackgroundRefresh()
+
+        let result = try LocalDataStore.resetLocalData(at: localStorageDirectoryURL)
+
+        accounts = []
+        transactions = []
+        itemStatuses = []
+        serverItemCount = 0
+        lastSyncDate = nil
+        isSetupComplete = false
+        isDemoMode = false
+        error = nil
+
+        balanceHistory = []
+        UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
+
+        return result
     }
 
     func startBackgroundRefresh() {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -123,8 +123,8 @@ final class AppState {
 
     // MARK: - Init
 
-    init(notificationService: any NotificationServiceProtocol = NotificationService.shared) {
-        self.notificationService = notificationService
+    init(notificationService: (any NotificationServiceProtocol)? = nil) {
+        self.notificationService = notificationService ?? NotificationService.shared
         loadSettings()
     }
 

--- a/Sources/PlaidBar/Resources/PlaidBar.entitlements
+++ b/Sources/PlaidBar/Resources/PlaidBar.entitlements
@@ -6,6 +6,10 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
+    <array>
+        <string>/.plaidbar/</string>
+    </array>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)com.ftchvs.PlaidBar</string>

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PlaidBarCore
 import Sparkle
+import AppKit
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -31,12 +32,15 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 480, height: 380)
+        .frame(width: 520, height: 500)
     }
 }
 
 struct GeneralSettingsView: View {
     @Environment(AppState.self) private var appState
+    @State private var isShowingResetConfirmation = false
+    @State private var resetResultMessage: String?
+    @State private var resetErrorMessage: String?
 
     var body: some View {
         @Bindable var state = appState
@@ -77,8 +81,95 @@ struct GeneralSettingsView: View {
             .help("Credit cards above this utilization threshold show warning colors")
 
             Toggle("Launch at login", isOn: $state.launchAtLogin)
+
+            Section("Local Data") {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    LabeledContent("Storage path") {
+                        Text(appState.localStoragePathText)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                    }
+
+                    Text(appState.localStorageResolvedPathText)
+                        .detailText()
+                        .textSelection(.enabled)
+
+                    HStack {
+                        Button {
+                            revealStorageDirectory()
+                        } label: {
+                            Label("Reveal", systemImage: "folder")
+                        }
+
+                        Button {
+                            copyStoragePath()
+                        } label: {
+                            Label("Copy Path", systemImage: "doc.on.doc")
+                        }
+
+                        Spacer()
+
+                        Button(role: .destructive) {
+                            isShowingResetConfirmation = true
+                        } label: {
+                            Label("Reset Local Data", systemImage: "trash")
+                        }
+                    }
+
+                    Text("Stores the local server database, Plaid item tokens, sync cursors, and app/server auth token. App preferences such as menu bar display, notification thresholds, and launch-at-login are kept.")
+                        .detailText()
+                }
+            }
         }
         .padding()
+        .alert("Reset Local PlaidBar Data?", isPresented: $isShowingResetConfirmation) {
+            Button("Reset Local Data", role: .destructive) {
+                resetLocalData()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This deletes files under \(appState.localStoragePathText), including the SQLite database, stored Plaid access tokens, sync cursors, and the app/server auth token. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
+        }
+        .alert("Local Data Reset", isPresented: Binding(
+            get: { resetResultMessage != nil },
+            set: { if !$0 { resetResultMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(resetResultMessage ?? "")
+        }
+        .alert("Reset Failed", isPresented: Binding(
+            get: { resetErrorMessage != nil },
+            set: { if !$0 { resetErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(resetErrorMessage ?? "")
+        }
+    }
+
+    private func revealStorageDirectory() {
+        let url = appState.localStorageDirectoryURL
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    private func copyStoragePath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(appState.localStorageResolvedPathText, forType: .string)
+    }
+
+    private func resetLocalData() {
+        do {
+            let result = try appState.resetLocalData()
+            if result.removedEntryCount == 0 {
+                resetResultMessage = "No existing files were found. \(appState.localStoragePathText) is ready for a fresh local server start."
+            } else {
+                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(appState.localStoragePathText). Restart PlaidBarServer before reconnecting accounts."
+            }
+        } catch {
+            resetErrorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
                     Label("About", systemImage: "info.circle")
                 }
         }
-        .frame(width: 520, height: 500)
+        .frame(width: 620, height: 560)
     }
 }
 
@@ -45,56 +45,78 @@ struct GeneralSettingsView: View {
     var body: some View {
         @Bindable var state = appState
 
-        Form {
-            Picker("Menu bar shows", selection: $state.menuBarSummaryMode) {
-                ForEach(MenuBarSummaryMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                }
-            }
-
-            Picker("Balance format", selection: $state.balanceFormat) {
-                Text("$12,450.32").tag(CurrencyFormat.full)
-                Text("$12.4K").tag(CurrencyFormat.abbreviated)
-                Text("$12,450").tag(CurrencyFormat.compact)
-            }
-            .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
-
-            Picker("Refresh interval", selection: $state.refreshInterval) {
-                Text("5 minutes").tag(TimeInterval(5 * 60))
-                Text("15 minutes").tag(TimeInterval(15 * 60))
-                Text("30 minutes").tag(TimeInterval(30 * 60))
-                Text("1 hour").tag(TimeInterval(60 * 60))
-            }
-
-            HStack {
-                Text("Credit warning")
-                Spacer()
-                TextField(
-                    "",
-                    value: $state.creditUtilizationThreshold,
-                    format: .number.precision(.fractionLength(0))
-                )
-                .frame(width: 60)
-                .textFieldStyle(.roundedBorder)
-                Text("%")
-            }
-            .help("Credit cards above this utilization threshold show warning colors")
-
-            Toggle("Launch at login", isOn: $state.launchAtLogin)
-
-            Section("Local Data") {
-                VStack(alignment: .leading, spacing: Spacing.sm) {
-                    LabeledContent("Storage path") {
-                        Text(appState.localStoragePathText)
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                SettingsCard {
+                    settingsRow("Menu bar shows") {
+                        Picker("Menu bar shows", selection: $state.menuBarSummaryMode) {
+                            ForEach(MenuBarSummaryMode.allCases, id: \.self) { mode in
+                                Text(mode.displayName).tag(mode)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 230)
                     }
 
-                    Text(appState.localStorageResolvedPathText)
-                        .detailText()
-                        .textSelection(.enabled)
+                    settingsRow("Balance format") {
+                        Picker("Balance format", selection: $state.balanceFormat) {
+                            Text("$12,450.32").tag(CurrencyFormat.full)
+                            Text("$12.4K").tag(CurrencyFormat.abbreviated)
+                            Text("$12,450").tag(CurrencyFormat.compact)
+                        }
+                        .labelsHidden()
+                        .frame(width: 230)
+                        .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
+                    }
 
-                    HStack {
+                    settingsRow("Refresh interval") {
+                        Picker("Refresh interval", selection: $state.refreshInterval) {
+                            Text("5 minutes").tag(TimeInterval(5 * 60))
+                            Text("15 minutes").tag(TimeInterval(15 * 60))
+                            Text("30 minutes").tag(TimeInterval(30 * 60))
+                            Text("1 hour").tag(TimeInterval(60 * 60))
+                        }
+                        .labelsHidden()
+                        .frame(width: 230)
+                    }
+
+                    settingsRow("Credit warning") {
+                        HStack(spacing: Spacing.sm) {
+                            TextField(
+                                "",
+                                value: $state.creditUtilizationThreshold,
+                                format: .number.precision(.fractionLength(0))
+                            )
+                            .frame(width: 72)
+                            .textFieldStyle(.roundedBorder)
+                            Text("%")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .help("Credit cards above this utilization threshold show warning colors")
+
+                    Toggle("Launch at login", isOn: $state.launchAtLogin)
+                        .padding(.top, Spacing.xs)
+                }
+
+                SettingsCard(title: "Local Data") {
+                    settingsRow("Storage path", alignment: .top) {
+                        VStack(alignment: .trailing, spacing: Spacing.xs) {
+                            Text(appState.localStoragePathText)
+                                .font(.system(.body, design: .monospaced))
+                                .lineLimit(2)
+                                .multilineTextAlignment(.trailing)
+                                .textSelection(.enabled)
+
+                            Text(appState.localStorageResolvedPathText)
+                                .detailText()
+                                .lineLimit(2)
+                                .multilineTextAlignment(.trailing)
+                                .textSelection(.enabled)
+                        }
+                    }
+
+                    HStack(spacing: Spacing.sm) {
                         Button {
                             revealStorageDirectory()
                         } label: {
@@ -112,16 +134,17 @@ struct GeneralSettingsView: View {
                         Button(role: .destructive) {
                             isShowingResetConfirmation = true
                         } label: {
-                            Label("Reset Local Data", systemImage: "trash")
+                            Label("Reset", systemImage: "trash")
                         }
                     }
 
-                    Text("Stores the local server database, Plaid item tokens, sync cursors, and app/server auth token. App preferences such as menu bar display, notification thresholds, and launch-at-login are kept.")
+                    Text("Stores the local server database, Plaid item tokens, sync cursors, and app/server auth token. App preferences stay in macOS preferences.")
                         .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
+            .padding(Spacing.lg)
         }
-        .padding()
         .alert("Reset Local PlaidBar Data?", isPresented: $isShowingResetConfirmation) {
             Button("Reset Local Data", role: .destructive) {
                 resetLocalData()
@@ -170,6 +193,50 @@ struct GeneralSettingsView: View {
         } catch {
             resetErrorMessage = error.localizedDescription
         }
+    }
+}
+
+private struct SettingsCard<Content: View>: View {
+    let title: String?
+    @ViewBuilder let content: Content
+
+    init(title: String? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            if let title {
+                Text(title)
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.md) {
+                content
+            }
+        }
+        .padding(Spacing.md)
+        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+@ViewBuilder
+private func settingsRow<Content: View>(
+    _ title: String,
+    alignment: VerticalAlignment = .center,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    HStack(alignment: alignment, spacing: Spacing.md) {
+        Text(title)
+            .foregroundStyle(.secondary)
+            .frame(width: 150, alignment: .leading)
+
+        Spacer(minLength: Spacing.md)
+
+        content()
+            .frame(maxWidth: 330, alignment: .trailing)
     }
 }
 

--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -80,11 +80,12 @@ struct SpendingHeatmapView: View {
             }
         }
         .padding(.horizontal, Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
     }
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline) {
+        HStack(alignment: .top, spacing: Spacing.sm) {
             VStack(alignment: .leading, spacing: Spacing.xxs) {
                 Text("Spending heatmap")
                     .sectionTitle()
@@ -98,6 +99,8 @@ struct SpendingHeatmapView: View {
                 .font(.callout.weight(.semibold))
                 .monospacedDigit()
                 .foregroundStyle(mode == .netCashflow && totalValue < 0 ? SemanticColors.positive : .primary)
+                .lineLimit(1)
+                .layoutPriority(1)
         }
     }
 

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -8,17 +8,17 @@ struct SpendingView: View {
     @State private var chartType: ChartType = .donut
 
     enum SpendingPeriod: String, CaseIterable, Sendable {
-        case thisWeek = "This Week"
-        case thisMonth = "This Month"
-        case last30Days = "Last 30 Days"
-        case last90Days = "Last 90 Days"
+        case thisWeek = "Week"
+        case thisMonth = "Month"
+        case last30Days = "30D"
+        case last90Days = "90D"
     }
 
     enum ChartType: String, CaseIterable, Sendable {
         case donut = "Categories"
         case heatmap = "Heatmap"
         case trend = "Trend"
-        case incomeExpense = "In vs Out"
+        case incomeExpense = "Flow"
     }
 
     /// Returns current/previous period starts for filtering and comparisons.

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+#if os(macOS)
+import Darwin
+#endif
+
+public struct LocalDataResetResult: Equatable, Sendable {
+    public let directoryPath: String
+    public let removedEntries: [String]
+
+    public var removedEntryCount: Int {
+        removedEntries.count
+    }
+
+    public init(directoryPath: String, removedEntries: [String]) {
+        self.directoryPath = directoryPath
+        self.removedEntries = removedEntries
+    }
+}
+
+public enum LocalDataStore {
+    public static let displayPath = "~/.plaidbar/"
+
+    public static func accountHomeDirectoryURL() -> URL {
+        #if os(macOS)
+        if let user = getpwuid(getuid()),
+           let home = user.pointee.pw_dir {
+            return URL(fileURLWithPath: String(cString: home), isDirectory: true)
+        }
+        #endif
+
+        return FileManager.default.homeDirectoryForCurrentUser
+    }
+
+    public static func storageDirectoryURL(
+        homeDirectory: URL = accountHomeDirectoryURL()
+    ) -> URL {
+        homeDirectory.appendingPathComponent(".plaidbar", isDirectory: true)
+    }
+
+    @discardableResult
+    public static func resetLocalData(
+        at directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws -> LocalDataResetResult {
+        var removedEntries: [String] = []
+        var isDirectory: ObjCBool = false
+
+        if fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                removedEntries = try fileManager
+                    .contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+                    .map(\.lastPathComponent)
+                    .sorted()
+            } else {
+                removedEntries = [directory.lastPathComponent]
+            }
+
+            try fileManager.removeItem(at: directory)
+        }
+
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        return LocalDataResetResult(
+            directoryPath: directory.path,
+            removedEntries: removedEntries
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -68,8 +68,7 @@ struct ServerConfig: Sendable {
     }
 
     static func dataDirectory() -> String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return "\(home)/.plaidbar"
+        LocalDataStore.storageDirectoryURL().path
     }
 }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -673,4 +673,50 @@ struct PlaidBarCoreTests {
         #expect(recurring[0].merchantName == "Expensive")
         #expect(recurring[1].merchantName == "Cheap")
     }
+
+    // MARK: - Local Data Store
+
+    @Test("Local data store resolves hidden PlaidBar directory")
+    func localDataStorePathResolution() {
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        let directory = LocalDataStore.storageDirectoryURL(homeDirectory: home)
+
+        #expect(LocalDataStore.displayPath == "~/.plaidbar/")
+        #expect(directory.lastPathComponent == ".plaidbar")
+        #expect(directory.deletingLastPathComponent() == home)
+    }
+
+    @Test("Local data store resolves from account home by default")
+    func localDataStoreDefaultPathUsesAccountHome() {
+        let directory = LocalDataStore.storageDirectoryURL()
+
+        #expect(directory.lastPathComponent == ".plaidbar")
+        #expect(directory.deletingLastPathComponent() == LocalDataStore.accountHomeDirectoryURL())
+    }
+
+    @Test("Local data reset removes directory contents and recreates directory")
+    func localDataResetRemovesContents() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let database = directory.appendingPathComponent("plaidbar.sqlite")
+        let authToken = directory.appendingPathComponent("auth-token")
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try "db".write(to: database, atomically: true, encoding: .utf8)
+        try "token".write(to: authToken, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = try LocalDataStore.resetLocalData(at: directory)
+
+        #expect(result.directoryPath == directory.path)
+        #expect(result.removedEntries == ["auth-token", "plaidbar.sqlite"])
+
+        var isDirectory: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- adds a trust-first Local Data section to Settings with the `~/.plaidbar/` path and resolved path
- adds Reveal and Copy Path actions for the local storage directory
- adds a confirmation-gated Reset Local Data flow that deletes local PlaidBar storage and clears loaded app state while explaining what remains in Plaid
- adds a shared `LocalDataStore` helper and focused tests for path/reset behavior

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --filter PlaidBarCoreTests/localData --skip-update --disable-keychain (blocked locally by known `no such module 'Testing'` toolchain issue)
- secret scan over docs, sources, tests, commands, and .codex only found documented Plaid placeholders/schema field names

## Notes
- Build still shows existing SwiftPM resource warnings and the existing `NotificationService.shared` actor-isolation warning.
