### PR TITLE
fix: label notification permission status

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -636,10 +636,14 @@ struct NotificationSettingsView: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .accessibilityHint("Opens macOS Notification settings for PlaidBar.")
                     .padding(.top, Spacing.xs)
                 }
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("macOS notification permission: \(permissionLabel)")
+        .accessibilityHint(permissionDetail)
     }
 
     private func refreshPermissionStatus() async {


### PR DESCRIPTION
## Summary
- add explicit accessibility label and hint for the macOS notification permission status row
- add a hint to the denied-permission System Settings button

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan only matched existing sandbox fixture access tokens in tests
