### PR TITLE
feat: dashboard redesign — RepoBar-style height + left account fly-out

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,10 +23,15 @@ Visual design spec and component catalog for PlaidBar.
 
 ### Utilization Gradient
 
+Yellow is excluded from the text ramp: yellow caption text falls below 4.5:1
+contrast in both appearances. The icon ladder carries the severity step inside
+the shared orange band, and dashboard rows show the icon + tint only at or
+above the user's warning threshold — below it the line stays `.secondary`.
+
 | Range | Color | Icon |
 |-------|-------|------|
 | 0-29% | Green | `checkmark.circle` |
-| 30-49% | Yellow | `exclamationmark.triangle` |
+| 30-49% | Orange | `exclamationmark.triangle` |
 | 50-74% | Orange | `exclamationmark.triangle.fill` |
 | 75%+ | Red | `xmark.octagon` |
 
@@ -56,12 +61,16 @@ Category colors from `SpendingCategory.colorHex` — fixed hex values for chart 
 
 ## Typography Scale
 
-5 levels, implemented as ViewModifiers in `Typography.swift`:
+Implemented as ViewModifiers in `Typography.swift`. Weights are capped at
+semibold; labels are medium — hierarchy comes from size, casing, and opacity,
+not boldness.
 
 | Level | Token | SwiftUI | Used For |
 |-------|-------|---------|----------|
-| Hero | `.heroBalance()` | `.system(size: 28, weight: .bold, design: .rounded).monospacedDigit()` | Net balance header |
-| Title | `.sectionTitle()` | `.caption.weight(.semibold).textCase(.uppercase)` | BANK ACCOUNTS, CREDIT CARDS |
+| Display | `.displayBalance()` | `.system(size: 30, weight: .semibold).monospacedDigit()` | The one hero number per surface (net worth) |
+| Hero (legacy) | `.heroBalance()` | `.system(size: 28, weight: .bold, design: .rounded).monospacedDigit()` | Legacy detail surfaces only |
+| Title | `.sectionTitle()` | `.caption.weight(.medium).textCase(.uppercase)` | ACCOUNTS, 365D SPEND |
+| Data | `.dataText()` | `.callout.weight(.semibold).monospacedDigit()` | Row amounts, tabular figures |
 | Body | system `.body` | default | Account names, transaction names |
 | Detail | `.detailText()` | `.caption` + `.secondary` | Masks, categories, dates |
 | Micro | `.microText()` | `.caption2.weight(.medium)` | Pending badge, percentages |
@@ -106,18 +115,24 @@ Category colors from `SpendingCategory.colorHex` — fixed hex values for chart 
 ## Native Surface System
 
 PlaidBar is a macOS menu bar instrument, so surfaces should feel native,
-translucent, and compact rather than like stacked web cards. Shared surface
-tokens live in `SurfaceTokens` and shared modifiers live in
-`SharedModifiers.swift`.
+translucent, and compact rather than like stacked web cards. The dashboard
+uses the three-rank `glassSurface(_:)` system in `SharedModifiers.swift`:
+ranks use *hierarchical* shape styles (`.quaternary`/`.quinary`) so surfaces
+participate in macOS vibrancy over the `.regularMaterial` popover root.
+Default surfaces draw **no stroke** — separation comes from spacing;
+hairlines are reserved for emphasized (attention) states. Surfaces never
+nest more than two ranks below the popover root.
 
 | Token/Modifier | Purpose |
 |----------------|---------|
-| `SurfaceTokens.panelFillOpacity` | Default quiet panel fill for dashboard, detail, and recovery surfaces |
-| `SurfaceTokens.insetFillOpacity` | Compact inset controls such as segmented filters and metric pills |
-| `SurfaceTokens.selectedFillOpacity` | Selected account row highlight, backed by a visible accent rail |
-| `SurfaceTokens.panelStrokeOpacity` | Hairline separators around native surfaces |
-| `.nativePanelSurface(...)` | Shared rounded panel treatment with material/fill fallback and optional Liquid Glass enhancement |
-| `.nativeInsetSurface(...)` | Smaller, non-glass inset treatment for controls and dense metric pills |
+| `.glassSurface(.raised)` | Primary content panels: account list, fly-out, heatmap |
+| `.glassSurface(.inset)` | Quiet secondary surfaces: metric strip, balance mix, insights |
+| `.glassSurface(.emphasized(tint))` | Attention states only — tinted fill plus hairline |
+| `Radius.panel` / `.control` / `.cell` | 8 / 6 / 2pt corner radius scale |
+| `Sizing` | Icon (16/20/28), status dot (8), 24pt minimum hit target |
+| `MotionTokens.micro/.standard/.content` | 120ms / 200ms / spring(0.3, 0.85); all gated by `MotionTokens.animation(_:reduceMotion:)` |
+| `.hoverHighlight()` | Rounded, 120ms-animated hover wash for rows |
+| `.nativePanelSurface(...)` / `.nativeInsetSurface(...)` | Legacy fill+stroke treatment still used by setup/attention surfaces |
 
 Liquid Glass is a progressive enhancement only. Apple SwiftUI's `Glass.regular`
 and `glassEffect` APIs are macOS 26+, while PlaidBar currently supports
@@ -132,15 +147,18 @@ Liquid Glass and keep a SwiftUI material/fill fallback.
 filter bar, dense rows, selected row highlight, and chevron-based drill-in. Use
 the RepoBar visual language as inspiration, not as literal GitHub UI.
 
-**Target anatomy:** VStack | compact net-worth header | status strip |
-Financial heatmap header (`last 365 days`, Spend or Net mode) | segmented
-filter bar (`All`, `Cash`, `Credit`, `Savings`, `Debt`, `Status`) | summary and
-balance context | list of account/card rows | inline selected account/card
-detail surface.
+**Target anatomy:** HStack | optional account-detail fly-out (left, 320pt) |
+dashboard column: net-worth hero (alone — no wordmark, no status strip) |
+change receipt | financial heatmap (`last 365 days`, Spend or Net mode) |
+native segmented filter (`All`, `Cash`, `Credit`, `Savings`, `Debt`,
+`Status`) | account/card rows | summary and balance context | footer with the
+single sync/mode status line. Selecting a row opens the fly-out to the LEFT
+of the dashboard (popover widens 480 → 801pt); Esc, the ✕ button, re-clicking
+the row, or switching filters closes it.
 
 | Element | PlaidBar Meaning |
 |---------|------------------|
-| Heatmap header | Daily spending intensity or net cashflow from transactions, switchable in place. Spend mode uses a GitHub-style green Less/More legend; Net mode uses bidirectional Income/Outflow color keys. |
+| Heatmap header | Daily spending intensity or net cashflow from transactions, switchable in place. Spend mode uses a NEUTRAL Less/More intensity ramp (green means money-in everywhere else in the app); Net mode uses bidirectional Income/Outflow color keys with an explicit legend. |
 | Repo row | Account/card row with institution, type, balance, status, and freshness |
 | Repo stats | Balance, available credit, utilization, pending count, sync state |
 | Selected repo highlight | Selected account/card detail target |
@@ -160,6 +178,33 @@ trailing primary metric (balance owed/cash balance) | secondary metric
 | Degraded item | Warning status and `Reconnect` in detail surface |
 | Selected | Blue/accent highlight matching native menu selection; detail surface opens |
 | No data | Keep overview shell and show one compact recovery action |
+
+### AccountDetailFlyout
+
+The contextual account submenu. Opens to the LEFT of the dashboard when an
+account row is selected; one `raised`-rank surface, sections separated by
+spacing (never nested cards).
+
+**Anatomy:** header (account name + institution/type/mask metadata + close ✕)
+| Status (connection badge + sync freshness + recovery action when degraded)
+| Balances (Available / Current / Utilization) | Changes · 30 days (spending
+and income totals with signed deltas vs the prior 30-day window — arrow +
+sign + color, never color alone) | To review (pending + large transactions
+with reason chips) | Top categories · 30 days (icon + name + total + share
+bar) | Recent activity (6 rows) | account actions (reconnect / remove /
+settings).
+
+**Code reference:** `Sources/PlaidBar/Views/AccountDetailFlyout.swift`;
+insight math in `Sources/PlaidBarCore/Utilities/AccountDetailInsights.swift`
+(pure, tested).
+
+| State | Behavior |
+|-------|----------|
+| Open | Popover widens 480 → 801pt; fly-out animates in with `MotionTokens.content` (gated by Reduce Motion) |
+| Close | ✕ button, Esc, re-clicking the selected row, or switching filters |
+| Degraded item | Status section shows recovery detail + Reconnect/Refresh action |
+| No review items / categories | Sections are omitted entirely, never shown empty |
+| Demo mode | Actions reduce to the demo-safe set (`DashboardDrillInAction.accountDrillInActions`) |
 
 ### AccountRow
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -129,7 +129,7 @@ nest more than two ranks below the popover root.
 | `.glassSurface(.inset)` | Quiet secondary surfaces: metric strip, balance mix, insights |
 | `.glassSurface(.emphasized(tint))` | Attention states only — tinted fill plus hairline |
 | `Radius.panel` / `.control` / `.cell` | 8 / 6 / 2pt corner radius scale |
