### PR TITLE
Add Homebrew release packaging

### DIFF
--- a/Formula/plaidbar.rb
+++ b/Formula/plaidbar.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Homebrew formula for PlaidBar.
+class Plaidbar < Formula
+  desc "Private macOS menu bar dashboard for Plaid accounts"
+  homepage "https://github.com/ftchvs/PlaidBar"
+  url "https://github.com/ftchvs/PlaidBar.git", tag: "v0.3.0"
+  license "MIT"
+  head "https://github.com/ftchvs/PlaidBar.git", branch: "main"
+
+  depends_on xcode: ["16.0", :build]
+  depends_on macos: :sequoia
+
+  def install
+    system "swift", "build", "-c", "release", "--disable-sandbox"
+
+    bin.install ".build/release/PlaidBar" => "plaidbar"
+    bin.install ".build/release/PlaidBarServer" => "plaidbar-server"
+    bin.install "Scripts/plaidbar-run"
+
+    doc.install "README.md", "SECURITY.md", "LICENSE"
+  end
+
+  def caveats
+    <<~EOS
+      PlaidBar installs three commands:
+        plaidbar --demo                  # launch demo menu bar UI
+        plaidbar-server --sandbox        # run the local Plaid server
+        plaidbar-run --sandbox           # run server + app together
+
+      For sandbox or production data, set credentials before launching:
+        export PLAID_CLIENT_ID=...
+        export PLAID_SECRET=...
+    EOS
+  end
+
+  test do
+    assert_match "USAGE:", shell_output("#{bin}/plaidbar-server --help")
+    assert_match "Missing Plaid credentials", shell_output("#{bin}/plaidbar-run --sandbox 2>&1", 1)
+  end
+end

--- a/README.md
+++ b/README.md
@@ -54,7 +54,30 @@ Personal finance data lives behind bank website logins. The closest thing to a m
 
 ## Quick Start
 
