### PR TITLE
docs: add stable support policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ Configuration files: `.swiftformat` and `.swiftlint.yml` in the repo root.
 - Use the [bug report template](https://github.com/ftchvs/PlaidBar/issues/new?template=bug_report.yml) for bugs
 - Use the [feature request template](https://github.com/ftchvs/PlaidBar/issues/new?template=feature_request.yml) for ideas
 - Use the accessibility issue template for VoiceOver, keyboard, chart, contrast, or reduced-motion barriers
+- Read [SUPPORT.md](SUPPORT.md) before sharing logs, screenshots, or setup details
 
 ## Accessibility Expectations
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Additional project docs:
 - [Troubleshooting](docs/troubleshooting.md)
 - [Screenshots](docs/screenshots.md)
 - [QA Matrix](docs/qa-matrix.md)
+- [Support Policy](SUPPORT.md)
 - [1.0 Roadmap](docs/v1.0-roadmap.md)
 - [Release Notes Drafts](docs/release-notes.md)
 - [Changelog](CHANGELOG.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,14 @@ PlaidBar is a local-first macOS menu bar app for sensitive financial data. Treat
 
 ## Supported Versions
 
-The `main` branch is the supported development line before stable releases are published.
+| Version | Supported |
+|---------|-----------|
+| `1.0.x` | Yes |
+| `main` | Active development |
+| `< 1.0` | No; upgrade recommended |
+
+Security fixes target `main` first and may be released as a `1.0.x` patch when
+they affect the stable release line.
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,47 @@
+# Support
+
+PlaidBar is a local-first macOS utility for sensitive financial data. Public
+support should stay useful without exposing private account details.
+
+## Supported Versions
+
+| Version | Status |
+|---------|--------|
+| `1.0.x` | Supported stable release line |
+| `main` | Active development branch |
+| `< 1.0` | Historical pre-1.0 releases; upgrade recommended |
+
+Security fixes target `main` first and may be released as a `1.0.x` patch when
+they affect the stable release line.
+
+## Public Issues
+
+Use GitHub issues for:
+
+- setup bugs
+- demo or sandbox flow bugs
+- UI, accessibility, and documentation issues
+- feature requests
+- Homebrew formula/install problems
+
+Do not include:
+
+- real Plaid credentials or environment values
+- Plaid access tokens, public tokens, item IDs, or account IDs
+- screenshots with real balances, transactions, or institution details
+- local database files, auth-token files, or transaction exports
+
+Prefer demo mode, sandbox credentials, synthetic examples, and redacted logs.
+
+## Security Reports
+
+Do not open public issues for suspected vulnerabilities or private data
+exposure. Use GitHub private vulnerability reporting from the Security tab, or
+follow [SECURITY.md](SECURITY.md).
+
+## Plaid-Specific Support
+
+Plaid institution coverage, production approval, and Plaid API behavior may
+require Plaid documentation or Plaid support. PlaidBar can help make local
+server state and setup readiness visible, but it cannot grant Plaid production
+access or change institution support.


### PR DESCRIPTION
## Summary
- add SUPPORT.md for the v1.0 stable support line
- update SECURITY.md supported versions now that v1.0 is published
- link support guidance from README and CONTRIBUTING

## Verification
- `git diff --check`
- inspected README/CONTRIBUTING/SECURITY support links and supported-version language