### PR TITLE
feat: typed error severity model + token/storage safety verification (AND-315, AND-316)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -430,7 +430,7 @@ final class AppState {
         let serverPresentation = serverConnectionPresentation
         if isDemoMode { return serverPresentation.diagnosticsSummary }
         switch serverPresentation.issue {
-        case .offline, .localAuthMissing, .localAuthRejected:
+        case .offline, .localAuthMissing, .localAuthRejected, .serverModeMismatch:
             return serverPresentation.diagnosticsSummary
         case .demo, .syncing, .connected, .error:
             break

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -266,14 +266,21 @@ final class AppState {
         )
     }
 
+    var menuBarStatusPresentation: MenuBarStatusPresentation {
+        MenuBarStatusPresentation.evaluate(
+            isDemoMode: isDemoMode,
+            isLoading: isLoading,
+            serverConnected: serverConnected,
+            errorMessage: error,
+            erroredItemCount: erroredItemCount,
+            needsLoginItemCount: needsLoginItemCount,
+            isSyncStale: isSyncStale,
+            hasEverSynced: lastSyncDate != nil
+        )
+    }
+
     var menuBarAttentionText: String? {
-        if isDemoMode { return nil }
-        if serverConnectionPresentation.attentionText == "Auth" { return "Auth" }
-        if error != nil || erroredItemCount > 0 { return "Error" }
-        if let attentionText = serverConnectionPresentation.attentionText { return attentionText }
-        if needsLoginItemCount > 0 { return "Login" }
-        if isSyncStale { return lastSyncDate == nil ? "Never" : "Stale" }
-        return nil
+        menuBarStatusPresentation.attentionText
     }
 
     var menuBarHelpText: String {

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -4,12 +4,16 @@ struct MenuBarLabel: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
+        // State is carried by the symbol shape and attention text, not
+        // color: the menu bar renders template-style monochrome like every
+        // other status item, and degraded states swap the glyph instead of
+        // tinting a dot. The blocking/advisory split lives in
+        // MenuBarStatusPresentation (PlaidBarCore): advisory failures step
+        // down to the warning glyph and never paint attention text here.
+        let presentation = appState.menuBarStatusPresentation
         HStack(spacing: Spacing.xs) {
-            // State is carried by the symbol shape, not color: the menu bar
-            // renders template-style monochrome like every other status item,
-            // and degraded states swap the glyph instead of tinting a dot.
-            Image(systemName: statusSymbolName)
-            if let attentionText = appState.menuBarAttentionText {
+            Image(systemName: presentation.symbolName)
+            if let attentionText = presentation.attentionText {
                 Text(attentionText)
                     .font(.caption.weight(.medium))
                     .lineLimit(1)
@@ -21,21 +25,5 @@ struct MenuBarLabel: View {
         }
         .help(appState.menuBarHelpText)
         .accessibilityLabel(appState.menuBarAccessibilityLabel)
-    }
-
-    private var statusSymbolName: String {
-        if appState.error != nil || appState.erroredItemCount > 0 {
-            return "exclamationmark.octagon"
-        }
-        // Offline is checked before stale/login: when the server is
-        // unreachable, isSyncStale is usually also true (no recent or no
-        // first sync), so the offline glyph must win to stay distinct.
-        if !appState.serverConnected, !appState.isDemoMode {
-            return "network.slash"
-        }
-        if appState.needsLoginItemCount > 0 || appState.isSyncStale {
-            return "exclamationmark.triangle"
-        }
-        return "dollarsign.circle"
     }
 }

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -4,6 +4,17 @@ public enum AttentionQueueSeverity: String, Codable, Sendable {
     case healthy
     case warning
     case blocked
+
+    /// Severity tier of the failure this row represents; `nil` for healthy
+    /// rows, which carry no error. Warnings are advisory (inline recovery),
+    /// blocked rows gate the connection or credential path.
+    public var errorSeverity: ErrorSeverity? {
+        switch self {
+        case .healthy: nil
+        case .warning: .advisory
+        case .blocked: .blocking
+        }
+    }
 }
 
 public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
@@ -17,6 +28,11 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
     public let targetItemId: String?
     public let accessibilityLabel: String
     public let accessibilityHint: String?
+
+    /// Severity tier derived from the row's existing severity state.
+    public var errorSeverity: ErrorSeverity? {
+        severity.errorSeverity
+    }
 
     public init(
         id: String,
@@ -51,6 +67,13 @@ public struct AttentionQueue: Equatable, Sendable {
 
     public init(rows: [AttentionQueueRow]) {
         self.rows = Array(rows.prefix(Self.maximumRowCount))
+    }
+
+    /// Highest severity tier across the visible rows; `nil` when every row
+    /// is healthy. Chrome-level alert treatments (menu bar, status strip)
+    /// should key off `.blocking` only.
+    public var highestErrorSeverity: ErrorSeverity? {
+        rows.compactMap(\.errorSeverity).max()
     }
 
     public static func evaluate(
@@ -346,10 +369,12 @@ public struct AttentionQueue: Equatable, Sendable {
             case "first-sync-incomplete": return 10
             case "sync-stale": return 11
             default:
-                switch row.severity {
-                case .blocked: return 20
-                case .warning: return 30
-                case .healthy: return 40
+                // Unknown rows fall back to severity-tier ordering: blocking
+                // failures first, advisories next, healthy rows last.
+                switch row.errorSeverity {
+                case .blocking: return 20
+                case .advisory: return 30
+                case nil: return 40
                 }
             }
         }

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -4,6 +4,18 @@ public enum DashboardStatusReadinessLevel: String, Codable, Sendable {
     case healthy
     case warning
     case blocked
+
+    /// Severity tier of the failure this level represents; `nil` for the
+    /// healthy level. Warnings are advisory (inline recovery next to the
+    /// affected module), blocked levels gate the connection or credential
+    /// path and may use chrome-level alert treatments.
+    public var errorSeverity: ErrorSeverity? {
+        switch self {
+        case .healthy: nil
+        case .warning: .advisory
+        case .blocked: .blocking
+        }
+    }
 }
 
 public enum DashboardStatusReadinessAction: String, Codable, Sendable {
@@ -26,6 +38,12 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     public let primaryActionTitle: String?
     public let primaryActionIconName: String?
     public let secondaryActions: [DashboardStatusReadinessAction]
+
+    /// Severity tier derived from the readiness level this mapping already
+    /// computed.
+    public var errorSeverity: ErrorSeverity? {
+        level.errorSeverity
+    }
 
     public init(
         level: DashboardStatusReadinessLevel,

--- a/Sources/PlaidBarCore/Models/ErrorSeverity.swift
+++ b/Sources/PlaidBarCore/Models/ErrorSeverity.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Severity tier for user-facing failure states, shared by the presentation
+/// mappings (`DashboardStatusReadiness`, `AttentionQueue`,
+/// `ServerConnectionPresentation`, `MenuBarStatusPresentation`).
+///
+/// This is deliberately a property derived from the existing state mappings,
+/// not a parallel error taxonomy: each surface keeps its own copy/action
+/// model and exposes the severity of the state it already computed.
+///
+/// - `advisory`: degraded but recoverable in place (a transient action or
+///   cache hiccup while the server stays reachable). Advisory failures are
+///   rendered inline next to the affected module (status banner, attention
+///   queue) and expire on the next successful refresh, which clears the
+///   underlying error. They must never paint app-wide chrome.
+/// - `blocking`: the connection or credential path is down (server offline,
+///   local auth missing/rejected, credentials missing, item errors). The
+///   menu-bar and status-strip alert treatments are reserved for this tier.
+public enum ErrorSeverity: String, Codable, Sendable, CaseIterable, Comparable {
+    case advisory
+    case blocking
+
+    public static func < (lhs: ErrorSeverity, rhs: ErrorSeverity) -> Bool {
+        lhs.sortRank < rhs.sortRank
+    }
+
+    private var sortRank: Int {
+        switch self {
+        case .advisory: 0
+        case .blocking: 1
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Pure mapping for the menu-bar status chrome: the attention text shown
+/// next to the glyph and the glyph itself.
+///
+/// The menu-bar alert treatment is reserved for `.blocking` states (server
+/// offline, local auth failures, item errors). Advisory failures — a
+/// transient action error while the server stays reachable — step down to
+/// the warning glyph with no attention text, and are rendered inline in the
+/// popover (status banner, attention queue) instead. State is always
+/// carried by the glyph shape and text, never by color alone.
+public struct MenuBarStatusPresentation: Equatable, Sendable {
+    public let attentionText: String?
+    public let symbolName: String
+    public let severity: ErrorSeverity?
+
+    public init(attentionText: String?, symbolName: String, severity: ErrorSeverity?) {
+        self.attentionText = attentionText
+        self.symbolName = symbolName
+        self.severity = severity
+    }
+
+    public static func evaluate(
+        isDemoMode: Bool,
+        isLoading: Bool,
+        serverConnected: Bool,
+        errorMessage: String?,
+        erroredItemCount: Int,
+        needsLoginItemCount: Int,
+        isSyncStale: Bool,
+        hasEverSynced: Bool
+    ) -> MenuBarStatusPresentation {
+        let connection = ServerConnectionPresentation.evaluate(
+            isDemoMode: isDemoMode,
+            isLoading: isLoading,
+            serverConnected: serverConnected,
+            errorMessage: errorMessage
+        )
+
+        return MenuBarStatusPresentation(
+            attentionText: attentionText(
+                isDemoMode: isDemoMode,
+                connection: connection,
+                erroredItemCount: erroredItemCount,
+                needsLoginItemCount: needsLoginItemCount,
+                isSyncStale: isSyncStale,
+                hasEverSynced: hasEverSynced
+            ),
+            symbolName: symbolName(
+                isDemoMode: isDemoMode,
+                serverConnected: serverConnected,
+                connection: connection,
+                erroredItemCount: erroredItemCount,
+                needsLoginItemCount: needsLoginItemCount,
+                isSyncStale: isSyncStale
+            ),
+            severity: severity(
+                isDemoMode: isDemoMode,
+                connection: connection,
+                erroredItemCount: erroredItemCount,
+                needsLoginItemCount: needsLoginItemCount,
+                isSyncStale: isSyncStale
+            )
+        )
+    }
+
+    private static func attentionText(
+        isDemoMode: Bool,
+        connection: ServerConnectionPresentation,
+        erroredItemCount: Int,
+        needsLoginItemCount: Int,
+        isSyncStale: Bool,
+        hasEverSynced: Bool
+    ) -> String? {
+        if isDemoMode { return nil }
+        if connection.issue == .localAuthMissing || connection.issue == .localAuthRejected {
+            return "Auth"
+        }
+        if erroredItemCount > 0 { return "Error" }
+        // Advisory failures never paint the menu bar: their attention text
+        // stays inline in the popover. Blocking connection states keep
+        // their text ("Offline").
+        if connection.errorSeverity == .blocking, let attentionText = connection.attentionText {
+            return attentionText
+        }
+        if needsLoginItemCount > 0 { return "Login" }
+        if isSyncStale { return hasEverSynced ? "Stale" : "Never" }
+        return nil
+    }
+
+    private static func symbolName(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        connection: ServerConnectionPresentation,
+        erroredItemCount: Int,
+        needsLoginItemCount: Int,
+        isSyncStale: Bool
+    ) -> String {
+        // State is carried by the symbol shape, not color: the menu bar
+        // renders template-style monochrome, so degraded states swap the
+        // glyph instead of tinting it.
+        if erroredItemCount > 0 { return "exclamationmark.octagon" }
+        if !isDemoMode {
+            switch connection.errorSeverity {
+            case .blocking:
+                // Offline keeps its distinct glyph; other blocking states
+                // (local auth failures) read as hard failures.
+                return connection.issue == .offline
+                    ? "network.slash"
+                    : "exclamationmark.octagon"
+            case .advisory:
+                // A recent action failed but the server is reachable: a
+                // warning, not a dashboard-wide failure.
+                return "exclamationmark.triangle"
+            case nil:
+                // Offline is checked before stale/login: when the server is
+                // unreachable, isSyncStale is usually also true, so the
+                // offline glyph must win to stay distinct.
+                if !serverConnected { return "network.slash" }
+            }
+        }
+        if needsLoginItemCount > 0 || isSyncStale {
+            return "exclamationmark.triangle"
+        }
+        return "dollarsign.circle"
+    }
+
+    private static func severity(
+        isDemoMode: Bool,
+        connection: ServerConnectionPresentation,
+        erroredItemCount: Int,
+        needsLoginItemCount: Int,
+        isSyncStale: Bool
+    ) -> ErrorSeverity? {
+        if isDemoMode { return erroredItemCount > 0 ? .blocking : nil }
+        if erroredItemCount > 0 { return .blocking }
+        if let connectionSeverity = connection.errorSeverity { return connectionSeverity }
+        if needsLoginItemCount > 0 || isSyncStale { return .advisory }
+        return nil
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
@@ -7,6 +7,7 @@ public enum ServerConnectionIssue: Sendable, Equatable {
     case offline
     case localAuthMissing
     case localAuthRejected
+    case serverModeMismatch
     case error
 
     /// Severity tier of this connection state; `nil` when nothing failed.
@@ -17,7 +18,7 @@ public enum ServerConnectionIssue: Sendable, Equatable {
     public var errorSeverity: ErrorSeverity? {
         switch self {
         case .demo, .syncing, .connected: nil
-        case .offline, .localAuthMissing, .localAuthRejected: .blocking
+        case .offline, .localAuthMissing, .localAuthRejected, .serverModeMismatch: .blocking
         case .error: .advisory
         }
     }
@@ -60,8 +61,8 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
             )
         }
 
-        if let authIssue = localAuthIssue(from: errorMessage) {
-            return authIssue
+        if let blockingIssue = blockingIssue(from: errorMessage) {
+            return blockingIssue
         }
 
         if isLoading {
@@ -101,12 +102,22 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
         )
     }
 
-    private static func localAuthIssue(from message: String?) -> ServerConnectionPresentation? {
+    private static func blockingIssue(from message: String?) -> ServerConnectionPresentation? {
         guard let message else { return nil }
         let normalized = message
             .split(whereSeparator: \.isWhitespace)
             .joined(separator: " ")
             .lowercased()
+
+        if normalized.contains("server is running in") &&
+            (normalized.contains("not sandbox") || normalized.contains("not production")) {
+            return ServerConnectionPresentation(
+                issue: .serverModeMismatch,
+                statusText: "Mode mismatch",
+                diagnosticsSummary: "Server mode mismatch",
+                attentionText: "Mode"
+            )
+        }
 
         if normalized.contains("auth token is unavailable") {
             return ServerConnectionPresentation(

--- a/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
@@ -8,6 +8,19 @@ public enum ServerConnectionIssue: Sendable, Equatable {
     case localAuthMissing
     case localAuthRejected
     case error
+
+    /// Severity tier of this connection state; `nil` when nothing failed.
+    /// Offline and local-auth failures block every Plaid-backed action, so
+    /// they own the chrome-level alert treatments. A generic `.error` means
+    /// the server is still reachable and a recent action failed — advisory,
+    /// rendered inline and cleared by the next successful refresh.
+    public var errorSeverity: ErrorSeverity? {
+        switch self {
+        case .demo, .syncing, .connected: nil
+        case .offline, .localAuthMissing, .localAuthRejected: .blocking
+        case .error: .advisory
+        }
+    }
 }
 
 public struct ServerConnectionPresentation: Sendable, Equatable {
@@ -15,6 +28,11 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
     public let statusText: String
     public let diagnosticsSummary: String
     public let attentionText: String?
+
+    /// Severity tier derived from the issue this mapping already computed.
+    public var errorSeverity: ErrorSeverity? {
+        issue.errorSeverity
+    }
 
     public init(
         issue: ServerConnectionIssue,
@@ -54,21 +72,25 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
             )
         }
 
-        if let errorMessage, !errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return ServerConnectionPresentation(
-                issue: .error,
-                statusText: "Error",
-                diagnosticsSummary: "Recent action failed",
-                attentionText: "Error"
-            )
-        }
-
+        // Offline is evaluated before a generic error message: when the
+        // server is unreachable, that blocking state is the real condition
+        // and must win over whatever advisory error the last action left
+        // behind.
         guard serverConnected else {
             return ServerConnectionPresentation(
                 issue: .offline,
                 statusText: "Offline",
                 diagnosticsSummary: "Server offline",
                 attentionText: "Offline"
+            )
+        }
+
+        if let errorMessage, !errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ServerConnectionPresentation(
+                issue: .error,
+                statusText: "Error",
+                diagnosticsSummary: "Recent action failed",
+                attentionText: "Error"
             )
         }
 

--- a/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
+++ b/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
@@ -37,6 +37,7 @@ struct ErrorSeverityTests {
         #expect(ServerConnectionIssue.offline.errorSeverity == .blocking)
         #expect(ServerConnectionIssue.localAuthMissing.errorSeverity == .blocking)
         #expect(ServerConnectionIssue.localAuthRejected.errorSeverity == .blocking)
+        #expect(ServerConnectionIssue.serverModeMismatch.errorSeverity == .blocking)
         #expect(ServerConnectionIssue.error.errorSeverity == .advisory)
     }
 
@@ -183,6 +184,21 @@ struct ErrorSeverityTests {
 
         #expect(presentation.issue == .error)
         #expect(presentation.errorSeverity == .advisory)
+    }
+
+    @Test("Server mode mismatch remains blocking even when the server is reachable")
+    func serverModeMismatchIsBlocking() {
+        let presentation = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "Server is running in production, not sandbox. Restart with ./Scripts/run.sh --sandbox."
+        )
+
+        #expect(presentation.issue == .serverModeMismatch)
+        #expect(presentation.statusText == "Mode mismatch")
+        #expect(presentation.attentionText == "Mode")
+        #expect(presentation.errorSeverity == .blocking)
     }
 
     // MARK: - Menu bar chrome

--- a/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
+++ b/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
@@ -1,0 +1,370 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Error severity model")
+struct ErrorSeverityTests {
+    // MARK: - Severity ordering
+
+    @Test("Blocking outranks advisory")
+    func blockingOutranksAdvisory() {
+        #expect(ErrorSeverity.advisory < ErrorSeverity.blocking)
+        #expect([ErrorSeverity.advisory, .blocking].max() == .blocking)
+        #expect([ErrorSeverity.advisory, .advisory].max() == .advisory)
+    }
+
+    // MARK: - Severity is a property of the existing mappings
+
+    @Test("Attention queue severities map to error severity tiers")
+    func attentionQueueSeverityMapsToErrorSeverity() {
+        #expect(AttentionQueueSeverity.healthy.errorSeverity == nil)
+        #expect(AttentionQueueSeverity.warning.errorSeverity == .advisory)
+        #expect(AttentionQueueSeverity.blocked.errorSeverity == .blocking)
+    }
+
+    @Test("Dashboard readiness levels map to error severity tiers")
+    func dashboardReadinessLevelMapsToErrorSeverity() {
+        #expect(DashboardStatusReadinessLevel.healthy.errorSeverity == nil)
+        #expect(DashboardStatusReadinessLevel.warning.errorSeverity == .advisory)
+        #expect(DashboardStatusReadinessLevel.blocked.errorSeverity == .blocking)
+    }
+
+    @Test("Connection issues reserve blocking for connection-gating states")
+    func connectionIssueMapsToErrorSeverity() {
+        #expect(ServerConnectionIssue.demo.errorSeverity == nil)
+        #expect(ServerConnectionIssue.syncing.errorSeverity == nil)
+        #expect(ServerConnectionIssue.connected.errorSeverity == nil)
+        #expect(ServerConnectionIssue.offline.errorSeverity == .blocking)
+        #expect(ServerConnectionIssue.localAuthMissing.errorSeverity == .blocking)
+        #expect(ServerConnectionIssue.localAuthRejected.errorSeverity == .blocking)
+        #expect(ServerConnectionIssue.error.errorSeverity == .advisory)
+    }
+
+    @Test("Readiness presentation exposes the severity of its level")
+    func readinessPresentationExposesSeverity() {
+        let blocked = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: nil
+        )
+        let advisory = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: "Plaid sync failed."
+        )
+        let healthy = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil
+        )
+
+        #expect(blocked.errorSeverity == .blocking)
+        #expect(advisory.errorSeverity == .advisory)
+        #expect(healthy.errorSeverity == nil)
+    }
+
+    // MARK: - Attention queue ordering and rollup
+
+    @Test("Queue rolls up the highest severity across visible rows")
+    func queueRollsUpHighestSeverity() {
+        let blockedAndWarning = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            errorMessage: nil
+        )
+        let advisoryOnly = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            errorMessage: nil
+        )
+        let healthy = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil
+        )
+
+        #expect(blockedAndWarning.highestErrorSeverity == .blocking)
+        #expect(advisoryOnly.highestErrorSeverity == .advisory)
+        #expect(healthy.highestErrorSeverity == nil)
+    }
+
+    @Test("Queue orders blocking rows ahead of advisory rows")
+    func queueOrdersBlockingBeforeAdvisory() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 2,
+            accountCount: 2,
+            syncedItemCount: 2,
+            itemStatuses: [
+                ItemStatus(id: "item-login", institutionName: "Example Bank", status: .loginRequired),
+                ItemStatus(id: "item-error", institutionName: "City Credit", status: .error),
+            ],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            errorMessage: "Plaid sync failed."
+        )
+
+        let severities = queue.rows.compactMap(\.errorSeverity)
+        #expect(severities == severities.sorted(by: >))
+        #expect(queue.rows.first?.errorSeverity == .blocking)
+    }
+
+    // MARK: - Connection presentation
+
+    @Test("Offline wins over a stale advisory error message")
+    func offlineWinsOverAdvisoryError() {
+        let presentation = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: "Request to the VaultPeek companion server failed"
+        )
+
+        #expect(presentation.issue == .offline)
+        #expect(presentation.statusText == "Offline")
+        #expect(presentation.errorSeverity == .blocking)
+    }
+
+    @Test("A reachable server with a recent failure stays advisory")
+    func reachableServerWithRecentFailureIsAdvisory() {
+        let presentation = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "VaultPeek companion server returned 500: internal server error"
+        )
+
+        #expect(presentation.issue == .error)
+        #expect(presentation.errorSeverity == .advisory)
+    }
+
+    // MARK: - Menu bar chrome
+
+    @Test("Advisory failures never paint the menu bar attention text")
+    func advisoryFailureDoesNotPaintMenuBar() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "Failed to read cached transactions",
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true
+        )
+
+        #expect(presentation.attentionText == nil)
+        #expect(presentation.symbolName == "exclamationmark.triangle")
+        #expect(presentation.severity == .advisory)
+    }
+
+    @Test("Offline keeps its menu bar attention text and glyph")
+    func offlineKeepsMenuBarChrome() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: true,
+            hasEverSynced: true
+        )
+
+        #expect(presentation.attentionText == "Offline")
+        #expect(presentation.symbolName == "network.slash")
+        #expect(presentation.severity == .blocking)
+    }
+
+    @Test("Offline glyph and text win over a stale advisory error message")
+    func offlineWinsMenuBarChromeOverAdvisoryError() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: "Request to the VaultPeek companion server failed",
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: true,
+            hasEverSynced: true
+        )
+
+        #expect(presentation.attentionText == "Offline")
+        #expect(presentation.symbolName == "network.slash")
+        #expect(presentation.severity == .blocking)
+    }
+
+    @Test("Local auth failures keep the hard-failure menu bar chrome")
+    func localAuthFailureKeepsMenuBarChrome() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: "VaultPeek companion server returned 401: unauthorized",
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true
+        )
+
+        #expect(presentation.attentionText == "Auth")
+        #expect(presentation.symbolName == "exclamationmark.octagon")
+        #expect(presentation.severity == .blocking)
+    }
+
+    @Test("Item errors keep the hard-failure menu bar chrome")
+    func itemErrorsKeepMenuBarChrome() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 1,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true
+        )
+
+        #expect(presentation.attentionText == "Error")
+        #expect(presentation.symbolName == "exclamationmark.octagon")
+        #expect(presentation.severity == .blocking)
+    }
+
+    @Test("Login and stale states stay advisory in the menu bar")
+    func loginAndStaleStatesStayAdvisory() {
+        let login = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 1,
+            isSyncStale: false,
+            hasEverSynced: true
+        )
+        let stale = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: true,
+            hasEverSynced: true
+        )
+        let neverSynced = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: true,
+            hasEverSynced: false
+        )
+
+        #expect(login.attentionText == "Login")
+        #expect(login.symbolName == "exclamationmark.triangle")
+        #expect(login.severity == .advisory)
+        #expect(stale.attentionText == "Stale")
+        #expect(stale.symbolName == "exclamationmark.triangle")
+        #expect(neverSynced.attentionText == "Never")
+        #expect(neverSynced.severity == .advisory)
+    }
+
+    @Test("Healthy and demo states show no menu bar attention chrome")
+    func healthyAndDemoShowNoAttentionChrome() {
+        let healthy = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true
+        )
+        let demo = MenuBarStatusPresentation.evaluate(
+            isDemoMode: true,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: false
+        )
+
+        #expect(healthy.attentionText == nil)
+        #expect(healthy.symbolName == "dollarsign.circle")
+        #expect(healthy.severity == nil)
+        #expect(demo.attentionText == nil)
+        #expect(demo.symbolName == "dollarsign.circle")
+        #expect(demo.severity == nil)
+    }
+
+    @Test("Demo recovery scenarios keep the item-error glyph without text")
+    func demoRecoveryKeepsItemErrorGlyph() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: true,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil,
+            erroredItemCount: 1,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: false
+        )
+
+        #expect(presentation.attentionText == nil)
+        #expect(presentation.symbolName == "exclamationmark.octagon")
+        #expect(presentation.severity == .blocking)
+    }
+}

