### PR TITLE
fix: label transaction filter chips

### DIFF
--- a/Sources/PlaidBar/Views/FilterChipsView.swift
+++ b/Sources/PlaidBar/Views/FilterChipsView.swift
@@ -39,6 +39,8 @@ struct FilterChipsView: View {
                     )
                 }
                 .menuStyle(.borderlessButton)
+                .accessibilityLabel("Category filter")
+                .accessibilityValue(selectedCategory?.displayName ?? "All categories")
 
                 // Account filter
                 Menu {
@@ -53,11 +55,13 @@ struct FilterChipsView: View {
                     }
                 } label: {
                     chipLabel(
-                        text: accounts.first(where: { $0.id == selectedAccountId })?.name ?? "Account",
+                        text: selectedAccountName ?? "Account",
                         isActive: selectedAccountId != nil
                     )
                 }
                 .menuStyle(.borderlessButton)
+                .accessibilityLabel("Account filter")
+                .accessibilityValue(selectedAccountName ?? "All accounts")
 
                 // Date range filter
                 Menu {
@@ -73,6 +77,8 @@ struct FilterChipsView: View {
                     )
                 }
                 .menuStyle(.borderlessButton)
+                .accessibilityLabel("Date range filter")
+                .accessibilityValue(selectedDateRange.displayName)
 
                 // Clear all
                 if activeFilterCount > 0 {
@@ -95,6 +101,10 @@ struct FilterChipsView: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(activeFilterCount > 0 ? "\(activeFilterCount) filters active" : "Transaction filters")
+    }
+
+    private var selectedAccountName: String? {
+        accounts.first(where: { $0.id == selectedAccountId })?.name
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- add explicit VoiceOver labels and current values to category, account, and date range filter menus
- reuse a selected account name helper for visual and accessibility labels

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests