### PR TITLE
test: cover heatmap cell intensity

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendingHeatmapView.swift
@@ -300,8 +300,7 @@ private struct HeatmapCell: View {
     }
 
     private var intensity: Double {
-        guard day.transactionCount > 0 else { return 0 }
-        return min(max(abs(day.value) / peakValue, 0), 1)
+        SpendingHeatmap.cellIntensity(for: day, peakValue: peakValue)
     }
 
     private var helpText: String {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -106,6 +106,11 @@ public enum SpendingHeatmap {
         }
     }
 
+    public static func cellIntensity(for day: SpendingHeatmapDay, peakValue: Double) -> Double {
+        guard day.transactionCount > 0, peakValue > 0 else { return 0 }
+        return min(max(abs(day.value) / peakValue, 0), 1)
+    }
+
     public static func days(
         from transactions: [TransactionDTO],
         startDate: Date,

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -924,6 +924,15 @@ struct PlaidBarCoreTests {
         #expect(filtered.description.contains("transfers are excluded"))
     }
 
+    @Test("Heatmap cell intensity clamps and ignores empty days")
+    func heatmapCellIntensityClampsAndIgnoresEmptyDays() {
+        #expect(SpendingHeatmap.cellIntensity(for: SpendingHeatmapDay(date: "2026-01-01", value: 50, transactionCount: 1), peakValue: 200) == 0.25)
+        #expect(SpendingHeatmap.cellIntensity(for: SpendingHeatmapDay(date: "2026-01-02", value: -75, transactionCount: 2), peakValue: 150) == 0.5)
+        #expect(SpendingHeatmap.cellIntensity(for: SpendingHeatmapDay(date: "2026-01-03", value: 300, transactionCount: 1), peakValue: 100) == 1)
+        #expect(SpendingHeatmap.cellIntensity(for: SpendingHeatmapDay(date: "2026-01-04", value: 90, transactionCount: 0), peakValue: 100) == 0)
+        #expect(SpendingHeatmap.cellIntensity(for: SpendingHeatmapDay(date: "2026-01-05", value: 90, transactionCount: 1), peakValue: 0) == 0)
+    }
+
     // MARK: - AccountDTO Tests
 
     @Test("AccountDTO Codable roundtrip")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -78,7 +78,7 @@ and `docs/autonomous-roadmap.md`.
 - [x] T016: Confirm spend and cashflow intensity use distinguishable semantics.
 - [x] T017: Add accessible text for the strongest recent heatmap signals.
 - [x] T018: Improve empty heatmap copy for no data vs filtered-zero states.
-- [ ] T019: Add a focused test for heatmap bucket or legend behavior.
+- [x] T019: Add a focused test for heatmap bucket or legend behavior.
 - [ ] T020: Refresh screenshot evidence for the heatmap header.
 
 ### PR-005: Account And Card Rows

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -214,6 +214,9 @@ remain unmarked.
 - 2026-06-07 [T018]: split heatmap empty copy between missing synced data and
   filtered-zero spend/cashflow states so empty tiles do not incorrectly imply
   sync is missing; evidence: `SpendingHeatmapEmptyPresentation` and core tests.
+- 2026-06-07 [T019]: moved heatmap cell intensity into a focused core helper
+  with clamp/empty-day tests, keeping the SwiftUI cell on the same presentation
+  rule; evidence: `SpendingHeatmap.cellIntensity` and core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
@codex

## Summary
- Moves heatmap cell intensity calculation into a focused core helper
- Keeps the SwiftUI cell wired to that shared presentation rule
- Adds clamp, negative-value magnitude, empty-day, and zero-peak coverage
- Updates autonomous backlog/roadmap ledgers for T019

## Test Plan
- git diff --check
- swift build --target PlaidBar --skip-update --disable-keychain
- swift test --skip-update --disable-keychain
- changed-line secret scan

## Notes
- Local verification before PR: 261 tests passed.
