### PR TITLE
Respect custom PlaidBar server port

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,8 @@ All types are `Codable`, `Sendable`, and `Hashable` where appropriate.
 
 ### PlaidBarServer (Hummingbird 2)
 
-The companion server. Binds to `127.0.0.1:8484`.
+The companion server. Binds to `127.0.0.1:8484` by default, or the
+`PLAIDBAR_SERVER_PORT` / `--port` override when configured.
 
 **Routes:**
 
@@ -215,7 +216,7 @@ No data races by construction.
 
 1. Environment variables: `PLAID_CLIENT_ID`, `PLAID_SECRET`
 2. CLI flags: `--port`, `--sandbox`, `--config`
-3. Defaults: port 8484, sandbox mode if `--sandbox` flag
+3. Defaults: port 8484 unless `PLAIDBAR_SERVER_PORT` / `--port` is set, sandbox mode if `--sandbox` flag
 
 ### Data Storage
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ swift test
 # Run server standalone
 swift run PlaidBarServer --sandbox
 
+# Run server/app on a custom localhost port
+PLAIDBAR_SERVER_PORT=9494 ./Scripts/run.sh --sandbox
+
 # Run both (server + app)
 ./Scripts/run.sh --sandbox
 

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -3,9 +3,27 @@ import Foundation
 public enum PlaidBarConstants {
     public static let defaultServerPort: Int = 8484
     public static let defaultServerHost: String = "127.0.0.1"
+    public static let serverPortEnvironmentVariable: String = "PLAIDBAR_SERVER_PORT"
 
     public static var serverBaseURL: String {
-        "http://\(defaultServerHost):\(defaultServerPort)"
+        serverBaseURL(environment: ProcessInfo.processInfo.environment)
+    }
+
+    public static var serverPort: Int {
+        serverPort(environment: ProcessInfo.processInfo.environment)
+    }
+
+    public static func serverBaseURL(environment: [String: String]) -> String {
+        "http://\(defaultServerHost):\(serverPort(environment: environment))"
+    }
+
+    public static func serverPort(environment: [String: String]) -> Int {
+        guard let rawPort = environment[serverPortEnvironmentVariable]?.trimmedNonEmpty,
+              let port = Int(rawPort),
+              (1...65_535).contains(port) else {
+            return defaultServerPort
+        }
+        return port
     }
 
     // Refresh intervals
@@ -26,5 +44,14 @@ public enum PlaidBarConstants {
     public static let appName: String = "PlaidBar"
 
     // Plaid
-    public static let plaidSandboxRedirectUri: String = "http://localhost:8484/oauth/callback"
+    public static var plaidSandboxRedirectUri: String {
+        "http://localhost:\(serverPort)/oauth/callback"
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
 }

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -4,11 +4,12 @@ import Hummingbird
 import HummingbirdFluent
 import FluentSQLiteDriver
 import Logging
+import PlaidBarCore
 
 @main
 struct PlaidBarServer: AsyncParsableCommand {
     @Option(name: .long, help: "Server port")
-    var port: Int = 8484
+    var port: Int = PlaidBarConstants.serverPort
 
     @Flag(name: .long, help: "Use Plaid sandbox environment")
     var sandbox: Bool = false

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -72,7 +72,7 @@ struct ServerConfig: Sendable {
             authToken = generated
         }
 
-        let resolvedPort = portOverride ?? PlaidBarConstants.defaultServerPort
+        let resolvedPort = portOverride ?? PlaidBarConstants.serverPort
 
         return ServerConfig(
             port: resolvedPort,

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -606,7 +606,13 @@ struct PlaidBarCoreTests {
 
     @Test("Server URL uses correct port and host")
     func serverURL() {
-        #expect(PlaidBarConstants.serverBaseURL == "http://127.0.0.1:8484")
+        #expect(PlaidBarConstants.serverBaseURL(environment: [:]) == "http://127.0.0.1:8484")
+        #expect(PlaidBarConstants.serverBaseURL(environment: [
+            PlaidBarConstants.serverPortEnvironmentVariable: "9494",
+        ]) == "http://127.0.0.1:9494")
+        #expect(PlaidBarConstants.serverBaseURL(environment: [
+            PlaidBarConstants.serverPortEnvironmentVariable: "not-a-port",
+        ]) == "http://127.0.0.1:8484")
         #expect(PlaidBarConstants.defaultServerPort == 8484)
         #expect(PlaidBarConstants.defaultServerHost == "127.0.0.1")
     }


### PR DESCRIPTION
## Summary
- Make the app and server derive the local server port from `PLAIDBAR_SERVER_PORT` when set.
- Keep `--port` as the explicit server override while aligning direct server launches and app clients.
- Document the custom-port run path and update architecture notes.

## Test plan
- `git diff --check`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SERVER_PORT=18488 PLAIDBAR_SMOKE_PORT=18488 ./Scripts/smoke-sandbox.sh`
- Direct server env-port smoke: launched `.build/debug/PlaidBarServer --sandbox` with `PLAIDBAR_SERVER_PORT=18489` and verified `/health` on 18489
- Codex review: no actionable correctness issues after updating the server side too

## Notes
- Local `swift test` remains blocked by this Mac's CommandLineTools Swift Testing/toolchain mismatch; GitHub CI runs full tests.
