### PR TITLE
Upsert Plaid Keychain tokens

### DIFF
--- a/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
+++ b/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
@@ -60,13 +60,22 @@ enum PlaidTokenVault {
 
     #if canImport(Security)
     private static func saveToKeychain(accessToken: String, itemId: String) throws {
-        var query = keychainQuery(itemId: itemId)
-        SecItemDelete(query as CFDictionary)
+        let query = keychainQuery(itemId: itemId)
+        let attributes: [String: Any] = [
+            kSecValueData as String: Data(accessToken.utf8),
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
 
-        query[kSecValueData as String] = Data(accessToken.utf8)
-        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            throw PlaidTokenVaultError.keychainSaveFailed(Int32(updateStatus))
+        }
 
-        let status = SecItemAdd(query as CFDictionary, nil)
+        let addQuery = query.merging(attributes) { _, new in new }
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw PlaidTokenVaultError.keychainSaveFailed(Int32(status))
         }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -457,6 +457,23 @@ struct PlaidBarServerTests {
         #expect(try PlaidTokenVault.resolve(storedToken: storedToken) == "access-sandbox-token")
     }
 
+    @Test func plaidTokenVaultUpdatesExistingKeychainToken() throws {
+        let itemId = "test_item_\(UUID().uuidString)"
+        let firstReference = try PlaidTokenVault.store(
+            accessToken: "access-sandbox-token-old",
+            itemId: itemId
+        )
+        defer { try? PlaidTokenVault.delete(storedToken: firstReference, fallbackItemId: itemId) }
+
+        let secondReference = try PlaidTokenVault.store(
+            accessToken: "access-sandbox-token-new",
+            itemId: itemId
+        )
+
+        #expect(firstReference == secondReference)
+        #expect(try PlaidTokenVault.resolve(storedToken: secondReference) == "access-sandbox-token-new")
+    }
+
     @Test func accountRefreshFailsOnlyWhenEveryLinkedItemFails() {
         #expect(!AccountRoutes.shouldFailRefresh(attemptedItemCount: 0, successfulItemCount: 0))
         #expect(AccountRoutes.shouldFailRefresh(attemptedItemCount: 2, successfulItemCount: 0))


### PR DESCRIPTION
## Summary\n- update existing Plaid access tokens in Keychain in place instead of deleting first\n- keep add-only behavior for first-time item storage\n- add coverage that reconnect-style token writes keep the same reference and resolve the new token\n\n## Verification\n- swift build\n- swift build -Xswiftc -strict-concurrency=complete\n- swift test --filter plaidTokenVaultUpdatesExistingKeychainToken *(blocked locally: no such module 'Testing')*