### PR TITLE
Reuse shared credit balance presentation

### DIFF
--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -129,7 +129,7 @@ struct CreditCardRow: View {
     let threshold: Double
 
     private var balance: Double {
-        abs(account.balances.current ?? 0)
+        AccountPresentation.displayBalance(for: account)
     }
 
     private var limit: Double {
@@ -137,12 +137,11 @@ struct CreditCardRow: View {
     }
 
     private var utilization: Double {
-        guard limit > 0 else { return 0 }
-        return (balance / limit) * 100
+        account.balances.utilizationPercent ?? 0
     }
 
     private var available: Double {
-        max(0, limit - balance)
+        AccountPresentation.availableBalance(for: account)
     }
 
     private var barColor: Color {


### PR DESCRIPTION
## Summary
- Reuse AccountPresentation display and available-balance helpers in CreditCardRow
- Reuse BalanceDTO utilization semantics instead of duplicating utilization math in SwiftUI

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain