### PR TITLE
Harden release script checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Packaging checks
         run: |
-          bash -n Scripts/plaidbar-run Scripts/release.sh
+          bash -n Scripts/*.sh Scripts/plaidbar-run
           ruby -c Formula/plaidbar.rb
           brew style Formula/plaidbar.rb
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -93,7 +93,7 @@ fi
 echo "Running release gates for $TAG..."
 swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
 swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
-bash -n Scripts/plaidbar-run Scripts/release.sh
+bash -n Scripts/*.sh Scripts/plaidbar-run
 ruby -c Formula/plaidbar.rb
 
 if git rev-parse "$TAG" >/dev/null 2>&1; then

--- a/Scripts/screenshots.sh
+++ b/Scripts/screenshots.sh
@@ -6,12 +6,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ASSETS_DIR="$PROJECT_DIR/Assets"
+APP_LOG="$(mktemp -t plaidbar-screenshots.XXXXXX.log)"
 
 mkdir -p "$ASSETS_DIR"
 
 echo "Building PlaidBar in release mode..."
 cd "$PROJECT_DIR"
-swift build -c release --skip-update --disable-keychain
+swift build -c release --disable-keychain
 
 BINARY=".build/release/PlaidBar"
 APP_PID=""
@@ -21,11 +22,12 @@ cleanup() {
         kill "$APP_PID" 2>/dev/null || true
         wait "$APP_PID" 2>/dev/null || true
     fi
+    rm -f "$APP_LOG"
 }
 trap cleanup EXIT
 
 echo "Opening dashboard popover..."
-"$BINARY" --demo --show-popover >/tmp/plaidbar-screenshots.log 2>&1 &
+"$BINARY" --demo --show-popover >"$APP_LOG" 2>&1 &
 APP_PID=$!
 
 WINDOW_RECT=""
@@ -53,7 +55,7 @@ done
 if [ -z "$WINDOW_RECT" ] || [ "$WINDOW_RECT" = "missing value" ]; then
     echo "Error: Could not find the PlaidBar popover window."
     echo "App log:"
-    cat /tmp/plaidbar-screenshots.log 2>/dev/null || true
+    cat "$APP_LOG" 2>/dev/null || true
     exit 1
 fi
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,7 +31,7 @@ plaidbar-run --sandbox
 swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
 swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
 PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret ./Scripts/smoke-sandbox.sh
-bash -n Scripts/plaidbar-run Scripts/release.sh
+bash -n Scripts/*.sh Scripts/plaidbar-run
 ruby -c Formula/plaidbar.rb
 ```
 


### PR DESCRIPTION
## Summary
- remove the deprecated SwiftPM --skip-update flag from the screenshot pipeline
- use a per-run temporary app log for screenshot capture and clean it up on exit
- syntax-check every shipped shell script in CI and the release gate

## Verification
- bash -n Scripts/*.sh Scripts/plaidbar-run
- ruby -c Formula/plaidbar.rb
- brew style Formula/plaidbar.rb
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18491 ./Scripts/smoke-sandbox.sh