### PR TITLE
Refactor account row presentation helpers

### DIFF
--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -211,7 +211,7 @@ struct AccountRow: View {
     }
 
     private var formattedAmount: String {
-        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .full)
+        AccountPresentation.rowAmountText(for: account)
     }
 
     private var amountColor: Color {
@@ -219,23 +219,10 @@ struct AccountRow: View {
     }
 
     private var accessibilityLabel: String {
-        var components = [String]()
-        components.append(account.name)
-        if let institutionName = account.institutionName {
-            components.append(institutionName)
-        }
-        components.append(account.type.rawValue.capitalized)
-        if let mask = account.mask {
-            components.append("Ending in \(mask)")
-        }
-        components.append("\(formattedAmount)\(AccountPresentation.isDebt(account) ? " owed" : "")")
-        if let utilization = account.balances.utilizationPercent {
-            components.append("\(Formatters.percent(utilization)) utilization")
-            components.append(AccountPresentation.utilizationStatusLabel(
-                for: utilization,
-                threshold: utilizationThreshold
-            ))
-        }
-        return components.joined(separator: ", ")
+        AccountPresentation.rowAccessibilityLabel(
+            for: account,
+            amountText: formattedAmount,
+            utilizationThreshold: utilizationThreshold
+        )
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1106,21 +1106,14 @@ private struct AccountRowWithDrilldown: View {
     }
 
     private var accountAccessibilityLabel: String {
-        let balance = Formatters.currency(AccountPresentation.displayBalance(for: account), format: .full)
-        let selectedText = isSelected ? "selected" : "collapsed"
-        let pendingText = pendingCount > 0 ? ", \(pendingCount) pending transaction\(pendingCount == 1 ? "" : "s")" : ""
-        let metricText = account.balances.utilizationPercent.map {
-            let status = AccountPresentation.utilizationStatusLabel(
-                for: $0,
-                threshold: appState.creditUtilizationThreshold
-            )
-            return ", \(Formatters.percent($0, decimals: 0)) utilization, \(status)"
-        } ?? ", \(connectionPresentation.rowLabel)"
-        return "\(account.name), \(accountSubtitle), \(balance)\(metricText)\(pendingText), \(selectedText)"
-    }
-
-    private var accountSubtitle: String {
-        AccountPresentation.subtitle(for: account)
+        AccountPresentation.rowAccessibilityLabel(
+            for: account,
+            amountText: AccountPresentation.rowAmountText(for: account),
+            connectionLabel: connectionPresentation.rowLabel,
+            pendingCount: pendingCount,
+            isSelected: isSelected,
+            utilizationThreshold: appState.creditUtilizationThreshold
+        )
     }
 
     private var pendingCount: Int {
@@ -1322,13 +1315,15 @@ private struct DashboardAccountRow: View {
     }
 
     private var subtitle: String {
-        let mask = account.mask.map { " •••• \($0)" } ?? ""
-        let pending = pendingCount > 0 ? " • \(pendingCount) pending" : ""
-        return "\(account.institutionName ?? account.type.rawValue.capitalized)\(mask) • \(statusText)\(pending)"
+        AccountPresentation.dashboardRowSubtitle(
+            for: account,
+            connectionLabel: statusText,
+            pendingCount: pendingCount
+        )
     }
 
     private var amountText: String {
-        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .full)
+        AccountPresentation.rowAmountText(for: account)
     }
 
     private var accountTint: Color {

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -59,6 +59,65 @@ public enum AccountPresentation {
         return "\(account.type.rawValue.capitalized) • \(subtype)\(mask)"
     }
 
+    public static func rowAmountText(
+        for account: AccountDTO,
+        format: CurrencyFormat = .full
+    ) -> String {
+        Formatters.currency(displayBalance(for: account), format: format)
+    }
+
+    public static func dashboardRowSubtitle(
+        for account: AccountDTO,
+        connectionLabel: String,
+        pendingCount: Int = 0
+    ) -> String {
+        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        let pending = pendingCount > 0 ? " • \(pendingCount) pending" : ""
+        return "\(account.institutionName ?? account.type.rawValue.capitalized)\(mask) • \(connectionLabel)\(pending)"
+    }
+
+    public static func rowAccessibilityLabel(
+        for account: AccountDTO,
+        amountText: String? = nil,
+        connectionLabel: String? = nil,
+        pendingCount: Int = 0,
+        isSelected: Bool? = nil,
+        utilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
+    ) -> String {
+        var components = [String]()
+        components.append(account.name)
+        if let institutionName = account.institutionName {
+            components.append(institutionName)
+        }
+        components.append(account.type.rawValue.capitalized)
+        if let mask = account.mask {
+            components.append("Ending in \(mask)")
+        }
+
+        let balance = amountText ?? rowAmountText(for: account)
+        components.append("\(balance)\(isDebt(account) ? " owed" : "")")
+
+        if let utilization = account.balances.utilizationPercent {
+            components.append("\(Formatters.percent(utilization, decimals: 0)) utilization")
+            components.append(utilizationStatusLabel(
+                for: utilization,
+                threshold: utilizationThreshold
+            ))
+        } else if let connectionLabel {
+            components.append(connectionLabel)
+        }
+
+        if pendingCount > 0 {
+            components.append("\(pendingCount) pending transaction\(pendingCount == 1 ? "" : "s")")
+        }
+
+        if let isSelected {
+            components.append(isSelected ? "selected" : "collapsed")
+        }
+
+        return components.joined(separator: ", ")
+    }
+
     public static func iconName(for account: AccountDTO) -> String {
         switch account.type {
         case .credit:

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -323,6 +323,47 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.subtitle(for: fallback) == "Credit • Credit")
     }
 
+    @Test("Account presentation derives dashboard row labels")
+    func accountPresentationDashboardRowLabels() {
+        let checking = AccountDTO(
+            id: "1",
+            itemId: "i",
+            name: "Everyday",
+            type: .depository,
+            mask: "1234",
+            balances: BalanceDTO(current: 500),
+            institutionName: "Chase"
+        )
+        let credit = AccountDTO(
+            id: "2",
+            itemId: "i",
+            name: "Rewards",
+            type: .credit,
+            mask: "0005",
+            balances: BalanceDTO(current: -450, limit: 1_000),
+            institutionName: "Amex"
+        )
+
+        #expect(AccountPresentation.rowAmountText(for: checking, format: .compact) == "$500")
+        #expect(AccountPresentation.dashboardRowSubtitle(
+            for: checking,
+            connectionLabel: "2m ago",
+            pendingCount: 2
+        ) == "Chase •••• 1234 • 2m ago • 2 pending")
+        #expect(AccountPresentation.rowAccessibilityLabel(
+            for: checking,
+            connectionLabel: "2m ago",
+            pendingCount: 1,
+            isSelected: false
+        ) == "Everyday, Chase, Depository, Ending in 1234, $500.00, 2m ago, 1 pending transaction, collapsed")
+        #expect(AccountPresentation.rowAccessibilityLabel(
+            for: credit,
+            amountText: "$450.00",
+            connectionLabel: "2m ago",
+            isSelected: true
+        ) == "Rewards, Amex, Credit, Ending in 0005, $450.00 owed, 45% utilization, Warning, selected")
+    }
+
     @Test("Account presentation labels credit utilization status")
     func accountPresentationUtilizationStatusLabels() {
         #expect(AccountPresentation.utilizationStatusLabel(for: 12) == "Good")

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -102,6 +102,9 @@ Completed production-readiness slices:
   directory contract.
 - 2026-06-01: covered server-reported storage directory path resolution in
   `PlaidBarCore`.
+- 2026-06-01: shared balance composition totals through `PlaidBarCore`.
+- 2026-06-01: moved account row amounts, subtitles, and accessibility summary
+  composition into `PlaidBarCore`.
 
 ### Reliability And Trust
 


### PR DESCRIPTION
## Summary
- move account row amount, dashboard subtitle, and accessibility label composition into PlaidBarCore
- reuse shared presentation helpers in the legacy accounts list and dashboard drill-down rows
- update the autonomous roadmap ledger for #176 and this slice

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBarServer --skip-update --disable-keychain
- swift test --skip-update --disable-keychain (known local baseline: no such module 'Testing')
- secret scan command from commands/plaidbar-prod-loop.md (expected documentation/test placeholder matches only)