### PR TITLE
Keep auth token private after reset

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -93,6 +93,7 @@ public enum LocalDataStore {
         }
 
         try ensurePrivateDirectory(directory, fileManager: fileManager)
+        try ensurePrivateAuthTokenPermissions(in: directory, fileManager: fileManager)
 
         if resetKeychainTokens {
             try (keychainTokenReset ?? resetPlaidAccessTokenKeychainItems)()
@@ -212,6 +213,18 @@ public enum LocalDataStore {
         _ url: URL,
         fileManager: FileManager
     ) throws {
+        try fileManager.setAttributes(
+            [.posixPermissions: cacheFilePermissions],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static func ensurePrivateAuthTokenPermissions(
+        in directory: URL,
+        fileManager: FileManager
+    ) throws {
+        let url = authTokenURL(in: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return }
         try fileManager.setAttributes(
             [.posixPermissions: cacheFilePermissions],
             ofItemAtPath: url.path

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -931,6 +931,7 @@ struct PlaidBarCoreTests {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try "db".write(to: database, atomically: true, encoding: .utf8)
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: authToken.path)
         defer { try? FileManager.default.removeItem(at: root) }
 
         var didResetKeychainTokens = false
@@ -947,6 +948,7 @@ struct PlaidBarCoreTests {
         #expect(isDirectory.boolValue)
         #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["auth-token"])
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
+        #expect(try posixPermissions(at: authToken) == 0o600)
     }
 
     @Test("Local data reset keeps data directory private")


### PR DESCRIPTION
## Summary
- force the preserved app/server auth token file back to `0600` during local data reset
- keep existing reset behavior that preserves the token while deleting local data and Keychain Plaid tokens
- extend the reset test to cover auth-token permission repair

## Validation
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18498 ./Scripts/smoke-sandbox.sh`
- `codex exec review --uncommitted`
