### PR TITLE
feat: open PlaidBar dashboard popover by default

### DIFF
--- a/.codex/skills/plaidbar-production-loop/SKILL.md
+++ b/.codex/skills/plaidbar-production-loop/SKILL.md
@@ -11,8 +11,8 @@ ready, or run the repo-local `/goal` command.
 ## Goal
 
 PlaidBar should become a local-first macOS menu bar dashboard for Plaid data:
-CodexBar for personal finance. Favor trustworthy real-data readiness over new
-feature breadth.
+RepoBar/CodexBar for personal finance. Favor a dense, trustworthy, heatmap-first
+menu-bar instrument over new feature breadth.
 
 ## Rules
 
@@ -28,6 +28,7 @@ feature breadth.
 1. Inspect `git status --short --branch`, `GOAL.md`, `README.md`,
    `DESIGN.md`, and the files likely to change.
 2. Choose one production-readiness slice:
+   - RepoBar-style finance dashboard,
    - local data controls,
    - empty/error states,
    - server/config preflight,
@@ -46,7 +47,19 @@ feature breadth.
 
 ## Preferred Next Slice
 
-When no focus is supplied, implement trust-first local data controls:
+When no focus is supplied, implement the RepoBar-style finance dashboard:
+
+- study `https://repobar.app`, `https://github.com/steipete/RepoBar`, and the
+  local reference clone at `/Users/otto/.openclaw/workspace/repos/RepoBar` when
+  available,
+- lead the popover with a GitHub-style daily spend/cashflow heatmap,
+- add All/Cash/Credit/Savings/Debt/Status filters,
+- show checking, savings, credit cards, loans, and other accounts as compact
+  rows with balance/utilization/status/freshness,
+- open a focused account/card detail surface from a selected row,
+- keep finance semantics explicit and avoid full budgeting workflows.
+
+After that, continue with trust-first local data controls:
 
 - show `~/.plaidbar/` in Settings,
 - add copy/reveal actions if practical,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -105,6 +105,40 @@ Category colors from `SpendingCategory.colorHex` — fixed hex values for chart 
 
 ## Component Catalog
 
+### RepoBar-Style Finance Overview
+
+**Reference:** RepoBar menu popover pattern: contribution heatmap header, compact
+filter bar, dense rows, selected row highlight, and chevron-based drill-in. Use
+the RepoBar visual language as inspiration, not as literal GitHub UI.
+
+**Target anatomy:** VStack | Financial heatmap header (`last 12 months` or
+shorter fallback when data is limited) | segmented filter bar (`All`, `Cash`,
+`Credit`, `Savings`, `Debt`, `Status`) | list of account/card rows | selected
+account/card detail surface.
+
+| Element | PlaidBar Meaning |
+|---------|------------------|
+| Heatmap header | Daily spending intensity or net cashflow from transactions |
+| Repo row | Account/card row with institution, type, balance, status, and freshness |
+| Repo stats | Balance, available credit, utilization, pending count, sync state |
+| Selected repo highlight | Selected account/card detail target |
+| Submenu/drill-in | Account/card detail sheet or inline detail surface |
+
+**Account/card row anatomy:** status dot or account-type icon | institution +
+account name | secondary line with type, mask, sync freshness, pending count |
+trailing primary metric (balance owed/cash balance) | secondary metric
+(utilization, available credit, or last updated) | chevron.
+
+| State | Behavior |
+|-------|----------|
+| Healthy cash account | Green/neutral status, cash balance primary, latest sync secondary |
+| Savings account | Cash row with savings label; preserve same density as checking |
+| Credit card | Credit balance owed primary, utilization and available credit secondary |
+| High utilization | Warning/negative utilization color plus text label, not color alone |
+| Degraded item | Warning status and `Reconnect` in detail surface |
+| Selected | Blue/accent highlight matching native menu selection; detail surface opens |
+| No data | Keep overview shell and show one compact recovery action |
+
 ### AccountRow
 
 **Anatomy:** Institution avatar (28×28 circle, DJB2-hashed color) | Account name (`.body`) + mask (`.detailText()`) | Amount (`.monospacedDigit`) with semantic color | Credit accounts: `creditcard` icon prefix + utilization badge

--- a/GOAL.md
+++ b/GOAL.md
@@ -34,6 +34,14 @@ The public repo should prove three things:
 
 PlaidBar should feel like a compact financial instrument, not a bank website squeezed into a popover.
 
+The near-term visual target is RepoBar-style density adapted to finance:
+
+- **Heatmap first:** lead with a GitHub-contribution-style financial heatmap that makes daily spend/cashflow intensity visible before the user reads rows.
+- **Instrument rows:** show cash, savings, credit cards, loans, and other accounts as compact status rows with a dot/icon, name, key metric, secondary detail, and last-updated/sync clue.
+- **Filterable scope:** use a RepoBar-like segmented control for All, Cash, Credit, Savings, Debt, and Status so the popover stays one surface instead of separate finance silos.
+- **Drill-in details:** selecting an account or card opens a focused detail view/sheet with transactions, limits/utilization, due-date metadata when available, sync status, and reconnect/remove actions.
+- **Native translucency:** match the macOS menu-bar feel in the attached RepoBar reference: material background, separators, compact row height, subtle selected state, and minimal decorative chrome.
+
 Design principles:
 
 - **At-a-glance first:** the menu bar label and top popover area should prioritize one clear financial summary plus sync health.
@@ -48,42 +56,48 @@ Design principles:
 
 Prioritize these before adding new finance features:
 
-1. **Top status strip**
+1. **RepoBar-style finance dashboard**
+   - Reshape the main popover around a heatmap header, segmented finance filters, and dense account/card rows.
+   - Replace the tab-first mental model with one glanceable overview while preserving deeper screens through row selection.
+   - Make credit cards, savings/checking, and sync health readable from the same list.
+   - Use the attached RepoBar screenshot and `https://repobar.app` as the visual reference, but keep PlaidBar finance semantics.
+
+2. **Top status strip**
    - Show environment: Demo, Sandbox, or Production.
    - Show server state: Connected, Offline, Syncing, Error.
    - Show last sync time and stale-data warning.
 
-2. **Menu bar summary modes**
+3. **Menu bar summary modes**
    - Let users choose the menu bar label: Net cash, total cash, credit utilization, recent spend, or compact icon-only.
    - Keep the default conservative: net cash or account health, not noisy transaction counts.
    - Implemented local slice: settings picker, persisted mode, shared summary calculator, and focused tests.
 
-3. **Spending heatmap**
+4. **Spending heatmap**
    - Add a GitHub-style daily grid for recent spending intensity.
    - Support both total spend and net cashflow so income/refunds do not disappear from the story.
    - Keep day details local and glanceable: amount, transaction count, and date.
 
-4. **CodexBar-style health panel**
+5. **CodexBar-style health panel**
    - Add a small diagnostics/settings surface for local server URL, Plaid environment, item count, last sync, and refresh cadence.
    - Make failures actionable: missing credentials, server offline, token expired, Plaid error.
    - Implemented local slice: Status tab with server/sync/data/item diagnostics and refresh/connect/settings recovery actions.
 
-5. **Cleaner onboarding**
+6. **Cleaner onboarding**
    - Separate "View Demo", "Connect Sandbox", and "Use Production Credentials".
    - Never imply sandbox works without credentials unless the app can actually do that.
    - Explain what data is stored before the user links an account.
    - Implemented local slice: first-run chooser with Demo, Sandbox, and Production paths; server environment checks before Plaid Link; local storage disclosure before linking.
 
-6. **Sharper empty and error states**
+7. **Sharper empty and error states**
    - Accounts: explain whether there is no data, no server, or no linked institution.
    - Transactions: distinguish no synced history from filters returning zero results.
    - Credit: explain if no credit accounts are linked.
 
-7. **Trust-first settings**
+8. **Trust-first settings**
    - Add a local data section with `~/.plaidbar/` storage path, reset/delete options, and clear warnings.
    - Keep dangerous actions explicit and confirmation-gated.
 
-8. **Long-running production loop**
+9. **Long-running production loop**
    - Use `/goal` for multi-hour, Codex-assisted production-readiness work.
    - Keep each run focused on one reviewable slice with verification evidence.
    - Stop before push, PR, or merge unless explicitly approved.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The companion server exposes these localhost endpoints:
 | `GET` | `/api/status` | Server version, environment, item count |
 | `GET` | `/api/items` | List connected bank items |
 | `POST` | `/api/link/create` | Create Plaid Link token + URL |
+| `POST` | `/api/link/update/:itemId` | Create Plaid Link update-mode URL for reconnect |
 | `GET` | `/oauth/callback` | Plaid OAuth redirect handler |
 | `GET` | `/api/accounts` | List all accounts (cached) |
 | `GET` | `/api/accounts/balances` | Real-time balances |

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -488,6 +488,17 @@ final class AppState {
         }
     }
 
