### PR TITLE
Support PlaidBar server config files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,9 +214,19 @@ No data races by construction.
 
 ### Server Config Resolution
 
-1. Environment variables: `PLAID_CLIENT_ID`, `PLAID_SECRET`
-2. CLI flags: `--port`, `--sandbox`, `--config`
-3. Defaults: port 8484 unless `PLAIDBAR_SERVER_PORT` / `--port` is set, sandbox mode if `--sandbox` flag
+1. Environment variables: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `PLAIDBAR_SERVER_PORT`, `PLAIDBAR_DATA_DIR`
+2. Optional config file from `--config`, using the same `KEY=value` names as the environment
+3. CLI overrides: `--port`, `--sandbox`
+4. Defaults: production mode and port 8484 unless overridden
+
+When a config file is provided, its values override the inherited process
+environment. Explicit CLI flags still win so one-off launches can safely
+override a checked local config.
+
+The menu bar app does not read the server config file directly. If server config
+changes `PLAIDBAR_SERVER_PORT` or `PLAIDBAR_DATA_DIR`, the same values must be in
+the app process environment so `ServerClient` reaches the correct server and
+auth-token path.
 
 ### Data Storage
 
@@ -239,13 +249,13 @@ data.
 
 ## Testing Strategy
 
-61 tests across 3 suites, all using Swift Testing framework:
+Unit tests span 3 suites, all using Swift Testing framework:
 
