### PR TITLE
Harden local cache file permissions

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -173,7 +173,7 @@ struct GeneralSettingsView: View {
 
     private func revealStorageDirectory() {
         let url = appState.localStorageDirectoryURL
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try? LocalDataStore.prepareStorageDirectory(at: url)
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -32,6 +32,8 @@ public enum LocalDataStore {
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
     public static let authTokenFilename = "auth-token"
     public static let transactionCacheFilename = "transactions.json"
+    private static let directoryPermissions = 0o700
+    private static let cacheFilePermissions = 0o600
 
     public static func accountHomeDirectoryURL() -> URL {
         #if os(macOS)
@@ -81,7 +83,7 @@ public enum LocalDataStore {
             }
         }
 
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
 
         return LocalDataResetResult(
             directoryPath: directory.path,
@@ -100,6 +102,13 @@ public enum LocalDataStore {
         in directory: URL = storageDirectoryURL()
     ) -> URL {
         directory.appendingPathComponent(authTokenFilename)
+    }
+
+    public static func prepareStorageDirectory(
+        at directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws {
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
     }
 
     public static func loadTransactions(
@@ -122,12 +131,13 @@ public enum LocalDataStore {
         context: TransactionCacheContext? = nil,
         fileManager: FileManager = .default
     ) throws {
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
 
         let url = transactionCacheURL(in: directory, context: context)
         let cache = TransactionCache(context: context, transactions: transactions)
         let data = try JSONEncoder().encode(cache)
         try data.write(to: url, options: [.atomic])
+        try setPrivateCacheFilePermissions(url, fileManager: fileManager)
     }
 
     private static func transactionCacheFilename(for context: TransactionCacheContext?) -> String {
@@ -144,6 +154,31 @@ public enum LocalDataStore {
             hash &*= 1_099_511_628_211
         }
         return String(format: "%016llx", hash)
+    }
+
+    private static func ensurePrivateDirectory(
+        _ directory: URL,
+        fileManager: FileManager
+    ) throws {
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: directoryPermissions]
+        )
+        try fileManager.setAttributes(
+            [.posixPermissions: directoryPermissions],
+            ofItemAtPath: directory.path
+        )
+    }
+
+    private static func setPrivateCacheFilePermissions(
+        _ url: URL,
+        fileManager: FileManager
+    ) throws {
+        try fileManager.setAttributes(
+            [.posixPermissions: cacheFilePermissions],
+            ofItemAtPath: url.path
+        )
     }
 }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -892,6 +892,36 @@ struct PlaidBarCoreTests {
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
     }
 
+    @Test("Local data reset keeps data directory private")
+    func localDataResetKeepsDirectoryPrivate() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+
+        try LocalDataStore.resetLocalData(at: directory)
+
+        #expect(try posixPermissions(at: directory) == 0o700)
+    }
+
+    @Test("Preparing storage directory keeps it private")
+    func prepareStorageDirectoryKeepsDirectoryPrivate() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try LocalDataStore.prepareStorageDirectory(at: directory)
+
+        #expect(try posixPermissions(at: directory) == 0o700)
+    }
+
     @Test("Transaction cache survives incremental sync from existing cursor")
     func transactionCacheMergesIncrementalSync() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -927,6 +957,24 @@ struct PlaidBarCoreTests {
         #expect(LocalDataStore.transactionCacheURL(in: directory, context: context).lastPathComponent != LocalDataStore.transactionCacheFilename)
     }
 
+    @Test("Transaction cache saves with private file permissions")
+    func transactionCacheSavesWithPrivatePermissions() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let context = TransactionCacheContext(environment: .sandbox, storagePath: "\(directory.path)/plaidbar.sqlite")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "txn", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")],
+            to: directory,
+            context: context
+        )
+
+        #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(try posixPermissions(at: LocalDataStore.transactionCacheURL(in: directory, context: context)) == 0o600)
+    }
+
     @Test("Transaction cache persists account removal cleanup")
     func transactionCachePersistsAccountRemovalCleanup() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -947,5 +995,10 @@ struct PlaidBarCoreTests {
 
         let reloaded = try LocalDataStore.loadTransactions(from: directory, context: context)
         #expect(reloaded.map(\.id) == ["keep"])
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
     }
 }


### PR DESCRIPTION
## Summary
- force PlaidBar local data directories to 0700 when resetting or writing transaction caches
- force transaction cache JSON files to 0600 after atomic writes
- add core tests covering private directory and cache-file modes

## Verification
- git diff --check
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift build --target PlaidBar --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18489 ./Scripts/smoke-sandbox.sh
- codex exec review --base origin/main --title "Harden local cache permissions"

Note: local swift test is still blocked on this Mac by missing Swift Testing module (no such module 'Testing'); CI runs the full test suite.