### PR TITLE
Persist pending Plaid Link sessions

### DIFF
--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -38,7 +38,9 @@ struct PlaidBarServer: AsyncParsableCommand {
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent)
         _ = try? await tokenStore.pruneOrphanedKeychainTokens()
-        let pendingLinkSessions = PendingLinkSessionStore()
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: URL(fileURLWithPath: serverConfig.pendingLinkSessionsPath)
+        )
 
         // Build router
         let router = Router()

--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -2,12 +2,19 @@ import Foundation
 
 actor PendingLinkSessionStore {
     private let ttl: TimeInterval
+    private let storageURL: URL?
     private let now: @Sendable () -> Date
     private var sessions: [String: PendingLinkSession] = [:]
 
-    init(ttl: TimeInterval = 30 * 60, now: @escaping @Sendable () -> Date = { Date() }) {
+    init(
+        ttl: TimeInterval = 30 * 60,
+        storageURL: URL? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
         self.ttl = ttl
+        self.storageURL = storageURL
         self.now = now
+        self.sessions = Self.loadSessions(from: storageURL)
     }
 
     func issueState() -> String {
@@ -22,6 +29,7 @@ actor PendingLinkSessionStore {
             updateItemId: updateItemId,
             createdAt: now()
         )
+        persist()
     }
 
     func consume(state: String) -> PendingLinkSession? {
@@ -31,18 +39,53 @@ actor PendingLinkSessionStore {
         else {
             return nil
         }
+        persist()
         return session
     }
 
     private func purgeExpired() {
         let currentDate = now()
-        sessions = sessions.filter { _, session in
+        let activeSessions = sessions.filter { _, session in
             currentDate.timeIntervalSince(session.createdAt) <= ttl
         }
+        guard activeSessions.count != sessions.count else { return }
+        sessions = activeSessions
+        persist()
+    }
+
+    private func persist() {
+        guard let storageURL else { return }
+
+        do {
+            let directory = storageURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder().encode(sessions)
+            try data.write(to: storageURL, options: [.atomic])
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: storageURL.path
+            )
+        } catch {
+            // Pending Link sessions are short-lived; failing closed is better
+            // than failing Link token creation because persistence is unavailable.
+        }
+    }
+
+    private static func loadSessions(from storageURL: URL?) -> [String: PendingLinkSession] {
+        guard let storageURL,
+              let data = try? Data(contentsOf: storageURL),
+              let sessions = try? JSONDecoder().decode([String: PendingLinkSession].self, from: data)
+        else {
+            return [:]
+        }
+        return sessions
     }
 }
 
-struct PendingLinkSession: Sendable {
+struct PendingLinkSession: Codable, Sendable {
     let linkToken: String
     let updateItemId: String?
     let createdAt: Date

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -4,6 +4,7 @@ import PlaidBarCore
 struct ServerConfig: Sendable {
     static let legacyDatabaseFilename = "plaidbar.sqlite"
     static let legacyMigrationEnvironmentVariable = "PLAIDBAR_MIGRATE_LEGACY_DATABASE"
+    static let pendingLinkSessionsFilename = "pending-link-sessions.json"
     private static let sqliteSidecarSuffixes = ["-wal", "-shm", "-journal"]
 
     let port: Int
@@ -11,6 +12,7 @@ struct ServerConfig: Sendable {
     let plaidClientId: String
     let plaidSecret: String
     let databasePath: String
+    let pendingLinkSessionsPath: String
     let redirectUri: String
     let authToken: String
 
@@ -85,6 +87,9 @@ struct ServerConfig: Sendable {
                 environment: environment,
                 legacyMigrationEnvironment: try legacyMigrationEnvironment(from: environmentValues)
             ),
+            pendingLinkSessionsPath: URL(fileURLWithPath: dataDir, isDirectory: true)
+                .appendingPathComponent(pendingLinkSessionsFilename)
+                .path,
             redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
             authToken: authToken
         )

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -328,6 +328,25 @@ struct PlaidBarServerTests {
         #expect(expired == nil)
     }
 
+    @Test func pendingLinkSessionSurvivesStoreRecreation() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-link-session-\(UUID().uuidString)", isDirectory: true)
+        let storageURL = directory.appendingPathComponent("pending-link-sessions.json")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstStore = PendingLinkSessionStore(storageURL: storageURL)
+        let state = await firstStore.issueState()
+        await firstStore.save(state: state, linkToken: "link-token", updateItemId: "item-1")
+
+        let restartedStore = PendingLinkSessionStore(storageURL: storageURL)
+        let restored = await restartedStore.consume(state: state)
+        let replay = await restartedStore.consume(state: state)
+
+        #expect(restored?.linkToken == "link-token")
+        #expect(restored?.updateItemId == "item-1")
+        #expect(replay == nil)
+    }
+
     @Test func linkTokenGetResponseReadsHostedLinkSessionResults() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary
- persist short-lived hosted Plaid Link callback state under the PlaidBar data directory
- reload pending Link sessions after PlaidBarServer restarts so OAuth callbacks can still complete within the TTL
- preserve one-time consumption and TTL expiry behavior

## Verification
- git diff --check origin/main...HEAD && git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18498 ./Scripts/smoke-sandbox.sh