### PR TITLE
docs: add autonomous PlaidBar loop backlog

### DIFF
--- a/.codex/skills/plaidbar-production-loop/SKILL.md
+++ b/.codex/skills/plaidbar-production-loop/SKILL.md
@@ -16,10 +16,16 @@ menu-bar instrument over new feature breadth.
 
 ## Rules
 
-- Work locally unless Felipe explicitly approves push or PR creation.
-- Never merge from this skill.
-- Do not add hosted backend, telemetry, cloud sync, multi-user support, or
-  budgeting workflows.
+- Work locally by default. Use the scoped PlaidBar approval recorded in
+  `docs/autonomous-roadmap.md` for push, PR creation, and merge only when the
+  current task is clearly inside that scope.
+- Merge only after local gates pass, GitHub checks are green, review feedback is
+  addressed, and a final safety read finds no secrets, real financial data,
+  generated artifacts, or local-first boundary violations.
+- Do not add hosted backend, telemetry, cloud sync, multi-user support,
+  budgeting workflows, or cloud AI over private transaction data.
+- Keep optional AI local-only, off by default, explainable, reversible, and
+  non-blocking when no local model runtime is configured.
 - Do not overclaim security. If tokens are stored in SQLite, say that plainly.
 - Keep changes small, reviewable, and backed by verification evidence.
 
@@ -27,13 +33,8 @@ menu-bar instrument over new feature breadth.
 
 1. Inspect `git status --short --branch`, `GOAL.md`, `README.md`,
    `DESIGN.md`, and the files likely to change.
-2. Choose one production-readiness slice:
-   - RepoBar-style finance dashboard,
-   - local data controls,
-   - empty/error states,
-   - server/config preflight,
-   - reconnect and degraded item handling,
-   - demo/screenshot polish.
+2. Choose one unfinished task from `docs/autonomous-loop-backlog.md`, combining
+   adjacent tasks only when the PR remains easy to review.
 3. Implement using existing SwiftUI, `AppState`, `ServerClient`, settings,
    status, and `PlaidBarCore` patterns.
 4. Run:
@@ -42,8 +43,11 @@ menu-bar instrument over new feature breadth.
    - focused Swift tests when logic changed and the local toolchain supports it
    - a secret scan over docs, sources, tests, `commands`, and `.codex`
 5. Commit only one coherent slice at a time.
-6. Report progress with branch, changed files, validation, warnings, and next
-   slice.
+6. When scoped approval applies, push the branch, open or update the PR, request
+   review, wait for green checks, address feedback, and merge only after the
+   safety gate passes.
+7. Report progress with branch, task IDs, changed files, validation, warnings,
+   PR/check/merge status, and next slice.
 
 ## Preferred Next Slice
 

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: push
-description: Publish a PlaidBar branch and open a PR after approval.
+description: Publish a PlaidBar branch, open/update a PR, and merge only through the safe gate.
 ---
 
 # Push
 
-Use only after Felipe explicitly approves pushing/opening a PR.
+Use only after Felipe explicitly approves pushing/opening a PR, or when the run
+is clearly covered by the scoped PlaidBar approval recorded in
+`docs/autonomous-roadmap.md`.
 
 1. Confirm the branch and latest validation.
 2. Push the branch with tracking.
@@ -15,4 +17,10 @@ Use only after Felipe explicitly approves pushing/opening a PR.
    - product impact,
    - validation commands and results,
    - known warnings or blockers.
-5. Do not merge from this skill.
+5. Request review when appropriate, including `@codex review` when using Codex
+   as the reviewer.
+6. Wait for GitHub checks and address review feedback.
+7. Merge only when local gates passed, GitHub checks are green, review feedback
+   is addressed, and the final diff is safe: no secrets, no real financial data,
+   no generated artifacts, no unsafe destructive behavior, and no local-first
+   boundary violations.

--- a/commands/goal.md
+++ b/commands/goal.md
@@ -1,17 +1,18 @@
 ---
-description: Continue PlaidBar production-readiness work for multiple hours.
+description: Continue PlaidBar production-readiness work through the autonomous backlog.
 argument-hint: "[focus area] [--hours=2-4] [--no-commit]"
 ---
 
 # /goal
 
-Run the PlaidBar production-readiness loop for a multi-hour work session.
+Run the PlaidBar production-readiness loop for a multi-hour work session or
+one reviewable autonomous backlog task.
 
 Default goal:
 
-> Make PlaidBar feel like RepoBar for personal finance: a native macOS menu-bar
-> instrument with a GitHub-style heatmap header, dense account/card rows,
-> financial scope filters, and drill-in details for each account.
+> Advance the next safe PlaidBar production-readiness task while preserving the
+> local-first privacy contract, minimalist modern macOS design, and honest
+> security boundaries.
 
 ## How To Use
 
@@ -26,24 +27,28 @@ This command intentionally delegates the detailed operating loop to:
 
 ```text
 commands/plaidbar-prod-loop.md
+docs/autonomous-loop-backlog.md
+docs/autonomous-roadmap.md
 ```
 
-Read that file first, then execute the same loop with the `/goal` arguments as
-the requested focus/timebox.
+Read those files first, then execute the same loop with the `/goal` arguments
+as the requested focus/timebox. Treat one backlog task as the default iteration;
+combine adjacent tasks only when the resulting PR remains easy to review.
 
 ## Priority Order
 
-1. RepoBar-style finance dashboard:
-   - heatmap header at the top of the popover,
-   - segmented filters for All, Cash, Credit, Savings, Debt, and Status,
-   - compact rows for accounts/cards with balance, utilization/status, and last update,
-   - row selection or drill-in details for a specific credit card/account.
-2. Trust-first local data controls in Settings.
-3. Sharper empty and error states across Accounts, Transactions, and Credit.
-4. Server/config preflight for environment and credential readiness.
-5. Reconnect/degraded-item handling.
-6. Demo and screenshot polish.
-7. Distribution readiness only after the real Plaid flow is reliable.
+1. Minimalist modern dashboard polish: heatmap first, dense rows, semantic
+   color, compact native controls, no marketing chrome.
+2. Security and safety: token/storage invariants, status redaction, auth
+   behavior, logs, screenshots, and destructive-action confirmations.
+3. Local-first privacy: no PlaidBar backend, telemetry, cloud sync, multi-user
+   state, or cloud AI over transaction data.
+4. Plaid setup reliability: demo, sandbox, production preflight, reconnect,
+   degraded item handling, and status diagnostics.
+5. Optional local AI: local-only, off by default, explainable, reversible, and
+   non-blocking when no local model runtime is configured.
+6. Production readiness: QA matrix, release notes, troubleshooting, packaging
+   checks, and honest distribution assumptions.
 
 ## RepoBar Design Reference
 
@@ -68,8 +73,13 @@ Translate the pattern to finance instead of copying GitHub concepts literally:
 Stop and report when:
 
 - the requested timebox ends,
-- a coherent slice is committed and ready for push/PR approval,
+- a coherent task or PR slice is committed and ready for the PR/check/review
+  loop,
 - verification fails on a real regression,
 - a product/security decision needs Felipe.
 
-Never push, open PRs, or merge from `/goal` without explicit approval.
+Interactive `/goal` defaults to local work. Push, open PRs, or merge only when
+the current run is explicitly operating under the scoped PlaidBar approval
+documented in `docs/autonomous-roadmap.md`, all local and GitHub checks are
+green, and the safe PR loop says the diff is mergeable. If approval scope or
+safety is unclear, stop with a handoff instead of merging.

--- a/commands/plaidbar-prod-loop.md
+++ b/commands/plaidbar-prod-loop.md
@@ -1,12 +1,13 @@
 ---
-description: Run a multi-hour PlaidBar production-readiness loop with focused implementation, verification, and handoff.
+description: Run the PlaidBar autonomous production-readiness loop with focused implementation, verification, PR review, and safe handoff.
 argument-hint: "[focus area] [--hours=2-4] [--no-commit]"
 ---
 
 # /plaidbar-prod-loop
 
 Use this command to keep improving PlaidBar toward a production-ready,
-local-first macOS finance utility.
+local-first macOS finance utility through the 100+ task backlog in
+`docs/autonomous-loop-backlog.md`.
 
 The default goal is:
 
@@ -30,11 +31,31 @@ codex exec --cd /Users/otto/.openclaw/workspace/repos/PlaidBar \
   "$(cat commands/plaidbar-prod-loop.md)"
 ```
 
+For a focused autonomous iteration:
+
+```bash
+codex exec --cd /Users/otto/.openclaw/workspace/repos/PlaidBar \
+  "Read commands/plaidbar-prod-loop.md and complete the next unfinished task from docs/autonomous-loop-backlog.md for: <focus>"
+```
+
+For parallel review support, keep one primary editor agent and use optional
+read-only parallel agents for design, security/privacy, and QA. Parallel agents
+may inspect files and propose findings; the primary agent owns edits, commits,
+PR creation, and merge-safety decisions.
+
 ## Operating Boundaries
 
-- Work locally unless Felipe explicitly approves pushing or opening a PR.
-- Do not merge PRs from this command.
-- Do not add telemetry, cloud sync, hosted backend, or multi-user features.
+- Work locally by default. Use the scoped PlaidBar approval in
+  `docs/autonomous-roadmap.md` for push, PR, and merge only when the current
+  run is clearly inside that scope and the safe PR loop below passes.
+- When using repo-local `.codex/skills/`, follow their safe PR/check/review
+  gate; do not merge if any approval scope or safety condition is unclear.
+- Do not add telemetry, cloud sync, hosted backend, multi-user features, or
+  cloud AI over private transaction data.
+- Preserve local-first boundaries: app, localhost server, Plaid API, local
+  storage, and no PlaidBar-owned cloud service.
+- Optional AI must be local-only, off by default, explainable, reversible, and
+  non-blocking when no local model runtime is configured.
 - Do not claim token encryption, notarization, or production security properties
   unless the implementation actually provides them.
 - Do not commit screenshots, logs, build products, local databases, or secrets.
@@ -53,19 +74,24 @@ Repeat these phases until the timebox ends or a blocker appears:
    - Read `GOAL.md`, `README.md`, `DESIGN.md`, `docs/architecture.md`, and
      recent changed files before editing.
 
-2. Pick the highest-leverage next slice:
+2. Pick the highest-leverage next task:
    - Prefer the explicit focus area in `$ARGUMENTS`.
-   - Otherwise use the production-readiness backlog below.
-   - Keep the slice small enough to finish with verification evidence.
+   - Otherwise use `docs/autonomous-loop-backlog.md`.
+   - Treat one backlog task as one autonomous iteration.
+   - Combine adjacent tasks from the same PR slice only when the diff remains
+     small enough to finish with verification evidence.
    - If the focus mentions RepoBar, heatmap-first design, account rows, or the
      attached screenshot, use the RepoBar-style finance dashboard slice first.
 
 3. Implement:
    - Follow the app's existing SwiftUI, theme, and local-server patterns.
    - Put finance calculations in `PlaidBarCore` when they are testable logic.
-   - Keep UI dense, native, status-rich, and non-marketing.
+   - Keep UI minimalist, dense, native, status-rich, and non-marketing.
    - For the main popover, prefer a single overview surface with drill-in
      details over adding another tab.
+   - Keep risky actions explicit and confirmation-gated.
+   - Keep local AI optional and local-only; never send private financial data to
+     cloud AI services.
    - Update docs only when behavior or setup changes.
 
 4. Verify:
@@ -82,69 +108,42 @@ Repeat these phases until the timebox ends or a blocker appears:
    - If verification fails from a pre-existing baseline issue, document it and
      keep the branch reviewable.
 
-6. Report progress:
+6. Run the PR/check/review/merge loop when scoped approval applies:
+   - Push only the focused branch for the completed task or PR slice.
+   - Open or update a PR with task ID(s), changed files, local checks,
+     secret-scan result, privacy/security impact, and known limitations.
+   - Wait for GitHub checks; do not merge with failing, pending, skipped, or
+     ambiguous required checks.
+   - Review the final diff before merge for secrets, real financial data,
+     scope creep, generated artifacts, destructive behavior, and local-first
+     boundary violations.
+   - Merge only when local gates passed, GitHub checks are green, the diff is
+     safe under the existing scoped approval, and no user decision is needed.
+   - After merge, verify remote `main` moved as expected, then record the
+     completed task ID in the roadmap ledger.
+
+7. Report progress:
    - Every 30-45 minutes, summarize changed files, validation, and next slice.
    - End with branch name, commit SHA(s), checks, and whether it is ready for
-     Felipe to approve push/PR.
+     push, PR, review, or merge.
 
 ## Production-Readiness Backlog
 
-Work in this order unless Felipe gives a better focus:
+Use `docs/autonomous-loop-backlog.md` as the concrete backlog. It contains 120
+reviewable tasks grouped into PR slices covering:
 
-1. **RepoBar-style finance dashboard**
-   - Study RepoBar's live app/site and source before editing:
-     - `https://repobar.app`
-     - `https://github.com/steipete/RepoBar`
-     - local clone if available: `/Users/otto/.openclaw/workspace/repos/RepoBar`
-   - Target the attached reference screenshot:
-     - translucent macOS popover,
-     - heatmap header,
-     - segmented filter bar,
-     - dense rows with selected/highlighted state,
-     - chevron/drill-in affordance.
-   - Translate RepoBar concepts into finance:
-     - contribution heatmap -> daily spend/cashflow heatmap,
-     - repo rows -> checking, savings, credit card, loan, and other account rows,
-     - repo stats -> balance, available credit, utilization, pending count, sync freshness,
-     - repo submenu -> account/card detail view or sheet,
-     - All/Pinned/Local/Work -> All/Cash/Credit/Savings/Debt/Status.
-   - Build the first slice as an overview UI, not a full budgeting product:
-     - top heatmap from existing transaction/demo data,
-     - filterable account/card rows,
-     - one selected row detail surface for a specific credit card/account,
-     - preserve Status/Settings recovery actions.
+- minimalist modern design and RepoBar-style dashboard polish,
+- account rows, heatmaps, drill-in surfaces, empty states, and reconnect flows,
+- local data controls, token/storage safety, auth, status redaction, logs,
+  screenshots, and fixture safety,
+- demo, sandbox, production setup, accessibility, performance, and QA gates,
+- optional local AI boundaries, local-only insights, and reversible
+  categorization suggestions,
+- PR, review, check, and merge hygiene.
 
-2. **Trust-first local data controls**
-   - Show the local storage path (`~/.plaidbar/`) in Settings.
-   - Add copy/reveal actions for the storage directory when practical.
-   - Add confirmation-gated reset/delete local data flow.
-   - Keep language explicit about what is removed and what remains in Plaid.
-
-3. **Sharper empty and error states**
-   - Accounts: no server, no linked institution, no synced account data.
-   - Transactions: no synced history vs filters returning zero results.
-   - Credit: no linked credit accounts vs data unavailable.
-   - Include one clear recovery action per state.
-
-4. **Server/config preflight**
-   - Add a server endpoint or client helper that reports environment,
-     credential readiness, storage path, item count, and sync readiness.
-   - Use it before Plaid Link and in the Status tab.
-   - Avoid exposing secrets or raw tokens.
-
-5. **Reconnect and degraded-item handling**
-   - Surface item errors and token-expired states in the Status tab.
-   - Provide a clear reconnect/add-account path.
-
-6. **Demo and screenshot polish**
-   - Keep demo data realistic but synthetic.
-   - Ensure screenshots show the current product story:
-     menu summary, status, spending heatmap, onboarding, and settings.
-
-7. **Distribution readiness, later**
-   - Only after sandbox and production setup are reliable.
-   - Focus on packaging docs, signing assumptions, and release checklist.
-   - Do not implement notarization prematurely.
+If a task appears stale, first inspect the current implementation. Complete it
+only if there is still a real gap; otherwise mark the task as already satisfied
+in the roadmap ledger with evidence.
 
 ## Design Standard
 
@@ -187,4 +186,4 @@ Final report must include:
 - validation commands and results
 - known warnings or blockers
 - recommended next slice
