### PR TITLE
Extract transaction sync reducer

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -483,17 +483,7 @@ final class AppState {
             var hasMore = true
             while hasMore {
                 let response = try await serverClient.syncTransactions()
-                // Add new transactions
-                transactions.append(contentsOf: response.added)
-                // Update modified
-                for modified in response.modified {
-                    if let index = transactions.firstIndex(where: { $0.id == modified.id }) {
-                        transactions[index] = modified
-                    }
-                }
-                // Remove deleted
-                let removedIds = Set(response.removed)
-                transactions.removeAll { removedIds.contains($0.id) }
+                transactions = TransactionSyncReducer.applying(response, to: transactions)
                 hasMore = response.hasMore
             }
             lastSyncDate = Date()

--- a/Sources/PlaidBarCore/Utilities/TransactionSyncReducer.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionSyncReducer.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum TransactionSyncReducer {
+    public static func applying(
+        _ response: SyncResponse,
+        to transactions: [TransactionDTO]
+    ) -> [TransactionDTO] {
+        var transactionsById: [String: TransactionDTO] = [:]
+        var orderedIds: [String] = []
+
+        for transaction in transactions {
+            if transactionsById[transaction.id] == nil {
+                orderedIds.append(transaction.id)
+            }
+            transactionsById[transaction.id] = transaction
+        }
+
+        for transaction in response.added + response.modified {
+            if transactionsById[transaction.id] == nil {
+                orderedIds.append(transaction.id)
+            }
+            transactionsById[transaction.id] = transaction
+        }
+
+        let removedIds = Set(response.removed)
+        if !removedIds.isEmpty {
+            orderedIds.removeAll { removedIds.contains($0) }
+            for id in removedIds {
+                transactionsById.removeValue(forKey: id)
+            }
+        }
+
+        return orderedIds.compactMap { transactionsById[$0] }
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -263,6 +263,34 @@ struct PlaidBarCoreTests {
         #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
     }
 
+    @Test("Transaction sync reducer upserts and removes transactions")
+    func transactionSyncReducerUpsertsAndRemoves() {
+        let existing = [
+            TransactionDTO(id: "old", accountId: "a", amount: 10, date: "2026-01-01", name: "Old"),
+            TransactionDTO(id: "changed", accountId: "a", amount: 20, date: "2026-01-02", name: "Before"),
+            TransactionDTO(id: "duplicate", accountId: "a", amount: 30, date: "2026-01-03", name: "First duplicate"),
+            TransactionDTO(id: "duplicate", accountId: "a", amount: 40, date: "2026-01-04", name: "Second duplicate")
+        ]
+        let response = SyncResponse(
+            added: [
+                TransactionDTO(id: "new", accountId: "a", amount: 50, date: "2026-01-05", name: "New"),
+                TransactionDTO(id: "old", accountId: "a", amount: 15, date: "2026-01-01", name: "Old replacement")
+            ],
+            modified: [
+                TransactionDTO(id: "changed", accountId: "a", amount: 25, date: "2026-01-02", name: "After")
+            ],
+            removed: ["duplicate"],
+            hasMore: false
+        )
+
+        let transactions = TransactionSyncReducer.applying(response, to: existing)
+
+        #expect(transactions.map(\.id) == ["old", "changed", "new"])
+        #expect(transactions.first { $0.id == "old" }?.amount == 15)
+        #expect(transactions.first { $0.id == "changed" }?.name == "After")
+        #expect(transactions.first { $0.id == "new" }?.amount == 50)
+    }
+
     @Test("Net cashflow heatmap keeps Plaid amount signs")
     func netCashflowHeatmapKeepsSigns() {
         let day = Formatters.parseTransactionDate("2026-01-02")!


### PR DESCRIPTION
## Summary
- move transaction sync merge logic into a reusable PlaidBarCore reducer
- upsert repeated added/modified transaction IDs instead of appending duplicates
- preserve stable ordering while removing deleted IDs
- cover duplicate, modified, added, and removed transaction behavior in tests

## Verification
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- git diff --check

Note: local swift test remains blocked by the active CommandLineTools toolchain missing Swift Testing; GitHub CI uses Xcode.