### PR TITLE
fix: render net heatmap income intensity

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -506,7 +506,7 @@ private struct BalanceHeatmapCell: View {
 
     private var intensity: Double {
         guard day.transactionCount > 0 else { return 0 }
-        return min(max(day.value / peakValue, 0), 1)
+        return min(max(abs(day.value) / peakValue, 0), 1)
     }
 
     private var helpText: String {


### PR DESCRIPTION
## Summary
- render net-cashflow heatmap intensity from absolute daily value
- keeps income-heavy days visible instead of fading to the empty-cell color

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check