+    func reconnectItem(itemId: String) async {
+        do {
+            let linkResponse = try await serverClient.createUpdateLinkToken(itemId: itemId)
+            if let url = URL(string: linkResponse.linkUrl) {
+                NSWorkspace.shared.open(url)
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
     func startDemoMode() {
         isDemoMode = true
         loadDemoData()

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -35,6 +35,9 @@ final class AppState {
     var serverEnvironment: PlaidEnvironment?
     var serverVersion: String?
     var serverItemCount: Int?
+    var serverCredentialsConfigured: Bool?
+    var serverStoragePath: String?
+    var serverSyncReady: Bool?
     var itemStatuses: [ItemStatus] = []
     var isDemoMode = false
     var lastSyncDate: Date?
@@ -281,6 +284,25 @@ final class AppState {
         localStorageDirectoryURL.path
     }
 
+    var serverStoragePathText: String {
+        serverStoragePath ?? localStoragePathText
+    }
+
+    var serverStorageDisplayText: String {
+        guard let serverStoragePath else { return localStoragePathText }
+        return serverStoragePath.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+    }
+
+    var serverCredentialsText: String {
+        guard serverConnected else { return "Unknown" }
+        return serverCredentialsConfigured == true ? "Ready" : "Missing"
+    }
+
+    var serverSyncReadinessText: String {
+        guard serverConnected else { return "Unknown" }
+        return serverSyncReady == true ? "Ready" : "No items"
+    }
+
     var refreshCadenceText: String {
         "\(Int(refreshInterval / 60)) min"
     }
@@ -382,6 +404,9 @@ final class AppState {
             serverEnvironment = status.environment
             serverVersion = status.version
             serverItemCount = status.itemCount
+            serverCredentialsConfigured = status.credentialsConfigured
+            serverStoragePath = status.storagePath
+            serverSyncReady = status.syncReady
             lastSyncDate = status.lastSync
             isSetupComplete = status.itemCount > 0
             itemStatuses = (try? await serverClient.getItems()) ?? []
@@ -390,6 +415,9 @@ final class AppState {
             serverEnvironment = nil
             serverVersion = nil
             serverItemCount = nil
+            serverCredentialsConfigured = nil
+            serverStoragePath = nil
+            serverSyncReady = nil
             itemStatuses = []
             isSetupComplete = false
         }
@@ -401,6 +429,7 @@ final class AppState {
         do {
             accounts = try await serverClient.getAccounts()
             serverItemCount = Set(accounts.map(\.itemId)).count
+            serverSyncReady = (serverItemCount ?? 0) > 0
             isSetupComplete = !accounts.isEmpty
             itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
         } catch {
@@ -518,6 +547,9 @@ final class AppState {
         transactions = []
         itemStatuses = []
         serverItemCount = 0
+        serverCredentialsConfigured = nil
+        serverStoragePath = nil
+        serverSyncReady = nil
         lastSyncDate = nil
         isSetupComplete = false
         isDemoMode = false
@@ -720,6 +752,9 @@ final class AppState {
         serverEnvironment = .sandbox
         serverVersion = PlaidBarConstants.appVersion
         serverItemCount = Set(accounts.map(\.itemId)).count
+        serverCredentialsConfigured = true
+        serverStoragePath = LocalDataStore.displayPath
+        serverSyncReady = true
         itemStatuses = [
             ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: Date()),
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -4,15 +4,23 @@ import Sparkle
 
 @main
 struct PlaidBarApp: App {
-    @State private var appState = AppState()
+    @State private var appState: AppState
     private let updaterController: SPUStandardUpdaterController
 
     init() {
+        let state = AppState()
+        _appState = State(initialValue: state)
         updaterController = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        if CommandLine.arguments.contains("--show-popover") {
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(700))
+                state.isPopoverPresented = true
+            }
+        }
     }
 
     var body: some Scene {

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -42,6 +42,10 @@ actor ServerClient {
         try await post("/api/link/create")
     }
 
+    func createUpdateLinkToken(itemId: String) async throws -> LinkResponse {
+        try await post("/api/link/update/\(itemId)")
+    }
+
     func removeItem(itemId: String) async throws {
         guard let url = URL(string: "\(baseURL)/api/accounts/\(itemId)") else {
             throw ServerClientError.requestFailed

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -246,22 +246,82 @@ struct AccountSettingsView: View {
     var body: some View {
         VStack(alignment: .leading) {
             if appState.accounts.isEmpty {
-                ContentUnavailableView("No Accounts", systemImage: "building.columns")
+                ContentUnavailableView {
+                    Label(emptyTitle, systemImage: emptyIcon)
+                } description: {
+                    Text(emptyMessage)
+                } actions: {
+                    Button {
+                        Task { await appState.addAccount() }
+                    } label: {
+                        Label("Add Account", systemImage: "plus.circle")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
             } else {
                 List {
-                    ForEach(appState.accounts) { account in
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text(account.name)
-                                Text(account.type.rawValue.capitalized)
+                    ForEach(accountGroups) { group in
+                        VStack(alignment: .leading, spacing: Spacing.sm) {
+                            HStack(alignment: .top) {
+                                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                                    Text(group.institutionName)
+                                        .font(.headline)
+
+                                    HStack(spacing: Spacing.xs) {
+                                        Image(systemName: icon(for: group.status))
+                                            .foregroundStyle(color(for: group.status))
+                                        Text(label(for: group.status))
+                                            .foregroundStyle(color(for: group.status))
+                                        Text("\u{00B7}")
+                                            .foregroundStyle(.tertiary)
+                                        Text("\(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")")
+                                            .foregroundStyle(.secondary)
+                                    }
                                     .detailText()
+                                }
+
+                                Spacer()
+
+                                if group.status != .connected {
+                                    Button {
+                                        Task { await appState.reconnectItem(itemId: group.id) }
+                                    } label: {
+                                        Label("Reconnect", systemImage: "link.badge.plus")
+                                    }
+                                    .buttonStyle(.bordered)
+                                }
+
+                                Button(role: .destructive) {
+                                    Task { await appState.removeAccount(itemId: group.id) }
+                                } label: {
+                                    Label("Remove", systemImage: "trash")
+                                }
+                                .buttonStyle(.bordered)
                             }
-                            Spacer()
-                            Button("Remove") {
-                                Task { await appState.removeAccount(itemId: account.itemId) }
+
+                            ForEach(group.accounts) { account in
+                                HStack {
+                                    Image(systemName: account.type == .credit ? "creditcard" : "building.columns")
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 18)
+
+                                    VStack(alignment: .leading, spacing: Spacing.xxs) {
+                                        Text(account.name)
+                                        Text(account.type.rawValue.capitalized)
+                                            .detailText()
+                                    }
+
+                                    Spacer()
+
+                                    Text(Formatters.currency(account.balances.effectiveBalance, format: .compact))
+                                        .monospacedDigit()
+                                        .foregroundStyle(account.type == .credit ? SemanticColors.creditDebt : .secondary)
+                                }
+                                .padding(.leading, Spacing.md)
                             }
-                            .foregroundStyle(SemanticColors.negative)
                         }
+                        .padding(.vertical, Spacing.xs)
                     }
                 }
             }
@@ -276,6 +336,75 @@ struct AccountSettingsView: View {
             .padding()
         }
     }
+
+    private var accountGroups: [AccountItemGroup] {
+        Dictionary(grouping: appState.accounts, by: \.itemId)
+            .map { itemId, accounts in
+                let status = appState.itemStatuses.first(where: { $0.id == itemId })
+                let institutionName = accounts.compactMap(\.institutionName).first
+                    ?? status?.institutionName
+                    ?? "Plaid item"
+                return AccountItemGroup(
+                    id: itemId,
+                    institutionName: institutionName,
+                    status: status?.status ?? .connected,
+                    accounts: accounts.sorted { $0.name < $1.name }
+                )
+            }
+            .sorted { $0.institutionName < $1.institutionName }
+    }
+
+    private var emptyTitle: String {
+        if !appState.isDemoMode && !appState.serverConnected { return "Server Offline" }
+        if appState.statusItemCount == 0 { return "No Bank Linked" }
+        return "No Account Data"
+    }
+
+    private var emptyIcon: String {
+        if !appState.isDemoMode && !appState.serverConnected { return "server.rack" }
+        return "building.columns"
+    }
+
+    private var emptyMessage: String {
+        if !appState.isDemoMode && !appState.serverConnected {
+            return "Start PlaidBarServer before managing linked accounts."
+        }
+        if appState.statusItemCount == 0 {
+            return "Connect a Plaid institution to manage linked accounts here."
+        }
+        return "The server has a linked item, but account details are not loaded yet."
+    }
+
+    private func icon(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .connected: "checkmark.circle.fill"
+        case .loginRequired: "person.crop.circle.badge.exclamationmark"
+        case .error: "xmark.octagon.fill"
+        }
+    }
+
+    private func color(for status: ItemConnectionStatus) -> Color {
+        switch status {
+        case .connected: SemanticColors.positive
+        case .loginRequired: SemanticColors.warning
+        case .error: SemanticColors.negative
+        }
+    }
+
+    private func label(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .connected: "Connected"
+        case .loginRequired: "Login required"
+        case .error: "Error"
+        }
+    }
+}
+
+private struct AccountItemGroup: Identifiable {
+    let id: String
+    let institutionName: String
+    let status: ItemConnectionStatus
+    let accounts: [AccountDTO]
 }
 
 struct NotificationSettingsView: View {

--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -7,20 +7,7 @@ struct AccountsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if appState.accounts.isEmpty {
-                ContentUnavailableView {
-                    Label("No Accounts", systemImage: "building.columns")
-                } description: {
-                    Text("Connect a bank to see your balances here.")
-                } actions: {
-                    Button {
-                        Task { await appState.addAccount() }
-                    } label: {
-                        Label("Add Account", systemImage: "plus.circle")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                }
-                .padding()
+                emptyState
             } else {
                 // Depository accounts
                 if !appState.depositoryAccounts.isEmpty {
@@ -65,6 +52,56 @@ struct AccountsView: View {
                 .padding(.horizontal, Spacing.lg)
                 .padding(.vertical, Spacing.sm)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if !appState.isDemoMode && !appState.serverConnected {
+            ContentUnavailableView {
+                Label("Server Offline", systemImage: "server.rack")
+            } description: {
+                Text("Start PlaidBarServer, then check the connection again.")
+            } actions: {
+                Button {
+                    Task { await appState.checkServerConnection() }
+                } label: {
+                    Label("Check Server", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if appState.statusItemCount == 0 {
+            ContentUnavailableView {
+                Label("No Bank Linked", systemImage: "building.columns")
+            } description: {
+                Text("Connect a Plaid institution before balances can appear here.")
+            } actions: {
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else {
+            ContentUnavailableView {
+                Label("No Account Data", systemImage: "tray")
+            } description: {
+                Text("The server has a linked item, but no balances are loaded in the app yet.")
+            } actions: {
+                Button {
+                    Task { await appState.refreshAccounts() }
+                } label: {
+                    Label("Refresh Accounts", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
         }
     }
 

--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -18,20 +18,7 @@ struct CreditView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.md) {
             if appState.creditAccounts.isEmpty {
-                ContentUnavailableView {
-                    Label("No Credit Cards", systemImage: "creditcard")
-                } description: {
-                    Text("Link a credit card to track utilization and available credit.")
-                } actions: {
-                    Button {
-                        Task { await appState.addAccount() }
-                    } label: {
-                        Label("Add Account", systemImage: "plus.circle")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                }
-                .padding()
+                emptyState
             } else {
                 Text("Credit Utilization")
                     .sectionTitle()
@@ -75,6 +62,71 @@ struct CreditView: View {
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Total credit utilization \(Formatters.percent(totalUtilization))")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if !appState.isDemoMode && !appState.serverConnected {
+            ContentUnavailableView {
+                Label("Server Offline", systemImage: "server.rack")
+            } description: {
+                Text("Start PlaidBarServer before checking credit utilization.")
+            } actions: {
+                Button {
+                    Task { await appState.checkServerConnection() }
+                } label: {
+                    Label("Check Server", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if appState.statusItemCount == 0 {
+            ContentUnavailableView {
+                Label("No Bank Linked", systemImage: "creditcard")
+            } description: {
+                Text("Connect a Plaid institution with a credit card to track utilization.")
+            } actions: {
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if appState.accounts.isEmpty {
+            ContentUnavailableView {
+                Label("No Account Data", systemImage: "tray")
+            } description: {
+                Text("The linked item has not loaded account balances yet.")
+            } actions: {
+                Button {
+                    Task { await appState.refreshAccounts() }
+                } label: {
+                    Label("Refresh Accounts", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else {
+            ContentUnavailableView {
+                Label("No Credit Accounts", systemImage: "creditcard")
+            } description: {
+                Text("Your linked accounts do not include a credit card with utilization data.")
+            } actions: {
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Add Credit Card", systemImage: "plus.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .padding()
         }
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1,290 +1,729 @@
 import SwiftUI
-import Charts
 import PlaidBarCore
 
 struct MainPopover: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    @State private var selectedFilter: DashboardAccountFilter = .all
+    @State private var selectedAccountId: String?
     @State private var settingsCloseObserver: NSObjectProtocol?
 
+    private var selectedAccount: AccountDTO? {
+        let accounts = filteredAccounts
+        if let selectedAccountId,
+           let account = accounts.first(where: { $0.id == selectedAccountId }) {
+            return account
+        }
+        return accounts.first ?? appState.accounts.first
+    }
+
+    private var filteredAccounts: [AccountDTO] {
+        appState.accounts.filter { selectedFilter.includes($0, appState: appState) }
+    }
+
     var body: some View {
-        @Bindable var state = appState
-
         VStack(spacing: 0) {
-            TopStatusStrip(
-                mode: appState.statusModeText,
-                serverState: appState.statusServerText,
-                itemCount: appState.statusItemCount,
-                syncState: appState.statusSyncText,
-                serverColor: statusColor,
-                syncColor: appState.isSyncStale ? SemanticColors.warning : SemanticColors.positive
-            )
-            .padding(.horizontal, Spacing.lg)
-            .padding(.vertical, Spacing.xs)
-            .background(Color.primary.opacity(0.035))
-
-            Divider()
-
             if !appState.isSetupComplete {
                 SetupView()
+                    .frame(width: 600)
             } else {
-                // Header — balance as hero with sparkline
-                VStack(spacing: Spacing.xxs) {
-                    Text(Formatters.currency(appState.netBalance, format: .full))
-                        .heroBalance()
-                        .contentTransition(.numericText())
-                        .animation(.default, value: appState.netBalance)
-
-                    // Balance sparkline
-                    if appState.balanceHistory.count >= 2 {
-                        BalanceSparkline(history: appState.balanceHistory)
-                            .frame(height: 24)
-                            .padding(.horizontal, Spacing.xl * 2)
-                            .padding(.top, Spacing.xs)
-                    }
-
-                    HStack(spacing: Spacing.rowVertical) {
-                        Text("PlaidBar")
-                            .detailText()
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.top, Spacing.lg)
-                .padding(.bottom, Spacing.md)
-
-                // Tab picker
-                Picker("View", selection: $state.selectedTab) {
-                    ForEach(PopoverTab.allCases, id: \.self) { tab in
-                        Text(tab.rawValue).tag(tab)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .padding(.horizontal, Spacing.lg)
-                .padding(.bottom, Spacing.sm)
-
-                Divider()
-
-                // Content with tab animation
                 ScrollView {
-                    Group {
-                        switch appState.selectedTab {
-                        case .accounts:
-                            AccountsView()
-                        case .transactions:
-                            TransactionsView()
-                        case .spending:
-                            SpendingView()
-                        case .credit:
-                            CreditView()
-                        case .status:
-                            StatusView()
+                    VStack(alignment: .leading, spacing: 18) {
+                        DashboardHeader()
+                            .environment(appState)
+
+                        DashboardSummaryCards()
+                            .environment(appState)
+
+                        BalanceActivityHeatmap(transactions: appState.transactions)
+
+                        DashboardFilterBar(selection: $selectedFilter)
+
+                        AccountsSection(
+                            accounts: filteredAccounts,
+                            selectedAccountId: selectedAccount?.id,
+                            onSelect: { selectedAccountId = $0.id }
+                        )
+                        .environment(appState)
+
+                        if let selectedAccount {
+                            SelectedAccountPanel(account: selectedAccount)
+                                .environment(appState)
                         }
                     }
-                    .animation(.easeInOut(duration: 0.2), value: appState.selectedTab)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 22)
+                    .padding(.bottom, 18)
                 }
                 .scrollContentBackground(.hidden)
-                .frame(minHeight: 300, maxHeight: 480)
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: 690, maxHeight: 820)
 
                 Divider()
 
-                // Footer
-                HStack(spacing: Spacing.md) {
-                    Button {
-                        Task { await appState.addAccount() }
-                    } label: {
-                        Image(systemName: "plus.circle")
-                            .font(.body)
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Add Account (Cmd+N)")
-                    .keyboardShortcut("n", modifiers: .command)
-
-                    Spacer()
-
-                    Button {
-                        Task {
-                            await appState.refreshBalances()
-                            await appState.syncTransactions()
-                        }
-                    } label: {
-                        RefreshIcon(isLoading: appState.isLoading)
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Refresh (Cmd+R)")
-                    .keyboardShortcut("r", modifiers: .command)
-
-                    Button {
-                        openSettings()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            NSApp.setActivationPolicy(.regular)
-                            NSApp.activate(ignoringOtherApps: true)
-                            if let settingsWindow = NSApp.keyWindow ?? NSApp.windows.first(where: {
-                                $0.canBecomeKey && $0.isVisible && $0.level == .normal
-                            }) {
-                                settingsWindow.orderFrontRegardless()
-                                // Remove previous observer to prevent stacking
-                                if let existing = settingsCloseObserver {
-                                    NotificationCenter.default.removeObserver(existing)
-                                }
-                                settingsCloseObserver = NotificationCenter.default.addObserver(
-                                    forName: NSWindow.willCloseNotification,
-                                    object: settingsWindow,
-                                    queue: .main
-                                ) { _ in
-                                    NSApp.setActivationPolicy(.accessory)
-                                    if let observer = settingsCloseObserver {
-                                        NotificationCenter.default.removeObserver(observer)
-                                    }
-                                    settingsCloseObserver = nil
-                                }
-                            }
-                        }
-                    } label: {
-                        Image(systemName: "gear")
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Settings")
-                }
-                .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.sm)
+                DashboardFooter(
+                    settingsCloseObserver: $settingsCloseObserver,
+                    openSettings: openSettings
+                )
+                .environment(appState)
             }
 
-            // Error banner
             if let error = appState.error {
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.yellow)
-                    Text(error)
-                        .font(.caption)
-                        .lineLimit(2)
-                    Spacer()
-                    Button {
-                        appState.error = nil
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                    }
-                    .buttonStyle(.borderless)
-                }
-                .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.rowVertical)
-                .background(.red.opacity(0.1))
-                .transition(.move(edge: .bottom).combined(with: .opacity))
+                ErrorBanner(error: error)
+                    .environment(appState)
             }
         }
-        .frame(width: 360)
-        .animation(.easeInOut(duration: 0.25), value: appState.error != nil)
-        // Keyboard shortcuts for tab switching
-        .background {
-            Group {
-                Button("") { appState.selectedTab = .accounts }
-                    .keyboardShortcut("1", modifiers: .command)
-                Button("") { appState.selectedTab = .transactions }
-                    .keyboardShortcut("2", modifiers: .command)
-                Button("") { appState.selectedTab = .spending }
-                    .keyboardShortcut("3", modifiers: .command)
-                Button("") { appState.selectedTab = .credit }
-                    .keyboardShortcut("4", modifiers: .command)
-                Button("") { appState.selectedTab = .status }
-                    .keyboardShortcut("5", modifiers: .command)
-            }
-            .frame(width: 0, height: 0)
-            .opacity(0)
-        }
+        .frame(width: 600)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .animation(.easeInOut(duration: 0.2), value: appState.error != nil)
         .task {
             await appState.loadInitialData()
         }
-    }
-
-    private var statusColor: Color {
-        if appState.isLoading { return SemanticColors.warning }
-        if appState.error != nil { return SemanticColors.negative }
-        return appState.serverConnected ? SemanticColors.positive : .secondary
-    }
-}
-
-// MARK: - Top Status Strip
-
-private struct TopStatusStrip: View {
-    let mode: String
-    let serverState: String
-    let itemCount: Int
-    let syncState: String
-    let serverColor: Color
-    let syncColor: Color
-
-    var body: some View {
-        HStack(spacing: Spacing.sm) {
-            Text(mode)
-                .statusToken()
-                .foregroundStyle(.primary)
-
-            StatusDotLabel(color: serverColor, text: serverState)
-
-            Text("\(itemCount) \(itemCount == 1 ? "item" : "items")")
-                .statusToken()
-
-            Spacer(minLength: Spacing.xs)
-
-            StatusDotLabel(color: syncColor, text: syncState)
-                .layoutPriority(1)
+        .onChange(of: appState.accounts) { _, accounts in
+            guard selectedAccountId == nil || !accounts.contains(where: { $0.id == selectedAccountId }) else { return }
+            selectedAccountId = accounts.first?.id
         }
-        .frame(maxWidth: .infinity, minHeight: 20)
+        .onChange(of: selectedFilter) { _, _ in
+            selectedAccountId = filteredAccounts.first?.id
+        }
     }
 }
 
-private struct StatusDotLabel: View {
-    let color: Color
-    let text: String
+// MARK: - Dashboard Header
+
+private struct DashboardHeader: View {
+    @Environment(AppState.self) private var appState
 
     var body: some View {
-        HStack(spacing: Spacing.xs) {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Net Worth")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Text(Formatters.currency(appState.netBalance, format: .full))
+                    .font(.system(size: 42, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+            }
+
+            Spacer(minLength: 24)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("PlaidBar")
+                    .font(.headline.weight(.bold))
+                Text(appState.statusSyncText)
+                    .detailText()
+                    .lineLimit(1)
+            }
+            .padding(.top, 3)
+        }
+    }
+}
+
+private struct DashboardSummaryCards: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            MetricCard(
+                title: "Cash",
+                value: Formatters.currency(appState.totalCash, format: .compact),
+                tint: SemanticColors.available
+            )
+
+            MetricCard(
+                title: "Debt",
+                value: Formatters.currency(totalDebt, format: .compact),
+                tint: SemanticColors.creditDebt
+            )
+
+            MetricCard(
+                title: "Runway",
+                value: Formatters.currency(appState.netBalance, format: .compact),
+                tint: SemanticColors.brand
+            )
+        }
+    }
+
+    private var totalDebt: Double {
+        appState.creditAccounts.reduce(0) { total, account in
+            total + abs(account.balances.current ?? 0)
+        }
+    }
+}
+
+private struct MetricCard: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline.weight(.bold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 13)
+        .padding(.vertical, 13)
+        .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(tint.opacity(0.16), lineWidth: 1)
+        }
+    }
+}
+
+// MARK: - 365 Day Heatmap
+
+private struct BalanceActivityHeatmap: View {
+    let transactions: [TransactionDTO]
+
+    private let calendar = Calendar.current
+    private let spacing: CGFloat = 3
+
+    private var days: [SpendingHeatmapDay] {
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -364, to: end) ?? end
+        return SpendingHeatmap.days(
+            from: transactions,
+            startDate: start,
+            endDate: end,
+            mode: .spending,
+            calendar: calendar
+        )
+    }
+
+    private var peakValue: Double {
+        max(days.map(\.value).max() ?? 0, 1)
+    }
+
+    private var activeDayCount: Int {
+        days.filter { $0.transactionCount > 0 }.count
+    }
+
+    private var weekColumns: [[SpendingHeatmapDay?]] {
+        guard let firstDay = days.first,
+              let firstDate = Formatters.parseTransactionDate(firstDay.date) else {
+            return []
+        }
+
+        let weekday = calendar.component(.weekday, from: firstDate)
+        let leadingEmptyDays = (weekday - calendar.firstWeekday + 7) % 7
+        let padded: [SpendingHeatmapDay?] = Array(repeating: nil, count: leadingEmptyDays) + days.map(Optional.some)
+        return stride(from: 0, to: padded.count, by: 7).map { start in
+            let week = Array(padded[start..<min(start + 7, padded.count)])
+            return week + Array(repeating: nil, count: max(0, 7 - week.count))
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Balance Activity")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text("Last 365D")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            GeometryReader { proxy in
+                let weeks = max(weekColumns.count, 1)
+                let cell = max(6, min(9, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks))))
+
+                HStack(alignment: .top, spacing: spacing) {
+                    ForEach(Array(weekColumns.enumerated()), id: \.offset) { _, week in
+                        VStack(spacing: spacing) {
+                            ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                                if let day {
+                                    BalanceHeatmapCell(day: day, peakValue: peakValue, size: cell)
+                                } else {
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(.clear)
+                                        .frame(width: cell, height: cell)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: 7 * 9 + 6 * spacing)
+
+            HStack(spacing: 5) {
+                Text("Less")
+                    .microText()
+                    .foregroundStyle(.secondary)
+
+                ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(BalanceHeatmapCell.fillColor(intensity: intensity))
+                        .frame(width: 9, height: 9)
+                }
+
+                Text("More")
+                    .microText()
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text("\(activeDayCount) active days")
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(18)
+        .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Balance activity heatmap for the last 365 days with \(activeDayCount) active days.")
+    }
+}
+
+private struct BalanceHeatmapCell: View {
+    let day: SpendingHeatmapDay
+    let peakValue: Double
+    let size: CGFloat
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(Self.fillColor(intensity: intensity))
+            .frame(width: size, height: size)
+            .help(helpText)
+    }
+
+    private var intensity: Double {
+        guard day.transactionCount > 0 else { return 0 }
+        return min(max(day.value / peakValue, 0), 1)
+    }
+
+    private var helpText: String {
+        "\(Formatters.displayTransactionDate(day.date)): \(Formatters.currency(day.value, format: .full)) across \(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
+    }
+
+    static func fillColor(intensity: Double) -> Color {
+        guard intensity > 0 else { return Color.primary.opacity(0.08) }
+        return SemanticColors.positive.opacity(0.18 + (0.72 * intensity))
+    }
+}
+
+// MARK: - Account Filters
+
+private enum DashboardAccountFilter: String, CaseIterable, Identifiable {
+    case all = "All"
+    case cash = "Cash"
+    case credit = "Credit"
+    case savings = "Savings"
+    case debt = "Debt"
+    case status = "Status"
+
+    var id: String { rawValue }
+
+    @MainActor
+    func includes(_ account: AccountDTO, appState: AppState) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .cash:
+            return account.type == .depository
+        case .credit:
+            return account.type == .credit
+        case .savings:
+            return account.subtype?.localizedCaseInsensitiveContains("saving") == true
+        case .debt:
+            return account.type == .credit || account.type == .loan
+        case .status:
+            guard appState.needsLoginItemCount > 0 || appState.erroredItemCount > 0 else { return true }
+            let degradedItemIds = Set(
+                appState.itemStatuses
+                    .filter { $0.status == .loginRequired || $0.status == .error }
+                    .map(\.id)
+            )
+            return degradedItemIds.contains(account.itemId)
+        }
+    }
+}
+
+private struct DashboardFilterBar: View {
+    @Binding var selection: DashboardAccountFilter
+
+    var body: some View {
+        HStack(spacing: 1) {
+            ForEach(DashboardAccountFilter.allCases) { filter in
+                Button {
+                    selection = filter
+                } label: {
+                    Text(filter.rawValue)
+                        .font(.callout.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .foregroundStyle(selection == filter ? .white : .primary)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .background(selection == filter ? SemanticColors.brand : Color.clear)
+
+                if filter != DashboardAccountFilter.allCases.last {
+                    Divider()
+                        .padding(.vertical, 8)
+                }
+            }
+        }
+        .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+// MARK: - Account List
+
+private struct AccountsSection: View {
+    @Environment(AppState.self) private var appState
+    let accounts: [AccountDTO]
+    let selectedAccountId: String?
+    let onSelect: (AccountDTO) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Accounts")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(accounts.count)")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 2)
+            .padding(.bottom, 7)
+
+            if accounts.isEmpty {
+                Text("No accounts match this filter.")
+                    .detailText()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 18)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(accounts) { account in
+                        Button {
+                            onSelect(account)
+                        } label: {
+                            DashboardAccountRow(
+                                account: account,
+                                isSelected: selectedAccountId == account.id
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+    }
+}
+
+private struct DashboardAccountRow: View {
+    let account: AccountDTO
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 13) {
+            Image(systemName: account.type == .credit ? "creditcard.fill" : "building.columns.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(account.type == .credit ? SemanticColors.creditDebt : SemanticColors.available)
+                .frame(width: 40, height: 40)
+                .background((account.type == .credit ? SemanticColors.creditDebt : SemanticColors.available).opacity(0.16), in: RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(account.name)
+                    .font(.title3.weight(.semibold))
+                    .lineLimit(1)
+                Text(subtitle)
+                    .detailText()
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 12)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(amountText)
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(account.type == .credit ? SemanticColors.creditDebt : .primary)
+                    .lineLimit(1)
+
+                if let utilization = account.balances.utilizationPercent {
+                    Text(Formatters.percent(utilization, decimals: 0))
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(SemanticColors.utilization(for: utilization))
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(isSelected ? SemanticColors.brand.opacity(0.14) : Color.clear)
+        .contentShape(Rectangle())
+    }
+
+    private var subtitle: String {
+        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        return "\(account.institutionName ?? account.type.rawValue.capitalized)\(mask)"
+    }
+
+    private var amountText: String {
+        let amount = account.balances.current ?? account.balances.effectiveBalance
+        return Formatters.currency(account.type == .credit ? abs(amount) : amount, format: .full)
+    }
+}
+
+// MARK: - Selected Account
+
+private struct SelectedAccountPanel: View {
+    @Environment(AppState.self) private var appState
+    let account: AccountDTO
+
+    private var transactions: [TransactionDTO] {
+        Array(appState.transactionsForAccount(account.id).prefix(5))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Selected")
+                        .sectionTitle()
+                        .foregroundStyle(.secondary)
+                    Text(account.officialName ?? account.name)
+                        .font(.headline.weight(.bold))
+                        .lineLimit(1)
+                    Text(selectedSubtitle)
+                        .detailText()
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                HStack(spacing: 5) {
+                    Image(systemName: "ellipsis.circle")
+                    Image(systemName: "chevron.down")
+                        .font(.caption.weight(.bold))
+                }
+                .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 46) {
+                DetailValue(title: "Available", value: availableText, tint: SemanticColors.available)
+                DetailValue(title: "Current", value: currentText, tint: .primary)
+
+                if let utilization = account.balances.utilizationPercent {
+                    DetailValue(
+                        title: "Utilization",
+                        value: Formatters.percent(utilization, decimals: 0),
+                        tint: SemanticColors.utilization(for: utilization)
+                    )
+                }
+
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Recent Activity")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                if transactions.isEmpty {
+                    Text("No recent activity for this account.")
+                        .detailText()
+                        .padding(.vertical, 10)
+                } else {
+                    ForEach(transactions) { transaction in
+                        TransactionMiniRow(transaction: transaction)
+                    }
+                }
+            }
+        }
+        .padding(18)
+        .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var selectedSubtitle: String {
+        let subtype = account.subtype?.capitalized ?? account.type.rawValue.capitalized
+        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        return "\(account.type.rawValue.capitalized) • \(subtype)\(mask)"
+    }
+
+    private var availableText: String {
+        Formatters.currency(account.balances.available ?? account.balances.effectiveBalance, format: .compact)
+    }
+
+    private var currentText: String {
+        let amount = account.balances.current ?? account.balances.effectiveBalance
+        return Formatters.currency(account.type == .credit ? abs(amount) : amount, format: .compact)
+    }
+}
+
+private struct DetailValue: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.callout.weight(.bold))
+                .foregroundStyle(tint)
+                .monospacedDigit()
+        }
+    }
+}
+
+private struct TransactionMiniRow: View {
+    let transaction: TransactionDTO
+
+    var body: some View {
+        HStack(spacing: 10) {
             Circle()
-                .fill(color)
-                .frame(width: 6, height: 6)
-            Text(text)
-                .statusToken()
+                .fill(transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55))
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(transaction.displayName)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                Text(Formatters.displayTransactionDate(transaction.date))
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(amountText)
+                .font(.callout.weight(.bold))
+                .monospacedDigit()
+                .foregroundStyle(transaction.isIncome ? SemanticColors.positive : .primary)
         }
-        .lineLimit(1)
-        .minimumScaleFactor(0.82)
+    }
+
+    private var amountText: String {
+        let prefix = transaction.isIncome ? "+" : ""
+        return "\(prefix)\(Formatters.currency(transaction.displayAmount, format: .compact))"
     }
 }
 
-private extension View {
-    func statusToken() -> some View {
-        self
-            .font(.caption2.weight(.medium))
-            .foregroundStyle(.secondary)
-            .monospacedDigit()
-            .lineLimit(1)
-            .minimumScaleFactor(0.82)
-    }
-}
+// MARK: - Footer
 
-// MARK: - Balance Sparkline
-
-private struct BalanceSparkline: View {
-    let history: [BalanceSnapshot]
+private struct DashboardFooter: View {
+    @Environment(AppState.self) private var appState
+    @Binding var settingsCloseObserver: NSObjectProtocol?
+    let openSettings: OpenSettingsAction
 
     var body: some View {
-        Chart(history, id: \.date) { snapshot in
-            LineMark(
-                x: .value("Date", snapshot.date),
-                y: .value("Balance", snapshot.balance)
-            )
-            .interpolationMethod(.catmullRom)
-            .foregroundStyle(SemanticColors.sparkline.opacity(0.6))
+        HStack(spacing: 18) {
+            Button {
+                Task { await appState.addAccount() }
+            } label: {
+                Image(systemName: "plus.circle")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Add Account")
+            .keyboardShortcut("n", modifiers: .command)
 
-            AreaMark(
-                x: .value("Date", snapshot.date),
-                y: .value("Balance", snapshot.balance)
-            )
-            .interpolationMethod(.catmullRom)
-            .foregroundStyle(SemanticColors.sparkline.opacity(0.08))
+            Spacer()
+
+            Button {
+                Task {
+                    await appState.refreshBalances()
+                    await appState.syncTransactions()
+                }
+            } label: {
+                RefreshIcon(isLoading: appState.isLoading)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Refresh")
+            .keyboardShortcut("r", modifiers: .command)
+
+            Button {
+                openSettingsWindow()
+            } label: {
+                Image(systemName: "gearshape")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Settings")
         }
-        .chartXAxis(.hidden)
-        .chartYAxis(.hidden)
-        .chartLegend(.hidden)
+        .padding(.horizontal, 22)
+        .padding(.vertical, 12)
+    }
+
+    private func openSettingsWindow() {
+        openSettings()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            if let settingsWindow = NSApp.keyWindow ?? NSApp.windows.first(where: {
+                $0.canBecomeKey && $0.isVisible && $0.level == .normal
+            }) {
+                settingsWindow.orderFrontRegardless()
+                if let existing = settingsCloseObserver {
+                    NotificationCenter.default.removeObserver(existing)
+                }
+                settingsCloseObserver = NotificationCenter.default.addObserver(
+                    forName: NSWindow.willCloseNotification,
+                    object: settingsWindow,
+                    queue: .main
+                ) { _ in
+                    NSApp.setActivationPolicy(.accessory)
+                    if let observer = settingsCloseObserver {
+                        NotificationCenter.default.removeObserver(observer)
+                    }
+                    settingsCloseObserver = nil
+                }
+            }
+        }
+    }
+}
+
+private struct ErrorBanner: View {
+    @Environment(AppState.self) private var appState
+    let error: String
+
+    var body: some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+            Text(error)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+            Button {
+                appState.error = nil
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 8)
+        .background(.red.opacity(0.1))
+        .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 }

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -139,15 +139,27 @@ struct StatusView: View {
                                 .font(.callout.weight(.medium))
                                 .lineLimit(1)
 
-                            Text(item.lastSync.map { "Updated \(Formatters.relativeDate($0))" } ?? "No sync recorded")
+                            Text(statusDetail(for: item))
                                 .detailText()
                         }
 
                         Spacer()
 
-                        Text(label(for: item.status))
-                            .microText()
-                            .foregroundStyle(color(for: item.status))
+                        VStack(alignment: .trailing, spacing: Spacing.xs) {
+                            Text(label(for: item.status))
+                                .microText()
+                                .foregroundStyle(color(for: item.status))
+
+                            if item.status != .connected {
+                                Button {
+                                    Task { await appState.reconnectItem(itemId: item.id) }
+                                } label: {
+                                    Label("Reconnect", systemImage: "link.badge.plus")
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.mini)
+                            }
+                        }
                     }
                     .padding(.vertical, Spacing.xs)
                 }
@@ -250,6 +262,17 @@ struct StatusView: View {
         case .connected: "Connected"
         case .loginRequired: "Login"
         case .error: "Error"
+        }
+    }
+
+    private func statusDetail(for item: ItemStatus) -> String {
+        switch item.status {
+        case .connected:
+            item.lastSync.map { "Updated \(Formatters.relativeDate($0))" } ?? "No sync recorded"
+        case .loginRequired:
+            "Plaid requires a fresh bank login. Reconnect this item."
+        case .error:
+            "The last Plaid request failed. Reconnect or try refreshing again."
         }
     }
 }

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -83,6 +83,18 @@ struct StatusView: View {
                 color: itemHealthColor
             )
             DiagnosticTile(
+                title: "Credentials",
+                value: appState.serverCredentialsText,
+                icon: "key",
+                color: credentialsColor
+            )
+            DiagnosticTile(
+                title: "Sync ready",
+                value: appState.serverSyncReadinessText,
+                icon: "checklist.checked",
+                color: syncReadinessColor
+            )
+            DiagnosticTile(
                 title: "Version",
                 value: appState.serverVersion ?? PlaidBarConstants.appVersion,
                 icon: "number",
@@ -92,6 +104,12 @@ struct StatusView: View {
                 title: "Endpoint",
                 value: appState.localServerURLText.replacingOccurrences(of: "http://", with: ""),
                 icon: "network",
+                color: .secondary
+            )
+            DiagnosticTile(
+                title: "Storage",
+                value: appState.serverStorageDisplayText,
+                icon: "internaldrive",
                 color: .secondary
             )
             DiagnosticTile(
@@ -141,7 +159,7 @@ struct StatusView: View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(spacing: Spacing.xs) {
                 Image(systemName: "lock.doc")
-                Text("Local data path: \(appState.localStoragePathText)")
+                Text("Local data path: \(appState.serverStorageDisplayText)")
             }
             .detailText()
 
@@ -199,6 +217,16 @@ struct StatusView: View {
         if appState.connectedItemCount < appState.statusItemCount { return SemanticColors.warning }
         if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return SemanticColors.warning }
         return SemanticColors.positive
+    }
+
+    private var credentialsColor: Color {
+        guard appState.serverConnected else { return .secondary }
+        return appState.serverCredentialsConfigured == true ? SemanticColors.positive : SemanticColors.negative
+    }
+
+    private var syncReadinessColor: Color {
+        guard appState.serverConnected else { return .secondary }
+        return appState.serverSyncReady == true ? SemanticColors.positive : .secondary
     }
 
     private func icon(for status: ItemConnectionStatus) -> String {

--- a/Sources/PlaidBar/Views/TransactionsView.swift
+++ b/Sources/PlaidBar/Views/TransactionsView.swift
@@ -134,17 +134,7 @@ struct TransactionsView: View {
         Divider()
 
         if filteredTransactions.isEmpty {
-            ContentUnavailableView {
-                Label(
-                    searchText.isEmpty && !hasActiveFilters ? "No Transactions" : "No Results",
-                    systemImage: searchText.isEmpty && !hasActiveFilters ? "tray" : "magnifyingglass"
-                )
-            } description: {
-                Text(searchText.isEmpty && !hasActiveFilters
-                    ? "Transactions will appear after syncing with your bank."
-                    : "No transactions match your filters.")
-            }
-            .padding()
+            emptyState
         } else {
             ForEach(filteredTransactions, id: \.0) { date, transactions in
                 // Date header
@@ -165,6 +155,78 @@ struct TransactionsView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if !searchText.isEmpty || hasActiveFilters {
+            ContentUnavailableView {
+                Label("No Results", systemImage: "magnifyingglass")
+            } description: {
+                Text("No transactions match the current search or filters.")
+            } actions: {
+                Button {
+                    clearSearchAndFilters()
+                } label: {
+                    Label("Clear Filters", systemImage: "xmark.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if !appState.isDemoMode && !appState.serverConnected {
+            ContentUnavailableView {
+                Label("Server Offline", systemImage: "server.rack")
+            } description: {
+                Text("Start PlaidBarServer before syncing transaction history.")
+            } actions: {
+                Button {
+                    Task { await appState.checkServerConnection() }
+                } label: {
+                    Label("Check Server", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if appState.statusItemCount == 0 {
+            ContentUnavailableView {
+                Label("No Bank Linked", systemImage: "building.columns")
+            } description: {
+                Text("Connect a Plaid institution before transaction history can sync.")
+            } actions: {
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else {
+            ContentUnavailableView {
+                Label("No Synced Transactions", systemImage: "tray")
+            } description: {
+                Text("Run a transaction sync to load recent history for linked accounts.")
+            } actions: {
+                Button {
+                    Task { await appState.syncTransactions() }
+                } label: {
+                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        }
+    }
+
+    private func clearSearchAndFilters() {
+        searchText = ""
+        selectedCategory = nil
+        selectedAccountId = nil
+        selectedDateRange = .all
     }
 
 }

--- a/Sources/PlaidBarCore/Models/ServerStatus.swift
+++ b/Sources/PlaidBarCore/Models/ServerStatus.swift
@@ -6,12 +6,26 @@ public struct ServerStatus: Codable, Sendable {
     public let environment: PlaidEnvironment
     public let itemCount: Int
     public let lastSync: Date?
+    public let credentialsConfigured: Bool
+    public let storagePath: String
+    public let syncReady: Bool
 
-    public init(version: String, environment: PlaidEnvironment, itemCount: Int, lastSync: Date? = nil) {
+    public init(
+        version: String,
+        environment: PlaidEnvironment,
+        itemCount: Int,
+        lastSync: Date? = nil,
+        credentialsConfigured: Bool = true,
+        storagePath: String = LocalDataStore.displayPath,
+        syncReady: Bool? = nil
+    ) {
         self.version = version
         self.environment = environment
         self.itemCount = itemCount
         self.lastSync = lastSync
+        self.credentialsConfigured = credentialsConfigured
+        self.storagePath = storagePath
+        self.syncReady = syncReady ?? (itemCount > 0)
     }
 }
 

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -38,6 +38,20 @@ actor PlaidClient {
         return try await post("/link/token/create", body: body)
     }
 
+    func createUpdateLinkToken(userId: String, accessToken: String) async throws -> PlaidLinkTokenResponse {
+        let body = PlaidLinkTokenRequest(
+            clientId: config.plaidClientId,
+            secret: config.plaidSecret,
+            clientName: "PlaidBar",
+            user: .init(clientUserId: userId),
+            countryCodes: ["US"],
+            language: "en",
+            redirectUri: config.redirectUri,
+            accessToken: accessToken
+        )
+        return try await post("/link/token/create", body: body)
+    }
+
     // MARK: - Token Exchange
 
     func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse {

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -7,10 +7,33 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
     let secret: String
     let clientName: String
     let user: PlaidUser
-    let products: [String]
+    let products: [String]?
     let countryCodes: [String]
     let language: String
     let redirectUri: String
+    let accessToken: String?
+
+    init(
+        clientId: String,
+        secret: String,
+        clientName: String,
+        user: PlaidUser,
+        products: [String]? = nil,
+        countryCodes: [String],
+        language: String,
+        redirectUri: String,
+        accessToken: String? = nil
+    ) {
+        self.clientId = clientId
+        self.secret = secret
+        self.clientName = clientName
+        self.user = user
+        self.products = products
+        self.countryCodes = countryCodes
+        self.language = language
+        self.redirectUri = redirectUri
+        self.accessToken = accessToken
+    }
 
     struct PlaidUser: Encodable, Sendable {
         let clientUserId: String

--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -23,13 +23,23 @@ struct AccountRoutes: Sendable {
         var allAccounts: [AccountDTO] = []
 
         for item in items {
-            let response = try await plaidClient.getAccounts(
-                accessToken: item.accessToken
-            )
+            guard let itemId = item.id else { continue }
+
+            let response: PlaidAccountsResponse
+            do {
+                response = try await plaidClient.getAccounts(
+                    accessToken: item.accessToken
+                )
+                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+            } catch {
+                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                continue
+            }
+
             let accounts = response.accounts.map { account in
                 AccountDTO(
                     id: account.accountId,
-                    itemId: item.id ?? "",
+                    itemId: itemId,
                     name: account.name,
                     officialName: account.officialName,
                     type: AccountType(rawValue: account.type) ?? .other,
@@ -59,13 +69,23 @@ struct AccountRoutes: Sendable {
         var allAccounts: [AccountDTO] = []
 
         for item in items {
-            let response = try await plaidClient.getBalances(
-                accessToken: item.accessToken
-            )
+            guard let itemId = item.id else { continue }
+
+            let response: PlaidAccountsResponse
+            do {
+                response = try await plaidClient.getBalances(
+                    accessToken: item.accessToken
+                )
+                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+            } catch {
+                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                continue
+            }
+
             let accounts = response.accounts.map { account in
                 AccountDTO(
                     id: account.accountId,
-                    itemId: item.id ?? "",
+                    itemId: itemId,
                     name: account.name,
                     officialName: account.officialName,
                     type: AccountType(rawValue: account.type) ?? .other,
@@ -115,5 +135,13 @@ struct AccountRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+
+    private func itemStatus(for error: Error) -> ItemConnectionStatus {
+        if case PlaidError.apiError(_, _, let errorCode, _) = error,
+           errorCode == "ITEM_LOGIN_REQUIRED" {
+            return .loginRequired
+        }
+        return .error
     }
 }

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -9,8 +9,10 @@ struct LinkRoutes: Sendable {
     let config: ServerConfig
 
     func register(with group: RouterGroup<some RequestContext>) {
-        group.group("link")
-            .post("create", use: createLinkToken)
+        let link = group.group("link")
+        link.post("create", use: createLinkToken)
+        link.group("update")
+            .post("{itemId}", use: createUpdateLinkToken)
     }
 
     @Sendable
@@ -20,6 +22,35 @@ struct LinkRoutes: Sendable {
     ) async throws -> Response {
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let plaidResponse = try await plaidClient.createLinkToken(userId: userId)
+
+        let linkUrl = plaidResponse.hostedLinkUrl(redirectUri: config.redirectUri)
+        let dto = LinkResponse(linkToken: plaidResponse.linkToken, linkUrl: linkUrl)
+
+        let data = try JSONEncoder().encode(dto)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+
+    @Sendable
+    func createUpdateLinkToken(
+        request: Request,
+        context: some RequestContext
+    ) async throws -> Response {
+        guard let itemId = context.parameters.get("itemId") else {
+            throw HTTPError(.badRequest, message: "Missing itemId parameter")
+        }
+        guard let item = try await tokenStore.getItem(id: itemId) else {
+            throw HTTPError(.notFound, message: "Plaid item not found")
+        }
+
+        let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
+        let plaidResponse = try await plaidClient.createUpdateLinkToken(
+            userId: userId,
+            accessToken: item.accessToken
+        )
 
         let linkUrl = plaidResponse.hostedLinkUrl(redirectUri: config.redirectUri)
         let dto = LinkResponse(linkToken: plaidResponse.linkToken, linkUrl: linkUrl)

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -24,7 +24,10 @@ struct StatusRoutes: Sendable {
             version: PlaidBarConstants.appVersion,
             environment: config.plaidEnvironment,
             itemCount: itemCount,
-            lastSync: lastSync
+            lastSync: lastSync,
+            credentialsConfigured: !config.plaidClientId.isEmpty && !config.plaidSecret.isEmpty,
+            storagePath: config.databasePath,
+            syncReady: itemCount > 0
         )
 
         let encoder = JSONEncoder()

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -41,10 +41,17 @@ struct TransactionRoutes: Sendable {
             guard let itemId = item.id else { continue }
 
             let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
-            let response = try await plaidClient.syncTransactions(
-                accessToken: item.accessToken,
-                cursor: cursor
-            )
+            let response: PlaidTransactionsSyncResponse
+            do {
+                response = try await plaidClient.syncTransactions(
+                    accessToken: item.accessToken,
+                    cursor: cursor
+                )
+                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+            } catch {
+                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                continue
+            }
 
             allAdded.append(contentsOf: response.added.map { Self.toDTO($0) })
             allModified.append(contentsOf: response.modified.map { Self.toDTO($0) })
@@ -97,5 +104,13 @@ struct TransactionRoutes: Sendable {
             pending: plaidTx.pending,
             isoCurrencyCode: plaidTx.isoCurrencyCode
         )
+    }
+
+    private func itemStatus(for error: Error) -> ItemConnectionStatus {
+        if case PlaidError.apiError(_, _, let errorCode, _) = error,
+           errorCode == "ITEM_LOGIN_REQUIRED" {
+            return .loginRequired
+        }
+        return .error
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -400,6 +400,9 @@ struct PlaidBarCoreTests {
         #expect(decoded.environment == .sandbox)
         #expect(decoded.itemCount == 2)
         #expect(decoded.lastSync == nil)
+        #expect(decoded.credentialsConfigured)
+        #expect(decoded.storagePath == LocalDataStore.displayPath)
+        #expect(decoded.syncReady)
     }
 
     @Test("ServerStatus with lastSync")
@@ -414,6 +417,25 @@ struct PlaidBarCoreTests {
         let decoded = try decoder.decode(ServerStatus.self, from: data)
         #expect(decoded.environment == .production)
         #expect(decoded.lastSync != nil)
+    }
+
+    @Test("ServerStatus preflight fields")
+    func serverStatusPreflightFields() throws {
+        let status = ServerStatus(
+            version: "0.1.0",
+            environment: .sandbox,
+            itemCount: 0,
+            credentialsConfigured: false,
+            storagePath: "/tmp/plaidbar.sqlite",
+            syncReady: false
+        )
+
+        let data = try JSONEncoder().encode(status)
+        let decoded = try JSONDecoder().decode(ServerStatus.self, from: data)
+
+        #expect(decoded.credentialsConfigured == false)
+        #expect(decoded.storagePath == "/tmp/plaidbar.sqlite")
+        #expect(decoded.syncReady == false)
     }
 
     // MARK: - ItemStatus Tests

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -31,6 +31,9 @@ struct PlaidBarServerTests {
         #expect(decoded.version == "0.1.0")
         #expect(decoded.environment == .sandbox)
         #expect(decoded.itemCount == 2)
+        #expect(decoded.credentialsConfigured)
+        #expect(decoded.storagePath == LocalDataStore.displayPath)
+        #expect(decoded.syncReady)
     }
 
     @Test func linkResponseCodable() throws {

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -193,6 +193,9 @@ struct PlaidBarTests {
         #expect(decoded.version == "0.1.0")
         #expect(decoded.environment == .sandbox)
         #expect(decoded.itemCount == 2)
+        #expect(decoded.credentialsConfigured)
+        #expect(decoded.storagePath == LocalDataStore.displayPath)
+        #expect(decoded.syncReady)
     }
 
     // MARK: - Account Filtering (mirrors AppState computed properties)

--- a/commands/goal.md
+++ b/commands/goal.md
@@ -9,9 +9,9 @@ Run the PlaidBar production-readiness loop for a multi-hour work session.
 
 Default goal:
 
-> Make PlaidBar trustworthy and useful with real Plaid data: clear local data
-> controls, reliable sandbox/production setup, actionable diagnostics, and
-> polished empty/error states.
+> Make PlaidBar feel like RepoBar for personal finance: a native macOS menu-bar
+> instrument with a GitHub-style heatmap header, dense account/card rows,
+> financial scope filters, and drill-in details for each account.
 
 ## How To Use
 
@@ -19,6 +19,7 @@ Default goal:
 /goal
 /goal "trust-first local data controls" --hours=2
 /goal "empty states and error recovery" --hours=3
+/goal "RepoBar-style finance dashboard" --hours=4
 ```
 
 This command intentionally delegates the detailed operating loop to:
@@ -32,12 +33,35 @@ the requested focus/timebox.
 
 ## Priority Order
 
-1. Trust-first local data controls in Settings.
-2. Sharper empty and error states across Accounts, Transactions, and Credit.
-3. Server/config preflight for environment and credential readiness.
-4. Reconnect/degraded-item handling.
-5. Demo and screenshot polish.
-6. Distribution readiness only after the real Plaid flow is reliable.
+1. RepoBar-style finance dashboard:
+   - heatmap header at the top of the popover,
+   - segmented filters for All, Cash, Credit, Savings, Debt, and Status,
+   - compact rows for accounts/cards with balance, utilization/status, and last update,
+   - row selection or drill-in details for a specific credit card/account.
+2. Trust-first local data controls in Settings.
+3. Sharper empty and error states across Accounts, Transactions, and Credit.
+4. Server/config preflight for environment and credential readiness.
+5. Reconnect/degraded-item handling.
+6. Demo and screenshot polish.
+7. Distribution readiness only after the real Plaid flow is reliable.
+
+## RepoBar Design Reference
+
+Study RepoBar before changing PlaidBar's primary UI:
+
+- `https://repobar.app`
+- `https://github.com/steipete/RepoBar`
+- local reference clone, when present: `/Users/otto/.openclaw/workspace/repos/RepoBar`
+- attached screenshot target: translucent macOS popover, GitHub contribution
+  heatmap header, segmented filters, dense selected rows, and right-arrow drill-in.
+
+Translate the pattern to finance instead of copying GitHub concepts literally:
+
+- Repo heatmap -> daily spend/cashflow heatmap.
+- Repository cards/rows -> checking, savings, credit card, loan, and other account rows.
+- Issues/PRs/forks metadata -> balance, available credit, utilization, pending count, sync freshness.
+- Repository submenu -> account/card detail view with transactions, limits, status, and recovery actions.
+- Pinned/local/work filters -> All/Cash/Credit/Savings/Debt/Status finance filters.
 
 ## Stop Conditions
 

--- a/commands/plaidbar-prod-loop.md
+++ b/commands/plaidbar-prod-loop.md
@@ -10,8 +10,9 @@ local-first macOS finance utility.
 
 The default goal is:
 
-> Make PlaidBar feel trustworthy and useful with real Plaid data before
-> optimizing for packaging, distribution, or new finance verticals.
+> Make PlaidBar feel like RepoBar for personal finance: a native macOS menu-bar
+> instrument with a GitHub-style heatmap header, dense account/card rows,
+> financial scope filters, and drill-in details for each account.
 
 ## Usage
 
@@ -19,6 +20,7 @@ The default goal is:
 /plaidbar-prod-loop
 /plaidbar-prod-loop "local data controls" --hours=2
 /plaidbar-prod-loop "empty states and error recovery" --hours=3 --no-commit
+/plaidbar-prod-loop "RepoBar-style finance dashboard" --hours=4
 ```
 
 For Codex CLI non-interactive runs:
@@ -55,11 +57,15 @@ Repeat these phases until the timebox ends or a blocker appears:
    - Prefer the explicit focus area in `$ARGUMENTS`.
    - Otherwise use the production-readiness backlog below.
    - Keep the slice small enough to finish with verification evidence.
+   - If the focus mentions RepoBar, heatmap-first design, account rows, or the
+     attached screenshot, use the RepoBar-style finance dashboard slice first.
 
 3. Implement:
    - Follow the app's existing SwiftUI, theme, and local-server patterns.
    - Put finance calculations in `PlaidBarCore` when they are testable logic.
    - Keep UI dense, native, status-rich, and non-marketing.
+   - For the main popover, prefer a single overview surface with drill-in
+     details over adding another tab.
    - Update docs only when behavior or setup changes.
 
 4. Verify:
@@ -85,34 +91,57 @@ Repeat these phases until the timebox ends or a blocker appears:
 
 Work in this order unless Felipe gives a better focus:
 
-1. **Trust-first local data controls**
+1. **RepoBar-style finance dashboard**
+   - Study RepoBar's live app/site and source before editing:
+     - `https://repobar.app`
+     - `https://github.com/steipete/RepoBar`
+     - local clone if available: `/Users/otto/.openclaw/workspace/repos/RepoBar`
+   - Target the attached reference screenshot:
+     - translucent macOS popover,
+     - heatmap header,
+     - segmented filter bar,
+     - dense rows with selected/highlighted state,
+     - chevron/drill-in affordance.
+   - Translate RepoBar concepts into finance:
+     - contribution heatmap -> daily spend/cashflow heatmap,
+     - repo rows -> checking, savings, credit card, loan, and other account rows,
+     - repo stats -> balance, available credit, utilization, pending count, sync freshness,
+     - repo submenu -> account/card detail view or sheet,
+     - All/Pinned/Local/Work -> All/Cash/Credit/Savings/Debt/Status.
+   - Build the first slice as an overview UI, not a full budgeting product:
+     - top heatmap from existing transaction/demo data,
+     - filterable account/card rows,
+     - one selected row detail surface for a specific credit card/account,
+     - preserve Status/Settings recovery actions.
+
+2. **Trust-first local data controls**
    - Show the local storage path (`~/.plaidbar/`) in Settings.
    - Add copy/reveal actions for the storage directory when practical.
    - Add confirmation-gated reset/delete local data flow.
    - Keep language explicit about what is removed and what remains in Plaid.
 
-2. **Sharper empty and error states**
+3. **Sharper empty and error states**
    - Accounts: no server, no linked institution, no synced account data.
    - Transactions: no synced history vs filters returning zero results.
    - Credit: no linked credit accounts vs data unavailable.
    - Include one clear recovery action per state.
 
-3. **Server/config preflight**
+4. **Server/config preflight**
    - Add a server endpoint or client helper that reports environment,
      credential readiness, storage path, item count, and sync readiness.
    - Use it before Plaid Link and in the Status tab.
    - Avoid exposing secrets or raw tokens.
 
-4. **Reconnect and degraded-item handling**
+5. **Reconnect and degraded-item handling**
    - Surface item errors and token-expired states in the Status tab.
    - Provide a clear reconnect/add-account path.
 
-5. **Demo and screenshot polish**
+6. **Demo and screenshot polish**
    - Keep demo data realistic but synthetic.
    - Ensure screenshots show the current product story:
      menu summary, status, spending heatmap, onboarding, and settings.
 
-6. **Distribution readiness, later**
+7. **Distribution readiness, later**
    - Only after sandbox and production setup are reliable.
    - Focus on packaging docs, signing assumptions, and release checklist.
    - Do not implement notarization prematurely.


### PR DESCRIPTION
## Summary
- Redesigns the menu bar popover around a RepoBar-style financial dashboard.
- Opens the dashboard directly from the topbar/MenuBarExtra click.
- Adds a full-width GitHub-style 365-day heatmap plus account filters, dense account rows, and selected-account detail.
- Includes linked-account grouping, reconnect/status flow, server preflight diagnostics, and supporting production loop docs from the branch.

## Validation
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build -c release --target PlaidBar --skip-update --disable-keychain`
- `git diff --check`

## Notes
- `swift test` is currently blocked in this local environment because tests import `Testing`, but the available Swift toolchain reports `no such module Testing`.
- Visual QA capture support was added via `--show-popover`, though the raw SPM MenuBarExtra binary was not reliably capturable in this environment.