### PR TITLE
Show loans in Accounts section

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -374,6 +374,10 @@ final class AppState {
         accounts.filter { $0.type == .credit }
     }
 
+    var loanAccounts: [AccountDTO] {
+        accounts.filter { $0.type == .loan }
+    }
+
     var debtAccounts: [AccountDTO] {
         accounts.filter(AccountPresentation.isDebt)
     }

--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -25,9 +25,16 @@ struct AccountsView: View {
                     }
                 }
 
+                if !appState.loanAccounts.isEmpty {
+                    sectionHeader("Loans")
+                    ForEach(appState.loanAccounts) { account in
+                        AccountRow(account: account)
+                    }
+                }
+
                 // Other accounts
                 let otherAccounts = appState.accounts.filter {
-                    $0.type != .depository && $0.type != .credit
+                    $0.type != .depository && $0.type != .credit && $0.type != .loan
                 }
                 if !otherAccounts.isEmpty {
                     sectionHeader("Other")


### PR DESCRIPTION
## Summary
- add an AppState loan account grouping
- render loans in their own Accounts section
- keep true miscellaneous account types under Other

## Verification
- swift build --target PlaidBar --skip-update --disable-keychain
- git diff --check
- codex exec review --base main --title "Show loan accounts in their own Accounts section"