### PR TITLE
Defer transaction sync cursor commits

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -495,22 +495,16 @@ final class AppState {
     func syncTransactions() async {
         do {
             var hasMore = true
-            var cachePersistenceError: Error?
             while hasMore {
                 let response = try await serverClient.syncTransactions()
-                transactions = TransactionSyncReducer.applying(response, to: transactions)
-                do {
-                    try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
-                } catch {
-                    cachePersistenceError = error
-                }
+                let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
+                try LocalDataStore.saveTransactions(updatedTransactions, context: transactionCacheContext)
+                transactions = updatedTransactions
+                try await serverClient.commitSyncCursors(response.pendingCursors)
                 hasMore = response.hasMore
             }
             lastSyncDate = Date()
             itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
-            if let cachePersistenceError {
-                self.error = "Transaction cache failed to save: \(cachePersistenceError.localizedDescription)"
-            }
         } catch {
             itemStatuses = (try? await serverClient.getItems()) ?? itemStatuses
             self.error = error.localizedDescription

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -61,6 +61,14 @@ actor ServerClient {
         return try await get(url)
     }
 
+    func commitSyncCursors(_ cursors: [String: String]) async throws {
+        guard !cursors.isEmpty else { return }
+        guard let url = ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        try await post(url, body: SyncCursorCommitRequest(cursors: cursors))
+    }
+
     func createLinkToken() async throws -> LinkResponse {
         guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/link/create") else {
             throw ServerClientError.requestFailed
@@ -101,6 +109,15 @@ actor ServerClient {
         let (data, response) = try await data(for: request)
         try Self.validateHTTPResponse(response, data: data)
         return try decoder.decode(T.self, from: data)
+    }
+
+    private func post<T: Encodable & Sendable>(_ url: URL, body: T) async throws {
+        var request = try authorizedRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, response) = try await data(for: request)
+        try Self.validateHTTPResponse(response, data: data)
     }
 
     private func data(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Sources/PlaidBarCore/Models/SyncResponse.swift
+++ b/Sources/PlaidBarCore/Models/SyncResponse.swift
@@ -7,18 +7,48 @@ public struct SyncResponse: Codable, Sendable {
     public let removed: [String]  // transaction IDs
     public let hasMore: Bool
     public let nextCursor: String?
+    public let pendingCursors: [String: String]
 
     public init(
         added: [TransactionDTO],
         modified: [TransactionDTO],
         removed: [String],
         hasMore: Bool,
-        nextCursor: String? = nil
+        nextCursor: String? = nil,
+        pendingCursors: [String: String] = [:]
     ) {
         self.added = added
         self.modified = modified
         self.removed = removed
         self.hasMore = hasMore
         self.nextCursor = nextCursor
+        self.pendingCursors = pendingCursors
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case added
+        case modified
+        case removed
+        case hasMore
+        case nextCursor
+        case pendingCursors
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        added = try container.decode([TransactionDTO].self, forKey: .added)
+        modified = try container.decode([TransactionDTO].self, forKey: .modified)
+        removed = try container.decode([String].self, forKey: .removed)
+        hasMore = try container.decode(Bool.self, forKey: .hasMore)
+        nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor)
+        pendingCursors = try container.decodeIfPresent([String: String].self, forKey: .pendingCursors) ?? [:]
+    }
+}
+
+public struct SyncCursorCommitRequest: Codable, Sendable {
+    public let cursors: [String: String]
+
+    public init(cursors: [String: String]) {
+        self.cursors = cursors
     }
 }

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -16,6 +16,10 @@ public enum ServerEndpoint {
         return components.url
     }
 
+    public static func transactionCursorCommitURL(baseURL: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/transactions/sync/cursors")
+    }
+
     public static func updateLinkTokenURL(baseURL: String, itemId: String) -> URL? {
         url(baseURL: baseURL, path: "/api/link/update/\(percentEncodedPathComponent(itemId))")
     }

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -10,6 +10,7 @@ struct TransactionRoutes: Sendable {
     func register(with group: RouterGroup<some RequestContext>) {
         group.group("transactions")
             .get("sync", use: syncTransactions)
+            .post("sync/cursors", use: commitSyncCursors)
     }
 
     @Sendable
@@ -36,6 +37,7 @@ struct TransactionRoutes: Sendable {
         var allRemoved: [String] = []
         var hasMore = false
         var latestCursor: String?
+        var pendingCursors: [String: String] = [:]
         var attemptedItemCount = 0
         var successfulItemCount = 0
 
@@ -63,11 +65,8 @@ struct TransactionRoutes: Sendable {
             allRemoved.append(contentsOf: response.removed.map(\.transactionId))
 
             if !response.nextCursor.isEmpty {
-                try await tokenStore.saveSyncCursor(
-                    itemId: itemId,
-                    cursor: response.nextCursor
-                )
                 latestCursor = response.nextCursor
+                pendingCursors[itemId] = response.nextCursor
             }
 
             if response.hasMore {
@@ -84,7 +83,8 @@ struct TransactionRoutes: Sendable {
             modified: allModified,
             removed: allRemoved,
             hasMore: hasMore,
-            nextCursor: latestCursor
+            nextCursor: latestCursor,
+            pendingCursors: pendingCursors
         )
 
         let data = try JSONEncoder().encode(syncResponse)
@@ -93,6 +93,23 @@ struct TransactionRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+
+    @Sendable
+    func commitSyncCursors(
+        request: Request,
+        context: some RequestContext
+    ) async throws -> HTTPResponse.Status {
+        let commitRequest = try await request.decode(as: SyncCursorCommitRequest.self, context: context)
+        for (itemId, cursor) in commitRequest.cursors {
+            let trimmedCursor = cursor.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedCursor.isEmpty else { continue }
+            guard try await tokenStore.getItem(id: itemId) != nil else {
+                throw HTTPError(.badRequest, message: "Cannot commit cursor for unknown item")
+            }
+            try await tokenStore.saveSyncCursor(itemId: itemId, cursor: trimmedCursor)
+        }
+        return .ok
     }
 
     // MARK: - Helpers

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -319,10 +319,12 @@ struct PlaidBarCoreTests {
         let itemId = "item with/slash?and&symbols"
 
         let syncURL = try #require(ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId))
+        let cursorCommitURL = try #require(ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL))
         let updateURL = try #require(ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId))
         let removeURL = try #require(ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId))
 
         #expect(syncURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync?item_id=item%20with%2Fslash%3Fand%26symbols")
+        #expect(cursorCommitURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync/cursors")
         #expect(updateURL.absoluteString == "http://127.0.0.1:8484/api/link/update/item%20with%2Fslash%3Fand%26symbols")
         #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
     }
@@ -517,7 +519,8 @@ struct PlaidBarCoreTests {
             modified: [],
             removed: ["old_id"],
             hasMore: false,
-            nextCursor: "cursor_abc"
+            nextCursor: "cursor_abc",
+            pendingCursors: ["item_1": "cursor_abc"]
         )
         let data = try JSONEncoder().encode(response)
         let decoded = try JSONDecoder().decode(SyncResponse.self, from: data)
@@ -526,6 +529,7 @@ struct PlaidBarCoreTests {
         #expect(decoded.removed == ["old_id"])
         #expect(decoded.hasMore == false)
         #expect(decoded.nextCursor == "cursor_abc")
+        #expect(decoded.pendingCursors == ["item_1": "cursor_abc"])
     }
 
     @Test("SyncResponse empty")
@@ -538,6 +542,19 @@ struct PlaidBarCoreTests {
         #expect(decoded.removed.isEmpty)
         #expect(decoded.hasMore == false)
         #expect(decoded.nextCursor == nil)
+        #expect(decoded.pendingCursors.isEmpty)
+    }
+
+    @Test("SyncResponse decodes legacy responses without pending cursors")
+    func syncResponseDecodesLegacyPayload() throws {
+        let data = Data("""
+        {"added":[],"modified":[],"removed":[],"hasMore":false,"nextCursor":"cursor_legacy"}
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(SyncResponse.self, from: data)
+
+        #expect(decoded.nextCursor == "cursor_legacy")
+        #expect(decoded.pendingCursors.isEmpty)
     }
 
     // MARK: - LinkResponse Tests


### PR DESCRIPTION
## Summary
- return pending Plaid transaction sync cursors from `/api/transactions/sync` instead of saving them before the app persists transactions
- add authenticated `/api/transactions/sync/cursors` commit endpoint and app client call
- make `AppState.syncTransactions()` save the local transaction cache before committing cursors, with backward-compatible sync response decoding

## Validation
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18498 ./Scripts/smoke-sandbox.sh`
- `codex exec review --uncommitted`
