### PR TITLE
Polish PlaidBar dashboard recovery and release readiness

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -104,8 +104,8 @@ if ! grep -Fq "tag: \"$TAG\"" Formula/plaidbar.rb; then
 fi
 
 echo "Running release gates for $TAG..."
-swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
-swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
+swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
 bash -n Scripts/*.sh Scripts/plaidbar-run
 ruby -c Formula/plaidbar.rb
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -16,6 +16,9 @@ version tag, then creates a GitHub release for ftchvs/PlaidBar.
 This script expects to run from a clean main branch after CI has passed.
 Use --allow-current-branch only for release-prep PR validation; publishing still
 requires clean main.
+
+Set PLAIDBAR_RELEASE_SKIP_TESTS=1 only for the documented local Swift Testing
+toolchain mismatch; CI must still pass tests before publishing.
 EOF
 }
 
@@ -106,6 +109,12 @@ fi
 echo "Running release gates for $TAG..."
 swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
 swift build -c release -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain
+if [[ "${PLAIDBAR_RELEASE_SKIP_TESTS:-0}" == "1" ]]; then
+    echo "Skipping swift test because PLAIDBAR_RELEASE_SKIP_TESTS=1."
+    echo "Only use this for the documented local Swift Testing toolchain mismatch; CI must pass tests before publishing."
+else
+    swift test --skip-update --disable-keychain
+fi
 bash -n Scripts/*.sh Scripts/plaidbar-run
 ruby -c Formula/plaidbar.rb
 

--- a/Scripts/screenshots.sh
+++ b/Scripts/screenshots.sh
@@ -28,6 +28,7 @@ capture_dashboard() {
     local filter="$1"
     local output="$2"
     local account="${3:-}"
+    local extra_args="${4:-}"
     local window_rect=""
 
     APP_LOG="$(mktemp -t plaidbar-screenshots.XXXXXX.log)"
@@ -35,9 +36,9 @@ capture_dashboard() {
 
     echo "Opening dashboard popover (${filter})..."
     if [ -n "$account" ]; then
-        "$BINARY" --demo --show-popover --screenshot-filter "$filter" --screenshot-account "$account" >"$APP_LOG" 2>&1 &
+        "$BINARY" --demo --show-popover --screenshot-filter "$filter" --screenshot-account "$account" $extra_args >"$APP_LOG" 2>&1 &
     else
-        "$BINARY" --demo --show-popover --screenshot-filter "$filter" >"$APP_LOG" 2>&1 &
+        "$BINARY" --demo --show-popover --screenshot-filter "$filter" $extra_args >"$APP_LOG" 2>&1 &
     fi
     APP_PID=$!
 
@@ -246,7 +247,7 @@ capture_dashboard "Cash" "dashboard-cash.png" "demo_checking"
 capture_dashboard "Credit" "dashboard-credit.png" "demo_visa"
 capture_dashboard "Savings" "dashboard-savings.png" "demo_savings"
 capture_dashboard "Debt" "dashboard-debt.png" "demo_visa"
-capture_dashboard "Status" "dashboard-status.png"
+capture_dashboard "Status" "dashboard-status.png" "" "--screenshot-status-recovery"
 capture_settings "general" "settings-local-data.png"
 capture_settings "accounts" "settings-accounts.png"
 capture_settings "notifications" "settings-notifications.png"

--- a/Scripts/screenshots.sh
+++ b/Scripts/screenshots.sh
@@ -24,6 +24,35 @@ cleanup() {
 }
 trap cleanup EXIT
 
+run_osascript() {
+    local script="$1"
+    local timeout_seconds="${PLAIDBAR_SCREENSHOT_OSASCRIPT_TIMEOUT:-5}"
+    local output_file=""
+    local pid=""
+    local elapsed=0
+    local status=0
+
+    output_file="$(mktemp -t plaidbar-osascript.XXXXXX.out)"
+    osascript -e "$script" >"$output_file" 2>/dev/null &
+    pid=$!
+
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$elapsed" -ge "$timeout_seconds" ]; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            rm -f "$output_file"
+            return 124
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    wait "$pid" || status=$?
+    cat "$output_file"
+    rm -f "$output_file"
+    return "$status"
+}
+
 capture_dashboard() {
     local filter="$1"
     local output="$2"
@@ -43,7 +72,7 @@ capture_dashboard() {
     APP_PID=$!
 
     for _ in {1..20}; do
-        window_rect=$(osascript -e '
+        window_rect=$(run_osascript '
             tell application "System Events"
                 if exists process "PlaidBar" then
                     tell process "PlaidBar"
@@ -55,7 +84,7 @@ capture_dashboard() {
                     end tell
                 end if
             end tell
-        ' 2>/dev/null || true)
+        ' || true)
 
         if [ -n "$window_rect" ] && [ "$window_rect" != "missing value" ]; then
             break
@@ -93,7 +122,7 @@ capture_sandbox_preflight() {
     APP_PID=$!
 
     for _ in {1..20}; do
-        window_rect=$(osascript -e '
+        window_rect=$(run_osascript '
             tell application "System Events"
                 if exists process "PlaidBar" then
                     tell process "PlaidBar"
@@ -106,7 +135,7 @@ capture_sandbox_preflight() {
                     end tell
                 end if
             end tell
-        ' 2>/dev/null || true)
+        ' || true)
 
         if [ -n "$window_rect" ] && [ "$window_rect" != "missing value" ]; then
             break
@@ -121,17 +150,17 @@ capture_sandbox_preflight() {
         exit 1
     fi
 
-    osascript -e '
+    run_osascript '
         tell application "System Events"
             tell process "PlaidBar"
                 set frontmost to true
                 click button 5 of group 1 of window 1
             end tell
         end tell
-    ' 2>/dev/null || true
+    ' >/dev/null || true
     sleep 1
 
-    window_rect=$(osascript -e '
+    window_rect=$(run_osascript '
         tell application "System Events"
             tell process "PlaidBar"
                 set windowPosition to position of window 1
@@ -139,7 +168,7 @@ capture_sandbox_preflight() {
                 return (item 1 of windowPosition as text) & "," & (item 2 of windowPosition as text) & "," & (item 1 of windowSize as text) & "," & (item 2 of windowSize as text)
             end tell
         end tell
-    ' 2>/dev/null || true)
+    ' || true)
 
     echo "Capturing ${output}..."
     screencapture -R"$window_rect" "$ASSETS_DIR/$output"
@@ -166,7 +195,7 @@ capture_settings() {
 
     sleep 1
     for _ in {1..40}; do
-        window_rect=$(osascript -e '
+        window_rect=$(run_osascript '
             tell application "System Events"
                 if exists process "PlaidBar" then
                     tell process "PlaidBar"
@@ -175,7 +204,7 @@ capture_settings() {
                     end tell
                 end if
             end tell
-        ' 2>/dev/null || true)
+        ' || true)
 
         if [ "$window_rect" = "ready" ]; then
             break
@@ -190,17 +219,17 @@ capture_settings() {
         exit 1
     fi
 
-    osascript -e '
+    run_osascript '
         tell application "System Events"
             tell process "PlaidBar"
                 set frontmost to true
                 click button 3 of group 1 of window 1
             end tell
         end tell
-    ' 2>/dev/null || true
+    ' >/dev/null || true
 
     for _ in {1..24}; do
-        window_rect=$(osascript -e '
+        window_rect=$(run_osascript '
             tell application "System Events"
                 if exists process "PlaidBar" then
                     tell process "PlaidBar"
@@ -215,7 +244,7 @@ capture_settings() {
                     end tell
                 end if
             end tell
-        ' 2>/dev/null || true)
+        ' || true)
 
         if [ -n "$window_rect" ] && [ "$window_rect" != "missing value" ] && [ "$window_rect" != "ready" ]; then
             break

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -525,6 +525,8 @@ final class AppState {
     }
 
     func refreshAccounts() async {
+        if refreshDemoDataIfNeeded() { return }
+
         isLoading = true
         error = nil
         do {
@@ -542,6 +544,8 @@ final class AppState {
     }
 
     func refreshBalances() async {
+        if refreshDemoDataIfNeeded() { return }
+
         isLoading = true
         error = nil
         do {
@@ -558,6 +562,8 @@ final class AppState {
     }
 
     func syncTransactions() async {
+        if refreshDemoDataIfNeeded() { return }
+
         do {
             var hasMore = true
             var pageCount = 0
@@ -630,6 +636,11 @@ final class AppState {
     }
 
     func reconnectItem(itemId: String) async {
+        guard !isDemoMode else {
+            error = "Demo data is local. Connect a bank before reconnecting an institution."
+            return
+        }
+
         do {
             let linkResponse = try await serverClient.createUpdateLinkToken(itemId: itemId)
             guard let url = URL(string: linkResponse.linkUrl) else {
@@ -648,6 +659,16 @@ final class AppState {
     func startDemoMode() {
         isDemoMode = true
         loadDemoData()
+    }
+
+    func refreshDashboard() async {
+        if refreshDemoDataIfNeeded() { return }
+
+        await checkServerConnection()
+        if serverConnected {
+            await refreshAccounts()
+            await syncTransactions()
+        }
     }
 
     func connectForOnboarding(expectedEnvironment: PlaidEnvironment) async -> Bool {
@@ -775,8 +796,7 @@ final class AppState {
         refreshTask?.cancel()
         refreshTask = Task {
             while !Task.isCancelled {
-                await refreshAccounts()
-                await syncTransactions()
+                await refreshDashboard()
                 await evaluateNotifications()
                 try? await Task.sleep(for: .seconds(refreshInterval))
             }
@@ -909,6 +929,15 @@ final class AppState {
 
     private func updateSetupCompletion() {
         isSetupComplete = firstRunCompletionState.isReady
+    }
+
+    @discardableResult
+    private func refreshDemoDataIfNeeded() -> Bool {
+        guard isDemoMode else { return false }
+        error = nil
+        isLoading = false
+        loadDemoData()
+        return true
     }
 
     private func recordBalanceSnapshot() {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -42,6 +42,7 @@ final class AppState {
     var serverSyncedItemCount: Int?
     var itemStatuses: [ItemStatus] = []
     var isDemoMode = false
+    var isDemoStatusRecoveryScenario = false
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
 
@@ -386,6 +387,10 @@ final class AppState {
     }
 
     var diagnosticsSummary: String {
+        if isDemoStatusRecoveryScenario {
+            if erroredItemCount > 0 { return "\(erroredItemCount) demo item\(erroredItemCount == 1 ? "" : "s") need attention" }
+            if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(needsLoginItemCount == 1 ? "" : "s") need login" }
+        }
         if isDemoMode { return "Demo data loaded" }
         if !serverConnected { return "Server offline" }
         if statusItemCount == 0 { return "No Plaid items connected" }
@@ -408,7 +413,7 @@ final class AppState {
 
     var dashboardStatusReadiness: DashboardStatusReadiness {
         DashboardStatusReadiness.evaluate(
-            isDemoMode: isDemoMode,
+            isDemoMode: isDemoMode && !isDemoStatusRecoveryScenario,
             serverConnected: serverConnected,
             credentialsConfigured: serverCredentialsConfigured,
             linkedItemCount: statusItemCount,
@@ -783,6 +788,7 @@ final class AppState {
         lastSyncDate = nil
         isSetupComplete = false
         isDemoMode = false
+        isDemoStatusRecoveryScenario = false
         error = nil
 
         balanceHistory = []
@@ -955,6 +961,8 @@ final class AppState {
     // MARK: - Demo Data
 
     func loadDemoData() {
+        isDemoStatusRecoveryScenario = CommandLine.arguments.contains("--screenshot-status-recovery")
+
         let today = Self.dateString(daysAgo: 0)
         let yesterday = Self.dateString(daysAgo: 1)
         let twoDaysAgo = Self.dateString(daysAgo: 2)
@@ -1067,12 +1075,17 @@ final class AppState {
         serverCredentialsConfigured = true
         serverStoragePath = LocalDataStore.displayPath
         serverSyncReady = true
-        serverSyncedItemCount = serverItemCount
-        itemStatuses = [
+        serverSyncedItemCount = isDemoStatusRecoveryScenario ? 1 : serverItemCount
+        let recoveredSync = Calendar.current.date(byAdding: .minute, value: -18, to: Date()) ?? Date()
+        let needsLoginSync = Calendar.current.date(byAdding: .day, value: -3, to: Date()) ?? Date()
+        itemStatuses = isDemoStatusRecoveryScenario ? [
+            ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: recoveredSync),
+            ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .loginRequired, lastSync: needsLoginSync),
+        ] : [
             ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: Date()),
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),
         ]
-        lastSyncDate = Date()
+        lastSyncDate = isDemoStatusRecoveryScenario ? recoveredSync : Date()
     }
 
     private static func dateString(daysAgo: Int) -> String {

--- a/Sources/PlaidBar/Services/RefreshService.swift
+++ b/Sources/PlaidBar/Services/RefreshService.swift
@@ -16,8 +16,7 @@ final class RefreshService {
         let state = appState
         refreshTask = Task {
             while !Task.isCancelled {
-                await state.refreshAccounts()
-                await state.syncTransactions()
+                await state.refreshDashboard()
                 try? await Task.sleep(for: .seconds(state.refreshInterval))
             }
         }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -274,22 +274,20 @@ struct AccountSettingsView: View {
     @State private var isShowingAccountSetup = false
     @State private var pendingRemoval: PendingAccountRemoval?
 
+    private var emptyPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.accounts(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
             if appState.accounts.isEmpty {
-                ContentUnavailableView {
-                    Label(emptyTitle, systemImage: emptyIcon)
-                } description: {
-                    Text(emptyMessage)
-                } actions: {
-                    Button {
-                        handleAddAccount()
-                    } label: {
-                        Label("Add Account", systemImage: "plus.circle")
-                    }
-                    .buttonStyle(.borderedProminent)
+                SecondaryUnavailableView(presentation: emptyPresentation) {
+                    performEmptyAction(emptyPresentation.action)
                 }
-                .padding()
             } else {
                 List {
                     ForEach(accountGroups) { group in
@@ -401,6 +399,23 @@ struct AccountSettingsView: View {
         isShowingAccountSetup = true
     }
 
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            handleAddAccount()
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters, .showWiderPeriod:
+            break
+        }
+    }
+
     private var accountGroups: [AccountItemGroup] {
         Dictionary(grouping: appState.accounts, by: \.itemId)
             .map { itemId, accounts in
@@ -416,27 +431,6 @@ struct AccountSettingsView: View {
                 )
             }
             .sorted { $0.institutionName < $1.institutionName }
-    }
-
-    private var emptyTitle: String {
-        if !appState.isDemoMode && !appState.serverConnected { return "Server Offline" }
-        if appState.statusItemCount == 0 { return "No Bank Linked" }
-        return "No Account Data"
-    }
-
-    private var emptyIcon: String {
-        if !appState.isDemoMode && !appState.serverConnected { return "server.rack" }
-        return "building.columns"
-    }
-
-    private var emptyMessage: String {
-        if !appState.isDemoMode && !appState.serverConnected {
-            return "Start PlaidBarServer before managing linked accounts."
-        }
-        if appState.statusItemCount == 0 {
-            return "Connect a Plaid institution to manage linked accounts here."
-        }
-        return "The server has a linked item, but account details are not loaded yet."
     }
 
     private func icon(for status: ItemConnectionStatus) -> String {

--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -4,6 +4,14 @@ import PlaidBarCore
 struct AccountsView: View {
     @Environment(AppState.self) private var appState
 
+    private var emptyPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.accounts(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if appState.accounts.isEmpty {
@@ -76,51 +84,25 @@ struct AccountsView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if !appState.isDemoMode && !appState.serverConnected {
-            ContentUnavailableView {
-                Label("Server Offline", systemImage: "server.rack")
-            } description: {
-                Text("Start PlaidBarServer, then check the connection again.")
-            } actions: {
-                Button {
-                    Task { await appState.checkServerConnection() }
-                } label: {
-                    Label("Check Server", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.statusItemCount == 0 {
-            ContentUnavailableView {
-                Label("No Bank Linked", systemImage: "building.columns")
-            } description: {
-                Text("Connect a Plaid institution before balances can appear here.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Account", systemImage: "plus.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else {
-            ContentUnavailableView {
-                Label("No Account Data", systemImage: "tray")
-            } description: {
-                Text("The server has a linked item, but no balances are loaded in the app yet.")
-            } actions: {
-                Button {
-                    Task { await appState.refreshAccounts() }
-                } label: {
-                    Label("Refresh Accounts", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
+        SecondaryUnavailableView(presentation: emptyPresentation) {
+            performEmptyAction(emptyPresentation.action)
+        }
+    }
+
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters, .showWiderPeriod:
+            break
         }
     }
 

--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -12,6 +12,15 @@ struct CreditView: View {
         appState.creditAccounts.contains { $0.balances.utilizationPercent != nil }
     }
 
+    private var emptyPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.credit(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount,
+            accountCount: appState.accounts.count
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.md) {
             if appState.creditAccounts.isEmpty {
@@ -112,66 +121,25 @@ struct CreditView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if !appState.isDemoMode && !appState.serverConnected {
-            ContentUnavailableView {
-                Label("Server Offline", systemImage: "server.rack")
-            } description: {
-                Text("Start PlaidBarServer before checking credit utilization.")
-            } actions: {
-                Button {
-                    Task { await appState.checkServerConnection() }
-                } label: {
-                    Label("Check Server", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.statusItemCount == 0 {
-            ContentUnavailableView {
-                Label("No Bank Linked", systemImage: "creditcard")
-            } description: {
-                Text("Connect a Plaid institution with a credit card to track utilization.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Account", systemImage: "plus.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.accounts.isEmpty {
-            ContentUnavailableView {
-                Label("No Account Data", systemImage: "tray")
-            } description: {
-                Text("The linked item has not loaded account balances yet.")
-            } actions: {
-                Button {
-                    Task { await appState.refreshAccounts() }
-                } label: {
-                    Label("Refresh Accounts", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else {
-            ContentUnavailableView {
-                Label("No Credit Accounts", systemImage: "creditcard")
-            } description: {
-                Text("Your linked accounts do not include a credit card with utilization data.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Credit Card", systemImage: "plus.circle")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-            .padding()
+        SecondaryUnavailableView(presentation: emptyPresentation) {
+            performEmptyAction(emptyPresentation.action)
+        }
+    }
+
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters, .showWiderPeriod:
+            break
         }
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -937,13 +937,7 @@ private struct DashboardStatusReadinessPanel: View {
         case .addAccount:
             onAddAccount()
         case .refresh:
-            Task {
-                await appState.checkServerConnection()
-                if appState.serverConnected {
-                    await appState.refreshAccounts()
-                    await appState.syncTransactions()
-                }
-            }
+            Task { await appState.refreshDashboard() }
         case .reconnect:
             guard let itemId = reconnectItemId else {
                 Task { await appState.refreshAccounts() }
@@ -1248,18 +1242,9 @@ private struct DashboardEmptyAccountState: View {
         case .checkServer:
             Task { await appState.checkServerConnection() }
         case .refresh:
-            Task {
-                await appState.checkServerConnection()
-                if appState.serverConnected {
-                    await appState.refreshAccounts()
-                    await appState.syncTransactions()
-                }
-            }
+            Task { await appState.refreshDashboard() }
         case .sync:
-            Task {
-                await appState.refreshBalances()
-                await appState.syncTransactions()
-            }
+            Task { await appState.refreshDashboard() }
         }
     }
 }
@@ -1504,10 +1489,7 @@ private struct SelectedAccountPanel: View {
                     }
 
                     Button {
-                        Task {
-                            await appState.refreshBalances()
-                            await appState.syncTransactions()
-                        }
+                        Task { await appState.refreshDashboard() }
                     } label: {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }
@@ -1746,10 +1728,7 @@ private struct DashboardFooter: View {
             Spacer()
 
             Button {
-                Task {
-                    await appState.refreshBalances()
-                    await appState.syncTransactions()
-                }
+                Task { await appState.refreshDashboard() }
             } label: {
                 RefreshIcon(isLoading: appState.isLoading)
                     .foregroundStyle(.secondary)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1145,6 +1145,7 @@ private struct AccountsSection: View {
                     ForEach(accounts) { account in
                         AccountRowWithDrilldown(
                             account: account,
+                            isStatusFilter: filter == .status,
                             isSelected: selectedAccountId == account.id,
                             onSelect: {
                                 if selectedAccountId == account.id {
@@ -1166,13 +1167,14 @@ private struct AccountsSection: View {
 private struct AccountRowWithDrilldown: View {
     @Environment(AppState.self) private var appState
     let account: AccountDTO
+    let isStatusFilter: Bool
     let isSelected: Bool
     let onSelect: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             Button(action: onSelect) {
-                DashboardAccountRow(account: account, isSelected: isSelected)
+                DashboardAccountRow(account: account, isStatusFilter: isStatusFilter, isSelected: isSelected)
             }
             .buttonStyle(.plain)
             .accessibilityElement(children: .ignore)
@@ -1180,7 +1182,7 @@ private struct AccountRowWithDrilldown: View {
             .accessibilityHint(isSelected ? "Collapses account details." : "Shows account details.")
 
             if isSelected {
-                SelectedAccountPanel(account: account)
+                SelectedAccountPanel(account: account, isStatusFilter: isStatusFilter)
                     .environment(appState)
                     .padding(.top, 10)
                     .padding(.bottom, 12)
@@ -1218,7 +1220,8 @@ private struct AccountRowWithDrilldown: View {
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
             itemStatus: itemStatus,
-            institutionName: itemConnectionStatus?.institutionName
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
         )
     }
 }
@@ -1343,6 +1346,7 @@ private struct DashboardEmptyAccountState: View {
 private struct DashboardAccountRow: View {
     @Environment(AppState.self) private var appState
     let account: AccountDTO
+    let isStatusFilter: Bool
     let isSelected: Bool
 
     var body: some View {
@@ -1415,7 +1419,7 @@ private struct DashboardAccountRow: View {
     private var subtitle: String {
         AccountPresentation.dashboardRowSubtitle(
             for: account,
-            connectionLabel: statusText,
+            connectionLabel: isStatusFilter ? connectionPresentation.statusFilterSubtitle : statusText,
             pendingCount: pendingCount
         )
     }
@@ -1456,7 +1460,8 @@ private struct DashboardAccountRow: View {
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
             itemStatus: itemStatus,
-            institutionName: itemConnectionStatus?.institutionName
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
         )
     }
 
@@ -1481,6 +1486,7 @@ private struct DashboardAccountRow: View {
 private struct SelectedAccountPanel: View {
     @Environment(AppState.self) private var appState
     let account: AccountDTO
+    let isStatusFilter: Bool
 
     private var transactions: [TransactionDTO] {
         Array(accountTransactions.prefix(5))
@@ -1572,6 +1578,22 @@ private struct SelectedAccountPanel: View {
                 )
             }
 
+            if isStatusFilter, let recoveryDetailLabel = connectionPresentation.recoveryDetailLabel {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: connectionIcon)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(connectionTint)
+                        .frame(width: 16)
+                    Text(recoveryDetailLabel)
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(connectionTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+                .accessibilityElement(children: .combine)
+            }
+
             if shouldShowRecoveryActions {
                 HStack(spacing: 8) {
                     if itemStatus == .loginRequired || itemStatus == .error {
@@ -1653,7 +1675,8 @@ private struct SelectedAccountPanel: View {
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
             itemStatus: itemStatus,
-            institutionName: itemConnectionStatus?.institutionName
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
         )
     }
 
@@ -1674,7 +1697,10 @@ private struct SelectedAccountPanel: View {
     }
 
     private var syncSignalText: String {
-        connectionPresentation.signalLabel
+        if isStatusFilter, let itemSyncLabel = connectionPresentation.itemSyncLabel {
+            return itemSyncLabel
+        }
+        return connectionPresentation.signalLabel
     }
 
     private var shouldShowRecoveryActions: Bool {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1204,7 +1204,11 @@ private struct AccountRowWithDrilldown: View {
     }
 
     private var itemStatus: ItemConnectionStatus? {
-        appState.itemStatuses.first { $0.id == account.itemId }?.status
+        itemConnectionStatus?.status
+    }
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
     }
 
     private var connectionPresentation: AccountConnectionPresentation {
@@ -1213,7 +1217,8 @@ private struct AccountRowWithDrilldown: View {
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
-            itemStatus: itemStatus
+            itemStatus: itemStatus,
+            institutionName: itemConnectionStatus?.institutionName
         )
     }
 }
@@ -1230,7 +1235,8 @@ private struct DashboardEmptyAccountState: View {
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,
-            degradedItemCount: appState.needsLoginItemCount + appState.erroredItemCount
+            degradedItemCount: appState.needsLoginItemCount + appState.erroredItemCount,
+            degradedItemRecoveryTitle: ItemRecoveryTarget.actionTitle(from: appState.itemStatuses)
         )
     }
 
@@ -1322,6 +1328,12 @@ private struct DashboardEmptyAccountState: View {
             Task { await appState.checkServerConnection() }
         case .refresh:
             Task { await appState.refreshDashboard() }
+        case .reconnect:
+            guard let itemId = ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
+                Task { await appState.refreshDashboard() }
+                return
+            }
+            Task { await appState.reconnectItem(itemId: itemId) }
         case .sync:
             Task { await appState.refreshDashboard() }
         }
@@ -1430,7 +1442,11 @@ private struct DashboardAccountRow: View {
     }
 
     private var itemStatus: ItemConnectionStatus? {
-        appState.itemStatuses.first { $0.id == account.itemId }?.status
+        itemConnectionStatus?.status
+    }
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
     }
 
     private var connectionPresentation: AccountConnectionPresentation {
@@ -1439,7 +1455,8 @@ private struct DashboardAccountRow: View {
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
-            itemStatus: itemStatus
+            itemStatus: itemStatus,
+            institutionName: itemConnectionStatus?.institutionName
         )
     }
 
@@ -1561,7 +1578,7 @@ private struct SelectedAccountPanel: View {
                         Button {
                             Task { await appState.reconnectItem(itemId: account.itemId) }
                         } label: {
-                            Label("Reconnect", systemImage: "link.badge.plus")
+                            Label(recoveryActionTitle, systemImage: "link.badge.plus")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
@@ -1622,7 +1639,11 @@ private struct SelectedAccountPanel: View {
     }
 
     private var itemStatus: ItemConnectionStatus? {
-        appState.itemStatuses.first { $0.id == account.itemId }?.status
+        itemConnectionStatus?.status
+    }
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
     }
 
     private var connectionPresentation: AccountConnectionPresentation {
@@ -1631,7 +1652,8 @@ private struct SelectedAccountPanel: View {
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
-            itemStatus: itemStatus
+            itemStatus: itemStatus,
+            institutionName: itemConnectionStatus?.institutionName
         )
     }
 
@@ -1657,6 +1679,10 @@ private struct SelectedAccountPanel: View {
 
     private var shouldShowRecoveryActions: Bool {
         connectionPresentation.showsRecoveryActions
+    }
+
+    private var recoveryActionTitle: String {
+        connectionPresentation.recoveryActionTitle ?? "Reconnect"
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -8,6 +8,7 @@ struct MainPopover: View {
     @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
     @State private var settingsCloseObserver: NSObjectProtocol?
     @State private var isShowingAccountSetup = false
+    @State private var shouldShowSetupRecoveryDashboard = false
 
     private var selectedFilter: DashboardAccountFilter {
         DashboardAccountFilter(rawValue: selectedFilterRawValue) ?? .all
@@ -25,7 +26,7 @@ struct MainPopover: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if !appState.isSetupComplete {
+            if shouldShowSetupScreen {
                 SetupView()
                     .frame(width: 600)
             } else {
@@ -91,8 +92,16 @@ struct MainPopover: View {
         .frame(width: 600)
         .background(Color(nsColor: .windowBackgroundColor))
         .animation(.easeInOut(duration: 0.2), value: appState.error != nil)
-        .sheet(isPresented: $isShowingAccountSetup) {
+        .sheet(
+            isPresented: $isShowingAccountSetup,
+            onDismiss: {
+                if !appState.isSetupComplete {
+                    shouldShowSetupRecoveryDashboard = true
+                }
+            }
+        ) {
             SetupView {
+                shouldShowSetupRecoveryDashboard = false
                 isShowingAccountSetup = false
             }
             .environment(appState)
@@ -107,10 +116,19 @@ struct MainPopover: View {
         .onChange(of: selectedFilterRawValue) { _, _ in
             selectedAccountId = ""
         }
+        .onChange(of: appState.isSetupComplete) { _, isComplete in
+            if isComplete {
+                shouldShowSetupRecoveryDashboard = false
+            }
+        }
+    }
+
+    private var shouldShowSetupScreen: Bool {
+        !appState.isSetupComplete && !shouldShowSetupRecoveryDashboard
     }
 
     private var shouldShowStatusReadinessPanel: Bool {
-        selectedFilter == .status || appState.dashboardStatusReadiness.level != .healthy
+        selectedFilter == .status || !appState.isSetupComplete || appState.dashboardStatusReadiness.level != .healthy
     }
 
     private var filterBinding: Binding<DashboardAccountFilter> {
@@ -874,6 +892,10 @@ private struct DashboardStatusReadinessPanel: View {
                 Spacer(minLength: 12)
             }
 
+            if !appState.isSetupComplete {
+                SetupRecoverySummary(state: appState.firstRunCompletionState)
+            }
+
             StatusMetricGrid()
                 .environment(appState)
 
@@ -959,6 +981,63 @@ private struct DashboardStatusReadinessPanel: View {
 
     private var reconnectItemId: String? {
         ItemRecoveryTarget.itemId(from: appState.itemStatuses)
+    }
+}
+
+private struct SetupRecoverySummary: View {
+    let state: FirstRunCompletionState
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(color)
+                .frame(width: 22, height: 22)
+                .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Setup recovery")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                Text(state.title)
+                    .font(.caption.weight(.semibold))
+                Text(state.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
+        .background(color.opacity(0.06), in: RoundedRectangle(cornerRadius: 7))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var icon: String {
+        switch state.step {
+        case .ready:
+            "checkmark.circle.fill"
+        case .blocked:
+            "exclamationmark.triangle.fill"
+        case .openPlaidLink:
+            "link.circle"
+        case .loadAccounts:
+            "building.columns"
+        case .syncTransactions:
+            "arrow.triangle.2.circlepath"
+        }
+    }
+
+    private var color: Color {
+        switch state.step {
+        case .ready:
+            SemanticColors.positive
+        case .blocked:
+            SemanticColors.negative
+        case .openPlaidLink, .loadAccounts, .syncTransactions:
+            SemanticColors.brand
+        }
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1455,7 +1455,7 @@ private struct DashboardAccountRow: View {
 
     private var connectionPresentation: AccountConnectionPresentation {
         AccountConnectionPresentation.evaluate(
-            isDemoMode: appState.isDemoMode,
+            isDemoMode: appState.isDemoMode && !appState.isDemoStatusRecoveryScenario,
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,

--- a/Sources/PlaidBar/Views/RecurringView.swift
+++ b/Sources/PlaidBar/Views/RecurringView.swift
@@ -4,6 +4,18 @@ import PlaidBarCore
 struct RecurringView: View {
     @Environment(AppState.self) private var appState
 
+    private var emptyPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.recurring(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount,
+            accountCount: appState.accounts.count,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            transactionCount: appState.transactions.count,
+            errorMessage: appState.error
+        )
+    }
+
     var body: some View {
         let recurring = appState.recurringTransactions
         let monthlyEstimate = appState.estimatedMonthlyRecurring
@@ -38,58 +50,25 @@ struct RecurringView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if !appState.isDemoMode && !appState.serverConnected {
-            ContentUnavailableView {
-                Label("Server Offline", systemImage: "server.rack")
-            } description: {
-                Text("Start PlaidBarServer before detecting recurring charges.")
-            } actions: {
-                Button {
-                    Task { await appState.checkServerConnection() }
-                } label: {
-                    Label("Check Server", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.statusItemCount == 0 {
-            ContentUnavailableView {
-                Label("No Bank Linked", systemImage: "building.columns")
-            } description: {
-                Text("Connect a Plaid institution before recurring charges can be detected.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Account", systemImage: "plus.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.transactions.isEmpty {
-            ContentUnavailableView {
-                Label("No Synced Transactions", systemImage: "tray")
-            } description: {
-                Text("Sync transaction history so PlaidBar can look for repeated charges.")
-            } actions: {
-                Button {
-                    Task { await appState.syncTransactions() }
-                } label: {
-                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else {
-            ContentUnavailableView {
-                Label("No Recurring Charges Found", systemImage: "arrow.clockwise")
-            } description: {
-                Text("PlaidBar needs repeated merchant charges, usually 2+ months of history, before it marks a charge as recurring.")
-            }
-            .padding()
+        SecondaryUnavailableView(presentation: emptyPresentation) {
+            performEmptyAction(emptyPresentation.action)
+        }
+    }
+
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters, .showWiderPeriod:
+            break
         }
     }
 }

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -149,6 +149,15 @@ struct SetupView: View {
             OnboardingPreflightPanel(environment: environment)
                 .environment(appState)
 
+            if let error = appState.error {
+                SetupRecoveryCallout(
+                    title: "Setup needs attention",
+                    detail: error,
+                    icon: "exclamationmark.triangle.fill",
+                    color: SemanticColors.negative
+                )
+            }
+
             Text(preflightHint(for: environment))
                 .detailText()
                 .multilineTextAlignment(.center)
@@ -186,13 +195,15 @@ struct SetupView: View {
         let completion = appState.firstRunCompletionState
 
         return VStack(spacing: Spacing.lg) {
-            ProgressView()
-                .scaleEffect(1.5)
+            if completion.step != .ready && completion.step != .blocked {
+                ProgressView()
+                    .scaleEffect(1.5)
+            }
 
-            Text("Opening Plaid Link...")
+            Text(connectingTitle(for: completion))
                 .font(.title3)
 
-            Text("Complete the \(environment.rawValue) login in your browser, then return here.")
+            Text(connectingDetail(for: completion, environment: environment))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .font(.callout)
@@ -206,10 +217,22 @@ struct SetupView: View {
                     }
                 }
             } label: {
-                Label(completion.isReady ? "Open Dashboard" : "Check Connection", systemImage: "arrow.clockwise")
+                Label(primaryCompletionActionTitle(for: completion), systemImage: primaryCompletionActionIcon(for: completion))
             }
             .buttonStyle(.bordered)
             .disabled(appState.isLoading || (!completion.canRetry && !completion.isReady))
+
+            if completion.step == .openPlaidLink {
+                Button {
+                    Task {
+                        _ = await appState.connectForOnboarding(expectedEnvironment: environment)
+                    }
+                } label: {
+                    Label("Open Link Again", systemImage: "link")
+                }
+                .buttonStyle(.bordered)
+                .disabled(appState.isLoading)
+            }
 
             Button("Cancel") {
                 setupMode = environment == .production ? .production : .sandbox
@@ -247,6 +270,67 @@ struct SetupView: View {
         }
 
         return "Ready to open Plaid Link in your browser."
+    }
+
+    private func connectingTitle(for completion: FirstRunCompletionState) -> String {
+        switch completion.step {
+        case .openPlaidLink:
+            "Waiting for Plaid Link"
+        case .loadAccounts:
+            "Linked item found"
+        case .syncTransactions:
+            "Finish first sync"
+        case .ready:
+            "Dashboard ready"
+        case .blocked:
+            "Connection needs attention"
+        }
+    }
+
+    private func connectingDetail(
+        for completion: FirstRunCompletionState,
+        environment: PlaidEnvironment
+    ) -> String {
+        switch completion.step {
+        case .openPlaidLink:
+            "Complete the \(environment.rawValue) login in your browser, then check for the linked item."
+        case .loadAccounts:
+            "PlaidBar found the linked institution. Load balances before opening the dashboard."
+        case .syncTransactions:
+            "Balances are loaded. Run the first transaction sync to complete onboarding."
+        case .ready:
+            "Setup checks passed. The dashboard can open now."
+        case .blocked:
+            "Resolve the issue below, then retry the setup check."
+        }
+    }
+
+    private func primaryCompletionActionTitle(for completion: FirstRunCompletionState) -> String {
+        switch completion.step {
+        case .openPlaidLink:
+            "Check for Linked Item"
+        case .loadAccounts:
+            "Load Accounts"
+        case .syncTransactions:
+            "Run First Sync"
+        case .ready:
+            "Open Dashboard"
+        case .blocked:
+            "Retry Setup Check"
+        }
+    }
+
+    private func primaryCompletionActionIcon(for completion: FirstRunCompletionState) -> String {
+        switch completion.step {
+        case .openPlaidLink, .blocked:
+            "arrow.clockwise"
+        case .loadAccounts:
+            "building.columns"
+        case .syncTransactions:
+            "arrow.triangle.2.circlepath"
+        case .ready:
+            "checkmark.circle"
+        }
     }
 }
 
@@ -297,6 +381,37 @@ private struct FirstRunCompletionPanel: View {
         case .openPlaidLink, .loadAccounts, .syncTransactions:
             SemanticColors.brand
         }
+    }
+}
+
+private struct SetupRecoveryCallout: View {
+    let title: String
+    let detail: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text(detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PlaidBarCore
 
 // MARK: - Hover Highlight
 
@@ -48,5 +49,27 @@ struct RefreshIcon: View {
                     }
                 }
             }
+    }
+}
+
+// MARK: - Secondary Empty State
+
+struct SecondaryUnavailableView: View {
+    let presentation: SecondaryContentUnavailableState
+    let action: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(presentation.title, systemImage: presentation.iconName)
+        } description: {
+            Text(presentation.detail)
+        } actions: {
+            Button(action: action) {
+                Label(presentation.actionTitle, systemImage: presentation.actionIconName)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding()
     }
 }

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -89,6 +89,25 @@ struct SpendingView: View {
         )
     }
 
+    private var emptyActivityPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.spendingActivity(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount,
+            accountCount: appState.accounts.count,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            transactionCount: appState.transactions.count,
+            errorMessage: appState.error
+        )
+    }
+
+    private var emptyPeriodPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.spendingPeriod(
+            periodLabel: selectedPeriod.rawValue,
+            canShowWiderPeriod: selectedPeriod != .last90Days
+        )
+    }
+
     var body: some View {
         let categories = chartCategories
         let total = totalFiltered
@@ -179,81 +198,34 @@ struct SpendingView: View {
 
     @ViewBuilder
     private var emptyTransactionState: some View {
-        if !appState.isDemoMode && !appState.serverConnected {
-            ContentUnavailableView {
-                Label("Server Offline", systemImage: "server.rack")
-            } description: {
-                Text("Start PlaidBarServer before spending activity can sync.")
-            } actions: {
-                Button {
-                    Task { await appState.checkServerConnection() }
-                } label: {
-                    Label("Check Server", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.statusItemCount == 0 {
-            ContentUnavailableView {
-                Label("No Bank Linked", systemImage: "building.columns")
-            } description: {
-                Text("Connect a Plaid institution before spending and cashflow charts can populate.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Account", systemImage: "plus.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else {
-            ContentUnavailableView {
-                Label("No Synced Activity", systemImage: "chart.bar.xaxis")
-            } description: {
-                Text("Sync transactions to build the spending heatmap, trend, and cashflow views.")
-            } actions: {
-                Button {
-                    Task { await appState.syncTransactions() }
-                } label: {
-                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
+        SecondaryUnavailableView(presentation: emptyActivityPresentation) {
+            performEmptyAction(emptyActivityPresentation.action)
         }
     }
 
     private var emptyPeriodState: some View {
-        ContentUnavailableView {
-            Label("No Activity in \(selectedPeriod.rawValue)", systemImage: "calendar.badge.clock")
-        } description: {
-            Text("No synced transactions fall inside this period. Choose a wider window or refresh the latest history.")
-        } actions: {
-            HStack {
-                if selectedPeriod != .last90Days {
-                    Button {
-                        selectedPeriod = .last90Days
-                    } label: {
-                        Label("Show 90D", systemImage: "calendar")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                }
-
-                Button {
-                    Task { await appState.syncTransactions() }
-                } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
+        SecondaryUnavailableView(presentation: emptyPeriodPresentation) {
+            performEmptyAction(emptyPeriodPresentation.action)
         }
-        .padding()
+    }
+
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters:
+            break
+        case .showWiderPeriod:
+            selectedPeriod = .last90Days
+        }
     }
 
     @ViewBuilder

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -131,8 +131,10 @@ struct StatusView: View {
                 ForEach(appState.itemStatuses) { item in
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: icon(for: item.status))
+                            .font(.callout.weight(.semibold))
                             .foregroundStyle(color(for: item.status))
-                            .frame(width: 18)
+                            .frame(width: 26, height: 26)
+                            .background(color(for: item.status).opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
 
                         VStack(alignment: .leading, spacing: Spacing.xxs) {
                             Text(item.institutionName ?? "Plaid item")
@@ -148,7 +150,10 @@ struct StatusView: View {
                         VStack(alignment: .trailing, spacing: Spacing.xs) {
                             Text(label(for: item.status))
                                 .microText()
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 4)
                                 .foregroundStyle(color(for: item.status))
+                                .background(color(for: item.status).opacity(0.12), in: Capsule())
 
                             if item.status != .connected {
                                 Button {
@@ -161,7 +166,8 @@ struct StatusView: View {
                             }
                         }
                     }
-                    .padding(.vertical, Spacing.xs)
+                    .padding(Spacing.sm)
+                    .background(itemBackground(for: item.status), in: RoundedRectangle(cornerRadius: 8))
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(itemAccessibilityLabel(for: item))
                 }
@@ -213,6 +219,9 @@ struct StatusView: View {
     }
 
     private var statusIcon: String {
+        if appState.isDemoStatusRecoveryScenario, appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 {
+            return "exclamationmark.triangle.fill"
+        }
         if appState.isDemoMode { return "play.circle.fill" }
         if !appState.serverConnected { return "xmark.octagon.fill" }
         if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return "exclamationmark.triangle.fill" }
@@ -220,6 +229,9 @@ struct StatusView: View {
     }
 
     private var statusColor: Color {
+        if appState.isDemoStatusRecoveryScenario, appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 {
+            return SemanticColors.warning
+        }
         if appState.isDemoMode { return SemanticColors.brandSecondary }
         if !appState.serverConnected { return SemanticColors.negative }
         if appState.erroredItemCount > 0 || appState.needsLoginItemCount > 0 { return SemanticColors.warning }
@@ -270,10 +282,21 @@ struct StatusView: View {
         }
     }
 
+    private func itemBackground(for status: ItemConnectionStatus) -> Color {
+        switch status {
+        case .connected:
+            return SemanticColors.positive.opacity(0.045)
+        case .loginRequired:
+            return SemanticColors.warning.opacity(0.08)
+        case .error:
+            return SemanticColors.negative.opacity(0.08)
+        }
+    }
+
     private func label(for status: ItemConnectionStatus) -> String {
         switch status {
-        case .connected: "Connected"
-        case .loginRequired: "Login"
+        case .connected: appState.isDemoStatusRecoveryScenario ? "Recovered" : "Synced"
+        case .loginRequired: "Needs login"
         case .error: "Error"
         }
     }
@@ -281,7 +304,11 @@ struct StatusView: View {
     private func statusDetail(for item: ItemStatus) -> String {
         switch item.status {
         case .connected:
-            item.lastSync.map { "Updated \(Formatters.relativeDate($0))" } ?? "No sync recorded"
+            if appState.isDemoStatusRecoveryScenario {
+                item.lastSync.map { "Recovered and synced \(Formatters.relativeDate($0))" } ?? "Connected; no sync recorded"
+            } else {
+                item.lastSync.map { "Updated \(Formatters.relativeDate($0))" } ?? "No sync recorded"
+            }
         case .loginRequired:
             "Plaid requires a fresh bank login. Reconnect this item."
         case .error:

--- a/Sources/PlaidBar/Views/TransactionsView.swift
+++ b/Sources/PlaidBar/Views/TransactionsView.swift
@@ -36,6 +36,20 @@ struct TransactionsView: View {
         selectedCategory != nil || selectedAccountId != nil || selectedDateRange != .all
     }
 
+    private var emptyPresentation: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.transactions(
+            isDemoMode: appState.isDemoMode,
+            serverConnected: appState.serverConnected,
+            linkedItemCount: appState.statusItemCount,
+            accountCount: appState.accounts.count,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            transactionCount: appState.transactions.count,
+            hasSearchText: !searchText.isEmpty,
+            hasActiveFilters: hasActiveFilters,
+            errorMessage: appState.error
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Segmented toggle: Recent / Recurring
@@ -132,96 +146,8 @@ struct TransactionsView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if !searchText.isEmpty || hasActiveFilters {
-            ContentUnavailableView {
-                Label("No Results", systemImage: "magnifyingglass")
-            } description: {
-                Text("No transactions match the current search or filters.")
-            } actions: {
-                Button {
-                    clearSearchAndFilters()
-                } label: {
-                    Label("Clear Filters", systemImage: "xmark.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if !appState.isDemoMode && !appState.serverConnected {
-            ContentUnavailableView {
-                Label("Server Offline", systemImage: "server.rack")
-            } description: {
-                Text("Start PlaidBarServer before syncing transaction history.")
-            } actions: {
-                Button {
-                    Task { await appState.checkServerConnection() }
-                } label: {
-                    Label("Check Server", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.statusItemCount == 0 {
-            ContentUnavailableView {
-                Label("No Bank Linked", systemImage: "building.columns")
-            } description: {
-                Text("Connect a Plaid institution before transaction history can sync.")
-            } actions: {
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Add Account", systemImage: "plus.circle")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if appState.accounts.isEmpty {
-            ContentUnavailableView {
-                Label("No Account Data", systemImage: "tray")
-            } description: {
-                Text("Balances have not loaded yet. Refresh accounts before syncing transaction history.")
-            } actions: {
-                Button {
-                    Task { await appState.refreshAccounts() }
-                } label: {
-                    Label("Refresh Accounts", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else if (appState.serverSyncedItemCount ?? 0) == 0 {
-            ContentUnavailableView {
-                Label("No Synced History", systemImage: "clock.arrow.circlepath")
-            } description: {
-                Text("Linked accounts are loaded, but transaction sync has not completed yet.")
-            } actions: {
-                Button {
-                    Task { await appState.syncTransactions() }
-                } label: {
-                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
-        } else {
-            ContentUnavailableView {
-                Label("No Transactions", systemImage: "list.bullet.rectangle")
-            } description: {
-                Text("No transaction history is available for the linked accounts yet.")
-            } actions: {
-                Button {
-                    Task { await appState.syncTransactions() }
-                } label: {
-                    Label("Sync Transactions", systemImage: "arrow.triangle.2.circlepath")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-            .padding()
+        SecondaryUnavailableView(presentation: emptyPresentation) {
+            performEmptyAction(emptyPresentation.action)
         }
     }
 
@@ -232,6 +158,24 @@ struct TransactionsView: View {
         selectedDateRange = .all
     }
 
+    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .clearFilters:
+            clearSearchAndFilters()
+        case .showWiderPeriod:
+            break
+        }
+    }
 }
 
 struct TransactionRow: View {

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -40,6 +40,7 @@ public enum DashboardAccountEmptyStateTone: String, Sendable {
 public enum DashboardAccountEmptyStateAction: String, Sendable {
     case checkServer
     case refresh
+    case reconnect
     case sync
 }
 
@@ -79,7 +80,8 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         serverConnected: Bool,
         linkedItemCount: Int,
         accountCount: Int,
-        degradedItemCount: Int
+        degradedItemCount: Int,
+        degradedItemRecoveryTitle: String? = nil
     ) -> DashboardAccountEmptyState {
         if !isDemoMode, !serverConnected {
             return DashboardAccountEmptyState(
@@ -110,13 +112,13 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         if filter == .status, degradedItemCount > 0 {
             return DashboardAccountEmptyState(
                 title: "\(degradedItemCount) item\(degradedItemCount == 1 ? "" : "s") \(degradedItemCount == 1 ? "needs" : "need") attention",
-                detail: "A linked institution needs recovery, but no matching account rows are loaded. Reconnect or refresh from the status panel above.",
+                detail: "A linked institution needs recovery, but no matching account rows are loaded. Reconnect the item from here, then refresh balances.",
                 iconName: "exclamationmark.triangle.fill",
                 tone: .warning,
                 showsAddAccount: false,
-                action: .refresh,
-                actionTitle: "Refresh",
-                actionIconName: "arrow.clockwise"
+                action: .reconnect,
+                actionTitle: degradedItemRecoveryTitle ?? "Reconnect Item",
+                actionIconName: "link.badge.plus"
             )
         }
 

--- a/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
@@ -71,8 +71,8 @@ public struct FirstRunCompletionState: Equatable, Sendable {
         guard linkedItemCount > 0 else {
             return FirstRunCompletionState(
                 step: .openPlaidLink,
-                title: "Waiting for Plaid Link",
-                detail: "Complete the bank connection in your browser, then check again.",
+                title: "No linked item returned",
+                detail: "PlaidBar cannot see a linked item yet. Finish Plaid Link in the browser, then check again.",
                 isReady: false,
                 canRetry: true
             )

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+public enum SecondaryContentSurface: String, Sendable {
+    case transactions
+    case spending
+    case recurring
+}
+
+public enum SecondaryContentUnavailableAction: String, Sendable {
+    case checkServer
+    case addAccount
+    case refreshAccounts
+    case syncTransactions
+    case refresh
+    case clearFilters
+    case showWiderPeriod
+}
+
+public struct SecondaryContentUnavailableState: Equatable, Sendable {
+    private static let maxRenderedErrorLength = 240
+
+    public let title: String
+    public let detail: String
+    public let iconName: String
+    public let action: SecondaryContentUnavailableAction
+    public let actionTitle: String
+    public let actionIconName: String
+
+    public init(
+        title: String,
+        detail: String,
+        iconName: String,
+        action: SecondaryContentUnavailableAction,
+        actionTitle: String,
+        actionIconName: String
+    ) {
+        self.title = title
+        self.detail = detail
+        self.iconName = iconName
+        self.action = action
+        self.actionTitle = actionTitle
+        self.actionIconName = actionIconName
+    }
+
+    public static func transactions(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int,
+        accountCount: Int,
+        syncedItemCount: Int,
+        transactionCount: Int,
+        hasSearchText: Bool,
+        hasActiveFilters: Bool,
+        errorMessage: String?
+    ) -> SecondaryContentUnavailableState {
+        if hasSearchText || hasActiveFilters {
+            return SecondaryContentUnavailableState(
+                title: "No matching transactions",
+                detail: "Synced history is loaded, but this search or filter set has no matches.",
+                iconName: "magnifyingglass",
+                action: .clearFilters,
+                actionTitle: "Clear Filters",
+                actionIconName: "xmark.circle"
+            )
+        }
+
+        if let errorState = recentActionFailure(from: errorMessage) {
+            return errorState
+        }
+
+        if !isDemoMode, !serverConnected {
+            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before syncing transaction history.")
+        }
+
+        if linkedItemCount == 0 {
+            return noBankLinkedState(detail: "Connect a Plaid institution before transaction history can sync.")
+        }
+
+        if accountCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No account data",
+                detail: "The server has linked items, but balances have not loaded yet. Refresh accounts before syncing transaction history.",
+                iconName: "tray",
+                action: .refreshAccounts,
+                actionTitle: "Refresh Accounts",
+                actionIconName: "arrow.clockwise"
+            )
+        }
+
+        if syncedItemCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "First sync needed",
+                detail: "Accounts are loaded, but no linked item has completed transaction sync yet.",
+                iconName: "clock.arrow.circlepath",
+                action: .syncTransactions,
+                actionTitle: "Sync Transactions",
+                actionIconName: "arrow.triangle.2.circlepath"
+            )
+        }
+
+        return SecondaryContentUnavailableState(
+            title: transactionCount == 0 ? "No transaction history" : "No transactions",
+            detail: "No transaction rows are available for the linked accounts yet. Sync again to check for recent history.",
+            iconName: "list.bullet.rectangle",
+            action: .syncTransactions,
+            actionTitle: "Sync Transactions",
+            actionIconName: "arrow.triangle.2.circlepath"
+        )
+    }
+
+    public static func spendingActivity(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int,
+        accountCount: Int,
+        syncedItemCount: Int,
+        transactionCount: Int,
+        errorMessage: String?
+    ) -> SecondaryContentUnavailableState {
+        if let errorState = recentActionFailure(from: errorMessage) {
+            return errorState
+        }
+
+        if !isDemoMode, !serverConnected {
+            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before spending activity can sync.")
+        }
+
+        if linkedItemCount == 0 {
+            return noBankLinkedState(detail: "Connect a Plaid institution before spending and cashflow charts can populate.")
+        }
+
+        if accountCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No account data",
+                detail: "Balances have not loaded yet. Refresh accounts before syncing spending activity.",
+                iconName: "tray",
+                action: .refreshAccounts,
+                actionTitle: "Refresh Accounts",
+                actionIconName: "arrow.clockwise"
+            )
+        }
+
+        return SecondaryContentUnavailableState(
+            title: syncedItemCount == 0 || transactionCount == 0 ? "No synced activity" : "No spending activity",
+            detail: "Sync transactions to build the spending heatmap, trend, and cashflow views.",
+            iconName: "chart.bar.xaxis",
+            action: .syncTransactions,
+            actionTitle: "Sync Transactions",
+            actionIconName: "arrow.triangle.2.circlepath"
+        )
+    }
+
+    public static func spendingPeriod(
+        periodLabel: String,
+        canShowWiderPeriod: Bool
+    ) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState(
+            title: "No activity in \(periodLabel)",
+            detail: canShowWiderPeriod
+                ? "No synced transactions fall inside this period. Choose a wider window to inspect older history."
+                : "No synced transactions fall inside this period. Refresh to check for the latest history.",
+            iconName: "calendar.badge.clock",
+            action: canShowWiderPeriod ? .showWiderPeriod : .refresh,
+            actionTitle: canShowWiderPeriod ? "Show 90D" : "Refresh",
+            actionIconName: canShowWiderPeriod ? "calendar" : "arrow.clockwise"
+        )
+    }
+
+    public static func recurring(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int,
+        accountCount: Int,
+        syncedItemCount: Int,
+        transactionCount: Int,
+        errorMessage: String?
+    ) -> SecondaryContentUnavailableState {
+        if let errorState = recentActionFailure(from: errorMessage) {
+            return errorState
+        }
+
+        if !isDemoMode, !serverConnected {
+            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before detecting recurring charges.")
+        }
+
+        if linkedItemCount == 0 {
+            return noBankLinkedState(detail: "Connect a Plaid institution before recurring charges can be detected.")
+        }
+
+        if accountCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No account data",
+                detail: "Balances have not loaded yet. Refresh accounts before detecting recurring charges.",
+                iconName: "tray",
+                action: .refreshAccounts,
+                actionTitle: "Refresh Accounts",
+                actionIconName: "arrow.clockwise"
+            )
+        }
+
+        if syncedItemCount == 0 || transactionCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No synced transactions",
+                detail: "Sync transaction history so PlaidBar can look for repeated charges.",
+                iconName: "tray",
+                action: .syncTransactions,
+                actionTitle: "Sync Transactions",
+                actionIconName: "arrow.triangle.2.circlepath"
+            )
+        }
+
+        return SecondaryContentUnavailableState(
+            title: "No recurring charges found",
+            detail: "PlaidBar needs repeated merchant charges, usually 2+ months of history, before it marks a charge as recurring.",
+            iconName: "arrow.clockwise",
+            action: .syncTransactions,
+            actionTitle: "Sync Latest",
+            actionIconName: "arrow.triangle.2.circlepath"
+        )
+    }
+
+    private static func serverOfflineState(detail: String) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState(
+            title: "Server offline",
+            detail: detail,
+            iconName: "server.rack",
+            action: .checkServer,
+            actionTitle: "Check Server",
+            actionIconName: "server.rack"
+        )
+    }
+
+    private static func noBankLinkedState(detail: String) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState(
+            title: "No bank linked",
+            detail: detail,
+            iconName: "building.columns",
+            action: .addAccount,
+            actionTitle: "Add Account",
+            actionIconName: "plus.circle"
+        )
+    }
+
+    private static func recentActionFailure(from message: String?) -> SecondaryContentUnavailableState? {
+        guard let detail = userFacingErrorDetail(from: message) else { return nil }
+        return SecondaryContentUnavailableState(
+            title: "Recent action failed",
+            detail: detail,
+            iconName: "exclamationmark.triangle.fill",
+            action: .refresh,
+            actionTitle: "Refresh",
+            actionIconName: "arrow.clockwise"
+        )
+    }
+
+    private static func userFacingErrorDetail(from message: String?) -> String? {
+        guard let message else { return nil }
+
+        let normalized = message
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+
+        guard !normalized.isEmpty else { return nil }
+        guard normalized.count > maxRenderedErrorLength else { return normalized }
+
+        return "\(normalized.prefix(maxRenderedErrorLength))..."
+    }
+}

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public enum SecondaryContentSurface: String, Sendable {
+    case accounts
+    case credit
     case transactions
     case spending
     case recurring
@@ -40,6 +42,71 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         self.action = action
         self.actionTitle = actionTitle
         self.actionIconName = actionIconName
+    }
+
+    public static func accounts(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int
+    ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, !serverConnected {
+            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before account balances can load.")
+        }
+
+        if linkedItemCount == 0 {
+            return noBankLinkedState(detail: "Connect a Plaid institution before balances can appear here.")
+        }
+
+        return SecondaryContentUnavailableState(
+            title: "No account data",
+            detail: "The server has linked items, but balances have not loaded yet. Refresh accounts to check for updated data.",
+            iconName: "tray",
+            action: .refreshAccounts,
+            actionTitle: "Refresh Accounts",
+            actionIconName: "arrow.clockwise"
+        )
+    }
+
+    public static func credit(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        linkedItemCount: Int,
+        accountCount: Int
+    ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, !serverConnected {
+            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before credit utilization can load.")
+        }
+
+        if linkedItemCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No bank linked",
+                detail: "Connect a Plaid institution with a credit card to track utilization.",
+                iconName: "creditcard",
+                action: .addAccount,
+                actionTitle: "Add Account",
+                actionIconName: "plus.circle"
+            )
+        }
+
+        if accountCount == 0 {
+            return SecondaryContentUnavailableState(
+                title: "No account data",
+                detail: "The linked item has not loaded account balances yet. Refresh accounts before checking credit utilization.",
+                iconName: "tray",
+                action: .refreshAccounts,
+                actionTitle: "Refresh Accounts",
+                actionIconName: "arrow.clockwise"
+            )
+        }
+
+        return SecondaryContentUnavailableState(
+            title: "No credit accounts",
+            detail: "Your linked accounts do not include a credit card with utilization data.",
+            iconName: "creditcard",
+            action: .addAccount,
+            actionTitle: "Add Credit Card",
+            actionIconName: "plus.circle"
+        )
     }
 
     public static func transactions(

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -17,13 +17,15 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
     public let signalLabel: String
     public let iconName: String
     public let showsRecoveryActions: Bool
+    public let recoveryActionTitle: String?
 
     public static func evaluate(
         isDemoMode: Bool,
         serverConnected: Bool,
         isSyncStale: Bool,
         statusSyncText: String,
-        itemStatus: ItemConnectionStatus?
+        itemStatus: ItemConnectionStatus?,
+        institutionName: String? = nil
     ) -> AccountConnectionPresentation {
         if isDemoMode {
             return AccountConnectionPresentation(
@@ -32,7 +34,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 detailLabel: "Demo data",
                 signalLabel: "Demo",
                 iconName: "play.circle.fill",
-                showsRecoveryActions: false
+                showsRecoveryActions: false,
+                recoveryActionTitle: nil
             )
         }
 
@@ -43,7 +46,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 detailLabel: "Server offline",
                 signalLabel: "Offline",
                 iconName: "server.rack",
-                showsRecoveryActions: false
+                showsRecoveryActions: false,
+                recoveryActionTitle: nil
             )
         }
 
@@ -57,20 +61,34 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
         case .loginRequired:
             return AccountConnectionPresentation(
                 level: .loginRequired,
-                rowLabel: "Reconnect",
-                detailLabel: "Login required",
+                rowLabel: reconnectActionTitle(institutionName: institutionName),
+                detailLabel: itemDetailLabel(
+                    institutionName: institutionName,
+                    fallback: "Login required",
+                    suffix: "login required"
+                ),
                 signalLabel: "Login",
                 iconName: "person.crop.circle.badge.exclamationmark.fill",
-                showsRecoveryActions: true
+                showsRecoveryActions: true,
+                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName)
             )
         case .error:
             return AccountConnectionPresentation(
                 level: .error,
-                rowLabel: "Item error",
-                detailLabel: "Item error",
+                rowLabel: itemDetailLabel(
+                    institutionName: institutionName,
+                    fallback: "Item error",
+                    suffix: "item error"
+                ),
+                detailLabel: itemDetailLabel(
+                    institutionName: institutionName,
+                    fallback: "Item error",
+                    suffix: "item error"
+                ),
                 signalLabel: "Error",
                 iconName: "exclamationmark.triangle.fill",
-                showsRecoveryActions: true
+                showsRecoveryActions: true,
+                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName)
             )
         case nil:
             return AccountConnectionPresentation.synced(
@@ -93,7 +111,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 detailLabel: "Item status unavailable",
                 signalLabel: "Unknown",
                 iconName: "link.circle.fill",
-                showsRecoveryActions: false
+                showsRecoveryActions: false,
+                recoveryActionTitle: nil
             )
         }
 
@@ -105,7 +124,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 detailLabel: "Last sync \(statusSyncText)",
                 signalLabel: "Stale",
                 iconName: "clock.badge.exclamationmark.fill",
-                showsRecoveryActions: true
+                showsRecoveryActions: true,
+                recoveryActionTitle: "Refresh"
             )
         }
 
@@ -115,7 +135,32 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             detailLabel: statusSyncText,
             signalLabel: "Fresh",
             iconName: "checkmark.circle.fill",
-            showsRecoveryActions: false
+            showsRecoveryActions: false,
+            recoveryActionTitle: nil
         )
+    }
+
+    private static func reconnectActionTitle(institutionName: String?) -> String {
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            return "Reconnect Item"
+        }
+        return "Reconnect \(institutionName)"
+    }
+
+    private static func itemDetailLabel(
+        institutionName: String?,
+        fallback: String,
+        suffix: String
+    ) -> String {
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            return fallback
+        }
+        return "\(institutionName) \(suffix)"
+    }
+
+    private static func normalizedInstitutionName(_ institutionName: String?) -> String? {
+        guard let institutionName else { return nil }
+        let trimmed = institutionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -18,6 +18,33 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
     public let iconName: String
     public let showsRecoveryActions: Bool
     public let recoveryActionTitle: String?
+    public let itemSyncLabel: String?
+    public let statusFilterSubtitle: String
+    public let recoveryDetailLabel: String?
+
+    public init(
+        level: AccountConnectionLevel,
+        rowLabel: String,
+        detailLabel: String,
+        signalLabel: String,
+        iconName: String,
+        showsRecoveryActions: Bool,
+        recoveryActionTitle: String?,
+        itemSyncLabel: String? = nil,
+        statusFilterSubtitle: String? = nil,
+        recoveryDetailLabel: String? = nil
+    ) {
+        self.level = level
+        self.rowLabel = rowLabel
+        self.detailLabel = detailLabel
+        self.signalLabel = signalLabel
+        self.iconName = iconName
+        self.showsRecoveryActions = showsRecoveryActions
+        self.recoveryActionTitle = recoveryActionTitle
+        self.itemSyncLabel = itemSyncLabel
+        self.statusFilterSubtitle = statusFilterSubtitle ?? detailLabel
+        self.recoveryDetailLabel = recoveryDetailLabel
+    }
 
     public static func evaluate(
         isDemoMode: Bool,
@@ -25,7 +52,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
         isSyncStale: Bool,
         statusSyncText: String,
         itemStatus: ItemConnectionStatus?,
-        institutionName: String? = nil
+        institutionName: String? = nil,
+        itemLastSyncRelative: String? = nil
     ) -> AccountConnectionPresentation {
         if isDemoMode {
             return AccountConnectionPresentation(
@@ -56,9 +84,11 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             return AccountConnectionPresentation.synced(
                 isSyncStale: isSyncStale,
                 statusSyncText: statusSyncText,
+                itemLastSyncRelative: itemLastSyncRelative,
                 unknownItem: false
             )
         case .loginRequired:
+            let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
             return AccountConnectionPresentation(
                 level: .loginRequired,
                 rowLabel: reconnectActionTitle(institutionName: institutionName),
@@ -70,9 +100,13 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 signalLabel: "Login",
                 iconName: "person.crop.circle.badge.exclamationmark.fill",
                 showsRecoveryActions: true,
-                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName)
+                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName),
+                itemSyncLabel: itemSyncLabel,
+                statusFilterSubtitle: "Login required • \(itemSyncLabel)",
+                recoveryDetailLabel: loginRecoveryDetailLabel(institutionName: institutionName)
             )
         case .error:
+            let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
             return AccountConnectionPresentation(
                 level: .error,
                 rowLabel: itemDetailLabel(
@@ -88,12 +122,16 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 signalLabel: "Error",
                 iconName: "exclamationmark.triangle.fill",
                 showsRecoveryActions: true,
-                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName)
+                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName),
+                itemSyncLabel: itemSyncLabel,
+                statusFilterSubtitle: "Item error • \(itemSyncLabel)",
+                recoveryDetailLabel: errorRecoveryDetailLabel(institutionName: institutionName)
             )
         case nil:
             return AccountConnectionPresentation.synced(
                 isSyncStale: isSyncStale,
                 statusSyncText: statusSyncText,
+                itemLastSyncRelative: itemLastSyncRelative,
                 unknownItem: true
             )
         }
@@ -102,8 +140,11 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
     private static func synced(
         isSyncStale: Bool,
         statusSyncText: String,
+        itemLastSyncRelative: String?,
         unknownItem: Bool
     ) -> AccountConnectionPresentation {
+        let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
+
         if unknownItem {
             return AccountConnectionPresentation(
                 level: .unknown,
@@ -112,7 +153,8 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 signalLabel: "Unknown",
                 iconName: "link.circle.fill",
                 showsRecoveryActions: false,
-                recoveryActionTitle: nil
+                recoveryActionTitle: nil,
+                itemSyncLabel: itemSyncLabel
             )
         }
 
@@ -125,7 +167,10 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 signalLabel: "Stale",
                 iconName: "clock.badge.exclamationmark.fill",
                 showsRecoveryActions: true,
-                recoveryActionTitle: "Refresh"
+                recoveryActionTitle: "Refresh",
+                itemSyncLabel: itemSyncLabel,
+                statusFilterSubtitle: "Stale sync • \(itemSyncLabel)",
+                recoveryDetailLabel: "This item has stale Plaid data. Refresh to pull current balances and transactions."
             )
         }
 
@@ -136,7 +181,9 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             signalLabel: "Fresh",
             iconName: "checkmark.circle.fill",
             showsRecoveryActions: false,
-            recoveryActionTitle: nil
+            recoveryActionTitle: nil,
+            itemSyncLabel: itemSyncLabel,
+            statusFilterSubtitle: "Healthy • \(itemSyncLabel)"
         )
     }
 
@@ -156,6 +203,27 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             return fallback
         }
         return "\(institutionName) \(suffix)"
+    }
+
+    private static func loginRecoveryDetailLabel(institutionName: String?) -> String {
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            return "Plaid requires a fresh bank login. Reconnect this item, then refresh."
+        }
+        return "Plaid requires a fresh \(institutionName) login. Reconnect this item, then refresh."
+    }
+
+    private static func errorRecoveryDetailLabel(institutionName: String?) -> String {
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            return "Plaid reported an item error. Reconnect this item, then refresh."
+        }
+        return "Plaid reported an item error for \(institutionName). Reconnect this item, then refresh."
+    }
+
+    private static func itemSyncLabel(_ itemLastSyncRelative: String?) -> String {
+        guard let itemLastSyncRelative, !itemLastSyncRelative.isEmpty else {
+            return "No sync recorded"
+        }
+        return "Last sync \(itemLastSyncRelative)"
     }
 
     private static func normalizedInstitutionName(_ institutionName: String?) -> String? {

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -492,6 +492,9 @@ struct PlaidBarCoreTests {
         #expect(loginRequired.detailLabel == "Login required")
         #expect(loginRequired.signalLabel == "Login")
         #expect(loginRequired.recoveryActionTitle == "Reconnect Item")
+        #expect(loginRequired.itemSyncLabel == "No sync recorded")
+        #expect(loginRequired.statusFilterSubtitle == "Login required • No sync recorded")
+        #expect(loginRequired.recoveryDetailLabel == "Plaid requires a fresh bank login. Reconnect this item, then refresh.")
         #expect(loginRequired.showsRecoveryActions)
 
         let errored = AccountConnectionPresentation.evaluate(
@@ -506,7 +509,40 @@ struct PlaidBarCoreTests {
         #expect(errored.rowLabel == "Item error")
         #expect(errored.signalLabel == "Error")
         #expect(errored.recoveryActionTitle == "Reconnect Item")
+        #expect(errored.statusFilterSubtitle == "Item error • No sync recorded")
+        #expect(errored.recoveryDetailLabel == "Plaid reported an item error. Reconnect this item, then refresh.")
         #expect(errored.showsRecoveryActions)
+    }
+
+    @Test("Account connection presentation surfaces item sync for status recovery")
+    func accountConnectionPresentationSurfacesItemSyncForStatusRecovery() {
+        let loginRequired = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .loginRequired,
+            institutionName: "Chase",
+            itemLastSyncRelative: "3h ago"
+        )
+
+        #expect(loginRequired.itemSyncLabel == "Last sync 3h ago")
+        #expect(loginRequired.statusFilterSubtitle == "Login required • Last sync 3h ago")
+        #expect(loginRequired.recoveryDetailLabel == "Plaid requires a fresh Chase login. Reconnect this item, then refresh.")
+
+        let errored = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .error,
+            institutionName: "Amex",
+            itemLastSyncRelative: "yesterday"
+        )
+
+        #expect(errored.itemSyncLabel == "Last sync yesterday")
+        #expect(errored.statusFilterSubtitle == "Item error • Last sync yesterday")
+        #expect(errored.recoveryDetailLabel == "Plaid reported an item error for Amex. Reconnect this item, then refresh.")
     }
 
     @Test("Account connection presentation names degraded institutions")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1271,6 +1271,106 @@ struct PlaidBarCoreTests {
         #expect(emptyState.actionIconName == "arrow.clockwise")
     }
 
+    @Test("Secondary transaction empty state clears filters before recovery errors")
+    func secondaryTransactionEmptyStateClearsFiltersFirst() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            transactionCount: 12,
+            hasSearchText: true,
+            hasActiveFilters: false,
+            errorMessage: "Refresh failed"
+        )
+
+        #expect(state.title == "No matching transactions")
+        #expect(state.action == .clearFilters)
+        #expect(state.actionTitle == "Clear Filters")
+    }
+
+    @Test("Secondary transaction empty state keeps recent error ahead of missing history")
+    func secondaryTransactionEmptyStateRecentErrorPriority() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            hasSearchText: false,
+            hasActiveFilters: false,
+            errorMessage: "Plaid sync failed"
+        )
+
+        #expect(state.title == "Recent action failed")
+        #expect(state.detail == "Plaid sync failed")
+        #expect(state.action == .refresh)
+    }
+
+    @Test("Secondary spending empty state points offline users at server check")
+    func secondarySpendingEmptyStateServerOffline() {
+        let state = SecondaryContentUnavailableState.spendingActivity(
+            isDemoMode: false,
+            serverConnected: false,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            transactionCount: 0,
+            errorMessage: nil
+        )
+
+        #expect(state.title == "Server offline")
+        #expect(state.action == .checkServer)
+        #expect(state.actionTitle == "Check Server")
+    }
+
+    @Test("Secondary spending period empty state widens before refresh")
+    func secondarySpendingPeriodEmptyStateWidening() {
+        let week = SecondaryContentUnavailableState.spendingPeriod(
+            periodLabel: "Week",
+            canShowWiderPeriod: true
+        )
+        let widest = SecondaryContentUnavailableState.spendingPeriod(
+            periodLabel: "90D",
+            canShowWiderPeriod: false
+        )
+
+        #expect(week.action == .showWiderPeriod)
+        #expect(week.actionTitle == "Show 90D")
+        #expect(widest.action == .refresh)
+        #expect(widest.actionTitle == "Refresh")
+    }
+
+    @Test("Secondary recurring empty state explains minimum synced history")
+    func secondaryRecurringEmptyStateNeedsHistory() {
+        let noTransactions = SecondaryContentUnavailableState.recurring(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            transactionCount: 0,
+            errorMessage: nil
+        )
+        let noPattern = SecondaryContentUnavailableState.recurring(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            transactionCount: 20,
+            errorMessage: nil
+        )
+
+        #expect(noTransactions.title == "No synced transactions")
+        #expect(noTransactions.action == .syncTransactions)
+        #expect(noPattern.title == "No recurring charges found")
+        #expect(noPattern.detail.contains("2+ months"))
+        #expect(noPattern.actionTitle == "Sync Latest")
+    }
+
     @Test("Dashboard status readiness ignores blank recent action failures")
     func dashboardStatusReadinessIgnoresBlankRecentActionFailures() {
         let readiness = DashboardStatusReadiness.evaluate(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -954,6 +954,8 @@ struct PlaidBarCoreTests {
         )
 
         #expect(state.step == .openPlaidLink)
+        #expect(state.title == "No linked item returned")
+        #expect(state.detail == "PlaidBar cannot see a linked item yet. Finish Plaid Link in the browser, then check again.")
         #expect(!state.isReady)
         #expect(state.canRetry)
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -491,6 +491,7 @@ struct PlaidBarCoreTests {
         #expect(loginRequired.rowLabel == "Reconnect")
         #expect(loginRequired.detailLabel == "Login required")
         #expect(loginRequired.signalLabel == "Login")
+        #expect(loginRequired.recoveryActionTitle == "Reconnect Item")
         #expect(loginRequired.showsRecoveryActions)
 
         let errored = AccountConnectionPresentation.evaluate(
@@ -504,7 +505,37 @@ struct PlaidBarCoreTests {
         #expect(errored.level == .error)
         #expect(errored.rowLabel == "Item error")
         #expect(errored.signalLabel == "Error")
+        #expect(errored.recoveryActionTitle == "Reconnect Item")
         #expect(errored.showsRecoveryActions)
+    }
+
+    @Test("Account connection presentation names degraded institutions")
+    func accountConnectionPresentationNamesDegradedInstitutions() {
+        let loginRequired = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .loginRequired,
+            institutionName: "Chase"
+        )
+
+        #expect(loginRequired.rowLabel == "Reconnect Chase")
+        #expect(loginRequired.detailLabel == "Chase login required")
+        #expect(loginRequired.recoveryActionTitle == "Reconnect Chase")
+
+        let errored = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .error,
+            institutionName: " American Express "
+        )
+
+        #expect(errored.rowLabel == "American Express item error")
+        #expect(errored.detailLabel == "American Express item error")
+        #expect(errored.recoveryActionTitle == "Reconnect American Express")
     }
 
     @Test("Menu bar summary estimates runway from recent monthly spend")
@@ -1176,7 +1207,8 @@ struct PlaidBarCoreTests {
             serverConnected: true,
             linkedItemCount: 1,
             accountCount: 3,
-            degradedItemCount: 1
+            degradedItemCount: 1,
+            degradedItemRecoveryTitle: "Reconnect Chase"
         )
 
         #expect(emptyState.title == "1 item needs attention")
@@ -1184,7 +1216,9 @@ struct PlaidBarCoreTests {
         #expect(emptyState.iconName == "exclamationmark.triangle.fill")
         #expect(emptyState.tone == .warning)
         #expect(!emptyState.showsAddAccount)
-        #expect(emptyState.action == .refresh)
+        #expect(emptyState.action == .reconnect)
+        #expect(emptyState.actionTitle == "Reconnect Chase")
+        #expect(emptyState.actionIconName == "link.badge.plus")
     }
 
     @Test("Dashboard account empty state keeps healthy status copy when no items are degraded")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -362,7 +362,7 @@ struct PlaidBarCoreTests {
         #expect(AccountPresentation.dashboardAvailableTitle(for: credit) == "Avail Credit")
         #expect(AccountPresentation.dashboardCurrentTitle(for: checking) == "Current")
         #expect(AccountPresentation.dashboardCurrentTitle(for: credit) == "Owed")
-        #expect(AccountPresentation.dashboardUtilizationDetailText(for: credit) == "45% of $1K, Warning")
+        #expect(AccountPresentation.dashboardUtilizationDetailText(for: credit) == "45% of $1,000, Warning")
         #expect(AccountPresentation.rowAccessibilityLabel(
             for: checking,
             connectionLabel: "2m ago",
@@ -488,7 +488,7 @@ struct PlaidBarCoreTests {
         )
 
         #expect(loginRequired.level == .loginRequired)
-        #expect(loginRequired.rowLabel == "Reconnect")
+        #expect(loginRequired.rowLabel == "Reconnect Item")
         #expect(loginRequired.detailLabel == "Login required")
         #expect(loginRequired.signalLabel == "Login")
         #expect(loginRequired.recoveryActionTitle == "Reconnect Item")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1290,6 +1290,54 @@ struct PlaidBarCoreTests {
         #expect(state.actionTitle == "Clear Filters")
     }
 
+    @Test("Secondary accounts empty state distinguishes offline linked and unloaded data")
+    func secondaryAccountsEmptyStateDistinguishesRecovery() {
+        let offline = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false,
+            serverConnected: false,
+            linkedItemCount: 1
+        )
+        let unlinked = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 0
+        )
+        let unloaded = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1
+        )
+
+        #expect(offline.title == "Server offline")
+        #expect(offline.action == .checkServer)
+        #expect(unlinked.title == "No bank linked")
+        #expect(unlinked.action == .addAccount)
+        #expect(unloaded.title == "No account data")
+        #expect(unloaded.action == .refreshAccounts)
+    }
+
+    @Test("Secondary credit empty state points credit gaps at card setup")
+    func secondaryCreditEmptyStateDistinguishesCreditGap() {
+        let noAccounts = SecondaryContentUnavailableState.credit(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 0
+        )
+        let noCredit = SecondaryContentUnavailableState.credit(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2
+        )
+
+        #expect(noAccounts.title == "No account data")
+        #expect(noAccounts.action == .refreshAccounts)
+        #expect(noCredit.title == "No credit accounts")
+        #expect(noCredit.action == .addAccount)
+        #expect(noCredit.actionTitle == "Add Credit Card")
+    }
+
     @Test("Secondary transaction empty state keeps recent error ahead of missing history")
     func secondaryTransactionEmptyStateRecentErrorPriority() {
         let state = SecondaryContentUnavailableState.transactions(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1207,10 +1207,10 @@ struct PlaidBarCoreTests {
 
     @Test("Dashboard account filters include only matching account kinds")
     func dashboardAccountFiltersMatchAccountKinds() {
-        let checking = AccountDTO(id: "checking", itemId: "item_cash", name: "Checking", type: .depository, subtype: "checking")
-        let savings = AccountDTO(id: "savings", itemId: "item_cash", name: "Savings", type: .depository, subtype: "savings")
-        let credit = AccountDTO(id: "credit", itemId: "item_card", name: "Card", type: .credit)
-        let loan = AccountDTO(id: "loan", itemId: "item_loan", name: "Loan", type: .loan)
+        let checking = AccountDTO(id: "checking", itemId: "item_cash", name: "Checking", type: .depository, subtype: "checking", balances: BalanceDTO())
+        let savings = AccountDTO(id: "savings", itemId: "item_cash", name: "Savings", type: .depository, subtype: "savings", balances: BalanceDTO())
+        let credit = AccountDTO(id: "credit", itemId: "item_card", name: "Card", type: .credit, balances: BalanceDTO())
+        let loan = AccountDTO(id: "loan", itemId: "item_loan", name: "Loan", type: .loan, balances: BalanceDTO())
 
         #expect(DashboardAccountFilterKind.all.includes(checking))
         #expect(DashboardAccountFilterKind.cash.includes(checking))
@@ -1226,8 +1226,8 @@ struct PlaidBarCoreTests {
 
     @Test("Dashboard status filter only shows degraded item accounts")
     func dashboardStatusFilterOnlyShowsDegradedItemAccounts() {
-        let healthy = AccountDTO(id: "checking", itemId: "item_cash", name: "Checking", type: .depository)
-        let degraded = AccountDTO(id: "card", itemId: "item_card", name: "Card", type: .credit)
+        let healthy = AccountDTO(id: "checking", itemId: "item_cash", name: "Checking", type: .depository, balances: BalanceDTO())
+        let degraded = AccountDTO(id: "card", itemId: "item_card", name: "Card", type: .credit, balances: BalanceDTO())
 
         #expect(!DashboardAccountFilterKind.status.includes(healthy))
         #expect(!DashboardAccountFilterKind.status.includes(degraded))

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,6 +45,25 @@ PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret ./Scripts/smoke-san
 ./Scripts/screenshots.sh
 ```
 
+The `ci_smoke_client` and `ci_smoke_secret` values are CI-safe dummy values for
+the server startup smoke only. The smoke script does not open Plaid Link or sync
+Plaid data, but it must still report sandbox credentials as configured.
+
+For non-publishing Homebrew verification from a development checkout, avoid
+uninstalling or reinstalling user packages. Use read-only or dry-run checks:
+
+```bash
+ruby -c Formula/plaidbar.rb
+HOMEBREW_NO_AUTO_UPDATE=1 brew audit --strict --formula plaidbar
+HOMEBREW_NO_AUTO_UPDATE=1 brew style plaidbar
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --dry-run --build-from-source plaidbar
+HOMEBREW_NO_AUTO_UPDATE=1 brew test plaidbar
+```
+
+If Homebrew reports that `plaidbar` is already installed and up to date during
+the dry run, that is enough for local branch verification. Do a destructive
+reinstall only on a clean release machine or disposable Homebrew environment.
+
 3. Open and merge the release-prep PR only after GitHub CI passes.
 
 ## Publish Checklist
@@ -60,12 +79,14 @@ Then verify the published install path:
 
 ```bash
 brew tap ftchvs/plaidbar https://github.com/ftchvs/PlaidBar
-brew uninstall plaidbar || true
-brew install --build-from-source plaidbar
+brew reinstall --build-from-source plaidbar
 plaidbar-server --help
 plaidbar-server --version
 plaidbar-run --help
 ```
+
+Run the published install check only on a clean release machine or disposable
+Homebrew environment so it does not disturb a user's existing local install.
 
 ## Formula-Only Scope
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -37,6 +37,10 @@ The script launches PlaidBar locally and captures:
 - Settings > Notifications
 - Settings > About
 
+The Status capture uses demo data with `--screenshot-status-recovery`. That
+fixture keeps the regular demo dashboard healthy, while the Status filter shows
+one recovered institution and one institution that needs login/reconnect.
+
 ## macOS Permissions
 
 The screenshot script uses macOS UI automation. Terminal needs:
@@ -69,6 +73,7 @@ app running the script.
 - Text is readable at README display sizes.
 - No real personal finance data appears.
 - Empty/degraded states are represented where relevant.
+- `dashboard-status.png` shows the recovery fixture, not a real Plaid error.
 - Button labels and status copy match the current app.
 - Settings screenshots show useful controls, not blank tabs.
 - Screenshots do not include unrelated desktop windows or notifications.


### PR DESCRIPTION
## Summary
- Keep demo dashboard refreshes local and improve dashboard/status recovery copy across setup, account, and item states.
- Add recovery-focused screenshot fixture/state polish while keeping normal demo data healthy.
- Harden screenshot automation, release gates, Homebrew release checks, and release preflight test visibility.

## Validation
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- strict concurrency and release builds during the overnight loop
- bash -n Scripts/*.sh Scripts/plaidbar-run
- ruby -c Formula/plaidbar.rb
- CI-safe sandbox smoke with dummy Plaid credentials
- Homebrew audit/style/dry-run/test
- secret scan showed only placeholders/config key names

## Known local/environment blockers
- Local swift test is blocked on this machine by the known Swift Testing toolchain issue: no such module 'Testing'. CI should be the canonical test signal.
- Full screenshot capture still depends on macOS Screen Recording/Accessibility/window detection, but now fails bounded instead of hanging.
- Real Plaid sandbox Link/sync needs actual PLAID_CLIENT_ID and PLAID_SECRET.