### PR TITLE
Show transaction detail source context

### DIFF
--- a/Sources/PlaidBar/Views/TransactionDetailView.swift
+++ b/Sources/PlaidBar/Views/TransactionDetailView.swift
@@ -46,6 +46,16 @@ struct TransactionDetailView: View {
                         }
                     }
 
+                    if let merchantName = transaction.merchantName {
+                        LabeledContent("Merchant") {
+                            Text(merchantName)
+                        }
+                    }
+
+                    LabeledContent("Raw Name") {
+                        Text(transaction.name)
+                    }
+
                     LabeledContent("Date") {
                         Text(Formatters.displayTransactionDate(transaction.date))
                     }
@@ -61,6 +71,10 @@ struct TransactionDetailView: View {
                                 .frame(width: 8, height: 8)
                             Text(transaction.pending ? "Pending" : "Posted")
                         }
+                    }
+
+                    LabeledContent("Source") {
+                        Text(sourceText)
                     }
                 }
             }
@@ -85,6 +99,13 @@ struct TransactionDetailView: View {
 
     private var amountColor: Color {
         transaction.isIncome ? SemanticColors.income : SemanticColors.expense
+    }
+
+    private var sourceText: String {
+        if transaction.category != nil {
+            return "Plaid category"
+        }
+        return "Uncategorized"
     }
 
 }


### PR DESCRIPTION
## Summary
- Add merchant and raw name fields to the transaction detail sheet
- Add a compact source/context row distinguishing categorized Plaid data from uncategorized transactions

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain