### PR TITLE
Print Swift toolchain diagnostics in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.app
 
+      - name: Toolchain diagnostics
+        run: |
+          xcode-select -p
+          xcrun --find swift
+          swift --version
+
       - name: Resolve dependencies
         run: swift package resolve
 


### PR DESCRIPTION
## Summary
- print selected Xcode developer directory in CI
- print the Swift binary resolved through `xcrun`
- print `swift --version` before dependency resolution/build/test

## Validation
- git diff --check
