### PR TITLE
Enforce local API bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sand
 For a fast sandbox preflight without opening the menu bar app, export sandbox
 credentials and run `./Scripts/smoke-sandbox.sh`. It builds the server, starts
 it on `127.0.0.1:${PLAIDBAR_SMOKE_PORT:-18484}`, checks `/health`, and verifies
-that `/api/status` reports sandbox mode with credentials configured. The smoke
-script uses a temporary data directory by default; set `PLAIDBAR_DATA_DIR` when
-you intentionally want to point it at a specific local store.
+that unauthenticated `/api` calls are rejected before checking `/api/status`
+with the generated local bearer token. The smoke script uses a temporary data
+directory by default; set `PLAIDBAR_DATA_DIR` when you intentionally want to
+point it at a specific local store.
 
 ## Keyboard Shortcuts
 
@@ -295,7 +296,9 @@ commit, push, review, and production-readiness work.
 
 ## Server API Reference
 
-The companion server exposes these localhost endpoints:
+The companion server exposes these localhost endpoints. `/health` and
+`/oauth/callback` are unauthenticated; `/api/*` requires the local bearer token
+stored under `~/.plaidbar/auth-token` or `PLAIDBAR_DATA_DIR/auth-token`.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -71,7 +71,18 @@ for _ in {1..30}; do
 done
 
 curl -fsS "http://127.0.0.1:$SERVER_PORT/health" >/dev/null
-STATUS_JSON="$(curl -fsS "http://127.0.0.1:$SERVER_PORT/api/status")"
+DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.plaidbar}"
+case "$DATA_DIR" in
+    "~")
+        DATA_DIR="$HOME"
+        ;;
+    "~/"*)
+        DATA_DIR="$HOME/${DATA_DIR#"~/"}"
+        ;;
+esac
+AUTH_TOKEN_PATH="$DATA_DIR/auth-token"
+AUTH_TOKEN="$(tr -d '\r\n' < "$AUTH_TOKEN_PATH")"
+STATUS_JSON="$(curl -fsS -H "Authorization: Bearer $AUTH_TOKEN" "http://127.0.0.1:$SERVER_PORT/api/status")"
 python3 - "$STATUS_JSON" <<'PY'
 import json
 import sys

--- a/Scripts/smoke-sandbox.sh
+++ b/Scripts/smoke-sandbox.sh
@@ -64,8 +64,16 @@ if ! curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null; then
     cat "$SERVER_LOG"
     exit 1
 fi
-STATUS_JSON="$(curl -fsS "http://127.0.0.1:$PORT/api/status")"
-ITEMS_JSON="$(curl -fsS "http://127.0.0.1:$PORT/api/items")"
+AUTH_TOKEN_PATH="$PLAIDBAR_DATA_DIR/auth-token"
+AUTH_TOKEN="$(tr -d '\r\n' < "$AUTH_TOKEN_PATH")"
+
+if curl -fsS "http://127.0.0.1:$PORT/api/status" >/dev/null 2>&1; then
+    echo "Smoke check failed: unauthenticated API status request succeeded" >&2
+    exit 1
+fi
+
+STATUS_JSON="$(curl -fsS -H "Authorization: Bearer $AUTH_TOKEN" "http://127.0.0.1:$PORT/api/status")"
+ITEMS_JSON="$(curl -fsS -H "Authorization: Bearer $AUTH_TOKEN" "http://127.0.0.1:$PORT/api/items")"
 
 python3 - "$STATUS_JSON" "$ITEMS_JSON" "$PLAIDBAR_DATA_DIR" <<'PY'
 import json
@@ -97,6 +105,14 @@ if not os.path.exists(auth_token_path):
     errors.append(f"auth token was not created at {auth_token_path}")
 elif os.path.getsize(auth_token_path) == 0:
     errors.append(f"auth token is empty at {auth_token_path}")
