### PR TITLE
Polish PlaidBar UX across screens

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -129,42 +129,45 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    HStack(spacing: Spacing.sm) {
+                    Text("Server database, Plaid item tokens, and sync cursors. Preferences, server.conf, and app/server auth stay in place.")
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(alignment: .center, spacing: Spacing.sm) {
                         Button {
                             revealStorageDirectory()
                         } label: {
-                            Label("Reveal", systemImage: "folder")
+                            Label("Open Folder", systemImage: "folder")
                         }
+                        .controlSize(.small)
 
                         Button {
                             copyStoragePath()
                         } label: {
                             Label("Copy Path", systemImage: "doc.on.doc")
                         }
+                        .controlSize(.small)
 
-                        Spacer()
-
-                        Button(role: .destructive) {
+                        Button {
                             isShowingResetConfirmation = true
                         } label: {
-                            Label("Reset", systemImage: "trash")
+                            Label("Reset Local Data", systemImage: "trash")
                         }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .foregroundStyle(.secondary)
                     }
-
-                    Text("Stores the local server database, Plaid item tokens, and sync cursors. App preferences, server.conf, and the app/server auth token stay in place.")
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(Spacing.lg)
         }
-        .alert("Reset Local PlaidBar Data?", isPresented: $isShowingResetConfirmation) {
+        .alert("Reset Local Data?", isPresented: $isShowingResetConfirmation) {
             Button("Reset Local Data", role: .destructive) {
                 resetLocalData()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This deletes files under \(appState.activeStorageDirectoryDisplayText), including the SQLite database, stored Plaid access tokens, and sync cursors. It keeps server.conf and the app/server auth token so local configuration and the running local server stay reachable. It also clears currently loaded accounts, transactions, and balance history from this app. It does not revoke bank permissions, remove Plaid dashboard Items, delete Plaid credentials from your shell environment, or change app preferences. Stop and restart PlaidBarServer after resetting.")
+            Text("Deletes the SQLite database, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart PlaidBarServer after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },
@@ -199,9 +202,9 @@ struct GeneralSettingsView: View {
         do {
             let result = try appState.resetLocalData()
             if result.removedEntryCount == 0 {
-                resetResultMessage = "No existing files were found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready for a fresh local server start. \(keychainResetText(for: result))"
+                resetResultMessage = "No local data found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready. \(keychainResetText(for: result))"
             } else {
-                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result)) Restart PlaidBarServer before reconnecting accounts."
+                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result)) Restart PlaidBarServer."
             }
         } catch {
             resetErrorMessage = error.localizedDescription
@@ -210,7 +213,7 @@ struct GeneralSettingsView: View {
 
     private var storageDetailText: String {
         if let serverStoragePath = appState.serverStoragePath {
-            return "Server storage directory: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
+            return "Server: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
         }
 
         return "Default: \(appState.localStorageResolvedDisplayPathText)"
@@ -218,8 +221,8 @@ struct GeneralSettingsView: View {
 
     private func keychainResetText(for result: LocalDataResetResult) -> String {
         result.keychainTokensCleared
-            ? "Stored Plaid access-token entries were cleared from Keychain when present."
-            : "Stored Plaid access-token entries were not cleared from Keychain."
+            ? "Keychain token entries were cleared when present."
+            : "Keychain token entries were not cleared."
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -213,7 +213,7 @@ private struct DashboardStatusStrip: View {
                 title: "Mode",
                 value: appState.statusModeText,
                 icon: appState.isDemoMode ? "play.circle.fill" : "server.rack",
-                tint: appState.isDemoMode ? SemanticColors.brandSecondary : SemanticColors.brand
+                tint: .secondary
             )
 
             StatusDivider()
@@ -231,7 +231,7 @@ private struct DashboardStatusStrip: View {
                 title: "Sync",
                 value: appState.statusSyncText,
                 icon: appState.isSyncStale ? "clock.badge.exclamationmark.fill" : "checkmark.circle.fill",
-                tint: appState.isSyncStale ? SemanticColors.warning : SemanticColors.positive
+                tint: appState.isSyncStale ? SemanticColors.warning : .secondary
             )
 
             StatusDivider()
@@ -261,10 +261,10 @@ private struct DashboardStatusStrip: View {
     }
 
     private var serverTint: Color {
-        if appState.isDemoMode { return SemanticColors.brandSecondary }
+        if appState.isDemoMode { return .secondary }
         if appState.isLoading { return SemanticColors.warning }
         if appState.error != nil { return SemanticColors.negative }
-        return appState.serverConnected ? SemanticColors.positive : .secondary
+        return .secondary
     }
 
     private var itemsText: String {
@@ -286,7 +286,7 @@ private struct DashboardStatusStrip: View {
     private var itemTint: Color {
         if appState.erroredItemCount > 0 { return SemanticColors.negative }
         if appState.needsLoginItemCount > 0 { return SemanticColors.warning }
-        return appState.statusItemCount > 0 ? SemanticColors.positive : .secondary
+        return .secondary
     }
 }
 
@@ -334,21 +334,23 @@ private struct DashboardSummaryCards: View {
                 title: "Cash",
                 value: Formatters.currency(appState.totalCash, format: .compact),
                 detail: "\(appState.depositoryAccounts.count) cash account\(appState.depositoryAccounts.count == 1 ? "" : "s")",
-                tint: SemanticColors.available
+                tint: .secondary
             )
 
             MetricCard(
                 title: "Debt",
                 value: Formatters.currency(appState.totalDebt, format: .compact),
                 detail: debtDetail,
-                tint: SemanticColors.creditDebt
+                tint: SemanticColors.creditDebt,
+                emphasizesTint: appState.totalDebt > 0
             )
 
             MetricCard(
                 title: "Runway",
                 value: appState.runwayText,
                 detail: appState.runwayBasisText,
-                tint: runwayTint
+                tint: runwayTint,
+                emphasizesTint: shouldEmphasizeRunway
             )
         }
     }
@@ -367,7 +369,12 @@ private struct DashboardSummaryCards: View {
         guard let months = appState.runwayMonths else { return .secondary }
         if months < 1 { return SemanticColors.negative }
         if months < 3 { return SemanticColors.warning }
-        return SemanticColors.available
+        return .secondary
+    }
+
+    private var shouldEmphasizeRunway: Bool {
+        guard let months = appState.runwayMonths else { return false }
+        return months < 3
     }
 }
 
@@ -376,6 +383,7 @@ private struct MetricCard: View {
     let value: String
     let detail: String
     let tint: Color
+    var emphasizesTint = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -384,6 +392,7 @@ private struct MetricCard: View {
                 .foregroundStyle(.secondary)
             Text(value)
                 .font(.headline.weight(.bold))
+                .foregroundStyle(emphasizesTint ? tint : .primary)
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
@@ -396,11 +405,27 @@ private struct MetricCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 10)
         .padding(.vertical, 10)
-        .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+        .background(cardFill, in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
-                .stroke(tint.opacity(0.16), lineWidth: 1)
+                .stroke(cardStroke, lineWidth: 1)
         }
+        .overlay(alignment: .leading) {
+            if emphasizesTint {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(tint)
+                    .frame(width: 3)
+                    .padding(.vertical, 8)
+            }
+        }
+    }
+
+    private var cardFill: Color {
+        emphasizesTint ? tint.opacity(0.09) : Color.primary.opacity(0.025)
+    }
+
+    private var cardStroke: Color {
+        emphasizesTint ? tint.opacity(0.18) : Color.primary.opacity(0.07)
     }
 }
 
@@ -415,7 +440,7 @@ private struct BalanceCompositionStrip: View {
                     from: appState.accounts,
                     type: .depository
                 ),
-                tint: SemanticColors.available
+                tint: Color.secondary.opacity(0.6)
             ),
             BalanceCompositionSegment(
                 title: "Investments",
@@ -423,7 +448,7 @@ private struct BalanceCompositionStrip: View {
                     from: appState.accounts,
                     type: .investment
                 ),
-                tint: SemanticColors.brand
+                tint: Color.primary.opacity(0.36)
             ),
             BalanceCompositionSegment(
                 title: "Credit",
@@ -485,7 +510,7 @@ private struct BalanceCompositionStrip: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 9)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color.primary.opacity(0.07), lineWidth: 1)
@@ -928,18 +953,32 @@ private struct DashboardStatusReadinessPanel: View {
 
             HStack(spacing: 8) {
                 if let primaryAction = readiness.primaryAction {
-                    Button {
-                        perform(primaryAction)
-                    } label: {
-                        Label(
-                            primaryActionLabel(for: primaryAction),
-                            systemImage: readiness.primaryActionIconName ?? primaryAction.icon
-                        )
+                    if readinessNeedsAttention {
+                        Button {
+                            perform(primaryAction)
+                        } label: {
+                            Label(
+                                primaryActionLabel(for: primaryAction),
+                                systemImage: readiness.primaryActionIconName ?? primaryAction.icon
+                            )
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .tint(tint)
+                        .disabled(appState.isLoading)
+                    } else {
+                        Button {
+                            perform(primaryAction)
+                        } label: {
+                            Label(
+                                primaryActionLabel(for: primaryAction),
+                                systemImage: readiness.primaryActionIconName ?? primaryAction.icon
+                            )
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(appState.isLoading)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .tint(tint)
-                    .disabled(appState.isLoading)
                 }
 
                 ForEach(readiness.secondaryActions, id: \.rawValue) { action in
@@ -958,7 +997,7 @@ private struct DashboardStatusReadinessPanel: View {
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
-                .stroke(tint.opacity(0.18), lineWidth: 1)
+                .stroke(panelStroke, lineWidth: 1)
         }
         .accessibilityElement(children: .contain)
     }
@@ -973,10 +1012,18 @@ private struct DashboardStatusReadinessPanel: View {
 
     private var tint: Color {
         switch readiness.level {
-        case .healthy: SemanticColors.positive
+        case .healthy: .secondary
         case .warning: SemanticColors.warning
         case .blocked: SemanticColors.negative
         }
+    }
+
+    private var readinessNeedsAttention: Bool {
+        readiness.level != .healthy
+    }
+
+    private var panelStroke: Color {
+        readinessNeedsAttention ? tint.opacity(0.18) : Color.primary.opacity(0.07)
     }
 
     private func perform(_ action: DashboardStatusReadinessAction) {
@@ -1059,7 +1106,7 @@ private struct SetupRecoverySummary: View {
     private var color: Color {
         switch state.step {
         case .ready:
-            SemanticColors.positive
+            .secondary
         case .blocked:
             SemanticColors.negative
         case .openPlaidLink, .loadAccounts, .syncTransactions:
@@ -1311,7 +1358,7 @@ private struct DashboardEmptyAccountState: View {
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
-                .stroke(tint.opacity(0.18), lineWidth: 1)
+                .stroke(panelStroke, lineWidth: 1)
         }
     }
 
@@ -1332,11 +1379,20 @@ private struct DashboardEmptyAccountState: View {
         case .brand:
             return SemanticColors.brand
         case .healthy:
-            return SemanticColors.positive
+            return .secondary
         case .offline, .secondary:
             return .secondary
         case .warning:
             return SemanticColors.warning
+        }
+    }
+
+    private var panelStroke: Color {
+        switch presentation.tone {
+        case .brand, .warning:
+            return tint.opacity(0.18)
+        case .healthy, .offline, .secondary:
+            return Color.primary.opacity(0.07)
         }
     }
 
@@ -1435,7 +1491,7 @@ private struct DashboardAccountRow: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(isSelected ? SemanticColors.brand.opacity(0.14) : Color.primary.opacity(0.018))
+        .background(isSelected ? Color.primary.opacity(0.055) : Color.primary.opacity(0.018))
         .overlay(alignment: .bottom) {
             Divider()
                 .opacity(0.55)
@@ -1460,9 +1516,9 @@ private struct DashboardAccountRow: View {
         case .credit, .loan:
             SemanticColors.creditDebt
         case .investment:
-            SemanticColors.sparkline
+            .secondary
         case .depository:
-            SemanticColors.available
+            .secondary
         case .other:
             .secondary
         }
@@ -1556,7 +1612,7 @@ private struct SelectedAccountPanel: View {
             }
 
             HStack(spacing: 8) {
-                DetailValue(title: availableTitle, value: availableText, tint: SemanticColors.available)
+                DetailValue(title: availableTitle, value: availableText, tint: .primary)
                 DetailValue(title: currentTitle, value: currentText, tint: currentTint)
 
                 if let utilization = account.balances.utilizationPercent,
@@ -1589,13 +1645,13 @@ private struct SelectedAccountPanel: View {
                     title: "30D Out",
                     value: Formatters.currency(activitySummary.outflowTotal, format: .compact),
                     icon: "arrow.up.right.circle.fill",
-                    tint: activitySummary.outflowTotal > 0 ? SemanticColors.negative : .secondary
+                    tint: .secondary
                 )
                 AccountSignalPill(
                     title: "30D In",
                     value: Formatters.currency(activitySummary.inflowTotal, format: .compact),
                     icon: "arrow.down.left.circle.fill",
-                    tint: activitySummary.inflowTotal > 0 ? SemanticColors.positive : .secondary
+                    tint: .secondary
                 )
                 AccountSignalPill(
                     title: "Sync",
@@ -1617,7 +1673,7 @@ private struct SelectedAccountPanel: View {
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
-                .background(connectionTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
+                .background(recoveryFill, in: RoundedRectangle(cornerRadius: 7))
                 .accessibilityElement(children: .combine)
             }
 
@@ -1663,7 +1719,7 @@ private struct SelectedAccountPanel: View {
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
-                .stroke(connectionTint.opacity(0.18), lineWidth: 1)
+                .stroke(panelStroke, lineWidth: 1)
         }
     }
 
@@ -1737,16 +1793,33 @@ private struct SelectedAccountPanel: View {
     private var recoveryActionTitle: String {
         connectionPresentation.recoveryActionTitle ?? "Reconnect"
     }
+
+    private var panelStroke: Color {
+        shouldEmphasizeConnection ? connectionTint.opacity(0.18) : Color.primary.opacity(0.07)
+    }
+
+    private var recoveryFill: Color {
+        shouldEmphasizeConnection ? connectionTint.opacity(0.08) : Color.primary.opacity(0.035)
+    }
+
+    private var shouldEmphasizeConnection: Bool {
+        switch connectionPresentation.level {
+        case .stale, .loginRequired, .error:
+            return true
+        case .demo, .offline, .healthy, .unknown:
+            return false
+        }
+    }
 }
 
 private func accountConnectionTint(for level: AccountConnectionLevel) -> Color {
     switch level {
     case .demo:
-        return SemanticColors.brandSecondary
+        return .secondary
     case .offline:
         return .secondary
     case .healthy:
-        return SemanticColors.positive
+        return .secondary
     case .stale, .loginRequired:
         return SemanticColors.warning
     case .error:

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -10,6 +10,17 @@ struct MainPopover: View {
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
 
+    private enum Layout {
+        static let dashboardWidth: CGFloat = 480
+        static let setupWidth: CGFloat = 560
+        static let dashboardMinHeight: CGFloat = 500
+        static let dashboardMaxHeight: CGFloat = 680
+        static let contentHorizontalPadding: CGFloat = 14
+        static let contentTopPadding: CGFloat = 14
+        static let contentBottomPadding: CGFloat = 12
+        static let sectionSpacing: CGFloat = 12
+    }
+
     private var selectedFilter: DashboardAccountFilter {
         DashboardAccountFilter(rawValue: selectedFilterRawValue) ?? .all
     }
@@ -28,10 +39,10 @@ struct MainPopover: View {
         VStack(spacing: 0) {
             if shouldShowSetupScreen {
                 SetupView()
-                    .frame(width: 600)
+                    .frame(width: Layout.setupWidth)
             } else {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
+                    VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                         DashboardHeader()
                             .environment(appState)
 
@@ -66,13 +77,13 @@ struct MainPopover: View {
                         )
                         .environment(appState)
                     }
-                    .padding(.horizontal, 22)
-                    .padding(.top, 22)
-                    .padding(.bottom, 18)
+                    .padding(.horizontal, Layout.contentHorizontalPadding)
+                    .padding(.top, Layout.contentTopPadding)
+                    .padding(.bottom, Layout.contentBottomPadding)
                 }
                 .scrollContentBackground(.hidden)
                 .frame(maxWidth: .infinity)
-                .frame(minHeight: 860, maxHeight: 1000)
+                .frame(minHeight: Layout.dashboardMinHeight, maxHeight: Layout.dashboardMaxHeight)
 
                 Divider()
 
@@ -89,7 +100,7 @@ struct MainPopover: View {
                     .environment(appState)
             }
         }
-        .frame(width: 600)
+        .frame(width: shouldShowSetupScreen ? Layout.setupWidth : Layout.dashboardWidth)
         .background(Color(nsColor: .windowBackgroundColor))
         .animation(.easeInOut(duration: 0.2), value: appState.error != nil)
         .sheet(
@@ -150,22 +161,22 @@ private struct DashboardHeader: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text("Net Worth")
                     .sectionTitle()
                     .foregroundStyle(.secondary)
 
                 Text(Formatters.currency(appState.netBalance, format: .full))
-                    .font(.system(size: 42, weight: .bold, design: .rounded))
+                    .font(.system(size: 34, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .contentTransition(.numericText())
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
             }
 
-            Spacer(minLength: 24)
+            Spacer(minLength: 16)
 
-            VStack(alignment: .trailing, spacing: 4) {
+            VStack(alignment: .trailing, spacing: 3) {
                 Text("PlaidBar")
                     .font(.headline.weight(.bold))
                 Text(appState.statusSyncText)
@@ -216,8 +227,8 @@ private struct DashboardStatusStrip: View {
                 tint: itemTint
             )
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 8)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
@@ -270,11 +281,11 @@ private struct StatusStripItem: View {
     let tint: Color
 
     var body: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 5) {
             Image(systemName: icon)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
-                .frame(width: 15)
+                .frame(width: 13)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -294,7 +305,7 @@ private struct StatusDivider: View {
     var body: some View {
         Divider()
             .padding(.vertical, 3)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 6)
     }
 }
 
@@ -302,7 +313,7 @@ private struct DashboardSummaryCards: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 8) {
             MetricCard(
                 title: "Cash",
                 value: Formatters.currency(appState.totalCash, format: .compact),
@@ -351,7 +362,7 @@ private struct MetricCard: View {
     let tint: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 4) {
             Text(title)
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -367,8 +378,8 @@ private struct MetricCard: View {
                 .minimumScaleFactor(0.75)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 13)
-        .padding(.vertical, 13)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
         .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
@@ -426,7 +437,7 @@ private struct BalanceCompositionStrip: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
+        VStack(alignment: .leading, spacing: 7) {
             HStack {
                 Text("Balance Mix")
                     .font(.caption.weight(.semibold))
@@ -450,14 +461,14 @@ private struct BalanceCompositionStrip: View {
             }
             .frame(height: 8)
 
-            HStack(spacing: 12) {
+            HStack(spacing: 8) {
                 ForEach(segments) { segment in
                     BalanceCompositionLegend(segment: segment)
                 }
             }
         }
-        .padding(.horizontal, 13)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
@@ -515,9 +526,9 @@ private struct BalanceActivityHeatmap: View {
     @AppStorage("dashboard.heatmapMode") private var modeRawValue = SpendingHeatmapMode.spending.rawValue
 
     private let calendar = Calendar.current
-    private let spacing: CGFloat = 3
-    private let monthLabelHeight: CGFloat = 12
-    private let monthLabelWidth: CGFloat = 26
+    private let spacing: CGFloat = 2
+    private let monthLabelHeight: CGFloat = 10
+    private let monthLabelWidth: CGFloat = 22
 
     private var mode: SpendingHeatmapMode {
         SpendingHeatmapMode(rawValue: modeRawValue) ?? .spending
@@ -608,7 +619,7 @@ private struct BalanceActivityHeatmap: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 11) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline) {
                 Text(title)
                     .sectionTitle()
@@ -634,7 +645,7 @@ private struct BalanceActivityHeatmap: View {
 
             GeometryReader { proxy in
                 let weeks = max(weekColumns.count, 1)
-                let cell = max(6, min(9, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks))))
+                let cell = max(5, min(8, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks))))
 
                 ZStack(alignment: .topLeading) {
                     ForEach(monthMarkers) { marker in
@@ -661,11 +672,11 @@ private struct BalanceActivityHeatmap: View {
                             }
                         }
                     }
-                    .offset(y: monthLabelHeight + 4)
+                    .offset(y: monthLabelHeight + 3)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-            .frame(height: monthLabelHeight + 4 + 7 * 9 + 6 * spacing)
+            .frame(height: monthLabelHeight + 3 + 7 * 8 + 6 * spacing)
 
             HStack(spacing: 5) {
                 if mode == .spending {
@@ -676,7 +687,7 @@ private struct BalanceActivityHeatmap: View {
                     ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
                         RoundedRectangle(cornerRadius: 2)
                             .fill(BalanceHeatmapCell.fillColor(intensity: intensity, value: intensity, mode: mode))
-                            .frame(width: 9, height: 9)
+                            .frame(width: 8, height: 8)
                     }
 
                     Text("More")
@@ -694,7 +705,7 @@ private struct BalanceActivityHeatmap: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(18)
+        .padding(12)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(title) heatmap for the last 365 days with \(activeDayCount) active days.")
@@ -726,7 +737,7 @@ private struct NetLegendKey: View {
         HStack(spacing: 4) {
             RoundedRectangle(cornerRadius: 2)
                 .fill(tint.opacity(0.72))
-                .frame(width: 9, height: 9)
+                .frame(width: 8, height: 8)
             Text(label)
                 .microText()
                 .foregroundStyle(.secondary)
@@ -835,7 +846,7 @@ private struct DashboardFilterBar: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.8)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
+                        .padding(.vertical, 6)
                         .foregroundStyle(selection == filter ? .white : .primary)
                         .contentShape(Rectangle())
                 }
@@ -847,7 +858,7 @@ private struct DashboardFilterBar: View {
 
                 if filter != DashboardAccountFilter.allCases.last {
                     Divider()
-                        .padding(.vertical, 8)
+                        .padding(.vertical, 6)
                 }
             }
         }
@@ -873,15 +884,15 @@ private struct DashboardStatusReadinessPanel: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 9) {
                 Image(systemName: icon)
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
-                    .frame(width: 34, height: 34)
+                    .frame(width: 28, height: 28)
                     .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
 
-                VStack(alignment: .leading, spacing: 5) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(readiness.title)
                         .font(.callout.weight(.semibold))
                     Text(readiness.detail)
@@ -889,7 +900,7 @@ private struct DashboardStatusReadinessPanel: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Spacer(minLength: 12)
+                Spacer(minLength: 8)
             }
 
             if !appState.isSetupComplete {
@@ -927,7 +938,7 @@ private struct DashboardStatusReadinessPanel: View {
                 }
             }
         }
-        .padding(16)
+        .padding(12)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
@@ -988,14 +999,14 @@ private struct SetupRecoverySummary: View {
     let state: FirstRunCompletionState
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: .top, spacing: 8) {
             Image(systemName: icon)
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(color)
-                .frame(width: 22, height: 22)
+                .frame(width: 20, height: 20)
                 .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text("Setup recovery")
                     .microText()
                     .foregroundStyle(.secondary)
@@ -1008,8 +1019,8 @@ private struct SetupRecoverySummary: View {
 
             Spacer(minLength: 8)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 9)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
         .background(color.opacity(0.06), in: RoundedRectangle(cornerRadius: 7))
         .accessibilityElement(children: .combine)
     }
@@ -1045,7 +1056,7 @@ private struct StatusMetricGrid: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
             StatusMetricPill(title: "Mode", value: appState.statusModeText)
             StatusMetricPill(title: "Server", value: appState.statusServerText)
             StatusMetricPill(title: "Items", value: "\(appState.statusItemCount) linked")
@@ -1058,9 +1069,9 @@ private struct StatusMetricGrid: View {
 
     private var columns: [GridItem] {
         [
-            GridItem(.flexible(minimum: 140), spacing: 8),
-            GridItem(.flexible(minimum: 140), spacing: 8),
-            GridItem(.flexible(minimum: 140), spacing: 8),
+            GridItem(.flexible(minimum: 112), spacing: 6),
+            GridItem(.flexible(minimum: 112), spacing: 6),
+            GridItem(.flexible(minimum: 112), spacing: 6),
         ]
     }
 
@@ -1074,7 +1085,7 @@ private struct StatusMetricPill: View {
     let value: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 2) {
             Text(title)
                 .microText()
                 .foregroundStyle(.secondary)
@@ -1084,8 +1095,8 @@ private struct StatusMetricPill: View {
                 .minimumScaleFactor(0.78)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 7))
     }
 }
@@ -1135,7 +1146,7 @@ private struct AccountsSection: View {
                     .foregroundStyle(.secondary)
             }
             .padding(.horizontal, 2)
-            .padding(.bottom, 7)
+            .padding(.bottom, 5)
 
             if accounts.isEmpty {
                 DashboardEmptyAccountState(filter: filter, onAddAccount: onAddAccount)
@@ -1184,8 +1195,8 @@ private struct AccountRowWithDrilldown: View {
             if isSelected {
                 SelectedAccountPanel(account: account, isStatusFilter: isStatusFilter)
                     .environment(appState)
-                    .padding(.top, 10)
-                    .padding(.bottom, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 9)
             }
         }
     }
@@ -1244,12 +1255,12 @@ private struct DashboardEmptyAccountState: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 11) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
                 Image(systemName: icon)
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
-                    .frame(width: 34, height: 34)
+                    .frame(width: 28, height: 28)
                     .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
 
                 VStack(alignment: .leading, spacing: 3) {
@@ -1279,7 +1290,7 @@ private struct DashboardEmptyAccountState: View {
                 .controlSize(.small)
             }
         }
-        .padding(16)
+        .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
@@ -1350,16 +1361,16 @@ private struct DashboardAccountRow: View {
     let isSelected: Bool
 
     var body: some View {
-        HStack(spacing: 11) {
+        HStack(spacing: 9) {
             Image(systemName: AccountPresentation.iconName(for: account))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(accountTint)
-                .frame(width: 34, height: 34)
+                .frame(width: 28, height: 28)
                 .background(accountTint.opacity(0.16), in: RoundedRectangle(cornerRadius: 8))
                 .overlay(alignment: .bottomTrailing) {
                     Circle()
                         .fill(statusTint)
-                        .frame(width: 9, height: 9)
+                        .frame(width: 8, height: 8)
                         .overlay {
                             Circle()
                                 .stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5)
@@ -1375,7 +1386,7 @@ private struct DashboardAccountRow: View {
                     .lineLimit(1)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: 8)
 
             VStack(alignment: .trailing, spacing: 4) {
                 Text(amountText)
@@ -1406,8 +1417,8 @@ private struct DashboardAccountRow: View {
                 .font(.caption.weight(.bold))
                 .foregroundStyle(.tertiary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
         .background(isSelected ? SemanticColors.brand.opacity(0.14) : Color.primary.opacity(0.018))
         .overlay(alignment: .bottom) {
             Divider()
@@ -1505,9 +1516,9 @@ private struct SelectedAccountPanel: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 3) {
                     Text("Details")
                         .sectionTitle()
                         .foregroundStyle(.secondary)
@@ -1528,7 +1539,7 @@ private struct SelectedAccountPanel: View {
                 )
             }
 
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 DetailValue(title: availableTitle, value: availableText, tint: SemanticColors.available)
                 DetailValue(title: currentTitle, value: currentText, tint: currentTint)
 
@@ -1551,7 +1562,7 @@ private struct SelectedAccountPanel: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(spacing: 10) {
+            HStack(spacing: 7) {
                 AccountSignalPill(
                     title: "Pending",
                     value: "\(pendingTransactions.count)",
@@ -1588,8 +1599,8 @@ private struct SelectedAccountPanel: View {
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
                 .background(connectionTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 7))
                 .accessibilityElement(children: .combine)
             }
@@ -1616,7 +1627,7 @@ private struct SelectedAccountPanel: View {
                 }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 6) {
                 Text("Recent Activity")
                     .sectionTitle()
                     .foregroundStyle(.secondary)
@@ -1632,7 +1643,7 @@ private struct SelectedAccountPanel: View {
                 }
             }
         }
-        .padding(18)
+        .padding(12)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
@@ -1739,8 +1750,8 @@ private struct AccountConnectionBadge: View {
             .font(.caption.weight(.semibold))
             .lineLimit(1)
             .foregroundStyle(tint)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 5)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
             .background(tint.opacity(0.12), in: Capsule())
     }
 }
@@ -1752,11 +1763,11 @@ private struct AccountSignalPill: View {
     let tint: Color
 
     var body: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 5) {
             Image(systemName: icon)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
-                .frame(width: 14)
+                .frame(width: 12)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
@@ -1769,8 +1780,8 @@ private struct AccountSignalPill: View {
                     .minimumScaleFactor(0.82)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 7))
         .accessibilityElement(children: .ignore)
@@ -1800,7 +1811,7 @@ private struct TransactionMiniRow: View {
     let transaction: TransactionDTO
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 8) {
             Circle()
                 .fill(transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55))
                 .frame(width: 8, height: 8)
@@ -1845,7 +1856,7 @@ private struct DashboardFooter: View {
     let onAddAccount: () -> Void
 
     var body: some View {
-        HStack(spacing: 18) {
+        HStack(spacing: 14) {
             Button(action: onAddAccount) {
                 Image(systemName: "plus.circle")
                     .font(.body)
@@ -1879,8 +1890,8 @@ private struct DashboardFooter: View {
             .help("Settings")
             .accessibilityLabel("Settings")
         }
-        .padding(.horizontal, 22)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
     }
 
     private func openSettingsWindow() {
@@ -1939,8 +1950,8 @@ private struct ErrorBanner: View {
             .help("Dismiss error")
             .accessibilityLabel("Dismiss error")
         }
-        .padding(.horizontal, 22)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
         .background(.red.opacity(0.1))
         .transition(.move(edge: .bottom).combined(with: .opacity))
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -46,12 +46,7 @@ struct MainPopover: View {
                         DashboardHeader()
                             .environment(appState)
 
-                        DashboardStatusStrip()
-                            .environment(appState)
-
-                        BalanceActivityHeatmap(transactions: appState.transactions)
-
-                        if shouldShowStatusReadinessPanel {
+                        if shouldElevateStatusReadinessPanel {
                             DashboardStatusReadinessPanel(
                                 openSettings: { openSettings() },
                                 onAddAccount: openAccountSetup
@@ -76,6 +71,19 @@ struct MainPopover: View {
                             onAddAccount: openAccountSetup
                         )
                         .environment(appState)
+
+                        DashboardStatusStrip()
+                            .environment(appState)
+
+                        BalanceActivityHeatmap(transactions: appState.transactions)
+
+                        if shouldShowLowerStatusReadinessPanel {
+                            DashboardStatusReadinessPanel(
+                                openSettings: { openSettings() },
+                                onAddAccount: openAccountSetup
+                            )
+                            .environment(appState)
+                        }
                     }
                     .padding(.horizontal, Layout.contentHorizontalPadding)
                     .padding(.top, Layout.contentTopPadding)
@@ -140,6 +148,14 @@ struct MainPopover: View {
 
     private var shouldShowStatusReadinessPanel: Bool {
         selectedFilter == .status || !appState.isSetupComplete || appState.dashboardStatusReadiness.level != .healthy
+    }
+
+    private var shouldElevateStatusReadinessPanel: Bool {
+        !appState.isSetupComplete || appState.dashboardStatusReadiness.level != .healthy
+    }
+
+    private var shouldShowLowerStatusReadinessPanel: Bool {
+        shouldShowStatusReadinessPanel && !shouldElevateStatusReadinessPanel
     }
 
     private var filterBinding: Binding<DashboardAccountFilter> {

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -23,16 +23,16 @@ struct SetupView: View {
                     environment: .sandbox,
                     icon: "testtube.2",
                     title: "Connect Sandbox",
-                    summary: "Uses Plaid's sandbox API with Plaid-hosted test institutions. This still requires your sandbox client ID and secret on the local server.",
-                    primaryTitle: "Open Sandbox Link"
+                    summary: "Test institutions with Plaid sandbox credentials on PlaidBarServer.",
+                    primaryTitle: "Open Link"
                 )
             case .production:
                 linkPrepView(
                     environment: .production,
                     icon: "lock.shield",
-                    title: "Use Production Credentials",
-                    summary: "Uses real Plaid production access. Production requires Plaid approval and will connect accounts with real financial data.",
-                    primaryTitle: "Open Production Link"
+                    title: "Connect Production",
+                    summary: "Real accounts with approved Plaid production credentials.",
+                    primaryTitle: "Open Link"
                 )
             case .connecting(let environment):
                 connectingView(environment: environment)
@@ -57,7 +57,7 @@ struct SetupView: View {
                         .font(.title2.weight(.bold))
                     Text("Menu bar finance, one click away.")
                         .font(.callout.weight(.medium))
-                    Text("Choose a data source before anything connects. Demo mode is local; sandbox and production require your local PlaidBarServer.")
+                    Text("Choose demo data or connect through your local PlaidBarServer.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -75,7 +75,7 @@ struct SetupView: View {
             VStack(spacing: Spacing.sm) {
                 OnboardingChoiceButton(
                     title: "View Demo",
-                    subtitle: "Local fixture data. No Plaid credentials or network calls.",
+                    subtitle: "Local sample data. No Plaid credentials.",
                     icon: "play.circle",
                     color: SemanticColors.brandSecondary
                 ) {
@@ -84,7 +84,7 @@ struct SetupView: View {
 
                 OnboardingChoiceButton(
                     title: "Connect Sandbox",
-                    subtitle: "Requires sandbox credentials on PlaidBarServer.",
+                    subtitle: "Plaid test institutions.",
                     icon: "testtube.2",
                     color: SemanticColors.brand
                 ) {
@@ -92,8 +92,8 @@ struct SetupView: View {
                 }
 
                 OnboardingChoiceButton(
-                    title: "Use Production Credentials",
-                    subtitle: "Requires Plaid approval. Connects real accounts.",
+                    title: "Connect Production",
+                    subtitle: "Approved Plaid access for real accounts.",
                     icon: "lock.shield",
                     color: SemanticColors.positive
                 ) {
@@ -131,15 +131,15 @@ struct SetupView: View {
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 StorageDisclosureRow(
                     icon: "externaldrive",
-                    text: "PlaidBar stores access tokens and synced account data locally under \(appState.activeStorageDirectoryDisplayText)."
+                    text: "Tokens and synced data stay local: \(appState.activeStorageDirectoryDisplayText)."
                 )
                 StorageDisclosureRow(
                     icon: "server.rack",
-                    text: "Plaid credentials stay in the local server environment, not in the menu bar app."
+                    text: "Plaid credentials stay in the local server environment."
                 )
                 StorageDisclosureRow(
                     icon: "eye.slash",
-                    text: "There is no PlaidBar cloud backend, analytics, or telemetry."
+                    text: "No PlaidBar cloud backend, analytics, or telemetry."
                 )
             }
             .padding(Spacing.md)
@@ -151,7 +151,7 @@ struct SetupView: View {
 
             if let error = appState.error {
                 SetupRecoveryCallout(
-                    title: "Setup needs attention",
+                    title: "Check setup",
                     detail: error,
                     icon: "exclamationmark.triangle.fill",
                     color: SemanticColors.negative
@@ -228,7 +228,7 @@ struct SetupView: View {
                         _ = await appState.connectForOnboarding(expectedEnvironment: environment)
                     }
                 } label: {
-                    Label("Open Link Again", systemImage: "link")
+                    Label("Open Link", systemImage: "link")
                 }
                 .buttonStyle(.bordered)
                 .disabled(appState.isLoading)
@@ -277,13 +277,13 @@ struct SetupView: View {
         case .openPlaidLink:
             "Waiting for Plaid Link"
         case .loadAccounts:
-            "Linked item found"
+            "Item linked"
         case .syncTransactions:
-            "Finish first sync"
+            "First sync"
         case .ready:
             "Dashboard ready"
         case .blocked:
-            "Connection needs attention"
+            "Check setup"
         }
     }
 
@@ -293,22 +293,22 @@ struct SetupView: View {
     ) -> String {
         switch completion.step {
         case .openPlaidLink:
-            "Complete the \(environment.rawValue) login in your browser, then check for the linked item."
+            "Finish Plaid Link in your browser, then check again."
         case .loadAccounts:
-            "PlaidBar found the linked institution. Load balances before opening the dashboard."
+            "Load balances before opening the dashboard."
         case .syncTransactions:
-            "Balances are loaded. Run the first transaction sync to complete onboarding."
+            "Run the first transaction sync to complete setup."
         case .ready:
-            "Setup checks passed. The dashboard can open now."
+            "Setup is complete."
         case .blocked:
-            "Resolve the issue below, then retry the setup check."
+            "Resolve the issue below, then check again."
         }
     }
 
     private func primaryCompletionActionTitle(for completion: FirstRunCompletionState) -> String {
         switch completion.step {
         case .openPlaidLink:
-            "Check for Linked Item"
+            "Check Again"
         case .loadAccounts:
             "Load Accounts"
         case .syncTransactions:
@@ -316,7 +316,7 @@ struct SetupView: View {
         case .ready:
             "Open Dashboard"
         case .blocked:
-            "Retry Setup Check"
+            "Check Again"
         }
     }
 

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -63,13 +63,28 @@ struct SecondaryUnavailableView: View {
             Label(presentation.title, systemImage: presentation.iconName)
         } description: {
             Text(presentation.detail)
+                .multilineTextAlignment(.center)
         } actions: {
-            Button(action: action) {
-                Label(presentation.actionTitle, systemImage: presentation.actionIconName)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
+            actionButton
         }
         .padding()
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        let button = Button(action: action) {
+            Label(presentation.actionTitle, systemImage: presentation.actionIconName)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .help(presentation.actionTitle)
+
+        if let hint = presentation.actionAccessibilityHint {
+            button.accessibilityHint(Text(hint))
+        } else {
+            button
+        }
     }
 }

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -27,6 +27,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
     public let action: SecondaryContentUnavailableAction
     public let actionTitle: String
     public let actionIconName: String
+    public let actionAccessibilityHint: String?
 
     public init(
         title: String,
@@ -34,7 +35,8 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         iconName: String,
         action: SecondaryContentUnavailableAction,
         actionTitle: String,
-        actionIconName: String
+        actionIconName: String,
+        actionAccessibilityHint: String? = nil
     ) {
         self.title = title
         self.detail = detail
@@ -42,6 +44,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         self.action = action
         self.actionTitle = actionTitle
         self.actionIconName = actionIconName
+        self.actionAccessibilityHint = actionAccessibilityHint
     }
 
     public static func accounts(
@@ -58,12 +61,13 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         }
 
         return SecondaryContentUnavailableState(
-            title: "No account data",
-            detail: "The server has linked items, but balances have not loaded yet. Refresh accounts to check for updated data.",
+            title: "Accounts not loaded",
+            detail: "PlaidBar found a linked bank, but no balances are available yet. Refresh accounts to load the latest balances.",
             iconName: "tray",
             action: .refreshAccounts,
             actionTitle: "Refresh Accounts",
-            actionIconName: "arrow.clockwise"
+            actionIconName: "arrow.clockwise",
+            actionAccessibilityHint: "Checks the server for account balances."
         )
     }
 
@@ -80,32 +84,35 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         if linkedItemCount == 0 {
             return SecondaryContentUnavailableState(
                 title: "No bank linked",
-                detail: "Connect a Plaid institution with a credit card to track utilization.",
+                detail: "Link a bank that includes a credit card before utilization can appear here.",
                 iconName: "creditcard",
                 action: .addAccount,
-                actionTitle: "Add Account",
-                actionIconName: "plus.circle"
+                actionTitle: "Link Bank",
+                actionIconName: "plus.circle",
+                actionAccessibilityHint: "Starts Plaid Link so you can connect a bank."
             )
         }
 
         if accountCount == 0 {
             return SecondaryContentUnavailableState(
-                title: "No account data",
-                detail: "The linked item has not loaded account balances yet. Refresh accounts before checking credit utilization.",
+                title: "Accounts not loaded",
+                detail: "A bank is linked, but balances have not loaded yet. Refresh accounts before checking credit utilization.",
                 iconName: "tray",
                 action: .refreshAccounts,
                 actionTitle: "Refresh Accounts",
-                actionIconName: "arrow.clockwise"
+                actionIconName: "arrow.clockwise",
+                actionAccessibilityHint: "Checks the server for account balances."
             )
         }
 
         return SecondaryContentUnavailableState(
-            title: "No credit accounts",
-            detail: "Your linked accounts do not include a credit card with utilization data.",
+            title: "No credit card linked",
+            detail: "Linked accounts do not include a credit card with utilization data. Link a credit card, or refresh if one was just added.",
             iconName: "creditcard",
             action: .addAccount,
-            actionTitle: "Add Credit Card",
-            actionIconName: "plus.circle"
+            actionTitle: "Link Credit Card",
+            actionIconName: "plus.circle",
+            actionAccessibilityHint: "Starts Plaid Link so you can connect a credit card."
         )
     }
 
@@ -123,11 +130,12 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         if hasSearchText || hasActiveFilters {
             return SecondaryContentUnavailableState(
                 title: "No matching transactions",
-                detail: "Synced history is loaded, but this search or filter set has no matches.",
+                detail: "Synced history is loaded, but nothing matches the current search or filters. Clear them to return to recent transactions.",
                 iconName: "magnifyingglass",
                 action: .clearFilters,
                 actionTitle: "Clear Filters",
-                actionIconName: "xmark.circle"
+                actionIconName: "xmark.circle",
+                actionAccessibilityHint: "Removes the current search text and filters."
             )
         }
 
@@ -145,33 +153,36 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
         if accountCount == 0 {
             return SecondaryContentUnavailableState(
-                title: "No account data",
-                detail: "The server has linked items, but balances have not loaded yet. Refresh accounts before syncing transaction history.",
+                title: "Accounts not loaded",
+                detail: "A bank is linked, but balances have not loaded yet. Refresh accounts before syncing transaction history.",
                 iconName: "tray",
                 action: .refreshAccounts,
                 actionTitle: "Refresh Accounts",
-                actionIconName: "arrow.clockwise"
+                actionIconName: "arrow.clockwise",
+                actionAccessibilityHint: "Checks the server for account balances."
             )
         }
 
         if syncedItemCount == 0 {
             return SecondaryContentUnavailableState(
                 title: "First sync needed",
-                detail: "Accounts are loaded, but no linked item has completed transaction sync yet.",
+                detail: "Accounts are loaded, but transaction history has not synced yet. Sync now to load recent activity.",
                 iconName: "clock.arrow.circlepath",
                 action: .syncTransactions,
                 actionTitle: "Sync Transactions",
-                actionIconName: "arrow.triangle.2.circlepath"
+                actionIconName: "arrow.triangle.2.circlepath",
+                actionAccessibilityHint: "Asks the server to sync transaction history."
             )
         }
 
         return SecondaryContentUnavailableState(
             title: transactionCount == 0 ? "No transaction history" : "No transactions",
-            detail: "No transaction rows are available for the linked accounts yet. Sync again to check for recent history.",
+            detail: "No transaction rows are available for the linked accounts. Sync again to check for new or recent history.",
             iconName: "list.bullet.rectangle",
             action: .syncTransactions,
             actionTitle: "Sync Transactions",
-            actionIconName: "arrow.triangle.2.circlepath"
+            actionIconName: "arrow.triangle.2.circlepath",
+            actionAccessibilityHint: "Asks the server to sync transaction history."
         )
     }
 
@@ -198,22 +209,24 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
         if accountCount == 0 {
             return SecondaryContentUnavailableState(
-                title: "No account data",
-                detail: "Balances have not loaded yet. Refresh accounts before syncing spending activity.",
+                title: "Accounts not loaded",
+                detail: "A bank is linked, but balances have not loaded yet. Refresh accounts before syncing spending activity.",
                 iconName: "tray",
                 action: .refreshAccounts,
                 actionTitle: "Refresh Accounts",
-                actionIconName: "arrow.clockwise"
+                actionIconName: "arrow.clockwise",
+                actionAccessibilityHint: "Checks the server for account balances."
             )
         }
 
         return SecondaryContentUnavailableState(
             title: syncedItemCount == 0 || transactionCount == 0 ? "No synced activity" : "No spending activity",
-            detail: "Sync transactions to build the spending heatmap, trend, and cashflow views.",
+            detail: "Spending views need synced transactions. Sync transaction history to build the heatmap, trend, and cashflow views.",
             iconName: "chart.bar.xaxis",
             action: .syncTransactions,
             actionTitle: "Sync Transactions",
-            actionIconName: "arrow.triangle.2.circlepath"
+            actionIconName: "arrow.triangle.2.circlepath",
+            actionAccessibilityHint: "Asks the server to sync transaction history."
         )
     }
 
@@ -224,12 +237,15 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         SecondaryContentUnavailableState(
             title: "No activity in \(periodLabel)",
             detail: canShowWiderPeriod
-                ? "No synced transactions fall inside this period. Choose a wider window to inspect older history."
-                : "No synced transactions fall inside this period. Refresh to check for the latest history.",
+                ? "No synced transactions fall inside this period. Show a wider window to inspect older history."
+                : "No synced transactions fall inside this period. Refresh to check for newly synced history.",
             iconName: "calendar.badge.clock",
             action: canShowWiderPeriod ? .showWiderPeriod : .refresh,
-            actionTitle: canShowWiderPeriod ? "Show 90D" : "Refresh",
-            actionIconName: canShowWiderPeriod ? "calendar" : "arrow.clockwise"
+            actionTitle: canShowWiderPeriod ? "Show 90 Days" : "Refresh",
+            actionIconName: canShowWiderPeriod ? "calendar" : "arrow.clockwise",
+            actionAccessibilityHint: canShowWiderPeriod
+                ? "Changes the spending period to 90 days."
+                : "Reloads the dashboard data."
         )
     }
 
@@ -256,33 +272,36 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
         if accountCount == 0 {
             return SecondaryContentUnavailableState(
-                title: "No account data",
-                detail: "Balances have not loaded yet. Refresh accounts before detecting recurring charges.",
+                title: "Accounts not loaded",
+                detail: "A bank is linked, but balances have not loaded yet. Refresh accounts before detecting recurring charges.",
                 iconName: "tray",
                 action: .refreshAccounts,
                 actionTitle: "Refresh Accounts",
-                actionIconName: "arrow.clockwise"
+                actionIconName: "arrow.clockwise",
+                actionAccessibilityHint: "Checks the server for account balances."
             )
         }
 
         if syncedItemCount == 0 || transactionCount == 0 {
             return SecondaryContentUnavailableState(
                 title: "No synced transactions",
-                detail: "Sync transaction history so PlaidBar can look for repeated charges.",
+                detail: "Recurring detection needs transaction history. Sync transactions so PlaidBar can look for repeated charges.",
                 iconName: "tray",
                 action: .syncTransactions,
                 actionTitle: "Sync Transactions",
-                actionIconName: "arrow.triangle.2.circlepath"
+                actionIconName: "arrow.triangle.2.circlepath",
+                actionAccessibilityHint: "Asks the server to sync transaction history."
             )
         }
 
         return SecondaryContentUnavailableState(
             title: "No recurring charges found",
-            detail: "PlaidBar needs repeated merchant charges, usually 2+ months of history, before it marks a charge as recurring.",
+            detail: "No repeated merchant charges were detected. PlaidBar usually needs at least 2 months of history before marking a charge as recurring.",
             iconName: "arrow.clockwise",
             action: .syncTransactions,
-            actionTitle: "Sync Latest",
-            actionIconName: "arrow.triangle.2.circlepath"
+            actionTitle: "Sync Latest Transactions",
+            actionIconName: "arrow.triangle.2.circlepath",
+            actionAccessibilityHint: "Checks for newer transactions that may complete a recurring pattern."
         )
     }
 
@@ -292,8 +311,9 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
             detail: detail,
             iconName: "server.rack",
             action: .checkServer,
-            actionTitle: "Check Server",
-            actionIconName: "server.rack"
+            actionTitle: "Check Connection",
+            actionIconName: "server.rack",
+            actionAccessibilityHint: "Checks whether PlaidBarServer is reachable."
         )
     }
 
@@ -303,8 +323,9 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
             detail: detail,
             iconName: "building.columns",
             action: .addAccount,
-            actionTitle: "Add Account",
-            actionIconName: "plus.circle"
+            actionTitle: "Link Bank",
+            actionIconName: "plus.circle",
+            actionAccessibilityHint: "Starts Plaid Link so you can connect a bank."
         )
     }
 
@@ -315,8 +336,9 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
             detail: detail,
             iconName: "exclamationmark.triangle.fill",
             action: .refresh,
-            actionTitle: "Refresh",
-            actionIconName: "arrow.clockwise"
+            actionTitle: "Try Again",
+            actionIconName: "arrow.clockwise",
+            actionAccessibilityHint: "Reloads the dashboard data."
         )
     }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1384,7 +1384,7 @@ struct PlaidBarCoreTests {
         #expect(offline.action == .checkServer)
         #expect(unlinked.title == "No bank linked")
         #expect(unlinked.action == .addAccount)
-        #expect(unloaded.title == "No account data")
+        #expect(unloaded.title == "Accounts not loaded")
         #expect(unloaded.action == .refreshAccounts)
     }
 
@@ -1403,11 +1403,11 @@ struct PlaidBarCoreTests {
             accountCount: 2
         )
 
-        #expect(noAccounts.title == "No account data")
+        #expect(noAccounts.title == "Accounts not loaded")
         #expect(noAccounts.action == .refreshAccounts)
-        #expect(noCredit.title == "No credit accounts")
+        #expect(noCredit.title == "No credit card linked")
         #expect(noCredit.action == .addAccount)
-        #expect(noCredit.actionTitle == "Add Credit Card")
+        #expect(noCredit.actionTitle == "Link Credit Card")
     }
 
     @Test("Secondary transaction empty state keeps recent error ahead of missing history")
@@ -1443,7 +1443,7 @@ struct PlaidBarCoreTests {
 
         #expect(state.title == "Server offline")
         #expect(state.action == .checkServer)
-        #expect(state.actionTitle == "Check Server")
+        #expect(state.actionTitle == "Check Connection")
     }
 
     @Test("Secondary spending period empty state widens before refresh")
@@ -1458,7 +1458,7 @@ struct PlaidBarCoreTests {
         )
 
         #expect(week.action == .showWiderPeriod)
-        #expect(week.actionTitle == "Show 90D")
+        #expect(week.actionTitle == "Show 90 Days")
         #expect(widest.action == .refresh)
         #expect(widest.actionTitle == "Refresh")
     }
@@ -1487,8 +1487,8 @@ struct PlaidBarCoreTests {
         #expect(noTransactions.title == "No synced transactions")
         #expect(noTransactions.action == .syncTransactions)
         #expect(noPattern.title == "No recurring charges found")
-        #expect(noPattern.detail.contains("2+ months"))
-        #expect(noPattern.actionTitle == "Sync Latest")
+        #expect(noPattern.detail.contains("2 months"))
+        #expect(noPattern.actionTitle == "Sync Latest Transactions")
     }
 
     @Test("Dashboard status readiness ignores blank recent action failures")


### PR DESCRIPTION
## Summary
- compacted the main menu bar popover and tightened dashboard spacing
- put the financial scan ahead of diagnostics while still elevating unhealthy states
- reduced healthy-state color noise and preserved semantic warning/error/debt colors
- tightened setup/settings copy and local-data action hierarchy
- clarified secondary empty/error states with action-oriented labels and accessibility hints

## Validation
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete