### PR TITLE
Restrict CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- set the CI workflow token permissions to read-only contents
- add a timeout to the CI build job
- leave Claude workflows unchanged because Claude review cannot validate PRs that modify its own workflow file

## Validation
- `git diff --check`
- parsed workflow YAML with Ruby YAML
- `codex exec review --uncommitted`
