### PR TITLE
Use random server auth tokens

### DIFF
--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -1,5 +1,8 @@
 import Foundation
 import PlaidBarCore
+#if canImport(Security)
+import Security
+#endif
 
 struct ServerConfig: Sendable {
     static let legacyDatabaseFilename = "plaidbar.sqlite"
@@ -66,7 +69,7 @@ struct ServerConfig: Sendable {
             )
             authToken = existing
         } else {
-            let generated = UUID().uuidString
+            let generated = generateAuthToken()
             try generated.write(to: authTokenURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes(
                 [.posixPermissions: 0o600],
@@ -93,6 +96,26 @@ struct ServerConfig: Sendable {
             redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
             authToken: authToken
         )
+    }
+
+    static func authTokenString(randomBytes bytes: [UInt8]) -> String {
+        Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func generateAuthToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        #if canImport(Security)
+        if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess {
+            return authTokenString(randomBytes: bytes)
+        }
+        #endif
+
+        return "\(UUID().uuidString)\(UUID().uuidString)"
+            .replacingOccurrences(of: "-", with: "")
     }
 
     static func dataDirectory() -> String {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -97,6 +97,16 @@ struct PlaidBarServerTests {
         #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
     }
 
+    @Test func serverAuthTokenUsesURLSafeRandomBytes() {
+        let token = ServerConfig.authTokenString(randomBytes: (0..<32).map(UInt8.init))
+
+        #expect(token.count == 43)
+        #expect(token.allSatisfy { character in
+            character.isLetter || character.isNumber || character == "-" || character == "_"
+        })
+        #expect(!token.contains("="))
+    }
+
     @Test func oauthCallbackErrorPageEscapesDynamicMessage() {
         let html = OAuthCallbackRoute.errorPage("<script>alert('x')</script> & retry \"soon\"")
 


### PR DESCRIPTION
## Summary
- generate new app/server auth tokens from 32 cryptographically random bytes when Security is available
- encode auth tokens as URL/header-safe base64 without padding
- keep a UUID-based fallback for platforms without Security randomness
- add a focused test for the token encoding shape

## Validation
- `git diff --check`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18498 ./Scripts/smoke-sandbox.sh`
- `codex exec review --uncommitted`