-| `Sizing` | Icon (16/20/28), status dot (8), 24pt minimum hit target |
+| `Sizing` | Icon (16/20/28), status dot (8), 28pt minimum hit target |
 | `MotionTokens.micro/.standard/.content` | 120ms / 200ms / spring(0.3, 0.85); all gated by `MotionTokens.animation(_:reduceMotion:)` |
 | `.hoverHighlight()` | Rounded, 120ms-animated hover wash for rows |
 | `.nativePanelSurface(...)` / `.nativeInsetSurface(...)` | Legacy fill+stroke treatment still used by setup/attention surfaces |

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -443,7 +443,10 @@ private struct FlyoutChangeRow: View {
     }
 
     private var accessibilityText: String {
-        let direction = delta > 0 ? "up" : delta < 0 ? "down" : "unchanged"
+        if delta == 0 {
+            return "\(title) \(Formatters.currency(total, format: .full)) in the last 30 days, unchanged versus the prior 30 days"
+        }
+        let direction = delta > 0 ? "up" : "down"
         return "\(title) \(Formatters.currency(total, format: .full)) in the last 30 days, \(direction) \(Formatters.currency(abs(delta), format: .full)) versus the prior 30 days"
     }
 }

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -1,0 +1,676 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Account Detail Fly-out
+
+/// The contextual account panel that opens to the LEFT of the dashboard when
+/// an account row is selected. One `raised` surface, sections separated by
+/// spacing: metadata header, status, balances, 30-day changes, transactions
+/// to review, top categories, recent activity, and account actions.
+struct AccountDetailFlyout: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
+    let account: AccountDTO
+    let isStatusFilter: Bool
+    let onClose: () -> Void
+    @State private var isConfirmingAccountRemoval = false
+
+    var body: some View {
+        // Derived once per body evaluation — the snapshot filters and sorts
+        // the full transaction feed, so it must never live in computed
+        // properties that re-run per access (same hoist-once rule as
+        // BalanceActivityHeatmap.currentLayout()).
+        let connection = connectionPresentation
+        let snapshot = appState.accountActivitySnapshot(for: account.id)
+        let insights = AccountDetailInsights.compute(transactions: snapshot.transactions)
+        let summary = DashboardAccountDrillInSummary.presentation(
+            for: account,
+            activitySnapshot: snapshot,
+            itemStatus: itemConnectionStatus,
+            fallbackFreshnessLabel: connection.signalLabel
+        )
+        let recent = Array(snapshot.transactions.prefix(6))
+
+        VStack(spacing: 0) {
+            header(summary: summary)
+                .padding(Spacing.md)
+
+            Divider()
+                .opacity(0.4)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    statusSection(connection: connection, summary: summary)
+                    balancesSection(summary: summary)
+                    changesSection(insights: insights)
+                    if !insights.reviewItems.isEmpty {
+                        reviewSection(insights: insights)
+                    }
+                    if !insights.topCategories.isEmpty {
+                        categoriesSection(insights: insights)
+                    }
+                    activitySection(
+                        recent: recent,
+                        emptyState: emptyState(snapshot: snapshot, connection: connection)
+                    )
+                    actionsSection(summary: summary)
+                }
+                .padding(Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Account details for \(summary.displayName)")
+        .confirmationDialog(
+            "Remove \(institutionRemovalName)?",
+            isPresented: $isConfirmingAccountRemoval,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Institution", role: .destructive) {
+                Task { await appState.removeAccount(itemId: account.itemId) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from PlaidBar. It does not close any bank account."
+            )
+        }
+    }
+
+    // MARK: Header (metadata)
+
+    private func header(summary: DashboardAccountDrillInSummary) -> some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(summary.displayName)
+                    .font(.headline.weight(.semibold))
+                    .lineLimit(1)
+                Text(summary.subtitle)
+                    .detailText()
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+                    .frame(
+                        minWidth: Sizing.hitTargetMin,
+                        minHeight: Sizing.hitTargetMin
+                    )
+            }
+            .buttonStyle(.borderless)
+            .help("Close account details")
+            .accessibilityLabel("Close account details")
+        }
+    }
+
+    // MARK: Status
+
+    private func statusSection(
+        connection: AccountConnectionPresentation,
+        summary: DashboardAccountDrillInSummary
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            FlyoutSectionLabel("Status")
+
+            HStack(spacing: Spacing.sm) {
+                AccountConnectionBadge(
+                    label: connection.detailLabel,
+                    icon: connection.iconName,
+                    tint: accountConnectionTint(for: connection.level)
+                )
+
+                Spacer(minLength: 0)
+
+                Text(syncSignalText(connection: connection))
+                    .detailText()
+                    .lineLimit(1)
+            }
+
+            if let recoveryDetailLabel = connection.recoveryDetailLabel {
+                Text(recoveryDetailLabel)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if connection.showsRecoveryActions {
+                Button {
+                    performConnectionRecoveryAction()
+                } label: {
+                    Label(connectionRecoveryActionTitle, systemImage: connectionRecoveryActionIcon)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel("\(connectionRecoveryActionTitle) for \(summary.displayName)")
+                .accessibilityHint(
+                    connection.recoveryDetailLabel
+                        ?? "Refreshes this account's PlaidBar status."
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Balances
+
+    private func balancesSection(summary: DashboardAccountDrillInSummary) -> some View {
+        HStack(alignment: .top, spacing: Spacing.lg) {
+            DetailValue(
+                title: summary.availableTitle,
+                value: Formatters.currency(summary.availableBalance, format: .compact),
+                tint: .primary
+            )
+            DetailValue(
+                title: summary.currentTitle,
+                value: Formatters.currency(summary.currentBalance, format: .compact),
+                tint: .primary
+            )
+
+            // Utilization stays .primary here — risk severity is carried by
+            // the tinted icon ladder in the row and the Status section, not
+            // by tinting small data text below contrast thresholds.
+            if account.balances.utilizationPercent != nil,
+               let utilizationText = AccountPresentation.dashboardUtilizationDetailText(
+                   for: account,
+                   threshold: appState.creditUtilizationThreshold
+               )
+            {
+                DetailValue(
+                    title: "Utilization",
+                    value: utilizationText,
+                    tint: .primary
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Balances for \(summary.displayName)")
+    }
+
+    // MARK: Changes (30D vs prior 30D)
+
+    private func changesSection(insights: AccountDetailInsights) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            FlyoutSectionLabel("Changes · 30 days")
+
+            FlyoutChangeRow(
+                title: "Spending",
+                total: insights.spendTotal,
+                delta: insights.spendDelta,
+                increaseIsFavorable: false
+            )
+            FlyoutChangeRow(
+                title: "Income",
+                total: insights.incomeTotal,
+                delta: insights.incomeDelta,
+                increaseIsFavorable: true
+            )
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Review
+
+    private func reviewSection(insights: AccountDetailInsights) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            FlyoutSectionLabel("To review")
+
+            ForEach(insights.reviewItems) { item in
+                HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                    TransactionMiniRow(transaction: item.transaction)
+                    ReviewReasonChip(reason: item.reason)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(insights.reviewItems.count) transactions to review")
+    }
+
+    // MARK: Categories
+
+    private func categoriesSection(insights: AccountDetailInsights) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            FlyoutSectionLabel("Top categories · 30 days")
+
+            ForEach(insights.topCategories) { slice in
+                CategorySliceRow(slice: slice)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Activity
+
+    private func activitySection(
+        recent: [TransactionDTO],
+        emptyState: AccountActivityEmptyState?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            FlyoutSectionLabel("Recent activity")
+
+            if recent.isEmpty {
+                if let emptyState {
+                    AccountActivityEmptyStateView(presentation: emptyState)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: Spacing.rowVertical) {
+                    ForEach(recent) { transaction in
+                        TransactionMiniRow(transaction: transaction)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func emptyState(
+        snapshot: AccountTransactionFeed.AccountActivitySnapshot,
+        connection: AccountConnectionPresentation
+    ) -> AccountActivityEmptyState? {
+        AccountActivityEmptyState.evaluate(
+            transactionCount: snapshot.transactionCount,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            connectionLevel: connection.level,
+            accountDisplayName: AccountPresentation.displayName(for: account)
+        )
+    }
+
+    // MARK: Actions
+
+    private func actionsSection(summary: DashboardAccountDrillInSummary) -> some View {
+        AccountDrillInActionBar(
+            actions: DashboardDrillInAction.accountDrillInActions(isDemoMode: appState.isDemoMode),
+            accountDisplayName: summary.displayName,
+            onAction: performDrillInAction
+        )
+    }
+
+    // MARK: Connection plumbing
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
+    }
+
+    private var connectionPresentation: AccountConnectionPresentation {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            isSyncStale: appState.isSyncStale,
+            statusSyncText: appState.statusSyncText,
+            itemStatus: itemConnectionStatus?.status,
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
+        )
+    }
+
+    private func syncSignalText(connection: AccountConnectionPresentation) -> String {
+        if isStatusFilter, let itemSyncLabel = connection.itemSyncLabel {
+            return itemSyncLabel
+        }
+        return connection.signalLabel
+    }
+
+    private var connectionRecoveryActionTitle: String {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            connectionPresentation.recoveryActionTitle ?? "Reconnect"
+        case .stale, .demo, .offline, .healthy, .unknown:
+            "Refresh"
+        }
+    }
+
+    private var connectionRecoveryActionIcon: String {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            "link.badge.plus"
+        case .stale, .demo, .offline, .healthy, .unknown:
+            "arrow.clockwise"
+        }
+    }
+
+    private func performConnectionRecoveryAction() {
+        switch connectionPresentation.level {
+        case .loginRequired, .error:
+            Task { await appState.reconnectItem(itemId: account.itemId) }
+        case .stale:
+            Task { await appState.refreshDashboard() }
+        case .demo, .offline, .healthy, .unknown:
+            break
+        }
+    }
+
+    private func performDrillInAction(_ action: DashboardDrillInAction) {
+        switch action {
+        case .reconnect:
+            Task { await appState.reconnectItem(itemId: account.itemId) }
+        case .remove:
+            isConfirmingAccountRemoval = true
+        case .settings:
+            SettingsWindowActivationRestorer.shared.open(openSettings: openSettings)
+        }
+    }
+
+    // MARK: Removal copy
+
+    private var institutionRemovalName: String {
+        itemConnectionStatus?.institutionName ?? AccountPresentation.displayName(for: account)
+    }
+
+    private var institutionAccountCountText: String {
+        let count = max(appState.accounts.count { $0.itemId == account.itemId }, 1)
+        return count == 1 ? "1 linked account" : "\(count) linked accounts"
+    }
+
+    private var institutionTransactionCountText: String {
+        // The dialog message is evaluated as part of the panel body, so gate
+        // the full transaction scan on the dialog actually being presented.
+        guard isConfirmingAccountRemoval else { return "0 cached local transactions" }
+        let institutionAccountIds = Set(
+            appState.accounts.filter { $0.itemId == account.itemId }.map(\.id)
+        )
+        let count = appState.transactions.count { institutionAccountIds.contains($0.accountId) }
+        return count == 1 ? "1 cached local transaction" : "\(count) cached local transactions"
+    }
+}
+
+// MARK: - Section Label
+
+private struct FlyoutSectionLabel: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title)
+            .sectionTitle()
+            .foregroundStyle(.secondary)
+    }
+}
+
+// MARK: - Change Row
+
+private struct FlyoutChangeRow: View {
+    let title: String
+    let total: Double
+    let delta: Double
+    let increaseIsFavorable: Bool
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 64, alignment: .leading)
+
+            Text(Formatters.currency(total, format: .compact))
+                .dataText()
+
+            Spacer(minLength: Spacing.xs)
+
+            if delta != 0 {
+                HStack(spacing: Spacing.xxs) {
+                    Image(systemName: delta > 0 ? "arrow.up.right" : "arrow.down.right")
+                        .font(.caption2.weight(.medium))
+                    Text("\(deltaPrefix)\(Formatters.currency(abs(delta), format: .compact)) vs prior")
+                        .font(.caption2.weight(.medium))
+                        .monospacedDigit()
+                }
+                .foregroundStyle(deltaTint)
+                .lineLimit(1)
+            } else {
+                Text("No change vs prior")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private var deltaPrefix: String {
+        delta > 0 ? "+" : "-"
+    }
+
+    private var deltaTint: Color {
+        let isFavorable = (delta > 0) == increaseIsFavorable
+        return isFavorable ? SemanticColors.positive : SemanticColors.negative
+    }
+
+    private var accessibilityText: String {
+        let direction = delta > 0 ? "up" : delta < 0 ? "down" : "unchanged"
+        return "\(title) \(Formatters.currency(total, format: .full)) in the last 30 days, \(direction) \(Formatters.currency(abs(delta), format: .full)) versus the prior 30 days"
+    }
+}
+
+// MARK: - Review Reason Chip
+
+private struct ReviewReasonChip: View {
+    let reason: AccountDetailInsights.ReviewItem.Reason
+
+    var body: some View {
+        Text(label)
+            .microText()
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.chipVertical)
+            .background(.quinary, in: Capsule())
+            .accessibilityLabel("Marked for review: \(label)")
+    }
+
+    private var label: String {
+        switch reason {
+        case .pending: "Pending"
+        case .largeAmount: "Large"
+        }
+    }
+}
+
+// MARK: - Category Slice Row
+
+private struct CategorySliceRow: View {
+    let slice: AccountDetailInsights.CategorySlice
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: slice.category.iconName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: Sizing.iconInline)
+
+                Text(slice.category.displayName)
+                    .font(.caption)
+                    .lineLimit(1)
+
+                Spacer(minLength: Spacing.xs)
+
+                Text(Formatters.currency(slice.total, format: .compact))
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+
+                Text(shareText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .frame(width: 34, alignment: .trailing)
+            }
+
+            GeometryReader { proxy in
+                Capsule()
+                    .fill(.quaternary.opacity(0.5))
+                    .overlay(alignment: .leading) {
+                        Capsule()
+                            .fill(.secondary)
+                            .frame(width: max(proxy.size.width * slice.share, 2))
+                    }
+            }
+            .frame(height: 3)
+            .padding(.leading, Sizing.iconInline + Spacing.sm)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(slice.category.displayName): \(Formatters.currency(slice.total, format: .full)), \(shareText) of 30 day spending, \(slice.transactionCount) transaction\(slice.transactionCount == 1 ? "" : "s")"
+        )
+    }
+
+    private var shareText: String {
+        "\(Int((slice.share * 100).rounded()))%"
+    }
+}
+
+// MARK: - Shared Detail Components
+
+func accountConnectionTint(for level: AccountConnectionLevel) -> Color {
+    switch level {
+    case .demo, .offline, .healthy, .unknown:
+        .secondary
+    case .stale, .loginRequired:
+        SemanticColors.warning
+    case .error:
+        SemanticColors.negative
+    }
+}
+
+struct AccountConnectionBadge: View {
+    let label: String
+    let icon: String
+    let tint: Color
+
+    var body: some View {
+        Label(label, systemImage: icon)
+            .font(.caption.weight(.medium))
+            .lineLimit(1)
+            .foregroundStyle(tint)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.chipVertical)
+            .background(.quinary, in: Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Account status: \(label)")
+    }
+}
+
+struct DetailValue: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .dataText()
+                .foregroundStyle(tint)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(value)")
+    }
+}
+
+struct TransactionMiniRow: View {
+    let transaction: TransactionDTO
+
+    var body: some View {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
+            Circle()
+                .fill(transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55))
+                .frame(width: Sizing.statusDot, height: Sizing.statusDot)
+
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
+                Text(transaction.displayName)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                Text(Formatters.displayTransactionDate(transaction.date))
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(amountText)
+                .dataText()
+                .foregroundStyle(transaction.isIncome ? SemanticColors.positive : .primary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var amountText: String {
+        let prefix = transaction.isIncome ? "+" : ""
+        return "\(prefix)\(Formatters.currency(transaction.displayAmount, format: .compact))"
+    }
+
+    private var accessibilityLabel: String {
+        let direction = transaction.isIncome ? "income" : "outflow"
+        return "\(transaction.displayName), \(direction), \(Formatters.currency(transaction.displayAmount, format: .full)), \(Formatters.displayTransactionDate(transaction.date))"
+    }
+}
+
+struct AccountActivityEmptyStateView: View {
+    let presentation: AccountActivityEmptyState
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.compactRowContentSpacing) {
+            Image(systemName: presentation.iconName)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(tint)
+                .frame(width: Sizing.iconInline + 2, height: Sizing.iconInline + 2)
+                .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
+                Text(presentation.title)
+                    .font(.caption.weight(.medium))
+                Text(presentation.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: Spacing.compactRowContentSpacing)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(presentation.accessibilityLabel)
+    }
+
+    private var tint: Color {
+        switch presentation.tone {
+        case .brand:
+            SemanticColors.brand
+        case .healthy, .offline, .secondary:
+            .secondary
+        case .warning:
+            SemanticColors.warning
+        }
+    }
+}
+
+struct AccountDrillInActionBar: View {
+    let actions: [DashboardDrillInAction]
+    let accountDisplayName: String
+    let onAction: (DashboardDrillInAction) -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
+            ForEach(actions, id: \.self) { action in
+                Button {
+                    onAction(action)
+                } label: {
+                    Label(action.title, systemImage: action.iconName)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(action == .remove ? SemanticColors.negative : nil)
+                .accessibilityLabel(action.accessibilityLabel(accountDisplayName: accountDisplayName))
+                .accessibilityHint(action.accessibilityHint)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Selected account actions")
+    }
+}

--- a/Sources/PlaidBar/Views/DashboardNavBand.swift
+++ b/Sources/PlaidBar/Views/DashboardNavBand.swift
@@ -1,229 +1,5 @@
-import AppKit
 import PlaidBarCore
 import SwiftUI
-
-// MARK: - Status Strip
-
-struct DashboardStatusStrip: View {
-    @Environment(AppState.self) private var appState
-    let openSettings: () -> Void
-    let onAddAccount: () -> Void
-
-    var body: some View {
-        HStack(spacing: 0) {
-            StatusStripItem(
-                title: "Mode",
-                value: appState.statusModeText,
-                icon: appState.isDemoMode ? "play.circle.fill" : "server.rack",
-                tint: .secondary
-            )
-
-            StatusDivider()
-
-            StatusStripItem(
-                title: "Server",
-                value: appState.statusServerText,
-                icon: serverIcon,
-                tint: serverTint
-            )
-
-            StatusDivider()
-
-            StatusStripItem(
-                title: "Sync",
-                value: appState.statusSyncText,
-                icon: appState.isSyncStale ? "clock.badge.exclamationmark.fill" : "checkmark.circle.fill",
-                tint: appState.isSyncStale ? SemanticColors.warning : .secondary
-            )
-
-            StatusDivider()
-
-            StatusStripItem(
-                title: "Items",
-                value: itemsText,
-                icon: itemIcon,
-                tint: itemTint
-            )
-
-            StatusDivider()
-
-            StatusStripActions(
-                actions: statusActions,
-                labelForAction: actionLabel,
-                isDisabled: appState.isLoading,
-                perform: perform
-            )
-        }
-        .padding(.horizontal, Spacing.sm)
-        .padding(.vertical, Spacing.rowVertical)
-        .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
-        .accessibilityElement(children: .contain)
-    }
-
-    private var readiness: DashboardStatusReadiness {
-        appState.dashboardStatusReadiness
-    }
-
-    private var statusActions: [DashboardStatusReadinessAction] {
-        var actions: [DashboardStatusReadinessAction] = []
-        if let primaryAction = readiness.primaryAction {
-            actions.append(primaryAction)
-        }
-        actions.append(contentsOf: readiness.secondaryActions)
-        let uniqueActions = actions.reduce(into: [DashboardStatusReadinessAction]()) { uniqueActions, action in
-            if !uniqueActions.contains(action) {
-                uniqueActions.append(action)
-            }
-        }
-        return Array(uniqueActions.prefix(2))
-    }
-
-    private var serverIcon: String {
-        if appState.isDemoMode { return "play.circle.fill" }
-        if appState.isLoading { return "arrow.triangle.2.circlepath" }
-        if appState.error != nil { return "xmark.octagon.fill" }
-        return appState.serverConnected ? "checkmark.circle.fill" : "server.rack"
-    }
-
-    private var serverTint: Color {
-        if appState.isDemoMode { return .secondary }
-        if appState.isLoading { return SemanticColors.warning }
-        if appState.error != nil { return SemanticColors.negative }
-        return .secondary
-    }
-
-    private var itemsText: String {
-        if appState.erroredItemCount > 0 {
-            return "\(appState.erroredItemCount) error"
-        }
-        if appState.needsLoginItemCount > 0 {
-            return "\(appState.needsLoginItemCount) login"
-        }
-        return "\(appState.statusItemCount) linked"
-    }
-
-    private var itemIcon: String {
-        if appState.erroredItemCount > 0 { return "exclamationmark.triangle.fill" }
-        if appState.needsLoginItemCount > 0 { return "person.crop.circle.badge.exclamationmark.fill" }
-        return "link.circle.fill"
-    }
-
-    private var itemTint: Color {
-        if appState.erroredItemCount > 0 { return SemanticColors.negative }
-        if appState.needsLoginItemCount > 0 { return SemanticColors.warning }
-        return .secondary
-    }
-
-    private func actionLabel(for action: DashboardStatusReadinessAction) -> String {
-        if action == .reconnect,
-           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
-            return title
-        }
-        if readiness.primaryAction == action {
-            return readiness.primaryActionTitle ?? action.defaultTitle
-        }
-        if action == .addAccount {
-            return "Connect Bank"
-        }
-        return action.defaultTitle
-    }
-
-    private func perform(_ action: DashboardStatusReadinessAction) {
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            onAddAccount()
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .reconnect:
-            guard let itemId = ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
-                Task { await appState.refreshDashboard() }
-                return
-            }
-            Task { await appState.reconnectItem(itemId: itemId) }
-        case .openSettings:
-            openSettings()
-        case .requestNotificationPermission:
-            Task { _ = await appState.requestNotificationPermission() }
-        case .openNotificationSettings:
-            openNotificationSettings()
-        }
-    }
-
-    private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-            openSettings()
-            return
-        }
-        NSWorkspace.shared.open(url)
-    }
-}
-
-private struct StatusStripItem: View {
-    let title: String
-    let value: String
-    let icon: String
-    let tint: Color
-
-    var body: some View {
-        HStack(spacing: 5) {
-            Image(systemName: icon)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tint)
-                .frame(width: 13)
-
-            VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text(title)
-                    .microText()
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                Text(value)
-                    .font(.caption.weight(.semibold))
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.82)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct StatusStripActions: View {
-    let actions: [DashboardStatusReadinessAction]
-    let labelForAction: (DashboardStatusReadinessAction) -> String
-    let isDisabled: Bool
-    let perform: (DashboardStatusReadinessAction) -> Void
-
-    var body: some View {
-        HStack(spacing: Spacing.xs) {
-            ForEach(actions, id: \.self) { action in
-                Button {
-                    perform(action)
-                } label: {
-                    Label(labelForAction(action), systemImage: action.defaultIconName)
-                        .labelStyle(.iconOnly)
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .help(labelForAction(action))
-                .accessibilityLabel(labelForAction(action))
-                .disabled(isDisabled)
-            }
-        }
-        .frame(minWidth: 46, alignment: .trailing)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Status actions")
-    }
-}
-
-private struct StatusDivider: View {
-    var body: some View {
-        Divider()
-            .padding(.vertical, Spacing.xxs)
-            .padding(.horizontal, Spacing.xs)
-    }
-}
 
 // MARK: - Account Filters
 
@@ -243,6 +19,11 @@ extension DashboardAccountFilterKind {
 
 // MARK: - Filter Bar
 
+/// Native segmented control for the dashboard's primary filter. Native
+/// before novel: the system control brings focus rings, vibrancy, light
+/// mode, and RTL for free. ⌘1–6 shortcuts are preserved via hidden
+/// equivalents; the per-filter counts live in the rows themselves and in
+/// each segment's help/accessibility text rather than in segment labels.
 struct DashboardFilterBar: View {
     @Environment(AppState.self) private var appState
     @Binding var selection: DashboardAccountFilter
@@ -256,129 +37,54 @@ struct DashboardFilterBar: View {
             degradedItemIds: appState.degradedItemIds
         )
 
-        // No container clipShape here: segments round their own outer
-        // corners (see `DashboardFilterSegment.backgroundShape`) so the
-        // keyboard focus ring on the first/last segment is never cropped.
-        HStack(spacing: 1) {
+        Picker("Account filter", selection: $selection) {
             ForEach(items) { item in
-                DashboardFilterSegment(
-                    item: item,
-                    isSelected: selection == item.kind,
-                    isFirst: item.kind == DashboardAccountFilterKind.allCases.first,
-                    isLast: item.kind == DashboardAccountFilterKind.allCases.last
-                ) {
-                    selection = item.kind
-                }
-
-                if item.kind != DashboardAccountFilterKind.allCases.last {
-                    Divider()
-                        .padding(.vertical, Spacing.rowVertical)
-                }
+                Text(item.title)
+                    .accessibilityLabel(item.accessibilityLabel)
+                    .accessibilityValue(item.accessibilityValue)
+                    .tag(item.kind)
             }
         }
-        .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .controlSize(.small)
+        .help(rollupText(items: items))
+        .background {
+            // Hidden, non-interactive keyboard equivalents: ⌘1-6 switch
+            // filters exactly as the old custom segments did.
+            ForEach(items) { item in
+                Button("") { selection = item.kind }
+                    .keyboardShortcut(
+                        KeyEquivalent(Character("\(item.shortcutOrdinal)")),
+                        modifiers: .command
+                    )
+                    .buttonStyle(.plain)
+                    .focusable(false)
+                    .frame(width: 0, height: 0)
+                    .opacity(0)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
+        }
         .accessibilityElement(children: .contain)
         // The selected-filter rollup lives in the container *label*, not the
         // container value: macOS VoiceOver announces a group's label when
-        // entering it but does not reliably read a group's AXValue.
-        .accessibilityLabel(DashboardNavBarModel.containerAccessibilityLabel(
-            selected: selection,
-            items: items,
-            hasSelectedAccount: hasSelectedAccount
-        ))
-    }
-}
-
-private struct DashboardFilterSegment: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let item: DashboardNavBarItem
-    let isSelected: Bool
-    let isFirst: Bool
-    let isLast: Bool
-    let onSelect: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: Spacing.xs) {
-                if let statusIconName = item.statusIconName {
-                    Image(systemName: statusIconName)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(statusIconTint)
-                }
-
-                Text(item.title)
-                    .font(.callout.weight(isSelected ? .semibold : .regular))
-                    .foregroundStyle(isSelected ? .primary : .secondary)
-
-                Text("\(item.count)")
-                    .microText()
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-            }
-            .lineLimit(1)
-            .minimumScaleFactor(0.8)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, Spacing.rowVertical)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        // Plain-styled buttons in this popover do not receive Tab focus by
-        // default; opt in explicitly so the segments stay keyboard-reachable
-        // (same pattern as AccountRowWithDrilldown in MainPopover).
-        .focusable(true)
-        .background(backgroundFill, in: backgroundShape)
-        .overlay(alignment: .bottom) {
-            selectionIndicator
-        }
-        .onHover { isHovered = $0 }
-        .keyboardShortcut(KeyEquivalent(Character("\(item.shortcutOrdinal)")), modifiers: .command)
-        .help(item.helpText)
-        .accessibilityLabel(item.accessibilityLabel)
-        .accessibilityValue(item.accessibilityValue)
-        .accessibilityHint("Filters the dashboard account list.")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    /// Warning tint is reserved for the status icon: orange digits at micro
-    /// size fall far below the 4.5:1 contrast small text needs in light
-    /// mode, so the count always stays `.secondary` and the triangle-vs-
-    /// checkmark shape carries the attention state — never color alone.
-    /// This mirrors the status strip, which tints icons but never text.
-    private var statusIconTint: Color {
-        item.showsAttentionBadge ? SemanticColors.warning : .secondary
-    }
-
-    private var backgroundFill: Color {
-        if isSelected {
-            return SemanticColors.brand.opacity(SurfaceTokens.selectedFillOpacity)
-        }
-        if isHovered {
-            return Color.primary.opacity(SurfaceTokens.insetFillOpacity)
-        }
-        return .clear
-    }
-
-    /// Rounds only the bar's outer corners on the first/last segment so the
-    /// hover/selection fill matches the inset surface without a container
-    /// `clipShape` — which would crop the keyboard focus ring at the ends.
-    private var backgroundShape: UnevenRoundedRectangle {
-        UnevenRoundedRectangle(
-            topLeadingRadius: isFirst ? SurfaceTokens.panelCornerRadius : 0,
-            bottomLeadingRadius: isFirst ? SurfaceTokens.panelCornerRadius : 0,
-            bottomTrailingRadius: isLast ? SurfaceTokens.panelCornerRadius : 0,
-            topTrailingRadius: isLast ? SurfaceTokens.panelCornerRadius : 0
+        // entering it but does not reliably read a group's AXValue. The
+        // per-segment counts are rolled into the label too, because per-item
+        // modifiers do not reliably survive NSSegmentedControl bridging.
+        .accessibilityLabel(
+            "\(DashboardNavBarModel.containerAccessibilityLabel(selected: selection, items: items, hasSelectedAccount: hasSelectedAccount)). \(rollupText(items: items))"
         )
     }
 
-    private var selectionIndicator: some View {
-        Rectangle()
-            .fill(SemanticColors.brand)
-            .frame(height: Spacing.xxs)
-            .padding(.horizontal, Spacing.sm)
-            .opacity(isSelected ? 1 : 0)
-            .scaleEffect(x: isSelected ? 1 : 0.4, y: 1, anchor: .center)
-            .animation(reduceMotion ? nil : .snappy(duration: 0.15), value: isSelected)
+    /// "All 4, Cash 2, Credit 2 (needs attention), …" — counts for every
+    /// segment, used in the container accessibility label and the tooltip.
+    private func rollupText(items: [DashboardNavBarItem]) -> String {
+        items.map { item in
+            item.showsAttentionBadge
+                ? "\(item.title) \(item.count), needs attention"
+                : "\(item.title) \(item.count)"
+        }
+        .joined(separator: ", ")
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -5,20 +5,38 @@ import SwiftUI
 struct MainPopover: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage("dashboard.accountFilter") private var selectedFilterRawValue = DashboardAccountFilter.all.rawValue
     @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
+    @State private var dashboardContentHeight: CGFloat = 0
 
     private enum Layout {
         static let dashboardWidth: CGFloat = 480
-        static let setupWidth: CGFloat = 560
+        static let flyoutWidth: CGFloat = 320
         static let dashboardMinHeight: CGFloat = 460
-        static let dashboardMaxHeight = CGFloat(DashboardOverviewHeightBudget.realisticPopoverHeight)
+        /// Vertical breathing room kept below the popover: menu bar,
+        /// footer chrome, and a Dock-safe margin.
+        static let screenHeightInset: CGFloat = 120
+
         static let contentHorizontalPadding: CGFloat = 12
         static let contentTopPadding: CGFloat = 8
         static let contentBottomPadding: CGFloat = 8
-        static let sectionSpacing: CGFloat = 7
+        static let sectionSpacing: CGFloat = Spacing.sm
+        static let groupSpacing: CGFloat = Spacing.lg
+    }
+
+    /// RepoBar-style vertical sizing: the dashboard grows with its content
+    /// up to the available screen height instead of stopping at a fixed
+    /// budget. Short content hugs; long content fills the screen and
+    /// scrolls. Falls back to the height-budget model when no screen is
+    /// available (headless renders).
+    private var dashboardScrollHeight: CGFloat {
+        let fallback = CGFloat(DashboardOverviewHeightBudget.realisticPopoverHeight)
+        let screenCap = NSScreen.main.map { $0.visibleFrame.height - Layout.screenHeightInset } ?? fallback
+        let contentCap = dashboardContentHeight > 0 ? dashboardContentHeight : screenCap
+        return max(Layout.dashboardMinHeight, min(screenCap, contentCap))
     }
 
     private var selectedFilter: DashboardAccountFilter {
@@ -36,96 +54,38 @@ struct MainPopover: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if shouldShowSetupScreen {
-                SetupView()
-                    .frame(width: Layout.setupWidth)
-            } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-                        DashboardHeader()
-                            .environment(appState)
-
-                        DashboardStatusStrip(
-                            openSettings: { openSettings() },
-                            onAddAccount: openAccountSetup
-                        )
-                            .environment(appState)
-
-                        if selectedAccount == nil {
-                            DashboardChangeReceiptStrip()
-                                .environment(appState)
-                        }
-
-                        if shouldElevateStatusReadinessPanel {
-                            AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
-                                .environment(appState)
-
-                            DashboardStatusReadinessPanel(
-                                openSettings: { openSettings() },
-                                onAddAccount: openAccountSetup
-                            )
-                            .environment(appState)
-                        }
-
-                        DashboardOverviewStack(
-                            transactions: appState.transactions,
-                            accounts: filteredAccounts,
-                            filter: selectedFilter,
-                            filterSelection: filterBinding,
-                            selectedAccountId: selectedAccount?.id,
-                            onSelectAccount: { selectedAccountId = $0.id },
-                            onDeselectAccount: { selectedAccountId = "" },
-                            onAddAccount: openAccountSetup
-                        )
-                        .environment(appState)
-
-                        DashboardSummaryCards()
-                            .environment(appState)
-
-                        BalanceCompositionStrip()
-                            .environment(appState)
-
-                        LocalInsightsCard()
-                            .environment(appState)
-
-                        if shouldShowLowerStatusReadinessPanel {
-                            AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
-                                .environment(appState)
-
-                            DashboardStatusReadinessPanel(
-                                openSettings: { openSettings() },
-                                onAddAccount: openAccountSetup
-                            )
-                            .environment(appState)
-                        }
-                    }
-                    .padding(.horizontal, Layout.contentHorizontalPadding)
-                    .padding(.top, Layout.contentTopPadding)
-                    .padding(.bottom, Layout.contentBottomPadding)
-                }
-                .scrollContentBackground(.hidden)
-                .frame(maxWidth: .infinity)
-                .frame(minHeight: Layout.dashboardMinHeight, maxHeight: Layout.dashboardMaxHeight)
-
-                Divider()
-
-                DashboardFooter(
-                    settingsActivation: .shared,
-                    openSettings: openSettings,
-                    onAddAccount: openAccountSetup
+        HStack(alignment: .top, spacing: 0) {
+            if let selectedAccount, !shouldShowSetupScreen {
+                AccountDetailFlyout(
+                    account: selectedAccount,
+                    isStatusFilter: selectedFilter == .status,
+                    onClose: { selectedAccountId = "" }
                 )
                 .environment(appState)
+                .frame(width: Layout.flyoutWidth)
+                .transition(.move(edge: .leading).combined(with: .opacity))
+
+                Divider()
             }
 
-            if let error = appState.error {
-                ErrorBanner(error: error)
-                    .environment(appState)
-            }
+            dashboardColumn
+                .frame(width: Layout.dashboardWidth)
         }
-        .frame(width: shouldShowSetupScreen ? Layout.setupWidth : Layout.dashboardWidth)
+        .frame(width: popoverWidth)
         .background(.regularMaterial)
-        .animation(.easeInOut(duration: 0.2), value: appState.error != nil)
+        .animation(
+            MotionTokens.animation(MotionTokens.content, reduceMotion: reduceMotion),
+            value: selectedAccount?.id
+        )
+        // Esc closes the fly-out. The handler is nil when no account is
+        // selected so the key event falls through and closes the popover.
+        .onExitCommand(
+            perform: selectedAccountId.isEmpty ? nil : { selectedAccountId = "" }
+        )
+        .animation(
+            MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion),
+            value: appState.error != nil
+        )
         .sheet(
             isPresented: $isShowingAccountSetup,
             onDismiss: {
@@ -143,8 +103,8 @@ struct MainPopover: View {
         .task {
             await appState.loadInitialData()
         }
-        .onChange(of: appState.accounts) { _, accounts in
-            guard selectedAccountId.isEmpty || !accounts.contains(where: { $0.id == selectedAccountId }) else { return }
+        .onChange(of: filteredAccounts.map(\.id)) { _, ids in
+            guard !selectedAccountId.isEmpty, !ids.contains(selectedAccountId) else { return }
             selectedAccountId = ""
         }
         .onChange(of: selectedFilterRawValue) { _, _ in
@@ -153,6 +113,111 @@ struct MainPopover: View {
         .onChange(of: appState.isSetupComplete) { _, isComplete in
             if isComplete {
                 shouldShowSetupRecoveryDashboard = false
+            }
+        }
+    }
+
+    private var popoverWidth: CGFloat {
+        // Setup renders at the dashboard's width so first run never snaps
+        // between window sizes.
+        guard !shouldShowSetupScreen else { return Layout.dashboardWidth }
+        return Layout.dashboardWidth + (selectedAccount == nil ? 0 : Layout.flyoutWidth + 1)
+    }
+
+    private var dashboardColumn: some View {
+        VStack(spacing: 0) {
+            // The error banner outranks everything below it — including the
+            // setup screen, which previously swallowed errors entirely.
+            if let error = appState.error {
+                ErrorBanner(error: error)
+                    .environment(appState)
+            }
+
+            if shouldShowSetupScreen {
+                SetupView()
+            } else {
+                ScrollView {
+                    // 16pt between concept groups, 8pt between siblings
+                    // within a group — spacing is the hierarchy.
+                    VStack(alignment: .leading, spacing: Layout.groupSpacing) {
+                        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                            DashboardHeader()
+                                .environment(appState)
+
+                            DashboardChangeReceiptStrip()
+                                .environment(appState)
+                        }
+
+                        if shouldElevateStatusReadinessPanel {
+                            VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                                AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
+                                    .environment(appState)
+
+                                DashboardStatusReadinessPanel(
+                                    openSettings: { openSettings() },
+                                    onAddAccount: openAccountSetup
+                                )
+                                .environment(appState)
+                            }
+                        }
+
+                        DashboardOverviewStack(
+                            transactions: appState.transactions,
+                            accounts: filteredAccounts,
+                            filter: selectedFilter,
+                            filterSelection: filterBinding,
+                            selectedAccountId: selectedAccount?.id,
+                            onSelectAccount: { selectedAccountId = $0.id },
+                            onDeselectAccount: { selectedAccountId = "" },
+                            onAddAccount: openAccountSetup
+                        )
+                        .environment(appState)
+
+                        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                            DashboardSummaryCards()
+                                .environment(appState)
+
+                            BalanceCompositionStrip()
+                                .environment(appState)
+
+                            LocalInsightsCard()
+                                .environment(appState)
+                        }
+
+                        if shouldShowLowerStatusReadinessPanel {
+                            VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                                AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
+                                    .environment(appState)
+
+                                DashboardStatusReadinessPanel(
+                                    openSettings: { openSettings() },
+                                    onAddAccount: openAccountSetup
+                                )
+                                .environment(appState)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, Layout.contentHorizontalPadding)
+                    .padding(.top, Layout.contentTopPadding)
+                    .padding(.bottom, Layout.contentBottomPadding)
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { height in
+                        dashboardContentHeight = height
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .frame(maxWidth: .infinity)
+                .frame(height: dashboardScrollHeight)
+
+                Divider()
+
+                DashboardFooter(
+                    settingsActivation: .shared,
+                    openSettings: openSettings,
+                    onAddAccount: openAccountSetup
+                )
+                .environment(appState)
             }
         }
     }
@@ -195,48 +260,39 @@ private struct DashboardHeader: View {
     }
 
     var body: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 4) {
+        // One hero per surface: the net worth number is the only large text.
+        // Sync state lives in the footer; the app's own name does not belong
+        // inside its own popover.
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text("Net Worth")
                     .sectionTitle()
                     .foregroundStyle(.secondary)
 
                 Text(Formatters.currency(appState.netBalance, format: .full))
-                    .font(.system(size: 27, weight: .bold, design: .rounded))
-                    .monospacedDigit()
+                    .displayBalance()
                     .contentTransition(.numericText())
                     .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .minimumScaleFactor(0.8)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: Spacing.md)
 
             if let trend {
-                VStack(alignment: .trailing, spacing: 3) {
+                VStack(alignment: .trailing, spacing: Spacing.xxs) {
                     BalanceTrendChart(trend: trend)
                         .frame(width: 92, height: 21)
 
                     Text("\(trend.deltaText) \(trend.spanText)")
-                        .font(.caption2.weight(.semibold))
+                        .font(.caption2.weight(.medium))
                         .monospacedDigit()
                         .foregroundStyle(deltaTint(for: trend.direction))
                         .lineLimit(1)
                 }
-                .padding(.top, 3)
-                .padding(.trailing, 14)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(trend.accessibilitySummary)
                 .help(trend.accessibilitySummary)
             }
-
-            VStack(alignment: .trailing, spacing: 3) {
-                Text("PlaidBar")
-                    .font(.headline.weight(.bold))
-                Text(appState.statusSyncText)
-                    .detailText()
-                    .lineLimit(1)
-            }
-            .padding(.top, 3)
         }
     }
 
@@ -267,7 +323,7 @@ private struct DashboardChangeReceiptStrip: View {
         if let receipt {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(receipt.title.uppercased())
-                    .font(.caption2.weight(.semibold))
+                    .font(.caption2.weight(.medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
@@ -290,14 +346,10 @@ private struct DashboardChangeReceiptStrip: View {
                 }
                 .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, 9)
-            .padding(.vertical, 5)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.quaternary.opacity(0.38), in: Capsule())
-            .overlay(
-                Capsule()
-                    .strokeBorder(.secondary.opacity(0.10), lineWidth: 1)
-            )
+            .background(.quinary, in: Capsule())
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(receipt.accessibilitySummary)
             .help(receipt.accessibilitySummary)
@@ -309,49 +361,30 @@ private struct DashboardSummaryCards: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
-        VStack(spacing: 8) {
-            HStack(spacing: 8) {
-                MetricCard(
-                    title: "Cash",
-                    value: Formatters.currency(appState.totalCash, format: .compact),
-                    detail: "\(appState.depositoryAccounts.count) cash account\(appState.depositoryAccounts.count == 1 ? "" : "s")",
-                    tint: .secondary
-                )
+        // One metric row. Sync/server status is not a financial metric — it
+        // lives in the footer (healthy) or the attention queue (degraded).
+        HStack(spacing: Spacing.sm) {
+            MetricCard(
+                title: "Cash",
+                value: Formatters.currency(appState.totalCash, format: .compact),
+                detail: "\(appState.depositoryAccounts.count) cash account\(appState.depositoryAccounts.count == 1 ? "" : "s")",
+                tint: .secondary
+            )
 
-                MetricCard(
-                    title: "Credit",
-                    value: creditValue,
-                    detail: creditDetail,
-                    tint: SemanticColors.creditDebt,
-                    emphasizesTint: shouldEmphasizeCredit
-                )
+            MetricCard(
+                title: "Credit",
+                value: creditValue,
+                detail: creditDetail,
+                tint: SemanticColors.creditDebt,
+                emphasizesTint: shouldEmphasizeCredit
+            )
 
-                MetricCard(
-                    title: "7D Spend",
-                    value: Formatters.currency(appState.recentSpend, format: .compact),
-                    detail: recentSpendDetail,
-                    tint: recentSpendTint,
-                    emphasizesTint: appState.recentSpend > 0
-                )
-            }
-
-            HStack(spacing: 8) {
-                MetricCard(
-                    title: "Sync",
-                    value: appState.statusSyncText,
-                    detail: appState.statusServerText,
-                    tint: syncTint,
-                    emphasizesTint: appState.isSyncStale || !appState.serverConnected
-                )
-
-                MetricCard(
-                    title: "Action",
-                    value: actionValue,
-                    detail: actionDetail,
-                    tint: actionTint,
-                    emphasizesTint: appState.dashboardStatusReadiness.level != .healthy
-                )
-            }
+            MetricCard(
+                title: "7D Spend",
+                value: Formatters.currency(appState.recentSpend, format: .compact),
+                detail: recentSpendDetail,
+                tint: .secondary
+            )
         }
     }
 
@@ -383,42 +416,6 @@ private struct DashboardSummaryCards: View {
     private var recentSpendDetail: String {
         appState.recentSpend > 0 ? "Last 7 days" : "No 7D spend"
     }
-
-    private var recentSpendTint: Color {
-        appState.recentSpend > 0 ? SemanticColors.negative : .secondary
-    }
-
-    private var syncTint: Color {
-        if !appState.serverConnected { return SemanticColors.negative }
-        if appState.isSyncStale { return SemanticColors.warning }
-        return .secondary
-    }
-
-    private var actionValue: String {
-        switch appState.dashboardStatusReadiness.level {
-        case .healthy:
-            return "None"
-        case .warning:
-            return "Review"
-        case .blocked:
-            return "Blocked"
-        }
-    }
-
-    private var actionDetail: String {
-        appState.dashboardStatusReadiness.title
-    }
-
-    private var actionTint: Color {
-        switch appState.dashboardStatusReadiness.level {
-        case .healthy:
-            return .secondary
-        case .warning:
-            return SemanticColors.warning
-        case .blocked:
-            return SemanticColors.negative
-        }
-    }
 }
 
 private struct MetricCard: View {
@@ -429,45 +426,25 @@ private struct MetricCard: View {
     var emphasizesTint = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
             Text(title)
-                .font(.caption.weight(.semibold))
+                .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.headline.weight(.bold))
+                .dataText()
                 .foregroundStyle(emphasizesTint ? tint : .primary)
-                .monospacedDigit()
                 .lineLimit(1)
-                .minimumScaleFactor(0.75)
+                .minimumScaleFactor(0.8)
             Text(detail)
                 .microText()
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .minimumScaleFactor(0.75)
+                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(cardFill),
-            stroke: cardStroke
-        )
-        .overlay(alignment: .leading) {
-            if emphasizesTint {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(tint)
-                    .frame(width: 3)
-                    .padding(.vertical, 8)
-            }
-        }
-    }
-
-    private var cardFill: Color {
-        SurfaceTokens.panelFill(emphasisTint: emphasizesTint ? tint : nil)
-    }
-
-    private var cardStroke: Color {
-        SurfaceTokens.panelStroke(emphasisTint: emphasizesTint ? tint : nil)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.sm)
+        .glassSurface(emphasizesTint ? .emphasized(tint) : .inset)
     }
 }
 
@@ -522,10 +499,11 @@ private struct BalanceCompositionStrip: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
                 Text("Balance Mix")
-                    .font(.caption.weight(.semibold))
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
                 Spacer()
                 Text("\(appState.accountCount) accounts")
                     .microText()
@@ -535,7 +513,7 @@ private struct BalanceCompositionStrip: View {
             GeometryReader { proxy in
                 HStack(spacing: segmentSpacing) {
                     ForEach(activeSegments) { segment in
-                        RoundedRectangle(cornerRadius: 2)
+                        RoundedRectangle(cornerRadius: Radius.cell)
                             .fill(segment.fillColor)
                             .frame(width: segmentWidth(segment, totalWidth: proxy.size.width))
                             .accessibilityLabel(
@@ -546,21 +524,14 @@ private struct BalanceCompositionStrip: View {
             }
             .frame(height: 7)
 
-            Divider()
-                .opacity(0.55)
-
-            HStack(spacing: 8) {
+            HStack(spacing: Spacing.sm) {
                 ForEach(segments) { segment in
                     BalanceCompositionLegend(segment: segment)
                 }
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.panelFillOpacity)),
-            stroke: Color.primary.opacity(0.065)
-        )
+        .padding(Spacing.sm)
+        .glassSurface(.inset)
         .accessibilityElement(children: .contain)
     }
 
@@ -664,7 +635,7 @@ private struct BalanceActivityHeatmap: View {
                 .frame(width: 116)
 
                 Text(totalLabel(for: layout))
-                    .font(.caption.weight(.bold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(totalTint(for: layout))
                     .monospacedDigit()
                     .lineLimit(1)
@@ -689,9 +660,14 @@ private struct BalanceActivityHeatmap: View {
                             VStack(spacing: spacing) {
                                 ForEach(Array(week.enumerated()), id: \.offset) { _, day in
                                     if let day {
-                                        BalanceHeatmapCell(day: day, peakValue: layout.peakValue, mode: layout.mode, size: cell)
+                                        BalanceHeatmapCell(
+                                            day: day,
+                                            peakValue: layout.peakValue,
+                                            mode: layout.mode,
+                                            size: cell
+                                        )
                                     } else {
-                                        RoundedRectangle(cornerRadius: 2)
+                                        RoundedRectangle(cornerRadius: Radius.cell)
                                             .fill(.clear)
                                             .frame(width: cell, height: cell)
                                     }
@@ -712,8 +688,12 @@ private struct BalanceActivityHeatmap: View {
                         .foregroundStyle(.secondary)
 
                     ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(BalanceHeatmapCell.fillColor(intensity: intensity, value: intensity, mode: layout.mode))
+                        RoundedRectangle(cornerRadius: Radius.cell)
+                            .fill(BalanceHeatmapCell.fillColor(
+                                intensity: intensity,
+                                value: intensity,
+                                mode: layout.mode
+                            ))
                             .frame(width: 8, height: 8)
                     }
 
@@ -732,13 +712,12 @@ private struct BalanceActivityHeatmap: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(10)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.panelFillOpacity)),
-            stroke: Color.primary.opacity(0.065)
-        )
+        .padding(Spacing.sm)
+        .glassSurface(.raised)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription).")
+        .accessibilityLabel(
+            "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
+        )
     }
 
     private var modeBinding: Binding<SpendingHeatmapMode> {
@@ -776,7 +755,7 @@ private struct NetLegendKey: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            RoundedRectangle(cornerRadius: 2)
+            RoundedRectangle(cornerRadius: Radius.cell)
                 .fill(tint.opacity(0.72))
                 .frame(width: 8, height: 8)
             Text(label)
@@ -793,7 +772,7 @@ private struct BalanceHeatmapCell: View {
     let size: CGFloat
 
     var body: some View {
-        RoundedRectangle(cornerRadius: 2)
+        RoundedRectangle(cornerRadius: Radius.cell)
             .fill(Self.fillColor(intensity: intensity, value: day.value, mode: mode))
             .frame(width: size, height: size)
             .help(helpText)
@@ -817,13 +796,17 @@ private struct BalanceHeatmapCell: View {
     }
 
     static func fillColor(intensity: Double, value: Double, mode: SpendingHeatmapMode) -> Color {
-        guard intensity > 0 else { return Color.primary.opacity(0.08) }
+        guard intensity > 0 else { return Color.primary.opacity(0.06) }
 
-        let base: Color = if mode == .netCashflow, value < 0 {
-            SemanticColors.positive
-        } else {
-            mode == .netCashflow ? SemanticColors.negative : SemanticColors.positive
+        // Spend mode uses a neutral intensity ramp: green means money-in
+        // everywhere else in the app, so green-for-heavy-spending would
+        // invert the token semantics. Net mode keeps the green/red pairing
+        // with its explicit Income/Outflow legend.
+        guard mode == .netCashflow else {
+            return Color.primary.opacity(0.14 + (0.6 * intensity))
         }
+
+        let base: Color = value < 0 ? SemanticColors.positive : SemanticColors.negative
         return base.opacity(0.18 + (0.72 * intensity))
     }
 }
@@ -901,11 +884,8 @@ private struct LocalInsightsCard: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(10)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.panelFillOpacity)),
-            stroke: Color.primary.opacity(0.065)
-        )
+        .padding(Spacing.sm)
+        .glassSurface(.inset)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(receipt.accessibilitySummary)
     }
@@ -928,17 +908,17 @@ private struct LocalAIStatusPill: View {
     let availability: LocalAIAvailability
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: Spacing.xs) {
             Image(systemName: iconName)
-                .font(.caption2.weight(.bold))
+                .font(.caption2.weight(.medium))
             Text("Local - \(availability.state.displayName)")
-                .font(.caption2.weight(.semibold))
+                .font(.caption.weight(.medium))
                 .lineLimit(1)
         }
         .foregroundStyle(tint)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 4)
-        .nativeInsetSurface(cornerRadius: 7)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
         .help(availability.detail)
     }
 
@@ -970,19 +950,19 @@ private struct LocalInsightEvidenceChip: View {
                 Text(chip.label)
                     .lineLimit(1)
             }
-                .microText()
-                .foregroundStyle(.secondary)
+            .microText()
+            .foregroundStyle(.secondary)
 
             Text(chip.value)
-                .font(.caption.weight(.bold))
+                .font(.caption.weight(.semibold))
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.76)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .nativeInsetSurface(cornerRadius: 7)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.rowVertical)
+        .glassSurface(.inset, cornerRadius: Radius.control)
         .help("\(chip.label): \(chip.value)")
     }
 }
@@ -1003,7 +983,7 @@ private struct DashboardStatusReadinessPanel: View {
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
                     .frame(width: 28, height: 28)
-                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: Radius.panel))
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(readiness.title)
@@ -1054,11 +1034,8 @@ private struct DashboardStatusReadinessPanel: View {
                 }
             }
         }
-        .padding(12)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: readinessNeedsAttention ? tint : nil)),
-            stroke: panelStroke
-        )
+        .padding(Spacing.md)
+        .glassSurface(readinessNeedsAttention ? .emphasized(tint) : .raised)
         .accessibilityElement(children: .contain)
     }
 
@@ -1080,10 +1057,6 @@ private struct DashboardStatusReadinessPanel: View {
 
     private var readinessNeedsAttention: Bool {
         readiness.level != .healthy
-    }
-
-    private var panelStroke: Color {
-        readinessNeedsAttention ? tint.opacity(0.18) : Color.primary.opacity(0.07)
     }
 
     private func perform(_ action: DashboardStatusReadinessAction) {
@@ -1119,7 +1092,8 @@ private struct DashboardStatusReadinessPanel: View {
 
     private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {
         if action == .reconnect,
-           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
+           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses)
+        {
             return title
         }
         return readiness.primaryActionTitle ?? action.defaultTitle
@@ -1139,7 +1113,7 @@ private struct SetupRecoverySummary: View {
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(color)
                 .frame(width: 20, height: 20)
-                .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+                .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: Radius.control))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Setup recovery")
@@ -1154,9 +1128,6 @@ private struct SetupRecoverySummary: View {
 
             Spacer(minLength: 8)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(color.opacity(0.06), in: RoundedRectangle(cornerRadius: 7))
         .accessibilityElement(children: .combine)
     }
 
@@ -1230,9 +1201,6 @@ private struct StatusMetricPill: View {
                 .minimumScaleFactor(0.78)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(title): \(value)")
     }
@@ -1285,7 +1253,9 @@ private struct DashboardOverviewStack: View {
             }
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Overview with activity heatmap, account filters, account rows, and selected account details.")
+        .accessibilityLabel(
+            "Overview with activity heatmap, account filters, account rows, and selected account details."
+        )
     }
 
     private enum LayoutSpacing {
@@ -1305,7 +1275,10 @@ private struct DashboardOverviewFallbackBanner: View {
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(SemanticColors.brandSecondary)
                     .frame(width: 30, height: 30)
-                    .background(SemanticColors.brandSecondary.opacity(0.14), in: RoundedRectangle(cornerRadius: 9))
+                    .background(
+                        SemanticColors.brandSecondary.opacity(0.14),
+                        in: RoundedRectangle(cornerRadius: Radius.panel)
+                    )
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(presentation.title)
@@ -1324,12 +1297,9 @@ private struct DashboardOverviewFallbackBanner: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
         }
-        .padding(12)
+        .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: SemanticColors.brandSecondary.opacity(0.18))),
-            stroke: SemanticColors.brandSecondary.opacity(0.22)
-        )
+        .glassSurface(.emphasized(SemanticColors.brandSecondary))
     }
 }
 
