### PR TITLE
Persist transaction cache across app restarts

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -493,13 +493,22 @@ final class AppState {
     func syncTransactions() async {
         do {
             var hasMore = true
+            var cachePersistenceError: Error?
             while hasMore {
                 let response = try await serverClient.syncTransactions()
                 transactions = TransactionSyncReducer.applying(response, to: transactions)
+                do {
+                    try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+                } catch {
+                    cachePersistenceError = error
+                }
                 hasMore = response.hasMore
             }
             lastSyncDate = Date()
             itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
+            if let cachePersistenceError {
+                self.error = "Transaction cache failed to save: \(cachePersistenceError.localizedDescription)"
+            }
         } catch {
             self.error = error.localizedDescription
         }
@@ -572,6 +581,11 @@ final class AppState {
             accounts.removeAll { $0.itemId == removedItemId }
             transactions.removeAll { accountIdsForItem.contains($0.accountId) }
             serverItemCount = Set(accounts.map(\.itemId)).count
+            do {
+                try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+            } catch {
+                self.error = "Transaction cache failed to save: \(error.localizedDescription)"
+            }
         } catch {
             self.error = error.localizedDescription
         }
@@ -661,6 +675,11 @@ final class AppState {
         }
         await checkServerConnection()
         if serverConnected {
+            if statusItemCount > 0 {
+                loadCachedTransactions()
+            } else {
+                clearCachedTransactions()
+            }
             await refreshAccounts()
             await syncTransactions()
             startBackgroundRefresh()
@@ -668,6 +687,27 @@ final class AppState {
     }
 
     // MARK: - Balance History
+
+    private func loadCachedTransactions() {
+        do {
+            transactions = try LocalDataStore.loadTransactions(context: transactionCacheContext)
+        } catch {
+            self.error = "Transaction cache failed to load: \(error.localizedDescription)"
+        }
+    }
+
+    private func clearCachedTransactions() {
+        transactions = []
+        try? LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+    }
+
+    private var transactionCacheContext: TransactionCacheContext? {
+        guard let serverEnvironment, let serverStoragePath else { return nil }
+        return TransactionCacheContext(
+            environment: serverEnvironment,
+            storagePath: serverStoragePath
+        )
+    }
 
     private func recordBalanceSnapshot() {
         let snapshot = BalanceSnapshot(date: Date(), balance: netBalance)

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -17,9 +17,20 @@ public struct LocalDataResetResult: Equatable, Sendable {
     }
 }
 
+public struct TransactionCacheContext: Codable, Equatable, Sendable {
+    public let environment: PlaidEnvironment
+    public let storagePath: String
+
+    public init(environment: PlaidEnvironment, storagePath: String) {
+        self.environment = environment
+        self.storagePath = storagePath
+    }
+}
+
 public enum LocalDataStore {
     public static let displayPath = "~/.plaidbar/"
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
+    public static let transactionCacheFilename = "transactions.json"
 
     public static func accountHomeDirectoryURL() -> URL {
         #if os(macOS)
@@ -71,6 +82,62 @@ public enum LocalDataStore {
             removedEntries: removedEntries
         )
     }
+
+    public static func transactionCacheURL(
+        in directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil
+    ) -> URL {
+        directory.appendingPathComponent(transactionCacheFilename(for: context))
+    }
+
+    public static func loadTransactions(
+        from directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil,
+        fileManager: FileManager = .default
+    ) throws -> [TransactionDTO] {
+        let url = transactionCacheURL(in: directory, context: context)
+        guard fileManager.fileExists(atPath: url.path) else { return [] }
+
+        let data = try Data(contentsOf: url)
+        let cache = try JSONDecoder().decode(TransactionCache.self, from: data)
+        guard context == nil || cache.context == context else { return [] }
+        return cache.transactions
+    }
+
+    public static func saveTransactions(
+        _ transactions: [TransactionDTO],
+        to directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let url = transactionCacheURL(in: directory, context: context)
+        let cache = TransactionCache(context: context, transactions: transactions)
+        let data = try JSONEncoder().encode(cache)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    private static func transactionCacheFilename(for context: TransactionCacheContext?) -> String {
+        guard let context else { return transactionCacheFilename }
+
+        let key = "\(context.environment.rawValue)|\(context.storagePath)"
+        return "transactions-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+    }
+
+    private static func stableHashHex(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+private struct TransactionCache: Codable, Sendable {
+    let context: TransactionCacheContext?
+    let transactions: [TransactionDTO]
 }
 
 private extension String {

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -884,4 +884,61 @@ struct PlaidBarCoreTests {
         #expect(isDirectory.boolValue)
         #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
     }
+
+    @Test("Transaction cache survives incremental sync from existing cursor")
+    func transactionCacheMergesIncrementalSync() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let context = TransactionCacheContext(environment: .sandbox, storagePath: "\(directory.path)/plaidbar.sqlite")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let cached = [
+            TransactionDTO(id: "old", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")
+        ]
+        try LocalDataStore.saveTransactions(cached, to: directory, context: context)
+
+        let loaded = try LocalDataStore.loadTransactions(from: directory, context: context)
+        let delta = SyncResponse(
+            added: [
+                TransactionDTO(id: "new", accountId: "checking", amount: 25, date: "2026-01-02", name: "Lunch")
+            ],
+            modified: [],
+            removed: [],
+            hasMore: false
+        )
+        let merged = TransactionSyncReducer.applying(delta, to: loaded)
+        try LocalDataStore.saveTransactions(merged, to: directory, context: context)
+
+        let reloaded = try LocalDataStore.loadTransactions(from: directory, context: context)
+        #expect(reloaded.map(\.id) == ["old", "new"])
+        #expect(try LocalDataStore.loadTransactions(
+            from: directory,
+            context: TransactionCacheContext(environment: .production, storagePath: context.storagePath)
+        ).isEmpty)
+        #expect(LocalDataStore.transactionCacheURL(in: directory).lastPathComponent == LocalDataStore.transactionCacheFilename)
+        #expect(LocalDataStore.transactionCacheURL(in: directory, context: context).lastPathComponent != LocalDataStore.transactionCacheFilename)
+    }
+
+    @Test("Transaction cache persists account removal cleanup")
+    func transactionCachePersistsAccountRemovalCleanup() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let context = TransactionCacheContext(environment: .production, storagePath: "\(directory.path)/plaidbar.sqlite")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let transactions = [
+            TransactionDTO(id: "keep", accountId: "checking", amount: 10, date: "2026-01-01", name: "Coffee"),
+            TransactionDTO(id: "drop", accountId: "closed", amount: 100, date: "2026-01-02", name: "Old card")
+        ]
+        try LocalDataStore.saveTransactions(transactions, to: directory, context: context)
+
+        let cleaned = try LocalDataStore.loadTransactions(from: directory, context: context)
+            .filter { $0.accountId != "closed" }
+        try LocalDataStore.saveTransactions(cleaned, to: directory, context: context)
+
+        let reloaded = try LocalDataStore.loadTransactions(from: directory, context: context)
+        #expect(reloaded.map(\.id) == ["keep"])
+    }
 }


### PR DESCRIPTION
## Summary
- Persist synced transactions to a local cache after each successful sync page.
- Load the cache after confirming the local server context so existing cursors do not leave the app with an empty transaction list after restart.
- Namespace the cache by Plaid environment and server storage path, and keep explicit item removal cleanup persisted.

## Test plan
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh

## Notes
- Local `swift test --skip-update --disable-keychain` is blocked on this machine by CommandLineTools not exposing the Swift `Testing` module; GitHub CI should cover the full suite.