### PR TITLE
refactor: share spending chart filters

### DIFF
--- a/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
+++ b/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
@@ -32,7 +32,7 @@ struct IncomeExpenseChart: View {
 
         return grouped.map { monthStart, txns in
             let income = txns.filter(\.isIncome).reduce(0.0) { $0 + $1.displayAmount }
-            let expenses = txns.filter { !$0.isIncome && $0.category != .transfer && $0.category != .transferOut }
+            let expenses = SpendingSummary.expenseTransactions(from: txns)
                 .reduce(0.0) { $0 + $1.displayAmount }
             return MonthlyData(
                 month: monthStart,

--- a/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
@@ -6,9 +6,7 @@ struct SpendingTrendChart: View {
     let transactions: [TransactionDTO]
 
     private var dailySpending: [(Date, Double)] {
-        let expenses = transactions.filter {
-            !$0.isIncome && $0.category != .transfer && $0.category != .transferOut
-        }
+        let expenses = SpendingSummary.expenseTransactions(from: transactions)
 
         let grouped = Dictionary(grouping: expenses) { $0.date }
         let results: [(Date, Double)] = grouped.compactMap { dateString, txns in


### PR DESCRIPTION
## Summary
- Route spending trend chart expense filtering through `SpendingSummary.expenseTransactions`.
- Route income/expense chart expense totals through the same shared predicate.
- Keeps summary, trend, and flow views aligned on income/transfer exclusion rules.

## Verification
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] Secret scan from `commands/plaidbar-prod-loop.md` ran; hits were expected placeholders/source identifiers.
- [ ] `swift test --skip-update --disable-keychain` blocked by known local baseline: `no such module 'Testing'`.\n