### PR TITLE
chore: silence PlaidBar resource warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
                 .product(name: "KeychainAccess", package: "KeychainAccess"),
             ],
             path: "Sources/PlaidBar",
+            exclude: [
+                "Resources/Info.plist",
+                "Resources/PlaidBar.entitlements",
+            ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
 


### PR DESCRIPTION
## Summary
- explicitly exclude app bundle plist/entitlements files from the SPM executable target
- removes the repeated unhandled-file warnings from local and CI builds

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check