### PR TITLE
feat: label account drill-in accessibility

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -2082,11 +2082,14 @@ private struct SelectedAccountPanel: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .accessibilityLabel(connectionRecoveryAccessibilityLabel)
+                    .accessibilityHint(connectionRecoveryAccessibilityHint)
                 }
             }
 
             AccountDrillInActionBar(
                 actions: drillInActions,
+                accountDisplayName: drillInSummary.displayName,
                 onAction: performDrillInAction
             )
 
@@ -2111,6 +2114,8 @@ private struct SelectedAccountPanel: View {
             fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: shouldEmphasizeConnection ? connectionTint : nil)),
             stroke: panelStroke
         )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(drillInSummary.accessibilityLabel)
         .confirmationDialog(
             "Remove \(institutionRemovalName)?",
             isPresented: $isConfirmingAccountRemoval,
@@ -2229,6 +2234,14 @@ private struct SelectedAccountPanel: View {
         }
     }
 
+    private var connectionRecoveryAccessibilityLabel: String {
+        "\(connectionRecoveryActionTitle) for \(drillInSummary.displayName)"
+    }
+
+    private var connectionRecoveryAccessibilityHint: String {
+        connectionPresentation.recoveryDetailLabel ?? "Refreshes this selected account's PlaidBar status."
+    }
+
     private func performConnectionRecoveryAction() {
         switch connectionPresentation.level {
         case .loginRequired, .error:
@@ -2305,6 +2318,7 @@ private struct SelectedAccountPanel: View {
 
 private struct AccountDrillInActionBar: View {
     let actions: [DashboardDrillInAction]
+    let accountDisplayName: String
     let onAction: (DashboardDrillInAction) -> Void
 
     var body: some View {
@@ -2318,6 +2332,7 @@ private struct AccountDrillInActionBar: View {
                 .buttonStyle(.bordered)
                 .controlSize(.small)
                 .tint(action == .remove ? SemanticColors.negative : nil)
+                .accessibilityLabel(action.accessibilityLabel(accountDisplayName: accountDisplayName))
                 .accessibilityHint(action.accessibilityHint)
             }
         }
@@ -2380,6 +2395,8 @@ private struct AccountConnectionBadge: View {
             .padding(.horizontal, Spacing.compactRowHorizontalPadding)
             .padding(.vertical, Spacing.compactRowVerticalPadding)
             .background(tint.opacity(0.12), in: Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Selected account status: \(label)")
     }
 }
 
@@ -2431,6 +2448,8 @@ private struct DetailValue: View {
                 .foregroundStyle(tint)
                 .monospacedDigit()
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(value)")
     }
 }
 
@@ -2504,6 +2523,7 @@ private struct AccountActivityEmptyStateView: View {
             useLiquidGlass: false
         )
         .accessibilityElement(children: .combine)
+        .accessibilityLabel(presentation.accessibilityLabel)
     }
 
     private var tint: Color {

--- a/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
@@ -6,6 +6,10 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
     public let iconName: String
     public let tone: DashboardAccountEmptyStateTone
 
+    public var accessibilityLabel: String {
+        "\(title). \(detail)"
+    }
+
     public init(
         title: String,
         detail: String,

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -102,6 +102,17 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
         }
     }
 
+    public func accessibilityLabel(accountDisplayName: String) -> String {
+        switch self {
+        case .reconnect:
+            return "Reconnect \(accountDisplayName)"
+        case .remove:
+            return "Remove institution for \(accountDisplayName)"
+        case .settings:
+            return "Open PlaidBar settings from \(accountDisplayName)"
+        }
+    }
+
     public static var accountDrillInActions: [DashboardDrillInAction] {
         [.reconnect, .remove, .settings]
     }
@@ -157,6 +168,29 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
     public let latestTransactionDate: String?
     public let syncState: ItemConnectionStatus?
     public let freshnessLabel: String
+
+    public var accessibilityLabel: String {
+        var parts = [
+            "Selected account drill-in",
+            displayName,
+            subtitle,
+            "\(availableTitle) \(Formatters.currency(availableBalance, format: .full))",
+            "\(currentTitle) \(Formatters.currency(currentBalance, format: .full))",
+            "\(transactionCount) synced transaction\(transactionCount == 1 ? "" : "s")",
+            "\(pendingTransactionCount) pending transaction\(pendingTransactionCount == 1 ? "" : "s")",
+            "Sync \(freshnessLabel)"
+        ]
+
+        if let utilizationPercent {
+            parts.append("Utilization \(Formatters.percent(utilizationPercent, decimals: 0))")
+        }
+
+        if let latestTransactionDate {
+            parts.append("Latest transaction \(Formatters.displayTransactionDate(latestTransactionDate))")
+        }
+
+        return parts.joined(separator: ", ")
+    }
 
     public static func presentation(
         for account: AccountDTO,

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -551,6 +551,60 @@ struct PlaidBarCoreTests {
         #expect(!summary.subtitle.contains(account.itemId))
     }
 
+    @Test("Account drill-in summary accessibility stays display safe")
+    func accountDrillInSummaryAccessibilityStaysDisplaySafe() {
+        let account = AccountDTO(
+            id: "acct-internal-123",
+            itemId: "item-internal-456",
+            name: "Everyday",
+            type: .depository,
+            subtype: "checking",
+            mask: "1234",
+            balances: BalanceDTO(available: 500, current: 520),
+            institutionName: "Chase"
+        )
+        let summary = DashboardAccountDrillInSummary.presentation(
+            for: account,
+            transactions: [
+                TransactionDTO(id: "tx-1", accountId: account.id, amount: 24, date: "2026-06-01", name: "Coffee", pending: true)
+            ],
+            itemStatus: ItemStatus(id: account.itemId, institutionName: "Chase", status: .connected, lastSync: nil),
+            fallbackFreshnessLabel: "Fresh"
+        )
+
+        #expect(summary.accessibilityLabel.contains("Selected account drill-in"))
+        #expect(summary.accessibilityLabel.contains("Everyday"))
+        #expect(summary.accessibilityLabel.contains("Available $500.00"))
+        #expect(summary.accessibilityLabel.contains("1 synced transaction"))
+        #expect(summary.accessibilityLabel.contains("1 pending transaction"))
+        #expect(summary.accessibilityLabel.contains("Latest transaction Jun 1, 2026"))
+        #expect(!summary.accessibilityLabel.contains(account.id))
+        #expect(!summary.accessibilityLabel.contains(account.itemId))
+    }
+
+    @Test("Drill-in action accessibility labels include display names only")
+    func drillInActionAccessibilityLabelsUseDisplayNamesOnly() {
+        let displayName = "Everyday Checking"
+
+        #expect(DashboardDrillInAction.reconnect.accessibilityLabel(accountDisplayName: displayName) == "Reconnect Everyday Checking")
+        #expect(DashboardDrillInAction.remove.accessibilityLabel(accountDisplayName: displayName) == "Remove institution for Everyday Checking")
+        #expect(DashboardDrillInAction.settings.accessibilityLabel(accountDisplayName: displayName) == "Open PlaidBar settings from Everyday Checking")
+        #expect(DashboardDrillInAction.remove.accessibilityHint.contains("Requires confirmation"))
+    }
+
+    @Test("Account activity empty-state accessibility combines title and recovery detail")
+    func accountActivityEmptyStateAccessibilityCombinesTitleAndDetail() {
+        let presentation = AccountActivityEmptyState.evaluate(
+            transactionCount: 0,
+            isDemoMode: false,
+            serverConnected: false,
+            connectionLevel: .offline,
+            accountDisplayName: "Everyday Checking"
+        )
+
+        #expect(presentation?.accessibilityLabel == "Server offline. Start PlaidBarServer, then refresh to load recent activity for Everyday Checking.")
+    }
+
     @Test("Account presentation keeps credit metadata readable without due dates")
     func accountPresentationCreditMetadataWithoutDueDates() {
         let creditWithoutLimit = AccountDTO(

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -101,9 +101,9 @@ and `docs/autonomous-roadmap.md`.
   the selected account.
 - [x] T028: Keep reconnect, remove, and settings actions explicit and
   confirmation-gated where destructive.
-- [ ] T029: Add empty drill-in states for no synced transactions and server
+- [x] T029: Add empty drill-in states for no synced transactions and server
   offline.
-- [ ] T030: Add accessibility labels for drill-in status and action controls.
+- [x] T030: Add accessibility labels for drill-in status and action controls.
 
 ### PR-007: Empty, Loading, And Error States
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -252,6 +252,14 @@ remain unmarked.
   reconnect, remove, and settings, with destructive remove gated by a
   confirmation dialog; evidence: `DashboardDrillInAction` and selected account
   action bar tests.
+- 2026-06-08 [T029]: confirmed selected-account recent-activity empty states
+  distinguish no synced transactions, server offline, demo-only empty activity,
+  and item recovery states; evidence: `AccountActivityEmptyState` and core
+  tests.
+- 2026-06-08 [T030]: added display-safe accessibility labels for selected
+  account drill-in summaries, status badges, recovery buttons, action controls,
+  and empty activity panels; evidence: `DashboardAccountDrillInSummary`,
+  `DashboardDrillInAction`, `MainPopover`, and core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary

- Adds display-safe accessibility labels for selected-account drill-in summaries, status badges, balance/activity values, recovery controls, and action buttons.
- Reuses existing account activity empty-state presentations for no synced transactions and server-offline drill-in states, with explicit accessibility labels.
- Marks T029/T030 complete in the autonomous backlog and roadmap ledger.
- @codex please review.

## Autonomous task IDs

- Task ID(s): T029, T030
- Backlog slice: PR-006: Account Drill-In Surfaces
- Scope note: One focused accessibility/drill-in slice; no screenshots or hosted services.

## Agent coordination

- Builder agent: Otto (Hermes scheduled PlaidBar loop)
- Builder branch/worktree: `accessibility/drill-in-status-actions-t030` in `/private/tmp/PlaidBar-otto`
- Reviewer/merge steward: Otto
- Coordination note: Branch is pushed for review/CI; other agents should review only and avoid pushing unless coordinating via this PR.

## Changed files

- `Sources/PlaidBar/Views/MainPopover.swift`
- `Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift`
- `Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` not run: no server target, shared DTO, package, or server code changed.
- [x] `swift test --skip-update --disable-keychain` — 269 tests passed, 2 Keychain-gated tests skipped by environment assumption.
- [x] Changed-line secret scan over docs/source/tests/commands/workflows/agent prompt files — no changed-line secret patterns found.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are non-blocking per Felipe's standing instruction for this loop; substantive review/build/test findings still block merge.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status/diagnostic-like accessibility labels expose display-safe names, masked account hints, counts, and formatted presentation values; no raw Plaid IDs or tokens.
- [x] No server, storage, setup, or diagnostics boundary changed.
- [x] No optional AI behavior changed.
- [x] Documentation/tests use synthetic examples and do not imply production readiness, notarization, distribution, or unverified security properties.

## UI and accessibility checks

- [x] Keyboard path unchanged; existing row button/focus activation remains intact.
- [x] VoiceOver labels added/covered for selected drill-in summary, status, action controls, detail values, recovery action, and empty activity state.
- [x] Balances, risk, utilization, status, and actions remain text-labeled and not color-only.
- [x] Roadmap/backlog docs updated; screenshots not needed for this non-visual accessibility labeling slice.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`.
- [ ] PR head SHA will be rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [x] Completed task IDs are recorded in the roadmap ledger and backlog checklist in this PR.
