### PR TITLE
feat: surface menu bar attention states

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -205,6 +205,15 @@ final class AppState {
         )
     }
 
+    var menuBarAttentionText: String? {
+        if isDemoMode { return nil }
+        if error != nil || erroredItemCount > 0 { return "Error" }
+        if !serverConnected { return "Offline" }
+        if needsLoginItemCount > 0 { return "Login" }
+        if isSyncStale { return lastSyncDate == nil ? "Never" : "Stale" }
+        return nil
+    }
+
     var menuBarHelpText: String {
         let status = "Status: \(diagnosticsSummary)"
         switch menuBarSummaryMode {

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -13,6 +13,12 @@ struct MenuBarLabel: View {
                         .frame(width: 6, height: 6)
                         .offset(x: 2, y: 1)
                 }
+            if let attentionText = appState.menuBarAttentionText {
+                Text(attentionText)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(statusTint)
+                    .lineLimit(1)
+            }
             if !appState.menuBarText.isEmpty {
                 Text(appState.menuBarText)
                     .monospacedDigit()
@@ -32,6 +38,6 @@ struct MenuBarLabel: View {
         if appState.serverConnected || appState.isDemoMode {
             return SemanticColors.positive
         }
-        return .secondary
+        return SemanticColors.negative
     }
 }


### PR DESCRIPTION
## Summary
- show short menu bar attention text for Error, Offline, Login, Never, and Stale states
- keep Demo mode quiet and preserve the selected finance summary next to the attention state
- make offline status use the same high-visibility negative tint as other failure states

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check