### PR TITLE
feat: tighten post-1 dashboard recovery and local AI

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -50,6 +50,7 @@ final class AppState {
     var isDemoStatusRecoveryScenario = false
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
+    var notificationPermissionState: NotificationPermissionState = .notDetermined
 
     // MARK: - Settings (persisted to UserDefaults)
     var menuBarSummaryMode: MenuBarSummaryMode = .netCash {
@@ -443,8 +444,14 @@ final class AppState {
             erroredItemCount: erroredItemCount,
             isSyncStale: isSyncStale,
             lastSyncRelative: lastSyncRelative,
-            errorMessage: error
+            errorMessage: error,
+            notificationsEnabled: notificationsEnabled,
+            notificationPermission: notificationPermissionPresentation
         )
+    }
+
+    var notificationPermissionPresentation: NotificationPermissionPresentation {
+        NotificationPermissionPresentation.evaluate(kind: notificationPermissionState.presentationKind)
     }
 
     var usesDemoConnectionPresentation: Bool {
@@ -877,11 +884,14 @@ final class AppState {
     }
 
     func requestNotificationPermission() async -> Bool {
-        await notificationService.requestPermission()
+        let granted = await notificationService.requestPermission()
+        notificationPermissionState = await notificationService.checkPermissionStatus()
+        return granted
     }
 
     func notificationPermissionStatus() async -> NotificationPermissionState {
-        await notificationService.checkPermissionStatus()
+        notificationPermissionState = await notificationService.checkPermissionStatus()
+        return notificationPermissionState
     }
 
     func stopBackgroundRefresh() {
@@ -892,10 +902,7 @@ final class AppState {
     func loadInitialData() async {
         // Recheck notification permission at startup (user may have revoked in System Settings)
         if notificationsEnabled {
-            let permissionState = await notificationService.checkPermissionStatus()
-            if permissionState.shouldDisableNotifications {
-                notificationsEnabled = false
-            }
+            _ = await notificationPermissionStatus()
         }
 
         if CommandLine.arguments.contains("--demo") {

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -13,7 +13,7 @@ struct LocalAIInsightsService {
         guard let runtime, !runtime.isEmpty, runtime.lowercased() != "disabled" else {
             return LocalAIAvailability(
                 state: .disabled,
-                detail: "No local AI runtime is configured. PlaidBar is using deterministic local summaries only."
+                detail: "No local AI runtime is configured. PlaidBar is using deterministic local summaries and category hints only."
             )
         }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -588,10 +588,13 @@ private struct PendingAccountRemoval: Identifiable {
 
 struct NotificationSettingsView: View {
     @Environment(AppState.self) private var appState
-    @State private var permissionState: NotificationPermissionState = .notDetermined
 
     private var permissionPresentation: NotificationPermissionPresentation {
-        NotificationPermissionPresentation.evaluate(kind: permissionState.presentationKind)
+        appState.notificationPermissionPresentation
+    }
+
+    private var areNotificationControlsDisabled: Bool {
+        !appState.notificationsEnabled || permissionPresentation.shouldDisableNotifications
     }
 
     var body: some View {
@@ -609,7 +612,6 @@ struct NotificationSettingsView: View {
                                     let granted = await appState.requestNotificationPermission()
                                     await refreshPermissionStatus()
                                     guard granted else {
-                                        appState.notificationsEnabled = false
                                         return
                                     }
                                 }
@@ -622,7 +624,7 @@ struct NotificationSettingsView: View {
 
                 SettingsCard(title: "Transaction Alerts") {
                     Toggle("Large transactions", isOn: $state.notifyLargeTransaction)
-                        .disabled(!appState.notificationsEnabled)
+                        .disabled(areNotificationControlsDisabled)
 
                     settingsRow("Threshold") {
                         HStack(spacing: Spacing.sm) {
@@ -637,9 +639,9 @@ struct NotificationSettingsView: View {
                             .textFieldStyle(.roundedBorder)
                         }
                     }
-                    .disabled(!appState.notificationsEnabled || !appState.notifyLargeTransaction)
+                    .disabled(areNotificationControlsDisabled || !appState.notifyLargeTransaction)
 
-                    if appState.notificationsEnabled,
+                    if !areNotificationControlsDisabled,
                        appState.notifyLargeTransaction,
                        appState.largeTransactionThreshold <= 0 {
                         InlineSettingsNotice(
@@ -650,7 +652,7 @@ struct NotificationSettingsView: View {
                     }
 
                     Toggle("Low balance warning", isOn: $state.notifyLowBalance)
-                        .disabled(!appState.notificationsEnabled)
+                        .disabled(areNotificationControlsDisabled)
 
                     settingsRow("Threshold") {
                         HStack(spacing: Spacing.sm) {
@@ -665,12 +667,12 @@ struct NotificationSettingsView: View {
                             .textFieldStyle(.roundedBorder)
                         }
                     }
-                    .disabled(!appState.notificationsEnabled || !appState.notifyLowBalance)
+                    .disabled(areNotificationControlsDisabled || !appState.notifyLowBalance)
                 }
 
                 SettingsCard(title: "Credit Alerts") {
                     Toggle("High utilization", isOn: $state.notifyHighUtilization)
-                        .disabled(!appState.notificationsEnabled)
+                        .disabled(areNotificationControlsDisabled)
                     Text("Uses credit warning threshold (\(Formatters.percent(appState.creditUtilizationThreshold, decimals: 0)))")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
@@ -714,12 +716,7 @@ struct NotificationSettingsView: View {
     }
 
     private func refreshPermissionStatus() async {
-        let state = await appState.notificationPermissionStatus()
-        permissionState = state
-
-        if state.shouldDisableNotifications, appState.notificationsEnabled {
-            appState.notificationsEnabled = false
-        }
+        _ = await appState.notificationPermissionStatus()
     }
 
     private func openNotificationSettings() {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1,3 +1,4 @@
+import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -13,12 +14,12 @@ struct MainPopover: View {
     private enum Layout {
         static let dashboardWidth: CGFloat = 480
         static let setupWidth: CGFloat = 560
-        static let dashboardMinHeight: CGFloat = 480
+        static let dashboardMinHeight: CGFloat = 460
         static let dashboardMaxHeight: CGFloat = 660
         static let contentHorizontalPadding: CGFloat = 12
-        static let contentTopPadding: CGFloat = 10
-        static let contentBottomPadding: CGFloat = 10
-        static let sectionSpacing: CGFloat = 9
+        static let contentTopPadding: CGFloat = 8
+        static let contentBottomPadding: CGFloat = 8
+        static let sectionSpacing: CGFloat = 7
     }
 
     private var selectedFilter: DashboardAccountFilter {
@@ -59,9 +60,6 @@ struct MainPopover: View {
 
                         BalanceActivityHeatmap(transactions: appState.transactions)
 
-                        LocalInsightsCard()
-                            .environment(appState)
-
                         DashboardFilterBar(selection: filterBinding)
 
                         AccountsSection(
@@ -78,6 +76,9 @@ struct MainPopover: View {
                             .environment(appState)
 
                         BalanceCompositionStrip()
+                            .environment(appState)
+
+                        LocalInsightsCard()
                             .environment(appState)
 
                         if shouldShowLowerStatusReadinessPanel {
@@ -186,7 +187,7 @@ private struct DashboardHeader: View {
                     .foregroundStyle(.secondary)
 
                 Text(Formatters.currency(appState.netBalance, format: .full))
-                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .font(.system(size: 27, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .contentTransition(.numericText())
                     .lineLimit(1)
@@ -247,7 +248,7 @@ private struct DashboardStatusStrip: View {
             )
         }
         .padding(.horizontal, 9)
-        .padding(.vertical, 7)
+        .padding(.vertical, 6)
         .nativePanelSurface(
             fill: AnyShapeStyle(.regularMaterial),
             stroke: Color.primary.opacity(0.085)
@@ -669,7 +670,7 @@ private struct BalanceActivityHeatmap: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
                 Text(title)
                     .sectionTitle()
@@ -869,7 +870,7 @@ private struct LocalInsightsCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center, spacing: 8) {
                 Text("Local Insights")
                     .sectionTitle()
@@ -882,7 +883,7 @@ private struct LocalInsightsCard: View {
 
             Text(primarySummary?.generatedSummary ?? "Local summaries are ready when transaction history is available.")
                 .font(.caption.weight(.semibold))
-                .lineLimit(2)
+                .lineLimit(1)
                 .minimumScaleFactor(0.86)
 
             HStack(spacing: 6) {
@@ -891,7 +892,7 @@ private struct LocalInsightsCard: View {
                 }
             }
 
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 3) {
                 ForEach(Array(bullets.enumerated()), id: \.offset) { _, bullet in
                     HStack(alignment: .top, spacing: 6) {
                         Circle()
@@ -910,7 +911,7 @@ private struct LocalInsightsCard: View {
                 Image(systemName: "lock.shield.fill")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text("Local-only. No cloud model calls. Plaid categories remain the auditable fallback.")
+                Text(footerText)
                     .microText()
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -923,6 +924,14 @@ private struct LocalInsightsCard: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Local insights. \(availability.state.displayName). \(availability.detail)")
+    }
+
+    private var footerText: String {
+        let suggestionCount = primarySummary?.input.categorySuggestions.count ?? 0
+        guard suggestionCount > 0 else {
+            return "Local-only. No cloud model calls. Plaid categories remain the auditable fallback."
+        }
+        return "\(suggestionCount) deterministic category hint\(suggestionCount == 1 ? "" : "s"). Plaid categories remain fallback evidence."
     }
 }
 
@@ -1200,7 +1209,19 @@ private struct DashboardStatusReadinessPanel: View {
             Task { await appState.reconnectItem(itemId: itemId) }
         case .openSettings:
             openSettings()
+        case .requestNotificationPermission:
+            Task { _ = await appState.requestNotificationPermission() }
+        case .openNotificationSettings:
+            openNotificationSettings()
         }
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            openSettings()
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
     private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -14,6 +14,9 @@ struct NativePanelSurface: ViewModifier {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         if useLiquidGlass {
+            // Keep every reference to Liquid Glass APIs inside this compile-time
+            // gate. PlaidBar supports macOS 15, where the fallback fill/material
+            // surface below must remain the active type-checked path.
             #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
             if #available(macOS 26.0, *) {
                 content

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import PlaidBarCore
 
 struct StatusView: View {
@@ -337,7 +338,19 @@ struct StatusView: View {
             Task { await appState.reconnectItem(itemId: itemId) }
         case .openSettings:
             openSettings()
+        case .requestNotificationPermission:
+            Task { _ = await appState.requestNotificationPermission() }
+        case .openNotificationSettings:
+            openNotificationSettings()
         }
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            openSettings()
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
     private func primaryActionLabel(

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -12,6 +12,8 @@ public enum DashboardStatusReadinessAction: String, Codable, Sendable {
     case refresh
     case reconnect
     case openSettings
+    case requestNotificationPermission
+    case openNotificationSettings
 }
 
 public struct DashboardStatusReadiness: Equatable, Sendable {
@@ -54,7 +56,9 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         erroredItemCount: Int,
         isSyncStale: Bool,
         lastSyncRelative: String?,
-        errorMessage: String?
+        errorMessage: String?,
+        notificationsEnabled: Bool = false,
+        notificationPermission: NotificationPermissionPresentation? = nil
     ) -> DashboardStatusReadiness {
         if isDemoMode {
             return DashboardStatusReadiness(
@@ -188,6 +192,13 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             )
         }
 
+        if let notificationRecovery = notificationPermissionRecovery(
+            notificationsEnabled: notificationsEnabled,
+            permission: notificationPermission
+        ) {
+            return notificationRecovery
+        }
+
         return DashboardStatusReadiness(
             level: .healthy,
             title: "Plaid sync healthy",
@@ -264,6 +275,65 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     ) -> String {
         "\(count) item\(count == 1 ? "" : "s") \(count == 1 ? singularAction : pluralAction)"
     }
+
+    private static func notificationPermissionRecovery(
+        notificationsEnabled: Bool,
+        permission: NotificationPermissionPresentation?
+    ) -> DashboardStatusReadiness? {
+        guard notificationsEnabled,
+              let permission,
+              permission.shouldDisableNotifications
+        else { return nil }
+
+        switch permission.recoveryAction {
+        case .requestPermission:
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: "Notification permission not requested",
+                detail: "Local alerts are enabled, but macOS permission has not been requested yet.",
+                primaryAction: .requestNotificationPermission,
+                primaryActionTitle: permission.recoveryActionTitle,
+                primaryActionIconName: permission.recoveryActionIconName,
+                secondaryActions: [.openSettings]
+            )
+        case .openSystemSettings:
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: "Notifications blocked",
+                detail: "Local alerts are enabled, but macOS is blocking PlaidBar notifications. Enable PlaidBar in System Settings to recover alerts.",
+                primaryAction: .openNotificationSettings,
+                primaryActionTitle: permission.recoveryActionTitle,
+                primaryActionIconName: permission.recoveryActionIconName,
+                secondaryActions: [.openSettings]
+            )
+        case .checkAgain:
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: "Notification permission unknown",
+                detail: permission.detail,
+                primaryAction: .requestNotificationPermission,
+                primaryActionTitle: "Check Permission",
+                primaryActionIconName: "arrow.clockwise",
+                secondaryActions: [.openSettings]
+            )
+        case .runBundledApp:
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: "Notification identity unavailable",
+                detail: permission.detail,
+                primaryAction: .openSettings,
+                primaryActionTitle: permission.recoveryActionTitle,
+                primaryActionIconName: permission.recoveryActionIconName
+            )
+        case nil:
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: "Notifications unavailable",
+                detail: permission.detail,
+                primaryAction: .openSettings
+            )
+        }
+    }
 }
 
 public extension DashboardStatusReadinessAction {
@@ -274,6 +344,8 @@ public extension DashboardStatusReadinessAction {
         case .refresh: "Refresh"
         case .reconnect: "Reconnect"
         case .openSettings: "Settings"
+        case .requestNotificationPermission: "Request Permission"
+        case .openNotificationSettings: "Open System Settings"
         }
     }
 
@@ -284,6 +356,8 @@ public extension DashboardStatusReadinessAction {
         case .refresh: "arrow.clockwise"
         case .reconnect: "link.badge.plus"
         case .openSettings: "gearshape"
+        case .requestNotificationPermission: "bell.badge"
+        case .openNotificationSettings: "gearshape"
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -102,6 +102,7 @@ public struct LocalAIActivitySummaryInput: Codable, Sendable, Hashable {
     public let window: LocalAIInsightWindow
     public let currentRange: LocalAIInsightDateRange
     public let priorRange: LocalAIInsightDateRange?
+    public let categorySuggestions: [LocalAICategorySuggestion]
     public let accountSnapshot: LocalAIAccountSnapshot
     public let current: LocalAIActivityMetrics
     public let prior: LocalAIActivityMetrics?
@@ -112,6 +113,7 @@ public struct LocalAIActivitySummaryInput: Codable, Sendable, Hashable {
         window: LocalAIInsightWindow,
         currentRange: LocalAIInsightDateRange,
         priorRange: LocalAIInsightDateRange?,
+        categorySuggestions: [LocalAICategorySuggestion] = [],
         accountSnapshot: LocalAIAccountSnapshot,
         current: LocalAIActivityMetrics,
         prior: LocalAIActivityMetrics?,
@@ -121,6 +123,7 @@ public struct LocalAIActivitySummaryInput: Codable, Sendable, Hashable {
         self.window = window
         self.currentRange = currentRange
         self.priorRange = priorRange
+        self.categorySuggestions = categorySuggestions
         self.accountSnapshot = accountSnapshot
         self.current = current
         self.prior = prior

--- a/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
@@ -42,6 +42,115 @@ public enum LocalAICategorizationResolver {
     }
 }
 
+public enum LocalAICategorySuggestionGenerator {
+    public static let generatedBy = "local-ai/deterministic"
+
+    public static func suggestions(from transactions: [TransactionDTO]) -> [LocalAICategorySuggestion] {
+        transactions.compactMap(suggestion)
+            .sorted { lhs, rhs in
+                if lhs.transactionId != rhs.transactionId { return lhs.transactionId < rhs.transactionId }
+                if lhs.confidence != rhs.confidence { return lhs.confidence > rhs.confidence }
+                return lhs.suggestedCategory.rawValue < rhs.suggestedCategory.rawValue
+            }
+    }
+
+    private static func suggestion(for transaction: TransactionDTO) -> LocalAICategorySuggestion? {
+        guard let match = categoryMatch(for: transaction) else { return nil }
+        guard transaction.category != match.category else { return nil }
+
+        var evidence = [
+            LocalAIInsightEvidence(
+                kind: .localHeuristic,
+                sourceId: transaction.id,
+                label: match.reason,
+                transactionIds: [transaction.id],
+                accountIds: [transaction.accountId],
+                amount: transaction.displayAmount,
+                date: transaction.date
+            ),
+        ]
+
+        if let plaidCategory = transaction.category {
+            evidence.append(
+                LocalAIInsightEvidence(
+                    kind: .plaidCategory,
+                    sourceId: transaction.id,
+                    label: "Plaid category: \(plaidCategory.displayName)",
+                    transactionIds: [transaction.id],
+                    accountIds: [transaction.accountId]
+                )
+            )
+        }
+
+        return LocalAICategorySuggestion(
+            transactionId: transaction.id,
+            suggestedCategory: match.category,
+            confidence: match.confidence,
+            status: .proposed,
+            evidence: evidence,
+            generatedBy: generatedBy
+        )
+    }
+
+    private static func categoryMatch(for transaction: TransactionDTO)
+        -> (category: SpendingCategory, confidence: Double, reason: String)?
+    {
+        let text = normalizedSearchText(for: transaction)
+
+        if transaction.amount < 0, containsAny(text, ["payroll", "salary", "paycheck", "direct deposit", "stripe payout"]) {
+            return (.income, 0.95, "Income keyword matched local transaction text")
+        }
+
+        if containsAny(text, ["refund", "reversal", "cashback", "cash back", "credit adjustment"]) {
+            return (.income, 0.88, "Refund or credit keyword matched local transaction text")
+        }
+
+        if containsAny(text, ["transfer", "zelle", "venmo", "cash app", "paypal transfer"]) {
+            let category: SpendingCategory = transaction.amount < 0 ? .transfer : .transferOut
+            return (category, 0.88, "Transfer keyword matched local transaction text")
+        }
+
+        let expenseRules: [(SpendingCategory, Double, [String])] = [
+            (.foodAndDrink, 0.91, ["coffee", "cafe", "restaurant", "grocery", "supermarket", "whole foods", "trader joe", "doordash", "uber eats", "chipotle", "pizza"]),
+            (.transportation, 0.90, ["uber", "lyft", "taxi", "transit", "parking", "shell", "chevron", "exxon", "gas station", "metro"]),
+            (.shopping, 0.90, ["amazon", "target", "walmart", "costco", "best buy", "ebay", "store", "shop"]),
+            (.entertainment, 0.89, ["netflix", "spotify", "hulu", "disney", "amc", "cinema", "movie", "steam"]),
+            (.personalCare, 0.88, ["salon", "barber", "spa"]),
+            (.healthAndFitness, 0.89, ["pharmacy", "cvs", "walgreens", "doctor", "dentist", "gym", "medical"]),
+            (.billsAndUtilities, 0.90, ["rent", "utility", "electric", "power", "water", "internet", "comcast", "xfinity", "verizon", "at&t", "t-mobile"]),
+            (.homeImprovement, 0.88, ["home depot", "lowe", "ikea", "hardware"]),
+            (.travel, 0.90, ["airline", "hotel", "airbnb", "delta", "united", "southwest", "marriott", "hilton"]),
+            (.education, 0.88, ["tuition", "school", "university", "bookstore"]),
+            (.subscriptions, 0.88, ["subscription", "recurring", "apple.com/bill", "google storage", "adobe", "patreon"]),
+            (.bankFees, 0.91, ["atm fee", "overdraft", "bank fee", "monthly fee"]),
+            (.government, 0.88, ["irs", "tax", "dmv", "government"]),
+        ]
+
+        for rule in expenseRules where containsAny(text, rule.2) {
+            return (rule.0, rule.1, "\(rule.0.displayName) keyword matched local transaction text")
+        }
+
+        if transaction.amount < 0 {
+            return (.income, 0.86, "Incoming Plaid amount convention matched local transaction text")
+        }
+
+        return nil
+    }
+
+    private static func normalizedSearchText(for transaction: TransactionDTO) -> String {
+        [transaction.merchantName, transaction.name]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private static func containsAny(_ text: String, _ needles: [String]) -> Bool {
+        needles.contains { text.contains($0) }
+    }
+}
+
 public enum LocalAIInsightInputBuilder {
     public static func buildInputs(
         accounts: [AccountDTO],
@@ -74,7 +183,11 @@ public enum LocalAIInsightInputBuilder {
         calendar: Calendar = .current
     ) -> LocalAIActivitySummaryInput {
         let ranges = dateRanges(for: window, anchorDate: anchorDate, calendar: calendar)
-        let suggestionsByTransaction = preferredSuggestionsByTransaction(categorySuggestions)
+        let resolvedCategorySuggestions = resolvedCategorySuggestions(
+            explicitSuggestions: categorySuggestions,
+            transactions: transactions
+        )
+        let suggestionsByTransaction = preferredSuggestionsByTransaction(resolvedCategorySuggestions)
         let current = metrics(
             from: transactions,
             in: ranges.current,
@@ -105,11 +218,13 @@ public enum LocalAIInsightInputBuilder {
         evidence.append(contentsOf: current.categoryTotals.flatMap(\.evidence))
         evidence.append(contentsOf: current.topExpenses.flatMap(\.evidence))
         evidence.append(contentsOf: current.topIncome.flatMap(\.evidence))
+        evidence.append(contentsOf: resolvedCategorySuggestions.flatMap(\.evidence))
 
         return LocalAIActivitySummaryInput(
             window: window,
             currentRange: ranges.current,
             priorRange: ranges.prior,
+            categorySuggestions: resolvedCategorySuggestions,
             accountSnapshot: accountSnapshot,
             current: current,
             prior: prior,
@@ -376,6 +491,19 @@ public enum LocalAIInsightInputBuilder {
                 preferred[suggestion.transactionId] = suggestion
             }
         }
+    }
+
+    private static func resolvedCategorySuggestions(
+        explicitSuggestions: [LocalAICategorySuggestion],
+        transactions: [TransactionDTO]
+    ) -> [LocalAICategorySuggestion] {
+        let generated = LocalAICategorySuggestionGenerator.suggestions(from: transactions)
+        return Array(preferredSuggestionsByTransaction(explicitSuggestions + generated).values)
+            .sorted { lhs, rhs in
+                if lhs.transactionId != rhs.transactionId { return lhs.transactionId < rhs.transactionId }
+                if lhs.confidence != rhs.confidence { return lhs.confidence > rhs.confidence }
+                return lhs.suggestedCategory.rawValue < rhs.suggestedCategory.rawValue
+            }
     }
 }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1517,6 +1517,31 @@ struct PlaidBarCoreTests {
         #expect(presentation.shouldDisableNotifications)
     }
 
+    @Test("Dashboard status readiness converges notification permission recovery")
+    func dashboardStatusReadinessSurfacesNotificationPermissionRecovery() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: false,
+            lastSyncRelative: "just now",
+            errorMessage: nil,
+            notificationsEnabled: true,
+            notificationPermission: NotificationPermissionPresentation.evaluate(kind: .denied)
+        )
+
+        #expect(readiness.level == .warning)
+        #expect(readiness.title == "Notifications blocked")
+        #expect(readiness.primaryAction == .openNotificationSettings)
+        #expect(readiness.primaryActionTitle == "Open System Settings")
+        #expect(readiness.secondaryActions == [.openSettings])
+    }
+
     @Test("Dashboard account filters include only matching account kinds")
     func dashboardAccountFiltersMatchAccountKinds() {
         let checking = AccountDTO(id: "checking", itemId: "item_cash", name: "Checking", type: .depository, subtype: "checking", balances: BalanceDTO())
@@ -2841,6 +2866,61 @@ struct PlaidBarCoreTests {
         #expect(input.current.incomeTransactionIds == ["income"])
         #expect(input.current.expenseTransactionIds == ["expense"])
         #expect(Set(input.current.transferTransactionIds) == Set(["transfer-out", "transfer-in"]))
+    }
+
+    @Test("Local AI deterministic category suggestions preserve Plaid fallback evidence")
+    func localAIDeterministicCategorySuggestionsPreservePlaidFallbackEvidence() throws {
+        let anchor = try #require(Formatters.parseTransactionDate("2026-03-15"))
+        let transaction = TransactionDTO(
+            id: "amazon-miscoded",
+            accountId: "checking",
+            amount: 80,
+            date: "2026-03-15",
+            name: "AMAZON.COM",
+            merchantName: "Amazon",
+            category: .other
+        )
+
+        let input = LocalAIInsightInputBuilder.buildInput(
+            window: .last7days,
+            accounts: [],
+            transactions: [transaction],
+            recurringTransactions: [],
+            anchorDate: anchor
+        )
+
+        let suggestion = try #require(input.categorySuggestions.first)
+        #expect(suggestion.transactionId == "amazon-miscoded")
+        #expect(suggestion.suggestedCategory == .shopping)
+        #expect(suggestion.generatedBy == LocalAICategorySuggestionGenerator.generatedBy)
+        #expect(suggestion.evidence.contains { $0.kind == .plaidCategory && $0.label == "Plaid category: Other" })
+        #expect(input.current.categoryTotals.first?.category == .shopping)
+    }
+
+    @Test("Local AI deterministic transfer hints keep expenses auditable")
+    func localAIDeterministicTransferHintsKeepExpensesAuditable() throws {
+        let anchor = try #require(Formatters.parseTransactionDate("2026-03-15"))
+        let transaction = TransactionDTO(
+            id: "venmo-transfer",
+            accountId: "checking",
+            amount: 125,
+            date: "2026-03-15",
+            name: "VENMO TRANSFER",
+            merchantName: "Venmo",
+            category: .foodAndDrink
+        )
+
+        let input = LocalAIInsightInputBuilder.buildInput(
+            window: .last7days,
+            accounts: [],
+            transactions: [transaction],
+            recurringTransactions: [],
+            anchorDate: anchor
+        )
+
+        #expect(input.categorySuggestions.first?.suggestedCategory == .transferOut)
+        #expect(input.current.expenseTransactionIds.isEmpty)
+        #expect(input.current.transferTransactionIds == ["venmo-transfer"])
     }
 
     @Test("Local AI transfer suggestions move rows out of expense totals")


### PR DESCRIPTION
## Summary
- Tightens the post-1.0 dashboard toward a compact RepoBar-style finance instrument: denser layout, lower visual weight, and safer Liquid Glass progressive-enhancement guardrails.
- Converges dashboard/status/settings recovery for notification-permission failures alongside existing server, Plaid item, empty-data, and stale-sync recovery actions.
- Adds deterministic local-only AI category suggestions and local insight inputs while keeping Plaid categories as auditable fallback evidence and avoiding cloud model calls.

## Scope / Safety
- Local-first only; no telemetry, no hosted state, no cloud model integration.
- No release/distribution changes, repo settings changes, or destructive data behavior.
- Notification intent is preserved and surfaced as recovery state instead of silently disabling user preference when macOS permission blocks alerts.

## Validation
- `git diff --check`
- `env CLANG_MODULE_CACHE_PATH=/private/tmp/plaidbar-clang-module-cache swift build --target PlaidBar --disable-sandbox --skip-update --disable-keychain`
- `env CLANG_MODULE_CACHE_PATH=/private/tmp/plaidbar-clang-module-cache swift build --target PlaidBarServer --disable-sandbox --skip-update --disable-keychain`
- `env CLANG_MODULE_CACHE_PATH=/private/tmp/plaidbar-clang-module-cache swift test --disable-sandbox --skip-update --disable-keychain` — 247 tests passed
- Changed-file secret scan — no actual token-looking secrets found

@codex review
