### PR TITLE
docs: mark v1.0 release verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,8 +455,7 @@ when the local app created the Hosted Link session.
 ## Roadmap
 
 The detailed 1.0 plan lives in [docs/v1.0-roadmap.md](docs/v1.0-roadmap.md).
-It maps the remaining path from the v1.0 formula-only candidate to a stable
-public release:
+It maps the completed path to the v1.0 formula-only stable public release:
 product flows, design/frontend polish, local system architecture, security and
 privacy checks, distribution, docs, QA, and open-source readiness.
 
@@ -467,7 +466,7 @@ Near-term release priorities:
 - [x] Add architecture, privacy, troubleshooting, and changelog docs
 - [x] Finish security and local-data audit for 1.0
 - [x] Decide 1.0 packaging shape: formula-only first, notarized app bundle later
-- [ ] Verify Homebrew install path and release metadata from clean `main`
+- [x] Verify Homebrew install path and release metadata from clean `main`
 
 Post-1.0 candidates:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@ This file holds human-written release summaries before they are copied into a
 GitHub release. `CHANGELOG.md` may be generated from repository history, so keep
 curated release messaging here.
 
-## v1.0.0 - Unreleased
+## v1.0.0 - Published
 
 ### Added
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,9 +4,9 @@ PlaidBar 1.0 ships as a source-built Homebrew formula first. A signed,
 notarized `.app` bundle, cask, Sparkle appcast, and DMG/ZIP archive are deferred
 until the signing and clean-machine Gatekeeper path is real.
 
-## Current Candidate
+## Current Release
 
-- Candidate version: `v1.0.0`
+- Current version: `v1.0.0`
 - 1.0 distribution shape: formula-only SwiftPM executable install
 - GitHub release: tagged from clean `main`
 - Homebrew tap command:

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -36,7 +36,7 @@ good demo.
 | v0.7 | Dashboard and settings polish | Product feels native, dense, and predictable |
 | v0.8 | Security and local-data hardening | Data boundaries are technically enforced and documented |
 | v0.9 | Distribution candidate | Formula-only release train is ready; cask/notarization deferred |
-| v1.0 | Public stable release | Formula-only release candidate in progress |
+| v1.0 | Public stable release | Tagged release, install docs, QA matrix, and support policy complete |
 
 ## SDLC Plan
 
@@ -519,7 +519,7 @@ Good first contribution areas:
 | Docs | Architecture, privacy, troubleshooting docs | `docs/` | Done |
 | Security | Secret/log/status endpoint audit | PR #129 | Done |
 | Distribution | Final packaging decision: formula-only vs notarized app | Release docs | Formula-only selected for 1.0 |
-| Release | Release notes and 1.0 release checklist | Repo root/docs | v1.0 release candidate in progress |
+| Release | Release notes and 1.0 release checklist | Repo root/docs | Done |
 
 ## Post-1.0 Scope
 


### PR DESCRIPTION
## Summary
- mark v1.0.0 release notes as published
- update release runbook from current candidate to current release
- mark Homebrew install/release metadata verification complete in README and roadmap

## Verification
- `git diff --check`
- post-publish release verified: `gh release view v1.0.0`
- tag verified on origin: `git ls-remote --tags origin v1.0.0`
- Homebrew source install verified: `brew install --build-from-source plaidbar`
- installed version verified: `plaidbar-server --version` -> `1.0.0`
- formula test verified: `brew test plaidbar`