### PR TITLE
Write transaction cache privately

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -174,7 +174,7 @@ public enum LocalDataStore {
         let url = transactionCacheURL(in: directory, context: context)
         let cache = TransactionCache(context: context, transactions: transactions)
         let data = try JSONEncoder().encode(cache)
-        try data.write(to: url, options: [.atomic])
+        try writePrivateCacheFile(data, to: url, fileManager: fileManager)
         try setPrivateCacheFilePermissions(url, fileManager: fileManager)
     }
 
@@ -217,6 +217,60 @@ public enum LocalDataStore {
             [.posixPermissions: cacheFilePermissions],
             ofItemAtPath: url.path
         )
+    }
+
+    private static func writePrivateCacheFile(
+        _ data: Data,
+        to url: URL,
+        fileManager: FileManager
+    ) throws {
+        #if os(macOS)
+        let temporaryURL = url
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        let descriptor = open(
+            temporaryURL.path,
+            O_WRONLY | O_CREAT | O_EXCL,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        var shouldRemoveTemporaryFile = true
+        defer {
+            close(descriptor)
+            if shouldRemoveTemporaryFile {
+                try? fileManager.removeItem(at: temporaryURL)
+            }
+        }
+
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var bytesWritten = 0
+            while bytesWritten < buffer.count {
+                let result = write(
+                    descriptor,
+                    baseAddress.advanced(by: bytesWritten),
+                    buffer.count - bytesWritten
+                )
+                if result < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                guard result > 0 else {
+                    throw POSIXError(.EIO)
+                }
+                bytesWritten += result
+            }
+        }
+
+        guard rename(temporaryURL.path, url.path) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        shouldRemoveTemporaryFile = false
+        #else
+        try data.write(to: url, options: [.atomic])
+        #endif
     }
 
     private static func ensurePrivateAuthTokenPermissions(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1055,6 +1055,30 @@ struct PlaidBarCoreTests {
         #expect(try posixPermissions(at: LocalDataStore.transactionCacheURL(in: directory, context: context)) == 0o600)
     }
 
+    @Test("Transaction cache overwrite repairs existing file permissions")
+    func transactionCacheOverwriteRepairsExistingPermissions() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let context = TransactionCacheContext(environment: .sandbox, storagePath: "\(directory.path)/plaidbar.sqlite")
+        let cacheURL = LocalDataStore.transactionCacheURL(in: directory, context: context)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("old-cache".utf8).write(to: cacheURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: cacheURL.path)
+
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "txn", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")],
+            to: directory,
+            context: context
+        )
+
+        #expect(try LocalDataStore.loadTransactions(from: directory, context: context).map(\.id) == ["txn"])
+        #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(try posixPermissions(at: cacheURL) == 0o600)
+    }
+
     @Test("Transaction cache persists account removal cleanup")
     func transactionCachePersistsAccountRemovalCleanup() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- write transaction cache snapshots through private temp files and atomic rename
- preserve 0700 storage directory and 0600 cache file guarantees when overwriting existing cache files
- add regression coverage for permission repair on transaction cache overwrite

## Verification
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18490 ./Scripts/smoke-sandbox.sh

Note: local swift test is still blocked by this machine's missing Testing module, so CI remains the test gate.