@@ -1355,7 +1325,7 @@ private struct AccountsSection: View {
                     .sectionTitle()
                     .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, Spacing.compactRowTextSpacing)
+            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
             .padding(.bottom, Spacing.xs)
 
             if accounts.isEmpty {
@@ -1379,7 +1349,7 @@ private struct AccountsSection: View {
                         .environment(appState)
                     }
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .clipShape(RoundedRectangle(cornerRadius: Radius.panel))
             }
         }
     }
@@ -1393,29 +1363,19 @@ private struct AccountRowWithDrilldown: View {
     let onSelect: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            Button(action: onSelect) {
-                DashboardAccountRow(account: account, isStatusFilter: isStatusFilter, isSelected: isSelected)
-            }
-            .buttonStyle(.plain)
-            .focusable(true)
-            .help(drillInPath.pointerHelp)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(accountAccessibilityLabel)
-            .accessibilityHint(drillInPath.accessibilityHint)
-            .accessibilityAction(named: drillInPath.accessibilityActionName, onSelect)
-
-            if isSelected {
-                SelectedAccountPanel(
-                    account: account,
-                    isStatusFilter: isStatusFilter,
-                    activitySnapshot: appState.accountActivitySnapshot(for: account.id)
-                )
-                    .environment(appState)
-                    .padding(.top, Spacing.compactRowVerticalPadding)
-                    .padding(.bottom, Spacing.compactRowContentSpacing)
-            }
+        // Selection opens the AccountDetailFlyout to the left of the
+        // dashboard (mounted by MainPopover), not an inline panel below.
+        Button(action: onSelect) {
+            DashboardAccountRow(account: account, isStatusFilter: isStatusFilter, isSelected: isSelected)
         }
+        .buttonStyle(.plain)
+        .focusable(true)
+        .hoverHighlight()
+        .help(drillInPath.pointerHelp)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accountAccessibilityLabel)
+        .accessibilityHint(drillInPath.accessibilityHint)
+        .accessibilityAction(named: drillInPath.accessibilityActionName, onSelect)
     }
 
     private var accountAccessibilityLabel: String {
@@ -1484,7 +1444,7 @@ private struct DashboardEmptyAccountState: View {
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
                     .frame(width: 28, height: 28)
-                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: Radius.panel))
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
@@ -1513,12 +1473,9 @@ private struct DashboardEmptyAccountState: View {
                 .controlSize(.small)
             }
         }
