### PR TITLE
feat: gate selected account drill-in actions

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1928,8 +1928,10 @@ private struct DashboardAccountRow: View {
 
 private struct SelectedAccountPanel: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
     let account: AccountDTO
     let isStatusFilter: Bool
+    @State private var isConfirmingAccountRemoval = false
 
     private var transactions: [TransactionDTO] {
         Array(accountTransactions.prefix(5))
@@ -2066,6 +2068,11 @@ private struct SelectedAccountPanel: View {
                 }
             }
 
+            AccountDrillInActionBar(
+                actions: DashboardDrillInAction.accountDrillInActions,
+                onAction: performDrillInAction
+            )
+
             VStack(alignment: .leading, spacing: Spacing.rowVertical) {
                 Text("Recent Activity")
                     .sectionTitle()
@@ -2087,6 +2094,18 @@ private struct SelectedAccountPanel: View {
             fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: shouldEmphasizeConnection ? connectionTint : nil)),
             stroke: panelStroke
         )
+        .confirmationDialog(
+            "Remove \(AccountPresentation.displayName(for: account))?",
+            isPresented: $isConfirmingAccountRemoval,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Account", role: .destructive) {
+                Task { await appState.removeAccount(itemId: account.itemId) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the institution and cached local account data from PlaidBar. It does not close the bank account.")
+        }
     }
 
     private var availableText: String {
@@ -2193,6 +2212,17 @@ private struct SelectedAccountPanel: View {
         }
     }
 
+    private func performDrillInAction(_ action: DashboardDrillInAction) {
+        switch action {
+        case .reconnect:
+            Task { await appState.reconnectItem(itemId: account.itemId) }
+        case .remove:
+            isConfirmingAccountRemoval = true
+        case .settings:
+            openSettings()
+        }
+    }
+
     private var panelStroke: Color {
         shouldEmphasizeConnection ? connectionTint.opacity(0.18) : Color.primary.opacity(0.07)
     }
@@ -2208,6 +2238,29 @@ private struct SelectedAccountPanel: View {
         case .demo, .offline, .healthy, .unknown:
             return false
         }
