### PR TITLE
feat: add net-worth trend sparkline to the dashboard header

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1193,11 +1193,15 @@ final class AppState {
         ]
         transactions.append(contentsOf: Self.historicalDemoTransactions())
 
-        // Generate demo balance history (60 days for richer sparkline)
+        // Deterministic 60-day history with a gentle upward drift so the header
+        // trend reads the same on every demo launch and screenshots reproduce.
+        let demoNetWorth = 17_604.24
         balanceHistory = (0..<60).reversed().map { daysAgo in
             let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
-            let jitter = Double.random(in: -800...800)
-            return BalanceSnapshot(date: date, balance: 17_604.24 + jitter)
+            let progress = Double(60 - daysAgo) / 60
+            let drift = -650.0 + (650.0 * progress)
+            let wobble = sin(Double(daysAgo) / 4.5) * 180
+            return BalanceSnapshot(date: date, balance: demoNetWorth + drift + wobble)
         }
 
         isSetupComplete = true

--- a/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
@@ -1,0 +1,58 @@
+import Charts
+import PlaidBarCore
+import SwiftUI
+
+/// Quiet header sparkline for recorded net-worth history. The line draws in
+/// left-to-right once per appearance; direction color is reinforced by the
+/// signed delta text rendered next to it, so meaning never relies on color
+/// alone. Axes, legend, and grid stay hidden: this is a glance, not a chart.
+struct BalanceTrendChart: View {
+    let trend: BalanceTrend
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealFraction: CGFloat = 0
+
+    var body: some View {
+        Chart(trend.points, id: \.date) { snapshot in
+            LineMark(
+                x: .value("Date", snapshot.date),
+                y: .value("Net worth", snapshot.balance)
+            )
+            .interpolationMethod(.monotone)
+            .foregroundStyle(tint)
+            .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .chartYScale(domain: .automatic(includesZero: false))
+        .mask(alignment: .leading) {
+            GeometryReader { proxy in
+                Rectangle()
+                    .frame(width: proxy.size.width * revealFraction)
+            }
+        }
+        .onAppear {
+            guard !reduceMotion else {
+                revealFraction = 1
+                return
+            }
+            revealFraction = 0
+            withAnimation(.easeOut(duration: 0.55).delay(0.1)) {
+                revealFraction = 1
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var tint: Color {
+        switch trend.direction {
+        case .up:
+            SemanticColors.positive
+        case .down:
+            SemanticColors.negative
+        case .flat:
+            .secondary
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -177,6 +177,10 @@ struct MainPopover: View {
 private struct DashboardHeader: View {
     @Environment(AppState.self) private var appState
 
+    private var trend: BalanceTrend? {
+        BalanceTrend.evaluate(history: appState.balanceHistory)
+    }
+
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 4) {
@@ -192,7 +196,25 @@ private struct DashboardHeader: View {
                     .minimumScaleFactor(0.72)
             }
 
-            Spacer(minLength: 16)
+            Spacer(minLength: 12)
+
+            if let trend {
+                VStack(alignment: .trailing, spacing: 3) {
+                    BalanceTrendChart(trend: trend)
+                        .frame(width: 92, height: 21)
+
+                    Text("\(trend.deltaText) \(trend.spanText)")
+                        .font(.caption2.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(deltaTint(for: trend.direction))
+                        .lineLimit(1)
+                }
+                .padding(.top, 3)
+                .padding(.trailing, 14)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(trend.accessibilitySummary)
+                .help(trend.accessibilitySummary)
+            }
 
             VStack(alignment: .trailing, spacing: 3) {
                 Text("PlaidBar")
@@ -202,6 +224,17 @@ private struct DashboardHeader: View {
                     .lineLimit(1)
             }
             .padding(.top, 3)
+        }
+    }
+
+    private func deltaTint(for direction: BalanceTrend.Direction) -> Color {
+        switch direction {
+        case .up:
+            SemanticColors.positive
+        case .down:
+            SemanticColors.negative
+        case .flat:
+            .secondary
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/BalanceTrend.swift
+++ b/Sources/PlaidBarCore/Models/BalanceTrend.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Display-safe summary of the recorded net-worth history for the dashboard
+/// header sparkline: trend direction, signed delta, and the honest day span
+/// the data actually covers (which can be shorter than the requested window
+/// while history is still accumulating).
+public struct BalanceTrend: Sendable {
+    public enum Direction: Sendable {
+        case up
+        case down
+        case flat
+    }
+
+    public let direction: Direction
+    public let delta: Double
+    public let spanDays: Int
+    public let points: [BalanceSnapshot]
+
+    /// Signed compact delta, e.g. "+$1.2K", "-$420".
+    public var deltaText: String {
+        let magnitude = Formatters.currency(abs(delta), format: .abbreviated)
+        switch direction {
+        case .up:
+            return "+\(magnitude)"
+        case .down:
+            return "-\(magnitude)"
+        case .flat:
+            return magnitude
+        }
+    }
+
+    public var spanText: String {
+        "\(spanDays)D"
+    }
+
+    public var accessibilitySummary: String {
+        let change: String
+        switch direction {
+        case .up:
+            change = "up \(Formatters.currency(abs(delta), format: .full))"
+        case .down:
+            change = "down \(Formatters.currency(abs(delta), format: .full))"
+        case .flat:
+            change = "unchanged"
+        }
+        return "Net worth \(change) over the last \(spanDays) day\(spanDays == 1 ? "" : "s")."
+    }
+
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        now: Date = Date(),
+        windowDays: Int = 90,
+        calendar: Calendar = .current
+    ) -> BalanceTrend? {
+        guard windowDays > 0 else { return nil }
+        let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1), to: calendar.startOfDay(for: now))
+            ?? calendar.startOfDay(for: now)
+
+        let points = history
+            .filter { $0.date >= windowStart && $0.date <= now }
+            .sorted { $0.date < $1.date }
+
+        guard let first = points.first, let last = points.last, points.count >= 2 else {
+            return nil
+        }
+
+        let delta = last.balance - first.balance
+        let direction: Direction = if abs(delta) < 0.005 {
+            .flat
+        } else if delta > 0 {
+            .up
+        } else {
+            .down
+        }
+
+        let spanDays = max(calendar.dateComponents([.day], from: first.date, to: last.date).day ?? 1, 1)
+
+        return BalanceTrend(
+            direction: direction,
+            delta: delta,
+            spanDays: spanDays,
+            points: points
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2515,6 +2515,84 @@ struct PlaidBarCoreTests {
         #expect(ItemRecoveryTarget.actionTitle(from: statuses) == nil)
     }
 
+    // MARK: - Balance Trend Tests
+
+    @Test("Balance trend reports an upward delta with honest span")
+    func balanceTrendReportsUpwardDelta() throws {
+        let calendar = Calendar.current
+        let now = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let history = (0 ..< 30).map { daysAgo in
+            BalanceSnapshot(
+                date: calendar.date(byAdding: .day, value: -daysAgo, to: now)!,
+                balance: 17_000 - Double(daysAgo) * 40
+            )
+        }
+
+        let trend = try #require(BalanceTrend.evaluate(history: history, now: now, calendar: calendar))
+
+        #expect(trend.direction == .up)
+        #expect(abs(trend.delta - 1_160) < 0.01)
+        #expect(trend.spanDays == 29)
+        #expect(trend.spanText == "29D")
+        #expect(trend.deltaText.hasPrefix("+$"))
+        #expect(trend.accessibilitySummary.contains("up"))
+        #expect(trend.points.count == 30)
+        #expect(trend.points.map(\.date) == trend.points.map(\.date).sorted())
+    }
+
+    @Test("Balance trend reports downward and flat directions")
+    func balanceTrendReportsDownwardAndFlat() throws {
+        let calendar = Calendar.current
+        let now = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let yesterday = try #require(calendar.date(byAdding: .day, value: -1, to: now))
+
+        let down = try #require(BalanceTrend.evaluate(
+            history: [
+                BalanceSnapshot(date: yesterday, balance: 10_000),
+                BalanceSnapshot(date: now, balance: 9_400),
+            ],
+            now: now,
+            calendar: calendar
+        ))
+        #expect(down.direction == .down)
+        #expect(down.deltaText.hasPrefix("-$"))
+        #expect(down.accessibilitySummary.contains("down"))
+
+        let flat = try #require(BalanceTrend.evaluate(
+            history: [
+                BalanceSnapshot(date: yesterday, balance: 10_000),
+                BalanceSnapshot(date: now, balance: 10_000),
+            ],
+            now: now,
+            calendar: calendar
+        ))
+        #expect(flat.direction == .flat)
+        #expect(flat.accessibilitySummary.contains("unchanged"))
+    }
+
+    @Test("Balance trend needs two points inside the window")
+    func balanceTrendNeedsTwoPointsInWindow() throws {
+        let calendar = Calendar.current
+        let now = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let ancient = try #require(calendar.date(byAdding: .day, value: -200, to: now))
+
+        #expect(BalanceTrend.evaluate(history: [], now: now, calendar: calendar) == nil)
+        #expect(BalanceTrend.evaluate(
+            history: [BalanceSnapshot(date: now, balance: 5_000)],
+            now: now,
+            calendar: calendar
+        ) == nil)
+        // A second point outside the 90-day window does not count.
+        #expect(BalanceTrend.evaluate(
+            history: [
+                BalanceSnapshot(date: ancient, balance: 4_000),
+                BalanceSnapshot(date: now, balance: 5_000),
+            ],
+            now: now,
+            calendar: calendar
+        ) == nil)
+    }
+
     // MARK: - ItemStatus Tests
 
     @Test("ItemStatus Codable")


### PR DESCRIPTION
## Summary

- The dashboard header showed a static net-worth figure with no sense of direction. Recorded balance history (90-day window) now renders as a quiet sparkline in the header's unused middle space — **zero added height** against the `DashboardOverviewHeightBudget` contract — with a signed compact delta and the honest day span the data actually covers (e.g. `+$0.6K 59D`).
- Craft constraints honored per `DESIGN.md` review gates: no decorative gradients (1.5pt flat line, axes/legend/grid hidden), color only with financial meaning (up/down/flat tint), and meaning never carried by color alone (sign in text, full VoiceOver summary: "Net worth up $620.00 over the last 59 days."). The line draws in left-to-right once per appearance and respects Reduce Motion. With fewer than two in-window snapshots the surface stays hidden entirely — no placeholder noise.
- `BalanceTrend` (PlaidBarCore) owns window filtering, direction, delta text, honest span, and the accessibility summary, with focused tests (up/down/flat, insufficient data, out-of-window points).
- Demo balance history is now deterministic (gentle upward drift + sine wobble instead of `Double.random`), so the demo story reads the same every launch and screenshots reproduce.
- Pairs with #225, which makes balance history actually accumulate in live mode; in production the sparkline appears from the second day of history onward. Code-wise this PR is independent and merges cleanly in any order.

## Autonomous task IDs

- Task ID(s): none mapped directly; advances the v1.0 "dense native finance UX" goal. T020 (heatmap header screenshot refresh) remains open: `./Scripts/screenshots.sh` needs Screen Recording permission, which this session's terminal lacks — run it once after merge to refresh `Assets/*.png`.
- Backlog slice: UI modernization (restrained header polish)
- Scope note: one new core model, one new chart view, one header integration, deterministic demo history.

## Agent coordination

- Builder agent: Claude Code (interactive session with Felipe)
- Builder branch/worktree: `feature/networth-trend-header` at `/Users/ftchvs/Developer/PlaidBar`
- Reviewer/merge steward: Claude Code under the 2026-05-30 scoped approval
- Coordination note: no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Models/BalanceTrend.swift` (new)
- `Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift` (new)
- `Sources/PlaidBar/Views/MainPopover.swift` (DashboardHeader only)
- `Sources/PlaidBar/App/AppState.swift` (deterministic demo history)
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`

## Local gates

- [x] `git diff --check`
- [x] `swift build` (full package)
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test` — 279 tests passed (276 baseline + 3 new)
- [x] Runtime smoke: release binary launched with `--demo`, stayed alive, terminated cleanly.
- [x] Secret scan completed; synthetic data only.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes. (Sparkline is non-interactive; no focus order change.)
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes. (Trend block is a single combined element with a full-sentence label; chart itself is accessibility-hidden to avoid per-point noise.)
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone. (Signed delta text + VoiceOver wording carry direction.)
- [ ] I updated docs or screenshots if user-facing behavior changed. (Screenshots pending one `./Scripts/screenshots.sh` run with Screen Recording permission — also closes T020.)

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [x] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [x] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)