-        .padding(12)
+        .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: emphasizedTint)),
-            stroke: panelStroke
-        )
+        .glassSurface(emphasizedTint.map { SurfaceRank.emphasized($0) } ?? .raised)
     }
 
     private var title: String {
@@ -1536,31 +1493,22 @@ private struct DashboardEmptyAccountState: View {
     private var tint: Color {
         switch presentation.tone {
         case .brand:
-            return SemanticColors.brand
+            SemanticColors.brand
         case .healthy:
-            return .secondary
+            .secondary
         case .offline, .secondary:
-            return .secondary
+            .secondary
         case .warning:
-            return SemanticColors.warning
-        }
-    }
-
-    private var panelStroke: Color {
-        switch presentation.tone {
-        case .brand, .warning:
-            return tint.opacity(0.18)
-        case .healthy, .offline, .secondary:
-            return Color.primary.opacity(0.07)
+            SemanticColors.warning
         }
     }
 
     private var emphasizedTint: Color? {
         switch presentation.tone {
         case .brand, .warning:
-            return tint
+            tint
         case .healthy, .offline, .secondary:
-            return nil
+            nil
         }
     }
 
@@ -1603,17 +1551,17 @@ private struct DashboardAccountRow: View {
     var body: some View {
         HStack(spacing: Spacing.compactRowContentSpacing) {
             Image(systemName: AccountPresentation.iconName(for: account))
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(accountTint)
-                .frame(width: 28, height: 28)
-                .background(accountTint.opacity(0.16), in: RoundedRectangle(cornerRadius: 8))
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: Sizing.iconChip, height: Sizing.iconChip)
+                .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
                 .overlay(alignment: .bottomTrailing) {
                     // Decorative reinforcement only: the row subtitle carries
                     // the connection state in text, so the tinted dot is
                     // hidden from VoiceOver instead of being color-only.
                     Circle()
                         .fill(statusTint)
-                        .frame(width: 8, height: 8)
+                        .frame(width: Sizing.statusDot, height: Sizing.statusDot)
                         .overlay {
                             Circle()
                                 .stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5)
@@ -1623,7 +1571,7 @@ private struct DashboardAccountRow: View {
 
             VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
                 Text(account.name)
-                    .font(.callout.weight(.semibold))
+                    .font(.callout.weight(.medium))
                     .lineLimit(1)
                 Text(subtitle)
                     .detailText()
@@ -1633,49 +1581,69 @@ private struct DashboardAccountRow: View {
             Spacer(minLength: Spacing.compactRowContentSpacing)
 
             VStack(alignment: .trailing, spacing: Spacing.xs) {
+                // Amounts are data, not verdicts: always .primary. Risk is
+                // carried by the utilization line below — icon + tint + text,
+                // and only once the user's own threshold is crossed.
                 Text(amountText)
-                    .font(.callout.weight(.bold))
-                    .monospacedDigit()
-                    .foregroundStyle(AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .primary)
+                    .dataText()
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
 
                 if let utilization = account.balances.utilizationPercent {
-                    Text(trailingDetailText)
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(SemanticColors.utilization(
-                            for: utilization,
-                            threshold: appState.creditUtilizationThreshold
-                        ))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.78)
+                    // Mirrors the filter-bar rule: tint the icon, never the
+                    // text — orange caption text fails 4.5:1 contrast.
+                    HStack(spacing: Spacing.xxs) {
+                        if utilizationNeedsAttention {
+                            Image(systemName: SemanticColors.utilizationIcon(
+                                for: utilization,
+                                threshold: appState.creditUtilizationThreshold
+                            ))
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(SemanticColors.utilization(
+                                for: utilization,
+                                threshold: appState.creditUtilizationThreshold
+                            ))
+                        }
+                        Text(trailingDetailText)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(utilizationNeedsAttention ? AnyShapeStyle(.primary) :
+                                AnyShapeStyle(.secondary))
+                    }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
                 } else {
                     Text(trailingDetailText)
                         .microText()
                         .foregroundStyle(statusTint)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.78)
+                        .minimumScaleFactor(0.8)
                 }
             }
 
-            Image(systemName: isSelected ? "chevron.down" : "chevron.right")
-                .font(.caption.weight(.bold))
-                .foregroundStyle(.tertiary)
+            // The detail panel flies out on the leading side of the
+            // dashboard; chevron.backward flips correctly under RTL.
+            Image(systemName: "chevron.backward")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(isSelected ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.tertiary))
         }
         .padding(.horizontal, Spacing.compactRowHorizontalPadding)
         .padding(.vertical, Spacing.compactRowVerticalPadding)
-        .background(isSelected ? SemanticColors.brand.opacity(SurfaceTokens.selectedFillOpacity) : Color.primary.opacity(0.012))
-        .overlay(alignment: .leading) {
-            if isSelected {
-                Rectangle()
-                    .fill(SemanticColors.brand)
-                    .frame(width: 3)
+        .background(
+            isSelected ? Color.accentColor.opacity(SurfaceTokens.selectedFillOpacity) : .clear,
+            in: RoundedRectangle(cornerRadius: Radius.control)
+        )
+        .overlay(alignment: .bottom) {
+            if !isSelected {
+                Divider()
+                    .opacity(0.4)
             }
         }
-        .overlay(alignment: .bottom) {
-            Divider()
-                .opacity(0.55)
-        }
         .contentShape(Rectangle())
+    }
+
+    private var utilizationNeedsAttention: Bool {
+        guard let utilization = account.balances.utilizationPercent else { return false }
+        return utilization >= appState.creditUtilizationThreshold
     }
 
     private var subtitle: String {
@@ -1688,19 +1656,6 @@ private struct DashboardAccountRow: View {
 
     private var amountText: String {
         AccountPresentation.rowAmountText(for: account)
-    }
-
-    private var accountTint: Color {
-        switch account.type {
-        case .credit, .loan:
-            SemanticColors.creditDebt
-        case .investment:
-            .secondary
-        case .depository:
-            .secondary
-        case .other:
-            .secondary
-        }
     }
 
     private var pendingCount: Int {
@@ -1743,600 +1698,6 @@ private struct DashboardAccountRow: View {
     }
 }
 
-// MARK: - Selected Account
-
-private struct SelectedAccountPanel: View {
-    @Environment(AppState.self) private var appState
-    @Environment(\.openSettings) private var openSettings
-    let account: AccountDTO
-    let isStatusFilter: Bool
-    let activitySnapshot: AccountTransactionFeed.AccountActivitySnapshot
-    @State private var isConfirmingAccountRemoval = false
-
-    private var drillInSummary: DashboardAccountDrillInSummary {
-        DashboardAccountDrillInSummary.presentation(
-            for: account,
-            activitySnapshot: activitySnapshot,
-            itemStatus: itemConnectionStatus,
-            fallbackFreshnessLabel: connectionPresentation.signalLabel
-        )
-    }
-
-    private var transactions: [TransactionDTO] {
-        Array(activitySnapshot.transactions.prefix(5))
-    }
-
-    private var accountTransactions: [TransactionDTO] {
-        activitySnapshot.transactions
-    }
-
-    private var pendingTransactions: [TransactionDTO] {
-        activitySnapshot.pendingTransactions
-    }
-
-    private var activitySummary: AccountActivitySummary {
-        activitySnapshot.recentSummary
-    }
-
-    private var emptyState: AccountActivityEmptyState? {
-        AccountActivityEmptyState.evaluate(
-            transactionCount: activitySnapshot.transactionCount,
-            isDemoMode: appState.usesDemoConnectionPresentation,
-            serverConnected: appState.serverConnected,
-            connectionLevel: connectionPresentation.level,
-            accountDisplayName: AccountPresentation.displayName(for: account)
-        )
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.compactRowContentSpacing) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
-                    Text("Drill-in")
-                        .sectionTitle()
-                        .foregroundStyle(.secondary)
-                    Text(drillInSummary.displayName)
-                        .font(.headline.weight(.bold))
-                        .lineLimit(1)
-                    Text(drillInSummary.subtitle)
-                        .detailText()
-                        .lineLimit(1)
-                }
-
-                Spacer()
-
-                AccountConnectionBadge(
-                    label: connectionLabel,
-                    icon: connectionIcon,
-                    tint: connectionTint
-                )
-            }
-
-            DrillInSurfaceRail(surfaces: DashboardDrillInSurface.surfaces(for: account))
-
-            HStack(spacing: Spacing.compactRowContentSpacing) {
-                DetailValue(title: drillInSummary.availableTitle, value: availableText, tint: .primary)
-                DetailValue(title: drillInSummary.currentTitle, value: currentText, tint: currentTint)
-
-                if let utilization = account.balances.utilizationPercent,
-                   let utilizationText = AccountPresentation.dashboardUtilizationDetailText(
-                       for: account,
-                       threshold: appState.creditUtilizationThreshold
-                   ) {
-                    DetailValue(
-                        title: "Utilization",
-                        value: utilizationText,
-                        tint: SemanticColors.utilization(
-                            for: utilization,
-                            threshold: appState.creditUtilizationThreshold
-                        )
-                    )
-                } else {
-                    DetailValue(title: "Activity", value: activityText, tint: connectionTint)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(spacing: Spacing.compactRowContentSpacing) {
-                AccountSignalPill(
-                    title: "Pending",
-                    value: "\(pendingTransactions.count)",
-                    icon: "clock.fill",
-                    tint: pendingTransactions.isEmpty ? .secondary : SemanticColors.pending
-                )
-                AccountSignalPill(
-                    title: "30D Out",
-                    value: Formatters.currency(activitySummary.outflowTotal, format: .compact),
-                    icon: "arrow.up.right.circle.fill",
-                    tint: .secondary
-                )
-                AccountSignalPill(
-                    title: "30D In",
-                    value: Formatters.currency(activitySummary.inflowTotal, format: .compact),
-                    icon: "arrow.down.left.circle.fill",
-                    tint: .secondary
-                )
-                AccountSignalPill(
-                    title: "Sync",
-                    value: syncSignalText,
-                    icon: connectionIcon,
-                    tint: connectionTint
-                )
-            }
-
-            if isStatusFilter, let recoveryDetailLabel = connectionPresentation.recoveryDetailLabel {
-                HStack(alignment: .top, spacing: Spacing.compactRowContentSpacing) {
-                    Image(systemName: connectionIcon)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(connectionTint)
-                        .frame(width: 16)
-                    Text(recoveryDetailLabel)
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-                .padding(.vertical, Spacing.compactRowVerticalPadding)
-                .nativePanelSurface(
-                    cornerRadius: SurfaceTokens.panelCornerRadius,
-                    fill: AnyShapeStyle(recoveryFill),
-                    stroke: connectionTint.opacity(shouldEmphasizeConnection ? 0.14 : 0.06),
-                    useLiquidGlass: false
-                )
-                .accessibilityElement(children: .combine)
-            }
-
-            if shouldShowRecoveryActions {
-                HStack(spacing: Spacing.compactRowContentSpacing) {
-                    Button {
-                        performConnectionRecoveryAction()
-                    } label: {
-                        Label(connectionRecoveryActionTitle, systemImage: connectionRecoveryActionIcon)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .accessibilityLabel(connectionRecoveryAccessibilityLabel)
-                    .accessibilityHint(connectionRecoveryAccessibilityHint)
-                }
-            }
-
-            AccountDrillInActionBar(
-                actions: drillInActions,
-                accountDisplayName: drillInSummary.displayName,
-                onAction: performDrillInAction
-            )
-
-            VStack(alignment: .leading, spacing: Spacing.rowVertical) {
-                Text("Recent Activity")
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
-
-                if transactions.isEmpty {
-                    if let emptyState {
-                        AccountActivityEmptyStateView(presentation: emptyState)
-                    }
-                } else {
-                    ForEach(transactions) { transaction in
-                        TransactionMiniRow(transaction: transaction)
-                    }
-                }
-            }
-        }
-        .padding(Spacing.md)
-        .nativePanelSurface(
-            fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: shouldEmphasizeConnection ? connectionTint : nil)),
-            stroke: panelStroke
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(drillInSummary.accessibilityLabel)
-        .confirmationDialog(
-            "Remove \(institutionRemovalName)?",
-            isPresented: $isConfirmingAccountRemoval,
-            titleVisibility: .visible
-        ) {
-            Button("Remove Institution", role: .destructive) {
-                Task { await appState.removeAccount(itemId: account.itemId) }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from PlaidBar. It does not close any bank account.")
-        }
-    }
-
-    private var institutionTransactionCount: Int {
-        // The dialog message is evaluated as part of the panel body, so gate
-        // the full transaction scan on the dialog actually being presented.
-        guard isConfirmingAccountRemoval else { return 0 }
-        let institutionAccountIds = Set(
-            appState.accounts.filter { $0.itemId == account.itemId }.map(\.id)
-        )
-        return appState.transactions.count { institutionAccountIds.contains($0.accountId) }
-    }
-
-    private var institutionTransactionCountText: String {
-        let count = institutionTransactionCount
-        return count == 1 ? "1 cached local transaction" : "\(count) cached local transactions"
-    }
-
-    private var availableText: String {
-        Formatters.currency(drillInSummary.availableBalance, format: .compact)
-    }
-
-    private var currentText: String {
-        Formatters.currency(drillInSummary.currentBalance, format: .compact)
-    }
-
-    private var currentTint: Color {
-        AccountPresentation.isDebt(account) ? SemanticColors.creditDebt : .primary
-    }
-
-    private var itemStatus: ItemConnectionStatus? {
-        itemConnectionStatus?.status
-    }
-
-    private var itemConnectionStatus: ItemStatus? {
-        appState.itemStatuses.first { $0.id == account.itemId }
-    }
-
-    private var institutionRemovalName: String {
-        itemConnectionStatus?.institutionName ?? AccountPresentation.displayName(for: account)
-    }
-
-    private var institutionAccountCount: Int {
-        appState.accounts.count { $0.itemId == account.itemId }
-    }
-
-    private var institutionAccountCountText: String {
-        let count = max(institutionAccountCount, 1)
-        return count == 1 ? "1 linked account" : "\(count) linked accounts"
-    }
-
-    private var drillInActions: [DashboardDrillInAction] {
-        DashboardDrillInAction.accountDrillInActions(
-            isDemoMode: appState.isDemoMode
-        )
-    }
-
-    private var connectionPresentation: AccountConnectionPresentation {
-        AccountConnectionPresentation.evaluate(
-            isDemoMode: appState.usesDemoConnectionPresentation,
-            serverConnected: appState.serverConnected,
-            isSyncStale: appState.isSyncStale,
-            statusSyncText: appState.statusSyncText,
-            itemStatus: itemStatus,
-            institutionName: itemConnectionStatus?.institutionName,
-            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
-        )
-    }
-
-    private var connectionLabel: String {
-        connectionPresentation.detailLabel
-    }
-
-    private var connectionIcon: String {
-        connectionPresentation.iconName
-    }
-
-    private var connectionTint: Color {
-        accountConnectionTint(for: connectionPresentation.level)
-    }
-
-    private var activityText: String {
-        "\(drillInSummary.transactionCount) tx"
-    }
-
-    private var syncSignalText: String {
-        if isStatusFilter, let itemSyncLabel = connectionPresentation.itemSyncLabel {
-            return itemSyncLabel
-        }
-        return connectionPresentation.signalLabel
-    }
-
-    private var shouldShowRecoveryActions: Bool {
-        connectionPresentation.showsRecoveryActions
-    }
-
-    private var recoveryActionTitle: String {
-        connectionPresentation.recoveryActionTitle ?? "Reconnect"
-    }
-
-    private var connectionRecoveryActionTitle: String {
-        switch connectionPresentation.level {
-        case .loginRequired, .error:
-            return recoveryActionTitle
-        case .stale:
-            return "Refresh"
-        case .demo, .offline, .healthy, .unknown:
-            return "Refresh"
-        }
-    }
-
-    private var connectionRecoveryActionIcon: String {
-        switch connectionPresentation.level {
-        case .loginRequired, .error:
-            return "link.badge.plus"
-        case .stale:
-            return "arrow.clockwise"
-        case .demo, .offline, .healthy, .unknown:
-            return "arrow.clockwise"
-        }
-    }
-
-    private var connectionRecoveryAccessibilityLabel: String {
-        "\(connectionRecoveryActionTitle) for \(drillInSummary.displayName)"
-    }
-
-    private var connectionRecoveryAccessibilityHint: String {
-        connectionPresentation.recoveryDetailLabel ?? "Refreshes this selected account's PlaidBar status."
-    }
-
-    private func performConnectionRecoveryAction() {
-        switch connectionPresentation.level {
-        case .loginRequired, .error:
-            Task { await appState.reconnectItem(itemId: account.itemId) }
-        case .stale:
-            Task { await appState.refreshDashboard() }
-        case .demo, .offline, .healthy, .unknown:
-            break
-        }
-    }
-
-    private func performDrillInAction(_ action: DashboardDrillInAction) {
-        switch action {
-        case .reconnect:
-            Task { await appState.reconnectItem(itemId: account.itemId) }
-        case .remove:
-            isConfirmingAccountRemoval = true
-        case .settings:
-            openSettingsWindow()
-        }
-    }
-
-    private func openSettingsWindow() {
-        SettingsWindowActivationRestorer.shared.open(openSettings: openSettings)
-    }
-
-    private var panelStroke: Color {
-        shouldEmphasizeConnection ? connectionTint.opacity(0.18) : Color.primary.opacity(0.07)
-    }
-
-    private var recoveryFill: Color {
-        shouldEmphasizeConnection ? connectionTint.opacity(0.08) : Color.primary.opacity(0.035)
-    }
-
-    private var shouldEmphasizeConnection: Bool {
-        switch connectionPresentation.level {
-        case .stale, .loginRequired, .error:
-            return true
-        case .demo, .offline, .healthy, .unknown:
-            return false
-        }
-    }
-}
-
-private struct AccountDrillInActionBar: View {
-    let actions: [DashboardDrillInAction]
-    let accountDisplayName: String
-    let onAction: (DashboardDrillInAction) -> Void
-
-    var body: some View {
-        HStack(spacing: Spacing.compactRowContentSpacing) {
-            ForEach(actions, id: \.self) { action in
-                Button {
-                    onAction(action)
-                } label: {
-                    Label(action.title, systemImage: action.iconName)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .tint(action == .remove ? SemanticColors.negative : nil)
-                .accessibilityLabel(action.accessibilityLabel(accountDisplayName: accountDisplayName))
-                .accessibilityHint(action.accessibilityHint)
-            }
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Selected account actions")
-    }
-}
-
-private func accountConnectionTint(for level: AccountConnectionLevel) -> Color {
-    switch level {
-    case .demo:
-        return .secondary
-    case .offline:
-        return .secondary
-    case .healthy:
-        return .secondary
-    case .stale, .loginRequired:
-        return SemanticColors.warning
-    case .error:
-        return SemanticColors.negative
-    case .unknown:
-        return .secondary
-    }
-}
-
-private struct DrillInSurfaceRail: View {
-    let surfaces: [DashboardDrillInSurface]
-
-    var body: some View {
-        HStack(spacing: Spacing.xs) {
-            ForEach(surfaces, id: \.self) { surface in
-                Label(surface.title, systemImage: surface.iconName)
-                    .font(.caption2.weight(.semibold))
-                    .lineLimit(1)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
-                    .background(Color.primary.opacity(0.04), in: Capsule())
-                    .accessibilityLabel("\(surface.title) drill-in")
-                    .accessibilityHint(surface.accessibilitySummary)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Selected account drill-in surfaces")
-    }
-}
-
-private struct AccountConnectionBadge: View {
-    let label: String
-    let icon: String
-    let tint: Color
-
-    var body: some View {
-        Label(label, systemImage: icon)
-            .font(.caption.weight(.semibold))
-            .lineLimit(1)
-            .foregroundStyle(tint)
-            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-            .padding(.vertical, Spacing.compactRowVerticalPadding)
-            .background(tint.opacity(0.12), in: Capsule())
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Selected account status: \(label)")
-    }
-}
-
-private struct AccountSignalPill: View {
-    let title: String
-    let value: String
-    let icon: String
-    let tint: Color
-
-    var body: some View {
-        HStack(spacing: Spacing.xs) {
-            Image(systemName: icon)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tint)
-                .frame(width: 12)
-
-            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
-                Text(title)
-                    .microText()
-                    .foregroundStyle(.secondary)
-                Text(value)
-                    .font(.caption.weight(.bold))
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.82)
-            }
-        }
-        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-        .padding(.vertical, Spacing.compactRowVerticalPadding)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .nativeInsetSurface(cornerRadius: SurfaceTokens.panelCornerRadius)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title): \(value)")
-    }
-}
-
-private struct DetailValue: View {
-    let title: String
-    let value: String
-    let tint: Color
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-            Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(.callout.weight(.bold))
-                .foregroundStyle(tint)
-                .monospacedDigit()
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title): \(value)")
-    }
-}
-
-private struct TransactionMiniRow: View {
-    let transaction: TransactionDTO
-
-    var body: some View {
-        HStack(spacing: Spacing.compactRowContentSpacing) {
-            Circle()
-                .fill(transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55))
-                .frame(width: 8, height: 8)
-
-            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
-                Text(transaction.displayName)
-                    .font(.callout.weight(.semibold))
-                    .lineLimit(1)
-                Text(Formatters.displayTransactionDate(transaction.date))
-                    .microText()
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            Text(amountText)
-                .font(.callout.weight(.bold))
-                .monospacedDigit()
-                .foregroundStyle(transaction.isIncome ? SemanticColors.positive : .primary)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private var amountText: String {
-        let prefix = transaction.isIncome ? "+" : ""
-        return "\(prefix)\(Formatters.currency(transaction.displayAmount, format: .compact))"
-    }
-
-    private var accessibilityLabel: String {
-        let direction = transaction.isIncome ? "income" : "outflow"
-        return "\(transaction.displayName), \(direction), \(Formatters.currency(transaction.displayAmount, format: .full)), \(Formatters.displayTransactionDate(transaction.date))"
-    }
-}
-
-private struct AccountActivityEmptyStateView: View {
-    let presentation: AccountActivityEmptyState
-
-    var body: some View {
-        HStack(alignment: .top, spacing: Spacing.compactRowContentSpacing) {
-            Image(systemName: presentation.iconName)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tint)
-                .frame(width: 18, height: 18)
-                .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 5))
-
-            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
-                Text(presentation.title)
-                    .font(.caption.weight(.semibold))
-                Text(presentation.detail)
-                    .detailText()
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: Spacing.compactRowContentSpacing)
-        }
-        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-        .padding(.vertical, Spacing.compactRowContentSpacing)
-        .nativePanelSurface(
-            cornerRadius: SurfaceTokens.panelCornerRadius,
-            fill: AnyShapeStyle(tint.opacity(0.055)),
-            stroke: tint.opacity(0.11),
-            useLiquidGlass: false
-        )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(presentation.accessibilityLabel)
-    }
-
-    private var tint: Color {
-        switch presentation.tone {
-        case .brand:
-            SemanticColors.brand
-        case .healthy:
-            .secondary
-        case .offline, .secondary:
-            .secondary
-        case .warning:
-            SemanticColors.warning
-        }
-    }
-}
-
 // MARK: - Footer
 
 private struct DashboardFooter: View {
@@ -2346,16 +1707,24 @@ private struct DashboardFooter: View {
     let onAddAccount: () -> Void
 
     var body: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: Spacing.md) {
             Button(action: onAddAccount) {
                 Image(systemName: "plus.circle")
                     .font(.body)
                     .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
             }
             .buttonStyle(.borderless)
             .help("Add Account")
             .accessibilityLabel("Add Account")
             .keyboardShortcut("n", modifiers: .command)
+
+            // The one place sync/mode status lives on a healthy dashboard.
+            Text(statusLineText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityLabel("Status: \(statusLineText)")
 
             Spacer()
 
@@ -2364,6 +1733,7 @@ private struct DashboardFooter: View {
             } label: {
                 RefreshIcon(isLoading: appState.isLoading)
                     .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
             }
             .buttonStyle(.borderless)
             .help("Refresh")
@@ -2375,13 +1745,23 @@ private struct DashboardFooter: View {
             } label: {
                 Image(systemName: "gearshape")
                     .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
             }
             .buttonStyle(.borderless)
             .help("Settings")
             .accessibilityLabel("Settings")
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.xs)
+    }
+
+    private var statusLineText: String {
+        var parts = [appState.statusModeText]
+        parts.append(appState.statusSyncText)
+        if appState.statusItemCount > 0 {
+            parts.append("\(appState.statusItemCount) linked")
+        }
+        return parts.joined(separator: " · ")
     }
 
     private func openSettingsWindow() {
@@ -2390,7 +1770,7 @@ private struct DashboardFooter: View {
 }
 
 @MainActor
-private final class SettingsWindowActivationRestorer {
+final class SettingsWindowActivationRestorer {
     static let shared = SettingsWindowActivationRestorer()
 
     private var closeObserver: NSObjectProtocol?
@@ -2431,8 +1811,8 @@ private final class SettingsWindowActivationRestorer {
         }
 
         DispatchQueue.main.async { [weak self] in
-            guard let self, self.discoveryObserver != nil else { return }
-            _ = self.focusCurrentSettingsWindow()
+            guard let self, discoveryObserver != nil else { return }
+            _ = focusCurrentSettingsWindow()
         }
     }
 
@@ -2524,10 +1904,10 @@ private struct ErrorBanner: View {
             .help("Dismiss error")
             .accessibilityLabel("Dismiss error")
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 7)
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
         .background(SemanticColors.negative.opacity(0.1))
-        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .transition(.move(edge: .top).combined(with: .opacity))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Error: \(error)")
         .task(id: error) {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -63,6 +63,11 @@ struct MainPopover: View {
                 )
                 .environment(appState)
                 .frame(width: Layout.flyoutWidth)
+                // Cap the fly-out to the same screen-bounded height as the
+                // dashboard scroll column so tall detail content scrolls
+                // inside the fly-out instead of growing the whole popover
+                // past the intended screen-bounded height.
+                .frame(maxHeight: dashboardScrollHeight)
                 .transition(.move(edge: .leading).combined(with: .opacity))
 
                 Divider()

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -39,7 +39,7 @@ struct SetupView: View {
             }
         }
         .padding()
-        .frame(width: 520)
+        .frame(maxWidth: .infinity)
         .animation(.easeInOut(duration: 0.25), value: setupMode)
     }
 

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -135,14 +135,14 @@ public struct DashboardAccountDrillInPath: Sendable, Equatable {
         let displayName = AccountPresentation.displayName(for: account)
         if isSelected {
             return Self(
-                accessibilityHint: "Press Return or Space to collapse the account drill-in.",
-                accessibilityActionName: "Collapse account details",
-                pointerHelp: "Collapse details for \(displayName)"
+                accessibilityHint: "Press Return or Space to close the account details panel.",
+                accessibilityActionName: "Close account details",
+                pointerHelp: "Close details for \(displayName)"
             )
         }
 
         return Self(
-            accessibilityHint: "Press Return or Space to open the account drill-in below this row.",
+            accessibilityHint: "Press Return or Space to open the account details panel beside the dashboard.",
             accessibilityActionName: "Open account details",
             pointerHelp: "Open details for \(displayName)"
         )

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -903,12 +903,12 @@ struct PlaidBarCoreTests {
         let collapsed = DashboardAccountDrillInPath.presentation(for: account, isSelected: false)
         let expanded = DashboardAccountDrillInPath.presentation(for: account, isSelected: true)
 
-        #expect(collapsed.accessibilityHint == "Press Return or Space to open the account drill-in below this row.")
+        #expect(collapsed.accessibilityHint == "Press Return or Space to open the account details panel beside the dashboard.")
         #expect(collapsed.accessibilityActionName == "Open account details")
         #expect(collapsed.pointerHelp == "Open details for Everyday")
-        #expect(expanded.accessibilityHint == "Press Return or Space to collapse the account drill-in.")
-        #expect(expanded.accessibilityActionName == "Collapse account details")
-        #expect(expanded.pointerHelp == "Collapse details for Everyday")
+        #expect(expanded.accessibilityHint == "Press Return or Space to close the account details panel.")
+        #expect(expanded.accessibilityActionName == "Close account details")
+        #expect(expanded.pointerHelp == "Close details for Everyday")
         #expect(!collapsed.pointerHelp.contains(account.id))
         #expect(!collapsed.pointerHelp.contains(account.itemId))
     }


### PR DESCRIPTION
## Summary

Dashboard redesign + the new account fly-out. One hero per surface (wordmark + status strip removed; status once in the footer, or attention queue/readiness panel when degraded — which also carry the quick actions from #245). Selecting a row opens a 320pt contextual panel to the LEFT (popover 480→801pt): metadata, status + recovery, balances, 30-day changes vs prior window, transactions to review, top categories, recent activity, account actions. RepoBar-style height: popover grows with content up to screen height via `onGeometryChange` instead of the fixed 460–660 budget. Native segmented filter (⌘1–6 kept), row hover + rounded accent selection, amounts `.primary` with icon-carried risk, neutral heatmap spend ramp, error banner on top and visible during setup, setup rendered at 480pt (no width snap). DESIGN.md updated to match.

## Autonomous task IDs

- Task ID(s): N/A — user-directed design-direction session (not a backlog T-task)
- Backlog slice: Design direction implementation, stacked PR 247 of 4 (#246 → #247 → #248 → #249)
- Scope note: Dashboard/fly-out views and DESIGN.md only; depends on #246 tokens

## Agent coordination

- Builder agent: Claude Code (Fable 5), interactive session with Felipe
- Builder branch/worktree: `feature/dashboard-flyout-redesign` built in worktree `/Users/ftchvs/Developer/PlaidBar/.claude/worktrees/infallible-driscoll-ad8f1c`
- Reviewer/merge steward: Felipe (human approval); Otto may steward the merge after approval
- Coordination note: Merge after #246; rebases of this branch are mine to do; review only

## Changed files

- `DESIGN.md`
- `Sources/PlaidBar/Views/AccountDetailFlyout.swift`
- `Sources/PlaidBar/Views/DashboardNavBand.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Sources/PlaidBar/Views/SetupView.swift`

## Local gates

- [x] `git diff --check` clean across the stack
- [x] `swift build` (all targets) and `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` clean on this branch
- [x] PlaidBarServer target built as part of the full-package build (no server code changed in this PR)
- [x] Full `swift test` on this branch: 374/374 pass
- [x] Secret scan of the diff completed: no credentials, tokens, account IDs, or real balances

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [ ] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [ ] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [ ] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [ ] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [ ] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [ ] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed.

## Merge safety

- [ ] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [ ] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
