### PR TITLE
Validate runtime version during release

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -65,6 +65,10 @@ fi
 
 INFO_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Sources/PlaidBar/Resources/Info.plist)"
 INFO_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' Sources/PlaidBar/Resources/Info.plist)"
+RUNTIME_VERSION="$(
+    sed -n 's/.*appVersion: String = "\([^"]*\)".*/\1/p' \
+        Sources/PlaidBarCore/Utilities/Constants.swift
+)"
 
 if [[ "$INFO_VERSION" != "$VERSION" ]]; then
     echo "Info.plist version $INFO_VERSION does not match version.env $VERSION" >&2
@@ -73,6 +77,11 @@ fi
 
 if [[ "$INFO_BUILD" != "$BUILD" ]]; then
     echo "Info.plist build $INFO_BUILD does not match version.env $BUILD" >&2
+    exit 1
+fi
+
+if [[ "$RUNTIME_VERSION" != "$VERSION" ]]; then
+    echo "PlaidBarConstants.appVersion $RUNTIME_VERSION does not match version.env $VERSION" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- make the release script verify `PlaidBarConstants.appVersion` matches `version.env`
- prevent future tags where the server status/CLI version drifts from the packaged release version

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `bash -n Scripts/release.sh`
- runtime version extraction check: `runtime version matches 0.3.2`

Note: `./Scripts/release.sh` intentionally refuses to run from a non-main branch, so this PR verifies syntax and the new version extraction logic locally; full release dry-run remains a post-merge main-branch gate.