### PR TITLE
Preserve account item when Plaid removal is retryable

### DIFF
--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -115,15 +115,32 @@ struct AccountRoutes: Sendable {
             throw HTTPError(.badRequest, message: "Missing itemId parameter")
         }
 
-        // Remove from Plaid first
+        // Remove from Plaid first so a failed revocation keeps the local token
+        // available for retry instead of leaving an orphaned Plaid Item active.
         if let item = try await tokenStore.getItem(id: itemId) {
-            try? await plaidClient.removeItem(accessToken: item.accessToken)
+            do {
+                try await plaidClient.removeItem(accessToken: item.accessToken)
+            } catch {
+                guard Self.canDeleteLocalItemAfterPlaidRemoveError(error) else {
+                    try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.error.rawValue)
+                    throw HTTPError(.badGateway, message: "Plaid item removal failed; local item was kept for retry")
+                }
+            }
         }
 
         // Remove from local storage
         try await tokenStore.deleteItem(id: itemId)
 
         return Response(status: .noContent)
+    }
+
+    static func canDeleteLocalItemAfterPlaidRemoveError(_ error: Error) -> Bool {
+        if case PlaidError.apiError(_, _, let errorCode, _) = error {
+            return errorCode == "INVALID_ACCESS_TOKEN"
+                || errorCode == "ITEM_NOT_FOUND"
+                || errorCode == "ITEM_NOT_ACCESSIBLE"
+        }
+        return false
     }
 
     // MARK: - Helpers

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -115,4 +115,22 @@ struct PlaidBarServerTests {
 
         #expect(response.publicTokens.isEmpty)
     }
+
+    @Test func localDeleteAllowedForNonRetryablePlaidRemoveErrors() {
+        let invalidToken = PlaidError.apiError(
+            statusCode: 400,
+            errorType: "INVALID_INPUT",
+            errorCode: "INVALID_ACCESS_TOKEN",
+            errorMessage: "invalid access token"
+        )
+        let transient = PlaidError.apiError(
+            statusCode: 500,
+            errorType: "API_ERROR",
+            errorCode: "INTERNAL_SERVER_ERROR",
+            errorMessage: "temporary failure"
+        )
+
+        #expect(AccountRoutes.canDeleteLocalItemAfterPlaidRemoveError(invalidToken))
+        #expect(!AccountRoutes.canDeleteLocalItemAfterPlaidRemoveError(transient))
+    }
 }


### PR DESCRIPTION
## Summary
- Stop deleting local account items when Plaid `/item/remove` fails with a retryable error.
- Mark the item errored and return 502 so the app keeps the local token needed to retry revocation.
- Still allow local cleanup for non-retryable already-gone/invalid-token Plaid responses.
- Add tests for retryable vs permanent Plaid removal classification.

## Test plan
- `git diff --check`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- Codex review: no actionable issues

## Notes
- Local `swift test --skip-update --disable-keychain` remains blocked by this Mac’s CommandLineTools missing Swift `Testing`; GitHub CI runs the full test suite.