--- a/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
+++ b/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
@@ -1,0 +1,227 @@
+import FluentKit
+import FluentSQLiteDriver
+import Foundation
+import HummingbirdFluent
+import Logging
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+/// Some sandboxed test hosts cannot write to the macOS Keychain. Probe once
+/// with a synthetic item so Keychain-backed tests skip instead of failing.
+private let tokenVaultKeychainAvailable: Bool = {
+    let itemId = "test_keychain_probe_\(UUID().uuidString)"
+    do {
+        let storedToken = try PlaidTokenVault.store(accessToken: "probe-token", itemId: itemId)
+        try PlaidTokenVault.delete(storedToken: storedToken, fallbackItemId: itemId)
+        return true
+    } catch {
+        return false
+    }
+}()
+
+/// Token and storage safety invariants (PR-012, T056-T060): access-token
+/// bytes live only in the Keychain, SQLite rows hold only
+/// `keychain:<item_id>` references, storage files stay private, and the
+/// status payload never carries token-like values.
+///
+/// These tests only ever create Keychain entries under synthetic
+/// `test_item_<uuid>` accounts and delete exactly those entries; they never
+/// call `pruneOrphanedKeychainTokens` or enumerate the shared service, so a
+/// developer machine with real linked items is never touched.
+@Suite("Token and storage safety")
+struct TokenStorageSafetyTests {
+    @Test(
+        "SQLite rows hold only keychain references across the item lifecycle",
+        .enabled(if: tokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func sqliteRowsHoldOnlyKeychainReferences() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-token-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let itemId = "test_item_\(UUID().uuidString)"
+        let rawToken = "access-sandbox-\(UUID().uuidString)"
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+        let databasePath = directory.appendingPathComponent("plaidbar-sandbox.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.token-safety")
+
+        // First server lifetime: link an item and verify the stored row.
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(
+                id: itemId,
+                accessToken: rawToken,
+                institutionId: "ins_sandbox",
+                institutionName: "Test Bank"
+            )
+
+            let row = try #require(try await store.getItem(id: itemId))
+            #expect(row.accessToken == "keychain:\(itemId)")
+            #expect(!row.accessToken.contains(rawToken))
+            // The vault still resolves the reference back to the raw token.
+            #expect(try store.accessToken(for: row) == rawToken)
+
+            // Status updates (sync error paths) must not rewrite the stored
+            // reference with resolved token bytes.
+            try await store.updateItemStatus(id: itemId, status: "error")
+            let updated = try #require(try await store.getItem(id: itemId))
+            #expect(updated.accessToken == "keychain:\(itemId)")
+        }
+
+        // With the database fully flushed and closed, the raw token bytes
+        // must not appear anywhere in the SQLite store or its sidecars —
+        // only the keychain reference may be persisted.
+        var combinedStoreBytes = Data()
+        for storePath in [databasePath, databasePath + "-wal", databasePath + "-shm", databasePath + "-journal"]
+            where FileManager.default.fileExists(atPath: storePath)
+        {
+            let contents = try Data(contentsOf: URL(fileURLWithPath: storePath))
+            #expect(
+                contents.range(of: Data(rawToken.utf8)) == nil,
+                "Raw access token bytes leaked into \(URL(fileURLWithPath: storePath).lastPathComponent)"
+            )
+            combinedStoreBytes.append(contents)
+        }
+        #expect(combinedStoreBytes.range(of: Data("keychain:\(itemId)".utf8)) != nil)
+
+        // Second server lifetime: the reference survives a restart, and
+        // deleting the item removes both the row and the Keychain bytes.
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let restored = try #require(try await store.getItem(id: itemId))
+            #expect(restored.accessToken == "keychain:\(itemId)")
+
+            try await store.deleteItem(id: itemId)
+            #expect(try await store.getItem(id: itemId) == nil)
+        }
+
+        #expect(throws: PlaidTokenVaultError.self) {
+            _ = try PlaidTokenVault.resolve(storedToken: PlaidTokenVault.reference(for: itemId))
+        }
+    }
+
+    @Test(
+        "Vault delete tolerates legacy plaintext rows and missing entries",
+        .enabled(if: tokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func vaultDeleteToleratesLegacyPlaintextAndMissingEntries() throws {
+        let itemId = "test_item_\(UUID().uuidString)"
+
+        // Legacy rows stored the token bytes directly in SQLite. Deleting
+        // such an item must not throw even though no Keychain entry exists.
+        try PlaidTokenVault.delete(
+            storedToken: "access-sandbox-legacy-plaintext",
+            fallbackItemId: itemId
+        )
+
+        // Deleting an already-deleted reference is also a no-op.
+        try PlaidTokenVault.delete(
+            storedToken: PlaidTokenVault.reference(for: itemId),
+            fallbackItemId: itemId
+        )
+    }
+
+    @Test("Server config load keeps the data directory private")
+    func serverConfigLoadKeepsDataDirectoryPrivate() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Pre-create the data directory with permissive permissions; load
+        // must tighten it even when it already exists.
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dataDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o755]
+        )
+
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=config-client
+        PLAID_SECRET=config-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        _ = try ServerConfig.load(from: configURL.path)
+
+        let authTokenURL = dataDirectory.appendingPathComponent(LocalDataStore.authTokenFilename)
+        #expect(try posixPermissions(at: dataDirectory) == 0o700)
+        #expect(try posixPermissions(at: authTokenURL) == 0o600)
+    }
+
+    @Test("Status payload carries no token-like values")
+    func statusPayloadCarriesNoTokenLikeValues() throws {
+        let status = ServerStatus(
+            version: "0.8.0",
+            environment: .sandbox,
+            itemCount: 3,
+            lastSync: Date(timeIntervalSince1970: 1_800_000_000),
+            credentialsConfigured: true,
+            storagePath: "/Users/example/.plaidbar",
+            syncReady: true,
+            syncedItemCount: 3
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let payload = try #require(String(data: encoder.encode(status), encoding: .utf8))
+
+        // Value-level complement to the field-name checks in
+        // PlaidBarServerTests: no Plaid token prefixes, no Keychain
+        // references, and no bearer material may ever appear in /api/status.
+        let forbiddenValueFragments = [
+            "access-sandbox",
+            "access-production",
+            "public-sandbox",
+            "public-production",
+            "link-sandbox",
+            "link-production",
+            "keychain:",
+            "Bearer ",
+        ]
+        for fragment in forbiddenValueFragments {
+            #expect(!payload.contains(fragment), "Status payload contained \(fragment)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Runs `body` against a TokenStore backed by a real SQLite file, and
+    /// always shuts the Fluent stack down so WAL contents are flushed into
+    /// the main store before callers inspect raw bytes.
+    private func withTokenStore(
+        databasePath: String,
+        logger: Logger,
+        _ body: (TokenStore) async throws -> Void
+    ) async throws {
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(CreateSyncCursors())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(TokenStore(fluent: fluent, logger: logger))
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+}


### PR DESCRIPTION
## Summary

- **AND-315 — typed error severity model in PlaidBarCore.** Introduces `ErrorSeverity` (`advisory` vs `blocking`, `Comparable`) as a property of the existing presentation/state mappings — not a parallel taxonomy. `AttentionQueueSeverity`, `AttentionQueueRow`, `AttentionQueue` (with `highestErrorSeverity` rollup), `DashboardStatusReadinessLevel`/`DashboardStatusReadiness`, and `ServerConnectionIssue`/`ServerConnectionPresentation` all expose `errorSeverity` derived from the state they already computed.
- **Menu-bar chrome is now reserved for blocking states.** New `MenuBarStatusPresentation` mapping in PlaidBarCore moves the menu-bar attention text + glyph decision out of the app layer: an advisory failure (a recent action error while the server stays reachable — e.g. a transient cache-read hiccup) no longer paints "Error" + octagon in the menu bar; it steps down to the warning triangle and stays inline in the popover (status banner + attention queue). Blocking states (server offline, local auth missing/rejected, item errors) keep the alert chrome. `ServerConnectionPresentation.evaluate` now lets offline (blocking) win over a stale advisory error message instead of being masked by it. Advisories already auto-expire: every refresh action clears `error` on start/success, and severity is computed, not stored.
- **AND-316 — token & storage safety verification (PR-012 T056–T060).** New `TokenStorageSafetyTests` suite proves the storage invariants: SQLite item rows hold only `keychain:<item_id>` references across the full lifecycle (save → status update → server restart → delete) and the raw token bytes never appear in the closed SQLite store or its WAL/SHM/journal sidecars; `TokenStore.deleteItem` removes the Keychain bytes (resolve then fails closed); vault delete tolerates legacy plaintext rows and missing entries; `ServerConfig.load` tightens a pre-existing data directory to `0o700` and the auth-token file to `0o600`; and the `/api/status` payload passes a value-level scan (no Plaid token prefixes, `keychain:` references, or bearer material) complementing the existing field-name tests.

## Autonomous task IDs

- Task ID(s): AND-315, AND-316 (PR-012: T056, T057, T059-partial, T060)
- Backlog slice: PR-012: Token And Storage Safety + Product Experience Hardening (error severity model)
- Scope note: One focused slice: core severity model + highest-value consumers (attention queue ordering, menu-bar status presentation) and storage/token verification tests. Per-module inline advisory placement beyond the existing banner/attention queue, and T058 legacy-migration additions (already covered by existing tests), are out of scope. Backlog checkbox updates deliberately omitted to avoid serial conflicts with parallel autonomous slices.

## Agent coordination

- Builder agent: Claude Fable 5 (Claude Code session)
- Builder branch/worktree: feat/and-315-316-error-severity-token-safety in /Users/ftchvs/Developer/pb-worktrees/core
- Reviewer/merge steward: Felipe + Otto loop
- Coordination note: review-only for other agents; do not push to this branch

## Changed files

- Sources/PlaidBarCore/Models/ErrorSeverity.swift (new)
- Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift (new)
- Sources/PlaidBarCore/Models/AttentionQueue.swift
- Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
- Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
- Sources/PlaidBar/App/AppState.swift
- Sources/PlaidBar/Views/MenuBarLabel.swift
- Tests/PlaidBarCoreTests/ErrorSeverityTests.swift (new)
- Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift (new)

## Local gates

- [x] `git diff --check` — clean, no whitespace or conflict-marker errors.
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — "Build complete!", all three targets (PlaidBar, PlaidBarServer, PlaidBarCore); subsumes the per-target builds.
- [x] PlaidBarServer build — compiled in the same strict-concurrency build above (server + shared DTO code changed only in Tests/).
- [x] `swift test` — full suite: 414 tests passed, 0 failures, including 17 new error-severity tests and the new Token and storage safety suite (Keychain-gated tests executed, not skipped, on this host). `bash -n Scripts/*.sh` also passes (no scripts touched).
- [x] Secret scan completed — `git diff origin/main...HEAD | grep -iE 'client_secret|access-(sandbox|production)|api[_-]?key|BEGIN (RSA|EC|OPENSSH)'`: 4 hits, all synthetic sandbox-style test fixtures (UUID-suffixed fake tokens and forbidden-fragment assertion strings in new tests); no real credentials. Note: swiftformat 0.61.1 locally reformats 65 pre-existing files (version drift vs checked-in style), so formatting was applied only to files in this slice to keep the diff scoped; swiftlint is not installed on this host.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

GitHub Actions billing outage on 2026-06-12 — checks must be re-run once billing is restored; merge is held until green

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers (the severity model only re-tiers existing sanitized presentation states).
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data (test-only server changes).
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured (no AI surfaces touched).
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes — the menu-bar label is non-interactive content; no focusable elements were added or changed.
- [x] I spot-checked VoiceOver labels or announcements for UI changes — `menuBarAccessibilityLabel`/`menuBarHelpText` still announce the failure via `diagnosticsSummary` ("Recent action failed") even when the visual advisory text is suppressed, so screen-reader users lose no information.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone — severity is carried by glyph shape (octagon vs triangle vs network.slash) and text, never tint; the menu bar stays template-monochrome.
- [x] I updated docs or screenshots if user-facing behavior changed — no repo doc describes the menu-bar attention-text contract (verified by grep); the behavior change is documented in this PR and on AND-315.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)