### PR TITLE
Normalize persisted refresh intervals

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -64,6 +64,11 @@ final class AppState {
     }
     var refreshInterval: TimeInterval = PlaidBarConstants.backgroundRefreshInterval {
         didSet {
+            let normalizedInterval = PlaidBarConstants.normalizedBackgroundRefreshInterval(refreshInterval)
+            guard normalizedInterval == refreshInterval else {
+                refreshInterval = normalizedInterval
+                return
+            }
             guard refreshInterval != oldValue else { return }
             UserDefaults.standard.set(refreshInterval, forKey: Keys.refreshInterval)
             // Restart background refresh with new interval
@@ -148,7 +153,9 @@ final class AppState {
             creditUtilizationThreshold = defaults.double(forKey: Keys.creditUtilizationThreshold)
         }
         if defaults.object(forKey: Keys.refreshInterval) != nil {
-            refreshInterval = defaults.double(forKey: Keys.refreshInterval)
+            refreshInterval = PlaidBarConstants.normalizedBackgroundRefreshInterval(
+                defaults.double(forKey: Keys.refreshInterval)
+            )
         }
         // Notification settings
         if defaults.object(forKey: Keys.notificationsEnabled) != nil {

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -29,6 +29,15 @@ public enum PlaidBarConstants {
     // Refresh intervals
     public static let backgroundRefreshInterval: TimeInterval = 15 * 60  // 15 minutes
     public static let transactionSyncInterval: TimeInterval = 30 * 60    // 30 minutes
+    public static let minimumBackgroundRefreshInterval: TimeInterval = 5 * 60
+
+    public static func normalizedBackgroundRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
+        guard interval.isFinite,
+              interval >= minimumBackgroundRefreshInterval else {
+            return backgroundRefreshInterval
+        }
+        return interval
+    }
 
     // Display
     public static let creditUtilizationWarningThreshold: Double = 30.0

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -673,6 +673,7 @@ struct PlaidBarCoreTests {
     @Test("Constants have reasonable values")
     func constantsReasonable() {
         #expect(PlaidBarConstants.backgroundRefreshInterval > 0)
+        #expect(PlaidBarConstants.minimumBackgroundRefreshInterval > 0)
         #expect(PlaidBarConstants.transactionSyncInterval > 0)
         #expect(PlaidBarConstants.creditUtilizationWarningThreshold > 0)
         #expect(PlaidBarConstants.maxRecentTransactions > 0)
@@ -680,6 +681,16 @@ struct PlaidBarCoreTests {
         #expect(!PlaidBarConstants.keychainServiceName.isEmpty)
         #expect(!PlaidBarConstants.appVersion.isEmpty)
         #expect(!PlaidBarConstants.appName.isEmpty)
+    }
+
+    @Test("Background refresh interval rejects invalid persisted values")
+    func backgroundRefreshIntervalNormalization() {
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(5 * 60) == 5 * 60)
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(60 * 60) == 60 * 60)
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(0) == PlaidBarConstants.backgroundRefreshInterval)
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(-1) == PlaidBarConstants.backgroundRefreshInterval)
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(.infinity) == PlaidBarConstants.backgroundRefreshInterval)
+        #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(.nan) == PlaidBarConstants.backgroundRefreshInterval)
     }
 
     @Test("Version bumped to 0.3.0")


### PR DESCRIPTION
## Summary\n- add a core helper to reject invalid background refresh intervals\n- normalize persisted refresh interval values when AppState loads and before saving\n- cover zero, negative, infinite, and NaN interval values\n\n## Verification\n- swift build\n- swift build -Xswiftc -strict-concurrency=complete