### PR TITLE
fix: pin transaction date formatter to POSIX locale and Gregorian calendar

### DIFF
--- a/Sources/PlaidBarCore/Utilities/Formatters.swift
+++ b/Sources/PlaidBarCore/Utilities/Formatters.swift
@@ -67,6 +67,13 @@ public enum Formatters {
 
     private static let transactionDateFormatter: DateFormatter = {
         let f = DateFormatter()
+        // Plaid transaction dates are fixed-format Gregorian yyyy-MM-dd. Pin the
+        // locale and calendar (Apple QA1480): an unpinned formatter inherits the
+        // system calendar, so on a Buddhist- or Japanese-calendar system these
+        // keys would parse and render with shifted years (e.g. 2569-06-10),
+        // silently corrupting every date bucket and cache comparison.
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.calendar = Calendar(identifier: .gregorian)
         f.dateFormat = "yyyy-MM-dd"
         return f
     }()

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1226,6 +1226,24 @@ struct PlaidBarCoreTests {
         #expect(date != nil)
     }
 
+    @Test("Transaction date keys parse and render as Gregorian components")
+    func transactionDateKeysStayGregorian() throws {
+        // Plaid keys are fixed-format Gregorian. The formatter pins
+        // en_US_POSIX + Gregorian so a non-Gregorian system calendar
+        // (e.g. Buddhist, which renders 2026-06-10 as 2569-06-10) cannot
+        // shift parsed years or rendered cache keys.
+        let parsed = try #require(Formatters.parseTransactionDate("2026-06-10"))
+
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = .current
+        let components = gregorian.dateComponents([.year, .month, .day], from: parsed)
+        #expect(components.year == 2026)
+        #expect(components.month == 6)
+        #expect(components.day == 10)
+
+        #expect(Formatters.transactionDateString(parsed) == "2026-06-10")
+    }
+
     @Test("Date parsing invalid")
     func dateParsingInvalid() {
         let invalid = Formatters.parseTransactionDate("not-a-date")


### PR DESCRIPTION
## Summary

- The shared `yyyy-MM-dd` transaction date formatter set only `dateFormat`, inheriting the system locale **and calendar**. On a Mac whose default calendar is non-Gregorian (Thai Buddhist, Japanese), Plaid's Gregorian date strings parse with shifted years and locally rendered date keys shift the other way — silently corrupting every date bucket, heatmap cell, sync-window filter, recurring-detection interval, and cache comparison.
- Repro (release build, simulating a `th_TH@calendar=buddhist` system default): the old configuration parses `2026-06-10` to **Gregorian year 1483**, and renders today's date key as **`2569-06-10`**. The pinned formatter round-trips `2026-06-10` exactly.
- Fix per Apple QA1480: pin `en_US_POSIX` plus an explicit Gregorian calendar for fixed-format interchange dates. Display formatters (`displayDate`, relative dates) intentionally keep the user's locale.
- Added a regression test asserting parsed components and rendered keys stay canonical Gregorian.

## Autonomous task IDs

- Task ID(s): none (bug found during repo-wide bug hunt; closest slice is data-correctness hardening)
- Backlog slice: n/a — standalone correctness fix
- Scope note: two-line formatter configuration change plus one focused test.

## Agent coordination

- Builder agent: Claude Code (interactive session with Felipe)
- Builder branch/worktree: `fix/posix-locale-transaction-dates` at `/Users/ftchvs/Developer/PlaidBar`
- Reviewer/merge steward: Claude Code under the 2026-05-30 scoped approval
- Coordination note: no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Utilities/Formatters.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`

## Local gates

- [x] `git diff --check`
- [x] `swift build` (full package)
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test` — 277 tests passed (276 baseline + 1 new)
- [x] Secret scan completed; synthetic data only.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed. (No user-facing behavior change in this PR.)

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [x] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [x] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.