-- whether push/PR approval is needed
+- push/PR/review/merge status

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -1,0 +1,277 @@
+# Autonomous Loop Backlog
+
+This backlog is the source of truth for 100+ autonomous PlaidBar
+production-readiness iterations. Each task is intended to be independently
+reviewable. A PR slice may contain one task or a small contiguous group from
+the same section when the diff remains easy to review.
+
+Use this backlog with `commands/goal.md`, `commands/plaidbar-prod-loop.md`,
+and `docs/autonomous-roadmap.md`.
+
+## Selection Rules
+
+- Pick the first unfinished task that matches the requested focus.
+- If no focus is provided, prefer the earliest unfinished task in the highest
+  priority PR slice.
+- Keep each iteration local-first, privacy-preserving, and honest about the
+  current security model.
+- Do not add hosted backend, telemetry, cloud sync, multi-user accounts,
+  budgeting workflows, or cloud AI over transaction data.
+- Optional AI work must be local-only, off by default, explainable, reversible,
+  and non-blocking when no local model runtime is configured.
+- Merge only through the safe PR loop in `docs/autonomous-roadmap.md`.
+
+## Review Gates For Every Task
+
+- Local diff is scoped to the selected task or PR slice.
+- UI changes preserve minimalist modern macOS density: no marketing chrome, no
+  decorative gradients, no nested cards, no color without financial meaning.
+- Security changes do not expose Plaid secrets, access tokens, public tokens,
+  local bearer tokens, account IDs, item IDs, balances, or transactions through
+  status, logs, screenshots, or public docs.
+- Privacy docs remain true: PlaidBar has no hosted backend, analytics,
+  telemetry, tracking, cloud sync, or cloud dashboard.
+- Verification evidence is recorded in the commit, PR body, or final report.
+
+## PR Slices And Tasks
+
+### PR-001: Loop Governance And Backlog Hygiene
+
+- [ ] T001: Add a progress marker for completed backlog task IDs in the
+  autonomous roadmap ledger.
+- [ ] T002: Add a PR-body template section for task IDs, local gates, GitHub
+  checks, privacy impact, and merge safety.
+- [ ] T003: Add a reviewer checklist for local-first boundaries and secret
+  exposure risks.
+- [ ] T004: Add a rule that broad refactors must be split when they touch more
+  than one module boundary.
+- [ ] T005: Add a recurring audit that removes stale or duplicate backlog tasks.
+
+### PR-002: Minimalist Modern Design Audit
+
+- [ ] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.
+- [ ] T007: Replace decorative visual treatment with semantic spacing,
+  separators, and status color in one surface.
+- [ ] T008: Normalize compact row spacing against the existing design tokens.
+- [ ] T009: Tighten one verbose label group without hiding financial meaning.
+- [ ] T010: Add or update screenshot evidence for the changed minimalist surface.
+
+### PR-003: Dashboard Overview Structure
+
+- [ ] T011: Ensure the first popover view answers cash, credit, recent change,
+  sync health, and action-needed status.
+- [ ] T012: Keep the heatmap, filter bar, account rows, and selected detail in
+  one coherent overview.
+- [ ] T013: Preserve deeper account, transaction, credit, and status surfaces as
+  drill-ins rather than competing first-level tabs.
+- [ ] T014: Add a fallback overview state when demo data is unavailable.
+- [ ] T015: Verify the overview fits a realistic menu-bar popover height.
+
+### PR-004: Heatmap Readability
+
+- [ ] T016: Confirm spend and cashflow intensity use distinguishable semantics.
+- [ ] T017: Add accessible text for the strongest recent heatmap signals.
+- [ ] T018: Improve empty heatmap copy for no data vs filtered-zero states.
+- [ ] T019: Add a focused test for heatmap bucket or legend behavior.
+- [ ] T020: Refresh screenshot evidence for the heatmap header.
+
+### PR-005: Account And Card Rows
+
+- [ ] T021: Audit row density for checking, savings, credit card, loan, and
+  other account types.
+- [ ] T022: Ensure every row has a primary amount, secondary detail, freshness,
+  and status signal.
+- [ ] T023: Make credit utilization, available credit, and due metadata readable
+  without opening a budgeting workflow.
+- [ ] T024: Add a selected/highlighted row state that remains subtle in dark and
+  light appearances.
+- [ ] T025: Add focused tests for one shared row-presentation helper.
+
+### PR-006: Account Drill-In Surfaces
+
+- [ ] T026: Ensure account drill-in opens from a row with a predictable keyboard
+  and pointer path.
+- [ ] T027: Show transactions, balances, limits, freshness, and sync state for
+  the selected account.
+- [ ] T028: Keep reconnect, remove, and settings actions explicit and
+  confirmation-gated where destructive.
+- [ ] T029: Add empty drill-in states for no synced transactions and server
+  offline.
+- [ ] T030: Add accessibility labels for drill-in status and action controls.
+
+### PR-007: Empty, Loading, And Error States
+
+- [ ] T031: Distinguish no server, no credentials, no linked item, no synced
+  data, and filtered-zero states in one area.
+- [ ] T032: Add one clear recovery action to each state in that area.
+- [ ] T033: Preserve last-known local data during transient failures.
+- [ ] T034: Truncate or sanitize server error text before display.
+- [ ] T035: Add a focused test for one empty/error-state presenter.
+
+### PR-008: Setup And Plaid Link Preflight
+
+- [ ] T036: Verify demo, sandbox, and production setup choices explain their
+  data boundaries before Plaid Link opens.
+- [ ] T037: Fail fast when sandbox credentials are missing or wrong mode is
+  selected.
+- [ ] T038: Fail fast when production credentials or Plaid approval assumptions
+  are missing.
+- [ ] T039: Show the local storage path before linking accounts.
+- [ ] T040: Add a smoke or unit check for preflight readiness output.
+
+### PR-009: Reconnect And Degraded Items
+
+- [ ] T041: Surface token-expired and item-error states in dashboard status.
+- [ ] T042: Surface the same degraded item state in Settings or Status.
+- [ ] T043: Add a clear reconnect path that does not expose raw Plaid payloads.
+- [ ] T044: Handle browser-open failure with a copyable recovery path.
+- [ ] T045: Add focused tests for degraded item presentation.
+
+### PR-010: Status And Diagnostics
+
+- [ ] T046: Keep `/api/status` limited to readiness metadata.
+- [ ] T047: Add or verify UI treatment for server offline, syncing, stale data,
+  credentials missing, and linked item counts.
+- [ ] T048: Add a local-only diagnostic row for the active data directory.
+- [ ] T049: Make status refresh and connect actions reachable from the dashboard.
+- [ ] T050: Add tests that status presentation does not include sensitive IDs or
+  raw balances.
+
+### PR-011: Local Data Controls
+
+- [ ] T051: Keep Settings visibly anchored on `~/.plaidbar/` or the configured
+  `PLAIDBAR_DATA_DIR`.
+- [ ] T052: Ensure copy and reveal actions avoid leaking secrets in labels or
+  logs.
+- [ ] T053: Confirm reset/delete copy explains local-vs-Plaid-vs-bank
+  boundaries.
+- [ ] T054: Ensure destructive local data actions require confirmation.
+- [ ] T055: Add focused tests for reset-boundary wording or local data path
+  presentation.
+
+### PR-012: Token And Storage Safety
+
+- [ ] T056: Verify new storage files use private permissions where supported.
+- [ ] T057: Add a regression check for Keychain reference vs SQLite fallback
+  language.
+- [ ] T058: Ensure legacy database migration never mixes sandbox and production
+  stores.
+- [ ] T059: Verify local auth-token handling avoids public logs and screenshots.
+- [ ] T060: Add tests around one storage or token-vault invariant.
+
+### PR-013: API Auth And Status Security
+
+- [ ] T061: Verify `/api/*` rejects missing and invalid local bearer tokens.
+- [ ] T062: Add a negative test for status payload secret redaction.
+- [ ] T063: Confirm public localhost endpoints remain limited to `/health` and
+  OAuth callback behavior.
+- [ ] T064: Document any endpoint contract changes before adding new status
+  fields.
+- [ ] T065: Add a secret-scan pattern only when it catches a real PlaidBar risk.
+
+### PR-014: Logs, Fixtures, And Screenshot Safety
+
+- [ ] T066: Audit screenshots for real credentials, balances, account IDs, and
+  merchant histories.
+- [ ] T067: Audit fixtures for synthetic-only financial data.
+- [ ] T068: Ensure logs do not print raw transactions or token-like strings.
+- [ ] T069: Update screenshot docs when a new safe capture path is needed.
+- [ ] T070: Add a fixture or screenshot safety check that can run locally.
+
+### PR-015: Demo Mode Polish
+
+- [ ] T071: Keep demo data realistic, synthetic, and aligned with current UI
+  screenshots.
+- [ ] T072: Ensure demo mode never calls Plaid.
+- [ ] T073: Make demo balances, transactions, recurring charges, and credit
+  state tell a coherent product story.
+- [ ] T074: Add one demo edge case for stale sync or degraded status.
+- [ ] T075: Refresh README or screenshot references after demo UI changes.
+
+### PR-016: Sandbox Reliability
+
+- [ ] T076: Verify sandbox setup succeeds from a clean temporary data directory.
+- [ ] T077: Add clearer failure handling for missing sandbox credentials.
+- [ ] T078: Verify sandbox transaction sync preserves cursor state.
+- [ ] T079: Add smoke-script coverage for one new sandbox readiness assertion.
+- [ ] T080: Document any remaining sandbox limitation without implying
+  production readiness.
+
+### PR-017: Production Readiness Boundaries
+
+- [ ] T081: Keep production setup copy explicit about Plaid approval and real
+  financial data.
+- [ ] T082: Verify production mode uses separate storage from sandbox.
+- [ ] T083: Add a release checklist item for clean-profile production setup.
+- [ ] T084: Avoid notarization, appcast, or distribution claims until verified.
+- [ ] T085: Update troubleshooting for one production credential or mode failure.
+
+### PR-018: Accessibility And Keyboard Flow
+
+- [ ] T086: Add labels for one icon-only action group.
+- [ ] T087: Ensure color-coded financial status has text, icon, or shape backup.
+- [ ] T088: Verify tab order through overview, drill-in, refresh, reconnect, and
+  settings actions.
+- [ ] T089: Add VoiceOver summaries for one chart or status surface.
+- [ ] T090: Add focused tests or manual QA notes for the changed accessibility
+  behavior.
+
+### PR-019: Performance And Responsiveness
+
+- [ ] T091: Identify one slow or duplicate data calculation in the popover path.
+- [ ] T092: Move one reusable pure calculation into `PlaidBarCore`.
+- [ ] T093: Preserve cached last-known data during refresh.
+- [ ] T094: Avoid blocking the popover on optional diagnostics or AI output.
+- [ ] T095: Add a focused performance or reducer test for the moved calculation.
+
+### PR-020: Optional Local AI Boundaries
+
+- [ ] T096: Define the local AI runtime contract without naming a cloud model as
+  a dependency.
+- [ ] T097: Add copy that local AI is optional, off by default, and never
+  required for dashboard use.
+- [ ] T098: Ensure local AI prompts never include secrets, raw account IDs, or
+  tokens.
+- [ ] T099: Add an unavailable state when no local model runtime is configured.
+- [ ] T100: Add tests for local AI availability and disabled-state presentation.
+
+### PR-021: Local AI Insight Quality
+
+- [ ] T101: Summarize 7-day spending changes using local transaction data only.
+- [ ] T102: Summarize monthly income, expenses, recurring charges, and credit
+  utilization with source evidence.
+- [ ] T103: Add year-over-year wording only when enough local history exists.
+- [ ] T104: Show why an insight was generated using source transaction or
+  category evidence.
+- [ ] T105: Add a deterministic non-AI fallback summary for unsupported runtimes.
+
+### PR-022: Local AI Categorization Safety
+
+- [ ] T106: Treat Plaid category data as the auditable source-of-record fallback.
+- [ ] T107: Keep AI category suggestions separate from raw Plaid transaction
+  records.
+- [ ] T108: Allow a user correction path for suggested categories.
+- [ ] T109: Add reversible local-only storage for category corrections when
+  implemented.
+- [ ] T110: Add tests that AI suggestions do not mutate raw Plaid data.
+
+### PR-023: QA, CI, And Release Gates
+
+- [ ] T111: Keep `docs/qa-matrix.md` aligned with the current minimum PR gates.
+- [ ] T112: Add or update a local command for formula or package validation.
+- [ ] T113: Record known Swift toolchain baseline limitations accurately.
+- [ ] T114: Keep release notes honest about shipped behavior and deferred work.
+- [ ] T115: Add a final release-candidate checklist for privacy, security,
+  screenshots, and local setup.
+
+### PR-024: PR, Review, And Merge Hygiene
+
+- [ ] T116: Ensure every autonomous PR includes task IDs, changed files, local
+  checks, and secret-scan evidence.
+- [ ] T117: Require GitHub checks to be green before any merge attempt.
+- [ ] T118: Require a manual safety read of the diff before merging under scoped
+  approval.
+- [ ] T119: Block merge when app code, docs, screenshots, or generated files
+  include real private financial data.
+- [ ] T120: After a safe merge, update the progress ledger and choose the next
+  unfinished task.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -2,19 +2,25 @@
 
 This roadmap guides the recurring local agent loop that keeps PlaidBar aligned
 with its local-first menu bar finance vision. It complements `GOAL.md`,
-`commands/goal.md`, and the long-term product brief in
+`commands/goal.md`, `commands/plaidbar-prod-loop.md`, the concrete backlog in
+`docs/autonomous-loop-backlog.md`, and the long-term product brief in
 `docs/v1.0-roadmap.md`.
 
 ## Operating Contract
 
 - Work locally for implementation and verification.
 - Felipe granted scoped PlaidBar approval on 2026-05-30 to push branches, open
-  PRs, and merge to remote `main` after green local and GitHub checks.
+  PRs, and merge to remote `main` after green local and GitHub checks. Use that
+  approval only for focused PlaidBar work with a safe final diff review.
 - Do not publish releases or post externally outside normal GitHub PR/merge
   workflow without Felipe's explicit approval.
 - Keep each loop to one reviewable production-readiness slice.
 - Prefer fixes that make the 1.0 promise more true: local-first trust,
   reliable onboarding, clear recovery, and dense native finance UX.
+- Preserve the privacy boundary: no PlaidBar-hosted backend, telemetry, cloud
+  sync, multi-user accounts, or cloud AI over private transaction data.
+- Keep optional local AI local-only, off by default, explainable, reversible,
+  and non-blocking when no local model runtime is configured.
 - Commit only when local verification passes or baseline limitations are
   documented.
 - Leave the branch reviewable after every run.
@@ -25,13 +31,49 @@ The OpenClaw cron job `d6eb6833-969a-4436-af06-0fd0f1bd94e2` runs an isolated
 PlaidBar production-readiness loop every four hours. Each run should:
 
 1. Inspect `git status --short --branch` and recent commits.
-2. Read `GOAL.md`, `docs/v1.0-roadmap.md`, this file, and the touched area.
-3. Pick the highest-leverage unfinished slice from the backlog below.
-4. Implement the smallest coherent change.
-5. Run the relevant gates.
-6. Use Clawpatch or manual review for changed surfaces.
+2. Read `GOAL.md`, `commands/plaidbar-prod-loop.md`,
+   `docs/autonomous-loop-backlog.md`, this file, and the touched area.
+3. Pick the highest-leverage unfinished task ID from the backlog.
+4. Implement the smallest coherent change; combine adjacent task IDs only when
+   the PR remains easy to review.
+5. Run the relevant local gates.
+6. Use Clawpatch, manual review, or read-only parallel agents for changed
+   surfaces.
 7. Commit locally with a focused conventional commit when safe.
-8. Report branch, commits, checks, known limitations, and next slice.
+8. If scoped approval applies, run the PR/check/review/merge loop below.
+9. Report branch, commits, checks, known limitations, completed task IDs, and
+   next task ID.
+
+## Codex CLI And Parallel Agents
+
+- `commands/plaidbar-prod-loop.md` is the canonical Codex CLI prompt.
+- Use one primary editor agent for all writes, commits, PR updates, and merge
+  decisions.
+- Use optional read-only parallel agents for design, security/privacy, QA, or
+  docs review. They should return findings and suggested tests, not edit the
+  same files in parallel.
+- Prefer focused search and file reads over speculative repo-wide rewrites.
+- Do not run parallel push or merge attempts.
+
+## PR, Check, Review, And Merge Loop
+
+Use this loop only when the current run is inside the 2026-05-30 scoped
+PlaidBar approval. If approval scope, product safety, or security impact is
+unclear, stop and ask Felipe.
+
+1. Push only the focused branch for the completed task or PR slice.
+2. Open or update a PR with task ID(s), changed files, local verification,
+   secret-scan result, privacy/security impact, screenshots when relevant, and
+   known limitations.
+3. Wait for required GitHub checks. Do not merge with failing, pending,
+   skipped, cancelled, missing, or ambiguous required checks.
+4. Read the final diff before merge. Block merge for secrets, real financial
+   data, raw Plaid identifiers, scope creep, generated artifacts, unsafe
+   destructive behavior, or local-first boundary violations.
+5. Merge only when local gates passed, GitHub checks are green, the diff is
+   safe under the scoped approval, and no user decision is needed.
+6. After merge, verify remote `main` moved as expected and record completed
+   task ID(s) in the progress ledger.
 
 ## Always-Run Gates
 
@@ -46,9 +88,7 @@ supports the `Testing` module. On this machine, the current baseline is
 `no such module 'Testing'`; record that limitation instead of treating it as a
 new regression.
 
