### PR TITLE
feat(ui): tighten heatmap labels

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -610,7 +610,7 @@ private struct BalanceActivityHeatmap: View {
     }
 
     private var title: String {
-        mode == .spending ? "365D Spending Activity" : "365D Cashflow Activity"
+        mode == .spending ? "365D Spend" : "365D Cashflow"
     }
 
     private var totalLabel: String {
@@ -751,7 +751,7 @@ private struct BalanceActivityHeatmap: View {
 
                 Spacer()
 
-                Text("\(activeDayCount) days · Last 365D")
+                Text("\(activeDayCount) active days")
                     .microText()
                     .foregroundStyle(.secondary)
             }

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -59,7 +59,7 @@ and `docs/autonomous-roadmap.md`.
 - [x] T007: Replace decorative visual treatment with semantic spacing,
   separators, and status color in one surface.
 - [x] T008: Normalize compact row spacing against the existing design tokens.
-- [ ] T009: Tighten one verbose label group without hiding financial meaning.
+- [x] T009: Tighten one verbose label group without hiding financial meaning.
 - [ ] T010: Add or update screenshot evidence for the changed minimalist surface.
 
 ### PR-003: Dashboard Overview Structure

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -179,6 +179,9 @@ remain unmarked.
   `Sources/PlaidBar/Views/MainPopover.swift` updates.
 - 2026-06-07 [T006]: inventoried popover surfaces that still risk feeling
   tab-heavy or card-heavy; evidence: `DESIGN.md` popover surface inventory.
+- 2026-06-07 [T009]: tightened the dashboard heatmap label group while
+  preserving the 365-day spending and cashflow meaning; evidence:
+  `Sources/PlaidBar/Views/MainPopover.swift` UI copy update.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Completes T009 by tightening the dashboard heatmap label group.
- Changes `365D Spending Activity` / `365D Cashflow Activity` to `365D Spend` / `365D Cashflow`.
- Replaces duplicated footer copy `N days · Last 365D` with `N active days` while the 365-day window remains in the header/accessibility label.

## Autonomous task IDs
- [x] T009: Tighten one verbose label group without hiding financial meaning.

## Changed files
- `Sources/PlaidBar/Views/MainPopover.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] Changed-file secret scan: docs-only false positives for words like token/secret; no secret material or real financial data added.

## GitHub checks
- [ ] `build`
- [ ] `claude-review`

## Privacy / safety impact
- UI copy only plus backlog/ledger docs.
- No real balances, account IDs, item IDs, transaction data, tokens, screenshots, logging, hosted backend, telemetry, cloud sync, or Plaid/API behavior changes.

## UI / accessibility checks
- Visible labels are shorter while preserving the financial mode: spend vs cashflow.
- Accessibility label still says this is a heatmap for the last 365 days with active-day count.

## Merge safety
- Scope is one backlog task.
- Safe to merge after GitHub checks are green and final diff review confirms copy-only scope.

@codex review
