### PR TITLE
Preserve transaction cache after item removal

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -578,12 +578,28 @@ final class AppState {
         do {
             try await serverClient.removeItem(itemId: itemId)
             let removedItemId = itemId
-            let accountIdsForItem = Set(
+            let removedAccountIds = Set(
                 accounts.filter { $0.itemId == removedItemId }.map(\.id)
             )
             accounts.removeAll { $0.itemId == removedItemId }
-            transactions.removeAll { accountIdsForItem.contains($0.accountId) }
-            serverItemCount = Set(accounts.map(\.itemId)).count
+            let fallbackItemCount = Set(accounts.map(\.itemId)).count
+            if let refreshedItemStatuses = try? await serverClient.getItems() {
+                itemStatuses = refreshedItemStatuses
+                serverItemCount = refreshedItemStatuses.count
+            } else {
+                itemStatuses.removeAll { $0.id == removedItemId }
+                serverItemCount = max(itemStatuses.count, fallbackItemCount)
+            }
+            let remainingItemCount = serverItemCount ?? 0
+            serverSyncReady = remainingItemCount > 0
+            isSetupComplete = remainingItemCount > 0
+            if remainingItemCount == 0 {
+                lastSyncDate = nil
+            }
+            transactions.removeAll { transaction in
+                transaction.itemId == removedItemId ||
+                    (transaction.itemId == nil && removedAccountIds.contains(transaction.accountId))
+            }
             do {
                 try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
             } catch {
@@ -701,7 +717,11 @@ final class AppState {
 
     private func clearCachedTransactions() {
         transactions = []
-        try? LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+        do {
+            try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+        } catch {
+            self.error = "Transaction cache failed to clear: \(error.localizedDescription)"
+        }
     }
 
     private var transactionCacheContext: TransactionCacheContext? {

--- a/Sources/PlaidBarCore/Models/TransactionDTO.swift
+++ b/Sources/PlaidBarCore/Models/TransactionDTO.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
     public let id: String           // Plaid transaction_id
+    public let itemId: String?      // Plaid item_id, available for newly synced transactions
     public let accountId: String
     public let amount: Double       // Positive = money out, Negative = money in (Plaid convention)
     public let date: String         // YYYY-MM-DD
@@ -13,6 +14,7 @@ public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
 
     public init(
         id: String,
+        itemId: String? = nil,
         accountId: String,
         amount: Double,
         date: String,
@@ -23,6 +25,7 @@ public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
         isoCurrencyCode: String? = nil
     ) {
         self.id = id
+        self.itemId = itemId
         self.accountId = accountId
         self.amount = amount
         self.date = date

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -57,8 +57,8 @@ struct TransactionRoutes: Sendable {
                 continue
             }
 
-            allAdded.append(contentsOf: response.added.map { Self.toDTO($0) })
-            allModified.append(contentsOf: response.modified.map { Self.toDTO($0) })
+            allAdded.append(contentsOf: response.added.map { Self.toDTO($0, itemId: itemId) })
+            allModified.append(contentsOf: response.modified.map { Self.toDTO($0, itemId: itemId) })
             allRemoved.append(contentsOf: response.removed.map(\.transactionId))
 
             if !response.nextCursor.isEmpty {
@@ -100,13 +100,14 @@ struct TransactionRoutes: Sendable {
         attemptedItemCount > 0 && successfulItemCount == 0
     }
 
-    private static func toDTO(_ plaidTx: PlaidTransaction) -> TransactionDTO {
+    private static func toDTO(_ plaidTx: PlaidTransaction, itemId: String) -> TransactionDTO {
         let category: SpendingCategory? = plaidTx.personalFinanceCategory.flatMap {
             SpendingCategory(rawValue: $0.primary)
         }
 
         return TransactionDTO(
             id: plaidTx.transactionId,
+            itemId: itemId,
             accountId: plaidTx.accountId,
             amount: plaidTx.amount,
             date: plaidTx.date,

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -84,6 +84,42 @@ struct PlaidBarCoreTests {
         #expect(tx.displayAmount == 0)
     }
 
+    @Test("TransactionDTO preserves item ID when encoded")
+    func transactionItemIdCodable() throws {
+        let tx = TransactionDTO(
+            id: "6",
+            itemId: "item_1",
+            accountId: "a",
+            amount: 42,
+            date: "2026-01-15",
+            name: "Coffee"
+        )
+
+        let data = try JSONEncoder().encode(tx)
+        let decoded = try JSONDecoder().decode(TransactionDTO.self, from: data)
+
+        #expect(decoded.itemId == "item_1")
+    }
+
+    @Test("TransactionDTO decodes legacy cache without item ID")
+    func transactionLegacyCacheDecodesWithoutItemId() throws {
+        let data = Data("""
+        {
+          "id": "legacy",
+          "accountId": "a",
+          "amount": 42,
+          "date": "2026-01-15",
+          "name": "Coffee",
+          "pending": false
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(TransactionDTO.self, from: data)
+
+        #expect(decoded.itemId == nil)
+        #expect(decoded.id == "legacy")
+    }
+
     @Test("Spending heatmap fills every day in range")
     func spendingHeatmapFillsDateRange() {
         let start = Formatters.parseTransactionDate("2026-01-01")!

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -253,10 +253,14 @@ struct PlaidBarTests {
 
         // Verify transaction cleanup would work
         var transactions = [
-            TransactionDTO(id: "tx1", accountId: "a1", amount: 10, date: "2026-01-15", name: "X"),
-            TransactionDTO(id: "tx2", accountId: "a3", amount: 20, date: "2026-01-15", name: "Y"),
+            TransactionDTO(id: "tx1", itemId: "item_1", accountId: "stale_a1", amount: 10, date: "2026-01-15", name: "X"),
+            TransactionDTO(id: "tx2", itemId: "item_2", accountId: "a3", amount: 20, date: "2026-01-15", name: "Y"),
+            TransactionDTO(id: "tx3", accountId: "a2", amount: 30, date: "2026-01-15", name: "Legacy")
         ]
-        transactions.removeAll { accountIdsForItem.contains($0.accountId) }
+        transactions.removeAll { transaction in
+            transaction.itemId == removedItemId ||
+                (transaction.itemId == nil && accountIdsForItem.contains(transaction.accountId))
+        }
         #expect(transactions.count == 1)
         #expect(transactions[0].accountId == "a3")
     }


### PR DESCRIPTION
## Summary
- tag synced transactions with their Plaid item ID so account removal can clean only the removed bank's transactions
- keep legacy cached transactions removable by removed account IDs while preserving transactions from remaining items
- update setup/server state after item removal, including fallback behavior if item status refresh fails

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18493 ./Scripts/smoke-sandbox.sh
- codex exec review --base origin/main (no findings; Codex sandbox build hit known SwiftShims cache/toolchain issue)