### PR TITLE
Strengthen Homebrew formula tests

### DIFF
--- a/Formula/plaidbar.rb
+++ b/Formula/plaidbar.rb
@@ -40,6 +40,8 @@ class Plaidbar < Formula
 
   test do
     assert_match "USAGE:", shell_output("#{bin}/plaidbar-server --help")
+    assert_equal "#{version}\n", shell_output("#{bin}/plaidbar-server --version")
+    assert_match "Invalid port: nope", shell_output("#{bin}/plaidbar-run --port nope 2>&1", 2)
     assert_match "Missing Plaid credentials", shell_output("#{bin}/plaidbar-run --sandbox 2>&1", 1)
   end
 end


### PR DESCRIPTION
## Summary
- assert the installed server command reports the formula version
- assert the installed run helper rejects invalid custom ports
- keep the existing help and missing-credentials formula tests

## Verification
- ruby -c Formula/plaidbar.rb
- brew style Formula/plaidbar.rb
- brew test plaidbar

Note: Homebrew rejects direct testing of ./Formula/plaidbar.rb outside a tap, so brew test plaidbar verifies the installed tap formula; CI will style-check this changed formula.
