### PR TITLE
feat: add account row freshness signals

### DIFF
--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -145,20 +145,29 @@ private struct InstitutionAvatar: View {
 }
 
 struct AccountRow: View {
+    @Environment(AppState.self) private var appState
     let account: AccountDTO
     let utilizationThreshold: Double
 
     var body: some View {
         HStack(spacing: Spacing.md) {
             InstitutionAvatar(name: account.institutionName ?? account.name)
+                .overlay(alignment: .bottomTrailing) {
+                    Circle()
+                        .fill(connectionTint)
+                        .frame(width: 8, height: 8)
+                        .overlay {
+                            Circle()
+                                .stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5)
+                        }
+                }
 
             VStack(alignment: .leading, spacing: Spacing.xxs) {
                 Text(account.name)
                     .font(.body)
-                if let mask = account.mask {
-                    Text("\u{2022}\u{2022}\u{2022}\u{2022} \(mask)")
-                        .detailText()
-                }
+                Text(secondaryDetailText)
+                    .detailText()
+                    .lineLimit(1)
             }
             Spacer()
             VStack(alignment: .trailing, spacing: Spacing.xxs) {
@@ -173,16 +182,11 @@ struct AccountRow: View {
                         .monospacedDigit()
                         .foregroundStyle(amountColor)
                 }
-
-                if let utilization = account.balances.utilizationPercent {
-                    Text(Formatters.percent(utilization))
-                        .microText()
-                        .foregroundStyle(
-                            utilization >= utilizationThreshold
-                                ? SemanticColors.utilization(for: utilization, threshold: utilizationThreshold)
-                                : .secondary
-                        )
-                }
+                Text(trailingDetailText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+                    .foregroundStyle(trailingDetailColor)
+                    .font(trailingDetailFont)
             }
         }
         .padding(.horizontal, Spacing.lg)
@@ -190,6 +194,72 @@ struct AccountRow: View {
         .hoverHighlight()
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var connectionPresentation: AccountConnectionPresentation {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            isSyncStale: appState.isSyncStale,
+            statusSyncText: appState.statusSyncText,
+            itemStatus: itemStatus,
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
+        )
+    }
+
+    private var itemStatus: ItemConnectionStatus? {
+        itemConnectionStatus?.status
+    }
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
+    }
+
+    private var pendingCount: Int {
+        appState.transactionsForAccount(account.id).filter(\.pending).count
+    }
+
+    private var secondaryDetailText: String {
+        AccountPresentation.dashboardRowSubtitle(
+            for: account,
+            connectionLabel: connectionPresentation.itemSyncLabel ?? connectionPresentation.rowLabel,
+            pendingCount: pendingCount
+        )
+    }
+
+    private var trailingDetailText: String {
+        AccountPresentation.dashboardTrailingDetailText(
+            for: account,
+            connectionLabel: connectionPresentation.signalLabel
+        )
+    }
+
+    private var trailingDetailColor: Color {
+        if let utilization = account.balances.utilizationPercent {
+            return utilization >= utilizationThreshold
+                ? SemanticColors.utilization(for: utilization, threshold: utilizationThreshold)
+                : .secondary
+        }
+        return connectionTint
+    }
+
+    private var trailingDetailFont: Font {
+        if account.balances.utilizationPercent != nil {
+            return .caption.weight(.bold)
+        }
+        return .caption2
+    }
+
+    private var connectionTint: Color {
+        switch connectionPresentation.level {
+        case .demo, .offline, .healthy, .unknown:
+            return .secondary
+        case .stale, .loginRequired:
+            return SemanticColors.warning
+        case .error:
+            return SemanticColors.negative
+        }
     }
 
     private var formattedAmount: String {
@@ -204,6 +274,8 @@ struct AccountRow: View {
         AccountPresentation.rowAccessibilityLabel(
             for: account,
             amountText: formattedAmount,
+            connectionLabel: connectionPresentation.rowLabel,
+            pendingCount: pendingCount,
             utilizationThreshold: utilizationThreshold
         )
     }

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -85,7 +85,7 @@ and `docs/autonomous-roadmap.md`.
 
 - [x] T021: Audit row density for checking, savings, credit card, loan, and
   other account types.
-- [ ] T022: Ensure every row has a primary amount, secondary detail, freshness,
+- [x] T022: Ensure every row has a primary amount, secondary detail, freshness,
   and status signal.
 - [ ] T023: Make credit utilization, available credit, and due metadata readable
   without opening a budgeting workflow.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -227,6 +227,9 @@ remain unmarked.
 - 2026-06-08 [T021]: audited account-row density across checking, savings,
   credit card, loan, investment, and other rows; evidence: `DESIGN.md`
   documents the shared two-line dashboard row rhythm and follow-up constraints.
+- 2026-06-08 [T022]: ensured account rows expose a primary amount, secondary
+  account detail, freshness text, and connection status signal outside the
+  dashboard drill-in; evidence: `Sources/PlaidBar/Views/AccountsView.swift`.
 
 ## Backlog Source
 


### PR DESCRIPTION
@codex\n\n## Summary\n- Completes T022 by giving the Accounts surface row the same required signals as the dashboard row: primary amount, secondary account detail, freshness text, and connection status indicator.\n- Shows a compact connection dot on the institution avatar, includes item sync/freshness in the secondary line, and keeps the trailing detail populated for both credit utilization and non-credit status.\n- Updates the autonomous backlog and roadmap ledger for T022.\n\n## Task IDs\n- T022\n\n## Changed files\n- Sources/PlaidBar/Views/AccountsView.swift\n- docs/autonomous-loop-backlog.md\n- docs/autonomous-roadmap.md\n\n## Local verification\n- [x] git diff --check\n- [x] swift build --target PlaidBar --skip-update --disable-keychain\n- [x] swift test --skip-update --disable-keychain — 261 tests passed\n- [x] changed-line secret scan — 0 hits\n\n## GitHub checks\n- Pending after PR creation. Treat claude-review auth/session/quota automation failures as non-blocking per Felipe's scoped instruction for this loop; require GitHub build success.\n\n## Privacy / security impact\n- No hosted backend, telemetry, cloud sync, or cloud AI changes.\n- Does not expose Plaid secrets, tokens, raw account IDs, or real financial data; only existing local presentation fields are rearranged.\n\n## Merge safety\n- Focused T022 UI/docs diff; no destructive actions or generated artifacts.\n- Builder: Otto autonomous PlaidBar loop on branch ui/account-row-signals-t022.