### PR TITLE
fix: label credit utilization status

### DIFF
--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -214,6 +214,7 @@ struct AccountRow: View {
         components.append("\(formattedAmount)\(AccountPresentation.isDebt(account) ? " owed" : "")")
         if let utilization = account.balances.utilizationPercent {
             components.append("\(Formatters.percent(utilization)) utilization")
+            components.append(AccountPresentation.utilizationStatusLabel(for: utilization))
         }
         return components.joined(separator: ", ")
     }

--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -45,6 +45,9 @@ struct CreditView: View {
                         Text(Formatters.percent(totalUtilization))
                             .fontWeight(.semibold)
                             .foregroundStyle(SemanticColors.utilization(for: totalUtilization, threshold: appState.creditUtilizationThreshold))
+                        Text(totalUtilizationStatus)
+                            .microText()
+                            .foregroundStyle(.secondary)
                     }
                     Spacer()
                     Image(systemName: SemanticColors.utilizationIcon(for: totalUtilization))
@@ -53,9 +56,16 @@ struct CreditView: View {
                 .padding(.horizontal, Spacing.lg)
                 .padding(.bottom, Spacing.sm)
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel("Total credit utilization \(Formatters.percent(totalUtilization))")
+                .accessibilityLabel("Total credit utilization \(Formatters.percent(totalUtilization)), \(totalUtilizationStatus)")
             }
         }
+    }
+
+    private var totalUtilizationStatus: String {
+        AccountPresentation.utilizationStatusLabel(
+            for: totalUtilization,
+            threshold: appState.creditUtilizationThreshold
+        )
     }
 
     @ViewBuilder
@@ -148,6 +158,10 @@ struct CreditCardRow: View {
         SemanticColors.utilization(for: utilization, threshold: threshold)
     }
 
+    private var utilizationStatus: String {
+        AccountPresentation.utilizationStatusLabel(for: utilization, threshold: threshold)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.rowVertical) {
             HStack {
@@ -198,6 +212,6 @@ struct CreditCardRow: View {
         .padding(.horizontal, Spacing.lg)
         .padding(.vertical, Spacing.rowVertical)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(account.name), \(Formatters.percent(utilization)) utilization, \(Formatters.currency(available, format: .compact)) available")
+        .accessibilityLabel("\(account.name), \(Formatters.percent(utilization)) utilization, \(utilizationStatus), \(Formatters.currency(available, format: .compact)) available")
     }
 }

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -56,6 +56,22 @@ public enum AccountPresentation {
         }
     }
 
+    public static func utilizationStatusLabel(
+        for percent: Double,
+        threshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
+    ) -> String {
+        guard percent >= threshold else { return "Good" }
+
+        switch percent {
+        case ..<50:
+            return "Warning"
+        case 50..<75:
+            return "High"
+        default:
+            return "Very high"
+        }
+    }
+
     private static func depositoryIconName(forSubtype subtype: String?) -> String {
         let normalized = subtype?.lowercased() ?? ""
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -307,6 +307,15 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.subtitle(for: fallback) == "Credit • Credit")
     }
 
+    @Test("Account presentation labels credit utilization status")
+    func accountPresentationUtilizationStatusLabels() {
+        #expect(AccountPresentation.utilizationStatusLabel(for: 12) == "Good")
+        #expect(AccountPresentation.utilizationStatusLabel(for: 30) == "Warning")
+        #expect(AccountPresentation.utilizationStatusLabel(for: 50) == "High")
+        #expect(AccountPresentation.utilizationStatusLabel(for: 75) == "Very high")
+        #expect(AccountPresentation.utilizationStatusLabel(for: 25, threshold: 20) == "Warning")
+    }
+
     @Test("Account connection presentation covers demo, offline, and healthy sync")
     func accountConnectionPresentationCoreStates() {
         let demo = AccountConnectionPresentation.evaluate(

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -90,6 +90,8 @@ Completed production-readiness slices:
   rows.
 - 2026-06-01: made onboarding missing-credential failures explicit before
   opening Plaid Link.
+- 2026-06-01: labeled credit utilization status in summary and account
+  accessibility surfaces.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- Add a shared credit utilization status label in PlaidBarCore.
- Surface the status in the credit summary and account/card accessibility labels.
- Record the completed accessibility slice in the autonomous roadmap ledger.

## Test plan
- [x] git diff --check
- [x] swift build --target PlaidBar --skip-update --disable-keychain
- [x] swift build --target PlaidBarServer --skip-update --disable-keychain
- [x] Secret scan from docs/autonomous-roadmap.md; only documented placeholders/schema references and expected Tests/PlaidBarServerTests fixture strings found
- [ ] swift test --skip-update --disable-keychain (known local baseline: no such module 'Testing')