### PR TITLE
feat: add heatmap strongest signal accessibility

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -55,6 +55,10 @@ struct SpendingHeatmapView: View {
         return days.first { $0.date == selectedDate }
     }
 
+    private var strongestSignals: [SpendingHeatmapSignal] {
+        SpendingHeatmap.strongestSignals(from: days, mode: mode)
+    }
+
     private var weekColumns: [[SpendingHeatmapDay?]] {
         guard let firstDay = days.first,
               let firstDate = Formatters.parseTransactionDate(firstDay.date) else {
@@ -216,7 +220,9 @@ struct SpendingHeatmapView: View {
 
     private var accessibilitySummary: String {
         let activeDays = days.filter { $0.transactionCount > 0 }.count
-        return "\(mode == .spending ? "Spending" : "Net cashflow") heatmap with \(activeDays) active days. Peak day \(Formatters.currency(peakValue, format: .full)). Total \(totalLabel)."
+        let signalText = strongestSignals.map(\.accessibilitySummary).joined(separator: " ")
+        let signalSuffix = signalText.isEmpty ? "" : " \(signalText)"
+        return "\(mode == .spending ? "Spending" : "Net cashflow") heatmap with \(activeDays) active days. Peak day \(Formatters.currency(peakValue, format: .full)). Total \(totalLabel).\(signalSuffix)"
     }
 
     private var legendAccessibilityLabel: String {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -117,8 +117,29 @@ public enum SpendingHeatmap {
     ) -> [SpendingHeatmapSignal] {
         guard limit > 0 else { return [] }
 
-        return days
+        let candidates = days
             .filter { $0.transactionCount > 0 && abs($0.value) > 0 }
+
+        let rankedDays: [SpendingHeatmapDay]
+        switch mode {
+        case .spending:
+            rankedDays = ranked(candidates)
+        case .netCashflow:
+            let strongestIncome = ranked(candidates.filter { displayCashflowAmount($0.value) >= 0 }).first
+            let strongestOutflow = ranked(candidates.filter { displayCashflowAmount($0.value) < 0 }).first
+            rankedDays = ranked([strongestIncome, strongestOutflow].compactMap(\.self))
+        }
+
+        return rankedDays
+            .prefix(limit)
+            .enumerated()
+            .map { offset, day in
+                signal(for: day, mode: mode, rank: offset + 1)
+            }
+    }
+
+    private static func ranked(_ days: [SpendingHeatmapDay]) -> [SpendingHeatmapDay] {
+        days
             .sorted { lhs, rhs in
                 let lhsMagnitude = abs(lhs.value)
                 let rhsMagnitude = abs(rhs.value)
@@ -126,11 +147,6 @@ public enum SpendingHeatmap {
                     return lhs.date > rhs.date
                 }
                 return lhsMagnitude > rhsMagnitude
-            }
-            .prefix(limit)
-            .enumerated()
-            .map { offset, day in
-                signal(for: day, mode: mode, rank: offset + 1)
             }
     }
 

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -46,6 +46,24 @@ public struct SpendingHeatmapDay: Identifiable, Sendable, Hashable {
     }
 }
 
+public struct SpendingHeatmapSignal: Identifiable, Sendable, Hashable {
+    public let day: SpendingHeatmapDay
+    public let rank: Int
+    public let label: String
+    public let amountText: String
+    public let accessibilitySummary: String
+
+    public var id: String { "\(rank)-\(day.date)" }
+
+    public init(day: SpendingHeatmapDay, rank: Int, label: String, amountText: String, accessibilitySummary: String) {
+        self.day = day
+        self.rank = rank
+        self.label = label
+        self.amountText = amountText
+        self.accessibilitySummary = accessibilitySummary
+    }
+}
+
 public enum SpendingHeatmap {
     public static func displayCashflowAmount(_ value: Double) -> Double {
         -value
@@ -92,7 +110,59 @@ public enum SpendingHeatmap {
         }
     }
 
+    public static func strongestSignals(
+        from days: [SpendingHeatmapDay],
+        mode: SpendingHeatmapMode,
+        limit: Int = 2
+    ) -> [SpendingHeatmapSignal] {
+        guard limit > 0 else { return [] }
+
+        return days
+            .filter { $0.transactionCount > 0 && abs($0.value) > 0 }
+            .sorted { lhs, rhs in
+                let lhsMagnitude = abs(lhs.value)
+                let rhsMagnitude = abs(rhs.value)
+                if lhsMagnitude == rhsMagnitude {
+                    return lhs.date > rhs.date
+                }
+                return lhsMagnitude > rhsMagnitude
+            }
+            .prefix(limit)
+            .enumerated()
+            .map { offset, day in
+                signal(for: day, mode: mode, rank: offset + 1)
+            }
+    }
+
     private static func isTransfer(_ transaction: TransactionDTO) -> Bool {
         transaction.category == .transfer || transaction.category == .transferOut
+    }
+
+    private static func signal(for day: SpendingHeatmapDay, mode: SpendingHeatmapMode, rank: Int) -> SpendingHeatmapSignal {
+        let dateText = Formatters.displayTransactionDate(day.date)
+        let transactionText = "\(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
+
+        switch mode {
+        case .spending:
+            let amountText = Formatters.currency(day.value, format: .full)
+            return SpendingHeatmapSignal(
+                day: day,
+                rank: rank,
+                label: rank == 1 ? "Highest spend" : "Next highest spend",
+                amountText: amountText,
+                accessibilitySummary: "\(rank == 1 ? "Highest" : "Next highest") spend was \(amountText) on \(dateText) across \(transactionText)."
+            )
+        case .netCashflow:
+            let displayAmount = displayCashflowAmount(day.value)
+            let direction = displayAmount >= 0 ? "income" : "outflow"
+            let amountText = Formatters.currency(abs(displayAmount), format: .full)
+            return SpendingHeatmapSignal(
+                day: day,
+                rank: rank,
+                label: rank == 1 ? "Strongest \(direction)" : "Next strongest \(direction)",
+                amountText: amountText,
+                accessibilitySummary: "\(rank == 1 ? "Strongest" : "Next strongest") \(direction) was \(amountText) on \(dateText) across \(transactionText)."
+            )
+        }
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -851,6 +851,42 @@ struct PlaidBarCoreTests {
         #expect(SpendingHeatmapMode.netCashflow.semanticDescription.contains("Income minus outflows"))
     }
 
+    @Test("Heatmap strongest signals identify largest spend days")
+    func heatmapStrongestSignalsIdentifyLargestSpendDays() {
+        let signals = SpendingHeatmap.strongestSignals(
+            from: [
+                SpendingHeatmapDay(date: "2026-01-01", value: 20, transactionCount: 1),
+                SpendingHeatmapDay(date: "2026-01-02", value: 150, transactionCount: 3),
+                SpendingHeatmapDay(date: "2026-01-03", value: 90, transactionCount: 2),
+                SpendingHeatmapDay(date: "2026-01-04", value: 0, transactionCount: 0),
+            ],
+            mode: .spending
+        )
+
+        #expect(signals.map { $0.day.date } == ["2026-01-02", "2026-01-03"])
+        #expect(signals.first?.label == "Highest spend")
+        #expect(signals.first?.accessibilitySummary.contains("Highest spend was") == true)
+        #expect(signals.first?.accessibilitySummary.contains("3 transactions") == true)
+    }
+
+    @Test("Net cashflow strongest signals rank income and outflows by magnitude")
+    func netCashflowStrongestSignalsRankIncomeAndOutflowsByMagnitude() {
+        let signals = SpendingHeatmap.strongestSignals(
+            from: [
+                SpendingHeatmapDay(date: "2026-01-01", value: 120, transactionCount: 1),
+                SpendingHeatmapDay(date: "2026-01-02", value: -300, transactionCount: 2),
+                SpendingHeatmapDay(date: "2026-01-03", value: 250, transactionCount: 4),
+            ],
+            mode: .netCashflow
+        )
+
+        #expect(signals.map { $0.day.date } == ["2026-01-02", "2026-01-03"])
+        #expect(signals.first?.label == "Strongest income")
+        #expect(signals.last?.label == "Next strongest outflow")
+        #expect(signals.first?.accessibilitySummary.contains("income") == true)
+        #expect(signals.last?.accessibilitySummary.contains("outflow") == true)
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -887,6 +887,22 @@ struct PlaidBarCoreTests {
         #expect(signals.last?.accessibilitySummary.contains("outflow") == true)
     }
 
+    @Test("Net cashflow strongest signals preserve both directions when available")
+    func netCashflowStrongestSignalsPreserveBothDirectionsWhenAvailable() {
+        let signals = SpendingHeatmap.strongestSignals(
+            from: [
+                SpendingHeatmapDay(date: "2026-01-01", value: -500, transactionCount: 1),
+                SpendingHeatmapDay(date: "2026-01-02", value: -400, transactionCount: 1),
+                SpendingHeatmapDay(date: "2026-01-03", value: 75, transactionCount: 2),
+            ],
+            mode: .netCashflow
+        )
+
+        #expect(signals.map { $0.day.date } == ["2026-01-01", "2026-01-03"])
+        #expect(signals.first?.label == "Strongest income")
+        #expect(signals.last?.label == "Next strongest outflow")
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -76,7 +76,7 @@ and `docs/autonomous-roadmap.md`.
 ### PR-004: Heatmap Readability
 
 - [x] T016: Confirm spend and cashflow intensity use distinguishable semantics.
-- [ ] T017: Add accessible text for the strongest recent heatmap signals.
+- [x] T017: Add accessible text for the strongest recent heatmap signals.
 - [ ] T018: Improve empty heatmap copy for no data vs filtered-zero states.
 - [ ] T019: Add a focused test for heatmap bucket or legend behavior.
 - [ ] T020: Refresh screenshot evidence for the heatmap header.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -208,6 +208,9 @@ remain unmarked.
   distinguishable through shared mode labels, descriptions, and a focused core
   test; evidence: `SpendingHeatmapMode` labels and
   `heatmapModeLabelsDistinguishSemantics`.
+- 2026-06-07 [T017]: added strongest recent heatmap signal summaries for
+  VoiceOver so high-spend, income, and outflow days are exposed without cell-by-cell
+  scanning; evidence: `SpendingHeatmapSignal` and core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
@codex

## Summary
- Adds strongest recent heatmap signal summaries for accessibility
- Exposes high-spend, income, and outflow days without requiring cell-by-cell scanning
- Updates autonomous backlog and roadmap ledgers for T017

## Test Plan
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain
- changed-line secret scan

## Notes
- Local verification before PR: 257 tests passed.
