### PR TITLE
Log keychain cleanup failures

### DIFF
--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -43,8 +43,14 @@ struct PlaidBarServer: AsyncParsableCommand {
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)
 
         let plaidClient = PlaidClient(config: serverConfig)
-        let tokenStore = TokenStore(fluent: fluent)
-        _ = try? await tokenStore.pruneOrphanedKeychainTokens()
+        let tokenStore = TokenStore(fluent: fluent, logger: logger)
+        do {
+            try await tokenStore.pruneOrphanedKeychainTokens()
+        } catch {
+            logger.warning(
+                "Failed to prune orphaned Plaid Keychain tokens: \(String(describing: error))"
+            )
+        }
         let pendingLinkSessions = PendingLinkSessionStore(
             storageURL: URL(fileURLWithPath: serverConfig.pendingLinkSessionsPath)
         )

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -1,12 +1,15 @@
 import FluentKit
 import HummingbirdFluent
 import Foundation
+import Logging
 
 actor TokenStore {
     private let fluent: Fluent
+    private let logger: Logger
 
-    init(fluent: Fluent) {
+    init(fluent: Fluent, logger: Logger = Logger(label: "com.ftchvs.plaidbar-server.token-store")) {
         self.fluent = fluent
+        self.logger = logger
     }
 
     // MARK: - Items
@@ -44,7 +47,13 @@ actor TokenStore {
             try await cursor.delete(on: fluent.db())
         }
         try await item.delete(on: fluent.db())
-        _ = try? PlaidTokenVault.delete(storedToken: item.accessToken, fallbackItemId: id)
+        do {
+            try PlaidTokenVault.delete(storedToken: item.accessToken, fallbackItemId: id)
+        } catch {
+            logger.warning(
+                "Failed to delete Plaid access token from Keychain for item \(id): \(String(describing: error))"
+            )
+        }
     }
 
     func pruneOrphanedKeychainTokens() async throws {


### PR DESCRIPTION
## Summary
- log startup failures when orphaned Plaid Keychain token pruning fails
- log item-specific Keychain token deletion failures during local item removal
- keep cleanup best-effort without exposing Plaid access tokens in logs

## Verification
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- bash -n Scripts/*.sh Scripts/plaidbar-run && ruby -c Formula/plaidbar.rb
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18492 ./Scripts/smoke-sandbox.sh