### PR TITLE
docs: align storage directory copy

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -210,7 +210,7 @@ struct GeneralSettingsView: View {
 
     private var storageDetailText: String {
         if let serverStoragePath = appState.serverStoragePath {
-            return "Server database: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
+            return "Server storage directory: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
         }
 
         return "Default: \(appState.localStorageResolvedDisplayPathText)"

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -96,6 +96,8 @@ Completed production-readiness slices:
   selected details.
 - 2026-06-01: aligned credit utilization status icons and dashboard tinting
   with the configured warning threshold.
+- 2026-06-01: reported the local storage directory, not the SQLite file, in
+  status preflight and sandbox smoke checks.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- update Settings local-data detail copy to call the server value a storage directory
- record the merged status-preflight storage-directory slice in the autonomous roadmap ledger

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan from commands/plaidbar-prod-loop.md *(only documented placeholders and source references found)*