### PR TITLE
Label status diagnostic tiles

### DIFF
--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -315,5 +315,7 @@ private struct DiagnosticTile: View {
         .padding(Spacing.sm)
         .background(.quaternary.opacity(0.35))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value)")
     }
 }


### PR DESCRIPTION
## Summary
- Add combined VoiceOver labels to Status diagnostic tiles so title/value pairs are announced cleanly

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain