### PR TITLE
feat: summarize selected account drill-in

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1941,6 +1941,15 @@ private struct SelectedAccountPanel: View {
     @State private var isConfirmingAccountRemoval = false
     @State private var settingsCloseObserver: NSObjectProtocol?
 
+    private var drillInSummary: DashboardAccountDrillInSummary {
+        DashboardAccountDrillInSummary.presentation(
+            for: account,
+            transactions: appState.transactions,
+            itemStatus: itemConnectionStatus,
+            fallbackFreshnessLabel: connectionPresentation.signalLabel
+        )
+    }
+
     private var transactions: [TransactionDTO] {
         Array(accountTransactions.prefix(5))
     }
@@ -1974,10 +1983,10 @@ private struct SelectedAccountPanel: View {
                     Text("Drill-in")
                         .sectionTitle()
                         .foregroundStyle(.secondary)
-                    Text(AccountPresentation.displayName(for: account))
+                    Text(drillInSummary.displayName)
                         .font(.headline.weight(.bold))
                         .lineLimit(1)
-                    Text(AccountPresentation.subtitle(for: account))
+                    Text(drillInSummary.subtitle)
                         .detailText()
                         .lineLimit(1)
                 }
@@ -1994,8 +2003,8 @@ private struct SelectedAccountPanel: View {
             DrillInSurfaceRail(surfaces: DashboardDrillInSurface.surfaces(for: account))
 
             HStack(spacing: Spacing.compactRowContentSpacing) {
-                DetailValue(title: availableTitle, value: availableText, tint: .primary)
-                DetailValue(title: currentTitle, value: currentText, tint: currentTint)
+                DetailValue(title: drillInSummary.availableTitle, value: availableText, tint: .primary)
+                DetailValue(title: drillInSummary.currentTitle, value: currentText, tint: currentTint)
 
                 if let utilization = account.balances.utilizationPercent,
                    let utilizationText = AccountPresentation.dashboardUtilizationDetailText(
@@ -2117,19 +2126,11 @@ private struct SelectedAccountPanel: View {
     }
 
     private var availableText: String {
-        Formatters.currency(AccountPresentation.availableBalance(for: account), format: .compact)
-    }
-
-    private var availableTitle: String {
-        AccountPresentation.dashboardAvailableTitle(for: account)
+        Formatters.currency(drillInSummary.availableBalance, format: .compact)
     }
 
     private var currentText: String {
-        Formatters.currency(AccountPresentation.displayBalance(for: account), format: .compact)
-    }
-
-    private var currentTitle: String {
-        AccountPresentation.dashboardCurrentTitle(for: account)
+        Formatters.currency(drillInSummary.currentBalance, format: .compact)
     }
 
     private var currentTint: Color {
@@ -2188,7 +2189,7 @@ private struct SelectedAccountPanel: View {
     }
 
     private var activityText: String {
-        "\(accountTransactions.count) tx"
+        "\(drillInSummary.transactionCount) tx"
     }
 
     private var syncSignalText: String {

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -137,3 +137,56 @@ public struct DashboardAccountDrillInPath: Sendable, Equatable {
         )
     }
 }
+
+/// Display-safe summary values for the selected account drill-in.
+///
+/// This keeps the popover's account, activity, credit/limit, freshness, and
+/// sync-state facts in one testable presentation model without exposing raw
+/// account IDs, item IDs, tokens, or Plaid payloads.
+public struct DashboardAccountDrillInSummary: Sendable, Equatable {
+    public let displayName: String
+    public let subtitle: String
+    public let availableTitle: String
+    public let availableBalance: Double
+    public let currentTitle: String
+    public let currentBalance: Double
+    public let utilizationPercent: Double?
+    public let limit: Double?
+    public let transactionCount: Int
+    public let pendingTransactionCount: Int
+    public let latestTransactionDate: String?
+    public let syncState: ItemConnectionStatus?
+    public let freshnessLabel: String
+
+    public static func presentation(
+        for account: AccountDTO,
+        transactions: [TransactionDTO],
+        itemStatus: ItemStatus?,
+        fallbackFreshnessLabel: String
+    ) -> Self {
+        let accountTransactions = transactions.filter { $0.accountId == account.id }
+        let latestTransactionDate = accountTransactions
+            .compactMap { transaction -> (raw: String, parsed: Date)? in
+                guard let parsed = Formatters.parseTransactionDate(transaction.date) else { return nil }
+                return (transaction.date, parsed)
+            }
+            .max { $0.parsed < $1.parsed }?
+            .raw
+
+        return Self(
+            displayName: AccountPresentation.displayName(for: account),
+            subtitle: AccountPresentation.subtitle(for: account),
+            availableTitle: AccountPresentation.dashboardAvailableTitle(for: account),
+            availableBalance: AccountPresentation.availableBalance(for: account),
+            currentTitle: AccountPresentation.dashboardCurrentTitle(for: account),
+            currentBalance: AccountPresentation.displayBalance(for: account),
+            utilizationPercent: account.balances.utilizationPercent,
+            limit: account.balances.limit,
+            transactionCount: accountTransactions.count,
+            pendingTransactionCount: accountTransactions.count(where: \.pending),
+            latestTransactionDate: latestTransactionDate,
+            syncState: itemStatus?.status,
+            freshnessLabel: itemStatus?.lastSync.map(Formatters.relativeDate) ?? fallbackFreshnessLabel
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -511,6 +511,46 @@ struct PlaidBarCoreTests {
         ) == "Rewards, Amex, Credit, Ending in 0005, $450.00 owed, 45% utilization, Warning, $550.00 available credit, due not synced, 2m ago, selected")
     }
 
+    @Test("Account drill-in summary includes balances transactions freshness and sync")
+    func accountDrillInSummaryIncludesCoreSurfaces() {
+        let lastSync = Date(timeIntervalSince1970: 1_700_000_000)
+        let account = AccountDTO(
+            id: "acct-internal-123",
+            itemId: "item-internal-456",
+            name: "Rewards",
+            type: .credit,
+            mask: "0005",
+            balances: BalanceDTO(current: -450, limit: 1_000),
+            institutionName: "Amex"
+        )
+        let summary = DashboardAccountDrillInSummary.presentation(
+            for: account,
+            transactions: [
+                TransactionDTO(id: "tx-1", accountId: account.id, amount: 24, date: "2026-06-01", name: "Coffee"),
+                TransactionDTO(id: "tx-2", accountId: account.id, amount: -100, date: "2026-06-03", name: "Refund", pending: true),
+                TransactionDTO(id: "tx-other", accountId: "other", amount: 7, date: "2026-06-04", name: "Other"),
+            ],
+            itemStatus: ItemStatus(id: account.itemId, institutionName: "Amex", status: .loginRequired, lastSync: lastSync),
+            fallbackFreshnessLabel: "Not synced"
+        )
+
+        #expect(summary.displayName == "Rewards")
+        #expect(summary.subtitle == "Credit • Credit •••• 0005")
+        #expect(summary.availableTitle == "Avail Credit")
+        #expect(summary.availableBalance == 550)
+        #expect(summary.currentTitle == "Owed")
+        #expect(summary.currentBalance == 450)
+        #expect(summary.utilizationPercent == 45)
+        #expect(summary.limit == 1_000)
+        #expect(summary.transactionCount == 2)
+        #expect(summary.pendingTransactionCount == 1)
+        #expect(summary.latestTransactionDate == "2026-06-03")
+        #expect(summary.syncState == .loginRequired)
+        #expect(summary.freshnessLabel != "Not synced")
+        #expect(!summary.displayName.contains(account.id))
+        #expect(!summary.subtitle.contains(account.itemId))
+    }
+
     @Test("Account presentation keeps credit metadata readable without due dates")
     func accountPresentationCreditMetadataWithoutDueDates() {
         let creditWithoutLimit = AccountDTO(

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -97,7 +97,7 @@ and `docs/autonomous-roadmap.md`.
 
 - [x] T026: Ensure account drill-in opens from a row with a predictable keyboard
   and pointer path.
-- [ ] T027: Show transactions, balances, limits, freshness, and sync state for
+- [x] T027: Show transactions, balances, limits, freshness, and sync state for
   the selected account.
 - [x] T028: Keep reconnect, remove, and settings actions explicit and
   confirmation-gated where destructive.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -244,6 +244,10 @@ remain unmarked.
   pointer, keyboard, and assistive-technology activation paths shared open/collapse
   copy; evidence: `DashboardAccountDrillInPath`, dashboard row modifiers, and
   core tests.
+- 2026-06-08 [T027]: extracted a selected-account drill-in summary that keeps
+  transactions, balances, credit limits, freshness, and sync state in one
+  display-safe presentation model; evidence: `DashboardAccountDrillInSummary`,
+  `MainPopover` selected-account panel wiring, and core tests.
 - 2026-06-08 [T028]: added explicit selected-account drill-in actions for
   reconnect, remove, and settings, with destructive remove gated by a
   confirmation dialog; evidence: `DashboardDrillInAction` and selected account


### PR DESCRIPTION
@codex

## Summary
- Add a display-safe core summary for selected account drill-ins.
- Wire the popover selected-account panel through the summary for account labels, balances, and activity count.
- Mark T027 in the backlog and roadmap ledger while preserving the already-merged T026/T028 ledger entries after rebase.

## Autonomous task IDs
Task ID(s): T027
Backlog slice: PR-006 Account Drill-In Surfaces
Scope note: Selected account drill-in presentation summary only; no backend, storage, or credential handling changes.

## Agent coordination
Builder agent: Otto / Hermes Agent default profile
Builder branch/worktree: `ui/account-drill-in-summary-t027` at `/private/tmp/PlaidBar-otto`
Reviewer/merge steward: Otto / Hermes Agent default profile under Felipe's scoped PlaidBar autonomous approval
Coordination note: Single-writer branch; rebased onto `origin/main` after PR #214 merged.

## Changed files
- `Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates
- [x] `git diff --check origin/main...HEAD`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift test --skip-update --disable-keychain` — 266 tests passed
- [x] Changed-line secret scan — no hits

## GitHub checks
- [ ] `build` pending on `7b6e00477597f3688f9be8cd6ad4990fe4104e4f`
- [ ] `otto-openclaw-merge-gate` pending on `7b6e00477597f3688f9be8cd6ad4990fe4104e4f`
- [ ] `claude-review` pending/non-blocking unless it reports a real code/security issue; Felipe explicitly approved skipping quota/session/review-automation failures for this loop

## Privacy and safety impact
- Local UI/core presentation only; no hosted backend, telemetry, cloud sync, or cloud AI changes.
- Summary intentionally avoids exposing raw account IDs, item IDs, tokens, or Plaid payloads in display strings.

## Merge safety
- Final diff scoped to selected-account drill-in presentation, focused tests, and backlog/roadmap bookkeeping.
- Merge only after GitHub build, merge gate, final diff sanity, and unresolved review-thread check are clean.