-## Backlog
-
-### Progress Ledger
+## Progress Ledger
 
 Completed production-readiness slices:
 
@@ -107,52 +147,24 @@ Completed production-readiness slices:
 - 2026-06-01: moved account row amounts, subtitles, and accessibility summary
   composition into `PlaidBarCore`.
 
-### Reliability And Trust
+## Backlog Source
 
-1. Continue moving duplicated UI/service formulas into `PlaidBarCore` helpers
-   where they still exist, especially chart totals, credit/debt presentation,
-   and account detail summary logic.
-2. Harden local storage and token handling:
-   pre-open SQLite permissions, Keychain fallback copy, reset behavior, and
-   private-file invariants.
-3. Make sandbox and production setup failures explicit:
-   wrong mode, missing credentials, browser-open failure, and first-sync
-   partial completion.
-4. Keep status/reconnect paths available from dashboard, settings, and account
-   detail surfaces.
+Use `docs/autonomous-loop-backlog.md` for new work. It currently defines 120
+reviewable tasks across 24 PR slices:
 
-### Product Polish
+- loop governance, PR hygiene, checks, review, and merge safety
+- minimalist modern design, heatmap overview, dense rows, and drill-in surfaces
+- empty states, setup preflight, reconnect, status diagnostics, and local data
+  controls
+- token/storage safety, API auth, status redaction, logs, fixtures, and
+  screenshot safety
+- demo, sandbox, production setup, accessibility, performance, QA, and release
+  readiness
+- optional local AI boundaries, local-only insights, and reversible
+  categorization suggestions
 
-1. Improve empty and filtered-zero states for transactions, recurring charges,
-   credit, and account drill-down.
-2. Keep the dashboard compact and RepoBar-like:
-   heatmap first, dense rows, status-rich selected detail, no marketing chrome.
-3. Refresh demo fixtures and screenshots when UI behavior changes.
-4. Improve accessibility labels for icon-only controls and chart/status signals.
-
-### Local AI Insights
-
-1. Add an on-device AI summary layer for financial activity, with no cloud model
-   calls and no transaction data leaving the Mac.
-2. Summarize spending, income, recurring charges, credit utilization, balance
-   changes, and notable anomalies over the last 7 days, last month, and
-   year-over-year windows.
-3. Use local AI to improve categorization of expenses and income while keeping
-   Plaid categories as the auditable source-of-record fallback.
-4. Make AI output explainable and reversible: show the source transactions or
-   category evidence behind each summary, allow user correction, and never
-   mutate raw Plaid transaction data.
-5. Treat local-model availability as optional. If no model runtime is
-   configured, hide or disable insight surfaces with a clear setup/recovery
-   action instead of blocking the core dashboard.
-
-### Distribution And Open Source
-
-1. Keep README, troubleshooting, privacy, security, release notes, and QA matrix
-   aligned with actual behavior.
-2. Verify Homebrew formula syntax and source-build path after packaging changes.
-3. Maintain a release checklist that is honest about notarization, Plaid
-   production approval, and local data boundaries.
+When a task is completed or found already satisfied, add one dated ledger entry
+with the task ID, evidence, and PR or commit reference when available.
 
 ## Stop Conditions
 
@@ -162,5 +174,7 @@ Stop the current loop and report when:
 - A required decision would change product/security scope.
 - A clean local commit is made and the next slice is independent.
 - The branch contains user changes that conflict with the planned edit.
+- GitHub checks are not green or the final diff is not safe to merge under the
+  existing scoped approval.
 
 Do not stop merely because more roadmap work remains.


### PR DESCRIPTION
## Summary
- Updates `/goal` and `/plaidbar-prod-loop` to drive a >100-iteration autonomous production-readiness loop.
- Adds `docs/autonomous-loop-backlog.md` with 120 tasks grouped into 24 PR slices across minimalist modern design, security/safety, local-first privacy, optional local AI, production readiness, QA, and PR/merge hygiene.
- Aligns repo-local Codex skills with the safe PR/check/review/merge gate under the existing scoped PlaidBar approval.

## Task IDs / Scope
- Workflow/bootstrap slice for autonomous loop governance.
- Documentation-only: commands, roadmap, backlog, and `.codex/skills` instructions.
- No application code changed.

## Safety / Privacy Impact
- Reinforces no hosted backend, telemetry, cloud sync, multi-user state, or cloud AI over private transaction data.
- Local AI is explicitly optional, local-only, off by default, explainable, reversible, and non-blocking.
- Merge policy blocks unsafe diffs with secrets, real financial data, generated artifacts, destructive behavior, or local-first boundary violations.

## Validation
- `git diff --check` ✅
- `swift build --target PlaidBar --skip-update --disable-keychain` ✅
- Markdown structural checks: 120 tasks / 24 PR slices ✅
- Changed-file token scan: no actual token-looking secrets found ✅
- Frontmatter delimiter checks ✅

## Review
@codex review
