### PR TITLE
Include loans in dashboard debt total

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -188,6 +188,10 @@ final class AppState {
         MenuBarSummary.totalCash(from: accounts)
     }
 
+    var totalDebt: Double {
+        MenuBarSummary.totalDebt(from: accounts)
+    }
+
     var totalCreditUtilization: Double? {
         MenuBarSummary.creditUtilization(from: accounts)
     }
@@ -368,6 +372,10 @@ final class AppState {
 
     var creditAccounts: [AccountDTO] {
         accounts.filter { $0.type == .credit }
+    }
+
+    var debtAccounts: [AccountDTO] {
+        accounts.filter(AccountPresentation.isDebt)
     }
 
     var depositoryAccounts: [AccountDTO] {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -269,7 +269,7 @@ private struct DashboardSummaryCards: View {
 
             MetricCard(
                 title: "Debt",
-                value: Formatters.currency(totalDebt, format: .compact),
+                value: Formatters.currency(appState.totalDebt, format: .compact),
                 detail: debtDetail,
                 tint: SemanticColors.creditDebt
             )
@@ -283,17 +283,14 @@ private struct DashboardSummaryCards: View {
         }
     }
 
-    private var totalDebt: Double {
-        appState.creditAccounts.reduce(0) { total, account in
-            total + abs(account.balances.current ?? 0)
-        }
-    }
-
     private var debtDetail: String {
+        let debtCount = appState.debtAccounts.count
+        guard debtCount > 0 else { return "No debt linked" }
+
         guard let utilization = appState.totalCreditUtilization else {
-            return appState.creditAccounts.isEmpty ? "No credit linked" : "No limit data"
+            return "\(debtCount) debt account\(debtCount == 1 ? "" : "s")"
         }
-        return "\(Formatters.percent(utilization, decimals: 0)) utilization"
+        return "\(Formatters.percent(utilization, decimals: 0)) credit util"
     }
 
     private var runwayTint: Color {
@@ -427,7 +424,7 @@ private struct BalanceCompositionStrip: View {
     private func debt(for type: AccountType) -> Double {
         appState.accounts
             .filter { $0.type == type }
-            .reduce(0) { $0 + abs($1.balances.current ?? 0) }
+            .reduce(0) { $0 + AccountPresentation.displayBalance(for: $1) }
     }
 }
 
@@ -752,7 +749,7 @@ private enum DashboardAccountFilter: String, CaseIterable, Identifiable {
         case .savings:
             return account.subtype?.localizedCaseInsensitiveContains("saving") == true
         case .debt:
-            return account.type == .credit || account.type == .loan
+            return AccountPresentation.isDebt(account)
         case .status:
             guard appState.needsLoginItemCount > 0 || appState.erroredItemCount > 0 else { return true }
             let degradedItemIds = Set(

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -6,8 +6,10 @@ public enum AccountPresentation {
     }
 
     public static func displayBalance(for account: AccountDTO) -> Double {
-        let amount = account.balances.current ?? account.balances.effectiveBalance
-        return isDebt(account) ? abs(amount) : amount
+        if isDebt(account) {
+            return abs(account.balances.current ?? 0)
+        }
+        return account.balances.effectiveBalance
     }
 
     public static func iconName(for account: AccountDTO) -> String {

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -38,6 +38,12 @@ public enum MenuBarSummary {
             .reduce(0) { $0 + $1.balances.effectiveBalance }
     }
 
+    public static func totalDebt(from accounts: [AccountDTO]) -> Double {
+        accounts
+            .filter(AccountPresentation.isDebt)
+            .reduce(0) { $0 + AccountPresentation.displayBalance(for: $1) }
+    }
+
     public static func creditUtilization(from accounts: [AccountDTO]) -> Double? {
         let creditBalances = accounts
             .filter { $0.type == .credit }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -147,6 +147,18 @@ struct PlaidBarCoreTests {
         #expect(MenuBarSummary.totalCash(from: accounts) == 8_200)
     }
 
+    @Test("Menu bar summary totals credit and loan debt")
+    func menuBarSummaryTotalDebt() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -1_500, limit: 10_000)),
+            AccountDTO(id: "3", itemId: "i", name: "Auto Loan", type: .loan, balances: BalanceDTO(current: -7_250)),
+            AccountDTO(id: "4", itemId: "i", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 50_000)),
+        ]
+
+        #expect(MenuBarSummary.totalDebt(from: accounts) == 8_750)
+    }
+
     @Test("Menu bar summary aggregates credit utilization")
     func menuBarSummaryCreditUtilization() {
         let accounts = [
@@ -213,6 +225,7 @@ struct PlaidBarCoreTests {
         let checking = AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(current: 500))
         let credit = AccountDTO(id: "2", itemId: "i", name: "Card", type: .credit, balances: BalanceDTO(current: -125))
         let loan = AccountDTO(id: "3", itemId: "i", name: "Loan", type: .loan, balances: BalanceDTO(current: -750))
+        let availableCredit = AccountDTO(id: "4", itemId: "i", name: "Available", type: .credit, balances: BalanceDTO(available: 900))
 
         #expect(AccountPresentation.isDebt(checking) == false)
         #expect(AccountPresentation.isDebt(credit))
@@ -220,6 +233,7 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.displayBalance(for: checking) == 500)
         #expect(AccountPresentation.displayBalance(for: credit) == 125)
         #expect(AccountPresentation.displayBalance(for: loan) == 750)
+        #expect(AccountPresentation.displayBalance(for: availableCredit) == 0)
     }
 
     @Test("Menu bar summary estimates runway from recent monthly spend")


### PR DESCRIPTION
## Summary
- add shared total debt calculation that includes credit and loan accounts
- use the shared debt total in dashboard summary cards and balance mix
- make debt display avoid treating available credit as amount owed when current balance is absent

## Verification
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check
- codex exec review --base main --title "Include loans in dashboard debt total"

Note: Codex CLI review first flagged the available-credit edge case; this PR includes the correction and coverage.