### PR TITLE
Fail all-item Plaid account refresh explicitly

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -472,6 +472,7 @@ final class AppState {
             isSetupComplete = !accounts.isEmpty
             itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
         } catch {
+            itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
             self.error = error.localizedDescription
         }
         isLoading = false
@@ -485,6 +486,7 @@ final class AppState {
             lastSyncDate = Date()
             recordBalanceSnapshot()
         } catch {
+            itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
             self.error = error.localizedDescription
         }
         isLoading = false

--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -21,9 +21,12 @@ struct AccountRoutes: Sendable {
     ) async throws -> Response {
         let items = try await tokenStore.getAllItems()
         var allAccounts: [AccountDTO] = []
+        var attemptedItemCount = 0
+        var successfulItemCount = 0
 
         for item in items {
             guard let itemId = item.id else { continue }
+            attemptedItemCount += 1
 
             let response: PlaidAccountsResponse
             do {
@@ -31,6 +34,7 @@ struct AccountRoutes: Sendable {
                     accessToken: item.accessToken
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+                successfulItemCount += 1
             } catch {
                 try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
                 continue
@@ -57,6 +61,10 @@ struct AccountRoutes: Sendable {
             allAccounts.append(contentsOf: accounts)
         }
 
+        if Self.shouldFailRefresh(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
+            throw HTTPError(.badGateway, message: "Plaid account refresh failed for every linked item")
+        }
+
         return try Self.jsonResponse(allAccounts)
     }
 
@@ -67,9 +75,12 @@ struct AccountRoutes: Sendable {
     ) async throws -> Response {
         let items = try await tokenStore.getAllItems()
         var allAccounts: [AccountDTO] = []
+        var attemptedItemCount = 0
+        var successfulItemCount = 0
 
         for item in items {
             guard let itemId = item.id else { continue }
+            attemptedItemCount += 1
 
             let response: PlaidAccountsResponse
             do {
@@ -77,6 +88,7 @@ struct AccountRoutes: Sendable {
                     accessToken: item.accessToken
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+                successfulItemCount += 1
             } catch {
                 try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
                 continue
@@ -101,6 +113,10 @@ struct AccountRoutes: Sendable {
                 )
             }
             allAccounts.append(contentsOf: accounts)
+        }
+
+        if Self.shouldFailRefresh(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
+            throw HTTPError(.badGateway, message: "Plaid balance refresh failed for every linked item")
         }
 
         return try Self.jsonResponse(allAccounts)
@@ -141,6 +157,10 @@ struct AccountRoutes: Sendable {
                 || errorCode == "ITEM_NOT_ACCESSIBLE"
         }
         return false
+    }
+
+    static func shouldFailRefresh(attemptedItemCount: Int, successfulItemCount: Int) -> Bool {
+        attemptedItemCount > 0 && successfulItemCount == 0
     }
 
     // MARK: - Helpers

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -133,4 +133,10 @@ struct PlaidBarServerTests {
         #expect(AccountRoutes.canDeleteLocalItemAfterPlaidRemoveError(invalidToken))
         #expect(!AccountRoutes.canDeleteLocalItemAfterPlaidRemoveError(transient))
     }
+
+    @Test func accountRefreshFailsOnlyWhenEveryLinkedItemFails() {
+        #expect(!AccountRoutes.shouldFailRefresh(attemptedItemCount: 0, successfulItemCount: 0))
+        #expect(AccountRoutes.shouldFailRefresh(attemptedItemCount: 2, successfulItemCount: 0))
+        #expect(!AccountRoutes.shouldFailRefresh(attemptedItemCount: 2, successfulItemCount: 1))
+    }
 }


### PR DESCRIPTION
## Summary
- Return 502 when every linked Plaid item fails during account or balance refresh instead of returning successful-empty data.
- Preserve existing app account state while refreshing item statuses on refresh errors.
- Keep partial-success behavior when at least one linked item refreshes.
- Add tests for the all-failed refresh decision helper.

## Test plan
- git diff --check
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift build --target PlaidBar --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh
- Codex review: no actionable issues

## Notes
- Local full swift test remains blocked by this Mac's CommandLineTools Swift Testing/toolchain mismatch; GitHub CI runs the full suite.