### PR TITLE
Escape OAuth callback error messages

### DIFF
--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -204,17 +204,28 @@ struct OAuthCallbackRoute: Sendable {
         """
     }
 
-    private static func errorPage(_ message: String) -> String {
-        """
+    static func errorPage(_ message: String) -> String {
+        let escapedMessage = message.htmlEscaped
+        return """
         <!DOCTYPE html>
         <html>
         <head><title>PlaidBar -- Error</title></head>
         <body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;">
             <h1>Connection Error</h1>
-            <p>\(message)</p>
+            <p>\(escapedMessage)</p>
             <p>Please try again from PlaidBar.</p>
         </body>
         </html>
         """
+    }
+}
+
+private extension String {
+    var htmlEscaped: String {
+        replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -37,6 +37,14 @@ struct PlaidBarServerTests {
         #expect(decoded.syncReady)
     }
 
+    @Test func oauthCallbackErrorPageEscapesDynamicMessage() {
+        let html = OAuthCallbackRoute.errorPage("<script>alert('x')</script> & retry \"soon\"")
+
+        #expect(!html.contains("<script>"))
+        #expect(html.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"))
+        #expect(html.contains("&amp; retry &quot;soon&quot;"))
+    }
+
     @Test func serverDatabasePathIsScopedByPlaidEnvironment() {
         let dataDir = "/tmp/plaidbar-test-data"
 


### PR DESCRIPTION
## Summary
- Escape dynamic error text before rendering it into the OAuth callback HTML page.
- Add a regression test for script-like, ampersand, quote, and apostrophe content.

## Test plan
- `git diff --check`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- Codex review: no actionable correctness issues

## Notes
- Local `swift test --filter oauthCallbackErrorPageEscapesDynamicMessage` remains blocked by this Mac's CommandLineTools Swift Testing/toolchain mismatch; GitHub CI runs full tests.
