### PR TITLE
Add local server client timeouts

### DIFF
--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -2,6 +2,9 @@ import Foundation
 import PlaidBarCore
 
 actor ServerClient {
+    private static let requestTimeout: TimeInterval = 10
+    private static let resourceTimeout: TimeInterval = 30
+
     private let baseURL: String
     private let session: URLSession
     private let decoder: JSONDecoder
@@ -12,7 +15,11 @@ actor ServerClient {
         authTokenURL: URL = LocalDataStore.authTokenURL()
     ) {
         self.baseURL = baseURL
-        self.session = URLSession.shared
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = Self.requestTimeout
+        configuration.timeoutIntervalForResource = Self.resourceTimeout
+        configuration.waitsForConnectivity = false
+        self.session = URLSession(configuration: configuration)
         self.authTokenURL = authTokenURL
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601


### PR DESCRIPTION
## Summary
- use a dedicated ephemeral URLSession for the app's local PlaidBarServer client
- set short request/resource timeouts for localhost API calls
- disable waitsForConnectivity so offline server checks fail promptly

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain