### PR TITLE
feat: add local trust receipt to settings

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -154,9 +154,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    Text("Reset removes PlaidBar database files, account and transaction caches, pending Link sessions, and stored Plaid access-token entries. Preferences, server.conf, app/server auth, and unrelated files stay in place.")
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
+                    LocalTrustReceiptView(receipt: localTrustReceipt)
 
                     HStack(alignment: .center, spacing: Spacing.sm) {
                         Button {
@@ -245,6 +243,10 @@ struct GeneralSettingsView: View {
         return "Default: \(appState.localStorageResolvedDisplayPathText)"
     }
 
+    private var localTrustReceipt: LocalTrustReceipt {
+        LocalTrustReceipt.settingsReceipt(storagePath: appState.activeStorageDirectoryDisplayText)
+    }
+
     private var localAIAvailabilityIcon: String {
         switch appState.localAIAvailability.state {
         case .available: "cpu.fill"
@@ -297,6 +299,47 @@ private struct SettingsCard<Content: View>: View {
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct LocalTrustReceiptView: View {
+    let receipt: LocalTrustReceipt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(receipt.title)
+                    .font(.headline)
+
+                Text(receipt.subtitle)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                ForEach(receipt.rows) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                        Image(systemName: row.systemImage)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18)
+
+                        VStack(alignment: .leading, spacing: Spacing.xxs) {
+                            Text(row.title)
+                                .font(.caption.weight(.semibold))
+                            Text(row.detail)
+                                .detailText()
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(row.title). \(row.detail)")
+                }
+            }
+
+            Text(receipt.footer)
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
+++ b/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct LocalTrustReceipt: Equatable, Sendable {
+    public struct Row: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let title: String
+        public let detail: String
+        public let systemImage: String
+
+        public init(id: String, title: String, detail: String, systemImage: String) {
+            self.id = id
+            self.title = title
+            self.detail = detail
+            self.systemImage = systemImage
+        }
+    }
+
+    public let title: String
+    public let subtitle: String
+    public let rows: [Row]
+    public let footer: String
+
+    public init(
+        title: String,
+        subtitle: String,
+        rows: [Row],
+        footer: String
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.rows = rows
+        self.footer = footer
+    }
+
+    public static func settingsReceipt(storagePath: String) -> LocalTrustReceipt {
+        let trimmedStoragePath = storagePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayStoragePath = trimmedStoragePath.isEmpty ? LocalDataStore.displayPath : trimmedStoragePath
+
+        return LocalTrustReceipt(
+            title: "Local Trust Receipt",
+            subtitle: "PlaidBar keeps its control plane on this Mac.",
+            rows: [
+                Row(
+                    id: "storage",
+                    title: "Local storage",
+                    detail: "Active data directory: \(displayStoragePath)",
+                    systemImage: "externaldrive"
+                ),
+                Row(
+                    id: "network",
+                    title: "Network boundary",
+                    detail: "No PlaidBar-hosted backend, analytics, telemetry, cloud sync, or cloud dashboard.",
+                    systemImage: "network.slash"
+                ),
+                Row(
+                    id: "plaid",
+                    title: "Plaid access",
+                    detail: "Plaid calls happen only when you choose sandbox or production mode; demo mode stays local.",
+                    systemImage: "building.columns"
+                ),
+                Row(
+                    id: "reset",
+                    title: "Reset boundary",
+                    detail: "Reset clears PlaidBar data caches and stored access-token entries when present, but preserves server.conf and app/server auth.",
+                    systemImage: "arrow.counterclockwise"
+                ),
+            ],
+            footer: "Reset does not revoke bank permissions or remove items from Plaid Dashboard; review those accounts separately when you want full revocation."
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/LocalTrustReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalTrustReceiptTests.swift
@@ -1,0 +1,31 @@
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Local Trust Receipt Tests")
+struct LocalTrustReceiptTests {
+    @Test("Settings receipt explains storage and local-first boundaries")
+    func settingsReceiptExplainsStorageAndPrivacyBoundaries() {
+        let receipt = LocalTrustReceipt.settingsReceipt(storagePath: "~/.plaidbar")
+
+        #expect(receipt.title == "Local Trust Receipt")
+        #expect(receipt.subtitle.contains("on this Mac"))
+        #expect(receipt.rows.map(\.id) == ["storage", "network", "plaid", "reset"])
+        #expect(receipt.rows[0].detail.contains("~/.plaidbar"))
+        #expect(receipt.rows[1].detail.contains("No PlaidBar-hosted backend"))
+        #expect(receipt.rows[1].detail.contains("analytics"))
+        #expect(receipt.rows[1].detail.contains("telemetry"))
+        #expect(receipt.rows[1].detail.contains("cloud sync"))
+        #expect(receipt.rows[2].detail.contains("sandbox or production"))
+        #expect(receipt.rows[2].detail.contains("demo mode stays local"))
+        #expect(receipt.rows[3].detail.contains("preserves server.conf and app/server auth"))
+        #expect(receipt.footer.contains("does not revoke bank permissions"))
+        #expect(receipt.footer.contains("Plaid Dashboard"))
+    }
+
+    @Test("Settings receipt falls back to default storage label for blank path")
+    func settingsReceiptFallsBackForBlankStoragePath() {
+        let receipt = LocalTrustReceipt.settingsReceipt(storagePath: "   ")
+
+        #expect(receipt.rows.first?.detail.contains(LocalDataStore.displayPath) == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Settings > General Local Trust Receipt that states PlaidBar's local storage, network, Plaid-mode, and reset boundaries in-app.
- Moves the receipt copy into a tested PlaidBarCore presenter so privacy/trust wording is covered outside SwiftUI.
- Keeps the existing Local Data controls and reset confirmation behavior unchanged.

## Autonomous task IDs
Task ID(s): AND-299
Backlog slice: Linear PlaidBar — Add an in-app Local Trust Receipt for storage and privacy.
Scope note: Focused Settings/Core trust-copy slice only; no backend, telemetry, sync, credential, or reset-behavior changes.

## Agent coordination
Builder agent: Hermes/Otto (Codex CLI attempted; blocked by 401 auth before edits)
Builder branch/worktree: feat/local-trust-receipt @ 84e38f77c1d14c0e6377d919c354b880917bb174 in /Users/otto/workspace/PlaidBar
Reviewer/merge steward: Hermes/Otto scheduled PlaidBar autonomous product evolution cycle
Coordination note: No open PRs existed at selection time; do not push over this branch without re-checking the PR head SHA.

## Changed files
- `Sources/PlaidBarCore/Models/LocalTrustReceipt.swift`
- `Sources/PlaidBar/Settings/SettingsView.swift`
- `Tests/PlaidBarCoreTests/LocalTrustReceiptTests.swift`

## Local gates
- [x] `git diff --check` — pass
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` — pass
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` — pass
- [x] `swift test --skip-update --disable-keychain --filter LocalTrustReceiptTests` — pass, 2 tests
- [x] Changed-diff secret scan — pass, no matches
- [x] `swift test --skip-update --disable-keychain` — build completed, but test execution timed out locally after 600s before summary output; focused tests passed.

## GitHub checks
Pending on PR creation.

## Privacy and safety impact
- Reinforces PlaidBar's local-first boundary in-app: no PlaidBar-hosted backend, analytics, telemetry, cloud sync, or cloud dashboard.
- Clarifies Plaid calls only happen in sandbox/production modes and demo stays local.
- Clarifies reset preserves server.conf/app-server auth and does not revoke bank or Plaid Dashboard permissions.
- No secrets, tokens, account IDs, balances, transaction exports, screenshots, or local data files added.

## Merge safety
- Focused user-facing trust/Settings copy and core presenter tests.
- No destructive behavior, repo settings, release, cron, credential, or external service changes.
- Merge only after required GitHub checks and review gates are green.
