### PR TITLE
fix: label settings account rows

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -354,9 +354,13 @@ struct AccountSettingsView: View {
                                         .foregroundStyle(balanceTint(for: account))
                                 }
                                 .padding(.leading, Spacing.md)
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel(accountAccessibilityLabel(for: account))
                             }
                         }
                         .padding(.vertical, Spacing.xs)
+                        .accessibilityElement(children: .contain)
+                        .accessibilityLabel(groupAccessibilityLabel(for: group))
                     }
                 }
             }
@@ -470,6 +474,14 @@ struct AccountSettingsView: View {
 
     private func balanceTint(for account: AccountDTO) -> Color {
         AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .secondary
+    }
+
+    private func groupAccessibilityLabel(for group: AccountItemGroup) -> String {
+        "\(group.institutionName), \(label(for: group.status)), \(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")"
+    }
+
+    private func accountAccessibilityLabel(for account: AccountDTO) -> String {
+        "\(account.name), \(account.type.rawValue.capitalized), \(balanceText(for: account))"
     }
 
     private func label(for status: ItemConnectionStatus) -> String {


### PR DESCRIPTION
## Summary
- add accessibility summaries for Settings account institution groups
- add account row labels with account name, type, and displayed balance

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests