### PR TITLE
feat: answer key overview status at first glance

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -352,7 +352,7 @@ private struct DashboardSummaryCards: View {
                 MetricCard(
                     title: "7D Spend",
                     value: Formatters.currency(appState.recentSpend, format: .compact),
-                    detail: appState.runwayBasisText,
+                    detail: recentSpendDetail,
                     tint: recentSpendTint,
                     emphasizesTint: appState.recentSpend > 0
                 )
@@ -382,22 +382,29 @@ private struct DashboardSummaryCards: View {
         if let utilization = appState.totalCreditUtilization {
             return Formatters.percent(utilization, decimals: 0)
         }
-        return Formatters.currency(appState.totalDebt, format: .compact)
+        guard !appState.creditAccounts.isEmpty else { return "No credit" }
+        return Formatters.currency(MenuBarSummary.totalDebt(from: appState.creditAccounts), format: .compact)
     }
 
     private var creditDetail: String {
-        let debtCount = appState.debtAccounts.count
-        guard debtCount > 0 else { return "No credit linked" }
+        let creditCount = appState.creditAccounts.count
+        guard creditCount > 0 else { return "No credit linked" }
 
         if appState.totalCreditUtilization != nil {
-            return "\(Formatters.currency(appState.totalDebt, format: .compact)) owed"
+            return "\(Formatters.currency(MenuBarSummary.totalDebt(from: appState.creditAccounts), format: .compact)) owed"
         }
-        return "\(debtCount) debt account\(debtCount == 1 ? "" : "s")"
+        return "\(creditCount) credit account\(creditCount == 1 ? "" : "s")"
     }
 
     private var shouldEmphasizeCredit: Bool {
-        guard let utilization = appState.totalCreditUtilization else { return appState.totalDebt > 0 }
+        guard let utilization = appState.totalCreditUtilization else {
+            return MenuBarSummary.totalDebt(from: appState.creditAccounts) > 0
+        }
         return utilization >= appState.creditUtilizationThreshold
+    }
+
+    private var recentSpendDetail: String {
+        appState.recentSpend > 0 ? "Last 7 days" : "No 7D spend"
     }
 
     private var recentSpendTint: Color {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -332,52 +332,108 @@ private struct DashboardSummaryCards: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        HStack(spacing: 8) {
-            MetricCard(
-                title: "Cash",
-                value: Formatters.currency(appState.totalCash, format: .compact),
-                detail: "\(appState.depositoryAccounts.count) cash account\(appState.depositoryAccounts.count == 1 ? "" : "s")",
-                tint: .secondary
-            )
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                MetricCard(
+                    title: "Cash",
+                    value: Formatters.currency(appState.totalCash, format: .compact),
+                    detail: "\(appState.depositoryAccounts.count) cash account\(appState.depositoryAccounts.count == 1 ? "" : "s")",
+                    tint: .secondary
+                )
 
-            MetricCard(
-                title: "Debt",
-                value: Formatters.currency(appState.totalDebt, format: .compact),
-                detail: debtDetail,
-                tint: SemanticColors.creditDebt,
-                emphasizesTint: appState.totalDebt > 0
-            )
+                MetricCard(
+                    title: "Credit",
+                    value: creditValue,
+                    detail: creditDetail,
+                    tint: SemanticColors.creditDebt,
+                    emphasizesTint: shouldEmphasizeCredit
+                )
 
-            MetricCard(
-                title: "Runway",
-                value: appState.runwayText,
-                detail: appState.runwayBasisText,
-                tint: runwayTint,
-                emphasizesTint: shouldEmphasizeRunway
-            )
+                MetricCard(
+                    title: "7D Spend",
+                    value: Formatters.currency(appState.recentSpend, format: .compact),
+                    detail: appState.runwayBasisText,
+                    tint: recentSpendTint,
+                    emphasizesTint: appState.recentSpend > 0
+                )
+            }
+
+            HStack(spacing: 8) {
+                MetricCard(
+                    title: "Sync",
+                    value: appState.statusSyncText,
+                    detail: appState.statusServerText,
+                    tint: syncTint,
+                    emphasizesTint: appState.isSyncStale || !appState.serverConnected
+                )
+
+                MetricCard(
+                    title: "Action",
+                    value: actionValue,
+                    detail: actionDetail,
+                    tint: actionTint,
+                    emphasizesTint: appState.dashboardStatusReadiness.level != .healthy
+                )
+            }
         }
     }
 
