### PR TITLE
fix: install Sparkle framework in Homebrew formula

### DIFF
--- a/Formula/plaidbar.rb
+++ b/Formula/plaidbar.rb
@@ -17,6 +17,8 @@ class Plaidbar < Formula
     bin.install ".build/release/PlaidBar" => "plaidbar"
     bin.install ".build/release/PlaidBarServer" => "plaidbar-server"
     bin.install "Scripts/plaidbar-run"
+    lib.install ".build/release/Sparkle.framework"
+    MachO::Tools.add_rpath bin/"plaidbar", "@loader_path/../lib"
 
     doc.install "README.md", "SECURITY.md", "LICENSE"
   end


### PR DESCRIPTION
## Summary
- install Sparkle.framework into the Homebrew keg lib directory
- add an @loader_path/../lib rpath to the installed plaidbar executable with ruby-macho
- keep the fix scoped to formula packaging so the server executable remains unchanged

## Verification
- git diff --check
- ruby -c Formula/plaidbar.rb
- HOMEBREW_CACHE=/private/tmp/homebrew-cache brew style Formula/plaidbar.rb
- swift build -c release --disable-sandbox
- Cellar-layout smoke test: copied PlaidBar to bin/plaidbar, reproduced missing Sparkle dyld crash before patch, copied Sparkle.framework to lib, applied ruby-macho add_rpath, and confirmed the dyld Sparkle failure disappears

Note: a full local Homebrew reinstall was blocked by a Homebrew cache/source_modified_time issue unrelated to this formula change: ArgumentError no time information in empty string.