### PR TITLE
docs: add local AI roadmap priorities

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -160,6 +160,8 @@ native RepoBar-style finance instrument before expanding finance scope.
 | P1.3 | Liquid Glass readiness | **Given** PlaidBar is built with a macOS 26+ SDK, **When** SwiftUI Liquid Glass APIs are available, **Then** native panel surfaces may opt into `glassEffect` while preserving the macOS 15 material fallback |
 | P1.4 | RepoBar-style dashboard density | **Given** the menu bar popover opens, **When** dashboard content is scanned, **Then** the status strip and 365-day heatmap appear before account rows, with compact filters and selected account detail actions in the same surface |
 | P1.5 | Recovery convergence | **Given** common failures occur, **When** the user views dashboard or settings, **Then** server offline, wrong mode, missing credentials, stale sync, login-required item, empty account data, filtered-zero transactions, and denied notifications each expose one clear recovery action |
+| P1.6 | Local AI activity summaries | **Given** a local AI runtime is configured, **When** the user opens the dashboard or an insights surface, **Then** PlaidBar summarizes financial activity for the last 7 days, last month, and year-over-year windows, including spending, income, balance changes, recurring charges, credit utilization, and notable anomalies without sending data to cloud models |
+| P1.7 | Local AI categorization | **Given** synced transactions include Plaid categories, merchant names, raw names, amounts, dates, and account context, **When** local AI categorization is enabled, **Then** PlaidBar suggests smarter expense and income categories with confidence and evidence while preserving raw Plaid data and allowing user correction or fallback to Plaid categories |
 
 ### Future (not committed)
 
@@ -216,7 +218,9 @@ native RepoBar-style finance instrument before expanding finance scope.
 - **No cloud sync** — All data stays local. Period.
 - **No multi-user** — Single-user, single-machine
 - **No transaction editing** — Read-only view of bank data
-- **No AI/ML features** — Simple categorization from Plaid, no smart insights
+- **No cloud AI over financial data** — Post-1.0 local AI may summarize and
+  categorize activity only when it runs on-device, keeps data local, preserves
+  raw Plaid data, and exposes user-correctable suggestions
 
 ## Success Metrics
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,11 @@ Post-1.0 priorities:
       material fallback
 - [ ] Converge dashboard/settings recovery actions for server, Plaid item,
       empty-data, stale-sync, and notification-permission states
+- [ ] Add local AI summaries for financial activity over the last 7 days, last
+      month, and year-over-year windows without sending transaction data to
+      cloud models
+- [ ] Use local AI to suggest smarter expense and income categories while
+      preserving Plaid categories as the auditable fallback
 - [ ] Refresh screenshots and QA evidence after visual changes
 
 Deferred product candidates:

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -130,6 +130,22 @@ Completed production-readiness slices:
 3. Refresh demo fixtures and screenshots when UI behavior changes.
 4. Improve accessibility labels for icon-only controls and chart/status signals.
 
+### Local AI Insights
+
+1. Add an on-device AI summary layer for financial activity, with no cloud model
+   calls and no transaction data leaving the Mac.
+2. Summarize spending, income, recurring charges, credit utilization, balance
+   changes, and notable anomalies over the last 7 days, last month, and
+   year-over-year windows.
+3. Use local AI to improve categorization of expenses and income while keeping
+   Plaid categories as the auditable source-of-record fallback.
+4. Make AI output explainable and reversible: show the source transactions or
+   category evidence behind each summary, allow user correction, and never
+   mutate raw Plaid transaction data.
+5. Treat local-model availability as optional. If no model runtime is
+   configured, hide or disable insight surfaces with a clear setup/recovery
+   action instead of blocking the core dashboard.
+
 ### Distribution And Open Source
 
 1. Keep README, troubleshooting, privacy, security, release notes, and QA matrix

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -264,6 +264,10 @@ These ideas may fit if the core experience is stable:
 - Redacted CSV or JSON export.
 - Better recurring charge explanation.
 - Category-level budget alerts.
+- Local AI summaries for the last 7 days, last month, and year-over-year
+  financial activity, provided transaction data never leaves the Mac.
+- Local AI categorization suggestions for expenses and income, provided Plaid
+  categories remain the auditable fallback and corrections are reversible.
 - Signed app bundle and cask distribution.
 - Desktop widget for a small subset of signals.
 - Alternate Plaid-like provider support.
@@ -281,7 +285,8 @@ changes identity:
 - Multi-user finance platform.
 - iOS companion app.
 - Investment portfolio dashboard.
-- AI or ML insights over private transactions.
+- Cloud AI/ML over private transactions or any insight feature that sends raw
+  financial data off-device.
 - Generic Plaid developer playground.
 
 ## Architecture Vision


### PR DESCRIPTION
## Summary
- Add local AI activity summaries to the Post-1.0 roadmap for last 7 days, last month, and year-over-year windows
- Add local AI expense/income categorization as a roadmap priority with Plaid category fallback
- Update scope guardrails to reject cloud AI over private financial data while allowing on-device local AI

## Test plan
- [x] git diff --check
- [x] Reviewed modified roadmap/docs diff

@codex review