### PR TITLE
feat: clarify heatmap cashflow semantics

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -76,8 +76,8 @@ struct SpendingHeatmapView: View {
 
             if showModePicker {
                 Picker("Heatmap metric", selection: $mode) {
-                    Text("Spend").tag(SpendingHeatmapMode.spending)
-                    Text("Net").tag(SpendingHeatmapMode.netCashflow)
+                    Text(SpendingHeatmapMode.spending.shortLabel).tag(SpendingHeatmapMode.spending)
+                    Text(SpendingHeatmapMode.netCashflow.shortLabel).tag(SpendingHeatmapMode.netCashflow)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
@@ -107,7 +107,7 @@ struct SpendingHeatmapView: View {
             VStack(alignment: .leading, spacing: Spacing.xxs) {
                 Text("Spending heatmap")
                     .sectionTitle()
-                Text(mode == .spending ? "Daily outflow intensity" : "Money out minus money in")
+                Text(mode.semanticDescription)
                     .detailText()
             }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -671,7 +671,7 @@ private struct BalanceActivityHeatmap: View {
     }
 
     private var title: String {
-        mode == .spending ? "365D Spend" : "365D Cashflow"
+        mode.summaryTitle
     }
 
     private var totalLabel: String {
@@ -740,8 +740,8 @@ private struct BalanceActivityHeatmap: View {
                 Spacer()
 
                 Picker("Heatmap metric", selection: modeBinding) {
-                    Text("Spend").tag(SpendingHeatmapMode.spending)
-                    Text("Net").tag(SpendingHeatmapMode.netCashflow)
+                    Text(SpendingHeatmapMode.spending.shortLabel).tag(SpendingHeatmapMode.spending)
+                    Text(SpendingHeatmapMode.netCashflow.shortLabel).tag(SpendingHeatmapMode.netCashflow)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
@@ -823,7 +823,7 @@ private struct BalanceActivityHeatmap: View {
             stroke: Color.primary.opacity(0.065)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(title) heatmap for the last 365 days with \(activeDayCount) active days.")
+        .accessibilityLabel("\(title) heatmap for the last 365 days with \(activeDayCount) active days. \(mode.semanticDescription).")
     }
 
     private var modeBinding: Binding<SpendingHeatmapMode> {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -3,6 +3,33 @@ import Foundation
 public enum SpendingHeatmapMode: String, Codable, CaseIterable, Sendable {
     case spending
     case netCashflow
+
+    public var shortLabel: String {
+        switch self {
+        case .spending:
+            "Spend"
+        case .netCashflow:
+            "Cashflow"
+        }
+    }
+
+    public var summaryTitle: String {
+        switch self {
+        case .spending:
+            "365D Spend"
+        case .netCashflow:
+            "365D Net Cashflow"
+        }
+    }
+
+    public var semanticDescription: String {
+        switch self {
+        case .spending:
+            "Outflows only; income and transfers are excluded"
+        case .netCashflow:
+            "Income minus outflows; transfers are excluded"
+        }
+    }
 }
 
 public struct SpendingHeatmapDay: Identifiable, Sendable, Hashable {

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -841,6 +841,16 @@ struct PlaidBarCoreTests {
         #expect(SpendingHeatmap.displayCashflowAmount(0) == 0)
     }
 
+    @Test("Heatmap mode labels distinguish spend from net cashflow semantics")
+    func heatmapModeLabelsDistinguishSemantics() {
+        #expect(SpendingHeatmapMode.spending.shortLabel == "Spend")
+        #expect(SpendingHeatmapMode.spending.summaryTitle == "365D Spend")
+        #expect(SpendingHeatmapMode.spending.semanticDescription.contains("Outflows only"))
+        #expect(SpendingHeatmapMode.netCashflow.shortLabel == "Cashflow")
+        #expect(SpendingHeatmapMode.netCashflow.summaryTitle == "365D Net Cashflow")
+        #expect(SpendingHeatmapMode.netCashflow.semanticDescription.contains("Income minus outflows"))
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -75,7 +75,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-004: Heatmap Readability
 
-- [ ] T016: Confirm spend and cashflow intensity use distinguishable semantics.
+- [x] T016: Confirm spend and cashflow intensity use distinguishable semantics.
 - [ ] T017: Add accessible text for the strongest recent heatmap signals.
 - [ ] T018: Improve empty heatmap copy for no data vs filtered-zero states.
 - [ ] T019: Add a focused test for heatmap bucket or legend behavior.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -204,6 +204,10 @@ remain unmarked.
 - 2026-06-07 [T015]: verified the dashboard overview against a 660-point
   realistic menu-bar popover height budget with selected-row drill-in tests;
   evidence: `DashboardOverviewHeightBudget` and app tests.
+- 2026-06-07 [T016]: confirmed heatmap spend and net-cashflow semantics stay
+  distinguishable through shared mode labels, descriptions, and a focused core
+  test; evidence: `SpendingHeatmapMode` labels and
+  `heatmapModeLabelsDistinguishSemantics`.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Centralize heatmap mode labels/descriptions so spend and net-cashflow modes remain semantically distinct.
- Rename compact net mode from Net to Cashflow and dashboard title to 365D Net Cashflow.
- Add a focused core test for mode labels and semantics, then mark T016 complete.

## Task IDs
- T016

## Verification
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain
- changed-line secret scan

## Privacy impact
- UI copy/model-label only; no Plaid credentials, tokens, account identifiers, transaction data, telemetry, hosted backend, or cloud AI added.

@codex please review for product-copy clarity, accessibility/local-first boundaries, and whether the net-cashflow semantics are clearer without adding visual noise.