### PR TITLE
Label error banner dismissal

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1721,6 +1721,8 @@ private struct ErrorBanner: View {
                 Image(systemName: "xmark.circle.fill")
             }
             .buttonStyle(.borderless)
+            .help("Dismiss error")
+            .accessibilityLabel("Dismiss error")
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 8)


### PR DESCRIPTION
## Summary
- Add help and VoiceOver label to the dashboard error-banner dismiss control

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain