### PR TITLE
Align server command release metadata

### DIFF
--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -50,7 +50,7 @@ public enum PlaidBarConstants {
     public static let keychainServerTokenKey: String = "server-auth-token"
 
     // App Info
-    public static let appVersion: String = "0.3.0"
+    public static let appVersion: String = "0.3.1"
     public static let appName: String = "PlaidBar"
 
     // Plaid

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -8,6 +8,12 @@ import PlaidBarCore
 
 @main
 struct PlaidBarServer: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "plaidbar-server",
+        abstract: "Run the local PlaidBar companion server.",
+        version: PlaidBarConstants.appVersion
+    )
+
     @Option(name: .long, help: "Server port")
     var port: Int?
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -699,9 +699,9 @@ struct PlaidBarCoreTests {
         #expect(PlaidBarConstants.maxTransactionSyncPages < Int.max)
     }
 
-    @Test("Version bumped to 0.3.0")
+    @Test("Version bumped to 0.3.1")
     func versionBump() {
-        #expect(PlaidBarConstants.appVersion == "0.3.0")
+        #expect(PlaidBarConstants.appVersion == "0.3.1")
     }
 
     // MARK: - RecurringTransaction Model Tests


### PR DESCRIPTION
## Summary
- update PlaidBar runtime version constant and version regression test to v0.3.1
- configure the server CLI to advertise the installed `plaidbar-server` command name
- add `plaidbar-server --version` via ArgumentParser command configuration

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18493 ./Scripts/smoke-sandbox.sh`
- `.build/debug/PlaidBarServer --help`
- `.build/debug/PlaidBarServer --version`