### PR TITLE
Harden auth token file creation

### DIFF
--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -1,5 +1,8 @@
 import Foundation
 import PlaidBarCore
+#if canImport(Darwin)
+import Darwin
+#endif
 #if canImport(Security)
 import Security
 #endif
@@ -54,29 +57,10 @@ struct ServerConfig: Sendable {
             throw ServerConfigError.missingEnvironmentVariable("PLAID_SECRET")
         }
 
-        // Generate or load persistent auth token for app<->server auth
         let authTokenURL = LocalDataStore.authTokenURL(
             in: URL(fileURLWithPath: dataDir, isDirectory: true)
         )
-        let authToken: String
-        if let existing = try? String(contentsOf: authTokenURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !existing.isEmpty
-        {
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: authTokenURL.path
-            )
-            authToken = existing
-        } else {
-            let generated = generateAuthToken()
-            try generated.write(to: authTokenURL, atomically: true, encoding: .utf8)
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: authTokenURL.path
-            )
-            authToken = generated
-        }
+        let authToken = try loadOrCreateAuthToken(at: authTokenURL)
 
         let resolvedPort = portOverride ?? PlaidBarConstants.serverPort(environment: environmentValues)
 
@@ -116,6 +100,80 @@ struct ServerConfig: Sendable {
 
         return "\(UUID().uuidString)\(UUID().uuidString)"
             .replacingOccurrences(of: "-", with: "")
+    }
+
+    private static func loadOrCreateAuthToken(at url: URL) throws -> String {
+        if let existing = try? String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !existing.isEmpty
+        {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            return existing
+        }
+
+        let generated = generateAuthToken()
+        try writePrivateTextFile(generated, to: url)
+        return generated
+    }
+
+    private static func writePrivateTextFile(_ value: String, to url: URL) throws {
+        let data = Data(value.utf8)
+
+        #if canImport(Darwin)
+        let temporaryURL = url
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        let descriptor = open(
+            temporaryURL.path,
+            O_WRONLY | O_CREAT | O_EXCL,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        var shouldRemoveTemporaryFile = true
+        defer {
+            close(descriptor)
+            if shouldRemoveTemporaryFile {
+                try? FileManager.default.removeItem(at: temporaryURL)
+            }
+        }
+
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var bytesWritten = 0
+            while bytesWritten < buffer.count {
+                let result = write(
+                    descriptor,
+                    baseAddress.advanced(by: bytesWritten),
+                    buffer.count - bytesWritten
+                )
+                if result < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                guard result > 0 else {
+                    throw POSIXError(.EIO)
+                }
+                bytesWritten += result
+            }
+        }
+
+        guard rename(temporaryURL.path, url.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        shouldRemoveTemporaryFile = false
+        #else
+        try data.write(to: url, options: [.atomic])
+        #endif
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
     }
 
     static func dataDirectory() -> String {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -97,6 +97,56 @@ struct PlaidBarServerTests {
         #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
     }
 
+    @Test func serverConfigCreatesPrivateAuthTokenFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=config-client
+        PLAID_SECRET=config-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let config = try ServerConfig.load(from: configURL.path)
+        let authTokenURL = dataDirectory.appendingPathComponent(LocalDataStore.authTokenFilename)
+
+        #expect(try String(contentsOf: authTokenURL, encoding: .utf8) == config.authToken)
+        #expect(config.authToken.count >= 43)
+        #expect(try posixPermissions(at: authTokenURL) == 0o600)
+    }
+
+    @Test func serverConfigPreservesExistingAuthTokenAndTightensPermissions() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataDirectory, withIntermediateDirectories: true)
+        let authTokenURL = dataDirectory.appendingPathComponent(LocalDataStore.authTokenFilename)
+        try "existing-token\n".write(to: authTokenURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: authTokenURL.path)
+
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=config-client
+        PLAID_SECRET=config-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let config = try ServerConfig.load(from: configURL.path)
+
+        #expect(config.authToken == "existing-token")
+        #expect(try String(contentsOf: authTokenURL, encoding: .utf8) == "existing-token\n")
+        #expect(try posixPermissions(at: authTokenURL) == 0o600)
+    }
+
     @Test func serverAuthTokenUsesURLSafeRandomBytes() {
         let token = ServerConfig.authTokenString(randomBytes: (0..<32).map(UInt8.init))
 


### PR DESCRIPTION
## Summary
- create new app/server auth tokens through a private temporary file and atomic rename
- preserve existing auth tokens while tightening permissions to 0600
- add server config regression coverage for token creation and preservation

## Verification
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18488 ./Scripts/smoke-sandbox.sh

Note: local swift test is still blocked by this machine's missing Testing module, so CI remains the test gate.