### PR TITLE
Fail strict-concurrency warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: swift build -c release
 
       - name: Strict concurrency build
-        run: swift build -Xswiftc -strict-concurrency=complete
+        run: swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
 
       - name: Test
         run: swift test

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import UserNotifications
+@preconcurrency import UserNotifications
 import PlaidBarCore
 
 @MainActor

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -223,6 +223,7 @@ private struct SettingsCard<Content: View>: View {
 }
 
 @ViewBuilder
+@MainActor
 private func settingsRow<Content: View>(
     _ title: String,
     alignment: VerticalAlignment = .center,


### PR DESCRIPTION
## Summary
- upgrades the strict-concurrency CI build to treat warnings as errors
- prevents future actor-isolation/concurrency regressions from quietly shipping

## Test plan
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors