### PR TITLE
Encode server item endpoint URLs

### DIFF
--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -15,39 +15,56 @@ actor ServerClient {
     }
 
     func getStatus() async throws -> ServerStatus {
-        try await get("/api/status")
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/status") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
     }
 
     func getItems() async throws -> [ItemStatus] {
-        try await get("/api/items")
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/items") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
     }
 
     func getAccounts() async throws -> [AccountDTO] {
-        try await get("/api/accounts")
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/accounts") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
     }
 
     func getBalances() async throws -> [AccountDTO] {
-        try await get("/api/accounts/balances")
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/accounts/balances") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
     }
 
     func syncTransactions(itemId: String? = nil) async throws -> SyncResponse {
-        var path = "/api/transactions/sync"
-        if let itemId {
-            path += "?item_id=\(itemId)"
+        guard let url = ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId) else {
+            throw ServerClientError.requestFailed
         }
-        return try await get(path)
+        return try await get(url)
     }
 
     func createLinkToken() async throws -> LinkResponse {
-        try await post("/api/link/create")
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/link/create") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await post(url)
     }
 
     func createUpdateLinkToken(itemId: String) async throws -> LinkResponse {
-        try await post("/api/link/update/\(itemId)")
+        guard let url = ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await post(url)
     }
 
     func removeItem(itemId: String) async throws {
-        guard let url = URL(string: "\(baseURL)/api/accounts/\(itemId)") else {
+        guard let url = ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId) else {
             throw ServerClientError.requestFailed
         }
         var request = URLRequest(url: url)
@@ -61,10 +78,7 @@ actor ServerClient {
 
     // MARK: - Private
 
-    private func get<T: Decodable & Sendable>(_ path: String) async throws -> T {
-        guard let url = URL(string: "\(baseURL)\(path)") else {
-            throw ServerClientError.requestFailed
-        }
+    private func get<T: Decodable & Sendable>(_ url: URL) async throws -> T {
         let (data, response) = try await session.data(from: url)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
@@ -73,10 +87,7 @@ actor ServerClient {
         return try decoder.decode(T.self, from: data)
     }
 
-    private func post<T: Decodable & Sendable>(_ path: String) async throws -> T {
-        guard let url = URL(string: "\(baseURL)\(path)") else {
-            throw ServerClientError.requestFailed
-        }
+    private func post<T: Decodable & Sendable>(_ url: URL) async throws -> T {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public enum ServerEndpoint {
+    public static func url(baseURL: String, path: String) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        components.percentEncodedPath = path
+        return components.url
+    }
+
+    public static func transactionSyncURL(baseURL: String, itemId: String? = nil) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        components.path = "/api/transactions/sync"
+        if let itemId {
+            components.percentEncodedQuery = "item_id=\(percentEncodedQueryValue(itemId))"
+        }
+        return components.url
+    }
+
+    public static func updateLinkTokenURL(baseURL: String, itemId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/link/update/\(percentEncodedPathComponent(itemId))")
+    }
+
+    public static func removeItemURL(baseURL: String, itemId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/accounts/\(percentEncodedPathComponent(itemId))")
+    }
+
+    private static func percentEncodedPathComponent(_ value: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    private static func percentEncodedQueryValue(_ value: String) -> String {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: ":#[]@!$&'()*+,;=/?")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -207,6 +207,20 @@ struct PlaidBarCoreTests {
         #expect(MenuBarSummary.text(mode: .iconOnly, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
     }
 
+    @Test("Server endpoints percent encode item IDs in query and path components")
+    func serverEndpointsEncodeItemIds() throws {
+        let baseURL = "http://127.0.0.1:8484"
+        let itemId = "item with/slash?and&symbols"
+
+        let syncURL = try #require(ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId))
+        let updateURL = try #require(ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId))
+        let removeURL = try #require(ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId))
+
+        #expect(syncURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync?item_id=item%20with%2Fslash%3Fand%26symbols")
+        #expect(updateURL.absoluteString == "http://127.0.0.1:8484/api/link/update/item%20with%2Fslash%3Fand%26symbols")
+        #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
+    }
+
     @Test("Net cashflow heatmap keeps Plaid amount signs")
     func netCashflowHeatmapKeepsSigns() {
         let day = Formatters.parseTransactionDate("2026-01-02")!


### PR DESCRIPTION
## Summary
- add a shared `ServerEndpoint` builder for local server URLs
- percent-encode Plaid item IDs before putting them in query or path positions
- route `ServerClient` through concrete `URL` values instead of raw interpolated path strings

## Validation
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- git diff --check

Local note: swift test is still blocked on this machine by no such module 'Testing' under the active CommandLineTools toolchain; CI uses the Xcode toolchain.