+    }
+}
+
+private struct AccountDrillInActionBar: View {
+    let actions: [DashboardDrillInAction]
+    let onAction: (DashboardDrillInAction) -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
+            ForEach(actions, id: \.self) { action in
+                Button {
+                    onAction(action)
+                } label: {
+                    Label(action.title, systemImage: action.iconName)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(action == .remove ? SemanticColors.negative : nil)
+                .accessibilityHint(action.accessibilityHint)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Selected account actions")
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -2069,7 +2069,7 @@ private struct SelectedAccountPanel: View {
             }
 
             AccountDrillInActionBar(
-                actions: DashboardDrillInAction.accountDrillInActions,
+                actions: drillInActions,
                 onAction: performDrillInAction
             )
 
@@ -2095,16 +2095,16 @@ private struct SelectedAccountPanel: View {
             stroke: panelStroke
         )
         .confirmationDialog(
-            "Remove \(AccountPresentation.displayName(for: account))?",
+            "Remove \(institutionRemovalName)?",
             isPresented: $isConfirmingAccountRemoval,
             titleVisibility: .visible
         ) {
-            Button("Remove Account", role: .destructive) {
+            Button("Remove Institution", role: .destructive) {
                 Task { await appState.removeAccount(itemId: account.itemId) }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This removes the institution and cached local account data from PlaidBar. It does not close the bank account.")
+            Text("This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus cached local transactions from PlaidBar. It does not close any bank account.")
         }
     }
 
@@ -2134,6 +2134,25 @@ private struct SelectedAccountPanel: View {
 
     private var itemConnectionStatus: ItemStatus? {
         appState.itemStatuses.first { $0.id == account.itemId }
+    }
+
+    private var institutionRemovalName: String {
+        itemConnectionStatus?.institutionName ?? AccountPresentation.displayName(for: account)
+    }
+
+    private var institutionAccountCount: Int {
+        appState.accounts.count { $0.itemId == account.itemId }
+    }
+
+    private var institutionAccountCountText: String {
+        let count = max(institutionAccountCount, 1)
+        return count == 1 ? "1 linked account" : "\(count) linked accounts"
+    }
+
+    private var drillInActions: [DashboardDrillInAction] {
+        DashboardDrillInAction.accountDrillInActions.filter { action in
+            action != .remove || !appState.usesDemoConnectionPresentation
+        }
     }
 
     private var connectionPresentation: AccountConnectionPresentation {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -2150,9 +2150,9 @@ private struct SelectedAccountPanel: View {
     }
 
     private var drillInActions: [DashboardDrillInAction] {
-        DashboardDrillInAction.accountDrillInActions.filter { action in
-            action != .remove || !appState.usesDemoConnectionPresentation
-        }
+        DashboardDrillInAction.accountDrillInActions(
+            isDemoMode: appState.usesDemoConnectionPresentation
+        )
     }
 
     private var connectionPresentation: AccountConnectionPresentation {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1932,6 +1932,7 @@ private struct SelectedAccountPanel: View {
     let account: AccountDTO
     let isStatusFilter: Bool
     @State private var isConfirmingAccountRemoval = false
+    @State private var settingsCloseObserver: NSObjectProtocol?
 
     private var transactions: [TransactionDTO] {
         Array(accountTransactions.prefix(5))
@@ -2151,7 +2152,7 @@ private struct SelectedAccountPanel: View {
 
     private var drillInActions: [DashboardDrillInAction] {
         DashboardDrillInAction.accountDrillInActions(
-            isDemoMode: appState.usesDemoConnectionPresentation
+            isDemoMode: appState.isDemoMode
         )
     }
 
@@ -2238,8 +2239,42 @@ private struct SelectedAccountPanel: View {
         case .remove:
             isConfirmingAccountRemoval = true
         case .settings:
-            openSettings()
+            openSettingsWindow()
         }
+    }
+
+    private func openSettingsWindow() {
+        openSettings()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            if let settingsWindow = NSApp.keyWindow ?? NSApp.windows.first(where: {
+                $0.canBecomeKey && $0.isVisible && $0.level == .normal
+            }) {
+                settingsWindow.orderFrontRegardless()
+                if let existing = settingsCloseObserver {
+                    NotificationCenter.default.removeObserver(existing)
+                }
+                settingsCloseObserver = NotificationCenter.default.addObserver(
+                    forName: NSWindow.willCloseNotification,
+                    object: settingsWindow,
+                    queue: .main
+                ) { _ in
+                    Task { @MainActor in
+                        restoreAccessoryActivationPolicy()
+                    }
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func restoreAccessoryActivationPolicy() {
+        NSApp.setActivationPolicy(.accessory)
+        if let observer = settingsCloseObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        settingsCloseObserver = nil
     }
 
     private var panelStroke: Color {

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -105,4 +105,10 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
     public static var accountDrillInActions: [DashboardDrillInAction] {
         [.reconnect, .remove, .settings]
     }
+
+    public static func accountDrillInActions(isDemoMode: Bool) -> [DashboardDrillInAction] {
+        accountDrillInActions.filter { action in
+            !isDemoMode || action == .settings
+        }
+    }
 }

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -60,3 +60,49 @@ public enum DashboardDrillInSurface: String, CaseIterable, Sendable, Equatable {
         }
     }
 }
+
+/// Display-safe action copy for account drill-ins. Destructive actions stay
+/// explicit so the SwiftUI layer can gate them with confirmation before it
+/// calls the local server.
+public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
+    case reconnect
+    case remove
+    case settings
+
+    public var title: String {
+        switch self {
+        case .reconnect:
+            return "Reconnect"
+        case .remove:
+            return "Remove Account"
+        case .settings:
+            return "Settings"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .reconnect:
+            return "link.badge.plus"
+        case .remove:
+            return "trash"
+        case .settings:
+            return "gearshape"
+        }
+    }
+
+    public var accessibilityHint: String {
+        switch self {
+        case .reconnect:
+            return "Opens Plaid Link update mode for this institution."
+        case .remove:
+            return "Requires confirmation before removing this institution from local PlaidBar data."
+        case .settings:
+            return "Opens PlaidBar settings and local data controls."
+        }
+    }
+
+    public static var accountDrillInActions: [DashboardDrillInAction] {
+        [.reconnect, .remove, .settings]
+    }
+}

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -74,7 +74,7 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
         case .reconnect:
             return "Reconnect"
         case .remove:
-            return "Remove Account"
+            return "Remove Institution"
         case .settings:
             return "Settings"
         }
@@ -96,7 +96,7 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
         case .reconnect:
             return "Opens Plaid Link update mode for this institution."
         case .remove:
-            return "Requires confirmation before removing this institution from local PlaidBar data."
+            return "Requires confirmation before disconnecting this Plaid institution and removing its local PlaidBar data."
         case .settings:
             return "Opens PlaidBar settings and local data controls."
         }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3253,9 +3253,10 @@ struct PlaidBarCoreTests {
         let actions = DashboardDrillInAction.accountDrillInActions
 
         #expect(actions == [.reconnect, .remove, .settings])
-        #expect(DashboardDrillInAction.remove.title == "Remove Account")
+        #expect(DashboardDrillInAction.remove.title == "Remove Institution")
         #expect(DashboardDrillInAction.remove.iconName == "trash")
         #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("requires confirmation"))
+        #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("disconnecting this Plaid institution"))
         #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("local PlaidBar data"))
         #expect(DashboardDrillInAction.settings.accessibilityHint.localizedCaseInsensitiveContains("settings"))
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3248,6 +3248,18 @@ struct PlaidBarCoreTests {
         #expect(try encoder.encode(transaction) == originalData)
     }
 
+    @Test("Account drill-in actions keep destructive remove explicit")
+    func accountDrillInActionsExposeExplicitConfirmationCopy() {
+        let actions = DashboardDrillInAction.accountDrillInActions
+
+        #expect(actions == [.reconnect, .remove, .settings])
+        #expect(DashboardDrillInAction.remove.title == "Remove Account")
+        #expect(DashboardDrillInAction.remove.iconName == "trash")
+        #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("requires confirmation"))
+        #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("local PlaidBar data"))
+        #expect(DashboardDrillInAction.settings.accessibilityHint.localizedCaseInsensitiveContains("settings"))
+    }
+
     private func posixPermissions(at url: URL) throws -> Int {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3253,6 +3253,8 @@ struct PlaidBarCoreTests {
         let actions = DashboardDrillInAction.accountDrillInActions
 
         #expect(actions == [.reconnect, .remove, .settings])
+        #expect(DashboardDrillInAction.accountDrillInActions(isDemoMode: false) == [.reconnect, .remove, .settings])
+        #expect(DashboardDrillInAction.accountDrillInActions(isDemoMode: true) == [.settings])
         #expect(DashboardDrillInAction.remove.title == "Remove Institution")
         #expect(DashboardDrillInAction.remove.iconName == "trash")
         #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("requires confirmation"))

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -99,7 +99,7 @@ and `docs/autonomous-roadmap.md`.
   and pointer path.
 - [ ] T027: Show transactions, balances, limits, freshness, and sync state for
   the selected account.
-- [ ] T028: Keep reconnect, remove, and settings actions explicit and
+- [x] T028: Keep reconnect, remove, and settings actions explicit and
   confirmation-gated where destructive.
 - [ ] T029: Add empty drill-in states for no synced transactions and server
   offline.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -240,6 +240,10 @@ remain unmarked.
 - 2026-06-08 [T025]: added focused coverage for the shared account-row
   accessibility presentation helper, including display-safe field boundaries;
   evidence: `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`.
+- 2026-06-08 [T028]: added explicit selected-account drill-in actions for
+  reconnect, remove, and settings, with destructive remove gated by a
+  confirmation dialog; evidence: `DashboardDrillInAction` and selected account
+  action bar tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Adds explicit selected-account drill-in actions for reconnect, remove, and settings.
- Gates the destructive remove path behind a confirmation dialog that explains the local-data boundary.
- Records T028 completion in the autonomous backlog/roadmap ledger.

@codex please review.

## Autonomous task IDs
Task ID(s): T028
Backlog slice: PR-006 Account Drill-In Surfaces
Scope note: Minimal selected-account action UI and display-safe core action copy; no backend/API behavior change.

## Agent coordination
Builder agent: Otto (Hermes default profile)
Builder branch/worktree: /private/tmp/PlaidBar-otto on ui/drill-in-account-actions-t028
Reviewer/merge steward: Otto (Hermes default profile)
Coordination note: Single-writer branch; PRs #214/#215 remain blocked by branch policy and this branch is based on current main.

## Changed files
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates
- [x] `git diff --check` — passed
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` — passed
- [x] `swift test --skip-update --disable-keychain` — passed, 264 tests
- [x] changed-line secret scan — passed, no changed-line secret-pattern hits

## GitHub checks
- build: pending
- claude-review: non-blocking per Felipe's scoped loop instruction if quota/session/review automation only
- otto-openclaw merge gate: rerun requested after PR body template correction

## Privacy and safety impact
- No hosted backend, telemetry, cloud sync, or cloud AI changes.
- Remove copy clarifies that the action removes the institution and cached local account data from PlaidBar and does not close the bank account.
- No Plaid secrets, access tokens, account IDs, or transaction data added to docs/logs.

## Merge safety
- Final diff is scoped to selected account drill-in action UI, display-safe core action copy, focused tests, and backlog/roadmap ledger updates.
- Destructive account removal now requires explicit confirmation from the selected-account drill-in.
- Do not merge until GitHub build is successful, review threads are clear, and merge state is clean/mergeable.