-    private var debtDetail: String {
+    private var creditValue: String {
+        if let utilization = appState.totalCreditUtilization {
+            return Formatters.percent(utilization, decimals: 0)
+        }
+        return Formatters.currency(appState.totalDebt, format: .compact)
+    }
+
+    private var creditDetail: String {
         let debtCount = appState.debtAccounts.count
-        guard debtCount > 0 else { return "No debt linked" }
+        guard debtCount > 0 else { return "No credit linked" }
 
-        guard let utilization = appState.totalCreditUtilization else {
-            return "\(debtCount) debt account\(debtCount == 1 ? "" : "s")"
+        if appState.totalCreditUtilization != nil {
+            return "\(Formatters.currency(appState.totalDebt, format: .compact)) owed"
         }
-        return "\(Formatters.percent(utilization, decimals: 0)) credit util"
+        return "\(debtCount) debt account\(debtCount == 1 ? "" : "s")"
     }
 
-    private var runwayTint: Color {
-        guard let months = appState.runwayMonths else { return .secondary }
-        if months < 1 { return SemanticColors.negative }
-        if months < 3 { return SemanticColors.warning }
+    private var shouldEmphasizeCredit: Bool {
+        guard let utilization = appState.totalCreditUtilization else { return appState.totalDebt > 0 }
+        return utilization >= appState.creditUtilizationThreshold
+    }
+
+    private var recentSpendTint: Color {
+        appState.recentSpend > 0 ? SemanticColors.negative : .secondary
+    }
+
+    private var syncTint: Color {
+        if !appState.serverConnected { return SemanticColors.negative }
+        if appState.isSyncStale { return SemanticColors.warning }
         return .secondary
     }
 
-    private var shouldEmphasizeRunway: Bool {
-        guard let months = appState.runwayMonths else { return false }
-        return months < 3
+    private var actionValue: String {
+        switch appState.dashboardStatusReadiness.level {
+        case .healthy:
+            return "None"
+        case .warning:
+            return "Review"
+        case .blocked:
+            return "Blocked"
+        }
+    }
+
+    private var actionDetail: String {
+        appState.dashboardStatusReadiness.title
+    }
+
+    private var actionTint: Color {
+        switch appState.dashboardStatusReadiness.level {
+        case .healthy:
+            return .secondary
+        case .warning:
+            return SemanticColors.warning
+        case .blocked:
+            return SemanticColors.negative
+        }
     }
 }
 

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -58,6 +58,18 @@ struct PlaidBarTests {
         #expect(abs(net - 38000) < 0.01)
     }
 
+    @Test("Credit summary debt excludes loans when card is labeled credit")
+    func creditSummaryDebtExcludesLoans() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Auto Loan", type: .loan, balances: BalanceDTO(current: -12000)),
+            AccountDTO(id: "2", itemId: "i", name: "Credit", type: .credit, balances: BalanceDTO(current: -450, limit: nil)),
+        ]
+
+        let creditOnlyDebt = MenuBarSummary.totalDebt(from: accounts.filter { $0.type == .credit })
+
+        #expect(abs(creditOnlyDebt - 450) < 0.01)
+    }
+
     // MARK: - Spending Aggregation
 
     @Test("Spending aggregation by category")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -64,7 +64,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-003: Dashboard Overview Structure
 
-- [ ] T011: Ensure the first popover view answers cash, credit, recent change,
+- [x] T011: Ensure the first popover view answers cash, credit, recent change,
   sync health, and action-needed status.
 - [ ] T012: Keep the heatmap, filter bar, account rows, and selected detail in
   one coherent overview.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -187,6 +187,10 @@ remain unmarked.
   screenshot script capture PlaidBar windows by window ID instead of stale
   display rectangles; evidence: `Assets/*.png` screenshot refresh and
   `Scripts/screenshots.sh` capture update.
+- 2026-06-07 [T011]: expanded the first popover overview cards so the dashboard
+  answers cash, credit, recent spend, sync health, and action-needed status
+  before deeper account drill-ins; evidence:
+  `Sources/PlaidBar/Views/MainPopover.swift`.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Expand the first popover overview from three summary cards into cash, credit, 7D spend, sync, and action-needed status cards.
- Keep the overview local-first and route deeper analysis/recovery through existing drill-ins.
- Mark T011 complete in the autonomous backlog and roadmap ledger.

## Task IDs
- T011

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain
- changed-file secret scan

## Privacy impact
- UI-only summary changes over existing local AppState values.
- No Plaid secrets, tokens, account IDs, item IDs, transactions, telemetry, hosted backend, or cloud AI added.

@codex please review for UI density/regression risk and privacy/local-first boundaries.