### PR TITLE
fix: redact keyed Plaid identifiers in user-facing errors

### DIFF
--- a/Sources/PlaidBarCore/Utilities/UserFacingError.swift
+++ b/Sources/PlaidBarCore/Utilities/UserFacingError.swift
@@ -19,6 +19,8 @@ public enum UserFacingError {
             .redacting(pattern: #"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b"#, template: "Bearer [redacted]")
             .redacting(pattern: #"(?i)\b(access|public|link|processor)-(sandbox|development|production)-[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-token]")
             .redacting(pattern: #"(?i)["']?\b(access[-_ ]?token|public[-_ ]?token|link[-_ ]?token|processor[-_ ]?token|client[-_ ]?id|secret)\b["']?\s*[:=]\s*["']?[^"',}\s]+"#, template: "$1: [redacted]")
+            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)\[[^\]]*\]"#, template: "$1[redacted-id]")
+            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)(["']?)[^"',}\]\s&]+(["']?)"#, template: "$1$3[redacted-id]$4")
             .redacting(pattern: #"(?i)\b(access|public|link|processor|item|account|transaction|txn|ins)_[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-id]")
 
         sanitized = sanitized.removingStackTraceDetails()

--- a/Sources/PlaidBarCore/Utilities/UserFacingError.swift
+++ b/Sources/PlaidBarCore/Utilities/UserFacingError.swift
@@ -20,7 +20,7 @@ public enum UserFacingError {
             .redacting(pattern: #"(?i)\b(access|public|link|processor)-(sandbox|development|production)-[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-token]")
             .redacting(pattern: #"(?i)["']?\b(access[-_ ]?token|public[-_ ]?token|link[-_ ]?token|processor[-_ ]?token|client[-_ ]?id|secret)\b["']?\s*[:=]\s*["']?[^"',}\s]+"#, template: "$1: [redacted]")
             .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)\[[^\]]*\]"#, template: "$1[redacted-id]")
-            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)(["']?)[^"',}\]\s&]+(["']?)"#, template: "$1$3[redacted-id]$4")
+            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)(["']?)[^"',}\]\[\s&]+(["']?)"#, template: "$1$3[redacted-id]$4")
             .redacting(pattern: #"(?i)\b(access|public|link|processor|item|account|transaction|txn|ins)_[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-id]")
 
         sanitized = sanitized.removingStackTraceDetails()

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2173,6 +2173,8 @@ struct PlaidBarCoreTests {
         #expect(detail?.contains(requestID) == false)
         #expect(detail?.contains(cursor) == false)
         #expect(detail?.contains("latest balances") == true)
+        #expect(detail?.contains("transaction_ids\":[redacted-id]") == true)
+        #expect(detail?.contains("]]") == false)
         #expect(detail?.contains("[redacted-id]") == true)
     }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2139,17 +2139,57 @@ struct PlaidBarCoreTests {
         let tokenKey = "access" + "_token"
         let tokenValue = "access" + "-sandbox-secretvalue"
         let publicTokenValue = "public" + "-sandbox-publicvalue"
+        let bearerValue = "local-token-1234567890"
+        let authHeader = "Authorization: " + "Bearer " + bearerValue
         let detail = UserFacingError.sanitizedDetail(
-            from: "Plaid failed for item_id=item_123456789abcdef account_id=account_abcdef123456 \(tokenKey)=\(tokenValue) bare=\(publicTokenValue) Authorization: Bearer local-token-1234567890"
+            from: "Plaid failed for item_id=item_123456789abcdef account_id=account_abcdef123456 \(tokenKey)=\(tokenValue) bare=\(publicTokenValue) \(authHeader)"
         )
 
         #expect(detail?.contains("item_123456789abcdef") == false)
         #expect(detail?.contains("account_abcdef123456") == false)
         #expect(detail?.contains(tokenValue) == false)
         #expect(detail?.contains(publicTokenValue) == false)
-        #expect(detail?.contains("local-token-1234567890") == false)
-        #expect(detail?.contains("Authorization: Bearer [redacted]") == true)
+        #expect(detail?.contains(bearerValue) == false)
+        #expect(detail?.contains("Authorization: " + "Bearer [redacted]") == true)
         #expect(detail?.contains("[redacted") == true)
+    }
+
+    @Test("User-facing error detail redacts keyed unprefixed Plaid identifiers")
+    func userFacingErrorDetailRedactsKeyedUnprefixedPlaidIdentifiers() {
+        let itemID = "M5eVJqLnv3tbzdngLDp9FL5OlDNxlNhlE55op"
+        let accountID = "K6mPq8Jvl4fbxR2WQZk1"
+        let transactionID = "9N4kQx2Lw8mP0vYj"
+        let requestID = "req-7m8n9p0q1r2s"
+        let cursor = "eyJ2ZXJzaW9uIjoxLCJ2YWx1ZSI6InVucHJlZml4ZWQifQ"
+        let detail = UserFacingError.sanitizedDetail(
+            from: "Plaid failed {\"item_id\":\"\(itemID)\",\"account_id\":\"\(accountID)\",\"transaction_id\":\"\(transactionID)\",\"transaction_ids\":[\"txOneUnprefixed\",\"txTwoUnprefixed\"],\"request_id\":\"\(requestID)\",\"cursor\":\"\(cursor)\"} while syncing latest balances."
+        )
+
+        #expect(detail?.contains(itemID) == false)
+        #expect(detail?.contains(accountID) == false)
+        #expect(detail?.contains(transactionID) == false)
+        #expect(detail?.contains("txOneUnprefixed") == false)
+        #expect(detail?.contains("txTwoUnprefixed") == false)
+        #expect(detail?.contains(requestID) == false)
+        #expect(detail?.contains(cursor) == false)
+        #expect(detail?.contains("latest balances") == true)
+        #expect(detail?.contains("[redacted-id]") == true)
+    }
+
+    @Test("User-facing error detail redacts keyed Plaid identifiers in query strings")
+    func userFacingErrorDetailRedactsKeyedPlaidIdentifiersInQueryStrings() {
+        let itemID = "M5eVJqLnv3tbzdngLDp9FL5OlDNxlNhlE55op"
+        let accountID = "K6mPq8Jvl4fbxR2WQZk1"
+        let institutionID = "ins-109508"
+        let detail = UserFacingError.sanitizedDetail(
+            from: "Plaid request failed item_id=\(itemID)&account_id=\(accountID)&institution_id=\(institutionID) during reconnect"
+        )
+
+        #expect(detail?.contains(itemID) == false)
+        #expect(detail?.contains(accountID) == false)
+        #expect(detail?.contains(institutionID) == false)
+        #expect(detail?.contains("during reconnect") == true)
+        #expect(detail?.contains("item_id=[redacted-id]") == true)
     }
 
     @Test("User-facing error detail removes stack traces and truncates bodies")


### PR DESCRIPTION
## Summary
- Hardens `UserFacingError.sanitizedDetail` to redact keyed Plaid identifiers even when values are unprefixed.
- Covers JSON-style, array, and query-string forms for `item_id`, `account_id`, `transaction_id(s)`, `request_id`, `cursor`, and `institution_id`.
- Fixes the existing Bearer-token expectation to keep even synthetic bearer values out of assertions.
- Addresses Codex review feedback by preventing array redactions from being redacted a second time into malformed `]]` output.

## Autonomous task IDs
Task ID(s): AND-292; T034 follow-up
Backlog slice: Empty, Loading, And Error States / privacy follow-up from T034
Scope note: Redaction-only core sanitizer and focused PlaidBarCore regression tests; no UI, network, storage, or product-boundary changes.

## Agent coordination
Builder agent: Hermes/Otto Coder (Codex CLI attempted first, blocked by standalone Codex 401 auth)
Builder branch/worktree: `fix/and-292-keyed-plaid-id-redaction` in `/Users/otto/workspace/PlaidBar`
Reviewer/merge steward: Hermes/Otto Coder autonomous PlaidBar loop; Codex GitHub review comment addressed in `5528f3f`
Coordination note: Single-writer branch; no parallel worktree edits; final diff reviewed locally before push.

## Changed files
- `Sources/PlaidBarCore/Utilities/UserFacingError.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`

## Local gates
- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `swift test --skip-update --disable-keychain --filter PlaidBarCoreTests` (246 tests)
- [x] Focused new/changed tests:
  - `PlaidBarCoreTests/userFacingErrorDetailRedactsKeyedUnprefixedPlaidIdentifiers`
  - `PlaidBarCoreTests/userFacingErrorDetailRedactsKeyedPlaidIdentifiersInQueryStrings`
  - `PlaidBarCoreTests/userFacingErrorDetailRedactsPlaidIdentifiersAndTokens`
- [x] Added-diff secret scan for Plaid token/Bearer/private-key patterns: no non-synthetic matches

## GitHub checks
- Pending after latest push: CI `build`, `claude-review`, `otto-openclaw-policy-runner`, `otto-openclaw-merge-gate`.
- Merge steward must re-check latest head SHA `5528f3fde55af647cbe8c6c3987fbcb4f68401a6` before merge.

## Privacy and safety impact
- Privacy-positive redaction-only change.
- No Plaid credentials, access tokens, real account IDs, real balances, or transaction exports added.
- Preserves local-first boundary; no hosted backend, telemetry, cloud sync, or cloud AI changes.
- Screenshot evidence not applicable because this is core sanitizer/test-only work with no UI rendering change.

## Merge safety
- [x] Diff scoped to sanitizer and tests.
- [x] No generated/local artifacts included.
- [x] No destructive behavior, migrations, endpoint contract expansion, or repo settings changes.
- [x] Safe to merge only after GitHub checks and review gates are green on the latest head.

## Risks / Notes
- Codex CLI implementation worker was attempted but blocked by standalone Codex auth (`401 Unauthorized`); Hermes/Otto completed the minimal patch and validation directly.
- `claude-review` is currently blocked by external Claude session limit rather than a code/test failure; no merge attempted while that required check is red.
