### PR TITLE
fix: label status item rows

### DIFF
--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -162,6 +162,8 @@ struct StatusView: View {
                         }
                     }
                     .padding(.vertical, Spacing.xs)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(itemAccessibilityLabel(for: item))
                 }
             }
         }
@@ -285,6 +287,11 @@ struct StatusView: View {
         case .error:
             "The last Plaid request failed. Reconnect or try refreshing again."
         }
+    }
+
+    private func itemAccessibilityLabel(for item: ItemStatus) -> String {
+        let institutionName = item.institutionName ?? "Plaid item"
+        return "\(institutionName), \(label(for: item.status)), \(statusDetail(for: item))"
     }
 }
 


### PR DESCRIPTION
## Summary
- combine Plaid item status row children for accessibility
- add row labels with institution, connection state, and sync/recovery detail

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests