### PR TITLE
feat: add local status diagnostics

### DIFF
--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import AppKit
 import PlaidBarCore
+import SwiftUI
 
 struct StatusView: View {
     @Environment(AppState.self) private var appState
@@ -12,6 +12,8 @@ struct StatusView: View {
 
             AttentionQueueView(title: "ATTENTION")
                 .environment(appState)
+
+            localDataDirectoryRow
 
             diagnosticsGrid
 
@@ -46,6 +48,42 @@ struct StatusView: View {
         .padding(Spacing.md)
         .background(.quaternary.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var localDataDirectoryRow: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: "internaldrive")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 26, height: 26)
+                .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 7))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Active data directory")
+                    .font(.caption.weight(.semibold))
+
+                Text(appState.activeStorageDirectoryDisplayText)
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Text("Local-only diagnostics; credentials and Plaid IDs are not shown.")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: Spacing.xs)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.rowVertical)
+        .nativePanelSurface()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Active data directory: \(appState.activeStorageDirectoryDisplayText). Local-only diagnostics; credentials and Plaid IDs are not shown."
+        )
     }
 
     private var diagnosticsGrid: some View {
@@ -108,12 +146,6 @@ struct StatusView: View {
                 title: "Endpoint",
                 value: appState.localServerURLText.replacingOccurrences(of: "http://", with: ""),
                 icon: "network",
-                color: .secondary
-            )
-            DiagnosticTile(
-                title: "Storage",
-                value: appState.serverStorageDisplayText,
-                icon: "internaldrive",
                 color: .secondary
             )
             DiagnosticTile(
@@ -183,12 +215,6 @@ struct StatusView: View {
         let readiness = appState.dashboardStatusReadiness
 
         return VStack(alignment: .leading, spacing: Spacing.sm) {
-            HStack(spacing: Spacing.xs) {
-                Image(systemName: "lock.doc")
-                Text("Local data directory: \(appState.activeStorageDirectoryDisplayText)")
-            }
-            .detailText()
-
             Text("RECOVERY")
                 .sectionTitle()
                 .foregroundStyle(.secondary)
@@ -289,11 +315,11 @@ struct StatusView: View {
     private func itemBackground(for status: ItemConnectionStatus) -> Color {
         switch status {
         case .connected:
-            return SemanticColors.positive.opacity(0.045)
+            SemanticColors.positive.opacity(0.045)
         case .loginRequired:
-            return SemanticColors.warning.opacity(0.08)
+            SemanticColors.warning.opacity(0.08)
         case .error:
-            return SemanticColors.negative.opacity(0.08)
+            SemanticColors.negative.opacity(0.08)
         }
     }
 
@@ -361,7 +387,8 @@ struct StatusView: View {
         readiness: DashboardStatusReadiness
     ) -> String {
         if action == .reconnect,
-           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
+           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses)
+        {
             return title
         }
         return readiness.primaryActionTitle ?? action.defaultTitle

--- a/Sources/PlaidBarCore/Utilities/UserFacingError.swift
+++ b/Sources/PlaidBarCore/Utilities/UserFacingError.swift
@@ -15,13 +15,35 @@ public enum UserFacingError {
         guard !sanitized.isEmpty else { return nil }
 
         sanitized = sanitized
-            .redacting(pattern: #"(?i)["']?\b(authorization)\b["']?\s*[:=]\s*["']?Bearer\s+[^"',}\s]+"#, template: "$1: Bearer [redacted]")
+            .redacting(
+                pattern: #"(?i)["']?\b(authorization)\b["']?\s*[:=]\s*["']?Bearer\s+[^"',}\s]+"#,
+                template: "$1: Bearer [redacted]"
+            )
             .redacting(pattern: #"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b"#, template: "Bearer [redacted]")
-            .redacting(pattern: #"(?i)\b(access|public|link|processor)-(sandbox|development|production)-[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-token]")
-            .redacting(pattern: #"(?i)["']?\b(access[-_ ]?token|public[-_ ]?token|link[-_ ]?token|processor[-_ ]?token|client[-_ ]?id|client[-_ ]?secret|secret)\b["']?\s*[:=]\s*["']?[^"',}\s]+"#, template: "$1: [redacted]")
-            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)\[[^\]]*\]"#, template: "$1[redacted-id]")
-            .redacting(pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)(["']?)[^"',}\]\[\s&]+(["']?)"#, template: "$1$3[redacted-id]$4")
-            .redacting(pattern: #"(?i)\b(access|public|link|processor|item|account|transaction|txn|ins)_[A-Za-z0-9_-]{8,}\b"#, template: "[redacted-id]")
+            .redacting(
+                pattern: #"(?i)\b(access|public|link|processor)-(sandbox|development|production)-[A-Za-z0-9_-]{8,}\b"#,
+                template: "[redacted-token]"
+            )
+            .redacting(
+                pattern: #"(?i)["']?\b(access[-_ ]?token|public[-_ ]?token|link[-_ ]?token|processor[-_ ]?token|client[-_ ]?id|client[-_ ]?secret|secret)\b["']?\s*[:=]\s*["']?[^"',}\s]+"#,
+                template: "$1: [redacted]"
+            )
+            .redacting(
+                pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)\[[^\]]*\]"#,
+                template: "$1[redacted-id]"
+            )
+            .redacting(
+                pattern: #"(?i)(["']?\b(item_id|item_ids|account_id|account_ids|transaction_id|transaction_ids|txn_id|txn_ids|institution_id|institution_ids|request_id|cursor|cursor_id|link_session_id|transfer_id)\b["']?\s*[:=]\s*)(["']?)[^"',}\]\[\s&]+(["']?)"#,
+                template: "$1$3[redacted-id]$4"
+            )
+            .redacting(
+                pattern: #"(?i)(["']?\b(available|available_balance|balance|balances|current|current_balance|limit|balance_limit)\b["']?\s*[:=]\s*)(["']?)-?\$?\d[\d,]*(?:\.\d+)?(["']?)"#,
+                template: "$1$3[redacted-balance]$4"
+            )
+            .redacting(
+                pattern: #"(?i)\b(access|public|link|processor|item|account|transaction|txn|ins)_[A-Za-z0-9_-]{8,}\b"#,
+                template: "[redacted-id]"
+            )
 
         sanitized = sanitized.removingStackTraceDetails()
 
@@ -36,7 +58,7 @@ private extension String {
             return self
         }
 
-        let range = NSRange(startIndex..<endIndex, in: self)
+        let range = NSRange(startIndex ..< endIndex, in: self)
         return expression.stringByReplacingMatches(
             in: self,
             options: [],
@@ -51,7 +73,7 @@ private extension String {
             " traceback ",
             " at sources/",
             " at /",
-            ".swift:"
+            ".swift:",
         ]
         let lowercased = lowercased()
 

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import PlaidBarCore
+import Testing
 
 @Suite("AttentionQueue Tests")
 struct AttentionQueueTests {
@@ -59,6 +59,40 @@ struct AttentionQueueTests {
         #expect(joinedDisplayCopy.contains("\(secretName): [redacted]"))
     }
 
+    @Test("Queue presentation does not expose item IDs or raw balances")
+    func presentationHidesSensitiveIdentifiersAndBalances() {
+        let accountID = "accountSensitiveIdentifier"
+        let itemID = "itemSensitiveIdentifier"
+        let balance = "12345.67"
+        let currentBalance = "-890.12"
+
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: itemID, institutionName: "Example Bank", status: .loginRequired),
+            ],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: "Plaid failed account_id=\(accountID) item_id=\(itemID) balance=\(balance) current_balance=\(currentBalance)"
+        )
+
+        let joinedDisplayCopy = queue.rows
+            .flatMap { [$0.title, $0.detail, $0.actionTitle ?? "", $0.accessibilityLabel, $0.accessibilityHint ?? ""] }
+            .joined(separator: " ")
+
+        #expect(joinedDisplayCopy.contains(accountID) == false)
+        #expect(joinedDisplayCopy.contains(itemID) == false)
+        #expect(joinedDisplayCopy.contains(balance) == false)
+        #expect(joinedDisplayCopy.contains(currentBalance) == false)
+        #expect(joinedDisplayCopy.contains("[redacted-id]"))
+        #expect(joinedDisplayCopy.contains("[redacted-balance]"))
+    }
+
     @Test("Queue preserves server mode mismatch recovery action")
     func preservesServerModeMismatchRecoveryAction() {
         let queue = AttentionQueue.evaluate(
@@ -100,7 +134,8 @@ struct AttentionQueueTests {
 
         #expect(queue.rows.map(\.id) == ["credentials-missing"])
         #expect(queue.rows.first?.action == .openSettings)
-        #expect(queue.rows.contains { $0.action == .addAccount || $0.action == .reconnect || $0.action == .refresh } == false)
+        #expect(queue.rows
+            .contains { $0.action == .addAccount || $0.action == .reconnect || $0.action == .refresh } == false)
     }
 
     @Test("Queue ranks server mode mismatch above item reconnect rows")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2791,6 +2791,42 @@ struct PlaidBarCoreTests {
         #expect(readiness.primaryAction == .refresh)
     }
 
+    @Test("Dashboard status readiness hides sensitive IDs and raw balances")
+    func dashboardStatusReadinessHidesSensitiveIDsAndRawBalances() {
+        let accountID = "accountSensitiveIdentifier"
+        let itemID = "itemSensitiveIdentifier"
+        let balance = "12345.67"
+        let currentBalance = "-890.12"
+
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: "Plaid failed account_id=\(accountID) item_id=\(itemID) balance=\(balance) current_balance=\(currentBalance)"
+        )
+
+        let displayCopy = [
+            readiness.title,
+            readiness.detail,
+            readiness.primaryActionTitle ?? "",
+            readiness.primaryActionIconName ?? "",
+        ].joined(separator: " ")
+
+        #expect(displayCopy.contains(accountID) == false)
+        #expect(displayCopy.contains(itemID) == false)
+        #expect(displayCopy.contains(balance) == false)
+        #expect(displayCopy.contains(currentBalance) == false)
+        #expect(displayCopy.contains("[redacted-id]"))
+        #expect(displayCopy.contains("[redacted-balance]"))
+    }
+
     @Test("Dashboard status readiness blocks on missing credentials")
     func dashboardStatusReadinessBlocksOnMissingCredentials() {
         let readiness = DashboardStatusReadiness.evaluate(

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -138,9 +138,9 @@ and `docs/autonomous-roadmap.md`.
 - [ ] T046: Keep `/api/status` limited to readiness metadata.
 - [ ] T047: Add or verify UI treatment for server offline, syncing, stale data,
   credentials missing, and linked item counts.
-- [ ] T048: Add a local-only diagnostic row for the active data directory.
+- [x] T048: Add a local-only diagnostic row for the active data directory.
 - [ ] T049: Make status refresh and connect actions reachable from the dashboard.
-- [ ] T050: Add tests that status presentation does not include sensitive IDs or
+- [x] T050: Add tests that status presentation does not include sensitive IDs or
   raw balances.
 
 ### PR-011: Local Data Controls

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -323,6 +323,11 @@ remain unmarked.
   intent, dashboard story, expected recovery state, asset traceability, and
   reduced-noise composition guidance; evidence: `docs/demo-scenarios.md`,
   `docs/screenshots.md`, and `README.md`.
+- 2026-06-12 [T048] [T050]: added a dedicated local-only active data directory
+  diagnostic row to the Status surface and regression coverage that status
+  readiness and attention queue presentation copy redacts sensitive IDs and
+  keyed raw balances; evidence: `StatusView`, `UserFacingError`, and focused
+  core tests.
 
 ## Backlog Source
 


### PR DESCRIPTION
## Summary
- Adds a dedicated local-only active data directory row to the Status surface.
- Expands user-facing error redaction for keyed raw balances.
- Adds focused presentation tests for sensitive IDs and raw balance redaction.

## Autonomous task IDs
Task ID(s): T048, T050
Backlog slice: PR-010 Status And Diagnostics
Scope note: Status diagnostics UI and presentation redaction tests only; no Plaid API or persistence behavior changed.

## Agent coordination
Builder agent: Codex CLI autonomous worker
Builder branch/worktree: `auto/and-306-status-directory` / `/tmp/plaidbar-autonomous-20260611-172815/and-306-status-directory`
Reviewer/merge steward: Otto
Coordination note: Independent branch from `origin/main`; overlaps PR-010 backlog/roadmap ledger with sibling branches.

## Changed files
- `Sources/PlaidBar/Views/StatusView.swift`
- `Sources/PlaidBarCore/Utilities/UserFacingError.swift`
- `Tests/PlaidBarCoreTests/AttentionQueueTests.swift`
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`
- `docs/autonomous-loop-backlog.md`
- `docs/autonomous-roadmap.md`

## Local gates
- [x] `git diff --check`
- [x] `swift test --scratch-path /Users/otto/workspace/PlaidBar/.build-loop-and306 --skip-update --disable-keychain --filter AttentionQueueTests`
- [x] `swift test --scratch-path /Users/otto/workspace/PlaidBar/.build-loop-and306 --skip-update --disable-keychain --filter dashboardStatusReadinessHidesSensitiveIDsAndRawBalances`
- [x] `swift build --scratch-path /Users/otto/workspace/PlaidBar/.build-loop-and306 --target PlaidBar --skip-update --disable-keychain`
- [x] Changed-line secret scan: `secret-scan-clean`

## GitHub checks
Pending on PR creation.

## Privacy and safety impact
Displays only local filesystem diagnostics and adds regression coverage so status/readiness/attention presentation copy redacts sensitive IDs and keyed balances.

## Merge safety
UI/core test slice. Expected conflict area is PR-010 backlog/roadmap ledger if sibling status PRs merge first; preserve all completed task entries when rebasing.
