### PR TITLE
Resolve settings close actor warnings

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1484,14 +1484,21 @@ private struct DashboardFooter: View {
                     object: settingsWindow,
                     queue: .main
                 ) { _ in
-                    NSApp.setActivationPolicy(.accessory)
-                    if let observer = settingsCloseObserver {
-                        NotificationCenter.default.removeObserver(observer)
+                    Task { @MainActor in
+                        restoreAccessoryActivationPolicy()
                     }
-                    settingsCloseObserver = nil
                 }
             }
         }
+    }
+
+    @MainActor
+    private func restoreAccessoryActivationPolicy() {
+        NSApp.setActivationPolicy(.accessory)
+        if let observer = settingsCloseObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        settingsCloseObserver = nil
     }
 }
 


### PR DESCRIPTION
## Summary
- routes the settings window close observer back through the main actor
- removes strict-concurrency actor-isolation warnings around `NSApp` and the observer binding

## Test plan
- swift build -Xswiftc -strict-concurrency=complete
- git diff --check