### PR TITLE
fix: report storage directory in status preflight

### DIFF
--- a/Scripts/smoke-sandbox.sh
+++ b/Scripts/smoke-sandbox.sh
@@ -154,8 +154,8 @@ if not status.get("storagePath"):
     errors.append("status response missing storagePath")
 else:
     storage_path = os.path.realpath(status["storagePath"])
-    if not storage_path.startswith(data_dir + os.sep):
-        errors.append(f"expected storage path under {data_dir}, got {storage_path}")
+    if storage_path != data_dir:
+        errors.append(f"expected storage path to be {data_dir}, got {storage_path}")
 if not isinstance(items, list):
     errors.append("items response is not a JSON array")
 
@@ -173,15 +173,15 @@ data_dir_mode = os.stat(data_dir).st_mode & 0o777
 if data_dir_mode != 0o700:
     errors.append(f"expected data directory permissions 0700, got {data_dir_mode:04o}")
 
-if storage_path:
-    if not os.path.exists(storage_path):
-        errors.append(f"SQLite store was not created at {storage_path}")
-    else:
-        for path in [storage_path, f"{storage_path}-wal", f"{storage_path}-shm"]:
-            if os.path.exists(path):
-                store_mode = os.stat(path).st_mode & 0o777
-                if store_mode != 0o600:
-                    errors.append(f"expected SQLite store permissions 0600 for {path}, got {store_mode:04o}")
+sqlite_path = os.path.join(data_dir, "plaidbar-sandbox.sqlite")
+if not os.path.exists(sqlite_path):
+    errors.append(f"SQLite store was not created at {sqlite_path}")
+else:
+    for path in [sqlite_path, f"{sqlite_path}-wal", f"{sqlite_path}-shm"]:
+        if os.path.exists(path):
+            store_mode = os.stat(path).st_mode & 0o777
+            if store_mode != 0o600:
+                errors.append(f"expected SQLite store permissions 0600 for {path}, got {store_mode:04o}")
 
 if errors:
     for error in errors:

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -670,7 +670,7 @@ final class AppState {
         guard serverCredentialsConfigured == true else {
             switch expectedEnvironment {
             case .sandbox:
-                error = "Sandbox Plaid credentials are missing on PlaidBarServer. Add PLAID_CLIENT_ID and PLAID_SANDBOX_SECRET, then check again."
+                error = "Sandbox Plaid credentials are missing on PlaidBarServer. Add PLAID_CLIENT_ID and PLAID_SECRET, then check again."
             case .production:
                 error = "Production Plaid credentials are missing on PlaidBarServer. Add approved production credentials, then check again."
             }

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -107,7 +107,7 @@ struct StatusView: View {
                 color: .secondary
             )
             DiagnosticTile(
-                title: "Database",
+                title: "Storage",
                 value: appState.serverStorageDisplayText,
                 icon: "internaldrive",
                 color: .secondary

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -22,6 +22,12 @@ struct ServerConfig: Sendable {
     let redirectUri: String
     let authToken: String
 
+    var dataDirectoryPath: String {
+        URL(fileURLWithPath: databasePath)
+            .deletingLastPathComponent()
+            .path
+    }
+
     var plaidBaseURL: String {
         switch plaidEnvironment {
         case .sandbox: "https://sandbox.plaid.com"

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -27,7 +27,7 @@ struct StatusRoutes: Sendable {
             itemCount: itemCount,
             lastSync: lastSync,
             credentialsConfigured: !config.plaidClientId.isEmpty && !config.plaidSecret.isEmpty,
-            storagePath: config.databasePath,
+            storagePath: config.dataDirectoryPath,
             syncReady: itemCount > 0,
             syncedItemCount: syncedItemCount
         )

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -801,7 +801,7 @@ struct PlaidBarCoreTests {
             environment: .sandbox,
             itemCount: 0,
             credentialsConfigured: false,
-            storagePath: "/tmp/plaidbar.sqlite",
+            storagePath: "/tmp/.plaidbar",
             syncReady: false,
             syncedItemCount: 0
         )
@@ -810,7 +810,7 @@ struct PlaidBarCoreTests {
         let decoded = try JSONDecoder().decode(ServerStatus.self, from: data)
 
         #expect(decoded.credentialsConfigured == false)
-        #expect(decoded.storagePath == "/tmp/plaidbar.sqlite")
+        #expect(decoded.storagePath == "/tmp/.plaidbar")
         #expect(decoded.syncReady == false)
         #expect(decoded.syncedItemCount == 0)
     }
@@ -823,7 +823,7 @@ struct PlaidBarCoreTests {
           "environment": "sandbox",
           "itemCount": 2,
           "credentialsConfigured": true,
-          "storagePath": "/tmp/plaidbar.sqlite",
+          "storagePath": "/tmp/.plaidbar",
           "syncReady": true
         }
         """.data(using: .utf8)!

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -55,7 +55,7 @@ struct PlaidBarServerTests {
             itemCount: 2,
             lastSync: Date(timeIntervalSince1970: 1_800_000_000),
             credentialsConfigured: true,
-            storagePath: "/Users/example/.plaidbar/plaidbar-production.sqlite",
+            storagePath: "/Users/example/.plaidbar",
             syncReady: true,
             syncedItemCount: 2
         )
@@ -118,6 +118,7 @@ struct PlaidBarServerTests {
         #expect(config.plaidClientId == "config-client")
         #expect(config.plaidSecret == "config-secret")
         #expect(config.plaidEnvironment == .sandbox)
+        #expect(config.dataDirectoryPath == dataDirectory.path)
         #expect(config.port == 9494)
         #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
         #expect(config.databasePath.hasPrefix(dataDirectory.path))


### PR DESCRIPTION
## Summary
- report the PlaidBar data directory, not the SQLite file path, from the server status preflight
- rename the status diagnostic tile from Database to Storage
- align sandbox credential recovery copy with the server's PLAID_SECRET configuration

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift test --skip-update --disable-keychain *(known local baseline: no such module 'Testing')*
- secret scan from commands/plaidbar-prod-loop.md *(only documented placeholders and source references found)*