### PR TITLE
refactor: centralize spending summaries

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -440,13 +440,7 @@ final class AppState {
     }
 
     var spendingByCategory: [(SpendingCategory, Double)] {
-        let expenses = transactions.filter {
-            !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }
-        let grouped = Dictionary(grouping: expenses) { $0.category ?? .other }
-        return grouped.map { (category, txns) in
-            (category, txns.reduce(0) { $0 + $1.displayAmount })
-        }.sorted { $0.1 > $1.1 }
+        SpendingSummary.spendingByCategory(from: transactions)
     }
 
     var totalSpending: Double {
@@ -465,7 +459,7 @@ final class AppState {
 
     /// Monthly equivalent of all recurring charges (normalizes weekly/annual to monthly)
     var estimatedMonthlyRecurring: Double {
-        recurringTransactions.reduce(0) { $0 + $1.averageAmount * $1.frequency.monthlyMultiplier }
+        RecurringSummary.estimatedMonthlyTotal(from: recurringTransactions)
     }
 
     func transactionsForAccount(_ accountId: String) -> [TransactionDTO] {

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -51,14 +51,7 @@ struct SpendingView: View {
     }
 
     private var filteredSpending: [(SpendingCategory, Double)] {
-        let filtered = filteredTransactions.filter {
-            !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }
-
-        let grouped = Dictionary(grouping: filtered) { $0.category ?? .other }
-        return grouped.map { (category, txns) in
-            (category, txns.reduce(0) { $0 + $1.displayAmount })
-        }.sorted { $0.1 > $1.1 }
+        spendingSummary.categories
     }
 
     /// Top 5 categories + "Other" rollup to prevent tiny chart slivers
@@ -70,27 +63,30 @@ struct SpendingView: View {
     }
 
     private var totalFiltered: Double {
-        filteredSpending.reduce(0) { $0 + $1.1 }
+        spendingSummary.currentTotal
     }
 
     // MARK: - Month-over-Month Comparison
 
     private var previousPeriodSpending: Double {
-        let interval = periodInterval
-        let filtered = appState.transactions.filter {
-            $0.date >= interval.previous && $0.date < interval.current &&
-            !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }
-        return filtered.reduce(0) { $0 + $1.displayAmount }
+        spendingSummary.previousTotal
     }
 
     private var spendingDelta: Double {
-        totalFiltered - previousPeriodSpending
+        spendingSummary.delta
     }
 
     private var spendingDeltaPercent: Double {
-        guard previousPeriodSpending > 0 else { return 0 }
-        return (spendingDelta / previousPeriodSpending) * 100
+        spendingSummary.deltaPercent
+    }
+
+    private var spendingSummary: SpendingPeriodSummary {
+        let interval = periodInterval
+        return SpendingSummary.periodSummary(
+            from: appState.transactions,
+            currentStart: interval.current,
+            previousStart: interval.previous
+        )
     }
 
     var body: some View {

--- a/Sources/PlaidBarCore/Utilities/RecurringSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringSummary.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public enum RecurringSummary {
+    public static func estimatedMonthlyTotal(
+        from recurringTransactions: [RecurringTransaction]
+    ) -> Double {
+        recurringTransactions.reduce(0) {
+            $0 + $1.averageAmount * $1.frequency.monthlyMultiplier
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public struct SpendingPeriodSummary: Sendable {
+    public let currentTotal: Double
+    public let previousTotal: Double
+    public let delta: Double
+    public let deltaPercent: Double
+    public let categories: [(SpendingCategory, Double)]
+
+    public init(
+        currentTotal: Double,
+        previousTotal: Double,
+        categories: [(SpendingCategory, Double)]
+    ) {
+        self.currentTotal = currentTotal
+        self.previousTotal = previousTotal
+        self.delta = currentTotal - previousTotal
+        self.deltaPercent = previousTotal > 0 ? (delta / previousTotal) * 100 : 0
+        self.categories = categories
+    }
+}
+
+public enum SpendingSummary {
+    public static func periodSummary(
+        from transactions: [TransactionDTO],
+        currentStart: String,
+        previousStart: String
+    ) -> SpendingPeriodSummary {
+        let currentExpenses = expenseTransactions(
+            from: transactions,
+            startingAt: currentStart
+        )
+        let previousExpenses = expenseTransactions(
+            from: transactions,
+            startingAt: previousStart,
+            endingBefore: currentStart
+        )
+
+        let categories = spendingByCategory(from: currentExpenses)
+        let currentTotal = categories.reduce(0) { $0 + $1.1 }
+        let previousTotal = previousExpenses.reduce(0) { $0 + $1.displayAmount }
+
+        return SpendingPeriodSummary(
+            currentTotal: currentTotal,
+            previousTotal: previousTotal,
+            categories: categories
+        )
+    }
+
+    public static func spendingByCategory(
+        from transactions: [TransactionDTO]
+    ) -> [(SpendingCategory, Double)] {
+        let grouped = Dictionary(grouping: expenseTransactions(from: transactions)) {
+            $0.category ?? .other
+        }
+        return grouped.map { category, transactions in
+            (category, transactions.reduce(0) { $0 + $1.displayAmount })
+        }.sorted { $0.1 > $1.1 }
+    }
+
+    public static func expenseTransactions(
+        from transactions: [TransactionDTO],
+        startingAt startDate: String? = nil,
+        endingBefore endDate: String? = nil
+    ) -> [TransactionDTO] {
+        transactions.filter { transaction in
+            if let startDate, transaction.date < startDate { return false }
+            if let endDate, transaction.date >= endDate { return false }
+            return !transaction.isIncome
+                && transaction.category != .transfer
+                && transaction.category != .transferOut
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1524,6 +1524,58 @@ struct PlaidBarCoreTests {
         #expect(reloaded.map(\.id) == ["keep"])
     }
 
+    @Test("Spending summary groups expenses and excludes income and transfers")
+    func spendingSummaryGroupsExpenses() {
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 67, date: "2026-01-15", name: "Whole Foods", category: .foodAndDrink),
+            TransactionDTO(id: "2", accountId: "a", amount: 23, date: "2026-01-15", name: "Uber", category: .transportation),
+            TransactionDTO(id: "3", accountId: "a", amount: 45, date: "2026-01-14", name: "Restaurant", category: .foodAndDrink),
+            TransactionDTO(id: "4", accountId: "a", amount: -1200, date: "2026-01-14", name: "Stripe", category: .income),
+            TransactionDTO(id: "5", accountId: "a", amount: 500, date: "2026-01-14", name: "Transfer", category: .transfer),
+        ]
+
+        let spending = SpendingSummary.spendingByCategory(from: transactions)
+
+        #expect(spending.first { $0.0 == .foodAndDrink }?.1 == 112)
+        #expect(spending.first { $0.0 == .transportation }?.1 == 23)
+        #expect(spending.allSatisfy { $0.0 != .income && $0.0 != .transfer })
+    }
+
+    @Test("Spending summary calculates period delta")
+    func spendingSummaryPeriodDelta() {
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 100, date: "2026-03-15", name: "A", category: .foodAndDrink),
+            TransactionDTO(id: "2", accountId: "a", amount: 200, date: "2026-03-10", name: "B", category: .shopping),
+            TransactionDTO(id: "3", accountId: "a", amount: 150, date: "2026-02-15", name: "C", category: .foodAndDrink),
+            TransactionDTO(id: "4", accountId: "a", amount: 100, date: "2026-02-10", name: "D", category: .shopping),
+            TransactionDTO(id: "5", accountId: "a", amount: -3000, date: "2026-03-01", name: "Salary", category: .income),
+        ]
+
+        let summary = SpendingSummary.periodSummary(
+            from: transactions,
+            currentStart: "2026-03-01",
+            previousStart: "2026-02-01"
+        )
+
+        #expect(summary.currentTotal == 300)
+        #expect(summary.previousTotal == 250)
+        #expect(summary.delta == 50)
+        #expect(abs(summary.deltaPercent - 20.0) < 0.01)
+    }
+
+    @Test("Recurring summary normalizes estimated monthly total")
+    func recurringSummaryMonthlyTotal() {
+        let recurring = [
+            RecurringTransaction(merchantName: "Netflix", frequency: .monthly, averageAmount: 15.99, lastDate: "2026-03-15", nextExpectedDate: "2026-04-15", category: .entertainment, transactionCount: 3, confidence: 0.95),
+            RecurringTransaction(merchantName: "Gym", frequency: .monthly, averageAmount: 75.00, lastDate: "2026-03-15", nextExpectedDate: "2026-04-15", category: .healthAndFitness, transactionCount: 3, confidence: 0.90),
+            RecurringTransaction(merchantName: "Weekly Sub", frequency: .weekly, averageAmount: 5.00, lastDate: "2026-03-15", nextExpectedDate: "2026-03-22", category: .entertainment, transactionCount: 5, confidence: 0.85),
+        ]
+
+        let estimated = RecurringSummary.estimatedMonthlyTotal(from: recurring)
+
+        #expect(abs(estimated - 112.66) < 0.01)
+    }
+
     private func posixPermissions(at url: URL) throws -> Int {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -69,9 +69,7 @@ struct PlaidBarTests {
             TransactionDTO(id: "4", accountId: "a", amount: -1200, date: "2026-01-14", name: "Stripe", category: .income),
         ]
 
-        let expenses = transactions.filter { !$0.isIncome }
-        let grouped = Dictionary(grouping: expenses) { $0.category ?? .other }
-        let spending = grouped.map { ($0.key, $0.value.reduce(0.0) { $0 + $1.displayAmount }) }
+        let spending = SpendingSummary.spendingByCategory(from: transactions)
 
         let foodTotal = spending.first { $0.0 == .foodAndDrink }?.1
         #expect(foodTotal == 112)
@@ -86,7 +84,7 @@ struct PlaidBarTests {
             TransactionDTO(id: "1", accountId: "a", amount: -5000, date: "2026-01-15", name: "Salary", category: .income),
             TransactionDTO(id: "2", accountId: "a", amount: -200, date: "2026-01-15", name: "Refund", category: .income),
         ]
-        let expenses = transactions.filter { !$0.isIncome }
+        let expenses = SpendingSummary.expenseTransactions(from: transactions)
         #expect(expenses.isEmpty)
     }
 
@@ -327,26 +325,16 @@ struct PlaidBarTests {
             TransactionDTO(id: "5", accountId: "a", amount: -3000, date: "2026-03-01", name: "Salary", category: .income),
         ]
 
-        let currentStart = "2026-03-01"
-        let prevStart = "2026-02-01"
+        let summary = SpendingSummary.periodSummary(
+            from: transactions,
+            currentStart: "2026-03-01",
+            previousStart: "2026-02-01"
+        )
 
-        let currentSpending = transactions.filter {
-            $0.date >= currentStart && !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }.reduce(0.0) { $0 + $1.displayAmount }
-
-        let prevSpending = transactions.filter {
-            $0.date >= prevStart && $0.date < currentStart &&
-            !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }.reduce(0.0) { $0 + $1.displayAmount }
-
-        #expect(currentSpending == 300)
-        #expect(prevSpending == 250)
-
-        let delta = currentSpending - prevSpending
-        #expect(delta == 50)
-
-        let percent = (delta / prevSpending) * 100
-        #expect(abs(percent - 20.0) < 0.01)
+        #expect(summary.currentTotal == 300)
+        #expect(summary.previousTotal == 250)
+        #expect(summary.delta == 50)
+        #expect(abs(summary.deltaPercent - 20.0) < 0.01)
     }
 
     // MARK: - Category Filter Logic (mirrors TransactionsView)
@@ -452,7 +440,7 @@ struct PlaidBarTests {
         // Monthly: 15.99 + 75.00 = 90.99
         // Weekly $5 * (52/12) = ~$21.67
         // Total ≈ $112.66
-        let estimated = recurring.reduce(0) { $0 + $1.averageAmount * $1.frequency.monthlyMultiplier }
+        let estimated = RecurringSummary.estimatedMonthlyTotal(from: recurring)
 
         #expect(abs(estimated - 112.66) < 0.01)
     }


### PR DESCRIPTION
## Summary
- Add `SpendingSummary` for category rollups, period totals, and spending deltas.
- Add `RecurringSummary` for monthly recurring normalization.
- Route `SpendingView` and `AppState` through shared core helpers and move mirrored formula coverage into core tests.

## Verification
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] Secret scan from `commands/plaidbar-prod-loop.md` ran; hits were expected placeholders/source identifiers.
- [ ] `swift test --skip-update --disable-keychain` blocked by known local baseline: `no such module 'Testing'`.\n