### PR TITLE
Converge recovery action presentation

### DIFF
--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -18,20 +18,32 @@ enum NotificationPermissionState {
     case unsupported
     case status(UNAuthorizationStatus)
 
-    var authorizationStatus: UNAuthorizationStatus? {
-        guard case let .status(status) = self else { return nil }
-        return status
+    static let notDetermined: NotificationPermissionState = .status(.notDetermined)
+
+    var presentationKind: NotificationPermissionKind {
+        switch self {
+        case .unsupported:
+            return .unsupported
+        case .status(let status):
+            switch status {
+            case .authorized:
+                return .authorized
+            case .denied:
+                return .denied
+            case .notDetermined:
+                return .notDetermined
+            case .provisional:
+                return .provisional
+            case .ephemeral:
+                return .ephemeral
+            @unknown default:
+                return .unknown
+            }
+        }
     }
 
     var shouldDisableNotifications: Bool {
-        switch self {
-        case .unsupported:
-            true
-        case .status(.denied), .status(.notDetermined):
-            true
-        case .status:
-            false
-        }
+        NotificationPermissionPresentation.evaluate(kind: presentationKind).shouldDisableNotifications
     }
 }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import PlaidBarCore
 import Sparkle
 import AppKit
-@preconcurrency import UserNotifications
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -386,14 +385,16 @@ struct AccountSettingsView: View {
                 }
             }
 
