### PR TITLE
fix: guard onboarding credentials

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -667,6 +667,16 @@ final class AppState {
             return false
         }
 
+        guard serverCredentialsConfigured == true else {
+            switch expectedEnvironment {
+            case .sandbox:
+                error = "Sandbox Plaid credentials are missing on PlaidBarServer. Add PLAID_CLIENT_ID and PLAID_SANDBOX_SECRET, then check again."
+            case .production:
+                error = "Production Plaid credentials are missing on PlaidBarServer. Add approved production credentials, then check again."
+            }
+            return false
+        }
+
         await addAccount()
         return error == nil
     }


### PR DESCRIPTION
## Summary
- make onboarding Link startup fail explicitly when Plaid credentials are missing or unknown
- tailor missing-credential recovery copy for sandbox and production

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests
