### PR TITLE
feat: migrate default storage to VaultPeek directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ generic failure. To see demo data without any Plaid setup, choose **Demo**
 on the setup screen — no server or credentials needed.
 
 To use real or sandbox Plaid data, add your credentials to
-`~/.plaidbar/server.conf`:
+`~/.vaultpeek/server.conf`:
 
 ```bash
-mkdir -p ~/.plaidbar && chmod 700 ~/.plaidbar
-cat > ~/.plaidbar/server.conf <<'EOF'
+mkdir -p ~/.vaultpeek && chmod 700 ~/.vaultpeek
+cat > ~/.vaultpeek/server.conf <<'EOF'
 PLAID_CLIENT_ID=your_client_id
 PLAID_SECRET=your_secret
 # optional: PLAID_ENV=sandbox
 EOF
-chmod 600 ~/.plaidbar/server.conf
+chmod 600 ~/.vaultpeek/server.conf
 ```
 
 No restart dance required: the app notices the new credentials on its next
@@ -224,7 +224,7 @@ First run now asks you to choose a data source:
 - **Connect Sandbox** opens Plaid Link only when the local server is running in sandbox mode with sandbox credentials.
 - **Use Production Credentials** opens the same connect flow only when the local server reports production mode. Production uses real account data and requires Plaid approval.
 
-Before Plaid Link opens, the app explains that Plaid item records and synced account data are stored locally under `~/.plaidbar/`, Plaid access-token bytes are kept in macOS Keychain when available, and Plaid credentials remain in the local server environment.
+Before Plaid Link opens, the app explains that Plaid item records and synced account data are stored locally under `~/.vaultpeek/`, Plaid access-token bytes are kept in macOS Keychain when available, and Plaid credentials remain in the local server environment. Existing default `~/.plaidbar/` installs are copied into `~/.vaultpeek/` without overwriting newer files.
 
 ### 4. Use with real bank data (optional)
 
@@ -240,15 +240,15 @@ You can also keep server settings in a local key-value config file and pass it
 to the standalone server:
 
 ```bash
-mkdir -p ~/.plaidbar
-cat > ~/.plaidbar/server.conf <<'EOF'
+mkdir -p ~/.vaultpeek
+cat > ~/.vaultpeek/server.conf <<'EOF'
 PLAID_CLIENT_ID=your_client_id
 PLAID_SECRET=your_secret
 PLAID_ENV=sandbox
-PLAIDBAR_DATA_DIR=~/.plaidbar
+PLAIDBAR_DATA_DIR=~/.vaultpeek
 EOF
 
-swift run PlaidBarServer --config ~/.plaidbar/server.conf
+swift run PlaidBarServer --config ~/.vaultpeek/server.conf
 ```
 
 The config file uses the same keys as the environment. Values in the config
@@ -428,7 +428,7 @@ swift test
 swift run PlaidBarServer --sandbox
 
 # Run server with a local config file
-swift run PlaidBarServer --config ~/.plaidbar/server.conf
+swift run PlaidBarServer --config ~/.vaultpeek/server.conf
 
 # Run server/app on a custom localhost port
 PLAIDBAR_SERVER_PORT=9494 ./Scripts/run.sh --sandbox
@@ -483,7 +483,7 @@ commit, push, review, and production-readiness work.
 
 The companion server exposes these localhost endpoints. `/health` and
 `/oauth/callback` are unauthenticated; `/api/*` requires the local bearer token
-stored under `~/.plaidbar/auth-token` or `PLAIDBAR_DATA_DIR/auth-token`.
+stored under `~/.vaultpeek/auth-token` or `PLAIDBAR_DATA_DIR/auth-token`.
 Plaid Link completion callbacks must also include the one-time `state` generated
 when the local app created the Hosted Link session.
 

--- a/Scripts/plaidbar-run
+++ b/Scripts/plaidbar-run
@@ -116,7 +116,7 @@ done
 
 curl -fsS "http://127.0.0.1:$SERVER_PORT/health" >/dev/null
 
-DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.plaidbar}"
+DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.vaultpeek}"
 case "$DATA_DIR" in
     "~")
         DATA_DIR="$HOME"

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -111,7 +111,7 @@ for _ in {1..30}; do
 done
 
 curl -fsS "http://127.0.0.1:$SERVER_PORT/health" >/dev/null
-DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.plaidbar}"
+DATA_DIR="${PLAIDBAR_DATA_DIR:-$HOME/.vaultpeek}"
 case "$DATA_DIR" in
     "~")
         DATA_DIR="$HOME"

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -164,6 +164,7 @@ final class AppState {
     // MARK: - Init
 
     init(notificationService: (any NotificationServiceProtocol)? = nil) {
+        _ = try? LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
         self.notificationService = notificationService ?? NotificationService.shared
         loadSettings()
         isSetupComplete = storedSetupCompletion()

--- a/Sources/PlaidBar/Resources/PlaidBar.entitlements
+++ b/Sources/PlaidBar/Resources/PlaidBar.entitlements
@@ -8,6 +8,7 @@
     <true/>
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
     <array>
+        <string>/.vaultpeek/</string>
         <string>/.plaidbar/</string>
     </array>
     <key>keychain-access-groups</key>

--- a/Sources/PlaidBar/Services/ServerProcessService.swift
+++ b/Sources/PlaidBar/Services/ServerProcessService.swift
@@ -30,6 +30,7 @@ final class ServerProcessService {
         }
         guard managedProcess == nil else { return false }
 
+        _ = try? LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
         let storageDirectory = LocalDataStore.storageDirectoryURL()
         let configFileURL = storageDirectory.appendingPathComponent(LocalDataStore.serverConfigFilename)
         let configFileContents = try? String(contentsOf: configFileURL, encoding: .utf8)
@@ -158,7 +159,7 @@ final class ServerProcessService {
     }
 
     /// Opens the server log for appending with owner-only permissions,
-    /// matching the repo's private-file conventions for `~/.plaidbar`.
+    /// matching the repo's private-file conventions for local data storage.
     private static func makePrivateLogHandle(atPath path: String) -> FileHandle? {
         let fileManager = FileManager.default
         if !fileManager.fileExists(atPath: path) {

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -33,6 +33,32 @@ public struct LocalDataResetResult: Equatable, Sendable {
     }
 }
 
+public struct LocalDataMigrationResult: Equatable, Sendable {
+    public let legacyDirectoryPath: String
+    public let currentDirectoryPath: String
+    public let copiedEntries: [String]
+    public let preservedCurrentEntries: [String]
+    public let legacyDirectoryFound: Bool
+
+    public var didCopyEntries: Bool {
+        !copiedEntries.isEmpty
+    }
+
+    public init(
+        legacyDirectoryPath: String,
+        currentDirectoryPath: String,
+        copiedEntries: [String],
+        preservedCurrentEntries: [String],
+        legacyDirectoryFound: Bool
+    ) {
+        self.legacyDirectoryPath = legacyDirectoryPath
+        self.currentDirectoryPath = currentDirectoryPath
+        self.copiedEntries = copiedEntries
+        self.preservedCurrentEntries = preservedCurrentEntries
+        self.legacyDirectoryFound = legacyDirectoryFound
+    }
+}
+
 public struct TransactionCacheContext: Codable, Equatable, Sendable {
     public let environment: PlaidEnvironment
     public let storagePath: String
@@ -44,14 +70,20 @@ public struct TransactionCacheContext: Codable, Equatable, Sendable {
 }
 
 public enum LocalDataStore {
-    public static let displayPath = "~/.plaidbar/"
+    public static let displayPath = "~/.vaultpeek/"
+    public static let legacyDisplayPath = "~/.plaidbar/"
     public static let dataDirectoryEnvironmentVariable = "PLAIDBAR_DATA_DIR"
     public static let authTokenFilename = "auth-token"
     public static let serverConfigFilename = "server.conf"
     public static let accountCacheFilename = "accounts.json"
     public static let transactionCacheFilename = "transactions.json"
     public static let pendingLinkSessionsFilename = "pending-link-sessions.json"
+    public static let legacyMigrationResetMarkerFilename = ".legacy-migration-reset"
+    /// Preserve the existing Keychain service while moving local files so
+    /// SQLite `keychain:<item_id>` references continue to resolve.
     public static let plaidAccessTokenKeychainService = "PlaidBar.PlaidAccessToken"
+    private static let currentDirectoryName = ".vaultpeek"
+    private static let legacyDirectoryName = ".plaidbar"
     private static let directoryPermissions = 0o700
     private static let cacheFilePermissions = 0o600
 
@@ -74,7 +106,19 @@ public enum LocalDataStore {
             return URL(fileURLWithPath: NSString(string: override).expandingTildeInPath, isDirectory: true)
         }
 
-        return homeDirectory.appendingPathComponent(".plaidbar", isDirectory: true)
+        return currentStorageDirectoryURL(homeDirectory: homeDirectory)
+    }
+
+    public static func legacyStorageDirectoryURL(
+        homeDirectory: URL = accountHomeDirectoryURL()
+    ) -> URL {
+        homeDirectory.appendingPathComponent(legacyDirectoryName, isDirectory: true)
+    }
+
+    public static func currentStorageDirectoryURL(
+        homeDirectory: URL = accountHomeDirectoryURL()
+    ) -> URL {
+        homeDirectory.appendingPathComponent(currentDirectoryName, isDirectory: true)
     }
 
     public static func storageDirectoryURL(
@@ -154,6 +198,7 @@ public enum LocalDataStore {
 
         try ensurePrivateDirectory(directory, fileManager: fileManager)
         try ensurePrivatePreservedFilePermissions(in: directory, fileManager: fileManager)
+        try writeLegacyMigrationResetMarker(in: directory, fileManager: fileManager)
 
         var keychainTokensCleared = false
         if resetKeychainTokens {
@@ -203,6 +248,51 @@ public enum LocalDataStore {
 
     private static var sqliteSidecarSuffixes: [String] {
         ["-wal", "-shm", "-journal"]
+    }
+
+    private static func ensurePrivateKnownDataFilePermissions(
+        in directory: URL,
+        fileManager: FileManager
+    ) throws {
+        let entries = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        for entry in entries where isKnownPrivateDataFilename(entry.lastPathComponent) {
+            try setPrivateCacheFilePermissions(entry, fileManager: fileManager)
+        }
+    }
+
+    private static func isKnownPrivateDataFilename(_ filename: String) -> Bool {
+        filename == legacyMigrationResetMarkerFilename ||
+            resetPreservedFilenames.contains(filename) ||
+            filename == ServerAutoLaunchPlan.logFilename ||
+            isAccountCacheFilename(filename) ||
+            isTransactionCacheFilename(filename) ||
+            isPendingLinkSessionsFilename(filename) ||
+            plaidBarDatabaseFilenames.contains { databaseFilename in
+                filename == databaseFilename ||
+                    sqliteSidecarSuffixes.contains { filename == databaseFilename + $0 } ||
+                    filename.hasPrefix(databaseFilename + ".backup-") ||
+                    filename.hasPrefix(databaseFilename + ".migration-") ||
+                    filename == databaseFilename + ".migrated-from-legacy"
+            }
+    }
+
+    private static func sqliteStoreBaseFilename(for filename: String) -> String? {
+        plaidBarDatabaseFilenames.first { databaseFilename in
+            filename == databaseFilename ||
+                sqliteSidecarSuffixes.contains { filename == databaseFilename + $0 }
+        }
+    }
+
+    private static func sqliteStorePathCandidates(
+        in directory: URL,
+        databaseFilename: String
+    ) -> [URL] {
+        ([databaseFilename] + sqliteSidecarSuffixes.map { databaseFilename + $0 })
+            .map { directory.appendingPathComponent($0) }
     }
 
     private static func isTransactionCacheFilename(_ filename: String) -> Bool {
@@ -289,7 +379,223 @@ public enum LocalDataStore {
         at directory: URL = storageDirectoryURL(),
         fileManager: FileManager = .default
     ) throws {
+        try migrateLegacyDefaultStorageIfNeeded(
+            destinationDirectory: directory,
+            fileManager: fileManager
+        )
         try ensurePrivateDirectory(directory, fileManager: fileManager)
+    }
+
+    @discardableResult
+    public static func migrateLegacyDefaultStorageIfNeeded(
+        homeDirectory: URL = accountHomeDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws -> LocalDataMigrationResult {
+        try migrateLegacyDefaultStorageIfNeeded(
+            homeDirectory: homeDirectory,
+            destinationDirectory: currentStorageDirectoryURL(homeDirectory: homeDirectory),
+            fileManager: fileManager
+        )
+    }
+
+    @discardableResult
+    public static func migrateLegacyDefaultStorageIfNeeded(
+        homeDirectory: URL = accountHomeDirectoryURL(),
+        destinationDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws -> LocalDataMigrationResult {
+        let currentDirectory = currentStorageDirectoryURL(homeDirectory: homeDirectory)
+        let legacyDirectory = legacyStorageDirectoryURL(homeDirectory: homeDirectory)
+
+        guard destinationDirectory.standardizedFileURL == currentDirectory.standardizedFileURL else {
+            return LocalDataMigrationResult(
+                legacyDirectoryPath: legacyDirectory.path,
+                currentDirectoryPath: destinationDirectory.path,
+                copiedEntries: [],
+                preservedCurrentEntries: [],
+                legacyDirectoryFound: false
+            )
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: legacyDirectory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            try ensurePrivateDirectory(currentDirectory, fileManager: fileManager)
+            return LocalDataMigrationResult(
+                legacyDirectoryPath: legacyDirectory.path,
+                currentDirectoryPath: currentDirectory.path,
+                copiedEntries: [],
+                preservedCurrentEntries: [],
+                legacyDirectoryFound: false
+            )
+        }
+
+        try ensurePrivateDirectory(currentDirectory, fileManager: fileManager)
+
+        var copiedEntries: [String] = []
+        var preservedCurrentEntries: [String] = []
+        let resetMarkerExists = fileManager.fileExists(
+            atPath: currentDirectory.appendingPathComponent(legacyMigrationResetMarkerFilename).path
+        )
+        let legacyEntries = try fileManager.contentsOfDirectory(
+            at: legacyDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let preservedSQLiteBases = Set(plaidBarDatabaseFilenames.filter { databaseFilename in
+            sqliteStorePathCandidates(
+                in: currentDirectory,
+                databaseFilename: databaseFilename
+            ).contains { fileManager.fileExists(atPath: $0.path) }
+        })
+
+        for sourceURL in legacyEntries {
+            let filename = sourceURL.lastPathComponent
+            if resetMarkerExists && shouldRemoveDuringReset(filename) {
+                continue
+            }
+
+            if let databaseFilename = sqliteStoreBaseFilename(for: filename),
+               preservedSQLiteBases.contains(databaseFilename) {
+                preservedCurrentEntries.append(filename)
+                continue
+            }
+
+            let preparedCopy = try preparedLegacyMigrationCopy(
+                from: sourceURL,
+                legacyDirectory: legacyDirectory,
+                currentDirectory: currentDirectory
+            )
+            let destinationURL = preparedCopy.destinationURL
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                preservedCurrentEntries.append(destinationURL.lastPathComponent)
+                continue
+            }
+
+            if let data = preparedCopy.data {
+                try writePrivateCacheFile(data, to: destinationURL, fileManager: fileManager)
+            } else {
+                try fileManager.copyItem(at: sourceURL, to: destinationURL)
+            }
+            copiedEntries.append(destinationURL.lastPathComponent)
+        }
+
+        try ensurePrivatePreservedFilePermissions(in: currentDirectory, fileManager: fileManager)
+        try ensurePrivateKnownDataFilePermissions(in: currentDirectory, fileManager: fileManager)
+
+        return LocalDataMigrationResult(
+            legacyDirectoryPath: legacyDirectory.path,
+            currentDirectoryPath: currentDirectory.path,
+            copiedEntries: copiedEntries.sorted(),
+            preservedCurrentEntries: preservedCurrentEntries.sorted(),
+            legacyDirectoryFound: true
+        )
+    }
+
+    private static func preparedLegacyMigrationCopy(
+        from sourceURL: URL,
+        legacyDirectory: URL,
+        currentDirectory: URL
+    ) throws -> (destinationURL: URL, data: Data?) {
+        let filename = sourceURL.lastPathComponent
+        if isTransactionCacheFilename(filename),
+           let remapped = try remappedTransactionCacheCopy(
+            from: sourceURL,
+            legacyDirectory: legacyDirectory,
+            currentDirectory: currentDirectory
+           ) {
+            return remapped
+        }
+
+        if isAccountCacheFilename(filename),
+           let remapped = try remappedAccountCacheCopy(
+            from: sourceURL,
+            legacyDirectory: legacyDirectory,
+            currentDirectory: currentDirectory
+           ) {
+            return remapped
+        }
+
+        return (currentDirectory.appendingPathComponent(filename), nil)
+    }
+
+    private static func remappedTransactionCacheCopy(
+        from sourceURL: URL,
+        legacyDirectory: URL,
+        currentDirectory: URL
+    ) throws -> (destinationURL: URL, data: Data)? {
+        let data = try Data(contentsOf: sourceURL)
+        guard let cache = try? JSONDecoder().decode(TransactionCache.self, from: data) else {
+            return nil
+        }
+        guard let context = cache.context,
+              let remappedContext = remappedLegacyContext(
+                context,
+                legacyDirectory: legacyDirectory,
+                currentDirectory: currentDirectory
+              ) else {
+            return nil
+        }
+
+        let remappedCache = TransactionCache(
+            context: remappedContext,
+            transactions: cache.transactions
+        )
+        return (
+            transactionCacheURL(in: currentDirectory, context: remappedContext),
+            try JSONEncoder().encode(remappedCache)
+        )
+    }
+
+    private static func remappedAccountCacheCopy(
+        from sourceURL: URL,
+        legacyDirectory: URL,
+        currentDirectory: URL
+    ) throws -> (destinationURL: URL, data: Data)? {
+        let data = try Data(contentsOf: sourceURL)
+        guard let cache = try? JSONDecoder().decode(AccountCache.self, from: data) else {
+            return nil
+        }
+        guard let context = cache.context,
+              let remappedContext = remappedLegacyContext(
+                context,
+                legacyDirectory: legacyDirectory,
+                currentDirectory: currentDirectory
+              ) else {
+            return nil
+        }
+
+        let remappedCache = AccountCache(
+            context: remappedContext,
+            accounts: cache.accounts
+        )
+        return (
+            accountCacheURL(in: currentDirectory, context: remappedContext),
+            try JSONEncoder().encode(remappedCache)
+        )
+    }
+
+    private static func remappedLegacyContext(
+        _ context: TransactionCacheContext,
+        legacyDirectory: URL,
+        currentDirectory: URL
+    ) -> TransactionCacheContext? {
+        let legacyPath = legacyDirectory.standardizedFileURL.path
+        let currentPath = currentDirectory.standardizedFileURL.path
+        let storagePath = URL(fileURLWithPath: context.storagePath).standardizedFileURL.path
+
+        if storagePath == legacyPath {
+            return TransactionCacheContext(
+                environment: context.environment,
+                storagePath: currentPath
+            )
+        }
+
+        guard storagePath.hasPrefix(legacyPath + "/") else { return nil }
+        return TransactionCacheContext(
+            environment: context.environment,
+            storagePath: currentPath + String(storagePath.dropFirst(legacyPath.count))
+        )
     }
 
     public static func loadTransactions(
@@ -464,6 +770,16 @@ public enum LocalDataStore {
                 ofItemAtPath: url.path
             )
         }
+    }
+
+    private static func writeLegacyMigrationResetMarker(
+        in directory: URL,
+        fileManager: FileManager
+    ) throws {
+        let url = directory.appendingPathComponent(legacyMigrationResetMarkerFilename)
+        let marker = "reset_at=\(ISO8601DateFormatter().string(from: Date()))\n"
+        try writePrivateCacheFile(Data(marker.utf8), to: url, fileManager: fileManager)
+        try setPrivateCacheFilePermissions(url, fileManager: fileManager)
     }
 }
 

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -50,6 +50,9 @@ struct ServerConfig: Sendable {
         sandboxOverride: Bool? = nil
     ) throws -> ServerConfig {
         let environmentValues = try resolvedEnvironment(from: configPath)
+        if environmentValues[LocalDataStore.dataDirectoryEnvironmentVariable]?.trimmedNonEmpty == nil {
+            try LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
+        }
         let dataDir = dataDirectory(environment: environmentValues)
         try FileManager.default.createDirectory(
             atPath: dataDir,

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3466,15 +3466,16 @@ struct PlaidBarCoreTests {
 
     // MARK: - Local Data Store
 
-    @Test("Local data store resolves hidden PlaidBar directory")
+    @Test("Local data store resolves hidden VaultPeek directory")
     func localDataStorePathResolution() {
         let home = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
 
         let directory = LocalDataStore.storageDirectoryURL(homeDirectory: home)
 
-        #expect(LocalDataStore.displayPath == "~/.plaidbar/")
-        #expect(directory.lastPathComponent == ".plaidbar")
+        #expect(LocalDataStore.displayPath == "~/.vaultpeek/")
+        #expect(LocalDataStore.legacyDisplayPath == "~/.plaidbar/")
+        #expect(directory.lastPathComponent == ".vaultpeek")
         #expect(directory.deletingLastPathComponent() == home)
     }
 
@@ -3482,7 +3483,7 @@ struct PlaidBarCoreTests {
     func localDataStoreDefaultPathUsesAccountHome() {
         let directory = LocalDataStore.storageDirectoryURL()
 
-        #expect(directory.lastPathComponent == ".plaidbar")
+        #expect(directory.lastPathComponent == ".vaultpeek")
         #expect(directory.deletingLastPathComponent() == LocalDataStore.accountHomeDirectoryURL())
     }
 
@@ -3518,7 +3519,7 @@ struct PlaidBarCoreTests {
     func localDataStoreResolvesActiveDirectoryFromServerStorageDirectory() {
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            .appendingPathComponent(".plaidbar", isDirectory: true)
+            .appendingPathComponent(".vaultpeek", isDirectory: true)
 
         let resolved = LocalDataStore.storageDirectoryURL(
             forServerStoragePath: directory.path
@@ -3543,11 +3544,206 @@ struct PlaidBarCoreTests {
     @Test("Local data store display path abbreviates home")
     func localDataStoreDisplayPathAbbreviatesHome() {
         let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
-        let directory = home.appendingPathComponent(".plaidbar", isDirectory: true)
+        let directory = home.appendingPathComponent(".vaultpeek", isDirectory: true)
 
-        #expect(LocalDataStore.displayPath(for: directory, homeDirectory: home) == "~/.plaidbar")
+        #expect(LocalDataStore.displayPath(for: directory, homeDirectory: home) == "~/.vaultpeek")
         #expect(LocalDataStore.displayPath(for: home, homeDirectory: home) == "~")
         #expect(LocalDataStore.displayPath(for: URL(fileURLWithPath: "/var/tmp/plaidbar"), homeDirectory: home) == "/var/tmp/plaidbar")
+    }
+
+    @Test("Local data migration copies legacy files without overwriting current data")
+    func localDataMigrationCopiesLegacyFilesWithoutOverwritingCurrentData() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacyDirectory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let currentDirectory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+
+        let legacyAuthToken = legacyDirectory.appendingPathComponent("auth-token")
+        let legacyServerConfig = legacyDirectory.appendingPathComponent("server.conf")
+        let legacyDatabase = legacyDirectory.appendingPathComponent("plaidbar-production.sqlite")
+        let legacyDatabaseWAL = legacyDirectory.appendingPathComponent("plaidbar-production.sqlite-wal")
+        let legacyLog = legacyDirectory.appendingPathComponent("server.log")
+        let currentServerConfig = currentDirectory.appendingPathComponent("server.conf")
+
+        try "legacy-token".write(to: legacyAuthToken, atomically: true, encoding: .utf8)
+        try "PLAID_ENV=sandbox".write(to: legacyServerConfig, atomically: true, encoding: .utf8)
+        try "db".write(to: legacyDatabase, atomically: true, encoding: .utf8)
+        try "wal".write(to: legacyDatabaseWAL, atomically: true, encoding: .utf8)
+        try "log".write(to: legacyLog, atomically: true, encoding: .utf8)
+        try "PLAID_ENV=production".write(to: currentServerConfig, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: legacyAuthToken.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: legacyDatabase.path)
+
+        let result = try LocalDataStore.migrateLegacyDefaultStorageIfNeeded(homeDirectory: root)
+
+        #expect(result.legacyDirectoryFound)
+        #expect(result.copiedEntries == [
+            "auth-token",
+            "plaidbar-production.sqlite",
+            "plaidbar-production.sqlite-wal",
+            "server.log",
+        ])
+        #expect(result.preservedCurrentEntries == ["server.conf"])
+        #expect(try String(contentsOf: currentDirectory.appendingPathComponent("auth-token"), encoding: .utf8) == "legacy-token")
+        #expect(try String(contentsOf: currentServerConfig, encoding: .utf8) == "PLAID_ENV=production")
+        #expect(try String(contentsOf: legacyServerConfig, encoding: .utf8) == "PLAID_ENV=sandbox")
+        #expect(try posixPermissions(at: currentDirectory) == 0o700)
+        #expect(try posixPermissions(at: currentDirectory.appendingPathComponent("auth-token")) == 0o600)
+        #expect(try posixPermissions(at: currentDirectory.appendingPathComponent("plaidbar-production.sqlite")) == 0o600)
+
+        let secondResult = try LocalDataStore.migrateLegacyDefaultStorageIfNeeded(homeDirectory: root)
+        #expect(secondResult.copiedEntries == [])
+        #expect(secondResult.preservedCurrentEntries == [
+            "auth-token",
+            "plaidbar-production.sqlite",
+            "plaidbar-production.sqlite-wal",
+            "server.conf",
+            "server.log",
+        ])
+    }
+
+    @Test("Local data migration remaps path-scoped caches")
+    func localDataMigrationRemapsPathScopedCaches() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacyDirectory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let currentDirectory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacyDatabasePath = legacyDirectory
+            .appendingPathComponent("plaidbar.sqlite")
+            .path
+        let currentDatabasePath = currentDirectory
+            .appendingPathComponent("plaidbar.sqlite")
+            .path
+        let legacyContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: legacyDatabasePath
+        )
+        let currentContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: currentDatabasePath
+        )
+        let transactions = [
+            TransactionDTO(id: "txn", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")
+        ]
+        let accounts = [
+            AccountDTO(
+                id: "checking",
+                itemId: "item",
+                name: "Checking",
+                type: .depository,
+                balances: BalanceDTO(current: 100)
+            )
+        ]
+
+        try LocalDataStore.saveTransactions(transactions, to: legacyDirectory, context: legacyContext)
+        try LocalDataStore.saveAccounts(accounts, to: legacyDirectory, context: legacyContext)
+
+        let result = try LocalDataStore.migrateLegacyDefaultStorageIfNeeded(homeDirectory: root)
+
+        #expect(result.didCopyEntries)
+        #expect(try LocalDataStore.loadTransactions(
+            from: currentDirectory,
+            context: currentContext
+        ).map(\.id) == ["txn"])
+        #expect(try LocalDataStore.loadAccounts(
+            from: currentDirectory,
+            context: currentContext
+        ).map(\.id) == ["checking"])
+        #expect(try LocalDataStore.loadTransactions(
+            from: currentDirectory,
+            context: legacyContext
+        ).isEmpty)
+    }
+
+    @Test("Local data migration does not restore reset-cleared legacy data")
+    func localDataMigrationDoesNotRestoreResetClearedLegacyData() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacyDirectory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let currentDirectory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+        try "db".write(
+            to: legacyDirectory.appendingPathComponent("plaidbar-production.sqlite"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "sessions".write(
+            to: legacyDirectory.appendingPathComponent("pending-link-sessions.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "PLAID_ENV=production".write(
+            to: legacyDirectory.appendingPathComponent("server.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        _ = try LocalDataStore.resetLocalData(
+            at: currentDirectory,
+            resetKeychainTokens: false
+        )
+        let result = try LocalDataStore.migrateLegacyDefaultStorageIfNeeded(homeDirectory: root)
+
+        #expect(result.copiedEntries == ["server.conf"])
+        #expect(!FileManager.default.fileExists(
+            atPath: currentDirectory.appendingPathComponent("plaidbar-production.sqlite").path
+        ))
+        #expect(!FileManager.default.fileExists(
+            atPath: currentDirectory.appendingPathComponent("pending-link-sessions.json").path
+        ))
+        #expect(FileManager.default.fileExists(
+            atPath: currentDirectory.appendingPathComponent(LocalDataStore.legacyMigrationResetMarkerFilename).path
+        ))
+    }
+
+    @Test("Local data migration keeps SQLite sidecars with their owning database")
+    func localDataMigrationKeepsSQLiteSidecarsWithOwningDatabase() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacyDirectory = root.appendingPathComponent(".plaidbar", isDirectory: true)
+        let currentDirectory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try "legacy-db".write(
+            to: legacyDirectory.appendingPathComponent("plaidbar-production.sqlite"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "legacy-wal".write(
+            to: legacyDirectory.appendingPathComponent("plaidbar-production.sqlite-wal"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "current-db".write(
+            to: currentDirectory.appendingPathComponent("plaidbar-production.sqlite"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try LocalDataStore.migrateLegacyDefaultStorageIfNeeded(homeDirectory: root)
+
+        #expect(result.copiedEntries == [])
+        #expect(result.preservedCurrentEntries == [
+            "plaidbar-production.sqlite",
+            "plaidbar-production.sqlite-wal",
+        ])
+        #expect(!FileManager.default.fileExists(
+            atPath: currentDirectory.appendingPathComponent("plaidbar-production.sqlite-wal").path
+        ))
+        #expect(try String(
+            contentsOf: currentDirectory.appendingPathComponent("plaidbar-production.sqlite"),
+            encoding: .utf8
+        ) == "current-db")
     }
 
     @Test("Local data reset removes data files and keeps local server configuration")
@@ -3602,10 +3798,19 @@ struct PlaidBarCoreTests {
         var isDirectory: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
-        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == ["auth-token", "exports", "notes.txt", "server.conf"])
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == [
+            ".legacy-migration-reset",
+            "auth-token",
+            "exports",
+            "notes.txt",
+            "server.conf",
+        ])
         #expect(try String(contentsOf: authToken, encoding: .utf8) == "token")
         #expect(try String(contentsOf: serverConfig, encoding: .utf8) == "PLAID_ENV=sandbox")
         #expect(try String(contentsOf: unrelatedFile, encoding: .utf8) == "keep me")
+        #expect(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(LocalDataStore.legacyMigrationResetMarkerFilename).path
+        ))
         #expect(FileManager.default.fileExists(atPath: unrelatedDirectory.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
         #expect(try posixPermissions(at: authToken) == 0o600)

--- a/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("Server Auto-Launch Plan Tests")
 struct ServerAutoLaunchPlanTests {
     private let bundledPath = "/Applications/PlaidBar.app/Contents/MacOS/PlaidBarServer"
-    private let dataDirectory = "/Users/example/.plaidbar"
+    private let dataDirectory = "/Users/example/.vaultpeek"
 
     @Test("Plan launches the bundled server with the configured server.conf")
     func planLaunchesBundledServer() throws {
@@ -22,11 +22,11 @@ struct ServerAutoLaunchPlanTests {
 
         #expect(plan.executablePath == bundledPath)
         #expect(plan.arguments == [
-            "--config", "/Users/example/.plaidbar/server.conf",
+            "--config", "/Users/example/.vaultpeek/server.conf",
             "--port", "8484",
             "--exit-with-parent", "4242",
         ])
-        #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
+        #expect(plan.logFilePath == "/Users/example/.vaultpeek/server.log")
     }
 
     @Test("Plan normalizes a trailing slash in the data directory")