-### 1. Clone and build
+### Homebrew
+
+After the first tagged release, install PlaidBar from the repository tap:
+
+```bash
+brew tap ftchvs/plaidbar https://github.com/ftchvs/PlaidBar
+brew install plaidbar
+```
+
+Run local demo data without Plaid credentials:
+
+```bash
+plaidbar --demo
+```
+
+Run Plaid sandbox mode with the installed server and app:
+
+```bash
+export PLAID_CLIENT_ID=your_sandbox_client_id
+export PLAID_SECRET=your_sandbox_secret
+plaidbar-run --sandbox
+```
+
+### Source build
 
 ```bash
 git clone https://github.com/ftchvs/PlaidBar.git
@@ -276,6 +299,11 @@ swift build
 
 # Build release
 swift build -c release
+
+# Run installed Homebrew commands
+plaidbar --demo
+plaidbar-server --sandbox
+plaidbar-run --sandbox
 
 # Run tests
 swift test

--- a/Scripts/plaidbar-run
+++ b/Scripts/plaidbar-run
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVER_PID=""
+APP_PID=""
+
+cleanup() {
+    local exit_code=$?
+    if [[ -n "$APP_PID" ]]; then
+        kill "$APP_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$SERVER_PID" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+    fi
+    exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+usage() {
+    cat <<'EOF'
+Usage: plaidbar-run [--sandbox] [--port PORT]
+
+Starts the local PlaidBar server and the menu bar app using installed
+Homebrew commands. Set PLAID_CLIENT_ID and PLAID_SECRET before running
+against sandbox or production Plaid data.
+
+Options:
+  --sandbox       Use Plaid sandbox environment
+  --port PORT     Local server port (default: PLAIDBAR_SERVER_PORT or 8484)
+  -h, --help      Show this help
+EOF
+}
+
+SANDBOX_FLAG=""
+SERVER_PORT="${PLAIDBAR_SERVER_PORT:-8484}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --sandbox)
+            SANDBOX_FLAG="--sandbox"
+            shift
+            ;;
+        --port)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "Missing value for --port" >&2
+                exit 2
+            fi
+            SERVER_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "${PLAID_CLIENT_ID:-}" || -z "${PLAID_SECRET:-}" ]]; then
+    echo "Missing Plaid credentials."
+    echo ""
+    if [[ "$SANDBOX_FLAG" == "--sandbox" ]]; then
+        echo "Set sandbox credentials first:"
+        echo "  export PLAID_CLIENT_ID=your_sandbox_client_id"
+        echo "  export PLAID_SECRET=your_sandbox_secret"
+    else
+        echo "Set production credentials first:"
+        echo "  export PLAID_CLIENT_ID=your_client_id"
+        echo "  export PLAID_SECRET=your_secret"
+    fi
+    echo ""
+    echo "For screenshot/demo data without Plaid, run: plaidbar --demo"
+    exit 1
+fi
+
+PLAIDBAR_SERVER_BIN="${PLAIDBAR_SERVER_BIN:-$(command -v plaidbar-server || true)}"
+PLAIDBAR_APP_BIN="${PLAIDBAR_APP_BIN:-$(command -v plaidbar || true)}"
+
+if [[ -z "$PLAIDBAR_SERVER_BIN" ]]; then
+    echo "Could not find plaidbar-server on PATH." >&2
+    exit 1
+fi
+
+if [[ -z "$PLAIDBAR_APP_BIN" ]]; then
+    echo "Could not find plaidbar on PATH." >&2
+    exit 1
+fi
+
+echo "Starting PlaidBar server..."
+"$PLAIDBAR_SERVER_BIN" $SANDBOX_FLAG --port "$SERVER_PORT" &
+SERVER_PID=$!
+
+echo "Waiting for server health..."
+for _ in {1..30}; do
+    if curl -fsS "http://127.0.0.1:$SERVER_PORT/health" >/dev/null 2>&1; then
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "PlaidBar server exited before becoming healthy."
+        exit 1
+    fi
+    sleep 1
+done
+
+curl -fsS "http://127.0.0.1:$SERVER_PORT/health" >/dev/null
+
+DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.plaidbar}"
+case "$DATA_DIR" in
+    "~")
+        DATA_DIR="$HOME"
+        ;;
+    "~/"*)
+        DATA_DIR="$HOME/${DATA_DIR#"~/"}"
+        ;;
+esac
+
+AUTH_TOKEN_PATH="$DATA_DIR/auth-token"
+if [[ ! -r "$AUTH_TOKEN_PATH" ]]; then
+    echo "Server is healthy, but the local auth token is not readable at:"
+    echo "  $AUTH_TOKEN_PATH"
+    echo ""
+    echo "Check PLAIDBAR_DATA_DIR and the server startup logs, then retry."
+    exit 1
+fi
+
+AUTH_TOKEN="$(tr -d '\r\n' < "$AUTH_TOKEN_PATH")"
+curl -fsS -H "Authorization: Bearer $AUTH_TOKEN" "http://127.0.0.1:$SERVER_PORT/api/status" >/dev/null
+echo "Server ready on http://127.0.0.1:$SERVER_PORT"
+
+echo "Starting PlaidBar app..."
+"$PLAIDBAR_APP_BIN" &
+APP_PID=$!
+
+echo ""
+echo "PlaidBar is running!"
+echo "  Server PID: $SERVER_PID"
+echo "  App PID: $APP_PID"
+echo ""
+echo "Press Ctrl+C to stop"
+wait

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+usage() {
+    cat <<'EOF'
+Usage: ./Scripts/release.sh [--publish]
+
+Preflights the current PlaidBar release. With --publish, creates and pushes the
+version tag, then creates a GitHub release for ftchvs/PlaidBar.
+
+This script expects to run from a clean main branch after CI has passed.
+EOF
+}
+
+PUBLISH=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publish)
+            PUBLISH=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f version.env ]]; then
+    echo "Missing version.env" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source version.env
+
+if [[ -z "${VERSION:-}" || -z "${BUILD:-}" ]]; then
+    echo "version.env must define VERSION and BUILD" >&2
+    exit 1
+fi
+
+TAG="v$VERSION"
+BRANCH="$(git branch --show-current)"
+
+if [[ "$BRANCH" != "main" ]]; then
+    echo "Release must be run from main, currently on $BRANCH" >&2
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Release must be run from a clean worktree" >&2
+    git status --short >&2
+    exit 1
+fi
+
+INFO_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Sources/PlaidBar/Resources/Info.plist)"
+INFO_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' Sources/PlaidBar/Resources/Info.plist)"
+
+if [[ "$INFO_VERSION" != "$VERSION" ]]; then
+    echo "Info.plist version $INFO_VERSION does not match version.env $VERSION" >&2
+    exit 1
+fi
+
+if [[ "$INFO_BUILD" != "$BUILD" ]]; then
+    echo "Info.plist build $INFO_BUILD does not match version.env $BUILD" >&2
+    exit 1
+fi
+
+if ! grep -Fq "tag: \"$TAG\"" Formula/plaidbar.rb; then
+    echo "Formula/plaidbar.rb does not reference $TAG" >&2
+    exit 1
+fi
+
+echo "Running release gates for $TAG..."
+swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+bash -n Scripts/plaidbar-run Scripts/release.sh
+ruby -c Formula/plaidbar.rb
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Tag $TAG already exists locally" >&2
+    exit 1
+fi
+
+if git ls-remote --tags origin "$TAG" | grep -Fq "$TAG"; then
+    echo "Tag $TAG already exists on origin" >&2
+    exit 1
+fi
+
+if [[ "$PUBLISH" != "true" ]]; then
+    echo ""
+    echo "Dry run complete. Publish with:"
+    echo "  ./Scripts/release.sh --publish"
+    exit 0
+fi
+
+git tag -a "$TAG" -m "PlaidBar $TAG"
+git push origin "$TAG"
+gh release create "$TAG" \
+    --repo ftchvs/PlaidBar \
+    --title "PlaidBar $TAG" \
+    --generate-notes
+
+echo "Published $TAG."

--- a/Sources/PlaidBar/Resources/Info.plist
+++ b/Sources/PlaidBar/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.3.0</string>
     <key>LSMinimumSystemVersion</key>
     <string>15.0</string>
     <key>LSUIElement</key>

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,60 @@
+# Release Runbook
+
+PlaidBar's first public release should ship as a tagged GitHub release and a
+Homebrew tap formula.
+
+## Release Shape
+
+- GitHub release tag: `v0.3.0`
+- Homebrew tap command:
+
+```bash
+brew tap ftchvs/plaidbar https://github.com/ftchvs/PlaidBar
+brew install plaidbar
+```
+
+- Installed commands:
+
+```bash
+plaidbar --demo
+plaidbar-server --sandbox
+plaidbar-run --sandbox
+```
+
+## Checklist
+
+1. Confirm `version.env`, `Sources/PlaidBar/Resources/Info.plist`, and
+   `Formula/plaidbar.rb` all point to the same version.
+2. Run local gates:
+
+```bash
+swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret ./Scripts/smoke-sandbox.sh
+bash -n Scripts/plaidbar-run Scripts/release.sh
+ruby -c Formula/plaidbar.rb
+```
+
+3. Merge the release-prep PR to `main`.
+4. From clean `main`, publish the tag and GitHub release:
+
+```bash
+./Scripts/release.sh --publish
+```
+
+5. Verify Homebrew install from the repository tap:
+
+```bash
+brew tap ftchvs/plaidbar https://github.com/ftchvs/PlaidBar
+brew install --build-from-source plaidbar
+plaidbar-server --help
+plaidbar-run --help
+```
+
+## Notes
+
+The initial formula builds from source because PlaidBar is currently a SwiftPM
+menu bar executable plus a local server executable, not a signed and notarized
+`.app` bundle. A future cask should ship a notarized app archive once the app
+bundle, code signing, notarization, Sparkle appcast, and DMG/ZIP packaging are
+ready.


### PR DESCRIPTION
## Summary
- add a Homebrew formula that installs `plaidbar`, `plaidbar-server`, and `plaidbar-run`
- add an installed `plaidbar-run` helper for running the server and menu bar app together outside a source checkout
- add a release runbook/script and align app Info.plist version metadata with `version.env` for v0.3.0

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18491 ./Scripts/smoke-sandbox.sh`
- `bash -n Scripts/plaidbar-run Scripts/release.sh`
- `ruby -c Formula/plaidbar.rb`
- `brew style Formula/plaidbar.rb`
- `Scripts/plaidbar-run --help`
- `Scripts/plaidbar-run --sandbox` (expected credential error)