### PR TITLE
feat: clarify empty heatmap states

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -59,6 +59,10 @@ struct SpendingHeatmapView: View {
         SpendingHeatmap.strongestSignals(from: days, mode: mode)
     }
 
+    private var emptyPresentation: SpendingHeatmapEmptyPresentation {
+        SpendingHeatmap.emptyPresentation(transactionCount: transactions.count, mode: mode)
+    }
+
     private var weekColumns: [[SpendingHeatmapDay?]] {
         guard let firstDay = days.first,
               let firstDate = Formatters.parseTransactionDate(firstDay.date) else {
@@ -211,11 +215,13 @@ struct SpendingHeatmapView: View {
 
     private var emptyState: some View {
         ContentUnavailableView {
-            Label("No Heatmap Data", systemImage: "calendar.badge.exclamationmark")
+            Label(emptyPresentation.title, systemImage: emptyPresentation.systemImage)
         } description: {
-            Text("Daily spending intensity will appear after syncing transactions.")
+            Text(emptyPresentation.description)
         }
         .frame(height: 150)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(emptyPresentation.title). \(emptyPresentation.description)")
     }
 
     private var accessibilitySummary: String {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -64,9 +64,46 @@ public struct SpendingHeatmapSignal: Identifiable, Sendable, Hashable {
     }
 }
 
+public struct SpendingHeatmapEmptyPresentation: Sendable, Hashable {
+    public let title: String
+    public let systemImage: String
+    public let description: String
+
+    public init(title: String, systemImage: String, description: String) {
+        self.title = title
+        self.systemImage = systemImage
+        self.description = description
+    }
+}
+
 public enum SpendingHeatmap {
     public static func displayCashflowAmount(_ value: Double) -> Double {
         -value
+    }
+
+    public static func emptyPresentation(transactionCount: Int, mode: SpendingHeatmapMode) -> SpendingHeatmapEmptyPresentation {
+        guard transactionCount > 0 else {
+            return SpendingHeatmapEmptyPresentation(
+                title: "No Heatmap Data",
+                systemImage: "calendar.badge.exclamationmark",
+                description: "Daily activity will appear after syncing transactions."
+            )
+        }
+
+        switch mode {
+        case .spending:
+            return SpendingHeatmapEmptyPresentation(
+                title: "No Spending in This View",
+                systemImage: "line.3.horizontal.decrease.circle",
+                description: "Transactions exist for this range, but none count as spend after filters, income, and transfers are excluded."
+            )
+        case .netCashflow:
+            return SpendingHeatmapEmptyPresentation(
+                title: "No Cashflow in This View",
+                systemImage: "line.3.horizontal.decrease.circle",
+                description: "Transactions exist for this range, but none count toward net cashflow after filters and transfers are excluded."
+            )
+        }
     }
 
     public static func days(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -903,6 +903,27 @@ struct PlaidBarCoreTests {
         #expect(signals.last?.label == "Next strongest outflow")
     }
 
+    @Test("Heatmap empty copy distinguishes missing data from filtered-zero spend")
+    func heatmapEmptyCopyDistinguishesMissingDataFromFilteredZeroSpend() {
+        let missing = SpendingHeatmap.emptyPresentation(transactionCount: 0, mode: .spending)
+        let filtered = SpendingHeatmap.emptyPresentation(transactionCount: 3, mode: .spending)
+
+        #expect(missing.title == "No Heatmap Data")
+        #expect(missing.description.contains("after syncing transactions"))
+        #expect(filtered.title == "No Spending in This View")
+        #expect(filtered.description.contains("Transactions exist"))
+        #expect(filtered.description.contains("filters"))
+    }
+
+    @Test("Heatmap empty copy names filtered-zero cashflow separately")
+    func heatmapEmptyCopyNamesFilteredZeroCashflowSeparately() {
+        let filtered = SpendingHeatmap.emptyPresentation(transactionCount: 2, mode: .netCashflow)
+
+        #expect(filtered.title == "No Cashflow in This View")
+        #expect(filtered.description.contains("net cashflow"))
+        #expect(filtered.description.contains("transfers are excluded"))
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -77,7 +77,7 @@ and `docs/autonomous-roadmap.md`.
 
 - [x] T016: Confirm spend and cashflow intensity use distinguishable semantics.
 - [x] T017: Add accessible text for the strongest recent heatmap signals.
-- [ ] T018: Improve empty heatmap copy for no data vs filtered-zero states.
+- [x] T018: Improve empty heatmap copy for no data vs filtered-zero states.
 - [ ] T019: Add a focused test for heatmap bucket or legend behavior.
 - [ ] T020: Refresh screenshot evidence for the heatmap header.
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -211,6 +211,9 @@ remain unmarked.
 - 2026-06-07 [T017]: added strongest recent heatmap signal summaries for
   VoiceOver so high-spend, income, and outflow days are exposed without cell-by-cell
   scanning; evidence: `SpendingHeatmapSignal` and core tests.
+- 2026-06-07 [T018]: split heatmap empty copy between missing synced data and
+  filtered-zero spend/cashflow states so empty tiles do not incorrectly imply
+  sync is missing; evidence: `SpendingHeatmapEmptyPresentation` and core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
@codex

## Summary
- Splits heatmap empty copy between missing synced data and filtered-zero states
- Adds spend vs net-cashflow-specific filtered empty descriptions
- Adds focused core tests for the empty-copy presentation
- Updates autonomous backlog/roadmap ledgers for T018

## Test Plan
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain
- changed-line secret scan

## Notes
- Local verification before PR: 260 tests passed.
