### PR TITLE
feat: add menu bar health signal

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -206,32 +206,34 @@ final class AppState {
     }
 
     var menuBarHelpText: String {
+        let status = "Status: \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netCash:
-            return "PlaidBar - Net cash: \(menuBarText)"
+            return "PlaidBar - Net cash: \(menuBarText). \(status)"
         case .totalCash:
-            return "PlaidBar - Total cash: \(menuBarText)"
+            return "PlaidBar - Total cash: \(menuBarText). \(status)"
         case .creditUtilization:
-            return "PlaidBar - Credit utilization: \(menuBarText)"
+            return "PlaidBar - Credit utilization: \(menuBarText). \(status)"
         case .recentSpend:
-            return "PlaidBar - Recent spend: \(menuBarText)"
+            return "PlaidBar - Recent spend: \(menuBarText). \(status)"
         case .iconOnly:
-            return "PlaidBar"
+            return "PlaidBar. \(status)"
         }
     }
 
     var menuBarAccessibilityLabel: String {
+        let status = "Status \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netCash:
-            return "PlaidBar net cash \(menuBarText)"
+            return "PlaidBar net cash \(menuBarText). \(status)"
         case .totalCash:
-            return "PlaidBar total cash \(menuBarText)"
+            return "PlaidBar total cash \(menuBarText). \(status)"
         case .creditUtilization:
-            return "PlaidBar credit utilization \(menuBarText)"
+            return "PlaidBar credit utilization \(menuBarText). \(status)"
         case .recentSpend:
-            return "PlaidBar recent spend \(menuBarText)"
+            return "PlaidBar recent spend \(menuBarText). \(status)"
         case .iconOnly:
-            return "PlaidBar"
+            return "PlaidBar. \(status)"
         }
     }
 

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -6,7 +6,13 @@ struct MenuBarLabel: View {
     var body: some View {
         HStack(spacing: Spacing.xs) {
             Image(systemName: "dollarsign.circle.fill")
-                .foregroundStyle(SemanticColors.income)
+                .foregroundStyle(appState.serverConnected || appState.isDemoMode ? SemanticColors.income : .secondary)
+                .overlay(alignment: .bottomTrailing) {
+                    Circle()
+                        .fill(statusTint)
+                        .frame(width: 6, height: 6)
+                        .offset(x: 2, y: 1)
+                }
             if !appState.menuBarText.isEmpty {
                 Text(appState.menuBarText)
                     .monospacedDigit()
@@ -14,5 +20,18 @@ struct MenuBarLabel: View {
         }
         .help(appState.menuBarHelpText)
         .accessibilityLabel(appState.menuBarAccessibilityLabel)
+    }
+
+    private var statusTint: Color {
+        if appState.error != nil || appState.erroredItemCount > 0 {
+            return SemanticColors.negative
+        }
+        if appState.needsLoginItemCount > 0 || appState.isSyncStale {
+            return SemanticColors.warning
+        }
+        if appState.serverConnected || appState.isDemoMode {
+            return SemanticColors.positive
+        }
+        return .secondary
     }
 }


### PR DESCRIPTION
## Summary
- Adds a compact health dot to the menu bar icon so PlaidBar behaves more like a glanceable finance instrument.
- Reflects error, stale sync, login-required, connected, demo, and offline states directly in the menu bar label.
- Expands help/accessibility labels with diagnostics status context.

## Validation
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- Secret scan over docs, sources, tests, commands, and `.codex` found only expected documented Plaid placeholders/schema references.