-| Suite | Tests | Coverage |
-|-------|-------|----------|
-| PlaidBarCoreTests | 36 | DTOs, formatters, constants, Codable roundtrips |
-| PlaidBarServerTests | 5 | Plaid response decoding, config, type conversion |
-| PlaidBarTests | 20 | Business logic: net balance, spending aggregation, filtering |
+| Suite | Coverage |
+|-------|----------|
+| PlaidBarCoreTests | DTOs, formatters, constants, Codable roundtrips |
+| PlaidBarServerTests | Plaid response decoding, config, type conversion |
+| PlaidBarTests | Business logic: net balance, spending aggregation, filtering |
 
 Server integration tests (starting Hummingbird, making HTTP calls) are planned for v0.2.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,29 @@ export PLAID_SECRET=your_secret
 
 Get credentials free at [dashboard.plaid.com](https://dashboard.plaid.com). Sandbox credentials can be used immediately; production requires Plaid approval.
 
+You can also keep server settings in a local key-value config file and pass it
+to the standalone server:
+
+```bash
+mkdir -p ~/.plaidbar
+cat > ~/.plaidbar/server.conf <<'EOF'
+PLAID_CLIENT_ID=your_client_id
+PLAID_SECRET=your_secret
+PLAID_ENV=sandbox
+PLAIDBAR_DATA_DIR=~/.plaidbar
+EOF
+
+swift run PlaidBarServer --config ~/.plaidbar/server.conf
+```
+
+The config file uses the same keys as the environment. Values in the config
+file override the process environment; explicit CLI flags like `--port` and
+`--sandbox` override both.
+
+If the config file sets `PLAIDBAR_SERVER_PORT` or `PLAIDBAR_DATA_DIR` to a
+non-default value, export the same values before launching PlaidBar so the app
+connects to the right port and reads the same local auth token.
+
 ## Data Modes
 
 | Mode | Command | Plaid network calls | Data source | Intended use |
@@ -254,11 +277,14 @@ swift build
 # Build release
 swift build -c release
 
-# Run tests (61 tests)
+# Run tests
 swift test
 
 # Run server standalone
 swift run PlaidBarServer --sandbox
+
+# Run server with a local config file
+swift run PlaidBarServer --config ~/.plaidbar/server.conf
 
 # Run server/app on a custom localhost port
 PLAIDBAR_SERVER_PORT=9494 ./Scripts/run.sh --sandbox

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -9,7 +9,7 @@ import PlaidBarCore
 @main
 struct PlaidBarServer: AsyncParsableCommand {
     @Option(name: .long, help: "Server port")
-    var port: Int = PlaidBarConstants.serverPort
+    var port: Int?
 
     @Flag(name: .long, help: "Use Plaid sandbox environment")
     var sandbox: Bool = false
@@ -23,7 +23,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         let serverConfig = try ServerConfig.load(
             from: config,
             portOverride: port,
-            sandboxOverride: sandbox
+            sandboxOverride: sandbox ? true : nil
         )
 
         // Set up Fluent with SQLite

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -26,7 +26,8 @@ struct ServerConfig: Sendable {
         portOverride: Int? = nil,
         sandboxOverride: Bool? = nil
     ) throws -> ServerConfig {
-        let dataDir = dataDirectory()
+        let environmentValues = try resolvedEnvironment(from: configPath)
+        let dataDir = dataDirectory(environment: environmentValues)
         try FileManager.default.createDirectory(
             atPath: dataDir,
             withIntermediateDirectories: true
@@ -36,11 +37,11 @@ struct ServerConfig: Sendable {
             ofItemAtPath: dataDir
         )
 
-        let environment: PlaidEnvironment = (sandboxOverride == true)
-            ? .sandbox
-            : .production
+        let environment = try plaidEnvironment(
+            from: environmentValues,
+            sandboxOverride: sandboxOverride
+        )
 
-        let environmentValues = ProcessInfo.processInfo.environment
         guard let clientId = environmentValues["PLAID_CLIENT_ID"]?.trimmedNonEmpty else {
             throw ServerConfigError.missingEnvironmentVariable("PLAID_CLIENT_ID")
         }
@@ -72,7 +73,7 @@ struct ServerConfig: Sendable {
             authToken = generated
         }
 
-        let resolvedPort = portOverride ?? PlaidBarConstants.serverPort
+        let resolvedPort = portOverride ?? PlaidBarConstants.serverPort(environment: environmentValues)
 
         return ServerConfig(
             port: resolvedPort,
@@ -90,7 +91,11 @@ struct ServerConfig: Sendable {
     }
 
     static func dataDirectory() -> String {
-        LocalDataStore.storageDirectoryURL().path
+        dataDirectory(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func dataDirectory(environment: [String: String]) -> String {
+        LocalDataStore.storageDirectoryURL(environment: environment).path
     }
 
     static func databaseFilename(for environment: PlaidEnvironment) -> String {
@@ -168,6 +173,79 @@ struct ServerConfig: Sendable {
             )
         }
         return environment
+    }
+
+    private static func plaidEnvironment(
+        from environmentValues: [String: String],
+        sandboxOverride: Bool?
+    ) throws -> PlaidEnvironment {
+        if let sandboxOverride {
+            return sandboxOverride ? .sandbox : .production
+        }
+
+        guard let value = environmentValues["PLAID_ENV"]?.trimmedNonEmpty else {
+            return .production
+        }
+        guard let environment = PlaidEnvironment(rawValue: value) else {
+            throw ServerConfigError.invalidEnvironmentVariable("PLAID_ENV", value)
+        }
+        return environment
+    }
+
+    private static func resolvedEnvironment(from configPath: String?) throws -> [String: String] {
+        var environmentValues = ProcessInfo.processInfo.environment
+        guard let configPath = configPath?.trimmedNonEmpty else {
+            return environmentValues
+        }
+
+        let configValues = try loadConfigFile(at: configPath)
+        for (key, value) in configValues {
+            environmentValues[key] = value
+        }
+        return environmentValues
+    }
+
+    private static func loadConfigFile(at path: String) throws -> [String: String] {
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        let contents = try String(
+            contentsOfFile: expandedPath,
+            encoding: .utf8
+        )
+        var values: [String: String] = [:]
+
+        for (offset, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
+            var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+
+            if line.hasPrefix("export ") {
+                line.removeFirst("export ".count)
+                line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            guard let separator = line.firstIndex(of: "=") else {
+                throw ServerConfigError.invalidConfigLine(path: expandedPath, line: offset + 1)
+            }
+
+            let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawValue = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else {
+                throw ServerConfigError.invalidConfigLine(path: expandedPath, line: offset + 1)
+            }
+            values[key] = unquote(rawValue)
+        }
+
+        return values
+    }
+
+    private static func unquote(_ value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              let last = value.last,
+              (first == "\"" && last == "\"") || (first == "'" && last == "'")
+        else {
+            return value
+        }
+        return String(value.dropFirst().dropLast())
     }
 
     private static func shouldMigrateLegacyDatabase(
@@ -533,6 +611,7 @@ struct ServerConfig: Sendable {
 enum ServerConfigError: LocalizedError {
     case missingEnvironmentVariable(String)
     case invalidEnvironmentVariable(String, String)
+    case invalidConfigLine(path: String, line: Int)
 
     var errorDescription: String? {
         switch self {
@@ -540,6 +619,8 @@ enum ServerConfigError: LocalizedError {
             "Missing required environment variable: \(name)"
         case .invalidEnvironmentVariable(let name, let value):
             "Invalid value for \(name): \(value)"
+        case .invalidConfigLine(let path, let line):
+            "Invalid config line \(line) in \(path)"
         }
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -37,6 +37,66 @@ struct PlaidBarServerTests {
         #expect(decoded.syncReady)
     }
 
+    @Test func serverConfigLoadsExplicitConfigFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        let configContents = [
+            "# PlaidBar server config",
+            "PLAID_CLIENT_ID=config-client",
+            "export PLAID_SECRET=\"config-secret\"",
+            "PLAID_ENV=sandbox",
+            "PLAIDBAR_SERVER_PORT=9494",
+            "PLAIDBAR_DATA_DIR='\(dataDirectory.path)'",
+        ].joined(separator: "\r\n") + "\r\n"
+        try configContents.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let config = try ServerConfig.load(from: configURL.path)
+
+        #expect(config.plaidClientId == "config-client")
+        #expect(config.plaidSecret == "config-secret")
+        #expect(config.plaidEnvironment == .sandbox)
+        #expect(config.port == 9494)
+        #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(config.databasePath.hasPrefix(dataDirectory.path))
+        #expect(config.redirectUri == "http://localhost:9494/oauth/callback")
+        #expect(FileManager.default.fileExists(
+            atPath: dataDirectory.appendingPathComponent(LocalDataStore.authTokenFilename).path
+        ))
+    }
+
+    @Test func serverConfigCliOverridesConfigFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=config-client
+        PLAID_SECRET=config-secret
+        PLAID_ENV=production
+        PLAIDBAR_SERVER_PORT=9494
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let config = try ServerConfig.load(
+            from: configURL.path,
+            portOverride: 9595,
+            sandboxOverride: true
+        )
+
+        #expect(config.plaidEnvironment == .sandbox)
+        #expect(config.port == 9595)
+        #expect(config.redirectUri == "http://localhost:9595/oauth/callback")
+        #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
+    }
+
     @Test func serverDatabasePathIsScopedByPlaidEnvironment() {
         let dataDir = "/tmp/plaidbar-test-data"
 


### PR DESCRIPTION
## Summary\n- make PlaidBarServer --config load local KEY=value config files instead of silently ignoring them\n- allow config-backed PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENV, PLAIDBAR_SERVER_PORT, PLAIDBAR_DATA_DIR, with CLI --port/--sandbox taking precedence\n- document config precedence and add coverage for quoted/CRLF config files and CLI overrides\n\n## Verification\n- git diff --check\n- swift build --target PlaidBarServer --skip-update --disable-keychain\n- swift build --target PlaidBar --skip-update --disable-keychain\n- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh\n- CRLF config-file launch smoke on port 18488\n- codex exec review --base origin/main --title "Support PlaidBar server config files"\n\nNote: local swift test is still blocked on this Mac by missing Swift Testing module/toolchain mismatch; GitHub CI is the full-test gate.