### PR TITLE
Validate Plaid Hosted Link callback state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,7 +83,7 @@ The companion server. Binds to `127.0.0.1:8484`.
 ```
 GET  /health                    → 200 OK
 POST /api/link/create           → { linkToken, linkUrl }
-GET  /oauth/callback?public_token=...  → HTML success/error page
+GET  /oauth/callback?state=...  → Hosted Link success/error page
 GET  /api/accounts              → [AccountDTO]
 GET  /api/accounts/balances     → [AccountDTO] (real-time)
 DELETE /api/accounts/:itemId    → 204 No Content
@@ -167,14 +167,15 @@ A `Task` runs every 15 minutes to refresh account balances (free cached endpoint
 ```
 1. User clicks "Add Account"
 2. App → POST /api/link/create → Server
-3. Server → POST /link/token/create → Plaid
+3. Server creates a one-time local state and POSTs /link/token/create → Plaid
 4. Server returns { linkToken, linkUrl }
 5. App opens linkUrl in Safari
 6. User completes Plaid Link in browser
-7. Plaid redirects to localhost:8484/oauth/callback?public_token=xxx
-8. Server exchanges public_token → access_token
-9. Server stores access_token in SQLite
-10. App refreshes → new accounts appear
+7. Plaid redirects to localhost:8484/oauth/callback?state=xxx
+8. Server consumes the one-time state and fetches the completed Link session
+9. Server exchanges public_token → access_token
+10. Server stores access_token in SQLite
+11. App refreshes → new accounts appear
 ```
 
 ### Transaction Sync (F3)

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
         ),
         .testTarget(
             name: "PlaidBarServerTests",
-            dependencies: ["PlaidBarCore"],
+            dependencies: ["PlaidBarCore", "PlaidBarServer"],
             path: "Tests/PlaidBarServerTests",
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),

--- a/README.md
+++ b/README.md
@@ -299,15 +299,17 @@ commit, push, review, and production-readiness work.
 The companion server exposes these localhost endpoints. `/health` and
 `/oauth/callback` are unauthenticated; `/api/*` requires the local bearer token
 stored under `~/.plaidbar/auth-token` or `PLAIDBAR_DATA_DIR/auth-token`.
+Plaid Link completion callbacks must also include the one-time `state` generated
+when the local app created the Hosted Link session.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/health` | Health check |
 | `GET` | `/api/status` | Server version, environment, item count |
 | `GET` | `/api/items` | List connected bank items |
-| `POST` | `/api/link/create` | Create Plaid Link token + URL |
-| `POST` | `/api/link/update/:itemId` | Create Plaid Link update-mode URL for reconnect |
-| `GET` | `/oauth/callback` | Plaid OAuth redirect handler |
+| `POST` | `/api/link/create` | Create one-time Plaid Hosted Link token + URL |
+| `POST` | `/api/link/update/:itemId` | Create one-time Plaid Hosted Link update-mode URL for reconnect |
+| `GET` | `/oauth/callback` | Plaid Hosted Link completion redirect handler |
 | `GET` | `/api/accounts` | List all accounts (cached) |
 | `GET` | `/api/accounts/balances` | Real-time balances |
 | `DELETE` | `/api/accounts/:itemId` | Remove a bank connection |

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -36,6 +36,7 @@ struct PlaidBarServer: AsyncParsableCommand {
 
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent)
+        let pendingLinkSessions = PendingLinkSessionStore()
 
         // Build router
         let router = Router()
@@ -48,7 +49,12 @@ struct PlaidBarServer: AsyncParsableCommand {
         // API routes
         let api = router.group("api")
         api.add(middleware: APITokenMiddleware(authToken: serverConfig.authToken))
-        LinkRoutes(plaidClient: plaidClient, tokenStore: tokenStore, config: serverConfig)
+        LinkRoutes(
+            plaidClient: plaidClient,
+            tokenStore: tokenStore,
+            pendingLinkSessions: pendingLinkSessions,
+            config: serverConfig
+        )
             .register(with: api)
         AccountRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
             .register(with: api)
@@ -58,7 +64,11 @@ struct PlaidBarServer: AsyncParsableCommand {
             .register(with: api)
 
         // OAuth callback (top-level, not under /api)
-        OAuthCallbackRoute(plaidClient: plaidClient, tokenStore: tokenStore)
+        OAuthCallbackRoute(
+            plaidClient: plaidClient,
+            tokenStore: tokenStore,
+            pendingLinkSessions: pendingLinkSessions
+        )
             .register(with: router)
 
         // Build and run application

--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+actor PendingLinkSessionStore {
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+    private var sessions: [String: PendingLinkSession] = [:]
+
+    init(ttl: TimeInterval = 30 * 60, now: @escaping @Sendable () -> Date = { Date() }) {
+        self.ttl = ttl
+        self.now = now
+    }
+
+    func issueState() -> String {
+        purgeExpired()
+        return UUID().uuidString.lowercased()
+    }
+
+    func save(state: String, linkToken: String, updateItemId: String? = nil) {
+        purgeExpired()
+        sessions[state] = PendingLinkSession(
+            linkToken: linkToken,
+            updateItemId: updateItemId,
+            createdAt: now()
+        )
+    }
+
+    func consume(state: String) -> PendingLinkSession? {
+        purgeExpired()
+        guard let session = sessions.removeValue(forKey: state),
+              now().timeIntervalSince(session.createdAt) <= ttl
+        else {
+            return nil
+        }
+        return session
+    }
+
+    private func purgeExpired() {
+        let currentDate = now()
+        sessions = sessions.filter { _, session in
+            currentDate.timeIntervalSince(session.createdAt) <= ttl
+        }
+    }
+}
+
+struct PendingLinkSession: Sendable {
+    let linkToken: String
+    let updateItemId: String?
+    let createdAt: Date
+}

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -24,7 +24,10 @@ actor PlaidClient {
 
     // MARK: - Link Token
 
-    func createLinkToken(userId: String) async throws -> PlaidLinkTokenResponse {
+    func createLinkToken(
+        userId: String,
+        completionRedirectUri: String
+    ) async throws -> PlaidLinkTokenResponse {
         let body = PlaidLinkTokenRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
@@ -33,12 +36,20 @@ actor PlaidClient {
             products: ["transactions"],
             countryCodes: ["US"],
             language: "en",
-            redirectUri: config.redirectUri
+            redirectUri: config.redirectUri,
+            hostedLink: .init(
+                completionRedirectUri: completionRedirectUri,
+                urlLifetimeSeconds: 30 * 60
+            )
         )
         return try await post("/link/token/create", body: body)
     }
 
-    func createUpdateLinkToken(userId: String, accessToken: String) async throws -> PlaidLinkTokenResponse {
+    func createUpdateLinkToken(
+        userId: String,
+        accessToken: String,
+        completionRedirectUri: String
+    ) async throws -> PlaidLinkTokenResponse {
         let body = PlaidLinkTokenRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
@@ -47,9 +58,22 @@ actor PlaidClient {
             countryCodes: ["US"],
             language: "en",
             redirectUri: config.redirectUri,
+            hostedLink: .init(
+                completionRedirectUri: completionRedirectUri,
+                urlLifetimeSeconds: 30 * 60
+            ),
             accessToken: accessToken
         )
         return try await post("/link/token/create", body: body)
+    }
+
+    func getLinkToken(_ linkToken: String) async throws -> PlaidLinkTokenGetResponse {
+        let body = PlaidLinkTokenGetRequest(
+            clientId: config.plaidClientId,
+            secret: config.plaidSecret,
+            linkToken: linkToken
+        )
+        return try await post("/link/token/get", body: body)
     }
 
     // MARK: - Token Exchange

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -11,6 +11,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
     let countryCodes: [String]
     let language: String
     let redirectUri: String
+    let hostedLink: PlaidHostedLink?
     let accessToken: String?
 
     init(
@@ -22,6 +23,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
         countryCodes: [String],
         language: String,
         redirectUri: String,
+        hostedLink: PlaidHostedLink? = nil,
         accessToken: String? = nil
     ) {
         self.clientId = clientId
@@ -32,12 +34,24 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
         self.countryCodes = countryCodes
         self.language = language
         self.redirectUri = redirectUri
+        self.hostedLink = hostedLink
         self.accessToken = accessToken
     }
 
     struct PlaidUser: Encodable, Sendable {
         let clientUserId: String
     }
+}
+
+struct PlaidHostedLink: Encodable, Sendable {
+    let completionRedirectUri: String
+    let urlLifetimeSeconds: Int
+}
+
+struct PlaidLinkTokenGetRequest: Encodable, Sendable {
+    let clientId: String
+    let secret: String
+    let linkToken: String
 }
 
 struct PlaidTokenExchangeRequest: Encodable, Sendable {
@@ -77,11 +91,58 @@ struct PlaidLinkTokenResponse: Decodable, Sendable {
     let linkToken: String
     let expiration: String?
     let requestId: String?
+    let hostedLinkUrl: String?
+}
 
-    /// Constructs the hosted Link URL for browser-based flow
-    func hostedLinkUrl(redirectUri: String) -> String {
-        "https://cdn.plaid.com/link/v2/stable/link.html?token=\(linkToken)&redirect_uri=\(redirectUri)"
+struct PlaidLinkTokenGetResponse: Decodable, Sendable {
+    let linkToken: String?
+    let linkSessions: [PlaidLinkSession]?
+    let onSuccess: PlaidLinkSuccess?
+    let results: PlaidLinkResults?
+
+    var publicTokens: [String] {
+        let sessionTokens = linkSessions?
+            .flatMap { $0.results?.itemAddResults ?? [] }
+            .map(\.publicToken) ?? []
+        if !sessionTokens.isEmpty {
+            return sessionTokens
+        }
+        if let itemAddResults = results?.itemAddResults, !itemAddResults.isEmpty {
+            return itemAddResults.map(\.publicToken)
+        }
+        if let publicToken = onSuccess?.publicToken {
+            return [publicToken]
+        }
+        return []
     }
+}
+
+struct PlaidLinkSession: Decodable, Sendable {
+    let linkSessionId: String?
+    let results: PlaidLinkResults?
+}
+
+struct PlaidLinkResults: Decodable, Sendable {
+    let itemAddResults: [PlaidLinkItemAddResult]?
+}
+
+struct PlaidLinkItemAddResult: Decodable, Sendable {
+    let publicToken: String
+    let institution: PlaidLinkInstitution?
+}
+
+struct PlaidLinkSuccess: Decodable, Sendable {
+    let publicToken: String?
+    let metadata: PlaidLinkSuccessMetadata?
+}
+
+struct PlaidLinkSuccessMetadata: Decodable, Sendable {
+    let institution: PlaidLinkInstitution?
+}
+
+struct PlaidLinkInstitution: Decodable, Sendable {
+    let name: String?
+    let institutionId: String?
 }
 
 struct PlaidTokenExchangeResponse: Decodable, Sendable {

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -6,6 +6,7 @@ import PlaidBarCore
 struct LinkRoutes: Sendable {
     let plaidClient: PlaidClient
     let tokenStore: TokenStore
+    let pendingLinkSessions: PendingLinkSessionStore
     let config: ServerConfig
 
     func register(with group: RouterGroup<some RequestContext>) {
@@ -21,9 +22,16 @@ struct LinkRoutes: Sendable {
         context: some RequestContext
     ) async throws -> Response {
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
-        let plaidResponse = try await plaidClient.createLinkToken(userId: userId)
+        let state = await pendingLinkSessions.issueState()
+        let plaidResponse = try await plaidClient.createLinkToken(
+            userId: userId,
+            completionRedirectUri: callbackURL(state: state)
+        )
 
-        let linkUrl = plaidResponse.hostedLinkUrl(redirectUri: config.redirectUri)
+        guard let linkUrl = plaidResponse.hostedLinkUrl else {
+            throw HTTPError(.internalServerError, message: "Plaid did not return a hosted Link URL")
+        }
+        await pendingLinkSessions.save(state: state, linkToken: plaidResponse.linkToken)
         let dto = LinkResponse(linkToken: plaidResponse.linkToken, linkUrl: linkUrl)
 
         let data = try JSONEncoder().encode(dto)
@@ -47,12 +55,21 @@ struct LinkRoutes: Sendable {
         }
 
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
+        let state = await pendingLinkSessions.issueState()
         let plaidResponse = try await plaidClient.createUpdateLinkToken(
             userId: userId,
-            accessToken: item.accessToken
+            accessToken: item.accessToken,
+            completionRedirectUri: callbackURL(state: state)
         )
 
-        let linkUrl = plaidResponse.hostedLinkUrl(redirectUri: config.redirectUri)
+        guard let linkUrl = plaidResponse.hostedLinkUrl else {
+            throw HTTPError(.internalServerError, message: "Plaid did not return a hosted Link URL")
+        }
+        await pendingLinkSessions.save(
+            state: state,
+            linkToken: plaidResponse.linkToken,
+            updateItemId: itemId
+        )
         let dto = LinkResponse(linkToken: plaidResponse.linkToken, linkUrl: linkUrl)
 
         let data = try JSONEncoder().encode(dto)
@@ -62,6 +79,16 @@ struct LinkRoutes: Sendable {
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
     }
+
+    private func callbackURL(state: String) -> String {
+        guard var components = URLComponents(string: config.redirectUri) else {
+            return config.redirectUri
+        }
+        var queryItems = components.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "state", value: state))
+        components.queryItems = queryItems
+        return components.string ?? config.redirectUri
+    }
 }
 
 // MARK: - OAuth Callback (top-level route, not under /api)
@@ -69,6 +96,7 @@ struct LinkRoutes: Sendable {
 struct OAuthCallbackRoute: Sendable {
     let plaidClient: PlaidClient
     let tokenStore: TokenStore
+    let pendingLinkSessions: PendingLinkSessionStore
 
     func register(with router: Router<some RequestContext>) {
         router.get("oauth/callback", use: handleCallback)
@@ -79,40 +107,83 @@ struct OAuthCallbackRoute: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        // Extract public_token from query params
-        guard let publicToken = request.uri.queryParameters.get("public_token") else {
+        guard let stateParam = request.uri.queryParameters.get("state"),
+              let pendingSession = await pendingLinkSessions.consume(state: String(stateParam))
+        else {
             return Response(
                 status: .badRequest,
                 headers: [.contentType: "text/html"],
                 body: .init(byteBuffer: ByteBuffer(
-                    string: Self.errorPage("Missing public_token parameter")
+                    string: Self.errorPage("Missing or expired link session state")
                 ))
             )
         }
 
-        // Exchange public token for access token
-        let exchangeResponse = try await plaidClient.exchangePublicToken(
-            String(publicToken)
-        )
+        do {
+            let publicTokens = try await publicTokens(from: request, pendingSession: pendingSession)
+            if publicTokens.isEmpty, let updateItemId = pendingSession.updateItemId {
+                try await tokenStore.updateItemStatus(id: updateItemId, status: ItemConnectionStatus.connected.rawValue)
+                return Response(
+                    status: .ok,
+                    headers: [.contentType: "text/html"],
+                    body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
+                )
+            }
 
-        // Get account info to determine institution
+            guard !publicTokens.isEmpty else {
+                return Response(
+                    status: .badRequest,
+                    headers: [.contentType: "text/html"],
+                    body: .init(byteBuffer: ByteBuffer(
+                        string: Self.errorPage("Plaid Link completed without a public token")
+                    ))
+                )
+            }
+
+            for publicToken in publicTokens {
+                try await exchangeAndStore(publicToken: publicToken)
+            }
+
+            return Response(
+                status: .ok,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
+            )
+        } catch {
+            return Response(
+                status: .internalServerError,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(
+                    string: Self.errorPage(error.localizedDescription)
+                ))
+            )
+        }
+    }
+
+    private func publicTokens(
+        from request: Request,
+        pendingSession: PendingLinkSession
+    ) async throws -> [String] {
+        if let publicToken = request.uri.queryParameters.get("public_token") {
+            return [String(publicToken)]
+        }
+
+        let linkSession = try await plaidClient.getLinkToken(pendingSession.linkToken)
+        return linkSession.publicTokens
+    }
+
+    private func exchangeAndStore(publicToken: String) async throws {
+        let exchangeResponse = try await plaidClient.exchangePublicToken(publicToken)
         let accountsResponse = try await plaidClient.getAccounts(
             accessToken: exchangeResponse.accessToken
         )
         let institutionId = accountsResponse.item?.institutionId
 
-        // Store the item
         try await tokenStore.saveItem(
             id: exchangeResponse.itemId,
             accessToken: exchangeResponse.accessToken,
             institutionId: institutionId,
             institutionName: nil
-        )
-
-        return Response(
-            status: .ok,
-            headers: [.contentType: "text/html"],
-            body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
         )
     }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1,6 +1,7 @@
 import Testing
+import Foundation
 @testable import PlaidBarCore
-// Foundation symbols available via PlaidBarCore's transitive import
+@testable import PlaidBarServer
 
 @Suite("PlaidBarServer")
 struct PlaidBarServerTests {
@@ -46,5 +47,72 @@ struct PlaidBarServerTests {
     @Test func unknownAccountType() {
         let type = AccountType(rawValue: "brokerage") ?? .other
         #expect(type == .other)
+    }
+
+    @Test func pendingLinkSessionIsConsumedOnce() async {
+        let store = PendingLinkSessionStore()
+        let state = await store.issueState()
+        await store.save(state: state, linkToken: "link-token")
+
+        let first = await store.consume(state: state)
+        let replay = await store.consume(state: state)
+
+        #expect(first?.linkToken == "link-token")
+        #expect(replay == nil)
+    }
+
+    @Test func pendingLinkSessionExpires() async {
+        var currentDate = Date(timeIntervalSince1970: 1_000)
+        let store = PendingLinkSessionStore(ttl: 60) { currentDate }
+        let state = await store.issueState()
+        await store.save(state: state, linkToken: "link-token")
+
+        currentDate = currentDate.addingTimeInterval(61)
+
+        let expired = await store.consume(state: state)
+        #expect(expired == nil)
+    }
+
+    @Test func linkTokenGetResponseReadsHostedLinkSessionResults() throws {
+        let json = """
+        {
+          "link_token": "link-sandbox-token",
+          "link_sessions": [
+            {
+              "link_session_id": "session-one",
+              "results": {
+                "item_add_results": [
+                  { "public_token": "public-sandbox-one" },
+                  { "public_token": "public-sandbox-two" }
+                ]
+              }
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try decoder.decode(PlaidLinkTokenGetResponse.self, from: json)
+
+        #expect(response.publicTokens == ["public-sandbox-one", "public-sandbox-two"])
+    }
+
+    @Test func linkTokenGetResponseAllowsUpdateModeWithoutPublicToken() throws {
+        let json = """
+        {
+          "link_token": "link-sandbox-token",
+          "on_success": {
+            "public_token": null,
+            "metadata": {}
+          }
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try decoder.decode(PlaidLinkTokenGetResponse.self, from: json)
+
+        #expect(response.publicTokens.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- Move browser account linking to Plaid Hosted Link URLs with a one-time local completion `state`.
- Reject missing, expired, or replayed callback state before exchanging Plaid tokens.
- Fetch completed Hosted Link session results via `/link/token/get`, including update-mode completions that do not return a public token.
- Add server tests for one-time state consumption, expiry, Hosted Link result parsing, and update-mode null public tokens.

## Test plan
- `git diff --check`
- `swift build -c release --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- Codex review: no actionable bugs after fixes

## Notes
- Local `swift test --skip-update --disable-keychain` remains blocked by this Mac’s CommandLineTools missing Swift `Testing`; GitHub CI runs the full test suite.