### PR TITLE
docs: inventory popover surface density

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -317,6 +317,23 @@ Pattern for all empty states:
 | Settings | 4-tab TabView: General, Accounts, Notifications, About (480×380) | TabView |
 | Onboarding | Demo/Sandbox/Production choice with local-storage disclosure before Plaid Link | Mode choice, Back, Check Connection |
 
+### Popover Surface Inventory
+
+Inventory for T006: surfaces that still risk feeling tab-heavy or card-heavy.
+Keep this inventory about visual structure only. Do not record real balances,
+account masks, institution names, transaction names, item IDs, tokens, or local
+absolute paths when adding screenshot or review evidence.
+
+| Surface | Code reference | Current pattern | Risk | Recommended follow-up |
+|---------|----------------|-----------------|------|-----------------------|
+| Dashboard summary stack | `DashboardSummaryCards`, `MetricCard`, and `BalanceCompositionStrip` in `Sources/PlaidBar/Views/MainPopover.swift` | Several rounded panels appear after the heatmap and before account rows | Reads like stacked dashboard cards instead of one compact menu-bar instrument | Flatten at least one summary group into separator-backed inline metrics before adding more dashboard sections |
+| Selected account detail | `SelectedAccountPanel`, `AccountSignalPill`, recovery detail, and recent activity in `Sources/PlaidBar/Views/MainPopover.swift` | Inline drill-in uses an outer panel plus nested inset pills and a recovery panel | Clearest nested-card pattern in the main popover when an account is selected | Keep the inline drill-in, but reduce nested panel treatment to status color, separators, and compact rows |
+| Local insights | `LocalInsightsCard` and `InsightMetricPill` in `Sources/PlaidBar/Views/MainPopover.swift` | Optional local-only AI/status content is presented as a card with nested metric pills | Can feel like product/marketing chrome if it competes with financial rows | Prefer a compact disclosure or status row unless local insights become the selected detail focus |
+| Status and readiness | `DashboardStatusReadinessPanel` and `DashboardEmptyAccountState` in `Sources/PlaidBar/Views/MainPopover.swift` | Recovery and empty states use prominent rounded panels | Appropriate when degraded, but card-heavy if shown alongside several other panels | Keep panels exceptional for action-needed states; avoid duplicating status panels in normal healthy dashboard flow |
+| Legacy/detail surfaces | `AccountsView`, `TransactionsView`, `SpendingView`, `CreditView`, and `StatusView` | Older detail views include segmented controls, forms, grids, and diagnostic tiles | Tab-heavy if promoted back to first-level popover navigation | Treat as drill-ins or reference/screenshot surfaces; keep the main popover dashboard-first |
+| Settings | `SettingsView` | 4-tab macOS settings control plane | Tab-heavy by design, but outside the primary popover dashboard | Leave as settings unless a future settings-specific audit scopes a flatter layout |
+| Onboarding/setup | `SetupView` | Demo/Sandbox/Production choices, preflight rows, and local-storage disclosure use multiple callout blocks | First-run flow can feel card-heavy and marketing-like if choices duplicate each other | Keep boundary explanations, but consolidate duplicate choice surfaces before adding more setup panels |
+
 ## Extending the Design System
 
 ### Adding a New Component

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -55,7 +55,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-002: Minimalist Modern Design Audit
 
-- [ ] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.
+- [x] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.
 - [x] T007: Replace decorative visual treatment with semantic spacing,
   separators, and status color in one surface.
 - [x] T008: Normalize compact row spacing against the existing design tokens.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -177,6 +177,8 @@ remain unmarked.
   spacing through compact row design tokens; evidence:
   `Sources/PlaidBar/Theme/DesignTokens.swift` and
   `Sources/PlaidBar/Views/MainPopover.swift` updates.
+- 2026-06-07 [T006]: inventoried popover surfaces that still risk feeling
+  tab-heavy or card-heavy; evidence: `DESIGN.md` popover surface inventory.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Completes T006 by adding a popover surface inventory to `DESIGN.md`.
- Calls out surfaces that still risk feeling tab-heavy or card-heavy.
- Marks T006 complete in the autonomous backlog and roadmap ledger.

## Autonomous task IDs
- [x] T006: Inventory popover surfaces that still look tab-heavy or card-heavy.

## Changed files
- `DESIGN.md`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] Changed-file secret scan: docs-only false positives for words like token/secret; no secret material or real financial data added.

## GitHub checks
- [ ] `build`
- [ ] `claude-review`

## Privacy / safety impact
- Docs-only design inventory.
- Explicitly warns not to record real balances, account masks, institution names, transaction names, item IDs, tokens, or local absolute paths in screenshot/review evidence.
- No hosted backend, telemetry, cloud sync, cloud AI, or Plaid/API behavior changes.

## UI / accessibility checks
- No runtime UI code changed.
- Inventory is intended to guide later UI simplification toward semantic spacing, separators, and status color.

## Merge safety
- Scope is one backlog task.
- Safe to merge after GitHub checks are green and final diff review confirms docs-only scope.

@codex review
