### PR TITLE
Explain recurring charge confidence

### DIFF
--- a/Sources/PlaidBar/Views/RecurringView.swift
+++ b/Sources/PlaidBar/Views/RecurringView.swift
@@ -124,7 +124,10 @@ private struct RecurringRow: View {
                         .monospacedDigit()
                 }
 
-                Text("Last: \(Formatters.displayTransactionDate(item.lastDate))")
+                Text("Last: \(Formatters.displayTransactionDate(item.lastDate)) • Next: \(Formatters.displayTransactionDate(item.nextExpectedDate))")
+                    .detailText()
+
+                Text("\(item.transactionCount) matching charges • \(Formatters.percent(item.confidence * 100, decimals: 0)) confidence")
                     .detailText()
             }
 
@@ -134,6 +137,6 @@ private struct RecurringRow: View {
         .padding(.vertical, Spacing.sm)
         .hoverHighlight()
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(item.merchantName), \(item.frequency.displayName), \(Formatters.currency(item.averageAmount, format: .full))")
+        .accessibilityLabel("\(item.merchantName), \(item.frequency.displayName), \(Formatters.currency(item.averageAmount, format: .full)), \(item.transactionCount) matching charges, \(Formatters.percent(item.confidence * 100, decimals: 0)) confidence, next expected \(Formatters.displayTransactionDate(item.nextExpectedDate))")
     }
 }


### PR DESCRIPTION
## Summary
- Show next expected date for detected recurring charges
- Show matching charge count and confidence on recurring rows
- Include the added context in the combined VoiceOver row label

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain