### PR TITLE
docs: update dashboard design docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -287,13 +287,13 @@ Pattern for all empty states:
 
 | Screen | Components Used | Nav Pattern |
 |--------|----------------|-------------|
-| Menu bar popover (main) | TabView with 4 tabs: Accounts, Transactions, Spending, Credit | `Cmd+1` through `Cmd+4` |
-| Accounts tab | AccountRow list grouped by `.depository` / `.credit` | Scroll; pull-to-refresh via `Cmd+R` |
-| Transactions tab | Segmented picker (Recent/Recurring) + Search bar + FilterChipsView + TransactionRow list + date group headers → tap: TransactionDetailView sheet; OR RecurringView | Scroll; search via `Cmd+F` |
-| Spending tab | Period picker (segmented) + Hero total + SpendingComparison + Chart picker (Categories/Trend/In vs Out) + Donut/SpendingTrendChart/IncomeExpenseChart | Scroll; period and chart type selectable |
-| Credit tab | CreditCardRow list + Utilization gauge | Scroll |
+| Menu bar popover (main) | Dashboard header, status strip, summary values, 365-day heatmap, segmented finance filters, dense account rows, selected account drill-down, footer actions | One scroll surface; row selection drives drill-down; `Cmd+R` refreshes and `Cmd+N` adds account |
+| Account rows | Compact account/card rows with balance, utilization/status, sync freshness, pending count, and chevron affordance | Click row to update selected account panel |
+| Selected account panel | Connection badge, balance metrics, pending/inflow/outflow/sync pills, recent transactions, reconnect/refresh actions | Contextual recovery actions for stale or degraded items |
+| Spending activity | GitHub-style 365-day grid with month labels, intensity legend, and total spend header | Hover cells for day-level transaction count and spend |
+| Legacy detail views | AccountsView, TransactionsView, SpendingView, CreditView, StatusView remain available as implementation surfaces and screenshot/reference components | Prefer dashboard-first entry unless adding a focused detail surface |
 | Settings | 4-tab TabView: General, Accounts, Notifications, About (480×380) | TabView |
-| Onboarding | 3-step flow: Welcome → Plaid Link → Success | Next/Back buttons |
+| Onboarding | Demo/Sandbox/Production choice with local-storage disclosure before Plaid Link | Mode choice, Back, Check Connection |
 
 ## Extending the Design System
 

--- a/README.md
+++ b/README.md
@@ -116,12 +116,7 @@ Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sand
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd+1` | Accounts tab |
-| `Cmd+2` | Transactions tab |
-| `Cmd+3` | Spending tab |
-| `Cmd+4` | Credit tab |
-| `Cmd+5` | Status tab |
-| `Cmd+R` | Refresh balances |
+| `Cmd+R` | Refresh balances and sync transactions |
 | `Cmd+N` | Add account |
 
 ## Accessibility
@@ -189,7 +184,8 @@ PlaidBar/
 │   ├── PlaidBar/                    # macOS menu bar app
 │   │   ├── App/                     # @main entry, AppState
 │   │   ├── Theme/                   # Design tokens, typography
-│   │   ├── Views/                   # SwiftUI views (5 tabs)
+│   │   ├── Views/                   # Dashboard popover, setup, settings surfaces
+│   │   │   ├── MainPopover.swift    # Dashboard-first menu bar popover
 │   │   │   ├── AccountsView.swift   # Balance list by account type
 │   │   │   ├── TransactionsView.swift # Searchable grouped list
 │   │   │   ├── SpendingView.swift   # Donut/heatmap/trend/bar charts


### PR DESCRIPTION
## Summary
- Removes stale tab-first keyboard shortcut and architecture copy from README.
- Updates DESIGN screen patterns to document the dashboard-first popover, account rows, selected account drill-down, and heatmap behavior.
- Keeps legacy views described as implementation/reference surfaces instead of the primary navigation model.

## Validation
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- Secret scan over docs, sources, tests, commands, and `.codex` found only expected documented Plaid placeholders/schema references.