### PR TITLE
perf: reuse selected account transaction snapshot

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -556,7 +556,11 @@ final class AppState {
     }
 
     func transactionsForAccount(_ accountId: String) -> [TransactionDTO] {
-        AccountTransactionFeed.transactions(forAccountId: accountId, in: transactions)
+        accountActivitySnapshot(for: accountId).transactions
+    }
+
+    func accountActivitySnapshot(for accountId: String) -> AccountTransactionFeed.AccountActivitySnapshot {
+        AccountTransactionFeed.activitySnapshot(forAccountId: accountId, in: transactions)
     }
 
     func transactionsForMerchant(_ merchantName: String, excluding transactionId: String) -> [TransactionDTO] {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1340,7 +1340,11 @@ private struct AccountRowWithDrilldown: View {
             .accessibilityAction(named: drillInPath.accessibilityActionName, onSelect)
 
             if isSelected {
-                SelectedAccountPanel(account: account, isStatusFilter: isStatusFilter)
+                SelectedAccountPanel(
+                    account: account,
+                    isStatusFilter: isStatusFilter,
+                    activitySnapshot: appState.accountActivitySnapshot(for: account.id)
+                )
                     .environment(appState)
                     .padding(.top, Spacing.compactRowVerticalPadding)
                     .padding(.bottom, Spacing.compactRowContentSpacing)
@@ -1676,36 +1680,37 @@ private struct SelectedAccountPanel: View {
     @Environment(\.openSettings) private var openSettings
     let account: AccountDTO
     let isStatusFilter: Bool
+    let activitySnapshot: AccountTransactionFeed.AccountActivitySnapshot
     @State private var isConfirmingAccountRemoval = false
 
     private var drillInSummary: DashboardAccountDrillInSummary {
         DashboardAccountDrillInSummary.presentation(
             for: account,
-            transactions: appState.transactions,
+            activitySnapshot: activitySnapshot,
             itemStatus: itemConnectionStatus,
             fallbackFreshnessLabel: connectionPresentation.signalLabel
         )
     }
 
     private var transactions: [TransactionDTO] {
-        Array(accountTransactions.prefix(5))
+        Array(activitySnapshot.transactions.prefix(5))
     }
 
     private var accountTransactions: [TransactionDTO] {
-        appState.transactionsForAccount(account.id)
+        activitySnapshot.transactions
     }
 
     private var pendingTransactions: [TransactionDTO] {
-        accountTransactions.filter(\.pending)
+        activitySnapshot.pendingTransactions
     }
 
     private var activitySummary: AccountActivitySummary {
-        AccountActivitySummary.recent(from: accountTransactions)
+        activitySnapshot.recentSummary
     }
 
     private var emptyState: AccountActivityEmptyState? {
         AccountActivityEmptyState.evaluate(
-            transactionCount: accountTransactions.count,
+            transactionCount: activitySnapshot.transactionCount,
             isDemoMode: appState.usesDemoConnectionPresentation,
             serverConnected: appState.serverConnected,
             connectionLevel: connectionPresentation.level,

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -198,16 +198,21 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
         itemStatus: ItemStatus?,
         fallbackFreshnessLabel: String
     ) -> Self {
-        let accountTransactions = transactions.filter { $0.accountId == account.id }
-        let latestTransactionDate = accountTransactions
-            .compactMap { transaction -> (raw: String, parsed: Date)? in
-                guard let parsed = Formatters.parseTransactionDate(transaction.date) else { return nil }
-                return (transaction.date, parsed)
-            }
-            .max { $0.parsed < $1.parsed }?
-            .raw
+        presentation(
+            for: account,
+            activitySnapshot: AccountTransactionFeed.activitySnapshot(forAccountId: account.id, in: transactions),
+            itemStatus: itemStatus,
+            fallbackFreshnessLabel: fallbackFreshnessLabel
+        )
+    }
 
-        return Self(
+    public static func presentation(
+        for account: AccountDTO,
+        activitySnapshot: AccountTransactionFeed.AccountActivitySnapshot,
+        itemStatus: ItemStatus?,
+        fallbackFreshnessLabel: String
+    ) -> Self {
+        Self(
             displayName: AccountPresentation.displayName(for: account),
             subtitle: AccountPresentation.subtitle(for: account),
             availableTitle: AccountPresentation.dashboardAvailableTitle(for: account),
@@ -216,9 +221,9 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
             currentBalance: AccountPresentation.displayBalance(for: account),
             utilizationPercent: account.balances.utilizationPercent,
             limit: account.balances.limit,
-            transactionCount: accountTransactions.count,
-            pendingTransactionCount: accountTransactions.count(where: \.pending),
-            latestTransactionDate: latestTransactionDate,
+            transactionCount: activitySnapshot.transactionCount,
+            pendingTransactionCount: activitySnapshot.pendingTransactionCount,
+            latestTransactionDate: activitySnapshot.latestTransactionDate,
             syncState: itemStatus?.status,
             freshnessLabel: itemStatus?.lastSync.map(Formatters.relativeDate) ?? fallbackFreshnessLabel
         )

--- a/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
@@ -1,11 +1,38 @@
 import Foundation
 
 public enum AccountTransactionFeed {
+    public struct AccountActivitySnapshot: Sendable, Equatable {
+        public let transactions: [TransactionDTO]
+        public let transactionCount: Int
+        public let pendingTransactionCount: Int
+        public let latestTransactionDate: String?
+        public let recentSummary: AccountActivitySummary
+
+        public var pendingTransactions: [TransactionDTO] {
+            transactions.filter(\.pending)
+        }
+
+        public init(transactions: [TransactionDTO]) {
+            self.transactions = AccountTransactionFeed.sortedForFeed(transactions)
+            self.transactionCount = transactions.count
+            self.pendingTransactionCount = transactions.count(where: \.pending)
+            self.latestTransactionDate = transactions.latestTransactionDate
+            self.recentSummary = AccountActivitySummary.recent(from: self.transactions)
+        }
+    }
+
+    public static func activitySnapshot(
+        forAccountId accountId: String,
+        in transactions: [TransactionDTO]
+    ) -> AccountActivitySnapshot {
+        AccountActivitySnapshot(transactions: transactions.filter { $0.accountId == accountId })
+    }
+
     public static func transactions(
         forAccountId accountId: String,
         in transactions: [TransactionDTO]
     ) -> [TransactionDTO] {
-        sortedForFeed(transactions.filter { $0.accountId == accountId })
+        activitySnapshot(forAccountId: accountId, in: transactions).transactions
     }
 
     public static func relatedMerchantTransactions(
@@ -45,5 +72,16 @@ public enum AccountTransactionFeed {
         }
 
         return lhs.id < rhs.id
+    }
+}
+
+private extension Array where Element == TransactionDTO {
+    var latestTransactionDate: String? {
+        compactMap { transaction -> (raw: String, parsed: Date)? in
+            guard let parsed = Formatters.parseTransactionDate(transaction.date) else { return nil }
+            return (transaction.date, parsed)
+        }
+        .max { $0.parsed < $1.parsed }?
+        .raw
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -99,6 +99,24 @@ struct PlaidBarCoreTests {
         #expect(feed.map(\.id) == ["pending", "posted-large", "posted-small", "old"])
     }
 
+    @Test("Account transaction activity snapshot reuses filtered transactions for summary values")
+    func accountTransactionActivitySnapshotSummarizesFilteredTransactions() {
+        let transactions = [
+            TransactionDTO(id: "old", accountId: "checking", amount: 10, date: "2026-01-13", name: "Old"),
+            TransactionDTO(id: "other", accountId: "credit", amount: 999, date: "2026-01-16", name: "Other"),
+            TransactionDTO(id: "pending", accountId: "checking", amount: 30, date: "2026-01-15", name: "Pending", pending: true),
+            TransactionDTO(id: "invalid", accountId: "checking", amount: 8, date: "not-a-date", name: "Invalid"),
+        ]
+
+        let snapshot = AccountTransactionFeed.activitySnapshot(forAccountId: "checking", in: transactions)
+
+        #expect(snapshot.transactions.map(\.id) == ["pending", "old", "invalid"])
+        #expect(snapshot.transactionCount == 3)
+        #expect(snapshot.pendingTransactionCount == 1)
+        #expect(snapshot.latestTransactionDate == "2026-01-15")
+        #expect(snapshot.recentSummary.transactionCount == 2)
+    }
+
     @Test("Account transaction feed keeps invalid dates behind dated transactions")
     func accountTransactionFeedKeepsInvalidDatesBehindDatedTransactions() {
         let transactions = [


### PR DESCRIPTION
## Summary

- Optimizes selected-account drill-in transaction work by introducing a reusable `AccountActivitySnapshot` in `PlaidBarCore`.
- Reuses the filtered/sorted account transaction slice for drill-in summary counts, latest date, pending count, recent activity totals, and visible recent rows.
- Adds focused Swift Testing coverage for the snapshot so the summary values stay tied to the account-filtered transaction set.

## Autonomous task IDs

- Task ID(s): AND-276
- Backlog slice: PR-019: Performance And Responsiveness
- Scope note: Focused performance/maintainability slice for selected-account drill-in transaction summary filtering.

## Agent coordination

- Builder agent: Hermes/Otto; attempted Codex CLI but `/opt/homebrew/bin/codex exec` failed with OpenAI 401 auth before making changes.
- Builder branch/worktree: `perf/and-276-drill-in-summary-filter` at `/Users/otto/workspace/PlaidBar`
- Reviewer/merge steward: Otto
- Coordination note: No other agent should push to this branch; review-only agents are safe.

## Changed files

- `Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift`
- `Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift`
- `Sources/PlaidBar/App/AppState.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `swift test --skip-update --disable-keychain --filter 'accountTransaction|accountDrillInSummary'`
- [x] Secret scan completed for changed lines; no Plaid/token/API key patterns found.
- [x] Full `swift test --skip-update --disable-keychain` was attempted locally but produced no output after ~3 minutes in this cron session and was killed; GitHub CI `build` later ran the full Test step successfully.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed. No user-facing behavior or screenshot change.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.
