### PR TITLE
Preserve private reset file permissions

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -136,7 +136,7 @@ public enum LocalDataStore {
         }
 
         try ensurePrivateDirectory(directory, fileManager: fileManager)
-        try ensurePrivateAuthTokenPermissions(in: directory, fileManager: fileManager)
+        try ensurePrivatePreservedFilePermissions(in: directory, fileManager: fileManager)
 
         var keychainTokensCleared = false
         if resetKeychainTokens {
@@ -326,16 +326,18 @@ public enum LocalDataStore {
         #endif
     }
 
-    private static func ensurePrivateAuthTokenPermissions(
+    private static func ensurePrivatePreservedFilePermissions(
         in directory: URL,
         fileManager: FileManager
     ) throws {
-        let url = authTokenURL(in: directory)
-        guard fileManager.fileExists(atPath: url.path) else { return }
-        try fileManager.setAttributes(
-            [.posixPermissions: cacheFilePermissions],
-            ofItemAtPath: url.path
-        )
+        for filename in resetPreservedFilenames {
+            let url = directory.appendingPathComponent(filename)
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            try fileManager.setAttributes(
+                [.posixPermissions: cacheFilePermissions],
+                ofItemAtPath: url.path
+            )
+        }
     }
 }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1515,6 +1515,7 @@ struct PlaidBarCoreTests {
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
         try "PLAID_ENV=sandbox".write(to: serverConfig, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: authToken.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: serverConfig.path)
         defer { try? FileManager.default.removeItem(at: root) }
 
         var didResetKeychainTokens = false
@@ -1534,6 +1535,7 @@ struct PlaidBarCoreTests {
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
         #expect(try String(contentsOf: serverConfig, encoding: .utf8) == "PLAID_ENV=sandbox")
         #expect(try posixPermissions(at: authToken) == 0o600)
+        #expect(try posixPermissions(at: serverConfig) == 0o600)
     }
 
     @Test("Local data reset keeps data directory private")


### PR DESCRIPTION
## Summary
- Repair permissions for all reset-preserved local config files, not only the app/server auth token
- Keep preserved `server.conf` at `0600` after local data reset
- Extend LocalDataStore coverage for preserved file permissions

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
- secret scan matched only sandbox fixture strings in tests
