### PR TITLE
refactor: share balance composition totals

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -366,22 +366,34 @@ private struct BalanceCompositionStrip: View {
         [
             BalanceCompositionSegment(
                 title: "Cash",
-                value: sum(for: .depository),
+                value: AccountPresentation.positiveBalanceTotal(
+                    from: appState.accounts,
+                    type: .depository
+                ),
                 tint: SemanticColors.available
             ),
             BalanceCompositionSegment(
                 title: "Investments",
-                value: sum(for: .investment),
+                value: AccountPresentation.positiveBalanceTotal(
+                    from: appState.accounts,
+                    type: .investment
+                ),
                 tint: SemanticColors.brand
             ),
             BalanceCompositionSegment(
                 title: "Credit",
-                value: debt(for: .credit),
+                value: AccountPresentation.debtBalanceTotal(
+                    from: appState.accounts,
+                    type: .credit
+                ),
                 tint: SemanticColors.creditDebt
             ),
             BalanceCompositionSegment(
                 title: "Loans",
-                value: debt(for: .loan),
+                value: AccountPresentation.debtBalanceTotal(
+                    from: appState.accounts,
+                    type: .loan
+                ),
                 tint: SemanticColors.warning
             ),
         ]
@@ -440,18 +452,6 @@ private struct BalanceCompositionStrip: View {
         let gaps = CGFloat(max(activeSegments.count - 1, 0)) * 3
         let availableWidth = max(totalWidth - gaps, 0)
         return max(availableWidth * CGFloat(segment.value / total), 6)
-    }
-
-    private func sum(for type: AccountType) -> Double {
-        appState.accounts
-            .filter { $0.type == type }
-            .reduce(0) { $0 + max($1.balances.effectiveBalance, 0) }
-    }
-
-    private func debt(for type: AccountType) -> Double {
-        appState.accounts
-            .filter { $0.type == type }
-            .reduce(0) { $0 + AccountPresentation.displayBalance(for: $1) }
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -31,6 +31,24 @@ public enum AccountPresentation {
         return max(0, limit - displayBalance(for: account))
     }
 
+    public static func positiveBalanceTotal(
+        from accounts: [AccountDTO],
+        type: AccountType
+    ) -> Double {
+        accounts
+            .filter { $0.type == type }
+            .reduce(0) { $0 + max($1.balances.effectiveBalance, 0) }
+    }
+
+    public static func debtBalanceTotal(
+        from accounts: [AccountDTO],
+        type: AccountType
+    ) -> Double {
+        accounts
+            .filter { $0.type == type }
+            .reduce(0) { $0 + displayBalance(for: $1) }
+    }
+
     public static func displayName(for account: AccountDTO) -> String {
         account.officialName ?? account.name
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -287,6 +287,22 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.availableBalance(for: loan) == 0)
     }
 
+    @Test("Account presentation aggregates positive and debt balances")
+    func accountPresentationBalanceTotals() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(current: 500)),
+            AccountDTO(id: "2", itemId: "i", name: "Overdrawn", type: .depository, balances: BalanceDTO(current: -20)),
+            AccountDTO(id: "3", itemId: "i", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 1_200)),
+            AccountDTO(id: "4", itemId: "i", name: "Card", type: .credit, balances: BalanceDTO(current: -125)),
+            AccountDTO(id: "5", itemId: "i", name: "Loan", type: .loan, balances: BalanceDTO(current: -750)),
+        ]
+
+        #expect(AccountPresentation.positiveBalanceTotal(from: accounts, type: .depository) == 500)
+        #expect(AccountPresentation.positiveBalanceTotal(from: accounts, type: .investment) == 1_200)
+        #expect(AccountPresentation.debtBalanceTotal(from: accounts, type: .credit) == 125)
+        #expect(AccountPresentation.debtBalanceTotal(from: accounts, type: .loan) == 750)
+    }
+
     @Test("Account presentation derives account detail labels")
     func accountPresentationDetailLabels() {
         let account = AccountDTO(


### PR DESCRIPTION
## Summary
- move Balance Mix cash/investment and debt aggregation into PlaidBarCore account presentation helpers
- keep the dashboard strip using shared, tested account balance totals
- add core coverage for positive-balance and debt-balance aggregation

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift test --skip-update --disable-keychain *(known local baseline: no such module 'Testing')*
- secret scan from commands/plaidbar-prod-loop.md *(only documented placeholders and source references found)*