### PR TITLE
docs: add backlog task ledger markers

### DIFF
--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -92,6 +92,10 @@ new regression.
 
 Completed production-readiness slices:
 
+Use `[T###]` after the date for completed backlog task IDs, for example
+`2026-06-07 [T001]: ...`. Legacy entries without a mapped backlog task ID may
+remain unmarked.
+
 - 2026-05-30: moved notification trigger selection into `PlaidBarCore`.
 - 2026-05-30: moved transaction filtering into `PlaidBarCore`.
 - 2026-05-30: recorded scoped approval to push branches, open PRs, and merge
@@ -146,6 +150,8 @@ Completed production-readiness slices:
 - 2026-06-01: shared balance composition totals through `PlaidBarCore`.
 - 2026-06-01: moved account row amounts, subtitles, and accessibility summary
   composition into `PlaidBarCore`.
+- 2026-06-07 [T001]: documented the completed-task marker convention for
+  autonomous roadmap ledger entries; evidence: docs-only roadmap update.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Task IDs: T001
- Adds an explicit `[T###]` progress marker convention for completed autonomous backlog entries in `docs/autonomous-roadmap.md`
- Adds a dated T001 ledger entry demonstrating the convention

## Changed files
- `docs/autonomous-roadmap.md`

## Local verification
- `git diff --check` — passed
- `swift build --target PlaidBar --skip-update --disable-keychain` — passed; SwiftPM emitted the baseline deprecation warning for `--skip-update`
- Changed-file secret/token scan on `docs/autonomous-roadmap.md` — passed, no matches
- Full configured secret scan — reviewed baseline documentation/code references only; no new matches from this docs-only diff

## Privacy / security impact
- Docs-only governance change
- No app behavior changes, no financial data, no credentials, no screenshots, no generated artifacts
- Preserves local-first/privacy boundaries

## Known limitations
- Existing legacy ledger entries remain unmarked unless a future task maps them to backlog IDs

@codex review