### PR TITLE
feat: add dashboard change receipt

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -49,6 +49,11 @@ struct MainPopover: View {
                         DashboardStatusStrip()
                             .environment(appState)
 
+                        if selectedAccount == nil {
+                            DashboardChangeReceiptStrip()
+                                .environment(appState)
+                        }
+
                         if shouldElevateStatusReadinessPanel {
                             DashboardStatusReadinessPanel(
                                 openSettings: { openSettings() },
@@ -234,6 +239,59 @@ private struct DashboardHeader: View {
             SemanticColors.negative
         case .flat:
             .secondary
+        }
+    }
+}
+
+private struct DashboardChangeReceiptStrip: View {
+    @Environment(AppState.self) private var appState
+
+    private var receipt: DashboardChangeReceipt? {
+        DashboardChangeReceipt.evaluate(
+            history: appState.balanceHistory,
+            transactions: appState.transactions,
+            itemStatuses: appState.itemStatuses
+        )
+    }
+
+    var body: some View {
+        if let receipt {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(receipt.title.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Text(receipt.summary)
+                    .font(.caption2.weight(.medium))
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+
+                Spacer(minLength: 4)
+
+                HStack(spacing: 5) {
+                    ForEach(receipt.rows) { row in
+                        Text(row.value)
+                            .font(.caption2.weight(.semibold))
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .help(row.accessibilityText)
+                    }
+                }
+                .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary.opacity(0.38), in: Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(.secondary.opacity(0.10), lineWidth: 1)
+            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(receipt.accessibilitySummary)
+            .help(receipt.accessibilitySummary)
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
+++ b/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Display-safe, deterministic receipt for the dashboard's "what changed?" glance.
+///
+/// The receipt uses only local balance history, locally cached transactions, and
+/// local item status metadata. It summarizes the latest local snapshot window;
+/// it never includes account IDs, item IDs, raw Plaid payloads, or transaction names.
+public struct DashboardChangeReceipt: Equatable, Sendable {
+    public struct Row: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let label: String
+        public let value: String
+        public let accessibilityText: String
+
+        public init(id: String, label: String, value: String, accessibilityText: String) {
+            self.id = id
+            self.label = label
+            self.value = value
+            self.accessibilityText = accessibilityText
+        }
+    }
+
+    public let title: String
+    public let summary: String
+    public let rows: [Row]
+    public let accessibilitySummary: String
+
+    public init(title: String, summary: String, rows: [Row], accessibilitySummary: String) {
+        self.title = title
+        self.summary = summary
+        self.rows = rows
+        self.accessibilitySummary = accessibilitySummary
+    }
+
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        transactions: [TransactionDTO],
+        itemStatuses: [ItemStatus],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> DashboardChangeReceipt? {
+        let points = history
+            .filter { $0.date <= now }
+            .sorted { $0.date < $1.date }
+
+        guard let latest = points.last else { return nil }
+
+        let degradedItemCount = itemStatuses.count { $0.status == .loginRequired || $0.status == .error }
+
+        guard points.count >= 2 else {
+            var rows = [Row(
+                id: "baseline",
+                label: "Baseline",
+                value: "Saved",
+                accessibilityText: "First local snapshot saved. PlaidBar will compare future local snapshots against this baseline."
+            )]
+
+            if degradedItemCount > 0 {
+                rows.append(degradedItemsRow(count: degradedItemCount))
+            }
+
+            let summary = "First local snapshot saved"
+            return DashboardChangeReceipt(
+                title: "Latest local changes",
+                summary: summary,
+                rows: rows,
+                accessibilitySummary: "Latest local changes. \(summary). \(rows.map(\.accessibilityText).joined(separator: " "))"
+            )
+        }
+
+        let previous = points[points.count - 2]
+        let delta = latest.balance - previous.balance
+        let changedTransactions = transactionsChanged(since: previous.date, through: latest.date, transactions: transactions, calendar: calendar)
+
+        var rows: [Row] = [balanceRow(delta: delta)]
+        rows.append(transactionRow(count: changedTransactions.count))
+
+        if degradedItemCount > 0 {
+            rows.append(degradedItemsRow(count: degradedItemCount))
+        }
+
+        let summary = summaryText(delta: delta, transactionCount: changedTransactions.count, degradedItemCount: degradedItemCount)
+        return DashboardChangeReceipt(
+            title: "Latest local changes",
+            summary: summary,
+            rows: Array(rows.prefix(3)),
+            accessibilitySummary: "Latest local changes. \(summary). \(rows.map(\.accessibilityText).joined(separator: " "))"
+        )
+    }
+
+    private static func balanceRow(delta: Double) -> Row {
+        let direction: String
+        let value: String
+        if abs(delta) < 0.005 {
+            direction = "unchanged"
+            value = "No change"
+        } else if delta > 0 {
+            direction = "up"
+            value = "+\(Formatters.currency(abs(delta), format: .compact))"
+        } else {
+            direction = "down"
+            value = "-\(Formatters.currency(abs(delta), format: .compact))"
+        }
+
+        return Row(
+            id: "net-worth",
+            label: "Net",
+            value: value,
+            accessibilityText: "Net worth \(direction)\(abs(delta) < 0.005 ? "" : " " + Formatters.currency(abs(delta), format: .full))."
+        )
+    }
+
+    private static func transactionRow(count: Int) -> Row {
+        Row(
+            id: "transactions",
+            label: "Activity",
+            value: count == 0 ? "No new tx" : "\(count) new tx",
+            accessibilityText: count == 0
+                ? "No newly dated transactions since the prior local snapshot."
+                : "\(count) newly dated transaction\(count == 1 ? "" : "s") since the prior local snapshot."
+        )
+    }
+
+    private static func degradedItemsRow(count: Int) -> Row {
+        Row(
+            id: "attention",
+            label: "Needs attention",
+            value: "\(count) item\(count == 1 ? "" : "s")",
+            accessibilityText: "\(count) linked item\(count == 1 ? "" : "s") need\(count == 1 ? "s" : "") attention."
+        )
+    }
+
+    private static func summaryText(delta: Double, transactionCount: Int, degradedItemCount: Int) -> String {
+        var parts: [String] = []
+        if abs(delta) < 0.005 {
+            parts.append("net unchanged")
+        } else if delta > 0 {
+            parts.append("net up \(Formatters.currency(abs(delta), format: .compact))")
+        } else {
+            parts.append("net down \(Formatters.currency(abs(delta), format: .compact))")
+        }
+
+        if transactionCount > 0 {
+            parts.append("\(transactionCount) new tx")
+        }
+
+        if degradedItemCount > 0 {
+            parts.append("\(degradedItemCount) item\(degradedItemCount == 1 ? "" : "s") need attention")
+        }
+
+        return parts.joined(separator: " · ")
+    }
+
+    private static func transactionsChanged(
+        since startDate: Date,
+        through endDate: Date,
+        transactions: [TransactionDTO],
+        calendar: Calendar
+    ) -> [TransactionDTO] {
+        let startDay = calendar.startOfDay(for: startDate)
+        let endDay = calendar.startOfDay(for: endDate)
+        return transactions.filter { transaction in
+            guard let date = Formatters.parseTransactionDate(transaction.date) else { return false }
+            let transactionDay = calendar.startOfDay(for: date)
+            return transactionDay > startDay && transactionDay <= endDay
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/DashboardOverviewHeightBudget.swift
+++ b/Sources/PlaidBarCore/Models/DashboardOverviewHeightBudget.swift
@@ -18,12 +18,14 @@ public struct DashboardOverviewHeightBudget: Equatable, Sendable {
     public let accountsHeaderHeight: Double
     public let accountRowHeight: Double
     public let selectedDrillInHeight: Double
+    public let receiptHeight: Double
     public let verticalPadding: Double
     public let lowerSectionReserve: Double
 
     public init(
         headerHeight: Double = 42,
         statusStripHeight: Double = 34,
+        receiptHeight: Double = 28,
         overviewStackSpacing: Double = 14,
         heatmapHeight: Double = 96,
         captionAndFilterHeight: Double = 36,
@@ -35,6 +37,7 @@ public struct DashboardOverviewHeightBudget: Equatable, Sendable {
     ) {
         self.headerHeight = headerHeight
         self.statusStripHeight = statusStripHeight
+        self.receiptHeight = receiptHeight
         self.overviewStackSpacing = overviewStackSpacing
         self.heatmapHeight = heatmapHeight
         self.captionAndFilterHeight = captionAndFilterHeight
@@ -47,13 +50,16 @@ public struct DashboardOverviewHeightBudget: Equatable, Sendable {
 
     public func estimatedFirstGlanceHeight(
         visibleAccountRows: Int,
-        includesSelectedDrillIn: Bool
+        includesSelectedDrillIn: Bool,
+        includesChangeReceipt: Bool = false
     ) -> Double {
         let safeRows = max(0, visibleAccountRows)
         let drillInHeight = includesSelectedDrillIn ? selectedDrillInHeight : 0
+        let localReceiptHeight = includesChangeReceipt ? receiptHeight : 0
 
         return headerHeight
             + statusStripHeight
+            + localReceiptHeight
             + overviewStackSpacing
             + heatmapHeight
             + captionAndFilterHeight
@@ -67,11 +73,13 @@ public struct DashboardOverviewHeightBudget: Equatable, Sendable {
     public func fitsFirstGlance(
         visibleAccountRows: Int,
         includesSelectedDrillIn: Bool,
+        includesChangeReceipt: Bool = false,
         availableHeight: Double = Self.firstGlanceVisibleHeight
     ) -> Bool {
         estimatedFirstGlanceHeight(
             visibleAccountRows: visibleAccountRows,
-            includesSelectedDrillIn: includesSelectedDrillIn
+            includesSelectedDrillIn: includesSelectedDrillIn,
+            includesChangeReceipt: includesChangeReceipt
         ) <= availableHeight
     }
 }

--- a/Tests/PlaidBarCoreTests/DashboardChangeReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardChangeReceiptTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Dashboard Change Receipt Tests")
+struct DashboardChangeReceiptTests {
+    @Test("Receipt reports local net and transaction changes without identifiers")
+    func receiptReportsLocalChanges() throws {
+        let previous = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let now = try #require(Formatters.parseTransactionDate("2026-06-11"))
+
+        let receipt = try #require(DashboardChangeReceipt.evaluate(
+            history: [
+                BalanceSnapshot(date: previous, balance: 10_000),
+                BalanceSnapshot(date: now, balance: 10_240),
+            ],
+            transactions: [
+                TransactionDTO(id: "tx_recent", accountId: "acct_hidden", amount: 42, date: "2026-06-11", name: "SHOULD NOT LEAK"),
+                TransactionDTO(id: "tx_old", accountId: "acct_hidden", amount: 12, date: "2026-06-10", name: "OLD"),
+            ],
+            itemStatuses: [ItemStatus(id: "item_secret", institutionName: "Bank", status: .connected)],
+            now: now
+        ))
+
+        #expect(receipt.title == "Latest local changes")
+        #expect(receipt.summary.contains("net up"))
+        #expect(receipt.summary.contains("1 new tx"))
+        #expect(receipt.rows.map(\.id) == ["net-worth", "transactions"])
+        #expect(!receipt.accessibilitySummary.contains("acct_hidden"))
+        #expect(!receipt.accessibilitySummary.contains("item_secret"))
+        #expect(!receipt.accessibilitySummary.contains("SHOULD NOT LEAK"))
+    }
+
+    @Test("Receipt handles first local snapshot as a baseline")
+    func receiptHandlesFirstLocalSnapshot() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-11"))
+
+        let receipt = try #require(DashboardChangeReceipt.evaluate(
+            history: [BalanceSnapshot(date: now, balance: 8_400)],
+            transactions: [],
+            itemStatuses: [],
+            now: now
+        ))
+
+        #expect(receipt.summary == "First local snapshot saved")
+        #expect(receipt.rows.map(\.id) == ["baseline"])
+        #expect(receipt.accessibilitySummary.contains("First local snapshot saved"))
+    }
+
+    @Test("Receipt exposes degraded item count without raw item IDs")
+    func receiptExposesDegradedItemCount() throws {
+        let previous = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let now = try #require(Formatters.parseTransactionDate("2026-06-11"))
+
+        let receipt = try #require(DashboardChangeReceipt.evaluate(
+            history: [
+                BalanceSnapshot(date: previous, balance: 10_000),
+                BalanceSnapshot(date: now, balance: 10_000),
+            ],
+            transactions: [],
+            itemStatuses: [
+                ItemStatus(id: "item_login_secret", institutionName: "Bank", status: .loginRequired),
+                ItemStatus(id: "item_error_secret", institutionName: "Brokerage", status: .error),
+            ],
+            now: now
+        ))
+
+        #expect(receipt.summary.contains("2 items need attention"))
+        #expect(receipt.rows.map(\.id).contains("attention"))
+        #expect(!receipt.accessibilitySummary.contains("item_login_secret"))
+        #expect(!receipt.accessibilitySummary.contains("item_error_secret"))
+    }
+
+    @Test("Receipt bounds transactions to the compared snapshot window")
+    func receiptBoundsTransactionsToSnapshotWindow() throws {
+        let previous = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let latest = try #require(Formatters.parseTransactionDate("2026-06-11"))
+        let now = try #require(Formatters.parseTransactionDate("2026-06-12"))
+
+        let receipt = try #require(DashboardChangeReceipt.evaluate(
+            history: [
+                BalanceSnapshot(date: previous, balance: 10_000),
+                BalanceSnapshot(date: latest, balance: 10_100),
+            ],
+            transactions: [
+                TransactionDTO(id: "inside", accountId: "hidden", amount: 10, date: "2026-06-11", name: "IN WINDOW"),
+                TransactionDTO(id: "after", accountId: "hidden", amount: 20, date: "2026-06-12", name: "AFTER SNAPSHOT"),
+            ],
+            itemStatuses: [],
+            now: now
+        ))
+
+        #expect(receipt.summary.contains("1 new tx"))
+    }
+}

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -446,6 +446,8 @@ struct PlaidBarTests {
 
         #expect(DashboardOverviewHeightBudget.realisticPopoverHeight == 660)
         #expect(budget.fitsFirstGlance(visibleAccountRows: 1, includesSelectedDrillIn: true))
+        #expect(!budget.fitsFirstGlance(visibleAccountRows: 1, includesSelectedDrillIn: true, includesChangeReceipt: true))
+        #expect(budget.fitsFirstGlance(visibleAccountRows: 3, includesSelectedDrillIn: false, includesChangeReceipt: true))
         #expect(!budget.fitsFirstGlance(visibleAccountRows: 3, includesSelectedDrillIn: true))
         #expect(budget.estimatedFirstGlanceHeight(visibleAccountRows: 1, includesSelectedDrillIn: true) <= DashboardOverviewHeightBudget.firstGlanceVisibleHeight)
     }


### PR DESCRIPTION
## Summary

- Adds a compact local-only `Latest local changes` receipt to the dashboard top stack when no selected-account drill-in is open.
- Introduces a tested `DashboardChangeReceipt` presenter that compares local balance snapshots, locally cached transaction dates within the same snapshot window, and degraded item counts without exposing raw account/item/transaction identifiers.
- Handles the first-snapshot case with `First local snapshot saved` copy and a VoiceOver summary.

## Autonomous task IDs

- Task ID(s): AND-298
- Backlog slice: Linear PlaidBar high-priority product slice — local dashboard change receipt
- Scope note: one focused dashboard/core presenter slice; no backend, telemetry, cloud sync, AI, or release changes.

## Agent coordination

- Builder agent: Hermes/Otto; attempted Codex CLI but `/opt/homebrew/bin/codex exec` failed before edits with `401 Unauthorized: Missing bearer or basic authentication`.
- Builder branch/worktree: `feature/and-298-since-last-open-receipt` at `/Users/otto/workspace/PlaidBar`
- Reviewer/merge steward: Otto
- Coordination note: no other agent should mutate this branch while CI/review is pending.

## Changed files

- `Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift`
- `Sources/PlaidBarCore/Models/DashboardOverviewHeightBudget.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Tests/PlaidBarCoreTests/DashboardChangeReceiptTests.swift`
- `Tests/PlaidBarTests/PlaidBarTests.swift`

## Local gates

- [x] `git diff --check` — passed.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` — passed.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` — passed because shared package/core code changed.
- [x] Focused tests: `swift test --filter DashboardChangeReceiptTests --skip-update --disable-keychain` — 4 tests passed; `swift test --filter PlaidBarTests/dashboardOverviewBudgetFitsRealisticPopoverHeight --skip-update --disable-keychain` — passed; `swift test --filter PlaidBarTests/dashboardOverviewFallback --skip-update --disable-keychain` — 2 tests passed before the latest review fix and remains unrelated. Full `swift test --skip-update --disable-keychain` built successfully but timed out at 600s before test completion in this cron environment.
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files. Matches were existing placeholder/test strings; no new secret-bearing strings in this PR.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR when dedicated CI/review/gate checks are green.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude/Codex review auth/token/session/setup-only failures will be documented as non-blocking if they occur; code-review findings remain blocking until addressed.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage and local snapshots.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New dashboard receipt surface exposes only aggregate local snapshot/transaction/status counts, never private identifiers or raw transaction names.
- [x] This UI/core change keeps PlaidBar local-first: no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] No optional AI behavior was added.
- [x] Tests use synthetic data and do not imply production readiness, notarization, distribution, or unverified security properties.

## UI and accessibility checks

- [x] Keyboard access/focus impact checked by keeping the receipt non-interactive; existing controls remain unchanged.
- [x] VoiceOver summary added through `receipt.accessibilitySummary`.
- [x] Deltas are presented as explicit signed/text values and counts; meaning does not rely on color alone.
- [x] No screenshot update included in this PR; UI evidence should be refreshed in a follow-up once CI/review confirms the implementation.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md` after checks/reviews are green.
- [ ] PR head SHA will be rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and Linear AND-298 will be updated as appropriate.