@@ -42,9 +42,9 @@ struct ServerAutoLaunchPlanTests {
             parentProcessId: 4242
         ))
 
-        #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
+        #expect(plan.logFilePath == "/Users/example/.vaultpeek/server.log")
         #expect(plan.arguments.contains("--config"))
-        #expect(plan.arguments.contains("/Users/example/.plaidbar/server.conf"))
+        #expect(plan.arguments.contains("/Users/example/.vaultpeek/server.conf"))
     }
 
     @Test("Plan declines when managed server config moves the data directory")
@@ -110,7 +110,7 @@ struct ServerAutoLaunchPlanTests {
             "--port", "8484",
             "--exit-with-parent", "4242",
         ])
-        #expect(plan.logFilePath == "/Users/example/.plaidbar/server.log")
+        #expect(plan.logFilePath == "/Users/example/.vaultpeek/server.log")
     }
 
     @Test("Plan declines when server.conf exists but cannot be read")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ PlaidBar.app
 PlaidBarServer
   /health without auth
   /api/* with local bearer token
-  SQLite under ~/.plaidbar/
+  SQLite under ~/.vaultpeek/
   Plaid API client
         |
         | HTTPS
@@ -65,7 +65,7 @@ file, and explicit CLI flags. Later inputs override earlier ones.
 | `PLAID_SECRET` | Plaid secret for the selected environment |
 | `PLAID_ENV` | `sandbox` or `production` |
 | `PLAIDBAR_SERVER_PORT` | Local server port, default from `PlaidBarConstants` |
-| `PLAIDBAR_DATA_DIR` | Local data directory, default `~/.plaidbar/` |
+| `PLAIDBAR_DATA_DIR` | Local data directory, default `~/.vaultpeek/` |
 | `PLAIDBAR_MIGRATE_LEGACY_DATABASE` | Explicit legacy migration environment |
 
 The default server should bind to localhost only. If a future change expands
@@ -77,8 +77,13 @@ the setup UI.
 Default local data directory:
 
 ```text
-~/.plaidbar/
+~/.vaultpeek/
 ```
+
+Default installs copy missing files from the legacy `~/.plaidbar/` directory
+into `~/.vaultpeek/` on startup. Existing `~/.vaultpeek/` files win, so the
+migration is idempotent and does not overwrite newer data. `PLAIDBAR_DATA_DIR`
+keeps pointing app and server to an explicit custom directory when needed.
 
 Current important files:
 
@@ -94,6 +99,8 @@ The data directory is created with private user permissions. Cache/token files
 are written with private file permissions where the platform supports it.
 On macOS runtime builds with Security framework support, Plaid access-token
 bytes are stored in Keychain and SQLite stores `keychain:<item_id>` references.
+Those Keychain references intentionally keep the original PlaidBar service name
+during the storage migration so existing linked items keep resolving.
 Fallback builds without Keychain support may store token bytes locally in the
 SQLite store, so release/security docs must stay explicit about that boundary.
 

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -145,8 +145,8 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-011: Local Data Controls
 
-- [ ] T051: Keep Settings visibly anchored on `~/.plaidbar/` or the configured
-  `PLAIDBAR_DATA_DIR`.
+- [ ] T051: Keep Settings visibly anchored on the default local data path or
+  the configured `PLAIDBAR_DATA_DIR`.
 - [ ] T052: Ensure copy and reveal actions avoid leaking secrets in labels or
   logs.
 - [ ] T053: Confirm reset/delete copy explains local-vs-Plaid-vs-bank

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -38,10 +38,14 @@ PlaidBar does not include:
 By default, PlaidBar stores local data under:
 
 ```text
-~/.plaidbar/
+~/.vaultpeek/
 ```
 
 The directory can be overridden with `PLAIDBAR_DATA_DIR`.
+Existing default installs using `~/.plaidbar/` are copied into
+`~/.vaultpeek/` on startup when the new directory does not already contain the
+same file. The legacy directory is left in place as rollback evidence, and
+newer `~/.vaultpeek/` files are never overwritten by migration.
 
 Current local data may include:
 
@@ -53,6 +57,7 @@ Current local data may include:
 - balances
 - account and transaction caches
 - pending link-session state
+- local server logs
 
 Sandbox and production use separate scoped stores.
 
@@ -96,6 +101,10 @@ Resetting local data removes PlaidBar-owned database files, account and
 transaction caches, pending Link sessions, and stored Plaid access-token entries
 when present. It leaves `server.conf`, app/server auth, preferences, and
 unrelated files in the storage directory untouched.
+
+The storage-directory migration does not rename Keychain entries. Plaid access
+tokens continue to use the existing Keychain service so migrated SQLite
+`keychain:<item_id>` references keep working.
 
 Local reset does not necessarily delete records from the Plaid Dashboard or
 revoke bank permissions outside PlaidBar. Users who need complete revocation

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -62,7 +62,8 @@ local storage, notifications, and distribution.
 | Status contract test | Encoded `ServerStatus` contains only release-approved keys |
 | Auth middleware | `/api/*` rejects missing/invalid bearer token |
 | Auth comparison | Bearer token comparison accepts only exact token strings |
-| Data directory | `~/.plaidbar/` uses private user permissions where supported |
+| Data directory | `~/.vaultpeek/` uses private user permissions where supported |
+| Legacy storage migration | Missing default files copy from `~/.plaidbar/` without overwriting newer `~/.vaultpeek/` files |
 | Auth token | `auth-token` uses private file permissions where supported |
 | Plaid tokens | Runtime stores access-token bytes in Keychain when available; fallback builds are documented |
 | Sandbox/production | Stores and transaction cache are scoped by environment |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,9 +85,39 @@ directory.
 Checks:
 
 - Confirm the app and server use the same `PLAIDBAR_DATA_DIR`.
-- Confirm `~/.plaidbar/auth-token` exists.
+- Confirm `~/.vaultpeek/auth-token` exists for default installs.
+- If this Mac was used before the VaultPeek storage migration, confirm
+  `~/.plaidbar/auth-token` was copied or restart once with both directories
+  available.
 - Restart both the app and server after changing the data directory.
 - Avoid copying `auth-token` into public logs or issues.
+
+## Default Storage Did Not Migrate
+
+PlaidBar now uses `~/.vaultpeek/` as its default local data/config directory.
+On startup, default installs copy missing files from `~/.plaidbar/` into
+`~/.vaultpeek/`.
+
+Expected behavior:
+
+- Existing `auth-token`, `server.conf`, SQLite stores and sidecars, account and
+  transaction caches, pending link sessions, and `server.log` are copied when
+  the destination filename is absent.
+- Existing `~/.vaultpeek/` files are preserved and never overwritten.
+- `~/.plaidbar/` is left in place for rollback until the user deletes it.
+- After a local reset, PlaidBar writes a small reset marker so old databases,
+  caches, and pending link sessions are not copied back from `~/.plaidbar/`.
+- Keychain Plaid access tokens keep the existing service name so SQLite
+  `keychain:<item_id>` references remain valid after file migration.
+
+Recovery checks:
+
+- Quit PlaidBar and PlaidBarServer.
+- Confirm both directories are private to the current user.
+- Move only the missing file from `~/.plaidbar/` to `~/.vaultpeek/` if a newer
+  VaultPeek file is not already present.
+- To roll back temporarily, set `PLAIDBAR_DATA_DIR=~/.plaidbar` before starting
+  both the app and server.
 
 ## Accounts Are Linked But Transactions Are Empty
 


### PR DESCRIPTION
## Summary
- Move the default local data/config directory from `~/.plaidbar/` to `~/.vaultpeek/` without a visible product-string rename.
- Add idempotent default-directory migration that copies missing legacy files into `~/.vaultpeek/` while preserving any newer destination files.
- Keep existing Plaid Keychain service references intact so migrated SQLite `keychain:<item_id>` rows continue to resolve.
- Update sandbox entitlements, runner scripts, docs, and tests for the new default path and migration recovery/rollback behavior.

## Autonomous task IDs
Task ID(s): AND-328
Backlog slice: VaultPeek rename foundation / local data and config migration
Scope note: Data/config migration only. This intentionally does not rename visible PlaidBar product strings outside storage-path documentation.

## Agent coordination
Builder agent: Coding subagent (Codex)
Builder branch/worktree: `and-328-vaultpeek-data-config-migration` at `/Users/otto/.openclaw/workspace-coding/maintainer-checkouts/PlaidBar`
Reviewer/merge steward: Codex review requested with `@codex review`; human/maintainer merge steward remains Felipe/Otto policy gate.
Coordination note: Builds on merged AND-317 / PR #252. Codex review findings on reset re-migration, cache remapping, SQLite sidecar atomicity, and runner defaults were addressed in head `b5e14b5`.

## Changed files
- `Sources/PlaidBarCore/Utilities/LocalDataStore.swift` — new default `~/.vaultpeek/`, legacy path helpers, migration result, idempotent copy-forward migration, reset marker, path-scoped cache remapping, SQLite store/sidecar atomic preservation, and private permissions for migrated known data files.
- `Sources/PlaidBar/App/AppState.swift` and `Sources/PlaidBar/Services/ServerProcessService.swift` — invoke default migration before app/server storage use.
- `Sources/PlaidBarServer/Config/ServerConfig.swift` — runs default migration before provisioning server storage when `PLAIDBAR_DATA_DIR` is not explicitly set.
- `Scripts/run.sh` and `Scripts/plaidbar-run` — default auth-token lookup now matches `~/.vaultpeek/`.
- `Sources/PlaidBar/Resources/PlaidBar.entitlements` — allows sandboxed access to both `~/.vaultpeek/` and legacy `~/.plaidbar/` for migration.
- `Tests/PlaidBarCoreTests/*` — updates default-path expectations and covers no-overwrite/idempotency, reset marker behavior, cache context remapping, and SQLite sidecar ownership.
- `README.md`, `docs/architecture.md`, `docs/privacy.md`, `docs/qa-matrix.md`, `docs/troubleshooting.md`, `docs/autonomous-loop-backlog.md` — document default path, migration behavior, Keychain compatibility, reset marker, and rollback.

## Local gates
- [x] `swift test --filter PlaidBarCoreTests --skip-update` — 314/314 passed.
- [x] `swift test --skip-update` — 393/393 passed.
- [x] `git diff --check` — passed.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` — passed.
- [x] Secret scan over changed additions — no matches for real token/key patterns.
- [x] PR tagged with `@codex review`.

## GitHub checks
- CI: pending after latest push.
- Claude review: pending after latest push; if it fails only because Claude lacks tokens, treat as non-blocking per maintainer instruction.
- Otto OpenClaw merge gate: pending after latest push.

## Privacy and safety impact
- Positive: new default storage path is explicit and privately permissioned.
- Positive: migration copies only missing files and never overwrites newer `~/.vaultpeek/` data.
- Positive: legacy `~/.plaidbar/` remains available for rollback instead of being deleted or moved destructively.
- Positive: local reset writes a marker so reset-cleared databases/caches are not rehydrated from legacy storage on the next launch.
- Positive: path-scoped account/transaction caches are remapped to the new storage path, and SQLite sidecars are kept with their owning database.
- Positive: Keychain service compatibility is preserved so existing linked-item token references keep working.
- No hosted backend, telemetry, cloud sync, Plaid credential exposure, screenshots, local databases, logs, or generated artifacts added.

## Merge safety
- Runtime behavior changes are limited to default storage path selection, local copy-forward migration, and matching local runner defaults.
- `PLAIDBAR_DATA_DIR` custom storage remains authoritative and skips default-path migration.
- Migration copies local files only on the user's Mac and does not call Plaid.
- Follow-up visible product rename work should stay in separate PRs.
