### PR TITLE
Run sandbox smoke preflight in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,10 @@ jobs:
 
       - name: Test
         run: swift test
+
+      - name: Sandbox smoke
+        env:
+          PLAID_CLIENT_ID: ci_smoke_client
+          PLAID_SECRET: ci_smoke_secret
+          PLAIDBAR_SMOKE_PORT: 18487
+        run: ./Scripts/smoke-sandbox.sh


### PR DESCRIPTION
## Summary
- run the sandbox smoke preflight as part of CI after tests
- use isolated dummy Plaid sandbox credentials and a dedicated CI port

## Validation
- git diff --check
- PLAID_CLIENT_ID=smoke_client PLAID_SECRET=smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh