### PR TITLE
fix: specify dashboard recovery actions

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -883,7 +883,7 @@ private struct DashboardStatusReadinessPanel: View {
                         perform(primaryAction)
                     } label: {
                         Label(
-                            readiness.primaryActionTitle ?? primaryAction.label,
+                            primaryActionLabel(for: primaryAction),
                             systemImage: readiness.primaryActionIconName ?? primaryAction.icon
                         )
                     }
@@ -953,6 +953,14 @@ private struct DashboardStatusReadinessPanel: View {
         case .openSettings:
             openSettings()
         }
+    }
+
+    private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {
+        if action == .reconnect,
+           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
+            return title
+        }
+        return readiness.primaryActionTitle ?? action.label
     }
 
     private var reconnectItemId: String? {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -956,7 +956,7 @@ private struct DashboardStatusReadinessPanel: View {
     }
 
     private var reconnectItemId: String? {
-        appState.itemStatuses.first { $0.status == .loginRequired || $0.status == .error }?.id
+        ItemRecoveryTarget.itemId(from: appState.itemStatuses)
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -882,7 +882,10 @@ private struct DashboardStatusReadinessPanel: View {
                     Button {
                         perform(primaryAction)
                     } label: {
-                        Label(primaryAction.label, systemImage: primaryAction.icon)
+                        Label(
+                            readiness.primaryActionTitle ?? primaryAction.label,
+                            systemImage: readiness.primaryActionIconName ?? primaryAction.icon
+                        )
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -21,6 +21,8 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     public let title: String
     public let detail: String
     public let primaryAction: DashboardStatusReadinessAction?
+    public let primaryActionTitle: String?
+    public let primaryActionIconName: String?
     public let secondaryActions: [DashboardStatusReadinessAction]
 
     public init(
@@ -28,12 +30,16 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         title: String,
         detail: String,
         primaryAction: DashboardStatusReadinessAction? = nil,
+        primaryActionTitle: String? = nil,
+        primaryActionIconName: String? = nil,
         secondaryActions: [DashboardStatusReadinessAction] = []
     ) {
         self.level = level
         self.title = title
         self.detail = detail
         self.primaryAction = primaryAction
+        self.primaryActionTitle = primaryActionTitle ?? primaryAction?.defaultTitle
+        self.primaryActionIconName = primaryActionIconName ?? primaryAction?.defaultIconName
         self.secondaryActions = secondaryActions
     }
 
@@ -56,6 +62,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Demo data ready",
                 detail: "Local demo accounts are loaded. Connect a real institution when you are ready.",
                 primaryAction: .addAccount,
+                primaryActionTitle: "Connect Bank",
                 secondaryActions: [.openSettings]
             )
         }
@@ -123,6 +130,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "No institution linked",
                 detail: "Connect a Plaid institution before this dashboard can show balances and transactions.",
                 primaryAction: .addAccount,
+                primaryActionTitle: "Connect Bank",
                 secondaryActions: [.refresh]
             )
         }
@@ -133,6 +141,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Balances not loaded",
                 detail: "The server has linked items, but account balances have not loaded into the dashboard yet.",
                 primaryAction: .refresh,
+                primaryActionTitle: "Load Balances",
                 secondaryActions: [.addAccount]
             )
         }
@@ -143,6 +152,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "First sync needed",
                 detail: "Accounts are loaded, but no linked item has completed transaction sync yet. Refresh to run the first sync.",
                 primaryAction: .refresh,
+                primaryActionTitle: "Run First Sync",
                 secondaryActions: [.openSettings]
             )
         }
@@ -153,6 +163,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "First sync incomplete",
                 detail: "\(syncedItemCount) of \(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") have completed transaction sync. Refresh to finish the remaining item\(linkedItemCount - syncedItemCount == 1 ? "" : "s").",
                 primaryAction: .refresh,
+                primaryActionTitle: "Finish Sync",
                 secondaryActions: [.openSettings]
             )
         }
@@ -163,6 +174,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Sync is stale",
                 detail: "Last sync: \(lastSyncRelative ?? "never"). Refresh now to pull current balances and transactions.",
                 primaryAction: .refresh,
+                primaryActionTitle: "Refresh Now",
                 secondaryActions: [.openSettings]
             )
         }
@@ -172,6 +184,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             title: "Plaid sync healthy",
             detail: "\(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") connected. Last sync: \(lastSyncRelative ?? "just now").",
             primaryAction: .refresh,
+            primaryActionTitle: "Refresh Data",
             secondaryActions: [.addAccount]
         )
     }
@@ -195,5 +208,27 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         pluralAction: String
     ) -> String {
         "\(count) item\(count == 1 ? "" : "s") \(count == 1 ? singularAction : pluralAction)"
+    }
+}
+
+private extension DashboardStatusReadinessAction {
+    var defaultTitle: String {
+        switch self {
+        case .checkServer: "Check Server"
+        case .addAccount: "Add Account"
+        case .refresh: "Refresh"
+        case .reconnect: "Reconnect"
+        case .openSettings: "Settings"
+        }
+    }
+
+    var defaultIconName: String {
+        switch self {
+        case .checkServer: "server.rack"
+        case .addAccount: "plus.circle"
+        case .refresh: "arrow.clockwise"
+        case .reconnect: "link.badge.plus"
+        case .openSettings: "gearshape"
+        }
     }
 }

--- a/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
+++ b/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum ItemRecoveryTarget {
+    public static func itemId(from statuses: [ItemStatus]) -> String? {
+        statuses.first { $0.status == .error }?.id
+            ?? statuses.first { $0.status == .loginRequired }?.id
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
+++ b/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
@@ -1,8 +1,20 @@
 import Foundation
 
 public enum ItemRecoveryTarget {
+    public static func item(from statuses: [ItemStatus]) -> ItemStatus? {
+        statuses.first { $0.status == .error }
+            ?? statuses.first { $0.status == .loginRequired }
+    }
+
     public static func itemId(from statuses: [ItemStatus]) -> String? {
-        statuses.first { $0.status == .error }?.id
-            ?? statuses.first { $0.status == .loginRequired }?.id
+        item(from: statuses)?.id
+    }
+
+    public static func actionTitle(from statuses: [ItemStatus]) -> String? {
+        guard let item = item(from: statuses) else { return nil }
+        guard let institutionName = item.institutionName, !institutionName.isEmpty else {
+            return "Reconnect Item"
+        }
+        return "Reconnect \(institutionName)"
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1518,6 +1518,36 @@ struct PlaidBarCoreTests {
         #expect(readiness.secondaryActions.contains(.addAccount))
     }
 
+    @Test("Item recovery target prioritizes errored items")
+    func itemRecoveryTargetPrioritizesErroredItems() {
+        let statuses = [
+            ItemStatus(id: "login", status: .loginRequired),
+            ItemStatus(id: "error", status: .error),
+            ItemStatus(id: "connected", status: .connected),
+        ]
+
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "error")
+    }
+
+    @Test("Item recovery target falls back to login-required items")
+    func itemRecoveryTargetFallsBackToLoginRequiredItems() {
+        let statuses = [
+            ItemStatus(id: "connected", status: .connected),
+            ItemStatus(id: "login", status: .loginRequired),
+        ]
+
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "login")
+    }
+
+    @Test("Item recovery target ignores healthy items")
+    func itemRecoveryTargetIgnoresHealthyItems() {
+        let statuses = [
+            ItemStatus(id: "connected", status: .connected),
+        ]
+
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == nil)
+    }
+
     // MARK: - ItemStatus Tests
 
     @Test("ItemStatus Codable")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1521,22 +1521,35 @@ struct PlaidBarCoreTests {
     @Test("Item recovery target prioritizes errored items")
     func itemRecoveryTargetPrioritizesErroredItems() {
         let statuses = [
-            ItemStatus(id: "login", status: .loginRequired),
-            ItemStatus(id: "error", status: .error),
+            ItemStatus(id: "login", institutionName: "Chase", status: .loginRequired),
+            ItemStatus(id: "error", institutionName: "Amex", status: .error),
             ItemStatus(id: "connected", status: .connected),
         ]
 
+        #expect(ItemRecoveryTarget.item(from: statuses)?.institutionName == "Amex")
         #expect(ItemRecoveryTarget.itemId(from: statuses) == "error")
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == "Reconnect Amex")
     }
 
     @Test("Item recovery target falls back to login-required items")
     func itemRecoveryTargetFallsBackToLoginRequiredItems() {
         let statuses = [
             ItemStatus(id: "connected", status: .connected),
+            ItemStatus(id: "login", institutionName: "Chase", status: .loginRequired),
+        ]
+
+        #expect(ItemRecoveryTarget.item(from: statuses)?.institutionName == "Chase")
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "login")
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == "Reconnect Chase")
+    }
+
+    @Test("Item recovery target uses generic title without institution")
+    func itemRecoveryTargetUsesGenericTitleWithoutInstitution() {
+        let statuses = [
             ItemStatus(id: "login", status: .loginRequired),
         ]
 
-        #expect(ItemRecoveryTarget.itemId(from: statuses) == "login")
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == "Reconnect Item")
     }
 
     @Test("Item recovery target ignores healthy items")
