### PR TITLE
Add packaging checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
           xcrun --find swift
           swift --version
 
+      - name: Packaging checks
+        run: |
+          bash -n Scripts/plaidbar-run Scripts/release.sh
+          ruby -c Formula/plaidbar.rb
+          brew style Formula/plaidbar.rb
+
       - name: Resolve dependencies
         run: swift package resolve
 


### PR DESCRIPTION
## Summary
- run shell/Ruby syntax checks and Homebrew formula style in CI
- mark the Homebrew formula as macOS-only in addition to the macOS 15 minimum

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `bash -n Scripts/plaidbar-run Scripts/release.sh`
- `ruby -c Formula/plaidbar.rb`
- `brew style Formula/plaidbar.rb`