### PR TITLE
feat(ui): normalize compact account row spacing

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -84,6 +84,10 @@ enum Spacing {
     static let lg: CGFloat = 16
     static let xl: CGFloat = 24
     static let rowVertical: CGFloat = 6
+    static let compactRowHorizontalPadding: CGFloat = sm
+    static let compactRowVerticalPadding: CGFloat = xs
+    static let compactRowContentSpacing: CGFloat = sm
+    static let compactRowTextSpacing: CGFloat = xxs
 }
 
 // MARK: - Native Surfaces

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1365,8 +1365,8 @@ private struct AccountsSection: View {
                     .sectionTitle()
                     .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, 2)
-            .padding(.bottom, 5)
+            .padding(.horizontal, Spacing.compactRowTextSpacing)
+            .padding(.bottom, Spacing.xs)
 
             if accounts.isEmpty {
                 DashboardEmptyAccountState(filter: filter, onAddAccount: onAddAccount)
@@ -1415,8 +1415,8 @@ private struct AccountRowWithDrilldown: View {
             if isSelected {
                 SelectedAccountPanel(account: account, isStatusFilter: isStatusFilter)
                     .environment(appState)
-                    .padding(.top, 6)
-                    .padding(.bottom, 8)
+                    .padding(.top, Spacing.compactRowVerticalPadding)
+                    .padding(.bottom, Spacing.compactRowContentSpacing)
             }
         }
     }
