### PR TITLE
feat: rename visible app identity to VaultPeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ GitHub release once published):
 open .build/PlaidBar-*.dmg
 ```
 
-Then drag **PlaidBar.app** to **Applications** and launch it. On first
-launch, right-click PlaidBar.app and choose **Open** (the build is ad-hoc
+Then drag **VaultPeek.app** to **Applications** and launch it. On first
+launch, right-click VaultPeek.app and choose **Open** (the build is ad-hoc
 signed; Developer ID notarization is on the roadmap).
 
 The app starts its bundled companion server automatically — no terminal
@@ -302,7 +302,7 @@ PlaidBar uses a **two-process architecture** — a SwiftUI menu bar app talks to
 
 ```
 ┌─────────────────────────────────────┐
-│  PlaidBar.app (SwiftUI)             │
+│  VaultPeek.app (SwiftUI)            │
 │  MenuBarExtra · Swift Charts        │
 │  Accounts · Transactions · Spending │
 └──────────────┬──────────────────────┘

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Build a local PlaidBar.app bundle that includes SwiftPM dynamic frameworks.
+# Build a local VaultPeek.app bundle that includes SwiftPM dynamic frameworks.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIGURATION="${PLAIDBAR_PACKAGE_CONFIGURATION:-release}"
 BUILD_DIR="$PROJECT_DIR/.build/$CONFIGURATION"
-APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/PlaidBar.app}"
+APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/VaultPeek.app}"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
@@ -16,7 +16,7 @@ APP_BINARY="$MACOS_DIR/PlaidBar"
 if [ "$CONFIGURATION" = "release" ]; then
     BUILD_FLAGS=(-c release)
 else
-    BUILD_FLAGS=()
+    BUILD_FLAGS=("--configuration" "$CONFIGURATION")
 fi
 
 echo "Building PlaidBar ($CONFIGURATION)..."
@@ -63,7 +63,7 @@ if [ "${PLAIDBAR_PACKAGE_SMOKE_LAUNCH:-0}" = "1" ]; then
     app_pid=$!
     sleep 2
     if ! kill -0 "$app_pid" 2>/dev/null; then
-        echo "Packaged PlaidBar.app exited during smoke launch" >&2
+        echo "Packaged VaultPeek.app exited during smoke launch" >&2
         cat /tmp/plaidbar-package-smoke.log >&2 || true
         exit 1
     fi
@@ -71,4 +71,4 @@ if [ "${PLAIDBAR_PACKAGE_SMOKE_LAUNCH:-0}" = "1" ]; then
     wait "$app_pid" 2>/dev/null || true
 fi
 
-echo "Packaged PlaidBar.app at $APP_DIR"
+echo "Packaged VaultPeek.app at $APP_DIR"

--- a/Scripts/package-dmg.sh
+++ b/Scripts/package-dmg.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Build a drag-install PlaidBar DMG around the self-contained PlaidBar.app.
+# Build a drag-install PlaidBar DMG around the self-contained VaultPeek.app.
 #
 # Usage: ./Scripts/package-dmg.sh
 #
-# Produces .build/PlaidBar-<version>.dmg containing PlaidBar.app and an
+# Produces .build/PlaidBar-<version>.dmg containing VaultPeek.app and an
 # /Applications symlink. The app bundle includes PlaidBarServer, which the
 # app starts automatically on first launch, so non-developers only drag,
 # drop, and open.
@@ -15,7 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/PlaidBar.app}"
+APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/VaultPeek.app}"
 # Keep package-app.sh writing to the exact bundle path this script stages.
 export PLAIDBAR_PACKAGE_APP_DIR="$APP_DIR"
 STAGING_DIR="$PROJECT_DIR/.build/dmg-staging"
@@ -42,7 +42,7 @@ DMG_PATH="$PROJECT_DIR/.build/PlaidBar-$VERSION.dmg"
 
 rm -rf "$STAGING_DIR" "$DMG_PATH"
 mkdir -p "$STAGING_DIR"
-ditto "$APP_DIR" "$STAGING_DIR/PlaidBar.app"
+ditto "$APP_DIR" "$STAGING_DIR/VaultPeek.app"
 ln -s /Applications "$STAGING_DIR/Applications"
 
 echo "Creating $DMG_PATH..."
@@ -60,5 +60,5 @@ hdiutil verify "$DMG_PATH" >/dev/null
 
 echo ""
 echo "Built $DMG_PATH"
-echo "Install: open the DMG, drag PlaidBar.app to Applications, then"
-echo "right-click PlaidBar.app > Open on first launch (ad-hoc signed build)."
+echo "Install: open the DMG, drag VaultPeek.app to Applications, then"
+echo "right-click VaultPeek.app > Open on first launch (ad-hoc signed build)."

--- a/Scripts/validate-app-bundle.sh
+++ b/Scripts/validate-app-bundle.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Validate that a local PlaidBar.app bundle can resolve its embedded frameworks.
+# Validate that a local VaultPeek.app bundle can resolve its embedded frameworks.
 set -euo pipefail
 
 APP_DIR="${1:-}"
 if [ -z "$APP_DIR" ]; then
-    echo "Usage: $0 path/to/PlaidBar.app" >&2
+    echo "Usage: $0 path/to/VaultPeek.app" >&2
     exit 64
 fi
 
@@ -20,12 +20,12 @@ if [ ! -f "$INFO_PLIST" ]; then
 fi
 
 if [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST" 2>/dev/null || true)" != "PlaidBar" ]; then
-    echo "PlaidBar.app Info.plist must set CFBundleExecutable to PlaidBar" >&2
+    echo "VaultPeek.app Info.plist must keep CFBundleExecutable as PlaidBar until the binary rename slice lands" >&2
     exit 1
 fi
 
 if [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$INFO_PLIST" 2>/dev/null || true)" != "AppIcon" ]; then
-    echo "PlaidBar.app Info.plist must set CFBundleIconFile to AppIcon" >&2
+    echo "VaultPeek.app Info.plist must set CFBundleIconFile to AppIcon" >&2
     exit 1
 fi
 
@@ -56,9 +56,9 @@ if ! otool -L "$APP_BINARY" | grep -q "@rpath/Sparkle.framework"; then
 fi
 
 if ! otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"; then
-    echo "PlaidBar.app is missing @executable_path/../Frameworks rpath" >&2
+    echo "VaultPeek.app is missing @executable_path/../Frameworks rpath" >&2
     otool -l "$APP_BINARY" >&2
     exit 1
 fi
 
-echo "Validated PlaidBar.app bundle at $APP_DIR"
+echo "Validated VaultPeek.app bundle at $APP_DIR"

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -280,15 +280,15 @@ final class AppState {
         let status = "Status: \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netCash:
-            return "PlaidBar - Net cash: \(menuBarText). \(status)"
+            return "VaultPeek - Net cash: \(menuBarText). \(status)"
         case .totalCash:
-            return "PlaidBar - Total cash: \(menuBarText). \(status)"
+            return "VaultPeek - Total cash: \(menuBarText). \(status)"
         case .creditUtilization:
-            return "PlaidBar - Credit utilization: \(menuBarText). \(status)"
+            return "VaultPeek - Credit utilization: \(menuBarText). \(status)"
         case .recentSpend:
-            return "PlaidBar - Recent spend: \(menuBarText). \(status)"
+            return "VaultPeek - Recent spend: \(menuBarText). \(status)"
         case .iconOnly:
-            return "PlaidBar. \(status)"
+            return "VaultPeek. \(status)"
         }
     }
 
@@ -296,15 +296,15 @@ final class AppState {
         let status = "Status \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netCash:
-            return "PlaidBar net cash \(menuBarText). \(status)"
+            return "VaultPeek net cash \(menuBarText). \(status)"
         case .totalCash:
-            return "PlaidBar total cash \(menuBarText). \(status)"
+            return "VaultPeek total cash \(menuBarText). \(status)"
         case .creditUtilization:
-            return "PlaidBar credit utilization \(menuBarText). \(status)"
+            return "VaultPeek credit utilization \(menuBarText). \(status)"
         case .recentSpend:
-            return "PlaidBar recent spend \(menuBarText). \(status)"
+            return "VaultPeek recent spend \(menuBarText). \(status)"
         case .iconOnly:
-            return "PlaidBar. \(status)"
+            return "VaultPeek. \(status)"
         }
     }
 
@@ -793,19 +793,19 @@ final class AppState {
         }
 
         guard serverConnected else {
-            error = "Start PlaidBarServer before adding an account."
+            error = "Start the VaultPeek companion server before adding an account."
             return
         }
 
         guard serverCredentialsConfigured != false else {
-            error = "Plaid credentials are not configured on PlaidBarServer."
+            error = "Plaid credentials are not configured on the VaultPeek companion server."
             return
         }
 
         do {
             let linkResponse = try await serverClient.createLinkToken()
             guard let url = URL(string: linkResponse.linkUrl) else {
-                error = "PlaidBarServer returned an invalid Plaid Link URL."
+                error = "The VaultPeek companion server returned an invalid Plaid Link URL."
                 return
             }
 
@@ -868,9 +868,9 @@ final class AppState {
         guard serverConnected else {
             switch expectedEnvironment {
             case .sandbox:
-                error = "Start PlaidBarServer with --sandbox and sandbox credentials before connecting."
+                error = "Start the VaultPeek companion server with --sandbox and sandbox credentials before connecting."
             case .production:
-                error = "Start PlaidBarServer with production credentials before connecting real accounts."
+                error = "Start the VaultPeek companion server with production credentials before connecting real accounts."
             }
             return false
         }
@@ -889,9 +889,9 @@ final class AppState {
         guard serverCredentialsConfigured == true else {
             switch expectedEnvironment {
             case .sandbox:
-                error = "Sandbox Plaid credentials are missing on PlaidBarServer. Add PLAID_CLIENT_ID and PLAID_SECRET, then check again."
+                error = "Sandbox Plaid credentials are missing on the VaultPeek companion server. Add PLAID_CLIENT_ID and PLAID_SECRET, then check again."
             case .production:
-                error = "Production Plaid credentials are missing on PlaidBarServer. Add approved production credentials, then check again."
+                error = "Production Plaid credentials are missing on the VaultPeek companion server. Add approved production credentials, then check again."
             }
             return false
         }

--- a/Sources/PlaidBar/Resources/Info.plist
+++ b/Sources/PlaidBar/Resources/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleName</key>
-    <string>PlaidBar</string>
+    <string>VaultPeek</string>
     <key>CFBundleDisplayName</key>
-    <string>PlaidBar</string>
+    <string>VaultPeek</string>
     <key>CFBundleExecutable</key>
     <string>PlaidBar</string>
     <key>CFBundlePackageType</key>

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -13,7 +13,7 @@ struct LocalAIInsightsService {
         guard let runtime, !runtime.isEmpty, runtime.lowercased() != "disabled" else {
             return LocalAIAvailability(
                 state: .disabled,
-                detail: "No local AI runtime is configured. PlaidBar is using deterministic local summaries and category hints only."
+                detail: "No local AI runtime is configured. VaultPeek is using deterministic local summaries and category hints only."
             )
         }
 

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -234,14 +234,14 @@ enum ServerClientError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .requestFailed: "Request to PlaidBar server failed"
-        case .serverNotRunning: "PlaidBar server is not running"
+        case .requestFailed: "Request to the VaultPeek companion server failed"
+        case .serverNotRunning: "The VaultPeek companion server is not running"
         // Keep the "auth token is unavailable" substring intact: the recovery
         // matchers in DashboardStatusReadiness, AttentionQueue, and
         // ServerConnectionPresentation key off it.
-        case .authTokenUnavailable: "PlaidBar server auth token is unavailable. Start the server, then check again."
+        case .authTokenUnavailable: "VaultPeek companion server auth token is unavailable. Start the server, then check again."
         case let .httpError(statusCode, message):
-            "PlaidBar server returned \(statusCode): \(message)"
+            "VaultPeek companion server returned \(statusCode): \(message)"
         }
     }
 }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -132,7 +132,7 @@ struct GeneralSettingsView: View {
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
 
-                    Text("PlaidBar does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged.")
+                    Text("VaultPeek does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -190,7 +190,7 @@ struct GeneralSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Deletes the SQLite database, account and transaction caches, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart PlaidBarServer after resetting.")
+            Text("Deletes the SQLite database, account and transaction caches, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart the VaultPeek companion server after resetting.")
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },
@@ -228,7 +228,7 @@ struct GeneralSettingsView: View {
             if result.removedEntryCount == 0 {
                 resetResultMessage = "No local data found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready. \(keychainResetText(for: result))\(preservationText)"
             } else {
-                resetResultMessage = "Removed \(result.removedEntryCount) PlaidBar data item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result))\(preservationText) Restart PlaidBarServer."
+                resetResultMessage = "Removed \(result.removedEntryCount) VaultPeek data item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result))\(preservationText) Restart the VaultPeek companion server."
             }
         } catch {
             resetErrorMessage = error.localizedDescription
@@ -503,7 +503,7 @@ struct AccountSettingsView: View {
         .alert(item: $pendingRemoval) { removal in
             Alert(
                 title: Text("Remove \(removal.institutionName)?"),
-                message: Text("This removes \(removal.accountCount) linked account\(removal.accountCount == 1 ? "" : "s") from PlaidBar and clears matching cached transactions from this Mac. It does not delete the institution from Plaid's dashboard."),
+                message: Text("This removes \(removal.accountCount) linked account\(removal.accountCount == 1 ? "" : "s") from VaultPeek and clears matching cached transactions from this Mac. It does not delete the institution from Plaid's dashboard."),
                 primaryButton: .destructive(Text("Remove")) {
                     Task { await appState.removeAccount(itemId: removal.itemId) }
                 },
@@ -844,9 +844,9 @@ struct NotificationSettingsView: View {
     private func permissionActionAccessibilityHint(for action: NotificationPermissionRecoveryAction) -> Text {
         switch action {
         case .requestPermission:
-            Text("Requests macOS notification permission for PlaidBar.")
+            Text("Requests macOS notification permission for VaultPeek.")
         case .openSystemSettings:
-            Text("Opens macOS Notification settings for PlaidBar.")
+            Text("Opens macOS Notification settings for VaultPeek.")
         case .checkAgain:
             Text("Checks the current macOS notification permission again.")
         case .runBundledApp:
@@ -886,7 +886,7 @@ struct AboutView: View {
                         .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: Spacing.xs) {
-                        Text("PlaidBar")
+                        Text(PlaidBarConstants.appName)
                             .font(.title2)
                             .fontWeight(.bold)
 

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -74,7 +74,7 @@ struct AccountDetailFlyout: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
-                "This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from PlaidBar. It does not close any bank account."
+                "This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from VaultPeek. It does not close any bank account."
             )
         }
     }
@@ -148,7 +148,7 @@ struct AccountDetailFlyout: View {
                 .accessibilityLabel("\(connectionRecoveryActionTitle) for \(summary.displayName)")
                 .accessibilityHint(
                     connection.recoveryDetailLabel
-                        ?? "Refreshes this account's PlaidBar status."
+                        ?? "Refreshes this account's VaultPeek status."
                 )
             }
         }

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -27,7 +27,7 @@ struct SetupView: View {
                     environment: .sandbox,
                     icon: "testtube.2",
                     title: "Connect Sandbox",
-                    summary: "Test institutions with Plaid sandbox credentials on PlaidBarServer.",
+                    summary: "Test institutions with Plaid sandbox credentials on the VaultPeek companion server.",
                     primaryTitle: "Open Link"
                 )
             case .production:
@@ -62,10 +62,10 @@ struct SetupView: View {
                     .background(SemanticColors.brand.opacity(0.14), in: RoundedRectangle(cornerRadius: Radius.panel))
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
-                    Text("PlaidBar")
+                    Text(PlaidBarConstants.appName)
                         .font(.title3.weight(.semibold))
                     Text(
-                        "Your accounts, one click away. Choose demo data or connect through your local PlaidBarServer."
+                        "Your accounts, one click away. Choose demo data or connect through the local VaultPeek companion server."
                     )
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
@@ -145,7 +145,7 @@ struct SetupView: View {
                 )
                 StorageDisclosureRow(
                     icon: "eye.slash",
-                    text: "No PlaidBar cloud backend, analytics, or telemetry."
+                    text: "No VaultPeek cloud backend, analytics, or telemetry."
                 )
             }
             .padding(Spacing.md)

--- a/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
@@ -43,7 +43,7 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
         guard serverConnected else {
             return AccountActivityEmptyState(
                 title: "Server offline",
-                detail: "Start PlaidBarServer, then refresh to load recent activity for \(accountDisplayName).",
+                detail: "Start the VaultPeek companion server, then refresh to load recent activity for \(accountDisplayName).",
                 iconName: "server.rack",
                 tone: .offline
             )
@@ -53,7 +53,7 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
         case .loginRequired:
             return AccountActivityEmptyState(
                 title: "Reconnect to sync activity",
-                detail: "Plaid needs a fresh bank login before PlaidBar can update transactions for \(accountDisplayName).",
+                detail: "Plaid needs a fresh bank login before VaultPeek can update transactions for \(accountDisplayName).",
                 iconName: "person.crop.circle.badge.exclamationmark",
                 tone: .warning
             )
@@ -67,7 +67,7 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
         case .stale:
             return AccountActivityEmptyState(
                 title: "Activity may be stale",
-                detail: "Refresh PlaidBar to pull the latest transactions for \(accountDisplayName).",
+                detail: "Refresh VaultPeek to pull the latest transactions for \(accountDisplayName).",
                 iconName: "clock.badge.exclamationmark",
                 tone: .warning
             )

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -78,9 +78,9 @@ public struct AttentionQueue: Equatable, Sendable {
                 id: "server-offline",
                 severity: .blocked,
                 title: "Server offline",
-                detail: "Start PlaidBarServer, then check the connection.",
+                detail: "Start the VaultPeek companion server, then check the connection.",
                 action: .checkServer,
-                accessibilityHint: "Checks the local PlaidBarServer connection."
+                accessibilityHint: "Checks the local VaultPeek companion server connection."
             ))
         }
 
@@ -114,7 +114,7 @@ public struct AttentionQueue: Equatable, Sendable {
                 title: "Recent action failed",
                 detail: safeError,
                 action: .refresh,
-                accessibilityHint: "Refreshes local PlaidBar data."
+                accessibilityHint: "Refreshes local VaultPeek data."
             ))
         }
 
@@ -270,18 +270,20 @@ public struct AttentionQueue: Equatable, Sendable {
                 id: "local-auth-missing",
                 severity: .blocked,
                 title: "Local server auth missing",
-                detail: "Restart PlaidBarServer, then check the connection.",
+                detail: "Restart the VaultPeek companion server, then check the connection.",
                 action: .openSettings
             )
         }
 
         if normalized.contains("plaidbar server returned 401") ||
-            normalized.contains("plaidbar server returned 403") {
+            normalized.contains("plaidbar server returned 403") ||
+            normalized.contains("vaultpeek companion server returned 401") ||
+            normalized.contains("vaultpeek companion server returned 403") {
             return AttentionQueueRow(
                 id: "local-auth-rejected",
                 severity: .blocked,
                 title: "Local server auth rejected",
-                detail: "Restart PlaidBarServer so the local token is regenerated.",
+                detail: "Restart the VaultPeek companion server so the local token is regenerated.",
                 action: .openSettings
             )
         }
@@ -304,9 +306,9 @@ public struct AttentionQueue: Equatable, Sendable {
             id: "server-mode-mismatch",
             severity: .blocked,
             title: "Server mode mismatch",
-            detail: UserFacingError.sanitizedDetail(from: normalized, maxLength: maxRenderedErrorLength) ?? "Restart PlaidBarServer in the selected environment.",
+            detail: UserFacingError.sanitizedDetail(from: normalized, maxLength: maxRenderedErrorLength) ?? "Restart the VaultPeek companion server in the selected environment.",
             action: .checkServer,
-            accessibilityHint: "Checks whether PlaidBarServer is running in the selected Plaid environment."
+            accessibilityHint: "Checks whether the VaultPeek companion server is running in the selected Plaid environment."
         )
     }
 

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -88,7 +88,7 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         if !isDemoMode, !serverConnected {
             return DashboardAccountEmptyState(
                 title: "Server offline",
-                detail: "Start PlaidBarServer, then check the connection again.",
+                detail: "Start the VaultPeek companion server, then check the connection again.",
                 iconName: "server.rack",
                 tone: .offline,
                 showsAddAccount: false,

--- a/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
+++ b/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
@@ -52,7 +52,7 @@ public struct DashboardChangeReceipt: Equatable, Sendable {
                 id: "baseline",
                 label: "Baseline",
                 value: "Saved",
-                accessibilityText: "First local snapshot saved. PlaidBar will compare future local snapshots against this baseline."
+                accessibilityText: "First local snapshot saved. VaultPeek will compare future local snapshots against this baseline."
             )]
 
             if degradedItemCount > 0 {

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -96,9 +96,9 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
         case .reconnect:
             "Opens Plaid Link update mode for this institution."
         case .remove:
-            "Requires confirmation before disconnecting this Plaid institution and removing its local PlaidBar data."
+            "Requires confirmation before disconnecting this Plaid institution and removing its local VaultPeek data."
         case .settings:
-            "Opens PlaidBar settings and local data controls."
+            "Opens VaultPeek settings and local data controls."
         }
     }
 
@@ -109,7 +109,7 @@ public enum DashboardDrillInAction: String, CaseIterable, Sendable, Equatable {
         case .remove:
             "Remove institution for \(accountDisplayName)"
         case .settings:
-            "Open PlaidBar settings from \(accountDisplayName)"
+            "Open VaultPeek settings from \(accountDisplayName)"
         }
     }
 

--- a/Sources/PlaidBarCore/Models/DashboardOverviewFallbackState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardOverviewFallbackState.swift
@@ -34,7 +34,7 @@ public struct DashboardOverviewFallbackState: Equatable, Sendable {
 
         return DashboardOverviewFallbackState(
             title: "Overview needs data",
-            detail: "Demo data is not loaded yet. Start demo mode or connect PlaidBarServer to replace the empty overview with balances, activity, and status signals.",
+            detail: "Demo data is not loaded yet. Start demo mode or connect the VaultPeek companion server to replace the empty overview with balances, activity, and status signals.",
             iconName: "rectangle.stack.badge.play",
             actionTitle: "Choose Data Source",
             actionIconName: "plus.circle"

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -84,7 +84,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             return DashboardStatusReadiness(
                 level: .blocked,
                 title: "Server offline",
-                detail: "Start PlaidBarServer, then check the connection from this dashboard.",
+                detail: "Start the VaultPeek companion server, then check the connection from this dashboard.",
                 primaryAction: .checkServer
             )
         }
@@ -219,15 +219,17 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         if normalized.contains("auth token is unavailable") {
             return (
                 "Local server auth missing",
-                "PlaidBar cannot read the local app-server auth token. Restart PlaidBarServer, then check the connection again."
+                "VaultPeek cannot read the local app-server auth token. Restart the VaultPeek companion server, then check the connection again."
             )
         }
 
         if normalized.contains("plaidbar server returned 401") ||
-            normalized.contains("plaidbar server returned 403") {
+            normalized.contains("plaidbar server returned 403") ||
+            normalized.contains("vaultpeek companion server returned 401") ||
+            normalized.contains("vaultpeek companion server returned 403") {
             return (
                 "Local server auth rejected",
-                "PlaidBar reached the local server, but the app-server auth token was rejected. Restart PlaidBarServer so the local token is regenerated."
+                "VaultPeek reached the local server, but the app-server auth token was rejected. Restart the VaultPeek companion server so the local token is regenerated."
             )
         }
 
@@ -289,7 +291,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             return DashboardStatusReadiness(
                 level: .warning,
                 title: "Notifications blocked",
-                detail: "Local alerts are enabled, but macOS is blocking PlaidBar notifications. Enable PlaidBar in System Settings to recover alerts.",
+                detail: "Local alerts are enabled, but macOS is blocking VaultPeek notifications. Enable VaultPeek in System Settings to recover alerts.",
                 primaryAction: .openNotificationSettings,
                 primaryActionTitle: permission.recoveryActionTitle,
                 primaryActionIconName: permission.recoveryActionIconName,

--- a/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunCompletion.swift
@@ -62,7 +62,7 @@ public struct FirstRunCompletionState: Equatable, Sendable {
             return FirstRunCompletionState(
                 step: .blocked,
                 title: "Server offline",
-                detail: "Start PlaidBarServer, then check the connection again.",
+                detail: "Start the VaultPeek companion server, then check the connection again.",
                 isReady: false,
                 canRetry: true
             )
@@ -72,7 +72,7 @@ public struct FirstRunCompletionState: Equatable, Sendable {
             return FirstRunCompletionState(
                 step: .openPlaidLink,
                 title: "No linked item returned",
-                detail: "PlaidBar cannot see a linked item yet. Finish Plaid Link in the browser, then check again.",
+                detail: "VaultPeek cannot see a linked item yet. Finish Plaid Link in the browser, then check again.",
                 isReady: false,
                 canRetry: true
             )
@@ -82,7 +82,7 @@ public struct FirstRunCompletionState: Equatable, Sendable {
             return FirstRunCompletionState(
                 step: .loadAccounts,
                 title: "Linked item found",
-                detail: "PlaidBar can see the linked item. Load accounts to finish the first run.",
+                detail: "VaultPeek can see the linked item. Load accounts to finish the first run.",
                 isReady: false,
                 canRetry: true
             )
@@ -106,8 +106,8 @@ public struct FirstRunCompletionState: Equatable, Sendable {
             step: .ready,
             title: "Dashboard ready",
             detail: transactionCount == 1
-                ? "1 transaction synced. PlaidBar is ready."
-                : "\(transactionCount) transactions synced. PlaidBar is ready.",
+                ? "1 transaction synced. VaultPeek is ready."
+                : "\(transactionCount) transactions synced. VaultPeek is ready.",
             isReady: true,
             canRetry: false
         )

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -311,7 +311,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
             timeWindow: "No local history window",
             localOnlyBadge: "Local-only",
             confidence: "Confidence unavailable until local source rows exist.",
-            limitations: [availability.detail, "PlaidBar will not call a cloud AI service to fill this state."],
+            limitations: [availability.detail, "VaultPeek will not call a cloud AI service to fill this state."],
             unavailableState: unavailableState,
             reversibleActionCopy: "No insight action is available yet. Connect data locally or keep using the dashboard without AI.",
             accessibilitySummary: "Local insight receipt unavailable. \(availability.state.displayName). \(availability.detail)"
@@ -346,7 +346,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         if availability.state == .disabled {
             result.append("Local AI is off; this receipt uses deterministic local totals and heuristics.")
         } else if availability.state == .unavailable {
-            result.append("The configured local runtime is unavailable; PlaidBar does not fall back to cloud AI.")
+            result.append("The configured local runtime is unavailable; VaultPeek does not fall back to cloud AI.")
         }
 
         if input.current.transactionCount == 0 {

--- a/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
+++ b/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
@@ -38,7 +38,7 @@ public struct LocalTrustReceipt: Equatable, Sendable {
 
         return LocalTrustReceipt(
             title: "Local Trust Receipt",
-            subtitle: "PlaidBar keeps its control plane on this Mac.",
+            subtitle: "VaultPeek keeps its control plane on this Mac.",
             rows: [
                 Row(
                     id: "storage",
@@ -49,7 +49,7 @@ public struct LocalTrustReceipt: Equatable, Sendable {
                 Row(
                     id: "network",
                     title: "Network boundary",
-                    detail: "No PlaidBar-hosted backend, analytics, telemetry, cloud sync, or cloud dashboard.",
+                    detail: "No VaultPeek-hosted backend, analytics, telemetry, cloud sync, or cloud dashboard.",
                     systemImage: "network.slash"
                 ),
                 Row(
@@ -61,7 +61,7 @@ public struct LocalTrustReceipt: Equatable, Sendable {
                 Row(
                     id: "reset",
                     title: "Reset boundary",
-                    detail: "Reset clears PlaidBar data caches and stored access-token entries when present, but preserves server.conf and app/server auth.",
+                    detail: "Reset clears VaultPeek data caches and stored access-token entries when present, but preserves server.conf and app/server auth.",
                     systemImage: "arrow.counterclockwise"
                 ),
             ],

--- a/Sources/PlaidBarCore/Models/NotificationPermissionPresentation.swift
+++ b/Sources/PlaidBarCore/Models/NotificationPermissionPresentation.swift
@@ -64,7 +64,7 @@ public struct NotificationPermissionPresentation: Equatable, Sendable {
         case .unsupported:
             return NotificationPermissionPresentation(
                 label: "Unavailable",
-                detail: "This PlaidBar launch does not have a macOS notification identity. Run PlaidBar from the app bundle so macOS can register it as a notification source.",
+                detail: "This VaultPeek launch does not have a macOS notification identity. Run VaultPeek from the app bundle so macOS can register it as a notification source.",
                 iconName: "bell.slash.fill",
                 tone: .secondary,
                 recoveryAction: .runBundledApp,
@@ -75,7 +75,7 @@ public struct NotificationPermissionPresentation: Equatable, Sendable {
         case .authorized:
             return NotificationPermissionPresentation(
                 label: "Allowed",
-                detail: "PlaidBar can show local transaction, balance, and credit utilization alerts.",
+                detail: "VaultPeek can show local transaction, balance, and credit utilization alerts.",
                 iconName: "checkmark.circle.fill",
                 tone: .positive,
                 isNotificationToggleDisabled: false,
@@ -84,7 +84,7 @@ public struct NotificationPermissionPresentation: Equatable, Sendable {
         case .denied:
             return NotificationPermissionPresentation(
                 label: "Denied",
-                detail: "macOS is blocking PlaidBar notifications. Enable PlaidBar in System Settings to recover local alerts.",
+                detail: "macOS is blocking VaultPeek notifications. Enable VaultPeek in System Settings to recover local alerts.",
                 iconName: "exclamationmark.triangle.fill",
                 tone: .warning,
                 recoveryAction: .openSystemSettings,
@@ -122,7 +122,7 @@ public struct NotificationPermissionPresentation: Equatable, Sendable {
         case .unknown:
             return NotificationPermissionPresentation(
                 label: "Unknown",
-                detail: "PlaidBar could not classify the current notification permission. Check again before relying on local alerts.",
+                detail: "VaultPeek could not classify the current notification permission. Check again before relying on local alerts.",
                 iconName: "questionmark.circle",
                 tone: .secondary,
                 recoveryAction: .checkAgain,

--- a/Sources/PlaidBarCore/Models/OnboardingPreflight.swift
+++ b/Sources/PlaidBarCore/Models/OnboardingPreflight.swift
@@ -62,7 +62,7 @@ public struct OnboardingPreflight: Sendable, Equatable {
             state: serverConnected ? .ready : .blocked,
             accessibilityHint: serverConnected
                 ? "Server is ready."
-                : "Start PlaidBarServer, then check again."
+                : "Start the VaultPeek companion server, then check again."
         )
 
         let modeState: OnboardingPreflightRowState = serverConnected
@@ -76,7 +76,7 @@ public struct OnboardingPreflight: Sendable, Equatable {
             accessibilityHint: accessibilityHint(
                 for: modeState,
                 title: "Mode",
-                blockedHint: "Restart PlaidBarServer in \(expectedEnvironment.rawValue) mode."
+                blockedHint: "Restart the VaultPeek companion server in \(expectedEnvironment.rawValue) mode."
             )
         )
 
@@ -136,8 +136,8 @@ public struct OnboardingPreflight: Sendable, Equatable {
     ) -> String {
         guard serverConnected else {
             return expectedEnvironment == .sandbox
-                ? "Start PlaidBarServer with --sandbox, then Check Again."
-                : "Start PlaidBarServer with production credentials, then Check Again."
+                ? "Start the VaultPeek companion server with --sandbox, then Check Again."
+                : "Start the VaultPeek companion server with production credentials, then Check Again."
         }
 
         guard modeMatches else {
@@ -164,7 +164,7 @@ public struct OnboardingPreflight: Sendable, Equatable {
         case .blocked:
             blockedHint
         case .unknown:
-            "Start PlaidBarServer, then check again."
+            "Start the VaultPeek companion server, then check again."
         case .informational:
             "\(title) is informational."
         }

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -53,7 +53,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         linkedItemCount: Int
     ) -> SecondaryContentUnavailableState {
         if !isDemoMode, !serverConnected {
-            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before account balances can load.")
+            return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before account balances can load.")
         }
 
         if linkedItemCount == 0 {
@@ -62,7 +62,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
         return SecondaryContentUnavailableState(
             title: "Accounts not loaded",
-            detail: "PlaidBar found a linked bank, but no balances are available yet. Refresh accounts to load the latest balances.",
+            detail: "VaultPeek found a linked bank, but no balances are available yet. Refresh accounts to load the latest balances.",
             iconName: "tray",
             action: .refreshAccounts,
             actionTitle: "Refresh Accounts",
@@ -78,7 +78,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         accountCount: Int
     ) -> SecondaryContentUnavailableState {
         if !isDemoMode, !serverConnected {
-            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before credit utilization can load.")
+            return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before credit utilization can load.")
         }
 
         if linkedItemCount == 0 {
@@ -144,7 +144,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         }
 
         if !isDemoMode, !serverConnected {
-            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before syncing transaction history.")
+            return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before syncing transaction history.")
         }
 
         if linkedItemCount == 0 {
@@ -200,7 +200,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         }
 
         if !isDemoMode, !serverConnected {
-            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before spending activity can sync.")
+            return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before spending activity can sync.")
         }
 
         if linkedItemCount == 0 {
@@ -263,7 +263,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         }
 
         if !isDemoMode, !serverConnected {
-            return serverOfflineState(detail: "Start PlaidBarServer, then check the connection before detecting recurring charges.")
+            return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before detecting recurring charges.")
         }
 
         if linkedItemCount == 0 {
@@ -285,7 +285,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         if syncedItemCount == 0 || transactionCount == 0 {
             return SecondaryContentUnavailableState(
                 title: "No synced transactions",
-                detail: "Recurring detection needs transaction history. Sync transactions so PlaidBar can look for repeated charges.",
+                detail: "Recurring detection needs transaction history. Sync transactions so VaultPeek can look for repeated charges.",
                 iconName: "tray",
                 action: .syncTransactions,
                 actionTitle: "Sync Transactions",
@@ -296,7 +296,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
         return SecondaryContentUnavailableState(
             title: "No recurring charges found",
-            detail: "No repeated merchant charges were detected. PlaidBar usually needs at least 2 months of history before marking a charge as recurring.",
+            detail: "No repeated merchant charges were detected. VaultPeek usually needs at least 2 months of history before marking a charge as recurring.",
             iconName: "arrow.clockwise",
             action: .syncTransactions,
             actionTitle: "Sync Latest Transactions",
@@ -313,7 +313,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
             action: .checkServer,
             actionTitle: "Check Connection",
             actionIconName: "server.rack",
-            actionAccessibilityHint: "Checks whether PlaidBarServer is reachable."
+            actionAccessibilityHint: "Checks whether the VaultPeek companion server is reachable."
         )
     }
 

--- a/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
+++ b/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Decides whether the app should start the `PlaidBarServer` executable that
-/// ships inside `PlaidBar.app`, and with what process configuration.
+/// ships inside `VaultPeek.app`, and with what process configuration.
 ///
 /// The plan exists so DMG installs work without a separate server step while
 /// developer workflows stay untouched: `swift run`, `Scripts/run.sh`, and any

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -51,7 +51,7 @@ public enum PlaidBarConstants {
 
     // App Info
     public static let appVersion: String = "1.0.0"
-    public static let appName: String = "PlaidBar"
+    public static let appName: String = "VaultPeek"
 
     // Plaid
     public static var plaidSandboxRedirectUri: String {

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A redaction-safe chat prompt for an on-device language model.
 ///
-/// PlaidBar may run a small local model (e.g. a quantized Gemma) to phrase
+/// VaultPeek may run a small local model (e.g. a quantized Gemma) to phrase
 /// spending summaries in natural language. The model only ever sees the
 /// *display-safe aggregates* assembled here — never raw Plaid identifiers,
 /// access tokens, item IDs, transaction IDs, or account IDs. The deterministic
@@ -34,7 +34,7 @@ public enum LocalInsightPromptBuilder {
     /// The hard guardrails the model runs under. Kept terse so a small model
     /// follows them reliably.
     public static let systemInstruction = """
-    You are PlaidBar's on-device finance summarizer. Write a short, factual \
+    You are VaultPeek's on-device finance summarizer. Write a short, factual \
     summary of the user's own spending for the given period using ONLY the \
     numbers provided below. Rules: one or two sentences, plain English, no \
     financial advice, no predictions, never invent merchants or figures that \

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -154,13 +154,13 @@ public enum MenuBarSummary {
     ) -> String {
         switch mode {
         case .netCash:
-            guard !accounts.isEmpty else { return "PlaidBar" }
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             return Formatters.currency(netCash(from: accounts), format: currencyFormat)
         case .totalCash:
-            guard !accounts.isEmpty else { return "PlaidBar" }
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             return Formatters.currency(totalCash(from: accounts), format: currencyFormat)
         case .creditUtilization:
-            guard !accounts.isEmpty else { return "PlaidBar" }
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
             return Formatters.percent(utilization, decimals: 0)
         case .recentSpend:

--- a/Sources/PlaidBarCore/Utilities/ReconnectRecoveryMessage.swift
+++ b/Sources/PlaidBarCore/Utilities/ReconnectRecoveryMessage.swift
@@ -4,16 +4,16 @@ public enum ReconnectRecoveryMessage {
     private static let maxErrorDetailLength = 80
 
     public static func invalidUpdateLinkURL(institutionName: String?) -> String {
-        "PlaidBar could not prepare a safe reconnect link\(institutionSuffix(institutionName)). Refresh status, then use Settings > Accounts > \(reconnectAction(institutionName))."
+        "VaultPeek could not prepare a safe reconnect link\(institutionSuffix(institutionName)). Refresh status, then use Settings > Accounts > \(reconnectAction(institutionName))."
     }
 
     public static func browserOpenFailed(institutionName: String?) -> String {
-        "PlaidBar could not open Plaid Link in your browser\(institutionSuffix(institutionName)). Set a default browser, then use Settings > Accounts > \(reconnectAction(institutionName))."
+        "VaultPeek could not open Plaid Link in your browser\(institutionSuffix(institutionName)). Set a default browser, then use Settings > Accounts > \(reconnectAction(institutionName))."
     }
 
     public static func createFailed(errorMessage: String?, institutionName: String?) -> String {
         let safeDetail = UserFacingError.sanitizedDetail(from: errorMessage, maxLength: maxErrorDetailLength)
-        let fallback = "PlaidBar could not create a reconnect link\(institutionSuffix(institutionName))."
+        let fallback = "VaultPeek could not create a reconnect link\(institutionSuffix(institutionName))."
         let detail = safeDetail.map { "\(fallback) \($0)" } ?? fallback
         return "\(detail) Refresh status, then use Settings > Accounts > \(reconnectAction(institutionName))."
     }

--- a/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
@@ -96,7 +96,9 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
         }
 
         if normalized.contains("plaidbar server returned 401") ||
-            normalized.contains("plaidbar server returned 403") {
+            normalized.contains("plaidbar server returned 403") ||
+            normalized.contains("vaultpeek companion server returned 401") ||
+            normalized.contains("vaultpeek companion server returned 403") {
             return ServerConnectionPresentation(
                 issue: .localAuthRejected,
                 statusText: "Auth rejected",

--- a/Sources/PlaidBarCore/Utilities/UserFacingError.swift
+++ b/Sources/PlaidBarCore/Utilities/UserFacingError.swift
@@ -84,6 +84,6 @@ private extension String {
         }
 
         let prefix = self[..<marker.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
-        return prefix.isEmpty ? "A local PlaidBar error occurred. Check the server logs for details." : String(prefix)
+        return prefix.isEmpty ? "A local VaultPeek error occurred. Check the server logs for details." : String(prefix)
     }
 }

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -10,7 +10,7 @@ import PlaidBarCore
 struct PlaidBarServer: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "plaidbar-server",
-        abstract: "Run the local PlaidBar companion server.",
+        abstract: "Run the local VaultPeek companion server.",
         version: PlaidBarConstants.appVersion
     )
 
@@ -109,7 +109,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         )
         app.addServices(fluent)
 
-        logger.info("PlaidBar server starting on http://127.0.0.1:\(serverConfig.port)")
+        logger.info("VaultPeek companion server starting on http://127.0.0.1:\(serverConfig.port)")
         logger.info("Environment: \(serverConfig.plaidEnvironment.rawValue)")
         if !serverConfig.credentialsConfigured {
             logger.warning(

--- a/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
+++ b/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
@@ -19,7 +19,7 @@ struct SetupStateMiddleware<Context: RequestContext>: RouterMiddleware {
     let credentialsConfigured: Bool
 
     static var setupStateMessage: String {
-        "Plaid credentials are not configured on PlaidBarServer. "
+        "Plaid credentials are not configured on the VaultPeek companion server. "
             + "Add PLAID_CLIENT_ID and PLAID_SECRET to server.conf; "
             + "the menu bar app restarts its bundled server automatically."
     }

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PlaidBarCore
 #if canImport(FoundationNetworking)
     import FoundationNetworking
 #endif
@@ -40,7 +41,7 @@ actor PlaidClient {
         let body = PlaidLinkTokenRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
-            clientName: "PlaidBar",
+            clientName: PlaidBarConstants.appName,
             user: .init(clientUserId: userId),
             products: ["transactions"],
             countryCodes: ["US"],
@@ -62,7 +63,7 @@ actor PlaidClient {
         let body = PlaidLinkTokenRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
-            clientName: "PlaidBar",
+            clientName: PlaidBarConstants.appName,
             user: .init(clientUserId: userId),
             countryCodes: ["US"],
             language: "en",
@@ -273,7 +274,7 @@ enum PlaidError: Error, LocalizedError, Equatable, Sendable {
         switch self {
         case .credentialsNotConfigured:
             "Plaid credentials are not configured. Add PLAID_CLIENT_ID and PLAID_SECRET "
-                + "to server.conf, then restart PlaidBarServer."
+                + "to server.conf, then restart the VaultPeek companion server."
         case .invalidResponse:
             "Invalid response from Plaid API"
         case let .apiError(statusCode, _, _, message):

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -194,10 +194,10 @@ struct OAuthCallbackRoute: Sendable {
         """
         <!DOCTYPE html>
         <html>
-        <head><title>PlaidBar -- Connected!</title></head>
+        <head><title>VaultPeek -- Connected!</title></head>
         <body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;">
             <h1>Account Connected</h1>
-            <p>Your bank account has been linked to PlaidBar.</p>
+            <p>Your bank account has been linked to VaultPeek.</p>
             <p>You can close this tab and return to the app.</p>
             <script>setTimeout(() => window.close(), 3000);</script>
         </body>
@@ -210,11 +210,11 @@ struct OAuthCallbackRoute: Sendable {
         return """
         <!DOCTYPE html>
         <html>
-        <head><title>PlaidBar -- Error</title></head>
+        <head><title>VaultPeek -- Error</title></head>
         <body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;">
             <h1>Connection Error</h1>
             <p>\(escapedMessage)</p>
-            <p>Please try again from PlaidBar.</p>
+            <p>Please try again from VaultPeek.</p>
         </body>
         </html>
         """

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -96,7 +96,7 @@ struct LocalAIInsightReceiptTests {
 
     private static let disabledAvailability = LocalAIAvailability(
         state: .disabled,
-        detail: "No local AI runtime is configured. PlaidBar is using deterministic local summaries and category hints only."
+        detail: "No local AI runtime is configured. VaultPeek is using deterministic local summaries and category hints only."
     )
 
     private func makeInput(

--- a/Tests/PlaidBarCoreTests/LocalTrustReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalTrustReceiptTests.swift
@@ -11,7 +11,7 @@ struct LocalTrustReceiptTests {
         #expect(receipt.subtitle.contains("on this Mac"))
         #expect(receipt.rows.map(\.id) == ["storage", "network", "plaid", "reset"])
         #expect(receipt.rows[0].detail.contains("~/.plaidbar"))
-        #expect(receipt.rows[1].detail.contains("No PlaidBar-hosted backend"))
+        #expect(receipt.rows[1].detail.contains("No VaultPeek-hosted backend"))
         #expect(receipt.rows[1].detail.contains("analytics"))
         #expect(receipt.rows[1].detail.contains("telemetry"))
         #expect(receipt.rows[1].detail.contains("cloud sync"))

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -172,7 +172,7 @@ struct PlaidBarCoreTests {
 
         #expect(presentation?.title == "Server offline")
         #expect(presentation?.tone == .offline)
-        #expect(presentation?.detail.contains("Start PlaidBarServer") == true)
+        #expect(presentation?.detail.contains("Start the VaultPeek companion server") == true)
     }
 
     @Test("Account activity empty state explains login recovery")
@@ -821,7 +821,7 @@ struct PlaidBarCoreTests {
 
         #expect(DashboardDrillInAction.reconnect.accessibilityLabel(accountDisplayName: displayName) == "Reconnect Everyday Checking")
         #expect(DashboardDrillInAction.remove.accessibilityLabel(accountDisplayName: displayName) == "Remove institution for Everyday Checking")
-        #expect(DashboardDrillInAction.settings.accessibilityLabel(accountDisplayName: displayName) == "Open PlaidBar settings from Everyday Checking")
+        #expect(DashboardDrillInAction.settings.accessibilityLabel(accountDisplayName: displayName) == "Open VaultPeek settings from Everyday Checking")
         #expect(DashboardDrillInAction.remove.accessibilityHint.contains("Requires confirmation"))
     }
 
@@ -835,7 +835,7 @@ struct PlaidBarCoreTests {
             accountDisplayName: "Everyday Checking"
         )
 
-        #expect(presentation?.accessibilityLabel == "Server offline. Start PlaidBarServer, then refresh to load recent activity for Everyday Checking.")
+        #expect(presentation?.accessibilityLabel == "Server offline. Start the VaultPeek companion server, then refresh to load recent activity for Everyday Checking.")
     }
 
     @Test("Account presentation keeps credit metadata readable without due dates")
@@ -1742,7 +1742,7 @@ struct PlaidBarCoreTests {
 
         #expect(state.step == .openPlaidLink)
         #expect(state.title == "No linked item returned")
-        #expect(state.detail == "PlaidBar cannot see a linked item yet. Finish Plaid Link in the browser, then check again.")
+        #expect(state.detail == "VaultPeek cannot see a linked item yet. Finish Plaid Link in the browser, then check again.")
         #expect(!state.isReady)
         #expect(state.canRetry)
     }
@@ -1865,7 +1865,7 @@ struct PlaidBarCoreTests {
         )
 
         #expect(!preflight.isReady)
-        #expect(preflight.hint == "Start PlaidBarServer with --sandbox, then Check Again.")
+        #expect(preflight.hint == "Start the VaultPeek companion server with --sandbox, then Check Again.")
         #expect(preflight.rows.first { $0.title == "Server" }?.state == .blocked)
         #expect(preflight.rows.first { $0.title == "Mode" }?.state == .unknown)
         #expect(preflight.rows.first { $0.title == "Credentials" }?.state == .unknown)
@@ -1887,7 +1887,7 @@ struct PlaidBarCoreTests {
         #expect(!preflight.isReady)
         #expect(preflight.hint == "The running server is not in sandbox mode.")
         #expect(preflight.rows.first { $0.title == "Mode" }?.state == .blocked)
-        #expect(preflight.rows.first { $0.title == "Mode" }?.accessibilityHint == "Restart PlaidBarServer in sandbox mode.")
+        #expect(preflight.rows.first { $0.title == "Mode" }?.accessibilityHint == "Restart the VaultPeek companion server in sandbox mode.")
     }
 
     @Test("Onboarding preflight blocks Plaid Link on missing production credentials")
@@ -1947,7 +1947,7 @@ struct PlaidBarCoreTests {
         #expect(!preflight.isReady)
         #expect(preflight.hint == "The running server is not in production mode.")
         #expect(preflight.rows.first { $0.title == "Mode" }?.state == .blocked)
-        #expect(preflight.rows.first { $0.title == "Mode" }?.accessibilityHint == "Restart PlaidBarServer in production mode.")
+        #expect(preflight.rows.first { $0.title == "Mode" }?.accessibilityHint == "Restart the VaultPeek companion server in production mode.")
     }
 
     @Test("Onboarding preflight treats unknown credentials as blocked while connected")
@@ -1984,7 +1984,7 @@ struct PlaidBarCoreTests {
         )
 
         #expect(!preflight.isReady)
-        #expect(preflight.hint == "Start PlaidBarServer with production credentials, then Check Again.")
+        #expect(preflight.hint == "Start the VaultPeek companion server with production credentials, then Check Again.")
         #expect(preflight.rows.first { $0.title == "Mode" }?.value == "Unknown")
     }
 
@@ -2003,7 +2003,7 @@ struct PlaidBarCoreTests {
             erroredItemCount: 0,
             isSyncStale: true,
             lastSyncRelative: nil,
-            errorMessage: "PlaidBar server is not running"
+            errorMessage: "The VaultPeek companion server is not running"
         )
 
         #expect(readiness.level == .healthy)
@@ -2048,7 +2048,7 @@ struct PlaidBarCoreTests {
             erroredItemCount: 0,
             isSyncStale: true,
             lastSyncRelative: nil,
-            errorMessage: "PlaidBar server auth token is unavailable"
+            errorMessage: "VaultPeek companion server auth token is unavailable"
         )
 
         #expect(readiness.level == .blocked)
@@ -2071,7 +2071,7 @@ struct PlaidBarCoreTests {
             erroredItemCount: 0,
             isSyncStale: true,
             lastSyncRelative: nil,
-            errorMessage: "PlaidBar server returned 401: unauthorized"
+            errorMessage: "VaultPeek companion server returned 401: unauthorized"
         )
 
         #expect(readiness.level == .blocked)
@@ -2108,13 +2108,13 @@ struct PlaidBarCoreTests {
             isDemoMode: false,
             isLoading: false,
             serverConnected: false,
-            errorMessage: "PlaidBar server auth token is unavailable"
+            errorMessage: "VaultPeek companion server auth token is unavailable"
         )
         let rejected = ServerConnectionPresentation.evaluate(
             isDemoMode: false,
             isLoading: false,
             serverConnected: true,
-            errorMessage: "PlaidBar server returned 403: forbidden"
+            errorMessage: "VaultPeek companion server returned 403: forbidden"
         )
 
         #expect(missing.issue == .localAuthMissing)
@@ -2139,7 +2139,7 @@ struct PlaidBarCoreTests {
             isDemoMode: false,
             isLoading: false,
             serverConnected: true,
-            errorMessage: "PlaidBar server returned 500: internal server error"
+            errorMessage: "VaultPeek companion server returned 500: internal server error"
         )
 
         #expect(offline.issue == .offline)
@@ -2305,7 +2305,7 @@ struct PlaidBarCoreTests {
             accountCount: 0,
             transactionCount: 0,
             syncedItemCount: 0,
-            errorMessage: "PlaidBar server returned 500: {\"\(tokenKey)\":\"\(tokenValue)\",\"item_id\":\"item_123456789abcdef\"}"
+            errorMessage: "VaultPeek companion server returned 500: {\"\(tokenKey)\":\"\(tokenValue)\",\"item_id\":\"item_123456789abcdef\"}"
         )
 
         #expect(state.step == .blocked)
@@ -3226,6 +3226,7 @@ struct PlaidBarCoreTests {
         #expect(!PlaidBarConstants.keychainServiceName.isEmpty)
         #expect(!PlaidBarConstants.appVersion.isEmpty)
         #expect(!PlaidBarConstants.appName.isEmpty)
+        #expect(PlaidBarConstants.appName == "VaultPeek")
     }
 
     @Test("Background refresh interval rejects invalid persisted values")
@@ -4333,7 +4334,7 @@ struct PlaidBarCoreTests {
         #expect(DashboardDrillInAction.remove.iconName == "trash")
         #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("requires confirmation"))
         #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("disconnecting this Plaid institution"))
-        #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("local PlaidBar data"))
+        #expect(DashboardDrillInAction.remove.accessibilityHint.localizedCaseInsensitiveContains("local VaultPeek data"))
         #expect(DashboardDrillInAction.settings.accessibilityHint.localizedCaseInsensitiveContains("settings"))
     }
 

--- a/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerAutoLaunchPlanTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("Server Auto-Launch Plan Tests")
 struct ServerAutoLaunchPlanTests {
-    private let bundledPath = "/Applications/PlaidBar.app/Contents/MacOS/PlaidBarServer"
+    private let bundledPath = "/Applications/VaultPeek.app/Contents/MacOS/PlaidBarServer"
     private let dataDirectory = "/Users/example/.vaultpeek"
 
     @Test("Plan launches the bundled server with the configured server.conf")

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,7 @@ PlaidBar is proprietary software distributed privately to licensed users. The
 public Homebrew tap has been retired and `Formula/plaidbar.rb` removed.
 
 PlaidBar 1.0 ships as a drag-install DMG built with `./Scripts/package-dmg.sh`:
-it wraps a self-contained `PlaidBar.app` (app + bundled `PlaidBarServer`,
+it wraps a self-contained `VaultPeek.app` (app + bundled `PlaidBarServer`,
 auto-started on launch) with an `/Applications` symlink. The DMG is currently
 ad-hoc signed; Developer ID signing, notarization, and the Sparkle appcast
 remain deferred until the clean-machine Gatekeeper path is real, so first launch
@@ -20,7 +20,7 @@ regenerate `Sources/PlaidBar/Resources/AppIcon.icns` after design changes.
 - 1.0 distribution shape: privately-distributed drag-install DMG
 - GitHub release: tagged from clean `main` (private repo)
 
-Bundled commands (inside `PlaidBar.app`):
+Bundled commands (inside `VaultPeek.app`):
 
 ```bash
 plaidbar --demo
@@ -81,7 +81,7 @@ Distribute the resulting DMG privately to licensed users.
 
 ## Distribution Scope
 
-The DMG ships a self-contained `PlaidBar.app` bundling the menu bar app, local
+The DMG ships a self-contained `VaultPeek.app` bundling the menu bar app, local
 companion server, and launcher:
 
 - `plaidbar`


### PR DESCRIPTION
## Summary

- rename the visible app identity from PlaidBar to VaultPeek across app chrome, setup, settings/about, notifications, status/recovery copy, OAuth callback pages, Plaid Link client name, and local AI prompt wording
- update bundle display/name/identifier metadata to VaultPeek while intentionally keeping SwiftPM targets, executable names, and compatibility keychain service names staged for later rename slices
- package the app bundle as `.build/VaultPeek.app` while keeping the internal `PlaidBar` executable until AND-327/AND-330 handle command/binary/distribution renames

## Autonomous task IDs

- Task ID(s): AND-326
- Backlog slice: VaultPeek rename epic, visible app identity slice after AND-328 storage migration
- Scope note: focused user-visible app/bundle identity rename; package/target/binary/CLI renames are explicitly staged for AND-327/AND-330 to preserve compatibility and review size

## Agent coordination

- Builder agent: Codex
- Builder branch/worktree: `and-326-vaultpeek-visible-product-strings` in `/Users/otto/.openclaw/workspace-coding/maintainer-checkouts/PlaidBar`
- Reviewer/merge steward: Otto / Codex autonomous loop
- Coordination note: no other agent should push to this branch without re-running the listed gates

## Changed files

- App identity and visible copy: `Sources/PlaidBar/**`, `Sources/PlaidBarCore/**`, `Sources/PlaidBarServer/**`
- Bundle/package display path: `Sources/PlaidBar/Resources/Info.plist`, `Scripts/package-app.sh`, `Scripts/package-dmg.sh`, `Scripts/validate-app-bundle.sh`
- Regression expectations: `Tests/PlaidBarCoreTests/**`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` when server/shared DTO/package code changed, or documented why not needed.
- [x] Focused tests or `swift test` when core/server logic changed, or documented the local Swift Testing limitation: `swift test --filter PlaidBarCoreTests --skip-update` passed 314/314; `swift test --skip-update` passed 393/393.
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files: changed-additions scan found no matches.
- [x] `bash -n Scripts/package-app.sh Scripts/package-dmg.sh Scripts/validate-app-bundle.sh`
- [x] `PLAIDBAR_PACKAGE_CONFIGURATION=debug Scripts/package-app.sh` produced and validated `.build/VaultPeek.app`

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes. Copy-only UI change; no focus behavior changed.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes. Accessibility strings now use VaultPeek where applicable.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed. Screenshot/docs refresh is intentionally staged for AND-329/AND-331.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.
