### PR TITLE
[codex] Improve production readiness dashboard recovery states

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -237,8 +237,9 @@ final class AppState {
 
     var menuBarAttentionText: String? {
         if isDemoMode { return nil }
+        if serverConnectionPresentation.attentionText == "Auth" { return "Auth" }
         if error != nil || erroredItemCount > 0 { return "Error" }
-        if !serverConnected { return "Offline" }
+        if let attentionText = serverConnectionPresentation.attentionText { return attentionText }
         if needsLoginItemCount > 0 { return "Login" }
         if isSyncStale { return lastSyncDate == nil ? "Never" : "Stale" }
         return nil
@@ -291,10 +292,7 @@ final class AppState {
     }
 
     var statusServerText: String {
-        if isDemoMode { return "Local demo" }
-        if isLoading { return "Syncing" }
-        if error != nil { return "Error" }
-        return serverConnected ? "Connected" : "Offline"
+        serverConnectionPresentation.statusText
     }
 
     var statusItemCount: Int {
@@ -391,12 +389,28 @@ final class AppState {
             if erroredItemCount > 0 { return "\(erroredItemCount) demo item\(erroredItemCount == 1 ? "" : "s") need attention" }
             if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(needsLoginItemCount == 1 ? "" : "s") need login" }
         }
-        if isDemoMode { return "Demo data loaded" }
-        if !serverConnected { return "Server offline" }
+        let serverPresentation = serverConnectionPresentation
+        if isDemoMode { return serverPresentation.diagnosticsSummary }
+        switch serverPresentation.issue {
+        case .offline, .localAuthMissing, .localAuthRejected:
+            return serverPresentation.diagnosticsSummary
+        case .demo, .syncing, .connected, .error:
+            break
+        }
         if statusItemCount == 0 { return "No Plaid items connected" }
         if erroredItemCount > 0 { return "\(erroredItemCount) item\(erroredItemCount == 1 ? "" : "s") need attention" }
         if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(needsLoginItemCount == 1 ? "" : "s") need login" }
+        if serverPresentation.issue == .error { return serverPresentation.diagnosticsSummary }
         return "Plaid connection healthy"
+    }
+
+    private var serverConnectionPresentation: ServerConnectionPresentation {
+        ServerConnectionPresentation.evaluate(
+            isDemoMode: isDemoMode,
+            isLoading: isLoading,
+            serverConnected: serverConnected,
+            errorMessage: error
+        )
     }
 
     var firstRunCompletionState: FirstRunCompletionState {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -441,6 +441,10 @@ final class AppState {
         )
     }
 
+    var usesDemoConnectionPresentation: Bool {
+        isDemoMode && !isDemoStatusRecoveryScenario
+    }
+
     var isSyncStale: Bool {
         guard let lastSyncDate else { return true }
         let staleAfter = max(refreshInterval * 2, PlaidBarConstants.transactionSyncInterval * 2)

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -504,6 +504,7 @@ final class AppState {
         do {
             let status = try await serverClient.getStatus()
             serverConnected = true
+            error = nil
             serverEnvironment = status.environment
             serverVersion = status.version
             serverItemCount = status.itemCount
@@ -527,6 +528,11 @@ final class AppState {
             serverSyncReady = nil
             serverSyncedItemCount = nil
             itemStatuses = []
+            if case ServerClientError.serverNotRunning = error {
+                self.error = nil
+            } else {
+                self.error = error.localizedDescription
+            }
             updateSetupCompletion()
         }
     }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -487,13 +487,15 @@ final class AppState {
     }
 
     func transactionsForAccount(_ accountId: String) -> [TransactionDTO] {
-        transactions.filter { $0.accountId == accountId }
-            .sorted { $0.date > $1.date }
+        AccountTransactionFeed.transactions(forAccountId: accountId, in: transactions)
     }
 
     func transactionsForMerchant(_ merchantName: String, excluding transactionId: String) -> [TransactionDTO] {
-        transactions.filter { $0.merchantName == merchantName && $0.id != transactionId }
-            .sorted { $0.date > $1.date }
+        AccountTransactionFeed.relatedMerchantTransactions(
+            merchantName: merchantName,
+            excluding: transactionId,
+            in: transactions
+        )
     }
 
     // MARK: - Actions

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -307,25 +307,39 @@ struct AccountSettingsView: View {
                                         .font(.headline)
 
                                     HStack(spacing: Spacing.xs) {
-                                        Image(systemName: icon(for: group.status))
-                                            .foregroundStyle(color(for: group.status))
-                                        Text(label(for: group.status))
-                                            .foregroundStyle(color(for: group.status))
+                                        Image(systemName: group.connection.iconName)
+                                            .foregroundStyle(color(for: group.connection.level))
+                                        Text(group.connection.signalLabel)
+                                            .foregroundStyle(color(for: group.connection.level))
                                         Text("\u{00B7}")
                                             .foregroundStyle(.tertiary)
                                         Text("\(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")")
                                             .foregroundStyle(.secondary)
+                                        if let itemSyncLabel = group.connection.itemSyncLabel {
+                                            Text("\u{00B7}")
+                                                .foregroundStyle(.tertiary)
+                                            Text(itemSyncLabel)
+                                                .foregroundStyle(.secondary)
+                                        }
                                     }
                                     .detailText()
+
+                                    if let recoveryDetailLabel = group.connection.recoveryDetailLabel {
+                                        Text(recoveryDetailLabel)
+                                            .detailText()
+                                            .foregroundStyle(.secondary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
                                 }
 
                                 Spacer()
 
-                                if group.status != .connected {
+                                if group.connection.showsRecoveryActions,
+                                   let recoveryActionTitle = group.connection.recoveryActionTitle {
                                     Button {
-                                        Task { await appState.reconnectItem(itemId: group.id) }
+                                        performRecoveryAction(for: group)
                                     } label: {
-                                        Label("Reconnect", systemImage: "link.badge.plus")
+                                        Label(recoveryActionTitle, systemImage: group.connection.level == .stale ? "arrow.clockwise" : "link.badge.plus")
                                     }
                                     .buttonStyle(.bordered)
                                 }
@@ -435,26 +449,40 @@ struct AccountSettingsView: View {
                 return AccountItemGroup(
                     id: itemId,
                     institutionName: institutionName,
-                    status: status?.status ?? .connected,
+                    connection: AccountConnectionPresentation.evaluate(
+                        isDemoMode: appState.usesDemoConnectionPresentation,
+                        serverConnected: appState.serverConnected,
+                        isSyncStale: appState.isSyncStale,
+                        statusSyncText: appState.statusSyncText,
+                        itemStatus: status?.status ?? .connected,
+                        institutionName: institutionName,
+                        itemLastSyncRelative: status?.lastSync.map(Formatters.relativeDate)
+                    ),
                     accounts: accounts.sorted { $0.name < $1.name }
                 )
             }
             .sorted { $0.institutionName < $1.institutionName }
     }
 
-    private func icon(for status: ItemConnectionStatus) -> String {
-        switch status {
-        case .connected: "checkmark.circle.fill"
-        case .loginRequired: "person.crop.circle.badge.exclamationmark"
-        case .error: "xmark.octagon.fill"
+    private func performRecoveryAction(for group: AccountItemGroup) {
+        switch group.connection.level {
+        case .stale:
+            Task { await appState.refreshDashboard() }
+        case .loginRequired, .error:
+            Task { await appState.reconnectItem(itemId: group.id) }
+        case .demo, .offline, .healthy, .unknown:
+            break
         }
     }
 
-    private func color(for status: ItemConnectionStatus) -> Color {
-        switch status {
-        case .connected: SemanticColors.positive
-        case .loginRequired: SemanticColors.warning
-        case .error: SemanticColors.negative
+    private func color(for level: AccountConnectionLevel) -> Color {
+        switch level {
+        case .healthy, .demo:
+            SemanticColors.positive
+        case .stale, .loginRequired, .unknown:
+            SemanticColors.warning
+        case .error, .offline:
+            SemanticColors.negative
         }
     }
 
@@ -480,26 +508,30 @@ struct AccountSettingsView: View {
     }
 
     private func groupAccessibilityLabel(for group: AccountItemGroup) -> String {
-        "\(group.institutionName), \(label(for: group.status)), \(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")"
+        var parts = [
+            group.institutionName,
+            group.connection.signalLabel,
+            "\(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")",
+        ]
+        if let itemSyncLabel = group.connection.itemSyncLabel {
+            parts.append(itemSyncLabel)
+        }
+        if let recoveryDetailLabel = group.connection.recoveryDetailLabel {
+            parts.append(recoveryDetailLabel)
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func accountAccessibilityLabel(for account: AccountDTO) -> String {
         "\(account.name), \(account.type.rawValue.capitalized), \(balanceText(for: account))"
     }
 
-    private func label(for status: ItemConnectionStatus) -> String {
-        switch status {
-        case .connected: "Connected"
-        case .loginRequired: "Login required"
-        case .error: "Error"
-        }
-    }
 }
 
 private struct AccountItemGroup: Identifiable {
     let id: String
     let institutionName: String
-    let status: ItemConnectionStatus
+    let connection: AccountConnectionPresentation
     let accounts: [AccountDTO]
 }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -129,7 +129,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Server database, Plaid item tokens, and sync cursors. Preferences, server.conf, and app/server auth stay in place.")
+                    Text("Reset removes PlaidBar database files, transaction caches, pending Link sessions, and stored Plaid access-token entries. Preferences, server.conf, app/server auth, and unrelated files stay in place.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
 
@@ -201,10 +201,11 @@ struct GeneralSettingsView: View {
     private func resetLocalData() {
         do {
             let result = try appState.resetLocalData()
+            let preservationText = preservedEntriesText(for: result)
             if result.removedEntryCount == 0 {
-                resetResultMessage = "No local data found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready. \(keychainResetText(for: result))"
+                resetResultMessage = "No local data found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready. \(keychainResetText(for: result))\(preservationText)"
             } else {
-                resetResultMessage = "Removed \(result.removedEntryCount) item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result)) Restart PlaidBarServer."
+                resetResultMessage = "Removed \(result.removedEntryCount) PlaidBar data item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result))\(preservationText) Restart PlaidBarServer."
             }
         } catch {
             resetErrorMessage = error.localizedDescription
@@ -223,6 +224,11 @@ struct GeneralSettingsView: View {
         result.keychainTokensCleared
             ? "Keychain token entries were cleared when present."
             : "Keychain token entries were not cleared."
+    }
+
+    private func preservedEntriesText(for result: LocalDataResetResult) -> String {
+        guard result.preservedEntryCount > 0 else { return "" }
+        return " Left \(result.preservedEntryCount) config or unrelated item\(result.preservedEntryCount == 1 ? "" : "s") untouched."
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1289,7 +1289,7 @@ private struct AccountRowWithDrilldown: View {
 
     private var connectionPresentation: AccountConnectionPresentation {
         AccountConnectionPresentation.evaluate(
-            isDemoMode: appState.isDemoMode,
+            isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
@@ -1308,7 +1308,7 @@ private struct DashboardEmptyAccountState: View {
     private var presentation: DashboardAccountEmptyState {
         DashboardAccountEmptyState.evaluate(
             filter: filter.emptyStateKind,
-            isDemoMode: appState.isDemoMode,
+            isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,
@@ -1538,7 +1538,7 @@ private struct DashboardAccountRow: View {
 
     private var connectionPresentation: AccountConnectionPresentation {
         AccountConnectionPresentation.evaluate(
-            isDemoMode: appState.isDemoMode && !appState.isDemoStatusRecoveryScenario,
+            isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,
@@ -1590,7 +1590,7 @@ private struct SelectedAccountPanel: View {
     private var emptyState: AccountActivityEmptyState? {
         AccountActivityEmptyState.evaluate(
             transactionCount: accountTransactions.count,
-            isDemoMode: appState.isDemoMode && !appState.isDemoStatusRecoveryScenario,
+            isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             connectionLevel: connectionPresentation.level,
             accountDisplayName: AccountPresentation.displayName(for: account)
@@ -1763,7 +1763,7 @@ private struct SelectedAccountPanel: View {
 
     private var connectionPresentation: AccountConnectionPresentation {
         AccountConnectionPresentation.evaluate(
-            isDemoMode: appState.isDemoMode,
+            isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             isSyncStale: appState.isSyncStale,
             statusSyncText: appState.statusSyncText,

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1313,7 +1313,8 @@ private struct DashboardEmptyAccountState: View {
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,
             degradedItemCount: appState.needsLoginItemCount + appState.erroredItemCount,
-            degradedItemRecoveryTitle: ItemRecoveryTarget.actionTitle(from: appState.itemStatuses)
+            degradedItemRecoveryTitle: ItemRecoveryTarget.actionTitle(from: appState.itemStatuses),
+            degradedItemRecoveryDetail: ItemRecoveryTarget.recoveryDetail(from: appState.itemStatuses)
         )
     }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1587,6 +1587,16 @@ private struct SelectedAccountPanel: View {
         AccountActivitySummary.recent(from: accountTransactions)
     }
 
+    private var emptyState: AccountActivityEmptyState? {
+        AccountActivityEmptyState.evaluate(
+            transactionCount: accountTransactions.count,
+            isDemoMode: appState.isDemoMode && !appState.isDemoStatusRecoveryScenario,
+            serverConnected: appState.serverConnected,
+            connectionLevel: connectionPresentation.level,
+            accountDisplayName: AccountPresentation.displayName(for: account)
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
@@ -1705,9 +1715,9 @@ private struct SelectedAccountPanel: View {
                     .foregroundStyle(.secondary)
 
                 if transactions.isEmpty {
-                    Text("No recent activity for this account.")
-                        .detailText()
-                        .padding(.vertical, 10)
+                    if let emptyState {
+                        AccountActivityEmptyStateView(presentation: emptyState)
+                    }
                 } else {
                     ForEach(transactions) { transaction in
                         TransactionMiniRow(transaction: transaction)
@@ -1933,6 +1943,47 @@ private struct TransactionMiniRow: View {
     private var accessibilityLabel: String {
         let direction = transaction.isIncome ? "income" : "outflow"
         return "\(transaction.displayName), \(direction), \(Formatters.currency(transaction.displayAmount, format: .full)), \(Formatters.displayTransactionDate(transaction.date))"
+    }
+}
+
+private struct AccountActivityEmptyStateView: View {
+    let presentation: AccountActivityEmptyState
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: presentation.iconName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 18, height: 18)
+                .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(presentation.title)
+                    .font(.caption.weight(.semibold))
+                Text(presentation.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .background(tint.opacity(0.06), in: RoundedRectangle(cornerRadius: 7))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var tint: Color {
+        switch presentation.tone {
+        case .brand:
+            SemanticColors.brand
+        case .healthy:
+            .secondary
+        case .offline, .secondary:
+            .secondary
+        case .warning:
+            SemanticColors.warning
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public struct AccountActivityEmptyState: Equatable, Sendable {
+    public let title: String
+    public let detail: String
+    public let iconName: String
+    public let tone: DashboardAccountEmptyStateTone
+
+    public init(
+        title: String,
+        detail: String,
+        iconName: String,
+        tone: DashboardAccountEmptyStateTone
+    ) {
+        self.title = title
+        self.detail = detail
+        self.iconName = iconName
+        self.tone = tone
+    }
+
+    public static func evaluate(
+        transactionCount: Int,
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        connectionLevel: AccountConnectionLevel,
+        accountDisplayName: String
+    ) -> AccountActivityEmptyState? {
+        guard transactionCount == 0 else { return nil }
+
+        if isDemoMode {
+            return AccountActivityEmptyState(
+                title: "No demo activity",
+                detail: "\(accountDisplayName) has no sample transactions in the local demo fixture.",
+                iconName: "play.circle",
+                tone: .secondary
+            )
+        }
+
+        guard serverConnected else {
+            return AccountActivityEmptyState(
+                title: "Server offline",
+                detail: "Start PlaidBarServer, then refresh to load recent activity for \(accountDisplayName).",
+                iconName: "server.rack",
+                tone: .offline
+            )
+        }
+
+        switch connectionLevel {
+        case .loginRequired:
+            return AccountActivityEmptyState(
+                title: "Reconnect to sync activity",
+                detail: "Plaid needs a fresh bank login before PlaidBar can update transactions for \(accountDisplayName).",
+                iconName: "person.crop.circle.badge.exclamationmark",
+                tone: .warning
+            )
+        case .error:
+            return AccountActivityEmptyState(
+                title: "Item error blocks activity",
+                detail: "Reconnect this institution, then refresh transactions for \(accountDisplayName).",
+                iconName: "exclamationmark.triangle.fill",
+                tone: .warning
+            )
+        case .stale:
+            return AccountActivityEmptyState(
+                title: "Activity may be stale",
+                detail: "Refresh PlaidBar to pull the latest transactions for \(accountDisplayName).",
+                iconName: "clock.badge.exclamationmark",
+                tone: .warning
+            )
+        case .unknown:
+            return AccountActivityEmptyState(
+                title: "Item status unavailable",
+                detail: "Refresh account status before trusting activity for \(accountDisplayName).",
+                iconName: "link.circle",
+                tone: .secondary
+            )
+        case .demo, .offline:
+            return AccountActivityEmptyState(
+                title: "No recent activity",
+                detail: "\(accountDisplayName) has no recent synced transactions.",
+                iconName: "tray",
+                tone: .secondary
+            )
+        case .healthy:
+            return AccountActivityEmptyState(
+                title: "No recent activity",
+                detail: "\(accountDisplayName) is linked, but no recent transactions are synced for this account.",
+                iconName: "tray",
+                tone: .healthy
+            )
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -81,7 +81,8 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         linkedItemCount: Int,
         accountCount: Int,
         degradedItemCount: Int,
-        degradedItemRecoveryTitle: String? = nil
+        degradedItemRecoveryTitle: String? = nil,
+        degradedItemRecoveryDetail: String? = nil
     ) -> DashboardAccountEmptyState {
         if !isDemoMode, !serverConnected {
             return DashboardAccountEmptyState(
@@ -112,7 +113,7 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         if filter == .status, degradedItemCount > 0 {
             return DashboardAccountEmptyState(
                 title: "\(degradedItemCount) item\(degradedItemCount == 1 ? "" : "s") \(degradedItemCount == 1 ? "needs" : "need") attention",
-                detail: "A linked institution needs recovery, but no matching account rows are loaded. Reconnect the item from here, then refresh balances.",
+                detail: degradedItemRecoveryDetail ?? "A linked institution needs recovery, but no matching account rows are loaded. Reconnect the item from here, then refresh balances.",
                 iconName: "exclamationmark.triangle.fill",
                 tone: .warning,
                 showsAddAccount: false,

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -67,6 +67,16 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             )
         }
 
+        if let authError = localServerAuthError(from: errorMessage) {
+            return DashboardStatusReadiness(
+                level: .blocked,
+                title: authError.title,
+                detail: authError.detail,
+                primaryAction: .openSettings,
+                secondaryActions: [.checkServer]
+            )
+        }
+
         if !serverConnected {
             return DashboardStatusReadiness(
                 level: .blocked,
@@ -187,6 +197,31 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             primaryActionTitle: "Refresh Data",
             secondaryActions: [.addAccount]
         )
+    }
+
+    private static func localServerAuthError(from message: String?) -> (title: String, detail: String)? {
+        guard let message else { return nil }
+        let normalized = message
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
+
+        if normalized.contains("auth token is unavailable") {
+            return (
+                "Local server auth missing",
+                "PlaidBar cannot read the local app-server auth token. Restart PlaidBarServer, then check the connection again."
+            )
+        }
+
+        if normalized.contains("plaidbar server returned 401") ||
+            normalized.contains("plaidbar server returned 403") {
+            return (
+                "Local server auth rejected",
+                "PlaidBar reached the local server, but the app-server auth token was rejected. Restart PlaidBarServer so the local token is regenerated."
+            )
+        }
+
+        return nil
     }
 
     private static func userFacingErrorDetail(from message: String?) -> String? {

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -127,7 +127,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         hasActiveFilters: Bool,
         errorMessage: String?
     ) -> SecondaryContentUnavailableState {
-        if hasSearchText || hasActiveFilters {
+        if transactionCount > 0, hasSearchText || hasActiveFilters {
             return SecondaryContentUnavailableState(
                 title: "No matching transactions",
                 detail: "Synced history is loaded, but nothing matches the current search or filters. Clear them to return to recent transactions.",

--- a/Sources/PlaidBarCore/Utilities/AccountActivitySummary.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountActivitySummary.swift
@@ -23,17 +23,18 @@ public struct AccountActivitySummary: Sendable, Equatable {
 
     public static func recent(
         from transactions: [TransactionDTO],
-        now: Date = Date(),
+        now: Date? = nil,
         calendar: Calendar = .current,
         days: Int = 30
     ) -> AccountActivitySummary {
+        let referenceDate = now ?? latestTransactionDate(in: transactions) ?? Date()
         let startDate = calendar.startOfDay(
-            for: calendar.date(byAdding: .day, value: -(days - 1), to: now) ?? now
+            for: calendar.date(byAdding: .day, value: -(days - 1), to: referenceDate) ?? referenceDate
         )
 
         let recentTransactions = transactions.filter { transaction in
             guard let date = Formatters.parseTransactionDate(transaction.date) else { return false }
-            return date >= startDate && date <= now
+            return date >= startDate && date <= referenceDate
         }
 
         var inflowTotal = 0.0
@@ -54,6 +55,12 @@ public struct AccountActivitySummary: Sendable, Equatable {
             outflowTotal: outflowTotal,
             days: days
         )
+    }
+
+    private static func latestTransactionDate(in transactions: [TransactionDTO]) -> Date? {
+        transactions
+            .compactMap { Formatters.parseTransactionDate($0.date) }
+            .max()
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public enum AccountTransactionFeed {
+    public static func transactions(
+        forAccountId accountId: String,
+        in transactions: [TransactionDTO]
+    ) -> [TransactionDTO] {
+        sortedForFeed(transactions.filter { $0.accountId == accountId })
+    }
+
+    public static func relatedMerchantTransactions(
+        merchantName: String,
+        excluding transactionId: String,
+        in transactions: [TransactionDTO]
+    ) -> [TransactionDTO] {
+        sortedForFeed(
+            transactions.filter {
+                $0.merchantName == merchantName && $0.id != transactionId
+            }
+        )
+    }
+
+    public static func sortedForFeed(_ transactions: [TransactionDTO]) -> [TransactionDTO] {
+        transactions.sorted(by: isPreferredInFeed)
+    }
+
+    private static func isPreferredInFeed(_ lhs: TransactionDTO, _ rhs: TransactionDTO) -> Bool {
+        let lhsDate = Formatters.parseTransactionDate(lhs.date) ?? .distantPast
+        let rhsDate = Formatters.parseTransactionDate(rhs.date) ?? .distantPast
+        if lhsDate != rhsDate {
+            return lhsDate > rhsDate
+        }
+
+        if lhs.pending != rhs.pending {
+            return lhs.pending
+        }
+
+        if lhs.displayAmount != rhs.displayAmount {
+            return lhs.displayAmount > rhs.displayAmount
+        }
+
+        let nameComparison = lhs.displayName.localizedStandardCompare(rhs.displayName)
+        if nameComparison != .orderedSame {
+            return nameComparison == .orderedAscending
+        }
+
+        return lhs.id < rhs.id
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
+++ b/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
@@ -12,9 +12,34 @@ public enum ItemRecoveryTarget {
 
     public static func actionTitle(from statuses: [ItemStatus]) -> String? {
         guard let item = item(from: statuses) else { return nil }
-        guard let institutionName = item.institutionName, !institutionName.isEmpty else {
+        guard let institutionName = normalizedInstitutionName(item.institutionName) else {
             return "Reconnect Item"
         }
         return "Reconnect \(institutionName)"
+    }
+
+    public static func recoveryDetail(from statuses: [ItemStatus]) -> String? {
+        guard let item = item(from: statuses) else { return nil }
+
+        switch item.status {
+        case .loginRequired:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "Plaid requires a fresh \(institutionName) login before account rows can be recovered."
+            }
+            return "Plaid requires a fresh bank login before account rows can be recovered."
+        case .error:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "Plaid reported an item error for \(institutionName). Reconnect it, then refresh balances."
+            }
+            return "Plaid reported an item error. Reconnect the item, then refresh balances."
+        case .connected:
+            return nil
+        }
+    }
+
+    private static func normalizedInstitutionName(_ institutionName: String?) -> String? {
+        guard let institutionName else { return nil }
+        let trimmed = institutionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -9,19 +9,26 @@ import Darwin
 public struct LocalDataResetResult: Equatable, Sendable {
     public let directoryPath: String
     public let removedEntries: [String]
+    public let preservedEntries: [String]
     public let keychainTokensCleared: Bool
 
     public var removedEntryCount: Int {
         removedEntries.count
     }
 
+    public var preservedEntryCount: Int {
+        preservedEntries.count
+    }
+
     public init(
         directoryPath: String,
         removedEntries: [String],
+        preservedEntries: [String] = [],
         keychainTokensCleared: Bool
     ) {
         self.directoryPath = directoryPath
         self.removedEntries = removedEntries
+        self.preservedEntries = preservedEntries
         self.keychainTokensCleared = keychainTokensCleared
     }
 }
@@ -42,6 +49,7 @@ public enum LocalDataStore {
     public static let authTokenFilename = "auth-token"
     public static let serverConfigFilename = "server.conf"
     public static let transactionCacheFilename = "transactions.json"
+    public static let pendingLinkSessionsFilename = "pending-link-sessions.json"
     public static let plaidAccessTokenKeychainService = "PlaidBar.PlaidAccessToken"
     private static let directoryPermissions = 0o700
     private static let cacheFilePermissions = 0o600
@@ -115,6 +123,7 @@ public enum LocalDataStore {
         keychainTokenReset: (() throws -> Void)? = nil
     ) throws -> LocalDataResetResult {
         var removedEntries: [String] = []
+        var preservedEntries: [String] = []
         var isDirectory: ObjCBool = false
 
         if fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory) {
@@ -123,11 +132,18 @@ public enum LocalDataStore {
                     at: directory,
                     includingPropertiesForKeys: nil
                 )
-                for entry in entries where !resetPreservedFilenames.contains(entry.lastPathComponent) {
-                    try fileManager.removeItem(at: entry)
-                    removedEntries.append(entry.lastPathComponent)
+                for entry in entries {
+                    let filename = entry.lastPathComponent
+                    if shouldRemoveDuringReset(filename) {
+                        try fileManager.removeItem(at: entry)
+                        removedEntries.append(filename)
+                    } else {
+                        preservedEntries.append(filename)
+                    }
                 }
                 removedEntries = removedEntries
+                    .sorted()
+                preservedEntries = preservedEntries
                     .sorted()
             } else {
                 removedEntries = [directory.lastPathComponent]
@@ -147,15 +163,52 @@ public enum LocalDataStore {
         return LocalDataResetResult(
             directoryPath: directory.path,
             removedEntries: removedEntries,
+            preservedEntries: preservedEntries,
             keychainTokensCleared: keychainTokensCleared
         )
     }
 
+    private static func shouldRemoveDuringReset(_ filename: String) -> Bool {
+        if resetPreservedFilenames.contains(filename) {
+            return false
+        }
+
+        if isTransactionCacheFilename(filename) ||
+            filename == pendingLinkSessionsFilename {
+            return true
+        }
+
+        return plaidBarDatabaseFilenames.contains { databaseFilename in
+            filename == databaseFilename ||
+                sqliteSidecarSuffixes.contains { filename == databaseFilename + $0 } ||
+                filename.hasPrefix(databaseFilename + ".backup-") ||
+                filename.hasPrefix(databaseFilename + ".migration-") ||
+                filename == databaseFilename + ".migrated-from-legacy"
+        }
+    }
+
     private static var resetPreservedFilenames: Set<String> {
+        [authTokenFilename, serverConfigFilename]
+    }
+
+    private static var plaidBarDatabaseFilenames: [String] {
         [
-            authTokenFilename,
-            serverConfigFilename,
+            "plaidbar.sqlite",
+            "plaidbar-sandbox.sqlite",
+            "plaidbar-production.sqlite",
         ]
+    }
+
+    private static var sqliteSidecarSuffixes: [String] {
+        ["-wal", "-shm", "-journal"]
+    }
+
+    private static func isTransactionCacheFilename(_ filename: String) -> Bool {
+        filename == transactionCacheFilename ||
+            (
+                filename.hasPrefix("transactions-") &&
+                    (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
+            )
     }
 
     private static func resetPlaidAccessTokenKeychainItems() throws {

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -174,7 +174,7 @@ public enum LocalDataStore {
         }
 
         if isTransactionCacheFilename(filename) ||
-            filename == pendingLinkSessionsFilename {
+            isPendingLinkSessionsFilename(filename) {
             return true
         }
 
@@ -209,6 +209,11 @@ public enum LocalDataStore {
                 filename.hasPrefix("transactions-") &&
                     (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
             )
+    }
+
+    private static func isPendingLinkSessionsFilename(_ filename: String) -> Bool {
+        filename == pendingLinkSessionsFilename ||
+            filename.hasPrefix(pendingLinkSessionsFilename + ".backup-")
     }
 
     private static func resetPlaidAccessTokenKeychainItems() throws {

--- a/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+public enum ServerConnectionIssue: Sendable, Equatable {
+    case demo
+    case syncing
+    case connected
+    case offline
+    case localAuthMissing
+    case localAuthRejected
+    case error
+}
+
+public struct ServerConnectionPresentation: Sendable, Equatable {
+    public let issue: ServerConnectionIssue
+    public let statusText: String
+    public let diagnosticsSummary: String
+    public let attentionText: String?
+
+    public init(
+        issue: ServerConnectionIssue,
+        statusText: String,
+        diagnosticsSummary: String,
+        attentionText: String? = nil
+    ) {
+        self.issue = issue
+        self.statusText = statusText
+        self.diagnosticsSummary = diagnosticsSummary
+        self.attentionText = attentionText
+    }
+
+    public static func evaluate(
+        isDemoMode: Bool,
+        isLoading: Bool,
+        serverConnected: Bool,
+        errorMessage: String?
+    ) -> ServerConnectionPresentation {
+        if isDemoMode {
+            return ServerConnectionPresentation(
+                issue: .demo,
+                statusText: "Local demo",
+                diagnosticsSummary: "Demo data loaded"
+            )
+        }
+
+        if let authIssue = localAuthIssue(from: errorMessage) {
+            return authIssue
+        }
+
+        if isLoading {
+            return ServerConnectionPresentation(
+                issue: .syncing,
+                statusText: "Syncing",
+                diagnosticsSummary: "Plaid sync in progress"
+            )
+        }
+
+        if let errorMessage, !errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ServerConnectionPresentation(
+                issue: .error,
+                statusText: "Error",
+                diagnosticsSummary: "Recent action failed",
+                attentionText: "Error"
+            )
+        }
+
+        guard serverConnected else {
+            return ServerConnectionPresentation(
+                issue: .offline,
+                statusText: "Offline",
+                diagnosticsSummary: "Server offline",
+                attentionText: "Offline"
+            )
+        }
+
+        return ServerConnectionPresentation(
+            issue: .connected,
+            statusText: "Connected",
+            diagnosticsSummary: "Server connected"
+        )
+    }
+
+    private static func localAuthIssue(from message: String?) -> ServerConnectionPresentation? {
+        guard let message else { return nil }
+        let normalized = message
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
+
+        if normalized.contains("auth token is unavailable") {
+            return ServerConnectionPresentation(
+                issue: .localAuthMissing,
+                statusText: "Auth missing",
+                diagnosticsSummary: "Local server auth missing",
+                attentionText: "Auth"
+            )
+        }
+
+        if normalized.contains("plaidbar server returned 401") ||
+            normalized.contains("plaidbar server returned 403") {
+            return ServerConnectionPresentation(
+                issue: .localAuthRejected,
+                statusText: "Auth rejected",
+                diagnosticsSummary: "Local server auth rejected",
+                attentionText: "Auth"
+            )
+        }
+
+        return nil
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1331,6 +1331,56 @@ struct PlaidBarCoreTests {
         #expect(readiness.primaryActionTitle == "Connect Bank")
     }
 
+    @Test("Server connection presentation labels local auth failures")
+    func serverConnectionPresentationLabelsLocalAuthFailures() {
+        let missing = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: "PlaidBar server auth token is unavailable"
+        )
+        let rejected = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "PlaidBar server returned 403: forbidden"
+        )
+
+        #expect(missing.issue == .localAuthMissing)
+        #expect(missing.statusText == "Auth missing")
+        #expect(missing.diagnosticsSummary == "Local server auth missing")
+        #expect(missing.attentionText == "Auth")
+        #expect(rejected.issue == .localAuthRejected)
+        #expect(rejected.statusText == "Auth rejected")
+        #expect(rejected.diagnosticsSummary == "Local server auth rejected")
+        #expect(rejected.attentionText == "Auth")
+    }
+
+    @Test("Server connection presentation distinguishes offline and generic errors")
+    func serverConnectionPresentationDistinguishesOfflineAndGenericErrors() {
+        let offline = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil
+        )
+        let genericError = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "PlaidBar server returned 500: internal server error"
+        )
+
+        #expect(offline.issue == .offline)
+        #expect(offline.statusText == "Offline")
+        #expect(offline.diagnosticsSummary == "Server offline")
+        #expect(offline.attentionText == "Offline")
+        #expect(genericError.issue == .error)
+        #expect(genericError.statusText == "Error")
+        #expect(genericError.diagnosticsSummary == "Recent action failed")
+        #expect(genericError.attentionText == "Error")
+    }
+
     @Test("Dashboard status readiness surfaces recent action failure before empty data")
     func dashboardStatusReadinessSurfacesRecentActionFailureBeforeEmptyData() {
         let readiness = DashboardStatusReadiness.evaluate(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -677,6 +677,30 @@ struct PlaidBarCoreTests {
         #expect(errored.recoveryActionTitle == "Reconnect American Express")
     }
 
+    @Test("Item recovery target prioritizes item errors")
+    func itemRecoveryTargetPrioritizesItemErrors() {
+        let statuses = [
+            ItemStatus(id: "login", institutionName: "Chase", status: .loginRequired),
+            ItemStatus(id: "error", institutionName: "Amex", status: .error),
+        ]
+
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "error")
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == "Reconnect Amex")
+        #expect(ItemRecoveryTarget.recoveryDetail(from: statuses) == "Plaid reported an item error for Amex. Reconnect it, then refresh balances.")
+    }
+
+    @Test("Item recovery target explains login required recovery")
+    func itemRecoveryTargetExplainsLoginRequiredRecovery() {
+        let statuses = [
+            ItemStatus(id: "connected", institutionName: "Bank", status: .connected),
+            ItemStatus(id: "login", institutionName: " Chase ", status: .loginRequired),
+        ]
+
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "login")
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == "Reconnect Chase")
+        #expect(ItemRecoveryTarget.recoveryDetail(from: statuses) == "Plaid requires a fresh Chase login before account rows can be recovered.")
+    }
+
     @Test("Menu bar summary estimates runway from recent monthly spend")
     func menuBarSummaryRunwayMonths() {
         let now = Formatters.parseTransactionDate("2026-01-30")!
@@ -1443,11 +1467,12 @@ struct PlaidBarCoreTests {
             linkedItemCount: 1,
             accountCount: 3,
             degradedItemCount: 1,
-            degradedItemRecoveryTitle: "Reconnect Chase"
+            degradedItemRecoveryTitle: "Reconnect Chase",
+            degradedItemRecoveryDetail: "Plaid requires a fresh Chase login before account rows can be recovered."
         )
 
         #expect(emptyState.title == "1 item needs attention")
-        #expect(emptyState.detail.contains("needs recovery"))
+        #expect(emptyState.detail == "Plaid requires a fresh Chase login before account rows can be recovered.")
         #expect(emptyState.iconName == "exclamationmark.triangle.fill")
         #expect(emptyState.tone == .warning)
         #expect(!emptyState.showsAddAccount)

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1561,6 +1561,25 @@ struct PlaidBarCoreTests {
         #expect(state.actionTitle == "Clear Filters")
     }
 
+    @Test("Secondary transaction empty state does not blame filters before history exists")
+    func secondaryTransactionEmptyStateNeedsHistoryBeforeFilteredZero() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            hasSearchText: true,
+            hasActiveFilters: true,
+            errorMessage: nil
+        )
+
+        #expect(state.title == "First sync needed")
+        #expect(state.action == .syncTransactions)
+        #expect(state.actionTitle == "Sync Transactions")
+    }
+
     @Test("Secondary accounts empty state distinguishes offline linked and unloaded data")
     func secondaryAccountsEmptyStateDistinguishesRecovery() {
         let offline = SecondaryContentUnavailableState.accounts(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2295,6 +2295,7 @@ struct PlaidBarCoreTests {
         let databaseWAL = directory.appendingPathComponent("plaidbar.sqlite-wal")
         let transactionCache = directory.appendingPathComponent("transactions-sandbox-abc123.json")
         let pendingLinkSessions = directory.appendingPathComponent("pending-link-sessions.json")
+        let pendingLinkSessionsBackup = directory.appendingPathComponent("pending-link-sessions.json.backup-20260604")
         let authToken = directory.appendingPathComponent("auth-token")
         let serverConfig = directory.appendingPathComponent("server.conf")
         let unrelatedFile = directory.appendingPathComponent("notes.txt")
@@ -2306,6 +2307,7 @@ struct PlaidBarCoreTests {
         try "wal".write(to: databaseWAL, atomically: true, encoding: .utf8)
         try "cache".write(to: transactionCache, atomically: true, encoding: .utf8)
         try "sessions".write(to: pendingLinkSessions, atomically: true, encoding: .utf8)
+        try "old sessions".write(to: pendingLinkSessionsBackup, atomically: true, encoding: .utf8)
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
         try "PLAID_ENV=sandbox".write(to: serverConfig, atomically: true, encoding: .utf8)
         try "keep me".write(to: unrelatedFile, atomically: true, encoding: .utf8)
@@ -2322,6 +2324,7 @@ struct PlaidBarCoreTests {
         #expect(result.directoryPath == directory.path)
         #expect(result.removedEntries == [
             "pending-link-sessions.json",
+            "pending-link-sessions.json.backup-20260604",
             "plaidbar-sandbox.sqlite",
             "plaidbar.sqlite",
             "plaidbar.sqlite-wal",

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -129,6 +129,64 @@ struct PlaidBarCoreTests {
         #expect(feed.map(\.id) == ["pending", "old"])
     }
 
+    @Test("Account activity empty state is nil when transactions exist")
+    func accountActivityEmptyStateNilWithTransactions() {
+        let presentation = AccountActivityEmptyState.evaluate(
+            transactionCount: 1,
+            isDemoMode: false,
+            serverConnected: true,
+            connectionLevel: .healthy,
+            accountDisplayName: "Chase Checking"
+        )
+
+        #expect(presentation == nil)
+    }
+
+    @Test("Account activity empty state explains offline server")
+    func accountActivityEmptyStateOfflineServer() {
+        let presentation = AccountActivityEmptyState.evaluate(
+            transactionCount: 0,
+            isDemoMode: false,
+            serverConnected: false,
+            connectionLevel: .offline,
+            accountDisplayName: "Chase Checking"
+        )
+
+        #expect(presentation?.title == "Server offline")
+        #expect(presentation?.tone == .offline)
+        #expect(presentation?.detail.contains("Start PlaidBarServer") == true)
+    }
+
+    @Test("Account activity empty state explains login recovery")
+    func accountActivityEmptyStateLoginRecovery() {
+        let presentation = AccountActivityEmptyState.evaluate(
+            transactionCount: 0,
+            isDemoMode: false,
+            serverConnected: true,
+            connectionLevel: .loginRequired,
+            accountDisplayName: "Amex Gold"
+        )
+
+        #expect(presentation?.title == "Reconnect to sync activity")
+        #expect(presentation?.tone == .warning)
+        #expect(presentation?.detail.contains("fresh bank login") == true)
+    }
+
+    @Test("Account activity empty state explains healthy no history")
+    func accountActivityEmptyStateHealthyNoHistory() {
+        let presentation = AccountActivityEmptyState.evaluate(
+            transactionCount: 0,
+            isDemoMode: false,
+            serverConnected: true,
+            connectionLevel: .healthy,
+            accountDisplayName: "Savings"
+        )
+
+        #expect(presentation?.title == "No recent activity")
+        #expect(presentation?.tone == .healthy)
+        #expect(presentation?.detail.contains("linked") == true)
+    }
+
     @Test("TransactionDTO preserves item ID when encoded")
     func transactionItemIdCodable() throws {
         let tx = TransactionDTO(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -84,6 +84,51 @@ struct PlaidBarCoreTests {
         #expect(tx.displayAmount == 0)
     }
 
+    @Test("Account transaction feed sorts latest first with pending tie-breaker")
+    func accountTransactionFeedSortsLatestFirstWithPendingTieBreaker() {
+        let transactions = [
+            TransactionDTO(id: "old", accountId: "checking", amount: 10, date: "2026-01-13", name: "Old"),
+            TransactionDTO(id: "other", accountId: "credit", amount: 999, date: "2026-01-16", name: "Other"),
+            TransactionDTO(id: "posted-small", accountId: "checking", amount: 20, date: "2026-01-15", name: "Posted Small"),
+            TransactionDTO(id: "pending", accountId: "checking", amount: 30, date: "2026-01-15", name: "Pending", pending: true),
+            TransactionDTO(id: "posted-large", accountId: "checking", amount: 50, date: "2026-01-15", name: "Posted Large"),
+        ]
+
+        let feed = AccountTransactionFeed.transactions(forAccountId: "checking", in: transactions)
+
+        #expect(feed.map(\.id) == ["pending", "posted-large", "posted-small", "old"])
+    }
+
+    @Test("Account transaction feed keeps invalid dates behind dated transactions")
+    func accountTransactionFeedKeepsInvalidDatesBehindDatedTransactions() {
+        let transactions = [
+            TransactionDTO(id: "invalid", accountId: "checking", amount: 10, date: "not-a-date", name: "Invalid"),
+            TransactionDTO(id: "dated", accountId: "checking", amount: 20, date: "2026-01-15", name: "Dated"),
+        ]
+
+        let feed = AccountTransactionFeed.transactions(forAccountId: "checking", in: transactions)
+
+        #expect(feed.map(\.id) == ["dated", "invalid"])
+    }
+
+    @Test("Account transaction feed sorts related merchant transactions")
+    func accountTransactionFeedSortsRelatedMerchantTransactions() {
+        let transactions = [
+            TransactionDTO(id: "current", accountId: "a", amount: 20, date: "2026-01-15", name: "Current", merchantName: "Netflix"),
+            TransactionDTO(id: "old", accountId: "a", amount: 20, date: "2026-01-13", name: "Old", merchantName: "Netflix"),
+            TransactionDTO(id: "pending", accountId: "a", amount: 20, date: "2026-01-14", name: "Pending", merchantName: "Netflix", pending: true),
+            TransactionDTO(id: "other", accountId: "a", amount: 20, date: "2026-01-16", name: "Other", merchantName: "Spotify"),
+        ]
+
+        let feed = AccountTransactionFeed.relatedMerchantTransactions(
+            merchantName: "Netflix",
+            excluding: "current",
+            in: transactions
+        )
+
+        #expect(feed.map(\.id) == ["pending", "old"])
+    }
+
     @Test("TransactionDTO preserves item ID when encoded")
     func transactionItemIdCodable() throws {
         let tx = TransactionDTO(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -344,6 +344,36 @@ struct PlaidBarCoreTests {
         #expect(summary.days == 30)
     }
 
+    @Test("Account activity summary defaults to latest transaction date")
+    func accountActivitySummaryDefaultsToLatestTransactionDate() {
+        let transactions = [
+            TransactionDTO(id: "recent", accountId: "a", amount: 100, date: "2026-01-30", name: "Groceries"),
+            TransactionDTO(id: "included", accountId: "a", amount: -2_000, date: "2026-01-10", name: "Payroll", category: .income),
+            TransactionDTO(id: "old", accountId: "a", amount: 75, date: "2025-12-01", name: "Old"),
+            TransactionDTO(id: "invalid", accountId: "a", amount: 25, date: "not-a-date", name: "Invalid")
+        ]
+
+        let summary = AccountActivitySummary.recent(from: transactions)
+
+        #expect(summary.transactionCount == 2)
+        #expect(summary.outflowTotal == 100)
+        #expect(summary.inflowTotal == 2_000)
+    }
+
+    @Test("Account activity summary explicit now excludes future transactions")
+    func accountActivitySummaryExplicitNowExcludesFutureTransactions() {
+        let now = Formatters.parseTransactionDate("2026-01-15")!
+        let transactions = [
+            TransactionDTO(id: "current", accountId: "a", amount: 25, date: "2026-01-15", name: "Coffee"),
+            TransactionDTO(id: "future", accountId: "a", amount: 100, date: "2026-01-30", name: "Future")
+        ]
+
+        let summary = AccountActivitySummary.recent(from: transactions, now: now)
+
+        #expect(summary.transactionCount == 1)
+        #expect(summary.outflowTotal == 25)
+    }
+
     @Test("Account presentation picks subtype-aware icons")
     func accountPresentationIcons() {
         let checking = AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, subtype: "checking", balances: BalanceDTO(available: 100))

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1264,6 +1264,52 @@ struct PlaidBarCoreTests {
         #expect(readiness.secondaryActions.contains(.openSettings))
     }
 
+    @Test("Dashboard status readiness blocks on missing local server auth")
+    func dashboardStatusReadinessBlocksOnMissingLocalServerAuth() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: "PlaidBar server auth token is unavailable"
+        )
+
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Local server auth missing")
+        #expect(readiness.detail.contains("auth token"))
+        #expect(readiness.primaryAction == .openSettings)
+        #expect(readiness.secondaryActions.contains(.checkServer))
+    }
+
+    @Test("Dashboard status readiness blocks on rejected local server auth")
+    func dashboardStatusReadinessBlocksOnRejectedLocalServerAuth() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: "PlaidBar server returned 401: unauthorized"
+        )
+
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Local server auth rejected")
+        #expect(readiness.detail.contains("rejected"))
+        #expect(readiness.primaryAction == .openSettings)
+        #expect(readiness.secondaryActions.contains(.checkServer))
+    }
+
     @Test("Dashboard status readiness prompts add account with no items")
     func dashboardStatusReadinessPromptsAddAccount() {
         let readiness = DashboardStatusReadiness.evaluate(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2291,13 +2291,25 @@ struct PlaidBarCoreTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let directory = root.appendingPathComponent(".plaidbar", isDirectory: true)
         let database = directory.appendingPathComponent("plaidbar.sqlite")
+        let sandboxDatabase = directory.appendingPathComponent("plaidbar-sandbox.sqlite")
+        let databaseWAL = directory.appendingPathComponent("plaidbar.sqlite-wal")
+        let transactionCache = directory.appendingPathComponent("transactions-sandbox-abc123.json")
+        let pendingLinkSessions = directory.appendingPathComponent("pending-link-sessions.json")
         let authToken = directory.appendingPathComponent("auth-token")
         let serverConfig = directory.appendingPathComponent("server.conf")
+        let unrelatedFile = directory.appendingPathComponent("notes.txt")
+        let unrelatedDirectory = directory.appendingPathComponent("exports", isDirectory: true)
 
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try "db".write(to: database, atomically: true, encoding: .utf8)
+        try "sandbox".write(to: sandboxDatabase, atomically: true, encoding: .utf8)
+        try "wal".write(to: databaseWAL, atomically: true, encoding: .utf8)
+        try "cache".write(to: transactionCache, atomically: true, encoding: .utf8)
+        try "sessions".write(to: pendingLinkSessions, atomically: true, encoding: .utf8)
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
         try "PLAID_ENV=sandbox".write(to: serverConfig, atomically: true, encoding: .utf8)
+        try "keep me".write(to: unrelatedFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: unrelatedDirectory, withIntermediateDirectories: true)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: authToken.path)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: serverConfig.path)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -2308,16 +2320,26 @@ struct PlaidBarCoreTests {
         }
 
         #expect(result.directoryPath == directory.path)
-        #expect(result.removedEntries == ["plaidbar.sqlite"])
+        #expect(result.removedEntries == [
+            "pending-link-sessions.json",
+            "plaidbar-sandbox.sqlite",
+            "plaidbar.sqlite",
+            "plaidbar.sqlite-wal",
+            "transactions-sandbox-abc123.json",
+        ])
+        #expect(result.preservedEntries == ["auth-token", "exports", "notes.txt", "server.conf"])
         #expect(result.keychainTokensCleared)
         #expect(didResetKeychainTokens)
 
         var isDirectory: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
-        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == ["auth-token", "server.conf"])
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == ["auth-token", "exports", "notes.txt", "server.conf"])
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
         #expect(try String(contentsOf: serverConfig, encoding: .utf8) == "PLAID_ENV=sandbox")
+        #expect(try String(contentsOf: unrelatedFile, encoding: .utf8) == "keep me")
+        #expect(FileManager.default.fileExists(atPath: unrelatedDirectory.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
         #expect(try posixPermissions(at: authToken) == 0o600)
         #expect(try posixPermissions(at: serverConfig) == 0o600)
     }
@@ -2364,6 +2386,7 @@ struct PlaidBarCoreTests {
         }
 
         #expect(result.removedEntries == ["plaidbar.sqlite"])
+        #expect(result.preservedEntries == [])
         #expect(!result.keychainTokensCleared)
         #expect(!didResetKeychainTokens)
     }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -92,10 +92,14 @@ public GitHub issue.
 
 ## Local Reset Boundary
 
-Resetting local data removes PlaidBar's local cache and local stored item data.
-It does not necessarily delete records from the Plaid Dashboard or revoke bank
-permissions outside PlaidBar. Users who need complete revocation should also
-review Plaid Dashboard and bank-side permission settings.
+Resetting local data removes PlaidBar-owned database files, transaction caches,
+pending Link sessions, and stored Plaid access-token entries when present. It
+leaves `server.conf`, app/server auth, preferences, and unrelated files in the
+storage directory untouched.
+
+Local reset does not necessarily delete records from the Plaid Dashboard or
+revoke bank permissions outside PlaidBar. Users who need complete revocation
+should also review Plaid Dashboard and bank-side permission settings.
 
 ## 1.0 Privacy Checklist
 


### PR DESCRIPTION
## Summary
- adds production-readiness and recovery presentation models for dashboard/status surfaces
- tightens account activity summaries, transaction feed ordering, and empty/degraded item states
- hardens local data reset and pending link cleanup behavior
- updates account/settings recovery copy plus privacy docs

## Validation
- `bash -n Scripts/*.sh Scripts/plaidbar-run`
- `ruby -c Formula/plaidbar.rb`
- `brew style Formula/plaidbar.rb`
- `swift package resolve`
- `swift build -c release`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18487 ./Scripts/smoke-sandbox.sh`
- `git diff --check origin/main...HEAD`

## Note
- Local `swift test` was attempted but blocked by the active Command Line Tools toolchain failing to provide Swift's `Testing` module (`no such module 'Testing'`). GitHub CI selects `/Applications/Xcode_16.app`, so the PR CI should run the test suite in the intended environment.