### PR TITLE
fix: preserve account cache during transient failures

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -595,7 +595,11 @@ final class AppState {
             let refreshedAccounts = try await serverClient.getAccounts()
             await refreshItemStatuses()
             accounts = accountsPreservingUnavailableItems(refreshedAccounts)
-            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
+            try LocalDataStore.saveAccounts(
+                accounts,
+                to: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
             serverItemCount = Set(accounts.map(\.itemId)).count
             serverSyncReady = (serverItemCount ?? 0) > 0
             updateSetupCompletion()
@@ -615,7 +619,11 @@ final class AppState {
             let refreshedAccounts = try await serverClient.getBalances()
             await refreshItemStatuses()
             accounts = accountsPreservingUnavailableItems(refreshedAccounts)
-            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
+            try LocalDataStore.saveAccounts(
+                accounts,
+                to: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
             lastSyncDate = Date()
             recordBalanceSnapshot()
         } catch {
@@ -821,9 +829,14 @@ final class AppState {
                     (transaction.itemId == nil && removedAccountIds.contains(transaction.accountId))
             }
             do {
+                try LocalDataStore.saveAccounts(
+                    accounts,
+                    to: activeStorageDirectoryURL,
+                    context: transactionCacheContext
+                )
                 try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
             } catch {
-                self.error = "Transaction cache failed to save: \(error.localizedDescription)"
+                self.error = "Local cache failed to save: \(error.localizedDescription)"
             }
         } catch {
             self.error = error.localizedDescription
@@ -937,7 +950,10 @@ final class AppState {
 
     private func loadCachedAccounts() {
         do {
-            accounts = try LocalDataStore.loadAccounts(context: transactionCacheContext)
+            accounts = try LocalDataStore.loadAccounts(
+                from: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
         } catch {
             self.error = "Account cache failed to load: \(error.localizedDescription)"
         }
@@ -946,7 +962,11 @@ final class AppState {
     private func clearCachedAccounts() {
         accounts = []
         do {
-            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
+            try LocalDataStore.saveAccounts(
+                accounts,
+                to: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
         } catch {
             self.error = "Account cache failed to clear: \(error.localizedDescription)"
         }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -652,7 +652,11 @@ final class AppState {
                 }
                 let response = try await serverClient.syncTransactions()
                 let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
-                try LocalDataStore.saveTransactions(updatedTransactions, context: transactionCacheContext)
+                try LocalDataStore.saveTransactions(
+                    updatedTransactions,
+                    to: activeStorageDirectoryURL,
+                    context: transactionCacheContext
+                )
                 transactions = updatedTransactions
                 try await serverClient.commitSyncCursors(response.pendingCursors)
                 hasMore = response.hasMore
@@ -838,7 +842,11 @@ final class AppState {
                     to: activeStorageDirectoryURL,
                     context: transactionCacheContext
                 )
-                try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+                try LocalDataStore.saveTransactions(
+                    transactions,
+                    to: activeStorageDirectoryURL,
+                    context: transactionCacheContext
+                )
             } catch {
                 self.error = "Local cache failed to save: \(error.localizedDescription)"
             }
@@ -978,7 +986,10 @@ final class AppState {
 
     private func loadCachedTransactions() {
         do {
-            transactions = try LocalDataStore.loadTransactions(context: transactionCacheContext)
+            transactions = try LocalDataStore.loadTransactions(
+                from: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
         } catch {
             self.error = "Transaction cache failed to load: \(error.localizedDescription)"
         }
@@ -987,7 +998,11 @@ final class AppState {
     private func clearCachedTransactions() {
         transactions = []
         do {
-            try LocalDataStore.saveTransactions(transactions, context: transactionCacheContext)
+            try LocalDataStore.saveTransactions(
+                transactions,
+                to: activeStorageDirectoryURL,
+                context: transactionCacheContext
+            )
         } catch {
             self.error = "Transaction cache failed to clear: \(error.localizedDescription)"
         }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -595,6 +595,7 @@ final class AppState {
             let refreshedAccounts = try await serverClient.getAccounts()
             await refreshItemStatuses()
             accounts = accountsPreservingUnavailableItems(refreshedAccounts)
+            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
             serverItemCount = Set(accounts.map(\.itemId)).count
             serverSyncReady = (serverItemCount ?? 0) > 0
             updateSetupCompletion()
@@ -614,6 +615,7 @@ final class AppState {
             let refreshedAccounts = try await serverClient.getBalances()
             await refreshItemStatuses()
             accounts = accountsPreservingUnavailableItems(refreshedAccounts)
+            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
             lastSyncDate = Date()
             recordBalanceSnapshot()
         } catch {
@@ -919,8 +921,10 @@ final class AppState {
         await checkServerConnection()
         if serverConnected {
             if statusItemCount > 0 {
+                loadCachedAccounts()
                 loadCachedTransactions()
             } else {
+                clearCachedAccounts()
                 clearCachedTransactions()
             }
             await refreshAccounts()
@@ -930,6 +934,23 @@ final class AppState {
     }
 
     // MARK: - Balance History
+
+    private func loadCachedAccounts() {
+        do {
+            accounts = try LocalDataStore.loadAccounts(context: transactionCacheContext)
+        } catch {
+            self.error = "Account cache failed to load: \(error.localizedDescription)"
+        }
+    }
+
+    private func clearCachedAccounts() {
+        accounts = []
+        do {
+            try LocalDataStore.saveAccounts(accounts, context: transactionCacheContext)
+        } catch {
+            self.error = "Account cache failed to clear: \(error.localizedDescription)"
+        }
+    }
 
     private func loadCachedTransactions() {
         do {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -593,8 +593,10 @@ final class AppState {
         error = nil
         do {
             let refreshedAccounts = try await serverClient.getAccounts()
-            await refreshItemStatuses()
-            accounts = accountsPreservingUnavailableItems(refreshedAccounts)
+            let itemStatusesAvailable = await refreshItemStatuses()
+            accounts = itemStatusesAvailable
+                ? accountsPreservingUnavailableItems(refreshedAccounts)
+                : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
             try LocalDataStore.saveAccounts(
                 accounts,
                 to: activeStorageDirectoryURL,
@@ -617,8 +619,10 @@ final class AppState {
         error = nil
         do {
             let refreshedAccounts = try await serverClient.getBalances()
-            await refreshItemStatuses()
-            accounts = accountsPreservingUnavailableItems(refreshedAccounts)
+            let itemStatusesAvailable = await refreshItemStatuses()
+            accounts = itemStatusesAvailable
+                ? accountsPreservingUnavailableItems(refreshedAccounts)
+                : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
             try LocalDataStore.saveAccounts(
                 accounts,
                 to: activeStorageDirectoryURL,
@@ -1027,6 +1031,16 @@ final class AppState {
 
         let preservedAccounts = accounts.filter { account in
             unavailableItemIds.contains(account.itemId) && !refreshedAccountIds.contains(account.id)
+        }
+        return refreshedAccounts + preservedAccounts
+    }
+
+    private func accountsPreservingCachedAccountsMissingFromRefresh(_ refreshedAccounts: [AccountDTO]) -> [AccountDTO] {
+        guard !accounts.isEmpty else { return refreshedAccounts }
+
+        let refreshedAccountIds = Set(refreshedAccounts.map(\.id))
+        let preservedAccounts = accounts.filter { account in
+            !refreshedAccountIds.contains(account.id)
         }
         return refreshedAccounts + preservedAccounts
     }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -154,7 +154,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Reset removes PlaidBar database files, transaction caches, pending Link sessions, and stored Plaid access-token entries. Preferences, server.conf, app/server auth, and unrelated files stay in place.")
+                    Text("Reset removes PlaidBar database files, account and transaction caches, pending Link sessions, and stored Plaid access-token entries. Preferences, server.conf, app/server auth, and unrelated files stay in place.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
 
@@ -192,7 +192,7 @@ struct GeneralSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Deletes the SQLite database, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart PlaidBarServer after resetting.")
+            Text("Deletes the SQLite database, account and transaction caches, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart PlaidBarServer after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -48,6 +48,7 @@ public enum LocalDataStore {
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
     public static let authTokenFilename = "auth-token"
     public static let serverConfigFilename = "server.conf"
+    public static let accountCacheFilename = "accounts.json"
     public static let transactionCacheFilename = "transactions.json"
     public static let pendingLinkSessionsFilename = "pending-link-sessions.json"
     public static let plaidAccessTokenKeychainService = "PlaidBar.PlaidAccessToken"
@@ -173,7 +174,8 @@ public enum LocalDataStore {
             return false
         }
 
-        if isTransactionCacheFilename(filename) ||
+        if isAccountCacheFilename(filename) ||
+            isTransactionCacheFilename(filename) ||
             isPendingLinkSessionsFilename(filename) {
             return true
         }
@@ -207,6 +209,14 @@ public enum LocalDataStore {
         filename == transactionCacheFilename ||
             (
                 filename.hasPrefix("transactions-") &&
+                    (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
+            )
+    }
+
+    private static func isAccountCacheFilename(_ filename: String) -> Bool {
+        filename == accountCacheFilename ||
+            (
+                filename.hasPrefix("accounts-") &&
                     (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
             )
     }
@@ -247,6 +257,13 @@ public enum LocalDataStore {
         directory.appendingPathComponent(transactionCacheFilename(for: context))
     }
 
+    public static func accountCacheURL(
+        in directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil
+    ) -> URL {
+        directory.appendingPathComponent(accountCacheFilename(for: context))
+    }
+
     public static func authTokenURL(
         in directory: URL = storageDirectoryURL()
     ) -> URL {
@@ -274,6 +291,20 @@ public enum LocalDataStore {
         return cache.transactions
     }
 
+    public static func loadAccounts(
+        from directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil,
+        fileManager: FileManager = .default
+    ) throws -> [AccountDTO] {
+        let url = accountCacheURL(in: directory, context: context)
+        guard fileManager.fileExists(atPath: url.path) else { return [] }
+
+        let data = try Data(contentsOf: url)
+        let cache = try JSONDecoder().decode(AccountCache.self, from: data)
+        guard context == nil || cache.context == context else { return [] }
+        return cache.accounts
+    }
+
     public static func saveTransactions(
         _ transactions: [TransactionDTO],
         to directory: URL = storageDirectoryURL(),
@@ -287,6 +318,28 @@ public enum LocalDataStore {
         let data = try JSONEncoder().encode(cache)
         try writePrivateCacheFile(data, to: url, fileManager: fileManager)
         try setPrivateCacheFilePermissions(url, fileManager: fileManager)
+    }
+
+    public static func saveAccounts(
+        _ accounts: [AccountDTO],
+        to directory: URL = storageDirectoryURL(),
+        context: TransactionCacheContext? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
+
+        let url = accountCacheURL(in: directory, context: context)
+        let cache = AccountCache(context: context, accounts: accounts)
+        let data = try JSONEncoder().encode(cache)
+        try writePrivateCacheFile(data, to: url, fileManager: fileManager)
+        try setPrivateCacheFilePermissions(url, fileManager: fileManager)
+    }
+
+    private static func accountCacheFilename(for context: TransactionCacheContext?) -> String {
+        guard let context else { return accountCacheFilename }
+
+        let key = "\(context.environment.rawValue)|\(context.storagePath)"
+        return "accounts-\(context.environment.rawValue)-\(stableHashHex(key)).json"
     }
 
     private static func transactionCacheFilename(for context: TransactionCacheContext?) -> String {
@@ -402,6 +455,11 @@ public enum LocalDataStore {
 private struct TransactionCache: Codable, Sendable {
     let context: TransactionCacheContext?
     let transactions: [TransactionDTO]
+}
+
+private struct AccountCache: Codable, Sendable {
+    let context: TransactionCacheContext?
+    let accounts: [AccountDTO]
 }
 
 private extension String {

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -214,11 +214,26 @@ public enum LocalDataStore {
     }
 
     private static func isAccountCacheFilename(_ filename: String) -> Bool {
-        filename == accountCacheFilename ||
-            (
-                filename.hasPrefix("accounts-") &&
-                    (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
-            )
+        let cacheFilename = normalizedCacheFilename(filename)
+        if cacheFilename == accountCacheFilename { return true }
+
+        return [PlaidEnvironment.sandbox.rawValue, PlaidEnvironment.production.rawValue].contains { environment in
+            guard cacheFilename.hasPrefix("accounts-\(environment)-"),
+                  cacheFilename.hasSuffix(".json") else { return false }
+
+            let hashStart = cacheFilename.index(cacheFilename.startIndex, offsetBy: "accounts-\(environment)-".count)
+            let hashEnd = cacheFilename.index(cacheFilename.endIndex, offsetBy: -".json".count)
+            let hash = cacheFilename[hashStart..<hashEnd]
+            return hash.count == 16 && hash.allSatisfy(\.isHexDigit)
+        }
+    }
+
+    private static func normalizedCacheFilename(_ filename: String) -> String {
+        guard let backupRange = filename.range(of: ".json.backup-") else {
+            return filename
+        }
+
+        return String(filename[..<backupRange.lowerBound]) + ".json"
     }
 
     private static func isPendingLinkSessionsFilename(_ filename: String) -> Bool {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -427,24 +427,31 @@ struct PlaidBarServerTests {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        try LocalDataStore.saveAccounts(
-            [AccountDTO(
-                id: "checking",
-                itemId: "item-production",
-                name: "Everyday Checking",
-                type: .depository,
-                balances: BalanceDTO(current: 1_250)
-            )],
-            to: directory,
-            context: nil
+        let account = AccountDTO(
+            id: "checking",
+            itemId: "item-production",
+            name: "Everyday Checking",
+            type: .depository,
+            balances: BalanceDTO(current: 1_250)
         )
+        let context = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: directory.appendingPathComponent("plaidbar-sandbox.sqlite").path
+        )
+        let unrelatedExport = directory.appendingPathComponent("accounts-2026.json")
+        try Data("user export".utf8).write(to: unrelatedExport)
+        try LocalDataStore.saveAccounts([account], to: directory, context: nil)
+        try LocalDataStore.saveAccounts([account], to: directory, context: context)
 
-        _ = try LocalDataStore.resetLocalData(
+        let result = try LocalDataStore.resetLocalData(
             at: directory,
             resetKeychainTokens: false
         )
 
         #expect(try LocalDataStore.loadAccounts(from: directory).isEmpty)
+        #expect(try LocalDataStore.loadAccounts(from: directory, context: context).isEmpty)
+        #expect(FileManager.default.fileExists(atPath: unrelatedExport.path))
+        #expect(result.preservedEntries.contains("accounts-2026.json"))
     }
 
     @Test func serverCanCopyLegacyDatabaseAfterWrongEnvironmentCreatedEmptyDatabase() throws {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -393,6 +393,60 @@ struct PlaidBarServerTests {
         #expect(try Data(contentsOf: URL(fileURLWithPath: productionPath)) == Data("new-production-db".utf8))
     }
 
+    @Test func accountCacheIsScopedByEnvironmentAndStoragePath() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-account-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let productionContext = TransactionCacheContext(
+            environment: .production,
+            storagePath: directory.appendingPathComponent("plaidbar-production.sqlite").path
+        )
+        let sandboxContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: directory.appendingPathComponent("plaidbar-sandbox.sqlite").path
+        )
+        let account = AccountDTO(
+            id: "checking",
+            itemId: "item-production",
+            name: "Everyday Checking",
+            type: .depository,
+            balances: BalanceDTO(current: 1_250)
+        )
+
+        try LocalDataStore.saveAccounts([account], to: directory, context: productionContext)
+
+        #expect(try LocalDataStore.loadAccounts(from: directory, context: productionContext).map(\.id) == ["checking"])
+        #expect(try LocalDataStore.loadAccounts(from: directory, context: sandboxContext).isEmpty)
+    }
+
+    @Test func accountCacheIsRemovedDuringLocalDataReset() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-account-cache-reset-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try LocalDataStore.saveAccounts(
+            [AccountDTO(
+                id: "checking",
+                itemId: "item-production",
+                name: "Everyday Checking",
+                type: .depository,
+                balances: BalanceDTO(current: 1_250)
+            )],
+            to: directory,
+            context: nil
+        )
+
+        _ = try LocalDataStore.resetLocalData(
+            at: directory,
+            resetKeychainTokens: false
+        )
+
+        #expect(try LocalDataStore.loadAccounts(from: directory).isEmpty)
+    }
+
     @Test func serverCanCopyLegacyDatabaseAfterWrongEnvironmentCreatedEmptyDatabase() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -110,7 +110,7 @@ and `docs/autonomous-roadmap.md`.
 - [x] T031: Distinguish no server, no credentials, no linked item, no synced
   data, and filtered-zero states in one area.
 - [x] T032: Add one clear recovery action to each state in that area.
-- [ ] T033: Preserve last-known local data during transient failures.
+- [x] T033: Preserve last-known local data during transient failures.
 - [ ] T034: Truncate or sanitize server error text before display.
 - [ ] T035: Add a focused test for one empty/error-state presenter.
 

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -268,6 +268,10 @@ remain unmarked.
   explicit recovery action, including Check Server, Check Credentials, Check
   Status, Reconnect Item, Sync Balances, Refresh, and Refresh Data; evidence:
   `DashboardAccountEmptyState` action titles and core tests.
+- 2026-06-08 [T033]: preserved last-known account rows alongside transactions
+  in the local cache so transient refresh/balance failures keep usable dashboard
+  data scoped by environment and storage path; evidence: `LocalDataStore`
+  account cache, `AppState` cache load/save wiring, and server tests.
 
 ## Backlog Source
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -51,7 +51,7 @@ Current local data may include:
   Keychain when Security framework support is available
 - account metadata
 - balances
-- transaction cache
+- account and transaction caches
 - pending link-session state
 
 Sandbox and production use separate scoped stores.
@@ -92,10 +92,10 @@ public GitHub issue.
 
 ## Local Reset Boundary
 
-Resetting local data removes PlaidBar-owned database files, transaction caches,
-pending Link sessions, and stored Plaid access-token entries when present. It
-leaves `server.conf`, app/server auth, preferences, and unrelated files in the
-storage directory untouched.
+Resetting local data removes PlaidBar-owned database files, account and
+transaction caches, pending Link sessions, and stored Plaid access-token entries
+when present. It leaves `server.conf`, app/server auth, preferences, and
+unrelated files in the storage directory untouched.
 
 Local reset does not necessarily delete records from the Plaid Dashboard or
 revoke bank permissions outside PlaidBar. Users who need complete revocation


### PR DESCRIPTION
## Summary
- Adds a scoped local account cache alongside the existing transaction cache.
- Loads cached account rows before refresh and saves refreshed/balance account rows back to disk.
- Marks T033 complete in the autonomous backlog/roadmap.

@codex please review.

## Autonomous task IDs
Task ID(s): T033
Backlog slice: PR-007 Empty, Loading, And Error States
Scope note: Preserve last-known local account data during transient refresh/balance failures; no hosted backend, telemetry, or cloud sync changes.

## Agent coordination
Builder agent: Otto (Hermes default profile)
Builder branch/worktree: fix/preserve-account-cache-t033 at /private/tmp/PlaidBar-otto
Reviewer/merge steward: Otto autonomous loop; @codex requested for review
Coordination note: Single-branch slice based on latest main after PR #206 merge; no parallel writer expected.

## Changed files
- Sources/PlaidBar/App/AppState.swift
- Sources/PlaidBarCore/Utilities/LocalDataStore.swift
- Tests/PlaidBarServerTests/PlaidBarServerTests.swift
- docs/autonomous-loop-backlog.md
- docs/autonomous-roadmap.md

## Local gates
- [x] git diff --check
- [x] swift build --target PlaidBar --skip-update --disable-keychain
- [x] swift test --skip-update --disable-keychain (272 tests passed)
- [x] Changed-line secret scan passed

## GitHub checks
- [x] build passed on head e6326b8
- [x] claude-review passed
- [ ] otto-openclaw merge gate rerun after PR body template correction

## Privacy and safety impact
- Local-only cache under the configured PlaidBar data directory.
- Account cache is scoped by Plaid environment and storage path.
- No Plaid secrets, tokens, account IDs beyond existing local model fields, balances, or transactions are logged or documented.

## Merge safety
- Diff is scoped to T033 cache preservation, tests, and backlog/roadmap ledger updates.
- Requires green GitHub build, passing OpenClaw handoff gate, clean merge state, final diff sanity, and no unresolved real review threads before merge.