### PR TITLE
fix: label spending chart signals

### DIFF
--- a/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
+++ b/Sources/PlaidBar/Views/Charts/IncomeExpenseChart.swift
@@ -43,6 +43,18 @@ struct IncomeExpenseChart: View {
         }.sorted { $0.month < $1.month }
     }
 
+    private var chartAccessibilityLabel: String {
+        let data = monthlyData
+        guard let first = data.first, let last = data.last else {
+            return "Income and expense chart with no data."
+        }
+
+        let totalIncome = data.reduce(0.0) { $0 + $1.income }
+        let totalExpenses = data.reduce(0.0) { $0 + $1.expenses }
+        let peakExpense = data.max { $0.expenses < $1.expenses } ?? last
+        return "Income and expense chart from \(first.label) to \(last.label), total income \(Formatters.currency(totalIncome, format: .full)), total expenses \(Formatters.currency(totalExpenses, format: .full)), highest expense month \(peakExpense.label) at \(Formatters.currency(peakExpense.expenses, format: .full))."
+    }
+
     var body: some View {
         let data = monthlyData
         if data.isEmpty {
@@ -86,6 +98,8 @@ struct IncomeExpenseChart: View {
             }
             .frame(height: 170)
             .padding(.horizontal)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(chartAccessibilityLabel)
         }
     }
 }

--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -85,6 +85,8 @@ struct SpendingHeatmapView: View {
                 .onChange(of: mode) { _, _ in
                     selectedDate = nil
                 }
+                .accessibilityLabel("Heatmap metric")
+                .accessibilityValue(mode == .spending ? "Spend" : "Net cashflow")
             }
 
             if days.allSatisfy({ $0.transactionCount == 0 }) {
@@ -176,6 +178,8 @@ struct SpendingHeatmapView: View {
                 .microText()
                 .foregroundStyle(.secondary)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(legendAccessibilityLabel)
     }
 
     @ViewBuilder
@@ -196,6 +200,8 @@ struct SpendingHeatmapView: View {
             }
             .padding(Spacing.sm)
             .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(selectedDayAccessibilityLabel(selectedDay))
         }
     }
 
@@ -210,7 +216,18 @@ struct SpendingHeatmapView: View {
 
     private var accessibilitySummary: String {
         let activeDays = days.filter { $0.transactionCount > 0 }.count
-        return "Spending heatmap with \(activeDays) active days. Peak day \(Formatters.currency(peakValue, format: .full))."
+        return "\(mode == .spending ? "Spending" : "Net cashflow") heatmap with \(activeDays) active days. Peak day \(Formatters.currency(peakValue, format: .full)). Total \(totalLabel)."
+    }
+
+    private var legendAccessibilityLabel: String {
+        if mode == .spending {
+            return "Spending heatmap legend, lighter cells mean less spending and darker cells mean more spending. \(activeDayCount) active days."
+        }
+        return "Net cashflow heatmap legend, green cells mean income and red cells mean outflow. \(activeDayCount) active days."
+    }
+
+    private func selectedDayAccessibilityLabel(_ day: SpendingHeatmapDay) -> String {
+        "\(Formatters.displayTransactionDate(day.date)), \(dayValueText(day)) across \(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
     }
 
     private func dayValueText(_ day: SpendingHeatmapDay) -> String {

--- a/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingTrendChart.swift
@@ -5,6 +5,13 @@ import PlaidBarCore
 struct SpendingTrendChart: View {
     let transactions: [TransactionDTO]
 
+    private static let accessibilityDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
     private var dailySpending: [(Date, Double)] {
         let expenses = SpendingSummary.expenseTransactions(from: transactions)
 
@@ -15,6 +22,17 @@ struct SpendingTrendChart: View {
             return (date, total)
         }
         return results.sorted { $0.0 < $1.0 }
+    }
+
+    private var chartAccessibilityLabel: String {
+        let data = dailySpending
+        guard let first = data.first, let last = data.last else {
+            return "Spending trend chart with no spending data."
+        }
+
+        let total = data.reduce(0.0) { $0 + $1.1 }
+        let peak = data.max { $0.1 < $1.1 } ?? last
+        return "Spending trend chart from \(Self.accessibilityDateFormatter.string(from: first.0)) to \(Self.accessibilityDateFormatter.string(from: last.0)), total \(Formatters.currency(total, format: .full)), peak day \(Self.accessibilityDateFormatter.string(from: peak.0)) at \(Formatters.currency(peak.1, format: .full))."
     }
 
     var body: some View {
@@ -60,6 +78,8 @@ struct SpendingTrendChart: View {
             }
             .frame(height: 170)
             .padding(.horizontal)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(chartAccessibilityLabel)
         }
     }
 }

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -82,6 +82,8 @@ Completed production-readiness slices:
   status diagnostics, Plaid item status rows, and Settings account rows.
 - 2026-05-31: added VoiceOver labels for dashboard account filter chips,
   drill-down rows, selected account signal pills, and mini activity rows.
+- 2026-05-31: added VoiceOver summaries for spending trend, income/expense,
+  and standalone heatmap chart signals.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- add VoiceOver summaries for spending trend and income/expense charts
- label standalone heatmap metric picker, legend meaning, total context, and selected-day summary
- update the autonomous roadmap progress ledger

## Validation
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- rg -n "(PLAID_SECRET|client_secret|access_token|sk-|ghp_|github_pat_|BEGIN (RSA|OPENSSH|EC) PRIVATE KEY|api[_-]?key)" README.md GOAL.md CHANGELOG.md SECURITY.md DESIGN.md PRD.md docs Sources Tests commands .codex

Secret scan notes: hits are existing docs/example credential placeholders and expected server/test token-field references; no new secrets added.