### PR TITLE
Share account detail presentation rules

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1347,10 +1347,10 @@ private struct SelectedAccountPanel: View {
                     Text("Details")
                         .sectionTitle()
                         .foregroundStyle(.secondary)
-                    Text(account.officialName ?? account.name)
+                    Text(AccountPresentation.displayName(for: account))
                         .font(.headline.weight(.bold))
                         .lineLimit(1)
-                    Text(selectedSubtitle)
+                    Text(AccountPresentation.subtitle(for: account))
                         .detailText()
                         .lineLimit(1)
                 }
@@ -1456,14 +1456,8 @@ private struct SelectedAccountPanel: View {
         }
     }
 
-    private var selectedSubtitle: String {
-        let subtype = account.subtype?.capitalized ?? account.type.rawValue.capitalized
-        let mask = account.mask.map { " •••• \($0)" } ?? ""
-        return "\(account.type.rawValue.capitalized) • \(subtype)\(mask)"
-    }
-
     private var availableText: String {
-        Formatters.currency(account.balances.available ?? account.balances.effectiveBalance, format: .compact)
+        Formatters.currency(AccountPresentation.availableBalance(for: account), format: .compact)
     }
 
     private var currentText: String {

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -12,6 +12,35 @@ public enum AccountPresentation {
         return account.balances.effectiveBalance
     }
 
+    public static func availableBalance(for account: AccountDTO) -> Double {
+        if let available = account.balances.available {
+            return available
+        }
+
+        guard isDebt(account) else {
+            return account.balances.effectiveBalance
+        }
+
+        guard account.type == .credit,
+              let limit = account.balances.limit,
+              limit > 0
+        else {
+            return 0
+        }
+
+        return max(0, limit - displayBalance(for: account))
+    }
+
+    public static func displayName(for account: AccountDTO) -> String {
+        account.officialName ?? account.name
+    }
+
+    public static func subtitle(for account: AccountDTO) -> String {
+        let subtype = account.subtype?.capitalized ?? account.type.rawValue.capitalized
+        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        return "\(account.type.rawValue.capitalized) • \(subtype)\(mask)"
+    }
+
     public static func iconName(for account: AccountDTO) -> String {
         switch account.type {
         case .credit:

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -272,6 +272,41 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.displayBalance(for: availableCredit) == 0)
     }
 
+    @Test("Account presentation derives account detail balances")
+    func accountPresentationDetailBalances() {
+        let checking = AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 450, current: 500))
+        let creditWithAvailable = AccountDTO(id: "2", itemId: "i", name: "Card", type: .credit, balances: BalanceDTO(available: 850, current: -150, limit: 1_000))
+        let creditWithoutAvailable = AccountDTO(id: "3", itemId: "i", name: "Backup Card", type: .credit, balances: BalanceDTO(current: -200, limit: 1_000))
+        let overLimitCredit = AccountDTO(id: "4", itemId: "i", name: "Over Limit", type: .credit, balances: BalanceDTO(current: -1_200, limit: 1_000))
+        let loan = AccountDTO(id: "5", itemId: "i", name: "Loan", type: .loan, balances: BalanceDTO(current: -5_000))
+
+        #expect(AccountPresentation.availableBalance(for: checking) == 450)
+        #expect(AccountPresentation.availableBalance(for: creditWithAvailable) == 850)
+        #expect(AccountPresentation.availableBalance(for: creditWithoutAvailable) == 800)
+        #expect(AccountPresentation.availableBalance(for: overLimitCredit) == 0)
+        #expect(AccountPresentation.availableBalance(for: loan) == 0)
+    }
+
+    @Test("Account presentation derives account detail labels")
+    func accountPresentationDetailLabels() {
+        let account = AccountDTO(
+            id: "1",
+            itemId: "i",
+            name: "Everyday",
+            officialName: "Everyday Checking",
+            type: .depository,
+            subtype: "checking",
+            mask: "1234",
+            balances: BalanceDTO(current: 500)
+        )
+        let fallback = AccountDTO(id: "2", itemId: "i", name: "Card", type: .credit, balances: BalanceDTO(current: -100))
+
+        #expect(AccountPresentation.displayName(for: account) == "Everyday Checking")
+        #expect(AccountPresentation.subtitle(for: account) == "Depository • Checking •••• 1234")
+        #expect(AccountPresentation.displayName(for: fallback) == "Card")
+        #expect(AccountPresentation.subtitle(for: fallback) == "Credit • Credit")
+    }
+
     @Test("Account connection presentation covers demo, offline, and healthy sync")
     func accountConnectionPresentationCoreStates() {
         let demo = AccountConnectionPresentation.evaluate(


### PR DESCRIPTION
## Summary
- Move selected account title, subtitle, and available-balance semantics into PlaidBarCore AccountPresentation
- Use shared presentation helpers in the dashboard selected account panel
- Add focused PlaidBarCore coverage for detail balances and labels

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
- secret scan matched only sandbox fixture strings in tests

Note: local swift test remains blocked by this machine's documented Swift toolchain baseline: no such module 'Testing'.