### PR TITLE
Bound transaction sync pagination

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -502,7 +502,14 @@ final class AppState {
     func syncTransactions() async {
         do {
             var hasMore = true
+            var pageCount = 0
             while hasMore {
+                pageCount += 1
+                guard pageCount <= PlaidBarConstants.maxTransactionSyncPages else {
+                    throw AppStateError.transactionSyncPageLimitExceeded(
+                        maxPages: PlaidBarConstants.maxTransactionSyncPages
+                    )
+                }
                 let response = try await serverClient.syncTransactions()
                 let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
                 try LocalDataStore.saveTransactions(updatedTransactions, context: transactionCacheContext)
@@ -916,6 +923,17 @@ final class AppState {
     private static func seasonalAdjustment(daysAgo: Int, interval: Int) -> Double {
         let cycle = Double((daysAgo / max(interval, 1)) % 5)
         return cycle * 8.75
+    }
+}
+
+private enum AppStateError: LocalizedError {
+    case transactionSyncPageLimitExceeded(maxPages: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .transactionSyncPageLimitExceeded(let maxPages):
+            "Transaction sync did not finish after \(maxPages) pages. Try again later."
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -43,6 +43,7 @@ public enum PlaidBarConstants {
     public static let creditUtilizationWarningThreshold: Double = 30.0
     public static let maxRecentTransactions: Int = 50
     public static let initialSyncDays: Int = 90
+    public static let maxTransactionSyncPages: Int = 100
 
     // Keychain
     public static let keychainServiceName: String = "com.ftchvs.PlaidBar"

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -693,6 +693,12 @@ struct PlaidBarCoreTests {
         #expect(PlaidBarConstants.normalizedBackgroundRefreshInterval(.nan) == PlaidBarConstants.backgroundRefreshInterval)
     }
 
+    @Test("Transaction sync page cap is generous and finite")
+    func transactionSyncPageCapIsGenerousAndFinite() {
+        #expect(PlaidBarConstants.maxTransactionSyncPages >= 50)
+        #expect(PlaidBarConstants.maxTransactionSyncPages < Int.max)
+    }
+
     @Test("Version bumped to 0.3.0")
     func versionBump() {
         #expect(PlaidBarConstants.appVersion == "0.3.0")


### PR DESCRIPTION
## Summary
- adds a generous max page cap for client transaction sync pagination
- surfaces a clear error if sync never converges
- adds a core constant test to keep the cap finite and non-trivial

## Test plan
- swift build -Xswiftc -strict-concurrency=complete
- git diff --check

Note: local `swift test` is still blocked in this environment by `no such module Testing`; GitHub CI runs the full suite.