### PR TITLE
Fail transaction sync when every linked item fails

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -512,6 +512,7 @@ final class AppState {
                 self.error = "Transaction cache failed to save: \(cachePersistenceError.localizedDescription)"
             }
         } catch {
+            itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
             self.error = error.localizedDescription
         }
     }

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -36,9 +36,12 @@ struct TransactionRoutes: Sendable {
         var allRemoved: [String] = []
         var hasMore = false
         var latestCursor: String?
+        var attemptedItemCount = 0
+        var successfulItemCount = 0
 
         for item in items {
             guard let itemId = item.id else { continue }
+            attemptedItemCount += 1
 
             let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
             let response: PlaidTransactionsSyncResponse
@@ -48,6 +51,7 @@ struct TransactionRoutes: Sendable {
                     cursor: cursor
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+                successfulItemCount += 1
             } catch {
                 try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
                 continue
@@ -70,6 +74,10 @@ struct TransactionRoutes: Sendable {
             }
         }
 
+        if Self.shouldFailSync(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
+            throw HTTPError(.badGateway, message: "Plaid transaction sync failed for every linked item")
+        }
+
         let syncResponse = SyncResponse(
             added: allAdded,
             modified: allModified,
@@ -87,6 +95,10 @@ struct TransactionRoutes: Sendable {
     }
 
     // MARK: - Helpers
+
+    static func shouldFailSync(attemptedItemCount: Int, successfulItemCount: Int) -> Bool {
+        attemptedItemCount > 0 && successfulItemCount == 0
+    }
 
     private static func toDTO(_ plaidTx: PlaidTransaction) -> TransactionDTO {
         let category: SpendingCategory? = plaidTx.personalFinanceCategory.flatMap {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -216,6 +216,14 @@ struct PlaidBarServerTests {
         #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxPath)) == Data("legacy".utf8))
     }
 
+    @Test func transactionSyncFailsOnlyWhenEveryAttemptedItemFails() {
+        #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 0, successfulItemCount: 0))
+        #expect(TransactionRoutes.shouldFailSync(attemptedItemCount: 1, successfulItemCount: 0))
+        #expect(TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 0))
+        #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 1))
+        #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 3))
+    }
+
     @Test func linkResponseCodable() throws {
         let response = LinkResponse(linkToken: "token_123", linkUrl: "https://example.com/link")
         let data = try JSONEncoder().encode(response)


### PR DESCRIPTION
## Summary
- Track attempted and successful Plaid Item transaction syncs.
- Return 502 when every attempted linked item fails instead of returning a successful empty sync response.
- Keep partial-success sync behavior intact.
- Refresh item statuses in the app when transaction sync fails so reconnect/error state is visible.

## Test plan
- `git diff --check`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- Codex review: no actionable correctness issues

## Notes
- Local full `swift test` remains blocked by this Mac's CommandLineTools Swift Testing/toolchain mismatch; GitHub CI runs full tests.