### PR TITLE
test: cover server storage directory resolution

### DIFF
--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1524,6 +1524,19 @@ struct PlaidBarCoreTests {
         #expect(directory == database.deletingLastPathComponent())
     }
 
+    @Test("Local data store resolves active directory from server storage directory")
+    func localDataStoreResolvesActiveDirectoryFromServerStorageDirectory() {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent(".plaidbar", isDirectory: true)
+
+        let resolved = LocalDataStore.storageDirectoryURL(
+            forServerStoragePath: directory.path
+        )
+
+        #expect(resolved == directory)
+    }
+
     @Test("Local data store falls back for demo display path")
     func localDataStoreFallsBackForDemoDisplayPath() {
         let fallback = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- add core coverage for resolving an active PlaidBar storage directory when server status already reports a directory path
- keep legacy SQLite-file path coverage in place for backwards compatibility

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain *(known local baseline: no such module 'Testing')*
- secret scan from commands/plaidbar-prod-loop.md *(only documented placeholders and source references found)*