### PR TITLE
test: lock down status readiness payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ when the local app created the Hosted Link session.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/health` | Health check |
-| `GET` | `/api/status` | Server version, environment, item count, synced item count, storage readiness |
+| `GET` | `/api/status` | Readiness metadata only: server version, environment, item/synced counts, last sync, credential/storage readiness; no secrets, account IDs, balances, transactions, Plaid tokens, or raw payloads |
 | `GET` | `/api/items` | List connected bank items |
 | `POST` | `/api/link/create` | Create one-time Plaid Hosted Link token + URL |
 | `POST` | `/api/link/update/:itemId` | Create one-time Plaid Hosted Link update-mode URL for reconnect |

--- a/Sources/PlaidBarCore/Models/ServerStatus.swift
+++ b/Sources/PlaidBarCore/Models/ServerStatus.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Response from server's /api/status
+/// Response from server's /api/status.
+///
+/// Contract: readiness metadata only. Do not add secrets, account IDs,
+/// balances, transactions, Plaid tokens, or raw provider payloads here.
 public struct ServerStatus: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case version

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -59,7 +59,7 @@ struct PlaidBarServerTests {
         #expect(decoded.syncReady)
     }
 
-    @Test func serverStatusPayloadDoesNotExposeSecretsOrTokens() throws {
+    @Test func serverStatusPayloadIsLimitedToReadinessMetadata() throws {
         let status = ServerStatus(
             version: "0.8.0",
             environment: .production,
@@ -76,20 +76,8 @@ struct PlaidBarServerTests {
         let data = try encoder.encode(status)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let keys = Set(object.keys)
-        let forbiddenFragments = [
-            "account",
-            "access",
-            "balance",
-            "client",
-            "institution",
-            "itemId",
-            "public",
-            "secret",
-            "token",
-            "transaction",
-        ]
-
-        #expect(keys == [
+        let payload = try #require(String(data: data, encoding: .utf8))
+        let allowedReadinessKeys: Set<String> = [
             "version",
             "environment",
             "itemCount",
@@ -98,12 +86,39 @@ struct PlaidBarServerTests {
             "storagePath",
             "syncReady",
             "syncedItemCount",
-        ])
-        #expect(try !(#require(String(data: data, encoding: .utf8)?.contains("config-secret"))))
-        #expect(try !(#require(String(data: data, encoding: .utf8)?.contains("access-sandbox"))))
+        ]
+        let forbiddenFragments = [
+            "account",
+            "access",
+            "balance",
+            "client",
+            "institution",
+            "item_id",
+            "itemId",
+            "payload",
+            "plaid",
+            "public",
+            "raw",
+            "secret",
+            "token",
+            "transaction",
+        ]
+
+        #expect(keys == allowedReadinessKeys)
         #expect(keys.allSatisfy { key in
             forbiddenFragments.allSatisfy { !key.localizedCaseInsensitiveContains($0) }
         })
+        #expect(!payload.contains("\"accountId\""))
+        #expect(!payload.contains("\"account_id\""))
+        #expect(!payload.contains("\"access_token\""))
+        #expect(!payload.contains("\"balance\""))
+        #expect(!payload.contains("\"balances\""))
+        #expect(!payload.contains("\"clientSecret\""))
+        #expect(!payload.contains("\"client_secret\""))
+        #expect(!payload.contains("\"plaidToken\""))
+        #expect(!payload.contains("\"publicToken\""))
+        #expect(!payload.contains("\"rawPayload\""))
+        #expect(!payload.contains("\"transactions\""))
     }
 
     @Test func serverConfigLoadsExplicitConfigFile() throws {

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -135,7 +135,7 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-010: Status And Diagnostics
 
-- [ ] T046: Keep `/api/status` limited to readiness metadata.
+- [x] T046: Keep `/api/status` limited to readiness metadata.
 - [ ] T047: Add or verify UI treatment for server offline, syncing, stale data,
   credentials missing, and linked item counts.
 - [ ] T048: Add a local-only diagnostic row for the active data directory.


### PR DESCRIPTION
## Summary
- Locks `/api/status` to readiness metadata only.
- Documents the server status DTO privacy contract.
- Expands server payload coverage to reject sensitive account/token/balance/transaction/raw-payload keys.

## Autonomous task IDs
Task ID(s): T046
Backlog slice: PR-010 Status And Diagnostics
Scope note: Server status API contract and focused tests only; no runtime status fields were added.

## Agent coordination
Builder agent: Codex CLI autonomous worker
Builder branch/worktree: `auto/and-305-status-redaction` / `/tmp/plaidbar-autonomous-20260611-172815/and-305-status-redaction`
Reviewer/merge steward: Otto
Coordination note: Independent branch from `origin/main`; overlaps only the PR-010 backlog ledger with sibling status/diagnostics branches.

## Changed files
- `README.md`
- `Sources/PlaidBarCore/Models/ServerStatus.swift`
- `Tests/PlaidBarServerTests/PlaidBarServerTests.swift`
- `docs/autonomous-loop-backlog.md`

## Local gates
- [x] `git diff --check`
- [x] `swift test --scratch-path /Users/otto/workspace/PlaidBar/.build-loop-and305 --skip-update --disable-keychain --filter serverStatusPayloadIsLimitedToReadinessMetadata`
- [x] `swift build --scratch-path /Users/otto/workspace/PlaidBar/.build-loop-and305 --target PlaidBarServer --skip-update --disable-keychain`
- [x] Changed-line secret scan for actual token/key material: `secret-scan-clean`

## GitHub checks
Pending on PR creation.

## Privacy and safety impact
Improves privacy posture by making `/api/status` a readiness-only contract and testing that sensitive identifiers, balances, tokens, transactions, and raw payload keys are not present.

## Merge safety
Small server/test/docs slice. Expected conflict area is only `docs/autonomous-loop-backlog.md` if sibling PR-010 branches merge first; preserve all completed task checkmarks when rebasing.
