### PR TITLE
fix: align utilization threshold signals

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -66,13 +66,11 @@ enum SemanticColors {
     }
 
     /// SF Symbol for utilization status
-    static func utilizationIcon(for percent: Double) -> String {
-        switch percent {
-        case ..<30: return "checkmark.circle"
-        case 30..<50: return "exclamationmark.triangle"
-        case 50..<75: return "exclamationmark.triangle.fill"
-        default: return "xmark.octagon"
-        }
+    static func utilizationIcon(for percent: Double, threshold: Double = 30) -> String {
+        if percent < threshold { return "checkmark.circle" }
+        if percent < 50 { return "exclamationmark.triangle" }
+        if percent < 75 { return "exclamationmark.triangle.fill" }
+        return "xmark.octagon"
     }
 }
 

--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -50,7 +50,10 @@ struct CreditView: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    Image(systemName: SemanticColors.utilizationIcon(for: totalUtilization))
+                    Image(systemName: SemanticColors.utilizationIcon(
+                        for: totalUtilization,
+                        threshold: appState.creditUtilizationThreshold
+                    ))
                         .foregroundStyle(SemanticColors.utilization(for: totalUtilization, threshold: appState.creditUtilizationThreshold))
                 }
                 .padding(.horizontal, Spacing.lg)
@@ -169,7 +172,7 @@ struct CreditCardRow: View {
                     .font(.body)
                 Spacer()
                 // Issue #4: threshold-specific icons
-                Image(systemName: SemanticColors.utilizationIcon(for: utilization))
+                Image(systemName: SemanticColors.utilizationIcon(for: utilization, threshold: threshold))
                     .foregroundStyle(barColor)
                     .font(.caption)
             }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1110,7 +1110,10 @@ private struct AccountRowWithDrilldown: View {
         let selectedText = isSelected ? "selected" : "collapsed"
         let pendingText = pendingCount > 0 ? ", \(pendingCount) pending transaction\(pendingCount == 1 ? "" : "s")" : ""
         let metricText = account.balances.utilizationPercent.map {
-            let status = AccountPresentation.utilizationStatusLabel(for: $0)
+            let status = AccountPresentation.utilizationStatusLabel(
+                for: $0,
+                threshold: appState.creditUtilizationThreshold
+            )
             return ", \(Formatters.percent($0, decimals: 0)) utilization, \(status)"
         } ?? ", \(connectionPresentation.rowLabel)"
         return "\(account.name), \(accountSubtitle), \(balance)\(metricText)\(pendingText), \(selectedText)"
@@ -1292,7 +1295,10 @@ private struct DashboardAccountRow: View {
                 if let utilization = account.balances.utilizationPercent {
                     Text(Formatters.percent(utilization, decimals: 0))
                         .font(.caption.weight(.bold))
-                        .foregroundStyle(SemanticColors.utilization(for: utilization))
+                        .foregroundStyle(SemanticColors.utilization(
+                            for: utilization,
+                            threshold: appState.creditUtilizationThreshold
+                        ))
                 } else {
                     Text(statusText)
                         .microText()
@@ -1419,7 +1425,10 @@ private struct SelectedAccountPanel: View {
                     DetailValue(
                         title: "Utilization",
                         value: utilizationDetailText(for: utilization),
-                        tint: SemanticColors.utilization(for: utilization)
+                        tint: SemanticColors.utilization(
+                            for: utilization,
+                            threshold: appState.creditUtilizationThreshold
+                        )
                     )
                 } else {
                     DetailValue(title: "Activity", value: activityText, tint: connectionTint)
@@ -1542,7 +1551,10 @@ private struct SelectedAccountPanel: View {
     }
 
     private func utilizationDetailText(for utilization: Double) -> String {
-        let status = AccountPresentation.utilizationStatusLabel(for: utilization)
+        let status = AccountPresentation.utilizationStatusLabel(
+            for: utilization,
+            threshold: appState.creditUtilizationThreshold
+        )
         return "\(Formatters.percent(utilization, decimals: 0)), \(status)"
     }
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -94,6 +94,8 @@ Completed production-readiness slices:
   accessibility surfaces.
 - 2026-06-01: labeled dashboard credit utilization status in account rows and
   selected details.
+- 2026-06-01: aligned credit utilization status icons and dashboard tinting
+  with the configured warning threshold.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- Let credit utilization status icons use the configured warning threshold.
- Pass the configured threshold through credit and dashboard utilization colors/status labels.
- Record the completed threshold-signal slice in the autonomous roadmap ledger.

## Test plan
- [x] git diff --check
- [x] swift build --target PlaidBar --skip-update --disable-keychain
- [x] Secret scan from docs/autonomous-roadmap.md; only documented placeholders/schema references and expected Tests/PlaidBarServerTests fixture strings found