### PR TITLE
feat: gate first-run completion on sync readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ when the local app created the Hosted Link session.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/health` | Health check |
-| `GET` | `/api/status` | Server version, environment, item count |
+| `GET` | `/api/status` | Server version, environment, item count, synced item count, storage readiness |
 | `GET` | `/api/items` | List connected bank items |
 | `POST` | `/api/link/create` | Create one-time Plaid Hosted Link token + URL |
 | `POST` | `/api/link/update/:itemId` | Create one-time Plaid Hosted Link update-mode URL for reconnect |

--- a/Scripts/smoke-sandbox.sh
+++ b/Scripts/smoke-sandbox.sh
@@ -99,6 +99,10 @@ if status.get("credentialsConfigured") is not True:
     errors.append("expected credentialsConfigured=true")
 if "itemCount" not in status:
     errors.append("status response missing itemCount")
+if "syncedItemCount" not in status:
+    errors.append("status response missing syncedItemCount")
+elif not isinstance(status["syncedItemCount"], int):
+    errors.append("status response syncedItemCount is not an integer")
 storage_path = None
 if not status.get("storagePath"):
     errors.append("status response missing storagePath")

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -38,6 +38,7 @@ final class AppState {
     var serverCredentialsConfigured: Bool?
     var serverStoragePath: String?
     var serverSyncReady: Bool?
+    var serverSyncedItemCount: Int?
     var itemStatuses: [ItemStatus] = []
     var isDemoMode = false
     var lastSyncDate: Date?
@@ -366,6 +367,18 @@ final class AppState {
         return "Plaid connection healthy"
     }
 
+    var firstRunCompletionState: FirstRunCompletionState {
+        FirstRunCompletionState.evaluate(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            linkedItemCount: statusItemCount,
+            accountCount: accountCount,
+            transactionCount: transactionCount,
+            syncedItemCount: serverSyncedItemCount ?? 0,
+            errorMessage: error
+        )
+    }
+
     var isSyncStale: Bool {
         guard let lastSyncDate else { return true }
         let staleAfter = max(refreshInterval * 2, PlaidBarConstants.transactionSyncInterval * 2)
@@ -453,10 +466,12 @@ final class AppState {
             serverCredentialsConfigured = status.credentialsConfigured
             serverStoragePath = status.storagePath
             serverSyncReady = status.syncReady
+            serverSyncedItemCount = status.syncedItemCount
             lastSyncDate = status.lastSync
-            isSetupComplete = status.itemCount > 0
+            updateSetupCompletion()
             if !(await refreshItemStatuses()) {
                 itemStatuses = []
+                updateSetupCompletion()
             }
         } catch {
             serverConnected = false
@@ -466,8 +481,9 @@ final class AppState {
             serverCredentialsConfigured = nil
             serverStoragePath = nil
             serverSyncReady = nil
+            serverSyncedItemCount = nil
             itemStatuses = []
-            isSetupComplete = false
+            updateSetupCompletion()
         }
     }
 
@@ -478,7 +494,7 @@ final class AppState {
             accounts = try await serverClient.getAccounts()
             serverItemCount = Set(accounts.map(\.itemId)).count
             serverSyncReady = (serverItemCount ?? 0) > 0
-            isSetupComplete = (serverItemCount ?? 0) > 0
+            updateSetupCompletion()
             await refreshItemStatuses()
         } catch {
             await refreshItemStatuses()
@@ -521,7 +537,9 @@ final class AppState {
                 hasMore = response.hasMore
             }
             lastSyncDate = Date()
+            serverSyncedItemCount = statusItemCount
             await refreshItemStatuses()
+            updateSetupCompletion()
         } catch {
             await refreshItemStatuses()
             self.error = error.localizedDescription
@@ -536,6 +554,7 @@ final class AppState {
             isSetupComplete = false
             serverConnected = false
             serverEnvironment = nil
+            serverSyncedItemCount = nil
             return
         }
 
@@ -616,6 +635,28 @@ final class AppState {
         return error == nil
     }
 
+    @discardableResult
+    func completeFirstRunCheck() async -> Bool {
+        error = nil
+        await checkServerConnection()
+
+        guard serverConnected, statusItemCount > 0 else {
+            updateSetupCompletion()
+            return false
+        }
+
+        await refreshAccounts()
+
+        guard !accounts.isEmpty else {
+            updateSetupCompletion()
+            return false
+        }
+
+        await syncTransactions()
+        updateSetupCompletion()
+        return firstRunCompletionState.isReady
+    }
+
     func removeAccount(itemId: String) async {
         do {
             try await serverClient.removeItem(itemId: itemId)
@@ -629,11 +670,12 @@ final class AppState {
                 itemStatuses.removeAll { $0.id == removedItemId }
                 serverItemCount = max(itemStatuses.count, fallbackItemCount)
                 serverSyncReady = (serverItemCount ?? 0) > 0
-                isSetupComplete = (serverItemCount ?? 0) > 0
+                updateSetupCompletion()
             }
             let remainingItemCount = serverItemCount ?? 0
             if remainingItemCount == 0 {
                 lastSyncDate = nil
+                serverSyncedItemCount = 0
             }
             transactions.removeAll { transaction in
                 transaction.itemId == removedItemId ||
@@ -662,6 +704,7 @@ final class AppState {
         serverCredentialsConfigured = nil
         serverStoragePath = nil
         serverSyncReady = nil
+        serverSyncedItemCount = nil
         lastSyncDate = nil
         isSetupComplete = false
         isDemoMode = false
@@ -786,7 +829,11 @@ final class AppState {
         itemStatuses = statuses
         serverItemCount = statuses.count
         serverSyncReady = !statuses.isEmpty
-        isSetupComplete = !statuses.isEmpty
+        updateSetupCompletion()
+    }
+
+    private func updateSetupCompletion() {
+        isSetupComplete = firstRunCompletionState.isReady
     }
 
     private func recordBalanceSnapshot() {
@@ -916,6 +963,7 @@ final class AppState {
         serverCredentialsConfigured = true
         serverStoragePath = LocalDataStore.displayPath
         serverSyncReady = true
+        serverSyncedItemCount = serverItemCount
         itemStatuses = [
             ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: Date()),
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -183,7 +183,9 @@ struct SetupView: View {
     }
 
     private func connectingView(environment: PlaidEnvironment) -> some View {
-        VStack(spacing: Spacing.lg) {
+        let completion = appState.firstRunCompletionState
+
+        return VStack(spacing: Spacing.lg) {
             ProgressView()
                 .scaleEffect(1.5)
 
@@ -195,18 +197,19 @@ struct SetupView: View {
                 .foregroundStyle(.secondary)
                 .font(.callout)
 
+            FirstRunCompletionPanel(state: completion)
+
             Button {
                 Task {
-                    await appState.refreshAccounts()
-                    if appState.isSetupComplete {
-                        await appState.syncTransactions()
+                    if await appState.completeFirstRunCheck() {
                         onComplete?()
                     }
                 }
             } label: {
-                Label("Check Connection", systemImage: "arrow.clockwise")
+                Label(completion.isReady ? "Open Dashboard" : "Check Connection", systemImage: "arrow.clockwise")
             }
             .buttonStyle(.bordered)
+            .disabled(appState.isLoading || (!completion.canRetry && !completion.isReady))
 
             Button("Cancel") {
                 setupMode = environment == .production ? .production : .sandbox
@@ -244,6 +247,56 @@ struct SetupView: View {
         }
 
         return "Ready to open Plaid Link in your browser."
+    }
+}
+
+private struct FirstRunCompletionPanel: View {
+    let state: FirstRunCompletionState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                    .frame(width: 18)
+                Text(state.title)
+                    .font(.callout.weight(.semibold))
+                Spacer(minLength: Spacing.sm)
+            }
+
+            Text(state.detail)
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var icon: String {
+        switch state.step {
+        case .ready:
+            "checkmark.circle.fill"
+        case .blocked:
+            "exclamationmark.triangle.fill"
+        case .openPlaidLink:
+            "link.circle"
+        case .loadAccounts:
+            "building.columns"
+        case .syncTransactions:
+            "arrow.triangle.2.circlepath"
+        }
+    }
+
+    private var color: Color {
+        switch state.step {
+        case .ready:
+            SemanticColors.positive
+        case .blocked:
+            SemanticColors.negative
+        case .openPlaidLink, .loadAccounts, .syncTransactions:
+            SemanticColors.brand
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+public enum FirstRunCompletionStep: String, Codable, Sendable {
+    case openPlaidLink
+    case loadAccounts
+    case syncTransactions
+    case ready
+    case blocked
+}
+
+public struct FirstRunCompletionState: Equatable, Sendable {
+    public let step: FirstRunCompletionStep
+    public let title: String
+    public let detail: String
+    public let isReady: Bool
+    public let canRetry: Bool
+
+    public init(
+        step: FirstRunCompletionStep,
+        title: String,
+        detail: String,
+        isReady: Bool,
+        canRetry: Bool
+    ) {
+        self.step = step
+        self.title = title
+        self.detail = detail
+        self.isReady = isReady
+        self.canRetry = canRetry
+    }
+
+    public static func evaluate(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int,
+        accountCount: Int,
+        transactionCount: Int,
+        syncedItemCount: Int,
+        errorMessage: String?
+    ) -> FirstRunCompletionState {
+        if isDemoMode {
+            return FirstRunCompletionState(
+                step: .ready,
+                title: "Demo ready",
+                detail: "Local demo accounts and transactions are loaded.",
+                isReady: true,
+                canRetry: false
+            )
+        }
+
+        if let errorMessage, !errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return FirstRunCompletionState(
+                step: .blocked,
+                title: "Connection needs attention",
+                detail: errorMessage,
+                isReady: false,
+                canRetry: true
+            )
+        }
+
+        guard serverConnected else {
+            return FirstRunCompletionState(
+                step: .blocked,
+                title: "Server offline",
+                detail: "Start PlaidBarServer, then check the connection again.",
+                isReady: false,
+                canRetry: true
+            )
+        }
+
+        guard linkedItemCount > 0 else {
+            return FirstRunCompletionState(
+                step: .openPlaidLink,
+                title: "Waiting for Plaid Link",
+                detail: "Complete the bank connection in your browser, then check again.",
+                isReady: false,
+                canRetry: true
+            )
+        }
+
+        guard accountCount > 0 else {
+            return FirstRunCompletionState(
+                step: .loadAccounts,
+                title: "Linked item found",
+                detail: "PlaidBar can see the linked item. Load accounts to finish the first run.",
+                isReady: false,
+                canRetry: true
+            )
+        }
+
+        guard syncedItemCount >= linkedItemCount else {
+            return FirstRunCompletionState(
+                step: .syncTransactions,
+                title: "Accounts loaded",
+                detail: transactionCount > 0
+                    ? "\(syncedItemCount) of \(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") synced. Run one more check to finish setup."
+                    : "Run the first transaction sync check to finish setup.",
+                isReady: false,
+                canRetry: true
+            )
+        }
+
+        return FirstRunCompletionState(
+            step: .ready,
+            title: "Dashboard ready",
+            detail: transactionCount == 1
+                ? "1 transaction synced. PlaidBar is ready."
+                : "\(transactionCount) transactions synced. PlaidBar is ready.",
+            isReady: true,
+            canRetry: false
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/ServerStatus.swift
+++ b/Sources/PlaidBarCore/Models/ServerStatus.swift
@@ -2,6 +2,17 @@ import Foundation
 
 /// Response from server's /api/status
 public struct ServerStatus: Codable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case environment
+        case itemCount
+        case lastSync
+        case credentialsConfigured
+        case storagePath
+        case syncReady
+        case syncedItemCount
+    }
+
     public let version: String
     public let environment: PlaidEnvironment
     public let itemCount: Int
@@ -9,6 +20,7 @@ public struct ServerStatus: Codable, Sendable {
     public let credentialsConfigured: Bool
     public let storagePath: String
     public let syncReady: Bool
+    public let syncedItemCount: Int
 
     public init(
         version: String,
@@ -17,7 +29,8 @@ public struct ServerStatus: Codable, Sendable {
         lastSync: Date? = nil,
         credentialsConfigured: Bool = true,
         storagePath: String = LocalDataStore.displayPath,
-        syncReady: Bool? = nil
+        syncReady: Bool? = nil,
+        syncedItemCount: Int? = nil
     ) {
         self.version = version
         self.environment = environment
@@ -26,6 +39,30 @@ public struct ServerStatus: Codable, Sendable {
         self.credentialsConfigured = credentialsConfigured
         self.storagePath = storagePath
         self.syncReady = syncReady ?? (itemCount > 0)
+        self.syncedItemCount = syncedItemCount ?? (lastSync == nil ? 0 : itemCount)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(String.self, forKey: .version)
+        let environment = try container.decode(PlaidEnvironment.self, forKey: .environment)
+        let itemCount = try container.decode(Int.self, forKey: .itemCount)
+        let lastSync = try container.decodeIfPresent(Date.self, forKey: .lastSync)
+        let credentialsConfigured = try container.decodeIfPresent(Bool.self, forKey: .credentialsConfigured)
+        let storagePath = try container.decodeIfPresent(String.self, forKey: .storagePath)
+        let syncReady = try container.decodeIfPresent(Bool.self, forKey: .syncReady)
+        let syncedItemCount = try container.decodeIfPresent(Int.self, forKey: .syncedItemCount)
+
+        self.init(
+            version: version,
+            environment: environment,
+            itemCount: itemCount,
+            lastSync: lastSync,
+            credentialsConfigured: credentialsConfigured ?? true,
+            storagePath: storagePath ?? LocalDataStore.displayPath,
+            syncReady: syncReady,
+            syncedItemCount: syncedItemCount
+        )
     }
 }
 

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -19,6 +19,7 @@ struct StatusRoutes: Sendable {
     ) async throws -> Response {
         let itemCount = try await tokenStore.itemCount()
         let lastSync = try await tokenStore.lastSyncDate()
+        let syncedItemCount = try await tokenStore.syncedItemCount()
 
         let status = ServerStatus(
             version: PlaidBarConstants.appVersion,
@@ -27,7 +28,8 @@ struct StatusRoutes: Sendable {
             lastSync: lastSync,
             credentialsConfigured: !config.plaidClientId.isEmpty && !config.plaidSecret.isEmpty,
             storagePath: config.databasePath,
-            syncReady: itemCount > 0
+            syncReady: itemCount > 0,
+            syncedItemCount: syncedItemCount
         )
 
         let encoder = JSONEncoder()

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -96,6 +96,10 @@ actor TokenStore {
             .updatedAt
     }
 
+    func syncedItemCount() async throws -> Int {
+        try await SyncCursorModel.query(on: fluent.db()).count()
+    }
+
     nonisolated func accessToken(for item: ItemModel) throws -> String {
         try PlaidTokenVault.resolve(storedToken: item.accessToken)
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -586,6 +586,7 @@ struct PlaidBarCoreTests {
         #expect(decoded.credentialsConfigured)
         #expect(decoded.storagePath == LocalDataStore.displayPath)
         #expect(decoded.syncReady)
+        #expect(decoded.syncedItemCount == 0)
     }
 
     @Test("ServerStatus with lastSync")
@@ -600,6 +601,7 @@ struct PlaidBarCoreTests {
         let decoded = try decoder.decode(ServerStatus.self, from: data)
         #expect(decoded.environment == .production)
         #expect(decoded.lastSync != nil)
+        #expect(decoded.syncedItemCount == 1)
     }
 
     @Test("ServerStatus preflight fields")
@@ -610,7 +612,8 @@ struct PlaidBarCoreTests {
             itemCount: 0,
             credentialsConfigured: false,
             storagePath: "/tmp/plaidbar.sqlite",
-            syncReady: false
+            syncReady: false,
+            syncedItemCount: 0
         )
 
         let data = try JSONEncoder().encode(status)
@@ -619,6 +622,95 @@ struct PlaidBarCoreTests {
         #expect(decoded.credentialsConfigured == false)
         #expect(decoded.storagePath == "/tmp/plaidbar.sqlite")
         #expect(decoded.syncReady == false)
+        #expect(decoded.syncedItemCount == 0)
+    }
+
+    @Test("ServerStatus decodes legacy payload without synced item count")
+    func serverStatusLegacyPayload() throws {
+        let json = """
+        {
+          "version": "0.5.0",
+          "environment": "sandbox",
+          "itemCount": 2,
+          "credentialsConfigured": true,
+          "storagePath": "/tmp/plaidbar.sqlite",
+          "syncReady": true
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ServerStatus.self, from: json)
+
+        #expect(decoded.itemCount == 2)
+        #expect(decoded.syncedItemCount == 0)
+    }
+
+    // MARK: - First-run Completion Tests
+
+    @Test("First-run completion waits for Plaid Link")
+    func firstRunCompletionWaitsForLink() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 0,
+            accountCount: 0,
+            transactionCount: 0,
+            syncedItemCount: 0,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .openPlaidLink)
+        #expect(!state.isReady)
+        #expect(state.canRetry)
+    }
+
+    @Test("First-run completion requires accounts after item link")
+    func firstRunCompletionRequiresAccounts() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 0,
+            transactionCount: 0,
+            syncedItemCount: 0,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .loadAccounts)
+        #expect(!state.isReady)
+    }
+
+    @Test("First-run completion requires sync attempt after accounts load")
+    func firstRunCompletionRequiresSyncAttempt() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            transactionCount: 0,
+            syncedItemCount: 0,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .syncTransactions)
+        #expect(!state.isReady)
+        #expect(state.canRetry)
+    }
+
+    @Test("First-run completion is ready after accounts and sync")
+    func firstRunCompletionReadyAfterSync() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            transactionCount: 0,
+            syncedItemCount: 1,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .ready)
+        #expect(state.isReady)
+        #expect(!state.canRetry)
     }
 
     // MARK: - ItemStatus Tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,8 @@ Plaid API
 The app talks to the server through `ServerClient`. The server exposes:
 
 - `GET /health`
-- `GET /api/status`
+- `GET /api/status` for version, environment, credential readiness, storage
+  path, linked item count, synced item count, and last sync time
 - `GET /api/items`
 - `POST /api/link/create`
 - `POST /api/link/update/:itemId`

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -25,6 +25,9 @@ local storage, notifications, and distribution.
 | Demo | Launch with `--demo` | Dashboard renders fixture data without Plaid credentials |
 | First run | Click View Demo | Sheet dismisses and demo accounts appear |
 | Sandbox setup | Launch `./Scripts/run.sh --sandbox` with credentials | Preflight passes and Plaid Link opens |
+| Sandbox return | Complete Plaid Link, then click Check Connection | App verifies linked item, loads accounts, runs transaction sync, then opens dashboard |
+| Linked item pending accounts | Plaid item exists but accounts are empty | Setup stays in completion state and explains that accounts still need to load |
+| Accounts pending sync | Accounts exist but no sync has completed | Setup stays in completion state and asks for the first sync check |
 | Missing credentials | Launch sandbox without credentials | Preflight blocks Link and explains missing credentials |
 | Wrong mode | App expects sandbox but server is production, or reverse | Preflight shows environment mismatch |
 | Server offline | App opens without server in non-demo mode | Recovery state explains server offline |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,26 @@ This file holds human-written release summaries before they are copied into a
 GitHub release. `CHANGELOG.md` may be generated from repository history, so keep
 curated release messaging here.
 
-## v0.5.0 - In progress
+## v0.6.0 - Unreleased
+
+### Added
+
+- First-run completion state for Plaid Link return: setup now distinguishes
+  waiting for Link, linked item without accounts, accounts without first sync,
+  blocked errors, and dashboard-ready completion.
+
+### Changed
+
+- Onboarding only completes after a linked item has loaded accounts and the
+  first transaction sync check has completed.
+
+### Verification Targets
+
+- Clean-profile sandbox QA with `PLAIDBAR_DATA_DIR=$(mktemp -d)`.
+- `swift test --filter FirstRunCompletion --skip-update --disable-keychain`
+- `swift build --target PlaidBar --skip-update --disable-keychain`
+
+## v0.5.0 - Published
 
 ### Added
 

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -173,6 +173,9 @@ Requirements:
 - Production setup must clearly say that real account data requires Plaid
   production approval.
 - The app must explain local token/data storage before a Plaid link flow starts.
+- After the user returns from Plaid Link, setup must verify linked item,
+  accounts loaded, transaction sync attempted, and dashboard readiness before
+  dismissing onboarding.
 - Setup must offer recovery actions for:
   - server offline
   - wrong server mode
@@ -180,13 +183,16 @@ Requirements:
   - invalid Plaid Link URL
   - browser open failure
   - no linked items after returning
+  - linked item present but accounts not loaded
+  - accounts loaded but first transaction sync not complete
 
 Acceptance criteria:
 
 - A new user can launch `plaidbar --demo` and see dashboard data in under 30
   seconds.
 - A developer with sandbox credentials can run `plaidbar-run --sandbox`, connect
-  a sandbox item, and see accounts without editing source.
+  a sandbox item, complete the post-Link check, and land on the dashboard
+  without editing source.
 - No setup path appears clickable if it cannot complete.
 
 ### Dashboard


### PR DESCRIPTION
## Summary
- Add a typed first-run completion state for post-Plaid-Link onboarding.
- Gate setup completion on linked item, loaded accounts, and synced item count instead of item existence alone.
- Expose `syncedItemCount` from `/api/status` and update smoke/docs/QA coverage.

## Test plan
- [x] `git diff --check`
- [x] `bash -n Scripts/*.sh Scripts/plaidbar-run`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret ./Scripts/smoke-sandbox.sh`
- [x] `./Scripts/screenshots.sh` (passed; reverted unrelated randomized demo screenshot churn)
- [ ] `swift test --filter FirstRunCompletion --skip-update --disable-keychain` (blocked locally by existing Swift Testing module/toolchain issue: `no such module 'Testing'`)

## Notes
- Codex CLI review found no blocking issues. It flagged the global last-sync gate as a concern, so this PR now uses `syncedItemCount` from server cursor state.