-            HStack {
-                Spacer()
-                Button("Add Account") {
-                    handleAddAccount()
+            if !appState.accounts.isEmpty {
+                HStack {
+                    Spacer()
+                    Button("Add Account") {
+                        handleAddAccount()
+                    }
+                    .buttonStyle(.borderedProminent)
                 }
-                .buttonStyle(.borderedProminent)
+                .padding()
             }
-            .padding()
         }
         .sheet(isPresented: $isShowingAccountSetup) {
             SetupView {
@@ -545,7 +546,11 @@ private struct PendingAccountRemoval: Identifiable {
 
 struct NotificationSettingsView: View {
     @Environment(AppState.self) private var appState
-    @State private var permissionState: NotificationPermissionState = .status(.notDetermined)
+    @State private var permissionState: NotificationPermissionState = .notDetermined
+
+    private var permissionPresentation: NotificationPermissionPresentation {
+        NotificationPermissionPresentation.evaluate(kind: permissionState.presentationKind)
+    }
 
     var body: some View {
         @Bindable var state = appState
@@ -570,21 +575,7 @@ struct NotificationSettingsView: View {
                                 Task { await refreshPermissionStatus() }
                             }
                         }
-                        .disabled(permissionState.authorizationStatus == .denied || permissionState.authorizationStatus == nil)
-
-                    if permissionState.authorizationStatus == nil {
-                        InlineSettingsNotice(
-                            text: "Notifications are unavailable for this launch mode because macOS cannot register PlaidBar as a notification source.",
-                            icon: "bell.slash",
-                            tint: .secondary
-                        )
-                    } else if permissionState.authorizationStatus == .denied {
-                        InlineSettingsNotice(
-                            text: "Notifications are denied in macOS. Enable PlaidBar in System Settings before turning alerts on.",
-                            icon: "exclamationmark.triangle",
-                            tint: SemanticColors.warning
-                        )
-                    }
+                        .disabled(permissionPresentation.isNotificationToggleDisabled)
                 }
 
                 SettingsCard(title: "Transaction Alerts") {
@@ -669,16 +660,9 @@ struct NotificationSettingsView: View {
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
 
-                if permissionState.authorizationStatus == .denied {
-                    Button {
-                        openNotificationSettings()
-                    } label: {
-                        Label("Open System Settings", systemImage: "gearshape")
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .accessibilityHint("Opens macOS Notification settings for PlaidBar.")
-                    .padding(.top, Spacing.xs)
+                if let action = permissionPresentation.recoveryAction {
+                    permissionRecoveryAction(action)
+                        .padding(.top, Spacing.xs)
                 }
             }
         }
@@ -702,98 +686,81 @@ struct NotificationSettingsView: View {
     }
 
     private var permissionLabel: String {
-        switch permissionState {
-        case .unsupported:
-            "Unavailable"
-        case .status(let status):
-            permissionLabel(for: status)
-        }
-    }
-
-    private func permissionLabel(for status: UNAuthorizationStatus) -> String {
-        switch status {
-        case .authorized:
-            "Allowed"
-        case .denied:
-            "Denied"
-        case .notDetermined:
-            "Not requested"
-        case .provisional:
-            "Provisional"
-        case .ephemeral:
-            "Temporary"
-        @unknown default:
-            "Unknown"
-        }
+        permissionPresentation.label
     }
 
     private var permissionDetail: String {
-        switch permissionState {
-        case .unsupported:
-            "This PlaidBar launch does not have a macOS notification identity, so no System Settings entry is available."
-        case .status(let status):
-            permissionDetail(for: status)
-        }
-    }
-
-    private func permissionDetail(for status: UNAuthorizationStatus) -> String {
-        switch status {
-        case .authorized:
-            "PlaidBar can show local transaction, balance, and credit utilization alerts."
-        case .denied:
-            "macOS is blocking PlaidBar notifications. The app cannot override this setting."
-        case .notDetermined:
-            "Turn notifications on to request permission from macOS."
-        case .provisional:
-            "macOS may deliver alerts quietly until permission is fully allowed."
-        case .ephemeral:
-            "macOS granted a temporary notification permission."
-        @unknown default:
-            "PlaidBar could not classify the current notification permission."
-        }
+        permissionPresentation.detail
     }
 
     private var permissionIcon: String {
-        switch permissionState {
-        case .unsupported:
-            "bell.slash.fill"
-        case .status(let status):
-            permissionIcon(for: status)
-        }
-    }
-
-    private func permissionIcon(for status: UNAuthorizationStatus) -> String {
-        switch status {
-        case .authorized, .provisional, .ephemeral:
-            "checkmark.circle.fill"
-        case .denied:
-            "exclamationmark.triangle.fill"
-        case .notDetermined:
-            "questionmark.circle"
-        @unknown default:
-            "questionmark.circle"
-        }
+        permissionPresentation.iconName
     }
 
     private var permissionTint: Color {
-        switch permissionState {
-        case .unsupported:
+        switch permissionPresentation.tone {
+        case .positive:
+            SemanticColors.positive
+        case .warning:
+            SemanticColors.warning
+        case .secondary:
             .secondary
-        case .status(let status):
-            permissionTint(for: status)
         }
     }
 
-    private func permissionTint(for status: UNAuthorizationStatus) -> Color {
-        switch status {
-        case .authorized, .provisional, .ephemeral:
-            SemanticColors.positive
-        case .denied:
-            SemanticColors.warning
-        case .notDetermined:
-            .secondary
-        @unknown default:
-            .secondary
+    @ViewBuilder
+    private func permissionRecoveryAction(_ action: NotificationPermissionRecoveryAction) -> some View {
+        if permissionPresentation.isRecoveryActionInteractive {
+            Button {
+                performPermissionRecoveryAction(action)
+            } label: {
+                Label(
+                    permissionPresentation.recoveryActionTitle ?? "Recover Notifications",
+                    systemImage: permissionPresentation.recoveryActionIconName ?? "bell.badge"
+                )
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityHint(permissionActionAccessibilityHint(for: action))
+        } else {
+            Label(
+                permissionPresentation.recoveryActionTitle ?? "Recover Notifications",
+                systemImage: permissionPresentation.recoveryActionIconName ?? "bell.badge"
+            )
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(permissionTint)
+            .accessibilityLabel(permissionPresentation.recoveryActionTitle ?? "Recover Notifications")
+            .accessibilityHint(permissionPresentation.detail)
+        }
+    }
+
+    private func performPermissionRecoveryAction(_ action: NotificationPermissionRecoveryAction) {
+        switch action {
+        case .requestPermission:
+            Task {
+                let granted = await appState.requestNotificationPermission()
+                appState.notificationsEnabled = granted
+                await refreshPermissionStatus()
+            }
+        case .openSystemSettings:
+            openNotificationSettings()
+        case .checkAgain:
+            Task { await refreshPermissionStatus() }
+        case .runBundledApp:
+            break
+        }
+    }
+
+    private func permissionActionAccessibilityHint(for action: NotificationPermissionRecoveryAction) -> Text {
+        switch action {
+        case .requestPermission:
+            Text("Requests macOS notification permission for PlaidBar.")
+        case .openSystemSettings:
+            Text("Opens macOS Notification settings for PlaidBar.")
+        case .checkAgain:
+            Text("Checks the current macOS notification permission again.")
+        case .runBundledApp:
+            Text(permissionPresentation.detail)
         }
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -948,15 +948,15 @@ private struct DashboardStatusReadinessPanel: View {
             StatusMetricGrid()
                 .environment(appState)
 
-            HStack(spacing: 8) {
-                if let primaryAction = readiness.primaryAction {
+            if let primaryAction = readiness.primaryAction {
+                HStack(spacing: 8) {
                     if readinessNeedsAttention {
                         Button {
                             perform(primaryAction)
                         } label: {
                             Label(
                                 primaryActionLabel(for: primaryAction),
-                                systemImage: readiness.primaryActionIconName ?? primaryAction.icon
+                                systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
                             )
                         }
                         .buttonStyle(.borderedProminent)
@@ -969,24 +969,13 @@ private struct DashboardStatusReadinessPanel: View {
                         } label: {
                             Label(
                                 primaryActionLabel(for: primaryAction),
-                                systemImage: readiness.primaryActionIconName ?? primaryAction.icon
+                                systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
                             )
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .disabled(appState.isLoading)
                     }
-                }
-
-                ForEach(readiness.secondaryActions, id: \.rawValue) { action in
-                    Button {
-                        perform(action)
-                    } label: {
-                        Label(action.label, systemImage: action.icon)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(appState.isLoading)
                 }
             }
         }
@@ -1046,7 +1035,7 @@ private struct DashboardStatusReadinessPanel: View {
            let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
             return title
         }
-        return readiness.primaryActionTitle ?? action.label
+        return readiness.primaryActionTitle ?? action.defaultTitle
     }
 
     private var reconnectItemId: String? {
@@ -1157,28 +1146,6 @@ private struct StatusMetricPill: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
-    }
-}
-
-private extension DashboardStatusReadinessAction {
-    var label: String {
-        switch self {
-        case .checkServer: "Check Server"
-        case .addAccount: "Add Account"
-        case .refresh: "Refresh"
-        case .reconnect: "Reconnect"
-        case .openSettings: "Settings"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .checkServer: "server.rack"
-        case .addAccount: "plus.circle"
-        case .refresh: "arrow.clockwise"
-        case .reconnect: "link.badge.plus"
-        case .openSettings: "gearshape"
-        }
     }
 }
 
@@ -1706,20 +1673,10 @@ private struct SelectedAccountPanel: View {
 
             if shouldShowRecoveryActions {
                 HStack(spacing: 8) {
-                    if itemStatus == .loginRequired || itemStatus == .error {
-                        Button {
-                            Task { await appState.reconnectItem(itemId: account.itemId) }
-                        } label: {
-                            Label(recoveryActionTitle, systemImage: "link.badge.plus")
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-
                     Button {
-                        Task { await appState.refreshDashboard() }
+                        performConnectionRecoveryAction()
                     } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
+                        Label(connectionRecoveryActionTitle, systemImage: connectionRecoveryActionIcon)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
@@ -1818,6 +1775,39 @@ private struct SelectedAccountPanel: View {
 
     private var recoveryActionTitle: String {
         connectionPresentation.recoveryActionTitle ?? "Reconnect"
+    }
+
+    private var connectionRecoveryActionTitle: String {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            return recoveryActionTitle
+        case .stale:
+            return "Refresh"
+        case .demo, .offline, .healthy, .unknown:
+            return "Refresh"
+        }
+    }
+
+    private var connectionRecoveryActionIcon: String {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            return "link.badge.plus"
+        case .stale:
+            return "arrow.clockwise"
+        case .demo, .offline, .healthy, .unknown:
+            return "arrow.clockwise"
+        }
+    }
+
+    private func performConnectionRecoveryAction() {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            Task { await appState.reconnectItem(itemId: account.itemId) }
+        case .stale:
+            Task { await appState.refreshDashboard() }
+        case .demo, .offline, .healthy, .unknown:
+            break
+        }
     }
 
     private var panelStroke: Color {

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -176,7 +176,9 @@ struct StatusView: View {
     }
 
     private var recoveryActions: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        let readiness = appState.dashboardStatusReadiness
+
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(spacing: Spacing.xs) {
                 Image(systemName: "lock.doc")
                 Text("Local data directory: \(appState.activeStorageDirectoryDisplayText)")
@@ -187,33 +189,31 @@ struct StatusView: View {
                 .sectionTitle()
                 .foregroundStyle(.secondary)
 
-            HStack(spacing: Spacing.sm) {
-                Button {
-                    Task {
-                        await appState.checkServerConnection()
-                        if appState.serverConnected {
-                            await appState.refreshAccounts()
-                            await appState.syncTransactions()
-                        }
+            if let primaryAction = readiness.primaryAction {
+                if readiness.level == .healthy {
+                    Button {
+                        perform(readinessAction: primaryAction)
+                    } label: {
+                        Label(
+                            primaryActionLabel(for: primaryAction, readiness: readiness),
+                            systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                        )
                     }
-                } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
+                    .buttonStyle(.bordered)
+                    .disabled(appState.isLoading)
+                } else {
+                    Button {
+                        perform(readinessAction: primaryAction)
+                    } label: {
+                        Label(
+                            primaryActionLabel(for: primaryAction, readiness: readiness),
+                            systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(readinessTint(for: readiness.level))
+                    .disabled(appState.isLoading)
                 }
-                .buttonStyle(.bordered)
-
-                Button {
-                    Task { await appState.addAccount() }
-                } label: {
-                    Label("Connect", systemImage: "plus.circle")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    openSettings()
-                } label: {
-                    Label("Settings", systemImage: "gear")
-                }
-                .buttonStyle(.bordered)
             }
         }
     }
@@ -319,6 +319,47 @@ struct StatusView: View {
     private func itemAccessibilityLabel(for item: ItemStatus) -> String {
         let institutionName = item.institutionName ?? "Plaid item"
         return "\(institutionName), \(label(for: item.status)), \(statusDetail(for: item))"
+    }
+
+    private func perform(readinessAction action: DashboardStatusReadinessAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .reconnect:
+            guard let itemId = ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
+                Task { await appState.refreshDashboard() }
+                return
+            }
+            Task { await appState.reconnectItem(itemId: itemId) }
+        case .openSettings:
+            openSettings()
+        }
+    }
+
+    private func primaryActionLabel(
+        for action: DashboardStatusReadinessAction,
+        readiness: DashboardStatusReadiness
+    ) -> String {
+        if action == .reconnect,
+           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
+            return title
+        }
+        return readiness.primaryActionTitle ?? action.defaultTitle
+    }
+
+    private func readinessTint(for level: DashboardStatusReadinessLevel) -> Color {
+        switch level {
+        case .healthy:
+            .accentColor
+        case .warning:
+            SemanticColors.warning
+        case .blocked:
+            SemanticColors.negative
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -72,8 +72,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 level: .blocked,
                 title: authError.title,
                 detail: authError.detail,
-                primaryAction: .openSettings,
-                secondaryActions: [.checkServer]
+                primaryAction: .openSettings
             )
         }
 
@@ -82,8 +81,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 level: .blocked,
                 title: "Server offline",
                 detail: "Start PlaidBarServer, then check the connection from this dashboard.",
-                primaryAction: .checkServer,
-                secondaryActions: [.openSettings]
+                primaryAction: .checkServer
             )
         }
 
@@ -105,8 +103,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                     pluralAction: "need attention"
                 ),
                 detail: "A linked institution reported an error. Reconnect it, then refresh the dashboard.",
-                primaryAction: .reconnect,
-                secondaryActions: [.refresh, .openSettings]
+                primaryAction: .reconnect
             )
         }
 
@@ -119,8 +116,16 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                     pluralAction: "need login"
                 ),
                 detail: "One or more institutions need an updated login before sync can stay healthy.",
-                primaryAction: .reconnect,
-                secondaryActions: [.refresh]
+                primaryAction: .reconnect
+            )
+        }
+
+        if let modeMismatch = serverModeMismatchError(from: errorMessage) {
+            return DashboardStatusReadiness(
+                level: .blocked,
+                title: modeMismatch.title,
+                detail: modeMismatch.detail,
+                primaryAction: .checkServer
             )
         }
 
@@ -129,8 +134,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 level: .warning,
                 title: "Recent action failed",
                 detail: errorMessage,
-                primaryAction: .refresh,
-                secondaryActions: [.openSettings]
+                primaryAction: .refresh
             )
         }
 
@@ -140,8 +144,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "No institution linked",
                 detail: "Connect a Plaid institution before this dashboard can show balances and transactions.",
                 primaryAction: .addAccount,
-                primaryActionTitle: "Connect Bank",
-                secondaryActions: [.refresh]
+                primaryActionTitle: "Connect Bank"
             )
         }
 
@@ -151,8 +154,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Balances not loaded",
                 detail: "The server has linked items, but account balances have not loaded into the dashboard yet.",
                 primaryAction: .refresh,
-                primaryActionTitle: "Load Balances",
-                secondaryActions: [.addAccount]
+                primaryActionTitle: "Load Balances"
             )
         }
 
@@ -162,8 +164,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "First sync needed",
                 detail: "Accounts are loaded, but no linked item has completed transaction sync yet. Refresh to run the first sync.",
                 primaryAction: .refresh,
-                primaryActionTitle: "Run First Sync",
-                secondaryActions: [.openSettings]
+                primaryActionTitle: "Run First Sync"
             )
         }
 
@@ -173,8 +174,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "First sync incomplete",
                 detail: "\(syncedItemCount) of \(linkedItemCount) linked item\(linkedItemCount == 1 ? "" : "s") have completed transaction sync. Refresh to finish the remaining item\(linkedItemCount - syncedItemCount == 1 ? "" : "s").",
                 primaryAction: .refresh,
-                primaryActionTitle: "Finish Sync",
-                secondaryActions: [.openSettings]
+                primaryActionTitle: "Finish Sync"
             )
         }
 
@@ -184,8 +184,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Sync is stale",
                 detail: "Last sync: \(lastSyncRelative ?? "never"). Refresh now to pull current balances and transactions.",
                 primaryAction: .refresh,
-                primaryActionTitle: "Refresh Now",
-                secondaryActions: [.openSettings]
+                primaryActionTitle: "Refresh Now"
             )
         }
 
@@ -237,6 +236,27 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         return "\(normalized.prefix(maxRenderedErrorLength))..."
     }
 
+    private static func serverModeMismatchError(from message: String?) -> (title: String, detail: String)? {
+        guard let message else { return nil }
+        let normalized = message
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        let lowercased = normalized.lowercased()
+
+        guard lowercased.contains("server is running in"),
+              lowercased.contains("not sandbox") || lowercased.contains("not production")
+        else {
+            return nil
+        }
+
+        return (
+            "Server mode mismatch",
+            normalized.count > maxRenderedErrorLength
+                ? "\(normalized.prefix(maxRenderedErrorLength))..."
+                : normalized
+        )
+    }
+
     private static func itemRecoveryTitle(
         count: Int,
         singularAction: String,
@@ -246,7 +266,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     }
 }
 
-private extension DashboardStatusReadinessAction {
+public extension DashboardStatusReadinessAction {
     var defaultTitle: String {
         switch self {
         case .checkServer: "Check Server"

--- a/Sources/PlaidBarCore/Models/NotificationPermissionPresentation.swift
+++ b/Sources/PlaidBarCore/Models/NotificationPermissionPresentation.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+public enum NotificationPermissionKind: String, Sendable {
+    case unsupported
+    case authorized
+    case denied
+    case notDetermined
+    case provisional
+    case ephemeral
+    case unknown
+}
+
+public enum NotificationPermissionTone: String, Sendable {
+    case positive
+    case warning
+    case secondary
+}
+
+public enum NotificationPermissionRecoveryAction: String, Sendable {
+    case requestPermission
+    case openSystemSettings
+    case runBundledApp
+    case checkAgain
+}
+
+public struct NotificationPermissionPresentation: Equatable, Sendable {
+    public let label: String
+    public let detail: String
+    public let iconName: String
+    public let tone: NotificationPermissionTone
+    public let recoveryAction: NotificationPermissionRecoveryAction?
+    public let recoveryActionTitle: String?
+    public let recoveryActionIconName: String?
+    public let isRecoveryActionInteractive: Bool
+    public let isNotificationToggleDisabled: Bool
+    public let shouldDisableNotifications: Bool
+
+    public init(
+        label: String,
+        detail: String,
+        iconName: String,
+        tone: NotificationPermissionTone,
+        recoveryAction: NotificationPermissionRecoveryAction? = nil,
+        recoveryActionTitle: String? = nil,
+        recoveryActionIconName: String? = nil,
+        isRecoveryActionInteractive: Bool = true,
+        isNotificationToggleDisabled: Bool,
+        shouldDisableNotifications: Bool
+    ) {
+        self.label = label
+        self.detail = detail
+        self.iconName = iconName
+        self.tone = tone
+        self.recoveryAction = recoveryAction
+        self.recoveryActionTitle = recoveryActionTitle ?? recoveryAction?.defaultTitle
+        self.recoveryActionIconName = recoveryActionIconName ?? recoveryAction?.defaultIconName
+        self.isRecoveryActionInteractive = isRecoveryActionInteractive
+        self.isNotificationToggleDisabled = isNotificationToggleDisabled
+        self.shouldDisableNotifications = shouldDisableNotifications
+    }
+
+    public static func evaluate(kind: NotificationPermissionKind) -> NotificationPermissionPresentation {
+        switch kind {
+        case .unsupported:
+            return NotificationPermissionPresentation(
+                label: "Unavailable",
+                detail: "This PlaidBar launch does not have a macOS notification identity. Run PlaidBar from the app bundle so macOS can register it as a notification source.",
+                iconName: "bell.slash.fill",
+                tone: .secondary,
+                recoveryAction: .runBundledApp,
+                isRecoveryActionInteractive: false,
+                isNotificationToggleDisabled: true,
+                shouldDisableNotifications: true
+            )
+        case .authorized:
+            return NotificationPermissionPresentation(
+                label: "Allowed",
+                detail: "PlaidBar can show local transaction, balance, and credit utilization alerts.",
+                iconName: "checkmark.circle.fill",
+                tone: .positive,
+                isNotificationToggleDisabled: false,
+                shouldDisableNotifications: false
+            )
+        case .denied:
+            return NotificationPermissionPresentation(
+                label: "Denied",
+                detail: "macOS is blocking PlaidBar notifications. Enable PlaidBar in System Settings to recover local alerts.",
+                iconName: "exclamationmark.triangle.fill",
+                tone: .warning,
+                recoveryAction: .openSystemSettings,
+                isNotificationToggleDisabled: true,
+                shouldDisableNotifications: true
+            )
+        case .notDetermined:
+            return NotificationPermissionPresentation(
+                label: "Not requested",
+                detail: "Request macOS permission before enabling local transaction, balance, and credit alerts.",
+                iconName: "questionmark.circle",
+                tone: .secondary,
+                recoveryAction: .requestPermission,
+                isNotificationToggleDisabled: false,
+                shouldDisableNotifications: true
+            )
+        case .provisional:
+            return NotificationPermissionPresentation(
+                label: "Provisional",
+                detail: "macOS may deliver alerts quietly until permission is fully allowed.",
+                iconName: "checkmark.circle.fill",
+                tone: .positive,
+                isNotificationToggleDisabled: false,
+                shouldDisableNotifications: false
+            )
+        case .ephemeral:
+            return NotificationPermissionPresentation(
+                label: "Temporary",
+                detail: "macOS granted a temporary notification permission.",
+                iconName: "checkmark.circle.fill",
+                tone: .positive,
+                isNotificationToggleDisabled: false,
+                shouldDisableNotifications: false
+            )
+        case .unknown:
+            return NotificationPermissionPresentation(
+                label: "Unknown",
+                detail: "PlaidBar could not classify the current notification permission. Check again before relying on local alerts.",
+                iconName: "questionmark.circle",
+                tone: .secondary,
+                recoveryAction: .checkAgain,
+                isNotificationToggleDisabled: false,
+                shouldDisableNotifications: true
+            )
+        }
+    }
+}
+
+private extension NotificationPermissionRecoveryAction {
+    var defaultTitle: String {
+        switch self {
+        case .requestPermission: "Request Permission"
+        case .openSystemSettings: "Open System Settings"
+        case .runBundledApp: "Run App Bundle"
+        case .checkAgain: "Check Again"
+        }
+    }
+
+    var defaultIconName: String {
+        switch self {
+        case .requestPermission: "bell.badge"
+        case .openSystemSettings: "gearshape"
+        case .runBundledApp: "app.badge"
+        case .checkAgain: "arrow.clockwise"
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1315,7 +1315,7 @@ struct PlaidBarCoreTests {
 
         #expect(readiness.level == .blocked)
         #expect(readiness.primaryAction == .checkServer)
-        #expect(readiness.secondaryActions.contains(.openSettings))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness blocks on missing local server auth")
@@ -1338,7 +1338,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.title == "Local server auth missing")
         #expect(readiness.detail.contains("auth token"))
         #expect(readiness.primaryAction == .openSettings)
-        #expect(readiness.secondaryActions.contains(.checkServer))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness blocks on rejected local server auth")
@@ -1361,7 +1361,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.title == "Local server auth rejected")
         #expect(readiness.detail.contains("rejected"))
         #expect(readiness.primaryAction == .openSettings)
-        #expect(readiness.secondaryActions.contains(.checkServer))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness prompts add account with no items")
@@ -1448,14 +1448,73 @@ struct PlaidBarCoreTests {
             erroredItemCount: 0,
             isSyncStale: true,
             lastSyncRelative: nil,
-            errorMessage: "Server is running in production, not sandbox."
+            errorMessage: "Plaid sync failed."
         )
 
         #expect(readiness.level == .warning)
         #expect(readiness.title == "Recent action failed")
-        #expect(readiness.detail.contains("production"))
+        #expect(readiness.detail.contains("Plaid sync failed"))
         #expect(readiness.primaryAction == .refresh)
-        #expect(readiness.secondaryActions.contains(.openSettings))
+        #expect(readiness.secondaryActions.isEmpty)
+    }
+
+    @Test("Dashboard status readiness identifies server mode mismatch")
+    func dashboardStatusReadinessIdentifiesServerModeMismatch() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: "Server is running in production, not sandbox. Restart with ./Scripts/run.sh --sandbox."
+        )
+
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Server mode mismatch")
+        #expect(readiness.primaryAction == .checkServer)
+        #expect(readiness.primaryActionTitle == "Check Server")
+        #expect(readiness.secondaryActions.isEmpty)
+    }
+
+    @Test("Notification permission presentation gives denied state one settings action")
+    func notificationPermissionPresentationDeniedAction() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .denied)
+
+        #expect(presentation.label == "Denied")
+        #expect(presentation.recoveryAction == .openSystemSettings)
+        #expect(presentation.recoveryActionTitle == "Open System Settings")
+        #expect(presentation.recoveryActionIconName == "gearshape")
+        #expect(presentation.isRecoveryActionInteractive)
+        #expect(presentation.isNotificationToggleDisabled)
+        #expect(presentation.shouldDisableNotifications)
+    }
+
+    @Test("Notification permission presentation requests permission before first use")
+    func notificationPermissionPresentationNotDeterminedAction() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .notDetermined)
+
+        #expect(presentation.label == "Not requested")
+        #expect(presentation.recoveryAction == .requestPermission)
+        #expect(presentation.recoveryActionTitle == "Request Permission")
+        #expect(!presentation.isNotificationToggleDisabled)
+        #expect(presentation.shouldDisableNotifications)
+    }
+
+    @Test("Notification permission presentation handles unsupported launches")
+    func notificationPermissionPresentationUnsupportedAction() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .unsupported)
+
+        #expect(presentation.label == "Unavailable")
+        #expect(presentation.recoveryAction == .runBundledApp)
+        #expect(presentation.recoveryActionTitle == "Run App Bundle")
+        #expect(!presentation.isRecoveryActionInteractive)
+        #expect(presentation.isNotificationToggleDisabled)
+        #expect(presentation.shouldDisableNotifications)
     }
 
     @Test("Dashboard account filters include only matching account kinds")
