### PR TITLE
docs: align status storage directory copy

### DIFF
--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -173,7 +173,7 @@ struct StatusView: View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(spacing: Spacing.xs) {
                 Image(systemName: "lock.doc")
-                Text("Local data path: \(appState.activeStorageDirectoryDisplayText)")
+                Text("Local data directory: \(appState.activeStorageDirectoryDisplayText)")
             }
             .detailText()
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -98,6 +98,10 @@ Completed production-readiness slices:
   with the configured warning threshold.
 - 2026-06-01: reported the local storage directory, not the SQLite file, in
   status preflight and sandbox smoke checks.
+- 2026-06-01: aligned Settings local-data copy with the server storage
+  directory contract.
+- 2026-06-01: covered server-reported storage directory path resolution in
+  `PlaidBarCore`.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- update Status recovery copy to call the active PlaidBar location a local data directory
- record the Settings copy and core storage-directory test slices in the autonomous roadmap ledger

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- secret scan from commands/plaidbar-prod-loop.md *(only documented placeholders and source references found)*