@@ -1599,7 +1599,7 @@ private struct DashboardAccountRow: View {
     let isSelected: Bool
 
     var body: some View {
-        HStack(spacing: 9) {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
             Image(systemName: AccountPresentation.iconName(for: account))
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(accountTint)
@@ -1615,7 +1615,7 @@ private struct DashboardAccountRow: View {
                         }
                 }
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                 Text(account.name)
                     .font(.callout.weight(.semibold))
                     .lineLimit(1)
@@ -1624,9 +1624,9 @@ private struct DashboardAccountRow: View {
                     .lineLimit(1)
             }
 
-            Spacer(minLength: 8)
+            Spacer(minLength: Spacing.compactRowContentSpacing)
 
-            VStack(alignment: .trailing, spacing: 4) {
+            VStack(alignment: .trailing, spacing: Spacing.xs) {
                 Text(amountText)
                     .font(.callout.weight(.bold))
                     .monospacedDigit()
@@ -1655,8 +1655,8 @@ private struct DashboardAccountRow: View {
                 .font(.caption.weight(.bold))
                 .foregroundStyle(.tertiary)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+        .padding(.vertical, Spacing.compactRowVerticalPadding)
         .background(isSelected ? SemanticColors.brand.opacity(SurfaceTokens.selectedFillOpacity) : Color.primary.opacity(0.012))
         .overlay(alignment: .leading) {
             if isSelected {
@@ -1771,9 +1771,9 @@ private struct SelectedAccountPanel: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: Spacing.compactRowContentSpacing) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                     Text("Details")
                         .sectionTitle()
                         .foregroundStyle(.secondary)
@@ -1794,7 +1794,7 @@ private struct SelectedAccountPanel: View {
                 )
             }
 
-            HStack(spacing: 8) {
+            HStack(spacing: Spacing.compactRowContentSpacing) {
                 DetailValue(title: availableTitle, value: availableText, tint: .primary)
                 DetailValue(title: currentTitle, value: currentText, tint: currentTint)
 
@@ -1817,7 +1817,7 @@ private struct SelectedAccountPanel: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(spacing: 7) {
+            HStack(spacing: Spacing.compactRowContentSpacing) {
                 AccountSignalPill(
                     title: "Pending",
                     value: "\(pendingTransactions.count)",
@@ -1845,7 +1845,7 @@ private struct SelectedAccountPanel: View {
             }
 
             if isStatusFilter, let recoveryDetailLabel = connectionPresentation.recoveryDetailLabel {
-                HStack(alignment: .top, spacing: 8) {
+                HStack(alignment: .top, spacing: Spacing.compactRowContentSpacing) {
                     Image(systemName: connectionIcon)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(connectionTint)
@@ -1854,8 +1854,8 @@ private struct SelectedAccountPanel: View {
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+                .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+                .padding(.vertical, Spacing.compactRowVerticalPadding)
                 .nativePanelSurface(
                     cornerRadius: SurfaceTokens.panelCornerRadius,
                     fill: AnyShapeStyle(recoveryFill),
@@ -1866,7 +1866,7 @@ private struct SelectedAccountPanel: View {
             }
 
             if shouldShowRecoveryActions {
-                HStack(spacing: 8) {
+                HStack(spacing: Spacing.compactRowContentSpacing) {
                     Button {
                         performConnectionRecoveryAction()
                     } label: {
@@ -1877,7 +1877,7 @@ private struct SelectedAccountPanel: View {
                 }
             }
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: Spacing.rowVertical) {
                 Text("Recent Activity")
                     .sectionTitle()
                     .foregroundStyle(.secondary)
@@ -1893,7 +1893,7 @@ private struct SelectedAccountPanel: View {
                 }
             }
         }
-        .padding(12)
+        .padding(Spacing.md)
         .nativePanelSurface(
             fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: shouldEmphasizeConnection ? connectionTint : nil)),
             stroke: panelStroke
@@ -2049,8 +2049,8 @@ private struct AccountConnectionBadge: View {
             .font(.caption.weight(.semibold))
             .lineLimit(1)
             .foregroundStyle(tint)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+            .padding(.vertical, Spacing.compactRowVerticalPadding)
             .background(tint.opacity(0.12), in: Capsule())
     }
 }
@@ -2062,13 +2062,13 @@ private struct AccountSignalPill: View {
     let tint: Color
 
     var body: some View {
-        HStack(spacing: 5) {
+        HStack(spacing: Spacing.xs) {
             Image(systemName: icon)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
                 .frame(width: 12)
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                 Text(title)
                     .microText()
                     .foregroundStyle(.secondary)
@@ -2079,8 +2079,8 @@ private struct AccountSignalPill: View {
                     .minimumScaleFactor(0.82)
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
+        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+        .padding(.vertical, Spacing.compactRowVerticalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
         .accessibilityElement(children: .ignore)
@@ -2094,7 +2094,7 @@ private struct DetailValue: View {
     let tint: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
             Text(title)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -2110,12 +2110,12 @@ private struct TransactionMiniRow: View {
     let transaction: TransactionDTO
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
             Circle()
                 .fill(transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55))
                 .frame(width: 8, height: 8)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                 Text(transaction.displayName)
                     .font(.callout.weight(.semibold))
                     .lineLimit(1)
@@ -2150,14 +2150,14 @@ private struct AccountActivityEmptyStateView: View {
     let presentation: AccountActivityEmptyState
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: Spacing.compactRowContentSpacing) {
             Image(systemName: presentation.iconName)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
                 .frame(width: 18, height: 18)
                 .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                 Text(presentation.title)
                     .font(.caption.weight(.semibold))
                 Text(presentation.detail)
@@ -2165,10 +2165,10 @@ private struct AccountActivityEmptyStateView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Spacer(minLength: 8)
+            Spacer(minLength: Spacing.compactRowContentSpacing)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
+        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+        .padding(.vertical, Spacing.compactRowContentSpacing)
         .nativePanelSurface(
             cornerRadius: SurfaceTokens.panelCornerRadius,
             fill: AnyShapeStyle(tint.opacity(0.055)),

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -58,7 +58,7 @@ and `docs/autonomous-roadmap.md`.
 - [ ] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.
 - [x] T007: Replace decorative visual treatment with semantic spacing,
   separators, and status color in one surface.
-- [ ] T008: Normalize compact row spacing against the existing design tokens.
+- [x] T008: Normalize compact row spacing against the existing design tokens.
 - [ ] T009: Tighten one verbose label group without hiding financial meaning.
 - [ ] T010: Add or update screenshot evidence for the changed minimalist surface.
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -173,6 +173,10 @@ remain unmarked.
   duplicate, completed-but-unchecked, and product-boundary-mismatched backlog
   tasks; evidence: `docs/autonomous-loop-backlog.md` and
   `commands/plaidbar-prod-loop.md` updates.
+- 2026-06-07 [T008]: normalized dashboard account-row and selected-detail
+  spacing through compact row design tokens; evidence:
+  `Sources/PlaidBar/Theme/DesignTokens.swift` and
+  `Sources/PlaidBar/Views/MainPopover.swift` updates.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Task IDs
- T008: Normalize compact row spacing against the existing design tokens.

## Changed files
- `Sources/PlaidBar/Theme/DesignTokens.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Summary
- Added compact dashboard row spacing tokens to the shared `Spacing` design tokens.
- Replaced ad-hoc spacing and padding values in dashboard account rows, selected-account details, signal pills, recent activity rows, and account activity empty states.
- Marked T008 complete in the autonomous backlog and recorded ledger evidence.

## Local validation
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] Changed-file secret/token scan: no matches.
- [x] Safety path scan: no generated assets, screenshots, logs, local DBs, or build artifacts changed.

## GitHub checks
- Pending on PR creation.

## Privacy / security impact
- UI spacing and docs-only ledger update; no server, storage, token, Plaid API, auth, telemetry, cloud sync, or local AI behavior changes.
- No real financial data, secrets, generated artifacts, screenshots, logs, or local databases included.

## Known limitations
- No screenshot refresh in this slice; T010 remains available for screenshot evidence.
- Focused tests were not run because this change is SwiftUI spacing/token-only and does not change app/core/server logic.

## Merge safety
- Scoped to one UI backlog task.
- Local-first product boundary unchanged.
- Final diff should be reviewed for generated artifacts and secret exposure before merge.

@codex review
