### PR TITLE
test: harden security contract checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ First run now asks you to choose a data source:
 - **Connect Sandbox** opens Plaid Link only when the local server is running in sandbox mode with sandbox credentials.
 - **Use Production Credentials** opens the same connect flow only when the local server reports production mode. Production uses real account data and requires Plaid approval.
 
-Before Plaid Link opens, the app explains that Plaid access tokens and synced account data are stored locally under `~/.plaidbar/`, while Plaid credentials remain in the local server environment.
+Before Plaid Link opens, the app explains that Plaid item records and synced account data are stored locally under `~/.plaidbar/`, Plaid access-token bytes are kept in macOS Keychain when available, and Plaid credentials remain in the local server environment.
 
 ### 4. Use with real bank data (optional)
 
@@ -273,7 +273,7 @@ PlaidBar uses a **two-process architecture** — a SwiftUI menu bar app talks to
 
 **Why a companion server?** Plaid requires that `client_secret` and `access_token` never exist in the menu bar client. The server:
 1. Keeps Plaid credentials and access tokens out of the SwiftUI app process
-2. Stores item tokens in a local SQLite database under `~/.plaidbar/`
+2. Stores item records in local SQLite and Plaid access-token bytes in macOS Keychain when available
 3. Binds to `127.0.0.1` only — no LAN or cloud exposure
 4. Can be restarted independently of the UI
 5. Opens the door for future CLI tools or iOS companion
@@ -287,7 +287,7 @@ PlaidBar uses a **two-process architecture** — a SwiftUI menu bar app talks to
 | Design system | Semantic tokens + 8pt grid | Consistent, maintainable |
 | Local server | [Hummingbird 2](https://github.com/hummingbird-project/hummingbird) | Lightweight, SwiftNIO-based, same language as app |
 | Database | SQLite via [Fluent ORM](https://github.com/vapor/fluent-kit) | Migrations, queries, Hummingbird-native |
-| Secrets (app) | macOS Keychain | OS-level secure storage |
+| Plaid access-token vault | macOS Keychain + SQLite references | Keep token bytes out of the SwiftUI app and out of normal SQLite rows at runtime |
 | Auto-updates | [Sparkle 2](https://github.com/sparkle-project/Sparkle) | Standard for open-source macOS apps |
 | Launch at login | SMAppService | Native macOS Login Items API |
 
@@ -348,7 +348,8 @@ Rate limits are well within Plaid's allowances for personal use (~2-4 requests/h
 | Concern | How PlaidBar handles it |
 |---------|------------------------|
 | Plaid secrets | Read from environment variables at server startup, never embedded in the app binary |
-| Plaid access tokens | Stored in local SQLite under `~/.plaidbar/`; protect your Mac user account and disk |
+| Plaid access tokens | Stored in macOS Keychain at runtime when available; SQLite stores `keychain:<item_id>` references |
+| Local status endpoint | Authenticated `/api/status` exposes readiness metadata only, not tokens, account IDs, balances, or transactions |
 | Network exposure | Server binds to `127.0.0.1` only |
 | App ↔ Server auth | Shared token generated at first run |
 | Data at rest | macOS encrypted APFS volume |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,10 +30,20 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
 - PlaidBar has no hosted backend, analytics, telemetry, or tracking.
 - The companion server should bind to `127.0.0.1` only.
 - Plaid secrets and access tokens must not be embedded in the app binary.
-- The local server stores Plaid item access tokens in environment-scoped SQLite files under `~/.plaidbar/`:
+- The local server keeps Plaid item records in environment-scoped SQLite files under `~/.plaidbar/`:
   `plaidbar-sandbox.sqlite` for sandbox and `plaidbar-production.sqlite` for production.
+- On macOS builds with Security framework support, Plaid access-token bytes are
+  stored in Keychain under the `PlaidBar.PlaidAccessToken` service and SQLite
+  stores only a `keychain:<item_id>` reference. Build/test environments without
+  Keychain support may fall back to local SQLite token storage, so release
+  claims must distinguish runtime Keychain behavior from fallback builds.
 - Existing legacy `plaidbar.sqlite` data, SQLite sidecar files, and matching transaction cache are copied into a scoped database only when the legacy environment is explicit (`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from the existing transaction-cache context. Ambiguous legacy databases are left untouched to avoid sandbox/production token crossover. Explicit migration can replace an existing scoped store, backs up the previous scoped SQLite store and transaction cache before copying legacy data, and writes a migration marker so restarts do not reapply stale legacy data.
 - The app/server auth token is generated locally under `~/.plaidbar/auth-token`.
+- `/api/status` is authenticated and should expose only readiness metadata:
+  version, environment, credential availability, storage path, linked item
+  count, synced item count, sync readiness, and last sync time. It must not
+  include Plaid secrets, Plaid access tokens, public tokens, auth tokens,
+  account IDs, item IDs, balances, or transaction data.
 - Protect your macOS user account, disk encryption, backups, and shell history.
 - App-server communication should preserve local-only assumptions unless a future change explicitly documents otherwise.
 

--- a/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
+++ b/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
@@ -13,7 +13,7 @@ struct APITokenMiddleware<Context: RequestContext>: RouterMiddleware {
         context: Context,
         next: (Request, Context) async throws -> Response
     ) async throws -> Response {
-        guard Self.constantTimeEquals(
+        guard APITokenAuthorization.constantTimeEquals(
             request.headers[.authorization] ?? "",
             expectedAuthorizationHeader
         ) else {
@@ -22,8 +22,10 @@ struct APITokenMiddleware<Context: RequestContext>: RouterMiddleware {
 
         return try await next(request, context)
     }
+}
 
-    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+enum APITokenAuthorization {
+    static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
         let lhsBytes = Array(lhs.utf8)
         let rhsBytes = Array(rhs.utf8)
         let maxCount = max(lhsBytes.count, rhsBytes.count)

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -51,7 +51,7 @@ actor TokenStore {
             try PlaidTokenVault.delete(storedToken: item.accessToken, fallbackItemId: id)
         } catch {
             logger.warning(
-                "Failed to delete Plaid access token from Keychain for item \(id): \(String(describing: error))"
+                "Failed to delete Plaid access token from Keychain: \(String(describing: error))"
             )
         }
     }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -37,6 +37,42 @@ struct PlaidBarServerTests {
         #expect(decoded.syncReady)
     }
 
+    @Test func serverStatusPayloadDoesNotExposeSecretsOrTokens() throws {
+        let status = ServerStatus(
+            version: "0.8.0",
+            environment: .production,
+            itemCount: 2,
+            lastSync: Date(timeIntervalSince1970: 1_800_000_000),
+            credentialsConfigured: true,
+            storagePath: "/Users/example/.plaidbar/plaidbar-production.sqlite",
+            syncReady: true,
+            syncedItemCount: 2
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let data = try encoder.encode(status)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let keys = Set(object.keys)
+        let forbiddenFragments = ["client", "secret", "token", "access", "public"]
+
+        #expect(keys == [
+            "version",
+            "environment",
+            "itemCount",
+            "lastSync",
+            "credentialsConfigured",
+            "storagePath",
+            "syncReady",
+            "syncedItemCount",
+        ])
+        #expect(!String(data: data, encoding: .utf8)!.contains("config-secret"))
+        #expect(!String(data: data, encoding: .utf8)!.contains("access-sandbox"))
+        #expect(keys.allSatisfy { key in
+            forbiddenFragments.allSatisfy { !key.localizedCaseInsensitiveContains($0) }
+        })
+    }
+
     @Test func serverConfigLoadsExplicitConfigFile() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
@@ -155,6 +191,13 @@ struct PlaidBarServerTests {
             character.isLetter || character.isNumber || character == "-" || character == "_"
         })
         #expect(!token.contains("="))
+    }
+
+    @Test func apiTokenComparisonAcceptsOnlyExactBearerToken() {
+        #expect(APITokenAuthorization.constantTimeEquals("Bearer token-123", "Bearer token-123"))
+        #expect(!APITokenAuthorization.constantTimeEquals("Bearer token-123", "Bearer token-124"))
+        #expect(!APITokenAuthorization.constantTimeEquals("Bearer token-123", "token-123"))
+        #expect(!APITokenAuthorization.constantTimeEquals("Bearer token-123", "Bearer token-123-extra"))
     }
 
     @Test func oauthCallbackErrorPageEscapesDynamicMessage() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,13 +85,34 @@ Current important files:
 | File | Purpose |
 |------|---------|
 | `auth-token` | Local app-server bearer token |
-| `plaidbar-sandbox.sqlite` | Sandbox Plaid item/token/account storage |
-| `plaidbar-production.sqlite` | Production Plaid item/token/account storage |
+| `plaidbar-sandbox.sqlite` | Sandbox Plaid item/account storage and token references |
+| `plaidbar-production.sqlite` | Production Plaid item/account storage and token references |
 | `transactions-*.json` | Environment/path-scoped transaction cache |
 | `pending-link-sessions.json` | Pending Plaid Hosted Link state |
 
 The data directory is created with private user permissions. Cache/token files
 are written with private file permissions where the platform supports it.
+On macOS runtime builds with Security framework support, Plaid access-token
+bytes are stored in Keychain and SQLite stores `keychain:<item_id>` references.
+Fallback builds without Keychain support may store token bytes locally in the
+SQLite store, so release/security docs must stay explicit about that boundary.
+
+## Status Endpoint Contract
+
+`GET /api/status` is authenticated and release-auditable. It may expose only:
+
+- app/server version
+- Plaid environment
+- whether Plaid credentials are configured
+- local storage path
+- linked item count
+- synced item count
+- sync readiness
+- last sync time
+
+It must not expose Plaid client secrets, access tokens, public tokens, local
+auth tokens, account IDs, item IDs, account balances, transaction rows, or raw
+Plaid error payloads.
 
 ## Sandbox and Production Separation
 
@@ -131,7 +152,6 @@ states if any later step fails.
 ## 1.0 Architecture Debt
 
 - Add a clean architecture diagram to README or docs.
-- Add focused tests around local auth-token file permissions where practical.
 - Add endpoint-level documentation for request/response DTOs.
 - Add a clean duplicate-instance strategy and document expected behavior.
 - Decide whether the 1.0 install story is formula-only or notarized app bundle.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -47,13 +47,20 @@ Current local data may include:
 
 - local app-server auth token
 - Plaid item records
-- Plaid access tokens
+- Plaid access-token references in SQLite, with access-token bytes in macOS
+  Keychain when Security framework support is available
 - account metadata
 - balances
 - transaction cache
 - pending link-session state
 
 Sandbox and production use separate scoped stores.
+
+`/api/status` is authenticated and intentionally limited to readiness metadata:
+server version, Plaid environment, credential availability, storage path, item
+counts, synced item count, sync readiness, and last sync time. It should not
+contain Plaid secrets, Plaid access tokens, public tokens, local auth tokens,
+account IDs, item IDs, balances, or transactions.
 
 ## Credentials
 

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -60,9 +60,12 @@ local storage, notifications, and distribution.
 |-------|-----------------|
 | Secret scan | No real secrets, tokens, or private keys in docs/source/tests |
 | Status endpoint | `/api/status` exposes readiness metadata, not secrets |
+| Status contract test | Encoded `ServerStatus` contains only release-approved keys |
 | Auth middleware | `/api/*` rejects missing/invalid bearer token |
+| Auth comparison | Bearer token comparison accepts only exact token strings |
 | Data directory | `~/.plaidbar/` uses private user permissions where supported |
 | Auth token | `auth-token` uses private file permissions where supported |
+| Plaid tokens | Runtime stores access-token bytes in Keychain when available; fallback builds are documented |
 | Sandbox/production | Stores and transaction cache are scoped by environment |
 | Reset copy | UI explains local reset does not guarantee Plaid/bank revocation |
 | Screenshots | Assets contain demo/sandbox/synthetic data only |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ curated release messaging here.
 
 - Dashboard Status readiness panel with mode, server state, linked item count,
   synced item count, credential readiness, last sync, and recovery actions.
+- Security contract tests for the status payload and local bearer-token
+  comparison.
 
 ### Changed
 
@@ -17,11 +19,15 @@ curated release messaging here.
   prioritizes server offline, missing credentials, no linked item, unloaded
   balances, item errors, login-required items, incomplete first sync, and stale
   sync.
+- Security/privacy docs now distinguish macOS Keychain runtime token storage
+  from fallback builds and define the authenticated `/api/status` no-secret
+  payload contract.
 
 ### Verification Targets
 
 - Select Status in demo mode and verify healthy local demo readiness.
 - Verify offline server and stale sync states expose a single primary action.
+- Confirm `/api/status` exposes readiness metadata only.
 - `swift build --target PlaidBar --skip-update --disable-keychain`
 
 ## v0.6.0 - Unreleased

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -362,7 +362,7 @@ PlaidBar uses three major modules:
 - Local server binds to `127.0.0.1` by default.
 - App-server communication uses a locally generated auth token.
 - Plaid credentials stay in server environment/config, not in the app binary.
-- Plaid access tokens stay in local scoped stores under `~/.plaidbar/`.
+- Plaid item records and environment-scoped databases stay under `~/.plaidbar/`; access-token bytes use macOS Keychain when available, with fallback behavior documented for non-Keychain builds.
 - Sandbox and production stores remain separated.
 - Legacy database migration remains explicit or safely inferred.
 - UI surfaces must not need raw Plaid secrets.
@@ -515,7 +515,7 @@ Good first contribution areas:
 | v0.7 | Dashboard Status readiness/recovery panel | Main popover | In progress |
 | QA | Local `swift test` toolchain mismatch around `Testing` module | Tests/CI | Open |
 | Docs | Architecture, privacy, troubleshooting docs | `docs/` | Done |
-| Security | Secret/log/status endpoint audit | Source and scripts | Not started |
+| Security | Secret/log/status endpoint audit | Source and scripts | In progress |
 | Distribution | Final packaging decision: formula-only vs notarized app | Release docs | Not started |
 | Release | Release notes and 1.0 release checklist | Repo root/docs | v0.5 notes drafted; checklist not started |
 


### PR DESCRIPTION
## Summary
- add contract tests for the authenticated `/api/status` payload and local API token comparison
- avoid logging Plaid item IDs when Keychain token cleanup fails
- align README, SECURITY, privacy, architecture, QA, release notes, and v1 roadmap around Keychain token storage and metadata-only status responses

## Verification
- `git diff --check`
- `bash -n Scripts/*.sh Scripts/plaidbar-run`
- `swift build --target PlaidBar --skip-update --disable-keychain`
- `swift build --target PlaidBarServer --skip-update --disable-keychain`
- secret-pattern scan found placeholders/schema names only
- Codex review: no blockers

## Local test note
- `swift test --filter "serverStatusPayloadDoesNotExposeSecretsOrTokens|apiTokenComparisonAcceptsOnlyExactBearerToken" --skip-update --disable-keychain` is blocked on this machine by the existing `no such module Testing` local toolchain issue; CI remains the source of truth for tests.