@@ -1850,7 +1909,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.level == .blocked)
         #expect(readiness.primaryAction == .reconnect)
         #expect(readiness.title == "1 item needs attention")
-        #expect(readiness.secondaryActions.contains(.openSettings))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness pluralizes multiple item errors")
@@ -1955,7 +2014,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.detail == "1 of 2 linked items have completed transaction sync. Refresh to finish the remaining item.")
         #expect(readiness.primaryActionTitle == "Finish Sync")
         #expect(readiness.primaryActionIconName == "arrow.clockwise")
-        #expect(readiness.secondaryActions.contains(.openSettings))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness distinguishes first sync not started")
@@ -1979,7 +2038,7 @@ struct PlaidBarCoreTests {
         #expect(readiness.title == "First sync needed")
         #expect(readiness.detail == "Accounts are loaded, but no linked item has completed transaction sync yet. Refresh to run the first sync.")
         #expect(readiness.primaryActionTitle == "Run First Sync")
-        #expect(readiness.secondaryActions.contains(.openSettings))
+        #expect(readiness.secondaryActions.isEmpty)
     }
 
     @Test("Dashboard status readiness detects stale sync")


### PR DESCRIPTION
## Summary
- Moves notification permission recovery presentation into `PlaidBarCore` so Settings has a single modeled action for denied, not-requested, unsupported, and unknown states.
- Reuses dashboard/status readiness action titles and icons instead of duplicating UI-only mappings.
- Tightens dashboard recovery convergence by removing noisy secondary settings actions where the primary recovery path is already explicit, and adds server mode mismatch handling.

## Test Plan
- [x] `git diff --check HEAD~1..HEAD`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain`
- [ ] `swift test --skip-update --disable-keychain` — blocked locally by baseline toolchain limitation: `no such module 'Testing'`

@codex review
