### PR TITLE
Fix add account flow from demo mode

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -529,11 +529,42 @@ final class AppState {
     }
 
     func addAccount() async {
+        error = nil
+
+        if isDemoMode {
+            isDemoMode = false
+            isSetupComplete = false
+            serverConnected = false
+            serverEnvironment = nil
+            return
+        }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        if !serverConnected {
+            await checkServerConnection()
+        }
+
+        guard serverConnected else {
+            error = "Start PlaidBarServer before adding an account."
+            return
+        }
+
+        guard serverCredentialsConfigured != false else {
+            error = "Plaid credentials are not configured on PlaidBarServer."
+            return
+        }
+
         do {
             let linkResponse = try await serverClient.createLinkToken()
-            // Open Plaid Link in browser
-            if let url = URL(string: linkResponse.linkUrl) {
-                NSWorkspace.shared.open(url)
+            guard let url = URL(string: linkResponse.linkUrl) else {
+                error = "PlaidBarServer returned an invalid Plaid Link URL."
+                return
+            }
+
+            if !NSWorkspace.shared.open(url) {
+                error = "Could not open Plaid Link in the browser."
             }
         } catch {
             self.error = error.localizedDescription

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -244,6 +244,7 @@ private func settingsRow<Content: View>(
 
 struct AccountSettingsView: View {
     @Environment(AppState.self) private var appState
+    @State private var isShowingAccountSetup = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -254,7 +255,7 @@ struct AccountSettingsView: View {
                     Text(emptyMessage)
                 } actions: {
                     Button {
-                        Task { await appState.addAccount() }
+                        handleAddAccount()
                     } label: {
                         Label("Add Account", systemImage: "plus.circle")
                     }
@@ -331,11 +332,31 @@ struct AccountSettingsView: View {
             HStack {
                 Spacer()
                 Button("Add Account") {
-                    Task { await appState.addAccount() }
+                    handleAddAccount()
                 }
                 .buttonStyle(.borderedProminent)
             }
             .padding()
+        }
+        .sheet(isPresented: $isShowingAccountSetup) {
+            SetupView()
+                .environment(appState)
+        }
+        .onChange(of: appState.isSetupComplete) { _, isComplete in
+            if isComplete {
+                isShowingAccountSetup = false
+            }
+        }
+    }
+
+    private func handleAddAccount() {
+        if appState.isDemoMode {
+            Task {
+                await appState.addAccount()
+                isShowingAccountSetup = true
+            }
+        } else {
+            Task { await appState.addAccount() }
         }
     }
 


### PR DESCRIPTION
## Summary
- Route dashboard Add Account out of demo mode into the setup/connect chooser instead of attempting a server link token call
- Add server/credential/link URL validation and visible errors before opening Plaid Link
- Make Settings > Accounts Add Account open the setup/connect sheet from demo mode

## Verification
- swift build
- swift build -c release --disable-keychain
- git diff --check
- Manual visual smoke: dashboard Add Account opens setup chooser
- Manual visual smoke: Settings > Accounts Add Account opens setup/connect sheet

## Notes
- swift test is still blocked locally because this toolchain cannot resolve Swift's Testing module.