### PR TITLE
feat: allow local data directory override

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sand
 For a fast sandbox preflight without opening the menu bar app, export sandbox
 credentials and run `./Scripts/smoke-sandbox.sh`. It builds the server, starts
 it on `127.0.0.1:${PLAIDBAR_SMOKE_PORT:-18484}`, checks `/health`, and verifies
-that `/api/status` reports sandbox mode with credentials configured.
+that `/api/status` reports sandbox mode with credentials configured. The smoke
+script uses a temporary data directory by default; set `PLAIDBAR_DATA_DIR` when
+you intentionally want to point it at a specific local store.
 
 ## Keyboard Shortcuts
 

--- a/Scripts/smoke-sandbox.sh
+++ b/Scripts/smoke-sandbox.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 PORT="${PLAIDBAR_SMOKE_PORT:-18484}"
 SERVER_LOG="$(mktemp -t plaidbar-smoke-server.XXXXXX.log)"
+CREATED_DATA_DIR=""
 SERVER_PID=""
 
 cd "$PROJECT_DIR"
@@ -13,6 +14,9 @@ cleanup() {
     if [[ -n "$SERVER_PID" ]]; then
         kill "$SERVER_PID" 2>/dev/null || true
         wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$CREATED_DATA_DIR" ]]; then
+        rm -rf "$CREATED_DATA_DIR"
     fi
 }
 trap cleanup EXIT INT TERM
@@ -31,6 +35,11 @@ fi
 
 echo "Building PlaidBarServer..."
 swift build --target PlaidBarServer --skip-update --disable-keychain
+
+if [[ -z "${PLAIDBAR_DATA_DIR:-}" ]]; then
+    CREATED_DATA_DIR="$(mktemp -d -t plaidbar-smoke-data.XXXXXX)"
+    export PLAIDBAR_DATA_DIR="$CREATED_DATA_DIR"
+fi
 
 echo "Starting sandbox server on http://127.0.0.1:$PORT..."
 swift run PlaidBarServer --sandbox --port "$PORT" >"$SERVER_LOG" 2>&1 &

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -19,6 +19,7 @@ public struct LocalDataResetResult: Equatable, Sendable {
 
 public enum LocalDataStore {
     public static let displayPath = "~/.plaidbar/"
+    public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
 
     public static func accountHomeDirectoryURL() -> URL {
         #if os(macOS)
@@ -32,9 +33,14 @@ public enum LocalDataStore {
     }
 
     public static func storageDirectoryURL(
-        homeDirectory: URL = accountHomeDirectoryURL()
+        homeDirectory: URL = accountHomeDirectoryURL(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL {
-        homeDirectory.appendingPathComponent(".plaidbar", isDirectory: true)
+        if let override = environment[dataDirectoryEnvironmentVariable]?.trimmedNonEmpty {
+            return URL(fileURLWithPath: NSString(string: override).expandingTildeInPath, isDirectory: true)
+        }
+
+        return homeDirectory.appendingPathComponent(".plaidbar", isDirectory: true)
     }
 
     @discardableResult
@@ -64,5 +70,12 @@ public enum LocalDataStore {
             directoryPath: directory.path,
             removedEntries: removedEntries
         )
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -718,6 +718,19 @@ struct PlaidBarCoreTests {
         #expect(directory.deletingLastPathComponent() == LocalDataStore.accountHomeDirectoryURL())
     }
 
+    @Test("Local data store supports data directory override")
+    func localDataStorePathOverride() {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent("plaidbar-smoke", isDirectory: true)
+
+        let resolved = LocalDataStore.storageDirectoryURL(
+            environment: [LocalDataStore.dataDirectoryEnvironmentVariable: directory.path]
+        )
+
+        #expect(resolved == directory)
+    }
+
     @Test("Local data reset removes directory contents and recreates directory")
     func localDataResetRemovesContents() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- add PLAIDBAR_DATA_DIR override for local data storage
- make sandbox smoke checks use a temporary data directory by default
- add core test coverage for the storage override path
- document how to intentionally point smoke checks at a specific local store

## Validation
- swift build --target PlaidBar --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=smoke_client PLAID_SECRET=smoke_secret PLAIDBAR_SMOKE_PORT=18486 ./Scripts/smoke-sandbox.sh
- bash -n Scripts/smoke-sandbox.sh
- git diff --check