### PR TITLE
refactor: reuse credit utilization summary

### DIFF
--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -5,14 +5,7 @@ struct CreditView: View {
     @Environment(AppState.self) private var appState
 
     private var totalUtilization: Double {
-        let totalBalance = appState.creditAccounts.reduce(0.0) {
-            $0 + abs($1.balances.current ?? 0)
-        }
-        let totalLimit = appState.creditAccounts.reduce(0.0) {
-            $0 + ($1.balances.limit ?? 0)
-        }
-        guard totalLimit > 0 else { return 0 }
-        return (totalBalance / totalLimit) * 100
+        appState.totalCreditUtilization ?? 0
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Route `CreditView` total utilization through `AppState.totalCreditUtilization`.
- Reuse the shared `MenuBarSummary.creditUtilization` logic instead of recalculating aggregate utilization in the view.

## Verification
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] Secret scan from `commands/plaidbar-prod-loop.md` ran; hits were expected placeholders/source identifiers.
- [ ] `swift test --skip-update --disable-keychain` blocked by known local baseline: `no such module 'Testing'`.\n