### PR TITLE
Clear notification dedupe state on reset

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -630,6 +630,7 @@ final class AppState {
 
         balanceHistory = []
         UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
+        notificationService.resetDeduplicationState()
 
         return result
     }

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -6,6 +6,7 @@ import PlaidBarCore
 protocol NotificationServiceProtocol {
     func requestPermission() async -> Bool
     func checkPermissionStatus() async -> UNAuthorizationStatus
+    func resetDeduplicationState()
     func evaluateTriggers(
         transactions: [TransactionDTO],
         accounts: [AccountDTO],
@@ -37,6 +38,16 @@ final class NotificationService: NotificationServiceProtocol {
         let defaults = UserDefaults.standard
         defaults.set(notifiedTransactionIds, forKey: Self.notifiedTxKey)
         defaults.set(Array(notifiedAccountIds), forKey: Self.notifiedAccountKey)
+    }
+
+    func resetDeduplicationState() {
+        notifiedTransactionIds = []
+        notifiedTransactionIdSet = []
+        notifiedAccountIds = []
+
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: Self.notifiedTxKey)
+        defaults.removeObject(forKey: Self.notifiedAccountKey)
     }
 
     // MARK: - Notification Key Helpers


### PR DESCRIPTION
## Summary
- add a notification-service reset hook for persisted dedupe IDs
- clear large-transaction and account-condition dedupe state when local data is reset

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18494 ./Scripts/smoke-sandbox.sh