### PR TITLE
fix: simplify balance mix surface

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -433,6 +433,8 @@ private struct MetricCard: View {
 private struct BalanceCompositionStrip: View {
     @Environment(AppState.self) private var appState
 
+    private let segmentSpacing: CGFloat = 2
+
     private var segments: [BalanceCompositionSegment] {
         [
             BalanceCompositionSegment(
@@ -490,10 +492,10 @@ private struct BalanceCompositionStrip: View {
             }
 
             GeometryReader { proxy in
-                HStack(spacing: 3) {
+                HStack(spacing: segmentSpacing) {
                     ForEach(activeSegments) { segment in
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(segment.tint.gradient)
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(segment.fillColor)
                             .frame(width: segmentWidth(segment, totalWidth: proxy.size.width))
                             .accessibilityLabel(
                                 "\(segment.title), \(Formatters.currency(segment.value, format: .compact))"
@@ -501,7 +503,10 @@ private struct BalanceCompositionStrip: View {
                     }
                 }
             }
-            .frame(height: 8)
+            .frame(height: 7)
+
+            Divider()
+                .opacity(0.55)
 
             HStack(spacing: 8) {
                 ForEach(segments) { segment in
@@ -510,13 +515,16 @@ private struct BalanceCompositionStrip: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 9)
-        .nativePanelSurface()
+        .padding(.vertical, 8)
+        .nativePanelSurface(
+            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.panelFillOpacity)),
+            stroke: Color.primary.opacity(0.065)
+        )
         .accessibilityElement(children: .contain)
     }
 
     private func segmentWidth(_ segment: BalanceCompositionSegment, totalWidth: CGFloat) -> CGFloat {
-        let gaps = CGFloat(max(activeSegments.count - 1, 0)) * 3
+        let gaps = CGFloat(max(activeSegments.count - 1, 0)) * segmentSpacing
         let availableWidth = max(totalWidth - gaps, 0)
         return max(availableWidth * CGFloat(segment.value / total), 6)
     }
@@ -529,6 +537,10 @@ private struct BalanceCompositionSegment: Identifiable {
 
     var id: String {
         title
+    }
+
+    var fillColor: Color {
+        value > 0 ? tint.opacity(0.82) : Color.primary.opacity(0.08)
     }
 }
 

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -50,7 +50,7 @@ and `docs/autonomous-roadmap.md`.
 ### PR-002: Minimalist Modern Design Audit
 
 - [ ] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.
-- [ ] T007: Replace decorative visual treatment with semantic spacing,
+- [x] T007: Replace decorative visual treatment with semantic spacing,
   separators, and status color in one surface.
 - [ ] T008: Normalize compact row spacing against the existing design tokens.
 - [ ] T009: Tighten one verbose label group without hiding financial meaning.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -155,6 +155,10 @@ remain unmarked.
 - 2026-06-07 [T002]: expanded the pull request template with task IDs,
   local gates, GitHub checks, privacy impact, and merge safety sections;
   evidence: `.github/pull_request_template.md` checklist update.
+- 2026-06-07 [T007]: replaced decorative balance-mix gradients with semantic
+  flat account-type color, a lighter panel fill, and a separator in the main
+  dashboard surface; evidence: `Sources/PlaidBar/Views/MainPopover.swift` UI
+  update.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Task: T007 (PR-002 Minimalist Modern Design Audit)
- Replaces the balance-mix strip's decorative gradients with flat semantic account-type color.
- Tightens the strip height/padding and adds a quiet separator between the bar and legend.
- Records the T007 ledger entry in `docs/autonomous-roadmap.md`.

## Changed files
- `Sources/PlaidBar/Views/MainPopover.swift`
- `docs/autonomous-roadmap.md`

## Local validation
- `git diff --check` ✅
- `swift build --target PlaidBar --skip-update --disable-keychain` ✅
- Changed-file secret/token scan ✅ no matches
- Full configured scan fallback: `rg` is not installed locally; Python fallback found only existing placeholder/documentation/code references to credential names, not changes in this PR.

## Privacy / security impact
- UI-only dashboard polish plus roadmap ledger update.
- No Plaid tokens, account IDs, transactions, logs, screenshots, generated artifacts, destructive behavior, telemetry, hosted backend, or cloud sync added.

## Known limitations
- No screenshot refresh in this slice because the scheduled run is limited to one bounded task and Screen Recording/Accessibility may require interactive macOS permissions.

@codex review
