### PR TITLE
feat: add drag-install DMG with self-contained app bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PlaidBar is a local-first macOS menu bar dashboard for [Plaid](https://plaid.com) financial data. No cloud backend, no telemetry — all data stays on the user's machine. The product north star is RepoBar/CodexBar-style density: high-signal numbers one click away in a native macOS popover.
+
+## Commands
+
+```bash
+swift build                 # Build all 3 targets
+swift build -c release      # Release build (what CI builds)
+swift test                  # Run all tests
+swift run PlaidBar --demo   # Run app with local fixtures (no Plaid, no server, no credentials)
+swift run PlaidBarServer --sandbox          # Run server standalone
+./Scripts/run.sh --sandbox  # Build + run server AND app together (sandbox)
+./Scripts/smoke-sandbox.sh  # Headless sandbox preflight: /health + auth-gated /api/status
+./Scripts/screenshots.sh    # Capture README screenshots from demo data
+```
+
+Run a single test (Swift Testing, not XCTest):
+
+```bash
+swift test --filter PlaidBarCoreTests          # one suite
+swift test --filter "someTestFunctionName"     # one test by name
+```
+
+Before pushing, replicate CI locally — the strict-concurrency build is the gate that most often fails:
+
+```bash
+swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
+swift test
+```
+
+Lint/format (config in `.swiftformat`, `.swiftlint.yml`):
+
+```bash
+swiftformat Sources/ Tests/
+swiftlint
+```
+
+## Architecture: two processes, one shared library
+
+Three SPM targets in `Package.swift`. The split is a hard security boundary, not just organization:
+
+- **`PlaidBar`** (`Sources/PlaidBar/`) — SwiftUI `MenuBarExtra` app. The UI layer. It **only** talks to the local server over HTTP; it never sees Plaid `client_secret` or `access_token`.
+- **`PlaidBarServer`** (`Sources/PlaidBarServer/`) — Hummingbird 2 companion server. Proxies all Plaid API calls, owns credentials and token storage. Binds to `127.0.0.1` only.
+- **`PlaidBarCore`** (`Sources/PlaidBarCore/`) — shared library. DTOs (`Models/`) and pure utilities (`Utilities/`) used by both. **Most testable business logic lives here** — summaries, formatters, recurring detection, sync reduction, presentation/state mapping. Prefer adding logic here over embedding it in views or routes.
+
+Data flow: `PlaidBar.app` → HTTP `localhost:8484` → `PlaidBarServer` → HTTPS → Plaid API.
+
+**Why the server exists:** Plaid forbids the secret/access-token from living in the client. The server keeps them out of the SwiftUI process, stores Plaid item records in local SQLite and access-token *bytes* in macOS Keychain (SQLite holds only `keychain:<item_id>` references), and can restart independently of the UI.
+
+### Server internals (`Sources/PlaidBarServer/`)
+- `App.swift` — `@main` entry. Sets up Fluent/SQLite, runs migrations (`CreateItems`, `CreateSyncCursors`), wires the Hummingbird router. `/health` and `/oauth/callback` are unauthenticated; everything under `/api` is behind `APITokenMiddleware`.
+- `Routes/` — REST endpoints (Account, Link, Status, Transaction).
+- `Plaid/` — `PlaidClient` + `PlaidModels`.
+- `Storage/` — Fluent models/migrations (`Database.swift`), `TokenStore`, `PlaidTokenVault` (Keychain).
+- `Config/ServerConfig.swift` — loads config from CLI flags > config file > environment. Enforces private SQLite store permissions.
+- `Auth/` — `APITokenMiddleware`, `PendingLinkSessionStore` (one-time Hosted Link `state` validation).
+
+### App internals (`Sources/PlaidBar/`)
+- `App/` — `@main` `PlaidBarApp`, `AppState`.
+- `Services/` — `ServerClient` (HTTP), `RefreshService`, `SyncService`, `NotificationService`, `LaunchService`, `LocalAIInsightsService`.
+- `Views/` — `MainPopover` is the dashboard-first surface; filter states (Cash/Credit/Savings/Debt/Status) reuse the same visual system. `Charts/` holds Swift Charts components.
+- `Theme/` — `DesignTokens`, `Typography` (semantic tokens + 8pt grid). See `DESIGN.md`.
+
+## Conventions (enforced — see CONTRIBUTING.md)
+
+- **Swift 6 strict concurrency.** All types must be `Sendable`. CI builds with `-strict-concurrency=complete -warnings-as-errors`, so a non-`Sendable` type fails the build, not just a warning. Targets compile in Swift 5 language mode but under the Swift 6 toolchain.
+- **State: use `@Observable`**, not `ObservableObject`.
+- **Put shared logic in `PlaidBarCore`**, not in views or routes — keeps it `Sendable`, testable, and reusable across both processes.
+- **Never communicate balance, risk, utilization, errors, or chart meaning through color alone** (accessibility — `ACCESSIBILITY.md`).
+- **Always use sandbox or synthetic data** in tests, screenshots, and examples. Never commit real Plaid credentials, access tokens, account IDs, or balances.
+
+## Data modes
+
+| Mode | Command | Plaid calls | Source |
+|------|---------|-------------|--------|
+| Demo | `swift run PlaidBar --demo` | No | Hardcoded fixtures |
+| Sandbox | `./Scripts/run.sh --sandbox` | Yes (sandbox API) | Plaid sandbox creds |
+| Production | `./Scripts/run.sh` | Yes (prod API) | Plaid-approved creds |
+
+Sandbox/production need `PLAID_CLIENT_ID` and `PLAID_SECRET` exported (or set in `~/.plaidbar/server.conf`). Server port defaults to `8484` (`PLAIDBAR_SERVER_PORT` to override); local data lives under `~/.plaidbar/` (`PLAIDBAR_DATA_DIR` to override). Tunable constants are centralized in `Sources/PlaidBarCore/Utilities/Constants.swift` (refresh intervals, sync page caps, credit thresholds, app version).
+
+## Server API
+
+Localhost endpoints. `/health` and `/oauth/callback` are open; `/api/*` requires the bearer token at `~/.plaidbar/auth-token` (or `$PLAIDBAR_DATA_DIR/auth-token`). Full table in `README.md` ("Server API Reference"). `/api/status` deliberately exposes readiness metadata only — never tokens, account IDs, balances, or transactions.
+
+## Reference docs
+
+`README.md` (most complete), `ARCHITECTURE.md` + `docs/architecture.md`, `DESIGN.md`, `GOAL.md`, `PRD.md`, `SECURITY.md`, `ACCESSIBILITY.md`, `docs/troubleshooting.md`, `docs/qa-matrix.md`, `docs/v1.0-roadmap.md`.
+
+`commands/goal.md` (`/goal`) and `.codex/skills/` contain a repo-local agentic production-readiness loop. `docs/agent-collaboration.md` defines multi-agent channel rules (PRs for handoff, Linear for status, repo docs for durable policy).

--- a/README.md
+++ b/README.md
@@ -133,11 +133,21 @@ add your credentials to `~/.plaidbar/server.conf`, then quit and reopen
 PlaidBar — the app starts its bundled companion server automatically, no
 terminal needed:
 
-```ini
+```bash
+mkdir -p ~/.plaidbar && chmod 700 ~/.plaidbar
+cat > ~/.plaidbar/server.conf <<'EOF'
 PLAID_CLIENT_ID=your_client_id
 PLAID_SECRET=your_secret
 # optional: PLAID_ENV=sandbox
+EOF
+chmod 600 ~/.plaidbar/server.conf
 ```
+
+The app also enforces owner-only permissions on `server.conf` and the server
+log at launch. App-managed launches always bind the app's own port, so
+`PLAIDBAR_SERVER_PORT` or `PLAIDBAR_DATA_DIR` lines in `server.conf` are not
+supported there — set those as environment variables instead so the app and
+the server agree.
 
 ### Homebrew
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,32 @@ macOS Screen Recording and Accessibility permission for Terminal.
 
 ## Quick Start
 
+### DMG (easiest, no developer tools)
+
+Build a drag-install disk image from a checkout (or download one from a
+GitHub release once published):
+
+```bash
+./Scripts/package-dmg.sh
+open .build/PlaidBar-*.dmg
+```
+
+Then drag **PlaidBar.app** to **Applications** and launch it. On first
+launch, right-click PlaidBar.app and choose **Open** (the build is ad-hoc
+signed; Developer ID notarization is on the roadmap).
+
+To see demo data without any Plaid setup, choose **Demo** on the setup
+screen — no server or credentials needed. To use real or sandbox Plaid data,
+add your credentials to `~/.plaidbar/server.conf`, then quit and reopen
+PlaidBar — the app starts its bundled companion server automatically, no
+terminal needed:
+
+```ini
+PLAID_CLIENT_ID=your_client_id
+PLAID_SECRET=your_secret
+# optional: PLAID_ENV=sandbox
+```
+
 ### Homebrew
 
 Install PlaidBar from the repository tap:

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -44,6 +44,8 @@ mkdir -p "$MACOS_DIR" "$FRAMEWORKS_DIR"
 cp "$BUILD_DIR/PlaidBar" "$APP_BINARY"
 cp "$BUILD_DIR/PlaidBarServer" "$MACOS_DIR/PlaidBarServer"
 cp "$RESOURCES_DIR/Info.plist" "$CONTENTS_DIR/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable PlaidBar" "$CONTENTS_DIR/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string PlaidBar" "$CONTENTS_DIR/Info.plist"
 ditto "$BUILD_DIR/Sparkle.framework" "$FRAMEWORKS_DIR/Sparkle.framework"
 chmod +x "$APP_BINARY" "$MACOS_DIR/PlaidBarServer"
 

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -28,6 +28,11 @@ if [ ! -x "$BUILD_DIR/PlaidBar" ]; then
     exit 1
 fi
 
+if [ ! -x "$BUILD_DIR/PlaidBarServer" ]; then
+    echo "PlaidBarServer binary not found at $BUILD_DIR/PlaidBarServer" >&2
+    exit 1
+fi
+
 if [ ! -d "$BUILD_DIR/Sparkle.framework" ]; then
     echo "Sparkle.framework not found at $BUILD_DIR/Sparkle.framework" >&2
     exit 1
@@ -37,9 +42,10 @@ rm -rf "$APP_DIR"
 mkdir -p "$MACOS_DIR" "$FRAMEWORKS_DIR"
 
 cp "$BUILD_DIR/PlaidBar" "$APP_BINARY"
+cp "$BUILD_DIR/PlaidBarServer" "$MACOS_DIR/PlaidBarServer"
 cp "$RESOURCES_DIR/Info.plist" "$CONTENTS_DIR/Info.plist"
 ditto "$BUILD_DIR/Sparkle.framework" "$FRAMEWORKS_DIR/Sparkle.framework"
-chmod +x "$APP_BINARY"
+chmod +x "$APP_BINARY" "$MACOS_DIR/PlaidBarServer"
 
 if ! otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_BINARY"

--- a/Scripts/package-dmg.sh
+++ b/Scripts/package-dmg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build a drag-install PlaidBar DMG around the self-contained PlaidBar.app.
+#
+# Usage: ./Scripts/package-dmg.sh
+#
+# Produces .build/PlaidBar-<version>.dmg containing PlaidBar.app and an
+# /Applications symlink. The app bundle includes PlaidBarServer, which the
+# app starts automatically on first launch, so non-developers only drag,
+# drop, and open.
+#
+# The bundle is ad-hoc signed. Until Developer ID signing + notarization
+# ship (see docs/release.md), downloaded DMGs require right-click > Open on
+# first launch.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_DIR="$PROJECT_DIR/.build/PlaidBar.app"
+STAGING_DIR="$PROJECT_DIR/.build/dmg-staging"
+VOLUME_NAME="PlaidBar"
+
+cd "$PROJECT_DIR"
+
+if [ ! -f version.env ]; then
+    echo "Missing version.env" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source version.env
+
+if [ -z "${VERSION:-}" ]; then
+    echo "version.env must define VERSION" >&2
+    exit 1
+fi
+
+DMG_PATH="$PROJECT_DIR/.build/PlaidBar-$VERSION.dmg"
+
+"$SCRIPT_DIR/package-app.sh"
+
+rm -rf "$STAGING_DIR" "$DMG_PATH"
+mkdir -p "$STAGING_DIR"
+ditto "$APP_DIR" "$STAGING_DIR/PlaidBar.app"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+echo "Creating $DMG_PATH..."
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH" >/dev/null
+
+rm -rf "$STAGING_DIR"
+
+echo "Verifying DMG..."
+hdiutil verify "$DMG_PATH" >/dev/null
+
+echo ""
+echo "Built $DMG_PATH"
+echo "Install: open the DMG, drag PlaidBar.app to Applications, then"
+echo "right-click PlaidBar.app > Open on first launch (ad-hoc signed build)."

--- a/Scripts/package-dmg.sh
+++ b/Scripts/package-dmg.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-APP_DIR="$PROJECT_DIR/.build/PlaidBar.app"
+APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/PlaidBar.app}"
+# Keep package-app.sh writing to the exact bundle path this script stages.
+export PLAIDBAR_PACKAGE_APP_DIR="$APP_DIR"
 STAGING_DIR="$PROJECT_DIR/.build/dmg-staging"
 VOLUME_NAME="PlaidBar"
 

--- a/Scripts/validate-app-bundle.sh
+++ b/Scripts/validate-app-bundle.sh
@@ -11,6 +11,17 @@ fi
 APP_BINARY="$APP_DIR/Contents/MacOS/PlaidBar"
 SERVER_BINARY="$APP_DIR/Contents/MacOS/PlaidBarServer"
 SPARKLE_FRAMEWORK="$APP_DIR/Contents/Frameworks/Sparkle.framework"
+INFO_PLIST="$APP_DIR/Contents/Info.plist"
+
+if [ ! -f "$INFO_PLIST" ]; then
+    echo "Missing Info.plist at $INFO_PLIST" >&2
+    exit 1
+fi
+
+if [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST" 2>/dev/null || true)" != "PlaidBar" ]; then
+    echo "PlaidBar.app Info.plist must set CFBundleExecutable to PlaidBar" >&2
+    exit 1
+fi
 
 if [ ! -x "$APP_BINARY" ]; then
     echo "Missing executable PlaidBar binary at $APP_BINARY" >&2

--- a/Scripts/validate-app-bundle.sh
+++ b/Scripts/validate-app-bundle.sh
@@ -9,10 +9,16 @@ if [ -z "$APP_DIR" ]; then
 fi
 
 APP_BINARY="$APP_DIR/Contents/MacOS/PlaidBar"
+SERVER_BINARY="$APP_DIR/Contents/MacOS/PlaidBarServer"
 SPARKLE_FRAMEWORK="$APP_DIR/Contents/Frameworks/Sparkle.framework"
 
 if [ ! -x "$APP_BINARY" ]; then
     echo "Missing executable PlaidBar binary at $APP_BINARY" >&2
+    exit 1
+fi
+
+if [ ! -x "$SERVER_BINARY" ]; then
+    echo "Missing executable PlaidBarServer binary at $SERVER_BINARY" >&2
     exit 1
 fi
 

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -998,19 +998,28 @@ final class AppState {
         guard !CommandLine.arguments.contains("--demo") else { return }
         await checkServerConnection()
         guard !serverConnected else { return }
+        // The authenticated status check fails for an externally managed
+        // server when the local auth token is missing or stale. Probe the
+        // unauthenticated /health endpoint so that case never spawns a
+        // second server onto an occupied port.
+        guard !(await serverClient.isLocalServerResponding()) else { return }
         _ = ServerProcessService.shared.launchBundledServerIfNeeded(
             isDemoMode: isDemoMode,
-            serverAlreadyReachable: serverConnected
+            serverAlreadyReachable: false
         )
     }
 
     /// Popover-open path: start the bundled server if nothing did yet, then
     /// wait briefly for readiness (also covers a still-booting prewarm).
     private func startBundledServerIfAvailable() async {
-        let launched = ServerProcessService.shared.launchBundledServerIfNeeded(
-            isDemoMode: isDemoMode,
-            serverAlreadyReachable: serverConnected
-        )
+        var launched = false
+        if !ServerProcessService.shared.isManagingServer,
+           !(await serverClient.isLocalServerResponding()) {
+            launched = ServerProcessService.shared.launchBundledServerIfNeeded(
+                isDemoMode: isDemoMode,
+                serverAlreadyReachable: false
+            )
+        }
         guard launched || ServerProcessService.shared.isManagingServer else { return }
 
         for _ in 0 ..< 12 {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -974,6 +974,9 @@ final class AppState {
             return
         }
         await checkServerConnection()
+        if !serverConnected {
+            await startBundledServerIfAvailable()
+        }
         if serverConnected {
             if statusItemCount > 0 {
                 loadCachedAccounts()
@@ -985,6 +988,35 @@ final class AppState {
             await refreshAccounts()
             await syncTransactions()
             startBackgroundRefresh()
+        }
+    }
+
+    /// When installed as a standalone `.app` (DMG drag-install), the server
+    /// ships inside the bundle. Starts it at app launch so it is usually
+    /// ready before the popover first opens.
+    func prewarmBundledServer() async {
+        guard !CommandLine.arguments.contains("--demo") else { return }
+        await checkServerConnection()
+        guard !serverConnected else { return }
+        _ = ServerProcessService.shared.launchBundledServerIfNeeded(
+            isDemoMode: isDemoMode,
+            serverAlreadyReachable: serverConnected
+        )
+    }
+
+    /// Popover-open path: start the bundled server if nothing did yet, then
+    /// wait briefly for readiness (also covers a still-booting prewarm).
+    private func startBundledServerIfAvailable() async {
+        let launched = ServerProcessService.shared.launchBundledServerIfNeeded(
+            isDemoMode: isDemoMode,
+            serverAlreadyReachable: serverConnected
+        )
+        guard launched || ServerProcessService.shared.isManagingServer else { return }
+
+        for _ in 0 ..< 12 {
+            try? await Task.sleep(for: .milliseconds(400))
+            await checkServerConnection()
+            if serverConnected { break }
         }
     }
 

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -1,7 +1,7 @@
-import SwiftUI
 import MenuBarExtraAccess
 import PlaidBarCore
 import Sparkle
+import SwiftUI
 
 @main
 struct PlaidBarApp: App {
@@ -23,6 +23,9 @@ struct PlaidBarApp: App {
                 try? await Task.sleep(for: .milliseconds(700))
                 state.isPopoverPresented = true
             }
+        }
+        Task { @MainActor in
+            await state.prewarmBundledServer()
         }
     }
 

--- a/Sources/PlaidBar/Resources/Info.plist
+++ b/Sources/PlaidBar/Resources/Info.plist
@@ -6,6 +6,10 @@
     <string>PlaidBar</string>
     <key>CFBundleDisplayName</key>
     <string>PlaidBar</string>
+    <key>CFBundleExecutable</key>
+    <string>PlaidBar</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
     <key>CFBundleIdentifier</key>
     <string>com.ftchvs.PlaidBar</string>
     <key>CFBundleVersion</key>

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -120,6 +120,24 @@ actor ServerClient {
         try Self.validateHTTPResponse(response, data: data)
     }
 
+    /// Unauthenticated probe of `/health`. Distinguishes "no server is
+    /// listening" from "a server is up but this client cannot authenticate",
+    /// so the bundled-server auto-launch never races an externally managed
+    /// server just because the local auth token is missing or stale.
+    func isLocalServerResponding() async -> Bool {
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/health") else {
+            return false
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2
+        do {
+            let (_, response) = try await session.data(for: request)
+            return (response as? HTTPURLResponse).map { (200...299).contains($0.statusCode) } ?? false
+        } catch {
+            return false
+        }
+    }
+
     private func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         do {
             return try await session.data(for: request)

--- a/Sources/PlaidBar/Services/ServerProcessService.swift
+++ b/Sources/PlaidBar/Services/ServerProcessService.swift
@@ -32,6 +32,7 @@ final class ServerProcessService {
 
         let storageDirectory = LocalDataStore.storageDirectoryURL()
         let configFileURL = storageDirectory.appendingPathComponent(LocalDataStore.serverConfigFilename)
+        let configFileContents = try? String(contentsOf: configFileURL, encoding: .utf8)
         guard let plan = ServerAutoLaunchPlan.evaluate(
             bundledServerPath: Self.bundledServerExecutablePath(),
             isAppBundle: Self.isRunningFromAppBundle(),
@@ -39,6 +40,7 @@ final class ServerProcessService {
             serverAlreadyReachable: serverAlreadyReachable,
             dataDirectoryPath: storageDirectory.path,
             configFileExists: FileManager.default.fileExists(atPath: configFileURL.path),
+            configFileContents: configFileContents,
             port: PlaidBarConstants.serverPort(environment: ProcessInfo.processInfo.environment),
             parentProcessId: ProcessInfo.processInfo.processIdentifier
         ) else {

--- a/Sources/PlaidBar/Services/ServerProcessService.swift
+++ b/Sources/PlaidBar/Services/ServerProcessService.swift
@@ -1,0 +1,119 @@
+import AppKit
+import Foundation
+import PlaidBarCore
+
+/// Starts and supervises the `PlaidBarServer` executable bundled inside
+/// `PlaidBar.app`, so a drag-installed app works without a manual server step.
+///
+/// The service only ever manages a server it spawned itself. Externally
+/// started servers (Homebrew `plaidbar-run`, `Scripts/run.sh`, manual runs)
+/// are detected through the existing reachability check and left alone.
+@MainActor
+final class ServerProcessService {
+    static let shared = ServerProcessService()
+
+    private(set) var managedProcess: Process?
+    private var terminationObserver: NSObjectProtocol?
+
+    var isManagingServer: Bool {
+        managedProcess?.isRunning == true
+    }
+
+    /// Launches the bundled server when `ServerAutoLaunchPlan` allows it.
+    /// Returns `true` when a process was actually started.
+    func launchBundledServerIfNeeded(isDemoMode: Bool, serverAlreadyReachable: Bool) -> Bool {
+        guard managedProcess == nil else { return false }
+
+        let storageDirectory = LocalDataStore.storageDirectoryURL()
+        let configFileURL = storageDirectory.appendingPathComponent(LocalDataStore.serverConfigFilename)
+        guard let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: Self.bundledServerExecutablePath(),
+            isAppBundle: Self.isRunningFromAppBundle(),
+            isDemoMode: isDemoMode,
+            serverAlreadyReachable: serverAlreadyReachable,
+            dataDirectoryPath: storageDirectory.path,
+            configFileExists: FileManager.default.fileExists(atPath: configFileURL.path),
+            parentProcessId: ProcessInfo.processInfo.processIdentifier
+        ) else {
+            return false
+        }
+
+        try? LocalDataStore.prepareStorageDirectory(at: storageDirectory)
+        let logHandle = Self.makePrivateLogHandle(atPath: plan.logFilePath)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: plan.executablePath)
+        process.arguments = plan.arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = logHandle ?? FileHandle.nullDevice
+        process.standardError = logHandle ?? FileHandle.nullDevice
+        process.terminationHandler = { _ in
+            Task { @MainActor in
+                ServerProcessService.shared.managedProcess = nil
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+
+        managedProcess = process
+        installTerminationObserverIfNeeded()
+        return true
+    }
+
+    /// Sends SIGTERM to the managed server so Hummingbird can shut down
+    /// gracefully. Safe to call when nothing is managed.
+    func terminateManagedServer() {
+        guard let process = managedProcess, process.isRunning else {
+            managedProcess = nil
+            return
+        }
+        process.terminate()
+        managedProcess = nil
+    }
+
+    private func installTerminationObserverIfNeeded() {
+        guard terminationObserver == nil else { return }
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                ServerProcessService.shared.terminateManagedServer()
+            }
+        }
+    }
+
+    private static func isRunningFromAppBundle() -> Bool {
+        Bundle.main.bundleURL.pathExtension.lowercased() == "app"
+    }
+
+    private static func bundledServerExecutablePath() -> String? {
+        guard let url = Bundle.main.url(forAuxiliaryExecutable: "PlaidBarServer"),
+              FileManager.default.isExecutableFile(atPath: url.path)
+        else {
+            return nil
+        }
+        return url.path
+    }
+
+    /// Opens the server log for appending with owner-only permissions,
+    /// matching the repo's private-file conventions for `~/.plaidbar`.
+    private static func makePrivateLogHandle(atPath path: String) -> FileHandle? {
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: path) {
+            fileManager.createFile(
+                atPath: path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
+        }
+        guard let handle = FileHandle(forWritingAtPath: path) else { return nil }
+        handle.seekToEndOfFile()
+        return handle
+    }
+}

--- a/Sources/PlaidBar/Services/ServerProcessService.swift
+++ b/Sources/PlaidBar/Services/ServerProcessService.swift
@@ -7,7 +7,8 @@ import PlaidBarCore
 ///
 /// The service only ever manages a server it spawned itself. Externally
 /// started servers (Homebrew `plaidbar-run`, `Scripts/run.sh`, manual runs)
-/// are detected through the existing reachability check and left alone.
+/// are detected through an unauthenticated `/health` probe before any spawn
+/// decision and left alone.
 @MainActor
 final class ServerProcessService {
     static let shared = ServerProcessService()
@@ -22,6 +23,11 @@ final class ServerProcessService {
     /// Launches the bundled server when `ServerAutoLaunchPlan` allows it.
     /// Returns `true` when a process was actually started.
     func launchBundledServerIfNeeded(isDemoMode: Bool, serverAlreadyReachable: Bool) -> Bool {
+        // A previously managed server that already exited must not block a
+        // retry (e.g. it crashed on a bad config the user has since fixed).
+        if let process = managedProcess, !process.isRunning {
+            managedProcess = nil
+        }
         guard managedProcess == nil else { return false }
 
         let storageDirectory = LocalDataStore.storageDirectoryURL()
@@ -33,12 +39,15 @@ final class ServerProcessService {
             serverAlreadyReachable: serverAlreadyReachable,
             dataDirectoryPath: storageDirectory.path,
             configFileExists: FileManager.default.fileExists(atPath: configFileURL.path),
+            port: PlaidBarConstants.serverPort(environment: ProcessInfo.processInfo.environment),
             parentProcessId: ProcessInfo.processInfo.processIdentifier
         ) else {
             return false
         }
 
         try? LocalDataStore.prepareStorageDirectory(at: storageDirectory)
+        Self.enforcePrivatePermissions(atPath: configFileURL.path)
+        Self.enforcePrivatePermissions(atPath: plan.logFilePath)
         let logHandle = Self.makePrivateLogHandle(atPath: plan.logFilePath)
 
         let process = Process()
@@ -47,9 +56,15 @@ final class ServerProcessService {
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = logHandle ?? FileHandle.nullDevice
         process.standardError = logHandle ?? FileHandle.nullDevice
-        process.terminationHandler = { _ in
+        process.terminationHandler = { exited in
+            // Clear only the process that exited: a stale handler must never
+            // nil out a newer managed server.
+            let exitedPid = exited.processIdentifier
             Task { @MainActor in
-                ServerProcessService.shared.managedProcess = nil
+                let service = ServerProcessService.shared
+                if service.managedProcess?.processIdentifier == exitedPid {
+                    service.managedProcess = nil
+                }
             }
         }
 
@@ -99,6 +114,17 @@ final class ServerProcessService {
             return nil
         }
         return url.path
+    }
+
+    /// `server.conf` holds Plaid credentials and `server.log` may hold server
+    /// diagnostics; both must stay owner-only even if the user created them
+    /// with looser permissions.
+    private static func enforcePrivatePermissions(atPath path: String) {
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: path
+        )
     }
 
     /// Opens the server log for appending with owner-only permissions,

--- a/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
+++ b/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
@@ -18,6 +18,9 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
     }
 
     public static let logFilename = "server.log"
+    public static let blockedManagedConfigKeys: Set<String> = [
+        LocalDataStore.dataDirectoryEnvironmentVariable,
+    ]
 
     /// Returns a launch plan only when every precondition for managing a
     /// bundled server holds:
@@ -32,9 +35,12 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
     /// crash-loop. Without `server.conf`, first launch stays serverless and
     /// the app offers demo mode and setup guidance instead. The plan passes
     /// the config via `--config` so the credentials and environment selection
-    /// configured there apply to the app-managed server, the app's resolved
-    /// port via `--port` (CLI beats config) so a `PLAIDBAR_SERVER_PORT` line
-    /// in `server.conf` cannot start the server somewhere the app is not
+    /// configured there apply to the app-managed server. Managed launches
+    /// reject config files that move storage because the Finder-launched app
+    /// would otherwise keep reading the default auth-token path while the
+    /// server writes elsewhere. The plan still passes the app's resolved port
+    /// via `--port` (CLI beats config) so a `PLAIDBAR_SERVER_PORT` line in
+    /// `server.conf` cannot start the server somewhere the app is not
     /// listening, and the app's PID via `--exit-with-parent` so the server
     /// never outlives a crashed app.
     public static func evaluate(
@@ -44,11 +50,16 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
         serverAlreadyReachable: Bool,
         dataDirectoryPath: String,
         configFileExists: Bool,
+        configFileContents: String? = "",
         port: Int,
         parentProcessId: Int32?
     ) -> ServerAutoLaunchPlan? {
         guard isAppBundle, !isDemoMode, !serverAlreadyReachable, configFileExists else { return nil }
         guard let bundledServerPath, !bundledServerPath.isEmpty else { return nil }
+        guard let configFileContents else { return nil }
+        if containsBlockedManagedConfigKey(in: configFileContents) {
+            return nil
+        }
 
         let normalizedDataDirectory = dataDirectoryPath.hasSuffix("/")
             ? String(dataDirectoryPath.dropLast())
@@ -67,5 +78,21 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
             arguments: arguments,
             logFilePath: normalizedDataDirectory + "/" + logFilename
         )
+    }
+
+    public static func containsBlockedManagedConfigKey(in contents: String) -> Bool {
+        contents.components(separatedBy: .newlines).contains { rawLine in
+            var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, !line.hasPrefix("#") else { return false }
+
+            if line.hasPrefix("export ") {
+                line.removeFirst("export ".count)
+                line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            guard let separator = line.firstIndex(of: "=") else { return false }
+            let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return blockedManagedConfigKeys.contains(key)
+        }
     }
 }

--- a/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
+++ b/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
@@ -32,8 +32,11 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
     /// crash-loop. Without `server.conf`, first launch stays serverless and
     /// the app offers demo mode and setup guidance instead. The plan passes
     /// the config via `--config` so the credentials and environment selection
-    /// configured there apply to the app-managed server, and the app's PID
-    /// via `--exit-with-parent` so the server never outlives a crashed app.
+    /// configured there apply to the app-managed server, the app's resolved
+    /// port via `--port` (CLI beats config) so a `PLAIDBAR_SERVER_PORT` line
+    /// in `server.conf` cannot start the server somewhere the app is not
+    /// listening, and the app's PID via `--exit-with-parent` so the server
+    /// never outlives a crashed app.
     public static func evaluate(
         bundledServerPath: String?,
         isAppBundle: Bool,
@@ -41,6 +44,7 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
         serverAlreadyReachable: Bool,
         dataDirectoryPath: String,
         configFileExists: Bool,
+        port: Int,
         parentProcessId: Int32?
     ) -> ServerAutoLaunchPlan? {
         guard isAppBundle, !isDemoMode, !serverAlreadyReachable, configFileExists else { return nil }
@@ -50,7 +54,10 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
             ? String(dataDirectoryPath.dropLast())
             : dataDirectoryPath
 
-        var arguments = ["--config", normalizedDataDirectory + "/" + LocalDataStore.serverConfigFilename]
+        var arguments = [
+            "--config", normalizedDataDirectory + "/" + LocalDataStore.serverConfigFilename,
+            "--port", String(port),
+        ]
         if let parentProcessId {
             arguments += ["--exit-with-parent", String(parentProcessId)]
         }

--- a/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
+++ b/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Decides whether the app should start the `PlaidBarServer` executable that
+/// ships inside `PlaidBar.app`, and with what process configuration.
+///
+/// The plan exists so DMG installs work without a separate server step while
+/// developer workflows stay untouched: `swift run`, `Scripts/run.sh`, and any
+/// externally managed server all suppress auto-launch.
+public struct ServerAutoLaunchPlan: Equatable, Sendable {
+    public let executablePath: String
+    public let arguments: [String]
+    public let logFilePath: String
+
+    public init(executablePath: String, arguments: [String], logFilePath: String) {
+        self.executablePath = executablePath
+        self.arguments = arguments
+        self.logFilePath = logFilePath
+    }
+
+    public static let logFilename = "server.log"
+
+    /// Returns a launch plan only when every precondition for managing a
+    /// bundled server holds:
+    /// - the app is running from a real `.app` bundle (not `swift run`),
+    /// - the bundle actually contains a `PlaidBarServer` executable,
+    /// - no reachable server is already serving the configured port,
+    /// - the app is not in demo mode,
+    /// - `<data dir>/server.conf` exists.
+    ///
+    /// The config file is a hard requirement because the server refuses to
+    /// boot without Plaid credentials: spawning it credential-less would just
+    /// crash-loop. Without `server.conf`, first launch stays serverless and
+    /// the app offers demo mode and setup guidance instead. The plan passes
+    /// the config via `--config` so the credentials and environment selection
+    /// configured there apply to the app-managed server, and the app's PID
+    /// via `--exit-with-parent` so the server never outlives a crashed app.
+    public static func evaluate(
+        bundledServerPath: String?,
+        isAppBundle: Bool,
+        isDemoMode: Bool,
+        serverAlreadyReachable: Bool,
+        dataDirectoryPath: String,
+        configFileExists: Bool,
+        parentProcessId: Int32?
+    ) -> ServerAutoLaunchPlan? {
+        guard isAppBundle, !isDemoMode, !serverAlreadyReachable, configFileExists else { return nil }
+        guard let bundledServerPath, !bundledServerPath.isEmpty else { return nil }
+
+        let normalizedDataDirectory = dataDirectoryPath.hasSuffix("/")
+            ? String(dataDirectoryPath.dropLast())
+            : dataDirectoryPath
+
+        var arguments = ["--config", normalizedDataDirectory + "/" + LocalDataStore.serverConfigFilename]
+        if let parentProcessId {
+            arguments += ["--exit-with-parent", String(parentProcessId)]
+        }
+
+        return ServerAutoLaunchPlan(
+            executablePath: bundledServerPath,
+            arguments: arguments,
+            logFilePath: normalizedDataDirectory + "/" + logFilename
+        )
+    }
+}

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
+import FluentSQLiteDriver
 import Foundation
 import Hummingbird
 import HummingbirdFluent
-import FluentSQLiteDriver
 import Logging
 import PlaidBarCore
 
@@ -18,13 +18,20 @@ struct PlaidBarServer: AsyncParsableCommand {
     var port: Int?
 
     @Flag(name: .long, help: "Use Plaid sandbox environment")
-    var sandbox: Bool = false
+    var sandbox = false
 
     @Option(name: .long, help: "Path to config file")
     var config: String?
 
+    @Option(name: .long, help: "Exit when the process with this PID exits (used by app-managed launches)")
+    var exitWithParent: Int32?
+
     func run() async throws {
         let logger = Logger(label: "com.ftchvs.plaidbar-server")
+
+        if let parentPid = exitWithParent {
+            startParentWatchdog(parentPid: parentPid, logger: logger)
+        }
 
         let serverConfig = try ServerConfig.load(
             from: config,
@@ -73,7 +80,7 @@ struct PlaidBarServer: AsyncParsableCommand {
             pendingLinkSessions: pendingLinkSessions,
             config: serverConfig
         )
-            .register(with: api)
+        .register(with: api)
         AccountRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
             .register(with: api)
         TransactionRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
@@ -87,7 +94,7 @@ struct PlaidBarServer: AsyncParsableCommand {
             tokenStore: tokenStore,
             pendingLinkSessions: pendingLinkSessions
         )
-            .register(with: router)
+        .register(with: router)
 
         // Build and run application
         var app = Application(
@@ -103,5 +110,21 @@ struct PlaidBarServer: AsyncParsableCommand {
         logger.info("Environment: \(serverConfig.plaidEnvironment.rawValue)")
 
         try await app.runService()
+    }
+
+    /// App-managed launches pass the app's PID so a crashed or force-killed
+    /// app never leaves an orphaned server holding token access. Reparenting
+    /// (getppid change) is the death signal: it cannot race PID reuse.
+    private func startParentWatchdog(parentPid: Int32, logger: Logger) {
+        Task.detached {
+            while true {
+                try? await Task.sleep(for: .seconds(2))
+                if getppid() != parentPid {
+                    logger.info("Parent app exited; shutting down app-managed server.")
+                    kill(getpid(), SIGTERM)
+                    break
+                }
+            }
+        }
     }
 }

--- a/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Server Auto-Launch Plan Tests")
+struct ServerAutoLaunchPlanTests {
+    private let bundledPath = "/Applications/PlaidBar.app/Contents/MacOS/PlaidBarServer"
+    private let dataDirectory = "/Users/example/.plaidbar"
+
+    @Test("Plan launches the bundled server with the configured server.conf")
+    func planLaunchesBundledServer() throws {
+        let plan = try #require(ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            parentProcessId: 4242
+        ))
+
+        #expect(plan.executablePath == bundledPath)
+        #expect(plan.arguments == [
+            "--config", "/Users/example/.plaidbar/server.conf",
+            "--exit-with-parent", "4242",
+        ])
+        #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
+    }
+
+    @Test("Plan normalizes a trailing slash in the data directory")
+    func planNormalizesTrailingSlash() throws {
+        let plan = try #require(ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory + "/",
+            configFileExists: true,
+            parentProcessId: 4242
+        ))
+
+        #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
+        #expect(plan.arguments.contains("--config"))
+        #expect(plan.arguments.contains("/Users/example/.plaidbar/server.conf"))
+    }
+
+    @Test("Plan declines without server.conf because the server cannot boot credential-less")
+    func planDeclinesWithoutConfigFile() {
+        let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: false,
+            parentProcessId: 4242
+        )
+
+        #expect(plan == nil)
+    }
+
+    @Test("Plan declines outside an app bundle so swift run stays developer-managed")
+    func planDeclinesOutsideAppBundle() {
+        let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: false,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            parentProcessId: 4242
+        )
+
+        #expect(plan == nil)
+    }
+
+    @Test("Plan declines when a server is already reachable")
+    func planDeclinesWhenServerReachable() {
+        let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: true,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            parentProcessId: 4242
+        )
+
+        #expect(plan == nil)
+    }
+
+    @Test("Plan declines in demo mode")
+    func planDeclinesInDemoMode() {
+        let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: true,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            parentProcessId: 4242
+        )
+
+        #expect(plan == nil)
+    }
+
+    @Test("Plan declines when the bundle has no server executable")
+    func planDeclinesWithoutBundledServer() {
+        for missingPath in [nil, ""] as [String?] {
+            let plan = ServerAutoLaunchPlan.evaluate(
+                bundledServerPath: missingPath,
+                isAppBundle: true,
+                isDemoMode: false,
+                serverAlreadyReachable: false,
+                dataDirectoryPath: dataDirectory,
+                configFileExists: true,
+                parentProcessId: 4242
+            )
+
+            #expect(plan == nil)
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
@@ -16,12 +16,14 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: false,
             dataDirectoryPath: dataDirectory,
             configFileExists: true,
+            port: 8484,
             parentProcessId: 4242
         ))
 
         #expect(plan.executablePath == bundledPath)
         #expect(plan.arguments == [
             "--config", "/Users/example/.plaidbar/server.conf",
+            "--port", "8484",
             "--exit-with-parent", "4242",
         ])
         #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
@@ -36,6 +38,7 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: false,
             dataDirectoryPath: dataDirectory + "/",
             configFileExists: true,
+            port: 8484,
             parentProcessId: 4242
         ))
 
@@ -53,6 +56,7 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: false,
             dataDirectoryPath: dataDirectory,
             configFileExists: false,
+            port: 8484,
             parentProcessId: 4242
         )
 
@@ -68,6 +72,7 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: false,
             dataDirectoryPath: dataDirectory,
             configFileExists: true,
+            port: 8484,
             parentProcessId: 4242
         )
 
@@ -83,6 +88,7 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: true,
             dataDirectoryPath: dataDirectory,
             configFileExists: true,
+            port: 8484,
             parentProcessId: 4242
         )
 
@@ -98,6 +104,7 @@ struct ServerAutoLaunchPlanTests {
             serverAlreadyReachable: false,
             dataDirectoryPath: dataDirectory,
             configFileExists: true,
+            port: 8484,
             parentProcessId: 4242
         )
 
@@ -114,6 +121,7 @@ struct ServerAutoLaunchPlanTests {
                 serverAlreadyReachable: false,
                 dataDirectoryPath: dataDirectory,
                 configFileExists: true,
+                port: 8484,
                 parentProcessId: 4242
             )
 

--- a/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
@@ -47,6 +47,50 @@ struct ServerAutoLaunchPlanTests {
         #expect(plan.arguments.contains("/Users/example/.plaidbar/server.conf"))
     }
 
+    @Test("Plan declines when managed server config moves the data directory")
+    func planDeclinesWhenConfigMovesDataDirectory() {
+        let plan = ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            configFileContents: """
+            PLAID_CLIENT_ID=test-client
+            PLAID_SECRET=test-secret
+            export PLAIDBAR_DATA_DIR=/tmp/plaidbar-other
+            """,
+            port: 8484,
+            parentProcessId: 4242
+        )
+
+        #expect(plan == nil)
+    }
+
+    @Test("Plan keeps overriding a configured server port for managed launch")
+    func planOverridesConfiguredServerPort() throws {
+        let plan = try #require(ServerAutoLaunchPlan.evaluate(
+            bundledServerPath: bundledPath,
+            isAppBundle: true,
+            isDemoMode: false,
+            serverAlreadyReachable: false,
+            dataDirectoryPath: dataDirectory,
+            configFileExists: true,
+            configFileContents: """
+            PLAID_CLIENT_ID=test-client
+            PLAID_SECRET=test-secret
+            PLAIDBAR_SERVER_PORT=9494
+            """,
+            port: 8484,
+            parentProcessId: 4242
+        ))
+
+        #expect(plan.arguments.contains("--port"))
+        #expect(plan.arguments.contains("8484"))
+        #expect(!plan.arguments.contains("9494"))
+    }
+
     @Test("Plan declines without server.conf because the server cannot boot credential-less")
     func planDeclinesWithoutConfigFile() {
         let plan = ServerAutoLaunchPlan.evaluate(

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,8 +1,12 @@
 # Release Runbook
 
-PlaidBar 1.0 ships as a source-built Homebrew formula first. A signed,
-notarized `.app` bundle, cask, Sparkle appcast, and DMG/ZIP archive are deferred
-until the signing and clean-machine Gatekeeper path is real.
+PlaidBar 1.0 ships as a source-built Homebrew formula first. A local
+drag-install DMG can be built with `./Scripts/package-dmg.sh`: it wraps a
+self-contained `PlaidBar.app` (app + bundled `PlaidBarServer`, auto-started on
+launch) with an `/Applications` symlink. The DMG is ad-hoc signed; Developer ID
+signing, notarization, cask, and the Sparkle appcast remain deferred until the
+clean-machine Gatekeeper path is real, so first launch needs right-click >
+Open and release notes must say so.
 
 ## Current Release
 


### PR DESCRIPTION
## Summary

- Adds `Scripts/package-dmg.sh`: builds a verified, drag-install `PlaidBar-<version>.dmg` (app + /Applications symlink) so non-developers can install without a terminal.
- `PlaidBar.app` is now self-contained: `package-app.sh` bundles `PlaidBarServer` next to the app binary and `validate-app-bundle.sh` enforces it.
- The app auto-starts the bundled server at launch via a tested `ServerAutoLaunchPlan` (PlaidBarCore): only from a real .app bundle, never in demo mode, never when a server is already reachable, and only when `~/.plaidbar/server.conf` exists (the server cannot boot credential-less, so spawning without it would crash-loop).
- `ServerProcessService` supervises the child: private (0600) `server.log`, SIGTERM on graceful quit; new `--exit-with-parent` server option makes the server self-exit if the app crashes or is force-killed, so no orphan ever outlives the app.
- Adds repo `CLAUDE.md`; documents the DMG install path in README Quick Start and `docs/release.md` (ad-hoc signing limits stated honestly: right-click > Open on first launch; notarization still deferred).

## Autonomous task IDs

- Task ID(s): release-roadmap DMG packaging (docs/release.md deferred list)
- Backlog slice: distribution / installer ease for non-developers
- Scope note: one focused slice; packaging scripts + minimal app/server launch supervision; no notarization or Sparkle appcast work.

## Agent coordination

- Builder agent: Claude (Fable 5, Claude Code session)
- Builder branch/worktree: feature/dmg-installer-bundle @ /Users/ftchvs/Developer/PlaidBar
- Reviewer/merge steward: Felipe (ftchvs)
- Coordination note: review only; no other agent should push to this branch.

## Changed files

- Scripts/package-dmg.sh (new), Scripts/package-app.sh, Scripts/validate-app-bundle.sh
- Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift (new) + Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift (new)
- Sources/PlaidBar/Services/ServerProcessService.swift (new), Sources/PlaidBar/App/AppState.swift, Sources/PlaidBar/App/PlaidBarApp.swift
- Sources/PlaidBarServer/App.swift (--exit-with-parent watchdog)
- CLAUDE.md (new), README.md, docs/release.md

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain` clean
- [x] `swift build --target PlaidBarServer` covered by the full strict build above
- [x] `swift test` — 332 tests pass (7 new ServerAutoLaunchPlan tests)
- [x] Secret scan completed: docs/examples use placeholder credentials only; smoke tests used synthetic sandbox-style values in an isolated temp dir
- [x] End-to-end verification: DMG built, mounted, codesign verified; app launch spawned bundled server (/health 200); SIGKILL of app → server self-exited via watchdog

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data. The managed server still binds 127.0.0.1 only.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties (README/release.md explicitly state ad-hoc signing and Gatekeeper implications).

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data (server.log holds the server's own logs, written 0600 inside ~/.plaidbar which is 0700).
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking (no AI changes in this PR).
- [x] Documentation, examples, fixtures, tests use sandbox or synthetic data and do not imply notarization or distribution properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes (no UI changes: launch supervision only).
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed (README Quick Start + docs/release.md).

## Merge safety

- All local gates pass; required CI must be green before merge.
- The auto-launch path is conservative: every developer workflow (swift run, run.sh, Homebrew plaidbar-run, externally managed servers) is explicitly unaffected, covered by unit tests.
- Worst-case failure mode verified manually: app SIGKILL leaves no orphaned server process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)