### PR TITLE
Clarify demo-mode server status

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -289,6 +289,7 @@ final class AppState {
     }
 
     var statusServerText: String {
+        if isDemoMode { return "Local demo" }
         if isLoading { return "Syncing" }
         if error != nil { return "Error" }
         return serverConnected ? "Connected" : "Offline"
@@ -337,11 +338,13 @@ final class AppState {
     }
 
     var serverCredentialsText: String {
+        if isDemoMode { return "Not required" }
         guard serverConnected else { return "Unknown" }
         return serverCredentialsConfigured == true ? "Ready" : "Missing"
     }
 
     var serverSyncReadinessText: String {
+        if isDemoMode { return "Demo data" }
         guard serverConnected else { return "Unknown" }
         return serverSyncReady == true ? "Ready" : "No items"
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -191,12 +191,14 @@ private struct DashboardStatusStrip: View {
     }
 
     private var serverIcon: String {
+        if appState.isDemoMode { return "play.circle.fill" }
         if appState.isLoading { return "arrow.triangle.2.circlepath" }
         if appState.error != nil { return "xmark.octagon.fill" }
         return appState.serverConnected ? "checkmark.circle.fill" : "server.rack"
     }
 
     private var serverTint: Color {
+        if appState.isDemoMode { return SemanticColors.brandSecondary }
         if appState.isLoading { return SemanticColors.warning }
         if appState.error != nil { return SemanticColors.negative }
         return appState.serverConnected ? SemanticColors.positive : .secondary

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -55,8 +55,8 @@ struct StatusView: View {
             DiagnosticTile(
                 title: "Server",
                 value: appState.statusServerText,
-                icon: "server.rack",
-                color: appState.serverConnected ? SemanticColors.positive : SemanticColors.negative
+                icon: serverDiagnosticIcon,
+                color: serverDiagnosticColor
             )
             DiagnosticTile(
                 title: "Sync",
@@ -224,6 +224,15 @@ struct StatusView: View {
         return SemanticColors.positive
     }
 
+    private var serverDiagnosticIcon: String {
+        appState.isDemoMode ? "play.circle.fill" : "server.rack"
+    }
+
+    private var serverDiagnosticColor: Color {
+        if appState.isDemoMode { return SemanticColors.brandSecondary }
+        return appState.serverConnected ? SemanticColors.positive : SemanticColors.negative
+    }
+
     private var itemHealthColor: Color {
         if appState.statusItemCount == 0 { return .secondary }
         if appState.connectedItemCount < appState.statusItemCount { return SemanticColors.warning }
@@ -232,11 +241,13 @@ struct StatusView: View {
     }
 
     private var credentialsColor: Color {
+        if appState.isDemoMode { return .secondary }
         guard appState.serverConnected else { return .secondary }
         return appState.serverCredentialsConfigured == true ? SemanticColors.positive : SemanticColors.negative
     }
 
     private var syncReadinessColor: Color {
+        if appState.isDemoMode { return SemanticColors.brandSecondary }
         guard appState.serverConnected else { return .secondary }
         return appState.serverSyncReady == true ? SemanticColors.positive : .secondary
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -715,6 +715,28 @@ struct PlaidBarCoreTests {
 
     // MARK: - Dashboard Status Readiness Tests
 
+    @Test("Dashboard status readiness treats demo mode as local data")
+    func dashboardStatusReadinessTreatsDemoModeAsLocalData() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: true,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: "PlaidBar server is not running"
+        )
+
+        #expect(readiness.level == .healthy)
+        #expect(readiness.title == "Demo data ready")
+        #expect(readiness.detail.contains("Local demo accounts"))
+        #expect(readiness.primaryAction == .addAccount)
+    }
+
     @Test("Dashboard status readiness blocks on offline server")
     func dashboardStatusReadinessBlocksOnOfflineServer() {
         let readiness = DashboardStatusReadiness.evaluate(


### PR DESCRIPTION
## Summary
- show demo mode as local demo instead of a connected/offline server state
- mark credentials as not required and sync readiness as demo data
- add a focused readiness test for demo mode staying healthy without a server

## Verification
- swift build --disable-sandbox --product PlaidBar
- swift build -c release --disable-sandbox --product PlaidBar
- git diff --check

Local swift test is blocked by this machine toolchain missing Swift Testing; GitHub CI should run the test target.