@@ -1545,7 +1558,9 @@ struct PlaidBarCoreTests {
             ItemStatus(id: "connected", status: .connected),
         ]
 
+        #expect(ItemRecoveryTarget.item(from: statuses)?.id == nil)
         #expect(ItemRecoveryTarget.itemId(from: statuses) == nil)
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == nil)
     }
 
     // MARK: - ItemStatus Tests

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1052,6 +1052,8 @@ struct PlaidBarCoreTests {
         #expect(readiness.title == "Demo data ready")
         #expect(readiness.detail.contains("Local demo accounts"))
         #expect(readiness.primaryAction == .addAccount)
+        #expect(readiness.primaryActionTitle == "Connect Bank")
+        #expect(readiness.primaryActionIconName == "plus.circle")
     }
 
     @Test("Dashboard status readiness blocks on offline server")
@@ -1093,6 +1095,7 @@ struct PlaidBarCoreTests {
 
         #expect(readiness.level == .warning)
         #expect(readiness.primaryAction == .addAccount)
+        #expect(readiness.primaryActionTitle == "Connect Bank")
     }
 
     @Test("Dashboard status readiness surfaces recent action failure before empty data")
@@ -1442,6 +1445,8 @@ struct PlaidBarCoreTests {
         #expect(readiness.primaryAction == .refresh)
         #expect(readiness.title == "First sync incomplete")
         #expect(readiness.detail == "1 of 2 linked items have completed transaction sync. Refresh to finish the remaining item.")
+        #expect(readiness.primaryActionTitle == "Finish Sync")
+        #expect(readiness.primaryActionIconName == "arrow.clockwise")
         #expect(readiness.secondaryActions.contains(.openSettings))
     }
 
@@ -1465,6 +1470,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.primaryAction == .refresh)
         #expect(readiness.title == "First sync needed")
         #expect(readiness.detail == "Accounts are loaded, but no linked item has completed transaction sync yet. Refresh to run the first sync.")
+        #expect(readiness.primaryActionTitle == "Run First Sync")
         #expect(readiness.secondaryActions.contains(.openSettings))
     }
 
@@ -1487,6 +1493,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.level == .warning)
         #expect(readiness.primaryAction == .refresh)
         #expect(readiness.title == "Sync is stale")
+        #expect(readiness.primaryActionTitle == "Refresh Now")
     }
 
     @Test("Dashboard status readiness reports healthy sync")
@@ -1507,6 +1514,7 @@ struct PlaidBarCoreTests {
 
         #expect(readiness.level == .healthy)
         #expect(readiness.primaryAction == .refresh)
+        #expect(readiness.primaryActionTitle == "Refresh Data")
         #expect(readiness.secondaryActions.contains(.addAccount))
     }
 


### PR DESCRIPTION
## Summary
- specify dashboard recovery action copy for sync, login, and error states
- prioritize errored Plaid items before login-required items for reconnect actions
- name reconnect targets when institution metadata is available

## Verification
- swift test