### PR TITLE
Centralize debt balance presentation

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -405,17 +405,11 @@ struct AccountSettingsView: View {
     }
 
     private func balanceText(for account: AccountDTO) -> String {
-        let amount = account.balances.current ?? account.balances.effectiveBalance
-        let displayAmount = isDebtAccount(account) ? abs(amount) : amount
-        return Formatters.currency(displayAmount, format: .compact)
+        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .compact)
     }
 
     private func balanceTint(for account: AccountDTO) -> Color {
-        isDebtAccount(account) ? SemanticColors.creditDebt : .secondary
-    }
-
-    private func isDebtAccount(_ account: AccountDTO) -> Bool {
-        account.type == .credit || account.type == .loan
+        AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .secondary
     }
 
     private func label(for status: ItemConnectionStatus) -> String {

--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -161,9 +161,9 @@ struct AccountRow: View {
             Spacer()
             VStack(alignment: .trailing, spacing: Spacing.xxs) {
                 HStack(spacing: Spacing.xs) {
-                    // Issue #3: secondary cue for credit amounts (not color-only)
-                    if account.type == .credit {
-                        Image(systemName: "creditcard")
+                    // Issue #3: secondary cue for debt amounts (not color-only)
+                    if AccountPresentation.isDebt(account) {
+                        Image(systemName: AccountPresentation.iconName(for: account))
                             .font(.caption2)
                             .foregroundStyle(SemanticColors.creditDebt)
                     }
@@ -183,18 +183,14 @@ struct AccountRow: View {
         .padding(.vertical, Spacing.rowVertical)
         .hoverHighlight()
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(account.name), \(formattedAmount)\(account.type == .credit ? " owed" : "")")
+        .accessibilityLabel("\(account.name), \(formattedAmount)\(AccountPresentation.isDebt(account) ? " owed" : "")")
     }
 
     private var formattedAmount: String {
-        let amount = account.balances.current ?? account.balances.effectiveBalance
-        if account.type == .credit {
-            return Formatters.currency(abs(amount), format: .full)
-        }
-        return Formatters.currency(amount, format: .full)
+        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .full)
     }
 
     private var amountColor: Color {
-        account.type == .credit ? SemanticColors.creditDebt : .primary
+        AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .primary
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1011,7 +1011,7 @@ private struct DashboardAccountRow: View {
                 Text(amountText)
                     .font(.callout.weight(.bold))
                     .monospacedDigit()
-                    .foregroundStyle(account.type == .credit ? SemanticColors.creditDebt : .primary)
+                    .foregroundStyle(AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .primary)
                     .lineLimit(1)
 
                 if let utilization = account.balances.utilizationPercent {
@@ -1047,8 +1047,7 @@ private struct DashboardAccountRow: View {
     }
 
     private var amountText: String {
-        let amount = account.balances.current ?? account.balances.effectiveBalance
-        return Formatters.currency(account.type == .credit ? abs(amount) : amount, format: .full)
+        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .full)
     }
 
     private var accountTint: Color {
@@ -1254,8 +1253,7 @@ private struct SelectedAccountPanel: View {
     }
 
     private var currentText: String {
-        let amount = account.balances.current ?? account.balances.effectiveBalance
-        return Formatters.currency(account.type == .credit ? abs(amount) : amount, format: .compact)
+        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .compact)
     }
 
     private var itemStatus: ItemConnectionStatus? {

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 public enum AccountPresentation {
+    public static func isDebt(_ account: AccountDTO) -> Bool {
+        account.type == .credit || account.type == .loan
+    }
+
+    public static func displayBalance(for account: AccountDTO) -> Double {
+        let amount = account.balances.current ?? account.balances.effectiveBalance
+        return isDebt(account) ? abs(amount) : amount
+    }
+
     public static func iconName(for account: AccountDTO) -> String {
         switch account.type {
         case .credit:

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -208,6 +208,20 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.iconName(for: loan) == "dollarsign.circle.fill")
     }
 
+    @Test("Account presentation normalizes debt balances")
+    func accountPresentationDebtBalances() {
+        let checking = AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(current: 500))
+        let credit = AccountDTO(id: "2", itemId: "i", name: "Card", type: .credit, balances: BalanceDTO(current: -125))
+        let loan = AccountDTO(id: "3", itemId: "i", name: "Loan", type: .loan, balances: BalanceDTO(current: -750))
+
+        #expect(AccountPresentation.isDebt(checking) == false)
+        #expect(AccountPresentation.isDebt(credit))
+        #expect(AccountPresentation.isDebt(loan))
+        #expect(AccountPresentation.displayBalance(for: checking) == 500)
+        #expect(AccountPresentation.displayBalance(for: credit) == 125)
+        #expect(AccountPresentation.displayBalance(for: loan) == 750)
+    }
+
     @Test("Menu bar summary estimates runway from recent monthly spend")
     func menuBarSummaryRunwayMonths() {
         let now = Formatters.parseTransactionDate("2026-01-30")!


### PR DESCRIPTION
## Summary
- centralize debt-account detection and display-balance normalization in AccountPresentation
- reuse the same debt balance display in Accounts, Dashboard, selected account, and Settings rows
- add core coverage for credit and loan balance display normalization

## Verification
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check
- codex exec review --base main --title "Centralize debt balance display"

Note: local swift test is blocked on this machine by the existing CommandLineTools missing Swift Testing module (no such module 'Testing'); CI uses Xcode and should run tests.