### PR TITLE
Keep pending Link sessions private

### DIFF
--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -1,6 +1,12 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 
 actor PendingLinkSessionStore {
+    private static let directoryPermissions = 0o700
+    private static let filePermissions = 0o600
+
     private let ttl: TimeInterval
     private let storageURL: URL?
     private let now: @Sendable () -> Date
@@ -60,14 +66,15 @@ actor PendingLinkSessionStore {
             let directory = storageURL.deletingLastPathComponent()
             try FileManager.default.createDirectory(
                 at: directory,
-                withIntermediateDirectories: true
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: Self.directoryPermissions]
+            )
+            try FileManager.default.setAttributes(
+                [.posixPermissions: Self.directoryPermissions],
+                ofItemAtPath: directory.path
             )
             let data = try JSONEncoder().encode(sessions)
-            try data.write(to: storageURL, options: [.atomic])
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o600],
-                ofItemAtPath: storageURL.path
-            )
+            try Self.writePrivateFile(data, to: storageURL)
         } catch {
             // Pending Link sessions are short-lived; failing closed is better
             // than failing Link token creation because persistence is unavailable.
@@ -81,7 +88,70 @@ actor PendingLinkSessionStore {
         else {
             return [:]
         }
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: directoryPermissions],
+            ofItemAtPath: storageURL.deletingLastPathComponent().path
+        )
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: filePermissions],
+            ofItemAtPath: storageURL.path
+        )
         return sessions
+    }
+
+    private static func writePrivateFile(_ data: Data, to url: URL) throws {
+        #if canImport(Darwin)
+        let temporaryURL = url
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        let descriptor = open(
+            temporaryURL.path,
+            O_WRONLY | O_CREAT | O_EXCL,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        var shouldRemoveTemporaryFile = true
+        defer {
+            close(descriptor)
+            if shouldRemoveTemporaryFile {
+                try? FileManager.default.removeItem(at: temporaryURL)
+            }
+        }
+
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var bytesWritten = 0
+            while bytesWritten < buffer.count {
+                let result = write(
+                    descriptor,
+                    baseAddress.advanced(by: bytesWritten),
+                    buffer.count - bytesWritten
+                )
+                if result < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                guard result > 0 else {
+                    throw POSIXError(.EIO)
+                }
+                bytesWritten += result
+            }
+        }
+
+        guard rename(temporaryURL.path, url.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        shouldRemoveTemporaryFile = false
+        #else
+        try data.write(to: url, options: [.atomic])
+        #endif
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: filePermissions],
+            ofItemAtPath: url.path
+        )
     }
 }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -430,6 +430,40 @@ struct PlaidBarServerTests {
         #expect(restored?.linkToken == "link-token")
         #expect(restored?.updateItemId == "item-1")
         #expect(replay == nil)
+        #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(try posixPermissions(at: storageURL) == 0o600)
+    }
+
+    @Test func pendingLinkSessionLoadTightensPersistedFilePermissions() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-link-session-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let storageURL = directory.appendingPathComponent("pending-link-sessions.json")
+        let state = "state-\(UUID().uuidString)"
+        let sessions = [
+            state: PendingLinkSession(
+                linkToken: "link-token",
+                updateItemId: "item-1",
+                createdAt: Date()
+            )
+        ]
+        try JSONEncoder().encode(sessions).write(to: storageURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: storageURL.path)
+
+        let restartedStore = PendingLinkSessionStore(storageURL: storageURL)
+        #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(try posixPermissions(at: storageURL) == 0o600)
+
+        let restored = await restartedStore.consume(state: state)
+
+        #expect(restored?.linkToken == "link-token")
+        #expect(restored?.updateItemId == "item-1")
     }
 
     @Test func linkTokenGetResponseReadsHostedLinkSessionResults() throws {


### PR DESCRIPTION
## Summary
- persist pending Plaid Link session cache files through private temp files and atomic rename
- tighten pending Link session directory and file permissions to 0700/0600 on write and load
- extend server tests for persisted Link session privacy and permission repair

## Verification
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18489 ./Scripts/smoke-sandbox.sh

Note: local swift test is still blocked by this machine's missing Testing module, so CI remains the test gate.