### PR TITLE
style: align spending heatmap color

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -281,7 +281,7 @@ private struct HeatmapCell: View {
         if mode == .netCashflow && value < 0 {
             base = SemanticColors.positive
         } else {
-            base = mode == .netCashflow ? SemanticColors.negative : SemanticColors.brand
+            base = mode == .netCashflow ? SemanticColors.negative : SemanticColors.positive
         }
 
         return base.opacity(0.18 + (0.72 * intensity))


### PR DESCRIPTION
## Summary
- align the detailed Spending heatmap with the dashboard heatmap's GitHub-style green spending intensity
- keep Net mode bidirectional with green income and red outflow

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check