### PR TITLE
ux: strengthen error feedback and VoiceOver coverage on the dashboard

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1941,6 +1941,9 @@ private struct SelectedAccountPanel: View {
     }
 
     private var institutionTransactionCount: Int {
+        // The dialog message is evaluated as part of the panel body, so gate
+        // the full transaction scan on the dialog actually being presented.
+        guard isConfirmingAccountRemoval else { return 0 }
         let institutionAccountIds = Set(
             appState.accounts.filter { $0.itemId == account.itemId }.map(\.id)
         )
@@ -2525,7 +2528,11 @@ private struct ErrorBanner: View {
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Error: \(error)")
-        .onAppear {
+        .task(id: error) {
+            // Keyed by the error text so each distinct error is announced,
+            // not just the first one mounted; the task also yields once so
+            // the banner is in the hierarchy before VoiceOver speaks.
+            await Task.yield()
             AccessibilityNotification.Announcement("Error: \(error)").post()
         }
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -530,7 +530,7 @@ private struct BalanceCompositionStrip: View {
                             .fill(segment.fillColor)
                             .frame(width: segmentWidth(segment, totalWidth: proxy.size.width))
                             .accessibilityLabel(
-                                "\(segment.title), \(Formatters.currency(segment.value, format: .compact))"
+                                "\(segment.title), \(Formatters.currency(segment.value, format: .compact)), \(segmentPercentText(segment)) of balance mix"
                             )
                     }
                 }
@@ -559,6 +559,10 @@ private struct BalanceCompositionStrip: View {
         let gaps = CGFloat(max(activeSegments.count - 1, 0)) * segmentSpacing
         let availableWidth = max(totalWidth - gaps, 0)
         return max(availableWidth * CGFloat(segment.value / total), 6)
+    }
+
+    private func segmentPercentText(_ segment: BalanceCompositionSegment) -> String {
+        "\(Int((segment.value / total * 100).rounded()))%"
     }
 }
 
@@ -1227,6 +1231,8 @@ private struct StatusMetricPill: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(value)")
     }
 }
 
@@ -1600,6 +1606,9 @@ private struct DashboardAccountRow: View {
                 .frame(width: 28, height: 28)
                 .background(accountTint.opacity(0.16), in: RoundedRectangle(cornerRadius: 8))
                 .overlay(alignment: .bottomTrailing) {
+                    // Decorative reinforcement only: the row subtitle carries
+                    // the connection state in text, so the tinted dot is
+                    // hidden from VoiceOver instead of being color-only.
                     Circle()
                         .fill(statusTint)
                         .frame(width: 8, height: 8)
@@ -1607,6 +1616,7 @@ private struct DashboardAccountRow: View {
                             Circle()
                                 .stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5)
                         }
+                        .accessibilityHidden(true)
                 }
 
             VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
@@ -1926,8 +1936,20 @@ private struct SelectedAccountPanel: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus cached local transactions from PlaidBar. It does not close any bank account.")
+            Text("This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from PlaidBar. It does not close any bank account.")
         }
+    }
+
+    private var institutionTransactionCount: Int {
+        let institutionAccountIds = Set(
+            appState.accounts.filter { $0.itemId == account.itemId }.map(\.id)
+        )
+        return appState.transactions.count { institutionAccountIds.contains($0.accountId) }
+    }
+
+    private var institutionTransactionCountText: String {
+        let count = institutionTransactionCount
+        return count == 1 ? "1 cached local transaction" : "\(count) cached local transactions"
     }
 
     private var availableText: String {
@@ -2477,12 +2499,16 @@ private struct ErrorBanner: View {
     let error: String
 
     var body: some View {
-        HStack {
+        HStack(alignment: .firstTextBaseline) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.yellow)
+                .foregroundStyle(SemanticColors.negative)
+                .accessibilityHidden(true)
+            // Sanitized errors are capped at 220 characters upstream, so an
+            // uncapped line count stays bounded while never truncating the
+            // actionable part of the message.
             Text(error)
                 .font(.caption)
-                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
             Spacer()
             Button {
                 appState.error = nil
@@ -2495,7 +2521,12 @@ private struct ErrorBanner: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 7)
-        .background(.red.opacity(0.1))
+        .background(SemanticColors.negative.opacity(0.1))
         .transition(.move(edge: .bottom).combined(with: .opacity))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Error: \(error)")
+        .onAppear {
+            AccessibilityNotification.Announcement("Error: \(error)").post()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Five confirmed findings from a 35-agent Apple HIG design review (feedback + accessibility dimensions, per [HIG design principles](https://developer.apple.com/design/human-interface-guidelines/design-principles)), each adversarially verified before implementation:

- **ErrorBanner (high)**: the 2-line truncation could cut off actionable error text (sanitized errors run up to 220 chars); now shows the full message. The yellow icon on a red background mixed warning/error semantics — now uses the semantic negative color. Adds a combined `Error: …` VoiceOver label and posts an `AccessibilityNotification.Announcement` on appear so VoiceOver users hear errors immediately.
- **Balance Mix color-only meaning (high)**: each segment's VoiceOver label now includes its percentage of the mix, so the composition is understandable without the color legend.
- **Account removal dialog (medium)**: now states the exact cached-transaction count being removed (HIG forgiveness: tell the user precisely what a destructive action does).
- **StatusMetricPill (medium)**: combined VoiceOver label ("Server: Local") replaces two disconnected text nodes.
- **Account row status dot (medium)**: marked decorative for VoiceOver; the subtitle text already carries connection state, so the tinted dot is reinforcement, not a color-only channel.

Two spacing-token findings from the same review were intentionally **not** implemented: the suggested token swaps (10pt → `Spacing.sm`=8pt) would alter visuals under the guise of consistency — flagged as churn.

## Autonomous task IDs

- Task ID(s): HIG review findings hig-feedback#1, accessibility#2, hig-feedback#6, accessibility#7, accessibility#8
- Backlog slice: HIG feedback + accessibility fixes from 2026-06-11 multi-agent review
- Scope note: one focused slice; UI/accessibility only, no logic changes.

## Agent coordination

- Builder agent: Claude (Fable 5, Claude Code session)
- Builder branch/worktree: ux/hig-feedback-accessibility @ /Users/ftchvs/Developer/PlaidBar
- Reviewer/merge steward: Felipe (ftchvs)
- Coordination note: review only; no other agent should push to this branch.

## Changed files

- Sources/PlaidBar/Views/MainPopover.swift

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain` clean
- [x] No server/shared DTO changes (UI only)
- [x] `swift test` — 325 tests pass
- [x] Secret scan completed: no credentials or real data; demo render verified with fixtures
- [x] Demo-mode render sanity check passed (`--demo --show-popover`)

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary.
- [x] User-facing copy remains honest (removal dialog is now more precise about what is deleted).

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document secrets or real financial data (error text shown was already sanitized upstream by UserFacingError).
- [x] VoiceOver labels expose only data already rendered on screen.
- [x] No server, storage, setup, or diagnostics changes.
- [x] No AI behavior changes.
- [x] No fixtures or screenshots added.

## UI and accessibility checks

- [x] Keyboard access unchanged; dismiss button keeps its focusable borderless style.
- [x] VoiceOver labels spot-checked: ErrorBanner announces; pills and segments read combined labels.
- [x] Balance/error meaning no longer relies on color alone (percent labels, semantic negative color, decorative dot).
- [x] No user-visible flow changes requiring doc/screenshot updates (banner text length and dialog copy are more complete, same surfaces).

## Merge safety

- UI-only diff in MainPopover.swift; all gates green; demo render verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)