### PR TITLE
fix: label dashboard utilization status

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1110,7 +1110,8 @@ private struct AccountRowWithDrilldown: View {
         let selectedText = isSelected ? "selected" : "collapsed"
         let pendingText = pendingCount > 0 ? ", \(pendingCount) pending transaction\(pendingCount == 1 ? "" : "s")" : ""
         let metricText = account.balances.utilizationPercent.map {
-            ", \(Formatters.percent($0, decimals: 0)) utilization"
+            let status = AccountPresentation.utilizationStatusLabel(for: $0)
+            return ", \(Formatters.percent($0, decimals: 0)) utilization, \(status)"
         } ?? ", \(connectionPresentation.rowLabel)"
         return "\(account.name), \(accountSubtitle), \(balance)\(metricText)\(pendingText), \(selectedText)"
     }
@@ -1417,7 +1418,7 @@ private struct SelectedAccountPanel: View {
                 if let utilization = account.balances.utilizationPercent {
                     DetailValue(
                         title: "Utilization",
-                        value: Formatters.percent(utilization, decimals: 0),
+                        value: utilizationDetailText(for: utilization),
                         tint: SemanticColors.utilization(for: utilization)
                     )
                 } else {
@@ -1538,6 +1539,11 @@ private struct SelectedAccountPanel: View {
 
     private var activityText: String {
         "\(accountTransactions.count) tx"
+    }
+
+    private func utilizationDetailText(for utilization: Double) -> String {
+        let status = AccountPresentation.utilizationStatusLabel(for: utilization)
+        return "\(Formatters.percent(utilization, decimals: 0)), \(status)"
     }
 
     private var syncSignalText: String {

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -92,6 +92,8 @@ Completed production-readiness slices:
   opening Plaid Link.
 - 2026-06-01: labeled credit utilization status in summary and account
   accessibility surfaces.
+- 2026-06-01: labeled dashboard credit utilization status in account rows and
+  selected details.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- Add utilization status text to dashboard account row accessibility labels.
- Show selected-account utilization with its status label in the dashboard detail panel.
- Record the completed dashboard accessibility slice in the autonomous roadmap ledger.

## Test plan
- [x] git diff --check
- [x] swift build --target PlaidBar --skip-update --disable-keychain
- [x] Secret scan from docs/autonomous-roadmap.md; only documented placeholders/schema references and expected Tests/PlaidBarServerTests fixture strings found