### PR TITLE
Scope Plaid storage by environment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,9 +221,20 @@ No data races by construction.
 
 ```
 ~/.plaidbar/
-├── plaidbar.sqlite    # Fluent database (items + sync cursors)
+├── plaidbar-sandbox.sqlite       # Sandbox items + sync cursors
+├── plaidbar-production.sqlite    # Production items + sync cursors
 └── auth-token         # App ↔ server shared secret
 ```
+
+On upgrade, a legacy `plaidbar.sqlite`, its SQLite sidecar files, and its
+matching transaction cache are copied into an environment-scoped database only
+when the legacy environment is explicit
+(`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from
+the existing transaction-cache context. Ambiguous legacy databases stay
+untouched to avoid sandbox/production token crossover. Explicit migration backs
+up any existing scoped SQLite store and transaction cache before copying legacy
+data, then writes a migration marker so restarts do not reapply stale legacy
+data.
 
 ## Testing Strategy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,9 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
 - PlaidBar has no hosted backend, analytics, telemetry, or tracking.
 - The companion server should bind to `127.0.0.1` only.
 - Plaid secrets and access tokens must not be embedded in the app binary.
-- The local server stores Plaid item access tokens in SQLite under `~/.plaidbar/plaidbar.sqlite`.
+- The local server stores Plaid item access tokens in environment-scoped SQLite files under `~/.plaidbar/`:
+  `plaidbar-sandbox.sqlite` for sandbox and `plaidbar-production.sqlite` for production.
+- Existing legacy `plaidbar.sqlite` data, SQLite sidecar files, and matching transaction cache are copied into a scoped database only when the legacy environment is explicit (`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from the existing transaction-cache context. Ambiguous legacy databases are left untouched to avoid sandbox/production token crossover. Explicit migration can replace an existing scoped store, backs up the previous scoped SQLite store and transaction cache before copying legacy data, and writes a migration marker so restarts do not reapply stale legacy data.
 - The app/server auth token is generated locally under `~/.plaidbar/auth-token`.
 - Protect your macOS user account, disk encryption, backups, and shell history.
 - App-server communication should preserve local-only assumptions unless a future change explicitly documents otherwise.

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -2,6 +2,10 @@ import Foundation
 import PlaidBarCore
 
 struct ServerConfig: Sendable {
+    static let legacyDatabaseFilename = "plaidbar.sqlite"
+    static let legacyMigrationEnvironmentVariable = "PLAIDBAR_MIGRATE_LEGACY_DATABASE"
+    private static let sqliteSidecarSuffixes = ["-wal", "-shm", "-journal"]
+
     let port: Int
     let plaidEnvironment: PlaidEnvironment
     let plaidClientId: String
@@ -75,7 +79,11 @@ struct ServerConfig: Sendable {
             plaidEnvironment: environment,
             plaidClientId: clientId,
             plaidSecret: secret,
-            databasePath: "\(dataDir)/plaidbar.sqlite",
+            databasePath: try databasePathForStartup(
+                in: dataDir,
+                environment: environment,
+                legacyMigrationEnvironment: try legacyMigrationEnvironment(from: environmentValues)
+            ),
             redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
             authToken: authToken
         )
@@ -84,15 +92,454 @@ struct ServerConfig: Sendable {
     static func dataDirectory() -> String {
         LocalDataStore.storageDirectoryURL().path
     }
+
+    static func databaseFilename(for environment: PlaidEnvironment) -> String {
+        "plaidbar-\(environment.rawValue).sqlite"
+    }
+
+    static func databasePath(in dataDir: String, environment: PlaidEnvironment) -> String {
+        URL(fileURLWithPath: dataDir, isDirectory: true)
+            .appendingPathComponent(databaseFilename(for: environment))
+            .path
+    }
+
+    static func databasePathForStartup(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyMigrationEnvironment: PlaidEnvironment? = nil,
+        fileManager: FileManager = .default
+    ) throws -> String {
+        let scopedPath = databasePath(in: dataDir, environment: environment)
+        let legacyPath = URL(fileURLWithPath: dataDir, isDirectory: true)
+            .appendingPathComponent(legacyDatabaseFilename)
+            .path
+        guard fileManager.fileExists(atPath: legacyPath) else { return scopedPath }
+
+        let isReplacingScopedStore = fileManager.fileExists(atPath: scopedPath)
+        if isReplacingScopedStore {
+            guard legacyMigrationEnvironment == environment else { return scopedPath }
+            guard !fileManager.fileExists(
+                atPath: legacyMigrationMarkerPath(for: scopedPath)
+            ) else {
+                return scopedPath
+            }
+        }
+
+        guard shouldMigrateLegacyDatabase(
+            in: dataDir,
+            environment: environment,
+            legacyPath: legacyPath,
+            legacyMigrationEnvironment: legacyMigrationEnvironment,
+            fileManager: fileManager
+        ) else {
+            return scopedPath
+        }
+
+        if isReplacingScopedStore {
+            try replaceScopedStoreWithLegacy(
+                in: dataDir,
+                environment: environment,
+                legacyPath: legacyPath,
+                scopedPath: scopedPath,
+                fileManager: fileManager
+            )
+        } else {
+            try installLegacyStoreIntoEmptyScopedPath(
+                in: dataDir,
+                environment: environment,
+                legacyDatabasePath: legacyPath,
+                scopedDatabasePath: scopedPath,
+                fileManager: fileManager
+            )
+        }
+        return scopedPath
+    }
+
+    private static func legacyMigrationEnvironment(
+        from environmentValues: [String: String]
+    ) throws -> PlaidEnvironment? {
+        guard let value = environmentValues[legacyMigrationEnvironmentVariable]?.trimmedNonEmpty else {
+            return nil
+        }
+        guard let environment = PlaidEnvironment(rawValue: value) else {
+            throw ServerConfigError.invalidEnvironmentVariable(
+                legacyMigrationEnvironmentVariable,
+                value
+            )
+        }
+        return environment
+    }
+
+    private static func shouldMigrateLegacyDatabase(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyPath: String,
+        legacyMigrationEnvironment: PlaidEnvironment?,
+        fileManager: FileManager
+    ) -> Bool {
+        if let legacyMigrationEnvironment {
+            return legacyMigrationEnvironment == environment
+        }
+
+        let otherEnvironment: PlaidEnvironment = environment == .sandbox ? .production : .sandbox
+        let currentCacheExists = legacyTransactionCacheExists(
+            in: dataDir,
+            environment: environment,
+            legacyPath: legacyPath,
+            fileManager: fileManager
+        )
+        let otherCacheExists = legacyTransactionCacheExists(
+            in: dataDir,
+            environment: otherEnvironment,
+            legacyPath: legacyPath,
+            fileManager: fileManager
+        )
+        return currentCacheExists && !otherCacheExists
+    }
+
+    private static func legacyTransactionCacheExists(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyPath: String,
+        fileManager: FileManager
+    ) -> Bool {
+        let directory = URL(fileURLWithPath: dataDir, isDirectory: true)
+        let context = TransactionCacheContext(environment: environment, storagePath: legacyPath)
+        return fileManager.fileExists(
+            atPath: LocalDataStore.transactionCacheURL(in: directory, context: context).path
+        )
+    }
+
+    private static func copyLegacySQLiteStore(
+        from legacyPath: String,
+        to scopedPath: String,
+        fileManager: FileManager
+    ) throws {
+        var copiedPaths: [String] = []
+
+        do {
+            try fileManager.copyItem(atPath: legacyPath, toPath: scopedPath)
+            copiedPaths.append(scopedPath)
+
+            for suffix in sqliteSidecarSuffixes {
+                let sourcePath = legacyPath + suffix
+                guard fileManager.fileExists(atPath: sourcePath) else { continue }
+
+                let destinationPath = scopedPath + suffix
+                try fileManager.copyItem(atPath: sourcePath, toPath: destinationPath)
+                copiedPaths.append(destinationPath)
+            }
+        } catch {
+            for path in copiedPaths {
+                try? fileManager.removeItem(atPath: path)
+            }
+            throw error
+        }
+    }
+
+    private static func replaceScopedStoreWithLegacy(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyPath: String,
+        scopedPath: String,
+        fileManager: FileManager
+    ) throws {
+        let stagingPath = availableSQLiteStagingPath(for: scopedPath, fileManager: fileManager)
+        var storeBackupPath: String?
+        var cacheBackupPath: String?
+
+        do {
+            try copyLegacySQLiteStore(from: legacyPath, to: stagingPath, fileManager: fileManager)
+            storeBackupPath = try moveSQLiteStoreAside(at: scopedPath, fileManager: fileManager)
+            cacheBackupPath = try moveTransactionCacheAside(
+                in: dataDir,
+                environment: environment,
+                scopedDatabasePath: scopedPath,
+                fileManager: fileManager
+            )
+            try moveSQLiteStore(from: stagingPath, to: scopedPath, fileManager: fileManager)
+            copyLegacyTransactionCache(
+                in: dataDir,
+                environment: environment,
+                legacyDatabasePath: legacyPath,
+                scopedDatabasePath: scopedPath,
+                fileManager: fileManager
+            )
+            try writeLegacyMigrationMarker(
+                for: scopedPath,
+                environment: environment,
+                fileManager: fileManager
+            )
+        } catch {
+            try? removeSQLiteStore(at: scopedPath, fileManager: fileManager)
+            try? removeTransactionCache(
+                in: dataDir,
+                environment: environment,
+                scopedDatabasePath: scopedPath,
+                fileManager: fileManager
+            )
+            if let storeBackupPath {
+                try? moveSQLiteStore(from: storeBackupPath, to: scopedPath, fileManager: fileManager)
+            }
+            if let cacheBackupPath {
+                try? moveTransactionCache(
+                    from: cacheBackupPath,
+                    in: dataDir,
+                    environment: environment,
+                    scopedDatabasePath: scopedPath,
+                    fileManager: fileManager
+                )
+            }
+            try? removeSQLiteStore(at: stagingPath, fileManager: fileManager)
+            throw error
+        }
+    }
+
+    private static func installLegacyStoreIntoEmptyScopedPath(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyDatabasePath: String,
+        scopedDatabasePath: String,
+        fileManager: FileManager
+    ) throws {
+        let stagingPath = availableSQLiteStagingPath(
+            for: scopedDatabasePath,
+            fileManager: fileManager
+        )
+
+        do {
+            try copyLegacySQLiteStore(
+                from: legacyDatabasePath,
+                to: stagingPath,
+                fileManager: fileManager
+            )
+            try writeLegacyMigrationMarker(
+                for: scopedDatabasePath,
+                environment: environment,
+                fileManager: fileManager
+            )
+            try moveSQLiteStore(
+                from: stagingPath,
+                to: scopedDatabasePath,
+                fileManager: fileManager
+            )
+            copyLegacyTransactionCache(
+                in: dataDir,
+                environment: environment,
+                legacyDatabasePath: legacyDatabasePath,
+                scopedDatabasePath: scopedDatabasePath,
+                fileManager: fileManager
+            )
+        } catch {
+            try? removeSQLiteStore(at: stagingPath, fileManager: fileManager)
+            if !fileManager.fileExists(atPath: scopedDatabasePath) {
+                try? fileManager.removeItem(
+                    atPath: legacyMigrationMarkerPath(for: scopedDatabasePath)
+                )
+            }
+            throw error
+        }
+    }
+
+    private static func moveSQLiteStoreAside(
+        at path: String,
+        fileManager: FileManager
+    ) throws -> String {
+        let backupPath = availableSQLiteBackupPath(for: path, fileManager: fileManager)
+        try moveSQLiteStore(from: path, to: backupPath, fileManager: fileManager)
+        return backupPath
+    }
+
+    private static func moveSQLiteStore(
+        from path: String,
+        to destinationPath: String,
+        fileManager: FileManager
+    ) throws {
+        for storePath in sqliteStorePaths(for: path, fileManager: fileManager) {
+            let suffix = String(storePath.dropFirst(path.count))
+            try fileManager.moveItem(atPath: storePath, toPath: destinationPath + suffix)
+        }
+    }
+
+    private static func removeSQLiteStore(
+        at path: String,
+        fileManager: FileManager
+    ) throws {
+        for storePath in sqliteStorePaths(for: path, fileManager: fileManager) {
+            try fileManager.removeItem(atPath: storePath)
+        }
+    }
+
+    private static func sqliteStorePaths(
+        for path: String,
+        fileManager: FileManager
+    ) -> [String] {
+        ([path] + sqliteSidecarSuffixes.map { path + $0 })
+            .filter { fileManager.fileExists(atPath: $0) }
+    }
+
+    private static func availableSQLiteBackupPath(
+        for path: String,
+        fileManager: FileManager
+    ) -> String {
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let base = "\(path).backup-\(timestamp)"
+        guard fileManager.fileExists(atPath: base) else { return base }
+        return "\(base)-\(UUID().uuidString)"
+    }
+
+    private static func availableSQLiteStagingPath(
+        for path: String,
+        fileManager: FileManager
+    ) -> String {
+        let base = "\(path).migration-\(UUID().uuidString)"
+        guard fileManager.fileExists(atPath: base) else { return base }
+        return "\(base)-\(UUID().uuidString)"
+    }
+
+    private static func moveTransactionCacheAside(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        scopedDatabasePath: String,
+        fileManager: FileManager
+    ) throws -> String? {
+        let directory = URL(fileURLWithPath: dataDir, isDirectory: true)
+        let context = TransactionCacheContext(
+            environment: environment,
+            storagePath: scopedDatabasePath
+        )
+        let cachePath = LocalDataStore.transactionCacheURL(
+            in: directory,
+            context: context
+        ).path
+        guard fileManager.fileExists(atPath: cachePath) else { return nil }
+        let backupPath = availableTransactionCacheBackupPath(for: cachePath, fileManager: fileManager)
+
+        try fileManager.moveItem(
+            atPath: cachePath,
+            toPath: backupPath
+        )
+        return backupPath
+    }
+
+    private static func removeTransactionCache(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        scopedDatabasePath: String,
+        fileManager: FileManager
+    ) throws {
+        let cachePath = transactionCachePath(
+            in: dataDir,
+            environment: environment,
+            scopedDatabasePath: scopedDatabasePath
+        )
+        guard fileManager.fileExists(atPath: cachePath) else { return }
+        try fileManager.removeItem(atPath: cachePath)
+    }
+
+    private static func moveTransactionCache(
+        from backupPath: String,
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        scopedDatabasePath: String,
+        fileManager: FileManager
+    ) throws {
+        let cachePath = transactionCachePath(
+            in: dataDir,
+            environment: environment,
+            scopedDatabasePath: scopedDatabasePath
+        )
+        try fileManager.moveItem(atPath: backupPath, toPath: cachePath)
+    }
+
+    private static func transactionCachePath(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        scopedDatabasePath: String
+    ) -> String {
+        let directory = URL(fileURLWithPath: dataDir, isDirectory: true)
+        let context = TransactionCacheContext(
+            environment: environment,
+            storagePath: scopedDatabasePath
+        )
+        return LocalDataStore.transactionCacheURL(in: directory, context: context).path
+    }
+
+    private static func availableTransactionCacheBackupPath(
+        for path: String,
+        fileManager: FileManager
+    ) -> String {
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let base = "\(path).backup-\(timestamp)"
+        guard fileManager.fileExists(atPath: base) else { return base }
+        return "\(base)-\(UUID().uuidString)"
+    }
+
+    private static func legacyMigrationMarkerPath(for scopedPath: String) -> String {
+        "\(scopedPath).migrated-from-legacy"
+    }
+
+    private static func writeLegacyMigrationMarker(
+        for scopedPath: String,
+        environment: PlaidEnvironment,
+        fileManager: FileManager
+    ) throws {
+        let markerPath = legacyMigrationMarkerPath(for: scopedPath)
+        let contents = "environment=\(environment.rawValue)\n"
+        try Data(contents.utf8).write(
+            to: URL(fileURLWithPath: markerPath),
+            options: [.atomic]
+        )
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: markerPath)
+    }
+
+    private static func copyLegacyTransactionCache(
+        in dataDir: String,
+        environment: PlaidEnvironment,
+        legacyDatabasePath: String,
+        scopedDatabasePath: String,
+        fileManager: FileManager
+    ) {
+        let directory = URL(fileURLWithPath: dataDir, isDirectory: true)
+        let destinationContext = TransactionCacheContext(
+            environment: environment,
+            storagePath: scopedDatabasePath
+        )
+        let destinationURL = LocalDataStore.transactionCacheURL(
+            in: directory,
+            context: destinationContext
+        )
+        guard !fileManager.fileExists(atPath: destinationURL.path) else { return }
+
+        let sourceContext = TransactionCacheContext(
+            environment: environment,
+            storagePath: legacyDatabasePath
+        )
+        guard let transactions = try? LocalDataStore.loadTransactions(
+            from: directory,
+            context: sourceContext,
+            fileManager: fileManager
+        ), !transactions.isEmpty else { return }
+
+        try? LocalDataStore.saveTransactions(
+            transactions,
+            to: directory,
+            context: destinationContext,
+            fileManager: fileManager
+        )
+    }
 }
 
 enum ServerConfigError: LocalizedError {
     case missingEnvironmentVariable(String)
+    case invalidEnvironmentVariable(String, String)
 
     var errorDescription: String? {
         switch self {
         case .missingEnvironmentVariable(let name):
             "Missing required environment variable: \(name)"
+        case .invalidEnvironmentVariable(let name, let value):
+            "Invalid value for \(name): \(value)"
         }
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -37,6 +37,185 @@ struct PlaidBarServerTests {
         #expect(decoded.syncReady)
     }
 
+    @Test func serverDatabasePathIsScopedByPlaidEnvironment() {
+        let dataDir = "/tmp/plaidbar-test-data"
+
+        let sandboxPath = ServerConfig.databasePath(in: dataDir, environment: .sandbox)
+        let productionPath = ServerConfig.databasePath(in: dataDir, environment: .production)
+
+        #expect(sandboxPath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(productionPath.hasSuffix("/plaidbar-production.sqlite"))
+        #expect(sandboxPath != productionPath)
+    }
+
+    @Test func serverCopiesLegacyDatabaseIntoFirstScopedEnvironment() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let legacyURL = directory.appendingPathComponent(ServerConfig.legacyDatabaseFilename)
+        try Data("legacy".utf8).write(to: legacyURL)
+        try Data("wal".utf8).write(to: URL(fileURLWithPath: legacyURL.path + "-wal"))
+        try Data("shm".utf8).write(to: URL(fileURLWithPath: legacyURL.path + "-shm"))
+        try Data("journal".utf8).write(to: URL(fileURLWithPath: legacyURL.path + "-journal"))
+        let legacyCacheContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: legacyURL.path
+        )
+        let cachedTransactions = [
+            TransactionDTO(id: "tx-old", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")
+        ]
+        try LocalDataStore.saveTransactions(
+            cachedTransactions,
+            to: directory,
+            context: legacyCacheContext
+        )
+
+        let sandboxPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .sandbox
+        )
+
+        #expect(sandboxPath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(FileManager.default.fileExists(atPath: sandboxPath))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxPath + "-wal")) == Data("wal".utf8))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxPath + "-shm")) == Data("shm".utf8))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxPath + "-journal")) == Data("journal".utf8))
+        #expect(!FileManager.default.fileExists(
+            atPath: ServerConfig.databasePath(in: directory.path, environment: .production)
+        ))
+        let migratedCache = try LocalDataStore.loadTransactions(
+            from: directory,
+            context: TransactionCacheContext(environment: .sandbox, storagePath: sandboxPath)
+        )
+        #expect(migratedCache.map(\.id) == ["tx-old"])
+    }
+
+    @Test func serverDoesNotCopyAmbiguousLegacyDatabase() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let legacyURL = directory.appendingPathComponent(ServerConfig.legacyDatabaseFilename)
+        try Data("legacy".utf8).write(to: legacyURL)
+
+        let sandboxPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .sandbox
+        )
+
+        #expect(sandboxPath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(!FileManager.default.fileExists(atPath: sandboxPath))
+    }
+
+    @Test func serverCopiesExplicitLegacyDatabaseEnvironment() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let legacyURL = directory.appendingPathComponent(ServerConfig.legacyDatabaseFilename)
+        try Data("legacy".utf8).write(to: legacyURL)
+
+        let productionPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .production,
+            legacyMigrationEnvironment: .production
+        )
+
+        #expect(productionPath.hasSuffix("/plaidbar-production.sqlite"))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: productionPath)) == Data("legacy".utf8))
+    }
+
+    @Test func serverBacksUpExistingScopedDatabaseBeforeExplicitLegacyMigration() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let legacyURL = directory.appendingPathComponent(ServerConfig.legacyDatabaseFilename)
+        try Data("legacy".utf8).write(to: legacyURL)
+        let productionPath = ServerConfig.databasePath(in: directory.path, environment: .production)
+        try Data("empty-production-db".utf8).write(to: URL(fileURLWithPath: productionPath))
+        let legacyCacheContext = TransactionCacheContext(
+            environment: .production,
+            storagePath: legacyURL.path
+        )
+        let scopedCacheContext = TransactionCacheContext(
+            environment: .production,
+            storagePath: productionPath
+        )
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "tx-legacy", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")],
+            to: directory,
+            context: legacyCacheContext
+        )
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "tx-stale", accountId: "checking", amount: 20, date: "2026-01-02", name: "Lunch")],
+            to: directory,
+            context: scopedCacheContext
+        )
+
+        let migratedPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .production,
+            legacyMigrationEnvironment: .production
+        )
+
+        let backupFiles = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            .filter { $0.hasPrefix("plaidbar-production.sqlite.backup-") }
+
+        #expect(migratedPath == productionPath)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: productionPath)) == Data("legacy".utf8))
+        #expect(backupFiles.count == 1)
+        #expect(try Data(contentsOf: directory.appendingPathComponent(backupFiles[0])) == Data("empty-production-db".utf8))
+        #expect(try LocalDataStore.loadTransactions(
+            from: directory,
+            context: scopedCacheContext
+        ).map(\.id) == ["tx-legacy"])
+
+        try Data("new-production-db".utf8).write(to: URL(fileURLWithPath: productionPath))
+        let restartedPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .production,
+            legacyMigrationEnvironment: .production
+        )
+
+        #expect(restartedPath == productionPath)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: productionPath)) == Data("new-production-db".utf8))
+    }
+
+    @Test func serverCanCopyLegacyDatabaseAfterWrongEnvironmentCreatedEmptyDatabase() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let legacyURL = directory.appendingPathComponent(ServerConfig.legacyDatabaseFilename)
+        try Data("legacy".utf8).write(to: legacyURL)
+        let sandboxCacheContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: legacyURL.path
+        )
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "tx-old", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")],
+            to: directory,
+            context: sandboxCacheContext
+        )
+        let productionPath = ServerConfig.databasePath(in: directory.path, environment: .production)
+        try Data("empty-production-db".utf8).write(to: URL(fileURLWithPath: productionPath))
+
+        let sandboxPath = try ServerConfig.databasePathForStartup(
+            in: directory.path,
+            environment: .sandbox
+        )
+
+        #expect(sandboxPath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxPath)) == Data("legacy".utf8))
+    }
+
     @Test func linkResponseCodable() throws {
         let response = LinkResponse(linkToken: "token_123", linkUrl: "https://example.com/link")
         let data = try JSONEncoder().encode(response)


### PR DESCRIPTION
## Summary
- Store sandbox and production Plaid Items in separate SQLite databases.
- Avoid unsafe automatic legacy migration: legacy `plaidbar.sqlite` migrates only when the environment is explicit or inferred from transaction-cache context.
- Preserve SQLite sidecars and transaction cache during migration, back up existing scoped stores/caches for explicit migration, and write a marker to keep migration idempotent.
- Document scoped storage and add server config migration tests.

## Test plan
- `git diff --check`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- Codex review: no actionable code issues; docs wording fixed after P3 note

## Notes
- Local full `swift test` remains blocked by this Mac's CommandLineTools Swift Testing/toolchain mismatch; GitHub CI runs full tests.