### PR TITLE
docs: mark T001 backlog task complete

### DIFF
--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -37,7 +37,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-001: Loop Governance And Backlog Hygiene
 
-- [ ] T001: Add a progress marker for completed backlog task IDs in the
+- [x] T001: Add a progress marker for completed backlog task IDs in the
   autonomous roadmap ledger.
 - [ ] T002: Add a PR-body template section for task IDs, local gates, GitHub
   checks, privacy impact, and merge safety.


### PR DESCRIPTION
## Summary
- Task IDs: T001
- Marks T001 complete in `docs/autonomous-loop-backlog.md` after PR #188 added the roadmap ledger marker convention
- Addresses Codex review feedback from PR #188 that future loops would otherwise reselect T001

## Changed files
- `docs/autonomous-loop-backlog.md`

## Local verification
- `git diff --check` — passed
- `swift build --target PlaidBar --skip-update --disable-keychain` — passed; SwiftPM emitted the baseline deprecation warning for `--skip-update`
- Changed-file secret/token scan on `docs/autonomous-loop-backlog.md` — passed, no matches

## Privacy / security impact
- Docs-only backlog bookkeeping change
- No app behavior changes, no financial data, no credentials, no screenshots, no generated artifacts

## Known limitations
- Legacy ledger entries remain unmarked unless future tasks map them to backlog IDs

@codex review