### PR TITLE
Propagate custom run port to app

### DIFF
--- a/Scripts/plaidbar-run
+++ b/Scripts/plaidbar-run
@@ -61,6 +61,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if ! [[ "$SERVER_PORT" =~ ^[0-9]+$ ]] || (( SERVER_PORT < 1 || SERVER_PORT > 65535 )); then
+    echo "Invalid port: $SERVER_PORT" >&2
+    exit 2
+fi
+
+export PLAIDBAR_SERVER_PORT="$SERVER_PORT"
+
 if [[ -z "${PLAID_CLIENT_ID:-}" || -z "${PLAID_SECRET:-}" ]]; then
     echo "Missing Plaid credentials."
     echo ""

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -66,6 +66,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if ! [[ "$SERVER_PORT" =~ ^[0-9]+$ ]] || (( SERVER_PORT < 1 || SERVER_PORT > 65535 )); then
+    echo "Invalid port: $SERVER_PORT" >&2
+    exit 2
+fi
+
+export PLAIDBAR_SERVER_PORT="$SERVER_PORT"
+
 if [[ -z "${PLAID_CLIENT_ID:-}" || -z "${PLAID_SECRET:-}" ]]; then
     echo "Missing Plaid credentials."
     echo ""


### PR DESCRIPTION
## Summary
- validate custom ports in both source and Homebrew run helpers
- export PLAIDBAR_SERVER_PORT after resolving --port so the app talks to the same server port
- preserve the existing explicit server --port behavior

## Verification
- bash -n Scripts/*.sh Scripts/plaidbar-run
- ./Scripts/run.sh --port nope
- ./Scripts/plaidbar-run --port 70000
- ./Scripts/run.sh --help && ./Scripts/plaidbar-run --help
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18493 ./Scripts/smoke-sandbox.sh