### PR TITLE
Improve dashboard status and recovery context

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -326,7 +326,7 @@ final class AppState {
     }
 
     var localStorageResolvedDisplayPathText: String {
-        localStorageResolvedPathText.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        LocalDataStore.displayPath(for: localStorageDirectoryURL)
     }
 
     var serverStoragePathText: String {
@@ -335,7 +335,18 @@ final class AppState {
 
     var serverStorageDisplayText: String {
         guard let serverStoragePath else { return localStoragePathText }
-        return serverStoragePath.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        return LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath))
+    }
+
+    var activeStorageDirectoryURL: URL {
+        LocalDataStore.storageDirectoryURL(
+            forServerStoragePath: serverStoragePath,
+            fallback: localStorageDirectoryURL
+        )
+    }
+
+    var activeStorageDirectoryDisplayText: String {
+        LocalDataStore.displayPath(for: activeStorageDirectoryURL)
     }
 
     var serverCredentialsText: String {
@@ -715,7 +726,7 @@ final class AppState {
     func resetLocalData() throws -> LocalDataResetResult {
         stopBackgroundRefresh()
 
-        let result = try LocalDataStore.resetLocalData(at: localStorageDirectoryURL)
+        let result = try LocalDataStore.resetLocalData(at: activeStorageDirectoryURL)
 
         accounts = []
         transactions = []

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -115,13 +115,13 @@ struct GeneralSettingsView: View {
                 SettingsCard(title: "Local Data") {
                     settingsRow("Storage path", alignment: .top) {
                         VStack(alignment: .trailing, spacing: Spacing.xs) {
-                            Text(appState.localStoragePathText)
+                            Text(appState.activeStorageDirectoryDisplayText)
                                 .font(.system(.body, design: .monospaced))
                                 .lineLimit(2)
                                 .multilineTextAlignment(.trailing)
                                 .textSelection(.enabled)
 
-                            Text(appState.localStorageResolvedDisplayPathText)
+                            Text(storageDetailText)
                                 .detailText()
                                 .lineLimit(2)
                                 .multilineTextAlignment(.trailing)
@@ -164,7 +164,7 @@ struct GeneralSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This deletes files under \(appState.localStoragePathText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps the app/server auth token so the running local server stays reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
+            Text("This deletes files under \(appState.activeStorageDirectoryDisplayText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps the app/server auth token so the running local server stays reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },
@@ -185,27 +185,35 @@ struct GeneralSettingsView: View {
     }
 
     private func revealStorageDirectory() {
-        let url = appState.localStorageDirectoryURL
+        let url = appState.activeStorageDirectoryURL
         try? LocalDataStore.prepareStorageDirectory(at: url)
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
     private func copyStoragePath() {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(appState.localStorageResolvedPathText, forType: .string)
+        NSPasteboard.general.setString(appState.activeStorageDirectoryURL.path, forType: .string)
     }
 
     private func resetLocalData() {
         do {
             let result = try appState.resetLocalData()
             if result.removedEntryCount == 0 {
-                resetResultMessage = "No existing files were found. \(appState.localStoragePathText) is ready for a fresh local server start. \(keychainResetText(for: result))"
+                resetResultMessage = "No existing files were found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready for a fresh local server start. \(keychainResetText(for: result))"
             } else {
-                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(appState.localStoragePathText). \(keychainResetText(for: result)) Restart PlaidBarServer before reconnecting accounts."
+                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result)) Restart PlaidBarServer before reconnecting accounts."
             }
         } catch {
             resetErrorMessage = error.localizedDescription
         }
+    }
+
+    private var storageDetailText: String {
+        if let serverStoragePath = appState.serverStoragePath {
+            return "Server database: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
+        }
+
+        return "Default: \(appState.localStorageResolvedDisplayPathText)"
     }
 
     private func keychainResetText(for result: LocalDataResetResult) -> String {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -151,7 +151,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Stores the local server database, Plaid item tokens, and sync cursors. App preferences and the app/server auth token stay in place.")
+                    Text("Stores the local server database, Plaid item tokens, and sync cursors. App preferences, server.conf, and the app/server auth token stay in place.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -164,7 +164,7 @@ struct GeneralSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This deletes files under \(appState.activeStorageDirectoryDisplayText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps the app/server auth token so the running local server stays reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
+            Text("This deletes files under \(appState.activeStorageDirectoryDisplayText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps server.conf and the app/server auth token so local configuration and the running local server stay reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },

--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -39,8 +39,15 @@ struct SpendingHeatmapView: View {
         guard mode == .netCashflow else {
             return Formatters.currency(totalValue, format: .compact)
         }
-        let prefix = totalValue > 0 ? "+" : totalValue < 0 ? "-" : ""
-        return "\(prefix)\(Formatters.currency(abs(totalValue), format: .compact))"
+        return cashflowText(for: totalValue, format: .compact)
+    }
+
+    private var totalTint: Color {
+        guard mode == .netCashflow else { return .primary }
+        let displayAmount = SpendingHeatmap.displayCashflowAmount(totalValue)
+        if displayAmount > 0 { return SemanticColors.positive }
+        if displayAmount < 0 { return SemanticColors.negative }
+        return .primary
     }
 
     private var selectedDay: SpendingHeatmapDay? {
@@ -107,7 +114,7 @@ struct SpendingHeatmapView: View {
             Text(totalLabel)
                 .font(.callout.weight(.semibold))
                 .monospacedDigit()
-                .foregroundStyle(mode == .netCashflow && totalValue < 0 ? SemanticColors.positive : .primary)
+                .foregroundStyle(totalTint)
                 .lineLimit(1)
                 .layoutPriority(1)
         }
@@ -210,8 +217,13 @@ struct SpendingHeatmapView: View {
         guard mode == .netCashflow else {
             return Formatters.currency(day.value, format: .full)
         }
-        let prefix = day.value > 0 ? "+" : day.value < 0 ? "-" : ""
-        return "\(prefix)\(Formatters.currency(abs(day.value), format: .full))"
+        return cashflowText(for: day.value, format: .full)
+    }
+
+    private func cashflowText(for value: Double, format: CurrencyFormat) -> String {
+        let displayAmount = SpendingHeatmap.displayCashflowAmount(value)
+        let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
+        return "\(prefix)\(Formatters.currency(abs(displayAmount), format: format))"
     }
 
     private var cellSpacing: CGFloat {
@@ -266,8 +278,9 @@ private struct HeatmapCell: View {
     private var helpText: String {
         let amount: String
         if mode == .netCashflow {
-            let prefix = day.value > 0 ? "+" : day.value < 0 ? "-" : ""
-            amount = "\(prefix)\(Formatters.currency(abs(day.value), format: .full))"
+            let displayAmount = SpendingHeatmap.displayCashflowAmount(day.value)
+            let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
+            amount = "\(prefix)\(Formatters.currency(abs(displayAmount), format: .full))"
         } else {
             amount = Formatters.currency(day.value, format: .full)
         }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -537,13 +537,15 @@ private struct BalanceActivityHeatmap: View {
         guard mode == .netCashflow else {
             return Formatters.currency(totalValue, format: .compact)
         }
-        let prefix = totalValue > 0 ? "+" : totalValue < 0 ? "-" : ""
-        return "\(prefix)\(Formatters.currency(abs(totalValue), format: .compact))"
+        return cashflowText(for: totalValue)
     }
 
     private var totalTint: Color {
         guard mode == .netCashflow else { return .secondary }
-        return totalValue < 0 ? SemanticColors.positive : SemanticColors.negative
+        let displayAmount = SpendingHeatmap.displayCashflowAmount(totalValue)
+        if displayAmount > 0 { return SemanticColors.positive }
+        if displayAmount < 0 { return SemanticColors.negative }
+        return .secondary
     }
 
     private var weekColumns: [[SpendingHeatmapDay?]] {
@@ -690,6 +692,12 @@ private struct BalanceActivityHeatmap: View {
     private func monthLabel(for date: Date) -> String {
         calendar.shortMonthSymbols[calendar.component(.month, from: date) - 1]
     }
+
+    private func cashflowText(for value: Double) -> String {
+        let displayAmount = SpendingHeatmap.displayCashflowAmount(value)
+        let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
+        return "\(prefix)\(Formatters.currency(abs(displayAmount), format: .compact))"
+    }
 }
 
 private struct NetLegendKey: View {
@@ -736,8 +744,9 @@ private struct BalanceHeatmapCell: View {
     private var helpText: String {
         let amount: String
         if mode == .netCashflow {
-            let prefix = day.value > 0 ? "+" : day.value < 0 ? "-" : ""
-            amount = "\(prefix)\(Formatters.currency(abs(day.value), format: .full))"
+            let displayAmount = SpendingHeatmap.displayCashflowAmount(day.value)
+            let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
+            amount = "\(prefix)\(Formatters.currency(abs(displayAmount), format: .full))"
         } else {
             amount = Formatters.currency(day.value, format: .full)
         }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1299,36 +1299,22 @@ private struct DashboardAccountRow: View {
         appState.itemStatuses.first { $0.id == account.itemId }?.status
     }
 
-    private var statusText: String {
-        if appState.isDemoMode { return "Demo" }
-        if !appState.serverConnected { return "Server offline" }
+    private var connectionPresentation: AccountConnectionPresentation {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            isSyncStale: appState.isSyncStale,
+            statusSyncText: appState.statusSyncText,
+            itemStatus: itemStatus
+        )
+    }
 
-        switch itemStatus {
-        case .connected:
-            return appState.statusSyncText
-        case .loginRequired:
-            return "Reconnect"
-        case .error:
-            return "Item error"
-        case nil:
-            return appState.statusSyncText
-        }
+    private var statusText: String {
+        connectionPresentation.rowLabel
     }
 
     private var statusTint: Color {
-        if appState.isDemoMode { return SemanticColors.brandSecondary }
-        if !appState.serverConnected { return .secondary }
-
-        switch itemStatus {
-        case .connected:
-            return appState.isSyncStale ? SemanticColors.warning : SemanticColors.positive
-        case .loginRequired:
-            return SemanticColors.warning
-        case .error:
-            return SemanticColors.negative
-        case nil:
-            return appState.isSyncStale ? SemanticColors.warning : .secondary
-        }
+        accountConnectionTint(for: connectionPresentation.level)
     }
 }
 
@@ -1488,52 +1474,26 @@ private struct SelectedAccountPanel: View {
         appState.itemStatuses.first { $0.id == account.itemId }?.status
     }
 
-    private var connectionLabel: String {
-        if appState.isDemoMode { return "Demo data" }
-        if !appState.serverConnected { return "Server offline" }
+    private var connectionPresentation: AccountConnectionPresentation {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            isSyncStale: appState.isSyncStale,
+            statusSyncText: appState.statusSyncText,
+            itemStatus: itemStatus
+        )
+    }
 
-        switch itemStatus {
-        case .connected:
-            return appState.statusSyncText
-        case .loginRequired:
-            return "Login required"
-        case .error:
-            return "Item error"
-        case nil:
-            return appState.statusSyncText
-        }
+    private var connectionLabel: String {
+        connectionPresentation.detailLabel
     }
 
     private var connectionIcon: String {
-        if appState.isDemoMode { return "play.circle.fill" }
-        if !appState.serverConnected { return "server.rack" }
-
-        switch itemStatus {
-        case .connected:
-            return appState.isSyncStale ? "clock.badge.exclamationmark.fill" : "checkmark.circle.fill"
-        case .loginRequired:
-            return "person.crop.circle.badge.exclamationmark.fill"
-        case .error:
-            return "exclamationmark.triangle.fill"
-        case nil:
-            return appState.isSyncStale ? "clock.badge.exclamationmark.fill" : "link.circle.fill"
-        }
+        connectionPresentation.iconName
     }
 
     private var connectionTint: Color {
-        if appState.isDemoMode { return SemanticColors.brandSecondary }
-        if !appState.serverConnected { return .secondary }
-
-        switch itemStatus {
-        case .connected:
-            return appState.isSyncStale ? SemanticColors.warning : SemanticColors.positive
-        case .loginRequired:
-            return SemanticColors.warning
-        case .error:
-            return SemanticColors.negative
-        case nil:
-            return appState.isSyncStale ? SemanticColors.warning : .secondary
-        }
+        accountConnectionTint(for: connectionPresentation.level)
     }
 
     private var activityText: String {
@@ -1541,14 +1501,28 @@ private struct SelectedAccountPanel: View {
     }
 
     private var syncSignalText: String {
-        if itemStatus == .loginRequired { return "Login" }
-        if itemStatus == .error { return "Error" }
-        if appState.isSyncStale { return "Stale" }
-        return "Fresh"
+        connectionPresentation.signalLabel
     }
 
     private var shouldShowRecoveryActions: Bool {
-        !appState.isDemoMode && (appState.isSyncStale || itemStatus == .loginRequired || itemStatus == .error)
+        connectionPresentation.showsRecoveryActions
+    }
+}
+
+private func accountConnectionTint(for level: AccountConnectionLevel) -> Color {
+    switch level {
+    case .demo:
+        return SemanticColors.brandSecondary
+    case .offline:
+        return .secondary
+    case .healthy:
+        return SemanticColors.positive
+    case .stale, .loginRequired:
+        return SemanticColors.warning
+    case .error:
+        return SemanticColors.negative
+    case .unknown:
+        return .secondary
     }
 }
 

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -131,7 +131,7 @@ struct SetupView: View {
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 StorageDisclosureRow(
                     icon: "externaldrive",
-                    text: "PlaidBar stores access tokens and synced account data locally under \(appState.localStoragePathText)."
+                    text: "PlaidBar stores access tokens and synced account data locally under \(appState.activeStorageDirectoryDisplayText)."
                 )
                 StorageDisclosureRow(
                     icon: "server.rack",
@@ -493,7 +493,7 @@ private struct OnboardingPreflightPanel: View {
 
                 preflightRow(
                     title: "Storage",
-                    value: appState.serverStorageDisplayText,
+                    value: appState.activeStorageDirectoryDisplayText,
                     icon: "internaldrive",
                     state: appState.serverConnected ? .ready : .unknown
                 )

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -97,107 +97,203 @@ struct SpendingView: View {
         let deltaPercent = spendingDeltaPercent
 
         VStack(spacing: Spacing.md) {
-            // Period picker
-            Picker("Period", selection: $selectedPeriod) {
-                ForEach(SpendingPeriod.allCases, id: \.self) { period in
-                    Text(period.rawValue).tag(period)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal, Spacing.lg)
-            .padding(.top, Spacing.sm)
+            periodPicker
 
-            // Total — hero amount
-            Text(Formatters.currency(total, format: .full))
-                .heroBalance()
-                .contentTransition(.numericText())
-                .animation(.default, value: total)
-
-            // Month-over-month comparison
-            if prevSpending > 0 {
-                VStack(spacing: Spacing.xxs) {
-                    HStack(spacing: Spacing.xs) {
-                        Image(systemName: delta >= 0 ? "arrow.up.right" : "arrow.down.right")
-                            .font(.caption)
-                        Text("\(delta >= 0 ? "+" : "")\(Formatters.currency(abs(delta), format: .full)) (\(Formatters.percent(abs(deltaPercent), decimals: 1)))")
-                            .font(.callout.weight(.medium))
-                    }
-                    .foregroundStyle(delta >= 0 ? SemanticColors.negative : SemanticColors.positive)
+            if appState.transactions.isEmpty {
+                emptyTransactionState
+            } else if filteredTransactions.isEmpty {
+                emptyPeriodState
+            } else {
+                // Total — hero amount
+                Text(Formatters.currency(total, format: .full))
+                    .heroBalance()
                     .contentTransition(.numericText())
-                    .animation(.default, value: delta)
+                    .animation(.default, value: total)
 
-                    Text("vs. last period")
-                        .microText()
-                        .foregroundStyle(.secondary)
+                // Month-over-month comparison
+                if prevSpending > 0 {
+                    VStack(spacing: Spacing.xxs) {
+                        HStack(spacing: Spacing.xs) {
+                            Image(systemName: delta >= 0 ? "arrow.up.right" : "arrow.down.right")
+                                .font(.caption)
+                            Text("\(delta >= 0 ? "+" : "")\(Formatters.currency(abs(delta), format: .full)) (\(Formatters.percent(abs(deltaPercent), decimals: 1)))")
+                                .font(.callout.weight(.medium))
+                        }
+                        .foregroundStyle(delta >= 0 ? SemanticColors.negative : SemanticColors.positive)
+                        .contentTransition(.numericText())
+                        .animation(.default, value: delta)
+
+                        Text("vs. last period")
+                            .microText()
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Spending \(delta >= 0 ? "increased" : "decreased") by \(Formatters.currency(abs(delta), format: .full)), \(Formatters.percent(abs(deltaPercent), decimals: 1)) \(delta >= 0 ? "more" : "less") than last period")
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Spending \(delta >= 0 ? "increased" : "decreased") by \(Formatters.currency(abs(delta), format: .full)), \(Formatters.percent(abs(deltaPercent), decimals: 1)) \(delta >= 0 ? "more" : "less") than last period")
-            }
 
-            SpendingHeatmapView(
-                transactions: filteredTransactions,
-                startDate: periodInterval.currentDate,
-                endDate: Date(),
-                cellSize: 14,
-                showModePicker: true
-            )
-            .padding(.top, Spacing.xs)
+                SpendingHeatmapView(
+                    transactions: filteredTransactions,
+                    startDate: periodInterval.currentDate,
+                    endDate: Date(),
+                    cellSize: 14,
+                    showModePicker: true
+                )
+                .padding(.top, Spacing.xs)
 
-            Divider()
+                Divider()
+                    .padding(.horizontal, Spacing.lg)
+
+                Picker("Breakdown", selection: $breakdownType) {
+                    ForEach(BreakdownType.allCases, id: \.self) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
                 .padding(.horizontal, Spacing.lg)
 
-            Picker("Breakdown", selection: $breakdownType) {
-                ForEach(BreakdownType.allCases, id: \.self) { type in
-                    Text(type.rawValue).tag(type)
+                switch breakdownType {
+                case .categories:
+                    donutChart(categories: categories, total: total)
+                case .trend:
+                    SpendingTrendChart(transactions: filteredTransactions)
+                case .incomeExpense:
+                    IncomeExpenseChart(transactions: filteredTransactions)
                 }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal, Spacing.lg)
-
-            switch breakdownType {
-            case .categories:
-                donutChart(categories: categories, total: total)
-            case .trend:
-                SpendingTrendChart(transactions: filteredTransactions)
-            case .incomeExpense:
-                IncomeExpenseChart(transactions: filteredTransactions)
             }
         }
         .padding(.bottom, Spacing.sm)
     }
 
-    @ViewBuilder
-    private func donutChart(categories: [(SpendingCategory, Double)], total: Double) -> some View {
-        // Category breakdown legend
-        VStack(spacing: Spacing.xs) {
-            ForEach(categories, id: \.0) { category, amount in
-                HStack(spacing: Spacing.sm) {
-                    Circle()
-                        .fill(Color(hex: category.colorHex) ?? .gray)
-                        .frame(width: 10, height: 10)
-
-                    Text(category.displayName)
-                        .font(.body)
-
-                    Spacer()
-
-                    Text(Formatters.currency(amount, format: .full))
-                        .monospacedDigit()
-
-                    Text(total > 0 ? Formatters.percent(amount / total * 100, decimals: 0) : "\u{2014}")
-                        .microText()
-                        .foregroundStyle(.secondary)
-                        .frame(width: 35, alignment: .trailing)
-                }
-                .padding(.horizontal, Spacing.lg)
-                .padding(.vertical, Spacing.xxs)
+    private var periodPicker: some View {
+        Picker("Period", selection: $selectedPeriod) {
+            ForEach(SpendingPeriod.allCases, id: \.self) { period in
+                Text(period.rawValue).tag(period)
             }
         }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .padding(.horizontal, Spacing.lg)
+        .padding(.top, Spacing.sm)
+    }
 
-        // Donut chart
-        if !categories.isEmpty && total > 0 {
+    @ViewBuilder
+    private var emptyTransactionState: some View {
+        if !appState.isDemoMode && !appState.serverConnected {
+            ContentUnavailableView {
+                Label("Server Offline", systemImage: "server.rack")
+            } description: {
+                Text("Start PlaidBarServer before spending activity can sync.")
+            } actions: {
+                Button {
+                    Task { await appState.checkServerConnection() }
+                } label: {
+                    Label("Check Server", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else if appState.statusItemCount == 0 {
+            ContentUnavailableView {
+                Label("No Bank Linked", systemImage: "building.columns")
+            } description: {
+                Text("Connect a Plaid institution before spending and cashflow charts can populate.")
+            } actions: {
+                Button {
+                    Task { await appState.addAccount() }
+                } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        } else {
+            ContentUnavailableView {
+                Label("No Synced Activity", systemImage: "chart.bar.xaxis")
+            } description: {
+                Text("Sync transactions to build the spending heatmap, trend, and cashflow views.")
+            } actions: {
+                Button {
+                    Task { await appState.syncTransactions() }
+                } label: {
+                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+        }
+    }
+
+    private var emptyPeriodState: some View {
+        ContentUnavailableView {
+            Label("No Activity in \(selectedPeriod.rawValue)", systemImage: "calendar.badge.clock")
+        } description: {
+            Text("No synced transactions fall inside this period. Choose a wider window or refresh the latest history.")
+        } actions: {
+            HStack {
+                if selectedPeriod != .last90Days {
+                    Button {
+                        selectedPeriod = .last90Days
+                    } label: {
+                        Label("Show 90D", systemImage: "calendar")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+
+                Button {
+                    Task { await appState.syncTransactions() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private func donutChart(categories: [(SpendingCategory, Double)], total: Double) -> some View {
+        if categories.isEmpty || total <= 0 {
+            ContentUnavailableView {
+                Label("No Spending Categories", systemImage: "chart.pie")
+            } description: {
+                Text("This period has synced activity, but no categorized spending. Use Flow or Trend to inspect income, transfers, and zero-spend periods.")
+            }
+            .padding(.horizontal, Spacing.lg)
+            .padding(.vertical, Spacing.md)
+        } else {
+            // Category breakdown legend
+            VStack(spacing: Spacing.xs) {
+                ForEach(categories, id: \.0) { category, amount in
+                    HStack(spacing: Spacing.sm) {
+                        Circle()
+                            .fill(Color(hex: category.colorHex) ?? .gray)
+                            .frame(width: 10, height: 10)
+
+                        Text(category.displayName)
+                            .font(.body)
+
+                        Spacer()
+
+                        Text(Formatters.currency(amount, format: .full))
+                            .monospacedDigit()
+
+                        Text(Formatters.percent(amount / total * 100, decimals: 0))
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 35, alignment: .trailing)
+                    }
+                    .padding(.horizontal, Spacing.lg)
+                    .padding(.vertical, Spacing.xxs)
+                }
+            }
+
+            // Donut chart
             Chart(categories, id: \.0) { category, amount in
                 SectorMark(
                     angle: .value("Amount", amount),

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -107,7 +107,7 @@ struct StatusView: View {
                 color: .secondary
             )
             DiagnosticTile(
-                title: "Storage",
+                title: "Database",
                 value: appState.serverStorageDisplayText,
                 icon: "internaldrive",
                 color: .secondary
@@ -171,7 +171,7 @@ struct StatusView: View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(spacing: Spacing.xs) {
                 Image(systemName: "lock.doc")
-                Text("Local data path: \(appState.serverStorageDisplayText)")
+                Text("Local data path: \(appState.activeStorageDirectoryDisplayText)")
             }
             .detailText()
 

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -20,6 +20,10 @@ public struct SpendingHeatmapDay: Identifiable, Sendable, Hashable {
 }
 
 public enum SpendingHeatmap {
+    public static func displayCashflowAmount(_ value: Double) -> Double {
+        -value
+    }
+
     public static func days(
         from transactions: [TransactionDTO],
         startDate: Date,

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public enum AccountConnectionLevel: Sendable, Equatable {
+    case demo
+    case offline
+    case healthy
+    case stale
+    case loginRequired
+    case error
+    case unknown
+}
+
+public struct AccountConnectionPresentation: Sendable, Equatable {
+    public let level: AccountConnectionLevel
+    public let rowLabel: String
+    public let detailLabel: String
+    public let signalLabel: String
+    public let iconName: String
+    public let showsRecoveryActions: Bool
+
+    public static func evaluate(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        isSyncStale: Bool,
+        statusSyncText: String,
+        itemStatus: ItemConnectionStatus?
+    ) -> AccountConnectionPresentation {
+        if isDemoMode {
+            return AccountConnectionPresentation(
+                level: .demo,
+                rowLabel: "Demo",
+                detailLabel: "Demo data",
+                signalLabel: "Demo",
+                iconName: "play.circle.fill",
+                showsRecoveryActions: false
+            )
+        }
+
+        guard serverConnected else {
+            return AccountConnectionPresentation(
+                level: .offline,
+                rowLabel: "Server offline",
+                detailLabel: "Server offline",
+                signalLabel: "Offline",
+                iconName: "server.rack",
+                showsRecoveryActions: false
+            )
+        }
+
+        switch itemStatus {
+        case .connected:
+            return AccountConnectionPresentation.synced(
+                isSyncStale: isSyncStale,
+                statusSyncText: statusSyncText,
+                unknownItem: false
+            )
+        case .loginRequired:
+            return AccountConnectionPresentation(
+                level: .loginRequired,
+                rowLabel: "Reconnect",
+                detailLabel: "Login required",
+                signalLabel: "Login",
+                iconName: "person.crop.circle.badge.exclamationmark.fill",
+                showsRecoveryActions: true
+            )
+        case .error:
+            return AccountConnectionPresentation(
+                level: .error,
+                rowLabel: "Item error",
+                detailLabel: "Item error",
+                signalLabel: "Error",
+                iconName: "exclamationmark.triangle.fill",
+                showsRecoveryActions: true
+            )
+        case nil:
+            return AccountConnectionPresentation.synced(
+                isSyncStale: isSyncStale,
+                statusSyncText: statusSyncText,
+                unknownItem: true
+            )
+        }
+    }
+
+    private static func synced(
+        isSyncStale: Bool,
+        statusSyncText: String,
+        unknownItem: Bool
+    ) -> AccountConnectionPresentation {
+        if isSyncStale {
+            return AccountConnectionPresentation(
+                level: .stale,
+                rowLabel: statusSyncText,
+                detailLabel: statusSyncText,
+                signalLabel: "Stale",
+                iconName: "clock.badge.exclamationmark.fill",
+                showsRecoveryActions: true
+            )
+        }
+
+        return AccountConnectionPresentation(
+            level: unknownItem ? .unknown : .healthy,
+            rowLabel: statusSyncText,
+            detailLabel: statusSyncText,
+            signalLabel: "Fresh",
+            iconName: unknownItem ? "link.circle.fill" : "checkmark.circle.fill",
+            showsRecoveryActions: false
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -40,6 +40,7 @@ public enum LocalDataStore {
     public static let displayPath = "~/.plaidbar/"
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
     public static let authTokenFilename = "auth-token"
+    public static let serverConfigFilename = "server.conf"
     public static let transactionCacheFilename = "transactions.json"
     public static let plaidAccessTokenKeychainService = "PlaidBar.PlaidAccessToken"
     private static let directoryPermissions = 0o700
@@ -122,7 +123,7 @@ public enum LocalDataStore {
                     at: directory,
                     includingPropertiesForKeys: nil
                 )
-                for entry in entries where entry.lastPathComponent != authTokenFilename {
+                for entry in entries where !resetPreservedFilenames.contains(entry.lastPathComponent) {
                     try fileManager.removeItem(at: entry)
                     removedEntries.append(entry.lastPathComponent)
                 }
@@ -148,6 +149,13 @@ public enum LocalDataStore {
             removedEntries: removedEntries,
             keychainTokensCleared: keychainTokensCleared
         )
+    }
+
+    private static var resetPreservedFilenames: Set<String> {
+        [
+            authTokenFilename,
+            serverConfigFilename,
+        ]
     }
 
     private static func resetPlaidAccessTokenKeychainItems() throws {

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -67,6 +67,45 @@ public enum LocalDataStore {
         return homeDirectory.appendingPathComponent(".plaidbar", isDirectory: true)
     }
 
+    public static func storageDirectoryURL(
+        forServerStoragePath serverStoragePath: String?,
+        fallback: URL = storageDirectoryURL()
+    ) -> URL {
+        guard let storagePath = serverStoragePath?.trimmedNonEmpty else {
+            return fallback
+        }
+
+        if storagePath == displayPath {
+            return fallback
+        }
+
+        let expandedPath = NSString(string: storagePath).expandingTildeInPath
+        let storageURL = URL(fileURLWithPath: expandedPath)
+        if storageURL.pathExtension.lowercased() == "sqlite" {
+            return storageURL.deletingLastPathComponent()
+        }
+
+        return URL(fileURLWithPath: expandedPath, isDirectory: true)
+    }
+
+    public static func displayPath(
+        for url: URL,
+        homeDirectory: URL = accountHomeDirectoryURL()
+    ) -> String {
+        let homePath = homeDirectory.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+
+        if path == homePath {
+            return "~"
+        }
+
+        if path.hasPrefix(homePath + "/") {
+            return "~" + String(path.dropFirst(homePath.count))
+        }
+
+        return path
+    }
+
     @discardableResult
     public static func resetLocalData(
         at directory: URL = storageDirectoryURL(),

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -272,6 +272,92 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.displayBalance(for: availableCredit) == 0)
     }
 
+    @Test("Account connection presentation covers demo, offline, and healthy sync")
+    func accountConnectionPresentationCoreStates() {
+        let demo = AccountConnectionPresentation.evaluate(
+            isDemoMode: true,
+            serverConnected: false,
+            isSyncStale: true,
+            statusSyncText: "Never synced",
+            itemStatus: nil
+        )
+
+        #expect(demo.level == .demo)
+        #expect(demo.rowLabel == "Demo")
+        #expect(demo.detailLabel == "Demo data")
+        #expect(demo.iconName == "play.circle.fill")
+        #expect(!demo.showsRecoveryActions)
+
+        let offline = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            isSyncStale: true,
+            statusSyncText: "Never synced",
+            itemStatus: nil
+        )
+
+        #expect(offline.level == .offline)
+        #expect(offline.rowLabel == "Server offline")
+        #expect(offline.signalLabel == "Offline")
+        #expect(!offline.showsRecoveryActions)
+
+        let healthy = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .connected
+        )
+
+        #expect(healthy.level == .healthy)
+        #expect(healthy.rowLabel == "2m ago")
+        #expect(healthy.signalLabel == "Fresh")
+        #expect(healthy.iconName == "checkmark.circle.fill")
+    }
+
+    @Test("Account connection presentation flags stale and reconnectable items")
+    func accountConnectionPresentationRecoveryStates() {
+        let stale = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: true,
+            statusSyncText: "2h ago",
+            itemStatus: .connected
+        )
+
+        #expect(stale.level == .stale)
+        #expect(stale.signalLabel == "Stale")
+        #expect(stale.iconName == "clock.badge.exclamationmark.fill")
+        #expect(stale.showsRecoveryActions)
+
+        let loginRequired = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .loginRequired
+        )
+
+        #expect(loginRequired.level == .loginRequired)
+        #expect(loginRequired.rowLabel == "Reconnect")
+        #expect(loginRequired.detailLabel == "Login required")
+        #expect(loginRequired.signalLabel == "Login")
+        #expect(loginRequired.showsRecoveryActions)
+
+        let errored = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .error
+        )
+
+        #expect(errored.level == .error)
+        #expect(errored.rowLabel == "Item error")
+        #expect(errored.signalLabel == "Error")
+        #expect(errored.showsRecoveryActions)
+    }
+
     @Test("Menu bar summary estimates runway from recent monthly spend")
     func menuBarSummaryRunwayMonths() {
         let now = Formatters.parseTransactionDate("2026-01-30")!

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1466,17 +1466,19 @@ struct PlaidBarCoreTests {
         #expect(LocalDataStore.displayPath(for: URL(fileURLWithPath: "/var/tmp/plaidbar"), homeDirectory: home) == "/var/tmp/plaidbar")
     }
 
-    @Test("Local data reset removes data files and keeps server auth token")
-    func localDataResetRemovesDataFilesAndKeepsAuthToken() throws {
+    @Test("Local data reset removes data files and keeps local server configuration")
+    func localDataResetRemovesDataFilesAndKeepsLocalServerConfiguration() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
         let database = directory.appendingPathComponent("plaidbar.sqlite")
         let authToken = directory.appendingPathComponent("auth-token")
+        let serverConfig = directory.appendingPathComponent("server.conf")
 
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try "db".write(to: database, atomically: true, encoding: .utf8)
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
+        try "PLAID_ENV=sandbox".write(to: serverConfig, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: authToken.path)
         defer { try? FileManager.default.removeItem(at: root) }
 
@@ -1493,8 +1495,9 @@ struct PlaidBarCoreTests {
         var isDirectory: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
-        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["auth-token"])
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == ["auth-token", "server.conf"])
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
+        #expect(try String(contentsOf: serverConfig, encoding: .utf8) == "PLAID_ENV=sandbox")
         #expect(try posixPermissions(at: authToken) == 0o600)
     }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1342,6 +1342,44 @@ struct PlaidBarCoreTests {
         #expect(resolved == directory)
     }
 
+    @Test("Local data store resolves active directory from server database path")
+    func localDataStoreResolvesActiveDirectoryFromServerDatabasePath() {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let database = root
+            .appendingPathComponent("custom-plaidbar", isDirectory: true)
+            .appendingPathComponent("plaidbar-production.sqlite")
+
+        let directory = LocalDataStore.storageDirectoryURL(
+            forServerStoragePath: database.path
+        )
+
+        #expect(directory == database.deletingLastPathComponent())
+    }
+
+    @Test("Local data store falls back for demo display path")
+    func localDataStoreFallsBackForDemoDisplayPath() {
+        let fallback = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        let directory = LocalDataStore.storageDirectoryURL(
+            forServerStoragePath: LocalDataStore.displayPath,
+            fallback: fallback
+        )
+
+        #expect(directory == fallback)
+    }
+
+    @Test("Local data store display path abbreviates home")
+    func localDataStoreDisplayPathAbbreviatesHome() {
+        let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+        let directory = home.appendingPathComponent(".plaidbar", isDirectory: true)
+
+        #expect(LocalDataStore.displayPath(for: directory, homeDirectory: home) == "~/.plaidbar")
+        #expect(LocalDataStore.displayPath(for: home, homeDirectory: home) == "~")
+        #expect(LocalDataStore.displayPath(for: URL(fileURLWithPath: "/var/tmp/plaidbar"), homeDirectory: home) == "/var/tmp/plaidbar")
+    }
+
     @Test("Local data reset removes data files and keeps server auth token")
     func localDataResetRemovesDataFilesAndKeepsAuthToken() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -375,6 +375,13 @@ struct PlaidBarCoreTests {
         #expect(days.first?.transactionCount == 2)
     }
 
+    @Test("Net cashflow display flips Plaid signs for finance presentation")
+    func netCashflowDisplayFlipsPlaidSigns() {
+        #expect(SpendingHeatmap.displayCashflowAmount(-175) == 175)
+        #expect(SpendingHeatmap.displayCashflowAmount(75) == -75)
+        #expect(SpendingHeatmap.displayCashflowAmount(0) == 0)
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")


### PR DESCRIPTION
## Summary
- Clarify net cashflow heatmap sign handling and reset the active PlaidBar storage path in local data resets
- Share account connection presentation helpers across UI surfaces
- Add sharper spending empty states for offline, unlinked, unsynced, filtered-zero, and uncategorized states
- Preserve server.conf during local data reset

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift test --skip-update --disable-sandbox currently blocked by the documented local Swift toolchain baseline: no such module 'Testing'
- secret scan matched only sandbox fixture strings in tests