### PR TITLE
Surface reconnect Link open failures

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -624,8 +624,13 @@ final class AppState {
     func reconnectItem(itemId: String) async {
         do {
             let linkResponse = try await serverClient.createUpdateLinkToken(itemId: itemId)
-            if let url = URL(string: linkResponse.linkUrl) {
-                NSWorkspace.shared.open(url)
+            guard let url = URL(string: linkResponse.linkUrl) else {
+                error = "PlaidBarServer returned an invalid Plaid update Link URL."
+                return
+            }
+
+            if !NSWorkspace.shared.open(url) {
+                error = "Could not open Plaid update Link in the browser."
             }
         } catch {
             self.error = error.localizedDescription


### PR DESCRIPTION
## Summary
- Report invalid update Link URLs during item reconnect
- Report browser-open failures during item reconnect instead of silently doing nothing
- Align reconnect recovery with first-time Plaid Link behavior

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain