### PR TITLE
fix: clarify first-run partial sync recovery

### DIFF
--- a/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
@@ -91,10 +91,12 @@ public struct FirstRunCompletionState: Equatable, Sendable {
         guard syncedItemCount >= linkedItemCount else {
             return FirstRunCompletionState(
                 step: .syncTransactions,
-                title: "Accounts loaded",
-                detail: transactionCount > 0
-                    ? "\(syncedItemCount) of \(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") synced. Run one more check to finish setup."
-                    : "Run the first transaction sync check to finish setup.",
+                title: syncedItemCount > 0 ? "First sync incomplete" : "Accounts loaded",
+                detail: syncTransactionsDetail(
+                    linkedItemCount: linkedItemCount,
+                    syncedItemCount: syncedItemCount,
+                    transactionCount: transactionCount
+                ),
                 isReady: false,
                 canRetry: true
             )
@@ -109,5 +111,21 @@ public struct FirstRunCompletionState: Equatable, Sendable {
             isReady: true,
             canRetry: false
         )
+    }
+
+    private static func syncTransactionsDetail(
+        linkedItemCount: Int,
+        syncedItemCount: Int,
+        transactionCount: Int
+    ) -> String {
+        if syncedItemCount > 0 {
+            return "\(syncedItemCount) of \(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") synced. Run one more check to finish setup."
+        }
+
+        if transactionCount > 0 {
+            return "Transactions are present, but no linked item has completed its first sync. Check again to commit sync state."
+        }
+
+        return "Run the first transaction sync check to finish setup."
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -877,6 +877,43 @@ struct PlaidBarCoreTests {
         #expect(state.canRetry)
     }
 
+    @Test("First-run completion reports partial item sync")
+    func firstRunCompletionReportsPartialItemSync() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 2,
+            accountCount: 4,
+            transactionCount: 12,
+            syncedItemCount: 1,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .syncTransactions)
+        #expect(state.title == "First sync incomplete")
+        #expect(state.detail == "1 of 2 linked items synced. Run one more check to finish setup.")
+        #expect(!state.isReady)
+        #expect(state.canRetry)
+    }
+
+    @Test("First-run completion distinguishes uncommitted sync state")
+    func firstRunCompletionDistinguishesUncommittedSyncState() {
+        let state = FirstRunCompletionState.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            transactionCount: 8,
+            syncedItemCount: 0,
+            errorMessage: nil
+        )
+
+        #expect(state.step == .syncTransactions)
+        #expect(state.title == "Accounts loaded")
+        #expect(state.detail == "Transactions are present, but no linked item has completed its first sync. Check again to commit sync state.")
+        #expect(state.canRetry)
+    }
+
     @Test("First-run completion is ready after accounts and sync")
     func firstRunCompletionReadyAfterSync() {
         let state = FirstRunCompletionState.evaluate(


### PR DESCRIPTION
## Summary
- distinguish partial first-run item sync as First sync incomplete
- clarify recovery copy when transactions exist but no linked item has committed first-sync state
- add focused PlaidBarCore tests for partial and uncommitted sync states

## Verification
- git diff --check origin/main..HEAD
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests

## Known local limitation
- swift test remains blocked by the local Testing module baseline ()