### PR TITLE
docs: document heatmap color semantics

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -118,7 +118,7 @@ detail surface.
 
 | Element | PlaidBar Meaning |
 |---------|------------------|
-| Heatmap header | Daily spending intensity or net cashflow from transactions, switchable in place |
+| Heatmap header | Daily spending intensity or net cashflow from transactions, switchable in place. Spend mode uses a GitHub-style green Less/More legend; Net mode uses bidirectional Income/Outflow color keys. |
 | Repo row | Account/card row with institution, type, balance, status, and freshness |
 | Repo stats | Balance, available credit, utilization, pending count, sync state |
 | Selected repo highlight | Selected account/card detail target |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Personal finance data lives behind bank website logins. The closest thing to a m
 - **Inline account drill-down** — Click any row to expand balances, utilization, pending activity, inflow/outflow, recent transactions, and reconnect/refresh actions in place
 - **Status-rich filtering** — Switch between All, Cash, Credit, Savings, Debt, and Status without leaving the primary popover
 - **Recurring Detection** — Automatic identification of subscriptions and recurring charges with monthly total
-- **Spending Activity** — GitHub-style daily heatmap with Spend/Net modes, trend line, income vs expense views, and month-over-month comparison
+- **Spending Activity** — GitHub-style daily heatmap with Spend/Net modes, bidirectional Income/Outflow color keys, trend line, income vs expense views, and month-over-month comparison
 - **Credit Utilization** — Progress bars with configurable warning thresholds and gauge
 - **Smart Notifications** — Alerts for large transactions, low balances, and high credit utilization
 - **Balance History** — Sparkline showing net balance trend over time


### PR DESCRIPTION
## Summary
- document Spend mode as the GitHub-style green Less/More heatmap
- document Net mode as bidirectional Income/Outflow color keys

## Validation
- git diff --check