### PR TITLE
feat: clarify bidirectional heatmap legend

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -144,19 +144,24 @@ struct SpendingHeatmapView: View {
 
     private var legend: some View {
         HStack(spacing: Spacing.xs) {
-            Text("Less")
-                .microText()
-                .foregroundStyle(.secondary)
+            if mode == .spending {
+                Text("Less")
+                    .microText()
+                    .foregroundStyle(.secondary)
 
-            ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(HeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
-                    .frame(width: 13, height: 13)
+                ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(HeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
+                        .frame(width: 13, height: 13)
+                }
+
+                Text("More")
+                    .microText()
+                    .foregroundStyle(.secondary)
+            } else {
+                HeatmapLegendKey(label: "Income", tint: SemanticColors.positive, size: 13)
+                HeatmapLegendKey(label: "Outflow", tint: SemanticColors.negative, size: 13)
             }
-
-            Text("More")
-                .microText()
-                .foregroundStyle(.secondary)
 
             Spacer()
 
@@ -214,6 +219,23 @@ struct SpendingHeatmapView: View {
     }
 }
 
+private struct HeatmapLegendKey: View {
+    let label: String
+    let tint: Color
+    let size: CGFloat
+
+    var body: some View {
+        HStack(spacing: Spacing.xs) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(tint.opacity(0.72))
+                .frame(width: size, height: size)
+            Text(label)
+                .microText()
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
 private struct HeatmapCell: View {
     let day: SpendingHeatmapDay
     let peakValue: Double
@@ -259,7 +281,7 @@ private struct HeatmapCell: View {
         if mode == .netCashflow && value < 0 {
             base = SemanticColors.positive
         } else {
-            base = SemanticColors.brand
+            base = mode == .netCashflow ? SemanticColors.negative : SemanticColors.brand
         }
 
         return base.opacity(0.18 + (0.72 * intensity))

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -453,19 +453,24 @@ private struct BalanceActivityHeatmap: View {
             .frame(height: monthLabelHeight + 4 + 7 * 9 + 6 * spacing)
 
             HStack(spacing: 5) {
-                Text("Less")
-                    .microText()
-                    .foregroundStyle(.secondary)
+                if mode == .spending {
+                    Text("Less")
+                        .microText()
+                        .foregroundStyle(.secondary)
 
-                ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(BalanceHeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
-                        .frame(width: 9, height: 9)
+                    ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(BalanceHeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
+                            .frame(width: 9, height: 9)
+                    }
+
+                    Text("More")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                } else {
+                    NetLegendKey(label: "Income", tint: SemanticColors.positive)
+                    NetLegendKey(label: "Outflow", tint: SemanticColors.negative)
                 }
-
-                Text("More")
-                    .microText()
-                    .foregroundStyle(.secondary)
 
                 Spacer()
 
@@ -482,6 +487,22 @@ private struct BalanceActivityHeatmap: View {
 
     private func monthLabel(for date: Date) -> String {
         calendar.shortMonthSymbols[calendar.component(.month, from: date) - 1]
+    }
+}
+
+private struct NetLegendKey: View {
+    let label: String
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: 4) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(tint.opacity(0.72))
+                .frame(width: 9, height: 9)
+            Text(label)
+                .microText()
+                .foregroundStyle(.secondary)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show Income / Outflow legend keys when heatmaps are in Net mode
- keep Spend mode on the GitHub-style Less-to-More scale
- align the detailed Spending view net outflow color with dashboard finance semantics

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check