### PR TITLE
fix: distinguish account empty credentials state

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1661,6 +1661,7 @@ private struct DashboardEmptyAccountState: View {
             filter: filter.emptyStateKind,
             isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,
             degradedItemCount: appState.needsLoginItemCount + appState.erroredItemCount,

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -78,6 +78,7 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         filter: DashboardAccountFilterKind,
         isDemoMode: Bool,
         serverConnected: Bool,
+        credentialsConfigured: Bool? = nil,
         linkedItemCount: Int,
         accountCount: Int,
         degradedItemCount: Int,
@@ -94,6 +95,19 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
                 action: .checkServer,
                 actionTitle: "Check Server",
                 actionIconName: "server.rack"
+            )
+        }
+
+        if !isDemoMode, credentialsConfigured == false {
+            return DashboardAccountEmptyState(
+                title: "Plaid credentials missing",
+                detail: "Add Plaid credentials to the local server environment, then check status again.",
+                iconName: "key.slash",
+                tone: .warning,
+                showsAddAccount: false,
+                action: .refresh,
+                actionTitle: "Check Credentials",
+                actionIconName: "key"
             )
         }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1880,6 +1880,7 @@ struct PlaidBarCoreTests {
             filter: .status,
             isDemoMode: false,
             serverConnected: false,
+            credentialsConfigured: false,
             linkedItemCount: 1,
             accountCount: 0,
             degradedItemCount: 1
@@ -1889,6 +1890,27 @@ struct PlaidBarCoreTests {
         #expect(emptyState.action == .checkServer)
         #expect(emptyState.actionTitle == "Check Server")
         #expect(emptyState.actionIconName == "server.rack")
+    }
+
+    @Test("Dashboard account empty state distinguishes missing credentials before no linked bank")
+    func dashboardAccountEmptyStateCredentialsMissingBeforeLinkPrompt() {
+        let emptyState = DashboardAccountEmptyState.evaluate(
+            filter: .all,
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            degradedItemCount: 0
+        )
+
+        #expect(emptyState.title == "Plaid credentials missing")
+        #expect(emptyState.detail.contains("local server environment"))
+        #expect(emptyState.tone == .warning)
+        #expect(!emptyState.showsAddAccount)
+        #expect(emptyState.action == .refresh)
+        #expect(emptyState.actionTitle == "Check Credentials")
+        #expect(emptyState.actionIconName == "key")
     }
 
     @Test("Dashboard account empty state uses status check copy before a bank is linked")

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -107,7 +107,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-007: Empty, Loading, And Error States
 
-- [ ] T031: Distinguish no server, no credentials, no linked item, no synced
+- [x] T031: Distinguish no server, no credentials, no linked item, no synced
   data, and filtered-zero states in one area.
 - [ ] T032: Add one clear recovery action to each state in that area.
 - [ ] T033: Preserve last-known local data during transient failures.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -260,6 +260,10 @@ remain unmarked.
   account drill-in summaries, status badges, recovery buttons, action controls,
   and empty activity panels; evidence: `DashboardAccountDrillInSummary`,
   `DashboardDrillInAction`, `MainPopover`, and core tests.
+- 2026-06-08 [T031]: distinguished the dashboard account empty panel's no-server,
+  missing-credentials, no-linked-bank, no-account-data, healthy-status, and
+  filtered-zero states; evidence: `DashboardAccountEmptyState`, `MainPopover`,
+  and core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary

- Adds a missing-credentials branch to the dashboard account empty-state presenter before the no-linked-bank prompt.
- Wires the account empty panel to `AppState.serverCredentialsConfigured` so users see credential setup recovery instead of an Add Account prompt when PlaidBarServer lacks credentials.
- Marks T031 complete in the backlog/roadmap ledger.

@codex please review the focused T031 slice for product clarity, local-first/privacy boundaries, and test coverage.

## Autonomous task IDs

- Task ID(s): T031
- Backlog slice: PR-007: Empty, Loading, And Error States
- Scope note: One focused account empty-state presenter/UI wiring slice.

## Agent coordination

- Builder agent: Otto (Hermes scheduled PlaidBar loop)
- Builder branch/worktree: `ui/account-empty-credentials-t031` at `/private/tmp/PlaidBar-otto`
- Reviewer/merge steward: Otto
- Coordination note: Review only unless coordinating first; this scheduled loop owns pushes on this branch.

## Changed files

- `Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `swift test --skip-update --disable-keychain` — 270 tests passed; 2 Keychain tests skipped by environment condition.
- [x] Changed-line secret scan completed for docs, source, tests, commands, workflows, and agent prompt files.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review quota/session/setup-only failures are non-blocking per Felipe's instruction for this loop; substantive findings still block.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes: this reuses the existing empty-state button path and only changes the selected presenter copy/action.
- [x] I spot-checked VoiceOver labels or announcements for UI changes: the existing panel reads the new title/detail/action label.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs/backlog because user-facing empty-state behavior changed.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [x] After merge, completed task IDs are recorded in the roadmap ledger and backlog checklist.