+else:
+    token_mode = os.stat(auth_token_path).st_mode & 0o777
+    if token_mode != 0o600:
+        errors.append(f"expected auth token permissions 0600, got {token_mode:04o}")
+
+data_dir_mode = os.stat(data_dir).st_mode & 0o777
+if data_dir_mode != 0o700:
+    errors.append(f"expected data directory permissions 0700, got {data_dir_mode:04o}")
 
 if errors:
     for error in errors:

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -5,10 +5,15 @@ actor ServerClient {
     private let baseURL: String
     private let session: URLSession
     private let decoder: JSONDecoder
+    private let authTokenURL: URL
 
-    init(baseURL: String = PlaidBarConstants.serverBaseURL) {
+    init(
+        baseURL: String = PlaidBarConstants.serverBaseURL,
+        authTokenURL: URL = LocalDataStore.authTokenURL()
+    ) {
         self.baseURL = baseURL
         self.session = URLSession.shared
+        self.authTokenURL = authTokenURL
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         self.decoder = decoder
@@ -67,7 +72,7 @@ actor ServerClient {
         guard let url = ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId) else {
             throw ServerClientError.requestFailed
         }
-        var request = URLRequest(url: url)
+        var request = try authorizedRequest(url: url)
         request.httpMethod = "DELETE"
         let (_, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
@@ -79,7 +84,8 @@ actor ServerClient {
     // MARK: - Private
 
     private func get<T: Decodable & Sendable>(_ url: URL) async throws -> T {
-        let (data, response) = try await session.data(from: url)
+        let request = try authorizedRequest(url: url)
+        let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             throw ServerClientError.requestFailed
@@ -88,7 +94,7 @@ actor ServerClient {
     }
 
     private func post<T: Decodable & Sendable>(_ url: URL) async throws -> T {
-        var request = URLRequest(url: url)
+        var request = try authorizedRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let (data, response) = try await session.data(for: request)
@@ -98,16 +104,30 @@ actor ServerClient {
         }
         return try decoder.decode(T.self, from: data)
     }
+
+    private func authorizedRequest(url: URL) throws -> URLRequest {
+        let token = try String(contentsOf: authTokenURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw ServerClientError.authTokenUnavailable
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
 }
 
 enum ServerClientError: Error, LocalizedError, Sendable {
     case requestFailed
     case serverNotRunning
+    case authTokenUnavailable
 
     var errorDescription: String? {
         switch self {
         case .requestFailed: "Request to PlaidBar server failed"
         case .serverNotRunning: "PlaidBar server is not running"
+        case .authTokenUnavailable: "PlaidBar server auth token is unavailable"
         }
     }
 }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -138,7 +138,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Stores the local server database, Plaid item tokens, sync cursors, and app/server auth token. App preferences stay in macOS preferences.")
+                    Text("Stores the local server database, Plaid item tokens, and sync cursors. App preferences and the app/server auth token stay in place.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -151,7 +151,7 @@ struct GeneralSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This deletes files under \(appState.localStoragePathText), including the SQLite database, stored Plaid access tokens, sync cursors, and the app/server auth token. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
+            Text("This deletes files under \(appState.localStoragePathText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps the app/server auth token so the running local server stays reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -30,6 +30,7 @@ public struct TransactionCacheContext: Codable, Equatable, Sendable {
 public enum LocalDataStore {
     public static let displayPath = "~/.plaidbar/"
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
+    public static let authTokenFilename = "auth-token"
     public static let transactionCacheFilename = "transactions.json"
 
     public static func accountHomeDirectoryURL() -> URL {
@@ -64,15 +65,20 @@ public enum LocalDataStore {
 
         if fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory) {
             if isDirectory.boolValue {
-                removedEntries = try fileManager
-                    .contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-                    .map(\.lastPathComponent)
+                let entries = try fileManager.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: nil
+                )
+                for entry in entries where entry.lastPathComponent != authTokenFilename {
+                    try fileManager.removeItem(at: entry)
+                    removedEntries.append(entry.lastPathComponent)
+                }
+                removedEntries = removedEntries
                     .sorted()
             } else {
                 removedEntries = [directory.lastPathComponent]
+                try fileManager.removeItem(at: directory)
             }
-
-            try fileManager.removeItem(at: directory)
         }
 
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -88,6 +94,12 @@ public enum LocalDataStore {
         context: TransactionCacheContext? = nil
     ) -> URL {
         directory.appendingPathComponent(transactionCacheFilename(for: context))
+    }
+
+    public static func authTokenURL(
+        in directory: URL = storageDirectoryURL()
+    ) -> URL {
+        directory.appendingPathComponent(authTokenFilename)
     }
 
     public static func loadTransactions(

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -46,14 +46,16 @@ struct PlaidBarServer: AsyncParsableCommand {
         }
 
         // API routes
+        let api = router.group("api")
+        api.add(middleware: APITokenMiddleware(authToken: serverConfig.authToken))
         LinkRoutes(plaidClient: plaidClient, tokenStore: tokenStore, config: serverConfig)
-            .register(with: router.group("api"))
+            .register(with: api)
         AccountRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
-            .register(with: router.group("api"))
+            .register(with: api)
         TransactionRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
-            .register(with: router.group("api"))
+            .register(with: api)
         StatusRoutes(tokenStore: tokenStore, config: serverConfig)
-            .register(with: router.group("api"))
+            .register(with: api)
 
         // OAuth callback (top-level, not under /api)
         OAuthCallbackRoute(plaidClient: plaidClient, tokenStore: tokenStore)

--- a/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
+++ b/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Hummingbird
+
+struct APITokenMiddleware<Context: RequestContext>: RouterMiddleware {
+    private let expectedAuthorizationHeader: String
+
+    init(authToken: String) {
+        self.expectedAuthorizationHeader = "Bearer \(authToken)"
+    }
+
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        guard Self.constantTimeEquals(
+            request.headers[.authorization] ?? "",
+            expectedAuthorizationHeader
+        ) else {
+            throw HTTPError(.unauthorized, message: "Missing or invalid authorization token")
+        }
+
+        return try await next(request, context)
+    }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        let maxCount = max(lhsBytes.count, rhsBytes.count)
+        var difference = lhsBytes.count ^ rhsBytes.count
+
+        for index in 0..<maxCount {
+            let lhsByte = index < lhsBytes.count ? lhsBytes[index] : 0
+            let rhsByte = index < rhsBytes.count ? rhsBytes[index] : 0
+            difference |= Int(lhsByte ^ rhsByte)
+        }
+
+        return difference == 0
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -27,6 +27,10 @@ struct ServerConfig: Sendable {
             atPath: dataDir,
             withIntermediateDirectories: true
         )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: dataDir
+        )
 
         let environment: PlaidEnvironment = (sandboxOverride == true)
             ? .sandbox
@@ -41,16 +45,26 @@ struct ServerConfig: Sendable {
         }
 
         // Generate or load persistent auth token for app<->server auth
-        let authTokenPath = "\(dataDir)/auth-token"
+        let authTokenURL = LocalDataStore.authTokenURL(
+            in: URL(fileURLWithPath: dataDir, isDirectory: true)
+        )
         let authToken: String
-        if let existing = try? String(contentsOfFile: authTokenPath, encoding: .utf8)
+        if let existing = try? String(contentsOf: authTokenURL, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !existing.isEmpty
         {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: authTokenURL.path
+            )
             authToken = existing
         } else {
             let generated = UUID().uuidString
-            try generated.write(toFile: authTokenPath, atomically: true, encoding: .utf8)
+            try generated.write(to: authTokenURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: authTokenURL.path
+            )
             authToken = generated
         }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -861,8 +861,8 @@ struct PlaidBarCoreTests {
         #expect(resolved == directory)
     }
 
-    @Test("Local data reset removes directory contents and recreates directory")
-    func localDataResetRemovesContents() throws {
+    @Test("Local data reset removes data files and keeps server auth token")
+    func localDataResetRemovesDataFilesAndKeepsAuthToken() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
@@ -877,12 +877,13 @@ struct PlaidBarCoreTests {
         let result = try LocalDataStore.resetLocalData(at: directory)
 
         #expect(result.directoryPath == directory.path)
-        #expect(result.removedEntries == ["auth-token", "plaidbar.sqlite"])
+        #expect(result.removedEntries == ["plaidbar.sqlite"])
 
         var isDirectory: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
-        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["auth-token"])
+        #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
     }
 
     @Test("Transaction cache survives incremental sync from existing cursor")


### PR DESCRIPTION
## Summary
- Require the generated local bearer token on `/api/*` routes while keeping `/health` and the Plaid OAuth callback reachable.
- Send the token from the Swift client and local scripts.
- Preserve the app/server auth token across local data reset and restrict token/data-dir file permissions.

## Test plan
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_DATA_DIR="$(mktemp -d -t plaidbar-run-data.XXXXXX)" PLAIDBAR_SERVER_PORT=18488 bash -lc './Scripts/run.sh --sandbox & pid=$!; sleep 14; kill -TERM $pid 2>/dev/null || true; wait $pid 2>/dev/null || true'`\n\n## Notes\n- Local `swift test --skip-update --disable-keychain` is still blocked by this Mac’s CommandLineTools missing Swift `Testing`; GitHub CI covers the full suite.