### PR TITLE
Store Plaid access tokens in Keychain

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Security)
+import Security
+#endif
 #if os(macOS)
 import Darwin
 #endif
@@ -11,7 +14,10 @@ public struct LocalDataResetResult: Equatable, Sendable {
         removedEntries.count
     }
 
-    public init(directoryPath: String, removedEntries: [String]) {
+    public init(
+        directoryPath: String,
+        removedEntries: [String]
+    ) {
         self.directoryPath = directoryPath
         self.removedEntries = removedEntries
     }
@@ -32,6 +38,7 @@ public enum LocalDataStore {
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
     public static let authTokenFilename = "auth-token"
     public static let transactionCacheFilename = "transactions.json"
+    public static let plaidAccessTokenKeychainService = "PlaidBar.PlaidAccessToken"
     private static let directoryPermissions = 0o700
     private static let cacheFilePermissions = 0o600
 
@@ -60,7 +67,9 @@ public enum LocalDataStore {
     @discardableResult
     public static func resetLocalData(
         at directory: URL = storageDirectoryURL(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        resetKeychainTokens: Bool = true,
+        keychainTokenReset: (() throws -> Void)? = nil
     ) throws -> LocalDataResetResult {
         var removedEntries: [String] = []
         var isDirectory: ObjCBool = false
@@ -85,11 +94,39 @@ public enum LocalDataStore {
 
         try ensurePrivateDirectory(directory, fileManager: fileManager)
 
+        if resetKeychainTokens {
+            try (keychainTokenReset ?? resetPlaidAccessTokenKeychainItems)()
+        }
+
         return LocalDataResetResult(
             directoryPath: directory.path,
             removedEntries: removedEntries
         )
     }
+
+    private static func resetPlaidAccessTokenKeychainItems() throws {
+        #if canImport(Security)
+        let status = SecItemDelete(plaidAccessTokenKeychainServiceQuery() as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw NSError(
+                domain: NSOSStatusErrorDomain,
+                code: Int(status),
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to delete stored Plaid access tokens from Keychain (status \(status))"
+                ]
+            )
+        }
+        #endif
+    }
+
+    #if canImport(Security)
+    private static func plaidAccessTokenKeychainServiceQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: plaidAccessTokenKeychainService
+        ]
+    }
+    #endif
 
     public static func transactionCacheURL(
         in directory: URL = storageDirectoryURL(),

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -37,6 +37,7 @@ struct PlaidBarServer: AsyncParsableCommand {
 
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent)
+        _ = try? await tokenStore.pruneOrphanedKeychainTokens()
         let pendingLinkSessions = PendingLinkSessionStore()
 
         // Build router

--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -30,8 +30,9 @@ struct AccountRoutes: Sendable {
 
             let response: PlaidAccountsResponse
             do {
+                let accessToken = try tokenStore.accessToken(for: item)
                 response = try await plaidClient.getAccounts(
-                    accessToken: item.accessToken
+                    accessToken: accessToken
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
                 successfulItemCount += 1
@@ -84,8 +85,9 @@ struct AccountRoutes: Sendable {
 
             let response: PlaidAccountsResponse
             do {
+                let accessToken = try tokenStore.accessToken(for: item)
                 response = try await plaidClient.getBalances(
-                    accessToken: item.accessToken
+                    accessToken: accessToken
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
                 successfulItemCount += 1
@@ -135,7 +137,8 @@ struct AccountRoutes: Sendable {
         // available for retry instead of leaving an orphaned Plaid Item active.
         if let item = try await tokenStore.getItem(id: itemId) {
             do {
-                try await plaidClient.removeItem(accessToken: item.accessToken)
+                let accessToken = try tokenStore.accessToken(for: item)
+                try await plaidClient.removeItem(accessToken: accessToken)
             } catch {
                 guard Self.canDeleteLocalItemAfterPlaidRemoveError(error) else {
                     try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.error.rawValue)

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -53,12 +53,13 @@ struct LinkRoutes: Sendable {
         guard let item = try await tokenStore.getItem(id: itemId) else {
             throw HTTPError(.notFound, message: "Plaid item not found")
         }
+        let accessToken = try tokenStore.accessToken(for: item)
 
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let state = await pendingLinkSessions.issueState()
         let plaidResponse = try await plaidClient.createUpdateLinkToken(
             userId: userId,
-            accessToken: item.accessToken,
+            accessToken: accessToken,
             completionRedirectUri: callbackURL(state: state)
         )
 

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -46,8 +46,9 @@ struct TransactionRoutes: Sendable {
             let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
             let response: PlaidTransactionsSyncResponse
             do {
+                let accessToken = try tokenStore.accessToken(for: item)
                 response = try await plaidClient.syncTransactions(
-                    accessToken: item.accessToken,
+                    accessToken: accessToken,
                     cursor: cursor
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)

--- a/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
+++ b/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
@@ -1,0 +1,156 @@
+import Foundation
+import PlaidBarCore
+#if canImport(Security)
+import Security
+#endif
+
+enum PlaidTokenVault {
+    private static let referencePrefix = "keychain:"
+
+    static func store(accessToken: String, itemId: String) throws -> String {
+        #if canImport(Security)
+        try saveToKeychain(accessToken: accessToken, itemId: itemId)
+        return reference(for: itemId)
+        #else
+        return accessToken
+        #endif
+    }
+
+    static func resolve(storedToken: String) throws -> String {
+        guard let itemId = itemId(fromReference: storedToken) else {
+            return storedToken
+        }
+
+        #if canImport(Security)
+        return try loadFromKeychain(itemId: itemId)
+        #else
+        throw PlaidTokenVaultError.keychainUnavailable
+        #endif
+    }
+
+    static func delete(storedToken: String, fallbackItemId: String) throws {
+        let itemId = itemId(fromReference: storedToken) ?? fallbackItemId
+
+        #if canImport(Security)
+        try deleteFromKeychain(itemId: itemId)
+        #endif
+    }
+
+    static func deleteOrphanedTokens(referencedItemIds: Set<String>) throws {
+        #if canImport(Security)
+        for itemId in try storedKeychainItemIds() where !referencedItemIds.contains(itemId) {
+            try deleteFromKeychain(itemId: itemId)
+        }
+        #endif
+    }
+
+    static func reference(for itemId: String) -> String {
+        "\(referencePrefix)\(itemId)"
+    }
+
+    static func isReference(_ value: String) -> Bool {
+        itemId(fromReference: value) != nil
+    }
+
+    private static func itemId(fromReference value: String) -> String? {
+        guard value.hasPrefix(referencePrefix) else { return nil }
+        let itemId = String(value.dropFirst(referencePrefix.count))
+        return itemId.isEmpty ? nil : itemId
+    }
+
+    #if canImport(Security)
+    private static func saveToKeychain(accessToken: String, itemId: String) throws {
+        var query = keychainQuery(itemId: itemId)
+        SecItemDelete(query as CFDictionary)
+
+        query[kSecValueData as String] = Data(accessToken.utf8)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw PlaidTokenVaultError.keychainSaveFailed(Int32(status))
+        }
+    }
+
+    private static func loadFromKeychain(itemId: String) throws -> String {
+        var query = keychainQuery(itemId: itemId)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            throw PlaidTokenVaultError.keychainLoadFailed(Int32(status))
+        }
+        guard let data = result as? Data,
+              let token = String(data: data, encoding: .utf8),
+              !token.isEmpty else {
+            throw PlaidTokenVaultError.invalidStoredToken
+        }
+        return token
+    }
+
+    private static func deleteFromKeychain(itemId: String) throws {
+        let status = SecItemDelete(keychainQuery(itemId: itemId) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw PlaidTokenVaultError.keychainDeleteFailed(Int32(status))
+        }
+    }
+
+    private static func storedKeychainItemIds() throws -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: LocalDataStore.plaidAccessTokenKeychainService,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status != errSecItemNotFound else { return [] }
+        guard status == errSecSuccess else {
+            throw PlaidTokenVaultError.keychainLoadFailed(Int32(status))
+        }
+
+        if let values = result as? [[String: Any]] {
+            return values.compactMap { $0[kSecAttrAccount as String] as? String }
+        }
+        if let value = result as? [String: Any],
+           let itemId = value[kSecAttrAccount as String] as? String {
+            return [itemId]
+        }
+        return []
+    }
+
+    private static func keychainQuery(itemId: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: LocalDataStore.plaidAccessTokenKeychainService,
+            kSecAttrAccount as String: itemId
+        ]
+    }
+    #endif
+}
+
+enum PlaidTokenVaultError: Error, LocalizedError, Sendable {
+    case keychainUnavailable
+    case keychainSaveFailed(Int32)
+    case keychainLoadFailed(Int32)
+    case keychainDeleteFailed(Int32)
+    case invalidStoredToken
+
+    var errorDescription: String? {
+        switch self {
+        case .keychainUnavailable:
+            "macOS Keychain is unavailable"
+        case .keychainSaveFailed(let status):
+            "Failed to save Plaid access token to Keychain (status \(status))"
+        case .keychainLoadFailed(let status):
+            "Failed to load Plaid access token from Keychain (status \(status))"
+        case .keychainDeleteFailed(let status):
+            "Failed to delete Plaid access token from Keychain (status \(status))"
+        case .invalidStoredToken:
+            "Stored Plaid access token is invalid"
+        }
+    }
+}

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -17,9 +17,13 @@ actor TokenStore {
         institutionId: String?,
         institutionName: String?
     ) async throws {
+        let storedAccessToken = try PlaidTokenVault.store(
+            accessToken: accessToken,
+            itemId: id
+        )
         let item = ItemModel(
             id: id,
-            accessToken: accessToken,
+            accessToken: storedAccessToken,
             institutionId: institutionId,
             institutionName: institutionName
         )
@@ -36,12 +40,16 @@ actor TokenStore {
 
     func deleteItem(id: String) async throws {
         guard let item = try await ItemModel.find(id, on: fluent.db()) else { return }
-        try await item.delete(on: fluent.db())
-
-        // Also delete associated sync cursor
         if let cursor = try await SyncCursorModel.find(id, on: fluent.db()) {
             try await cursor.delete(on: fluent.db())
         }
+        try await item.delete(on: fluent.db())
+        _ = try? PlaidTokenVault.delete(storedToken: item.accessToken, fallbackItemId: id)
+    }
+
+    func pruneOrphanedKeychainTokens() async throws {
+        let referencedItemIds = Set(try await getAllItems().compactMap(\.id))
+        try PlaidTokenVault.deleteOrphanedTokens(referencedItemIds: referencedItemIds)
     }
 
     func updateItemStatus(id: String, status: String) async throws {
@@ -77,5 +85,9 @@ actor TokenStore {
             .sort(\.$updatedAt, .descending)
             .first()?
             .updatedAt
+    }
+
+    nonisolated func accessToken(for item: ItemModel) throws -> String {
+        try PlaidTokenVault.resolve(storedToken: item.accessToken)
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -916,10 +916,14 @@ struct PlaidBarCoreTests {
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let result = try LocalDataStore.resetLocalData(at: directory)
+        var didResetKeychainTokens = false
+        let result = try LocalDataStore.resetLocalData(at: directory) {
+            didResetKeychainTokens = true
+        }
 
         #expect(result.directoryPath == directory.path)
         #expect(result.removedEntries == ["plaidbar.sqlite"])
+        #expect(didResetKeychainTokens)
 
         var isDirectory: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
@@ -941,9 +945,13 @@ struct PlaidBarCoreTests {
             attributes: [.posixPermissions: 0o777]
         )
 
-        try LocalDataStore.resetLocalData(at: directory)
+        var didResetKeychainTokens = false
+        try LocalDataStore.resetLocalData(at: directory) {
+            didResetKeychainTokens = true
+        }
 
         #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(didResetKeychainTokens)
     }
 
     @Test("Preparing storage directory keeps it private")

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -407,6 +407,27 @@ struct PlaidBarServerTests {
         #expect(PlaidClient.retryDelayNanoseconds(baseDelayNanoseconds: 1_000_000_000, attempt: 10) == 8_000_000_000)
     }
 
+    @Test func plaidTokenVaultReferencesAreDistinctFromLegacyPlaintext() throws {
+        let reference = PlaidTokenVault.reference(for: "item_123")
+
+        #expect(reference == "keychain:item_123")
+        #expect(PlaidTokenVault.isReference(reference))
+        #expect(!PlaidTokenVault.isReference("access-sandbox-token"))
+        #expect(try PlaidTokenVault.resolve(storedToken: "access-sandbox-token") == "access-sandbox-token")
+    }
+
+    @Test func plaidTokenVaultStoresAndResolvesKeychainTokens() throws {
+        let itemId = "test_item_\(UUID().uuidString)"
+        let storedToken = try PlaidTokenVault.store(
+            accessToken: "access-sandbox-token",
+            itemId: itemId
+        )
+        defer { try? PlaidTokenVault.delete(storedToken: storedToken, fallbackItemId: itemId) }
+
+        #expect(PlaidTokenVault.isReference(storedToken))
+        #expect(try PlaidTokenVault.resolve(storedToken: storedToken) == "access-sandbox-token")
+    }
+
     @Test func accountRefreshFailsOnlyWhenEveryLinkedItemFails() {
         #expect(!AccountRoutes.shouldFailRefresh(attemptedItemCount: 0, successfulItemCount: 0))
         #expect(AccountRoutes.shouldFailRefresh(attemptedItemCount: 2, successfulItemCount: 0))


### PR DESCRIPTION
## Summary
- store newly linked Plaid access tokens in macOS Keychain and keep only keychain item references in SQLite
- keep legacy plaintext SQLite tokens readable so existing installs continue working
- resolve Keychain-backed tokens only at Plaid call sites so item listing and healthy linked items are not blocked by one bad token
- clean up item-scoped Keychain entries on item removal, clear PlaidBar token entries on local data reset, and prune orphaned Keychain entries at server startup

## Verification
- git diff --check origin/main...HEAD && git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18498 ./Scripts/smoke-sandbox.sh
- Codex review passes used for token resolution, reset cleanup, and delete-order edge cases; SwiftPM sandbox/toolchain failures inside Codex were ignored as local sandbox issues per project guidance

Note: local full swift test remains blocked by this machine's Testing-module/toolchain mismatch; GitHub CI is the full test gate.