### PR TITLE
feat: loading and skeleton states across data surfaces (AND-310)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1146,7 +1146,15 @@ final class AppState {
     /// ships inside the bundle. Starts it at app launch so it is usually
     /// ready before the popover first opens.
     func prewarmBundledServer() async {
-        guard !CommandLine.arguments.contains("--demo") else { return }
+        guard !CommandLine.arguments.contains("--demo") else {
+            isBooting = false
+            return
+        }
+        // The menu bar can be used without ever opening the popover. Once the
+        // launch/server probe settles, stop treating offline/stale states as
+        // placeholder skeletons even if `loadInitialData()` has not run yet.
+        defer { isBooting = false }
+
         await checkServerConnection()
         guard !serverConnected else { return }
         // The authenticated status check fails for an externally managed
@@ -1235,21 +1243,95 @@ final class AppState {
     /// surfacing an error during boot.
     private func preloadCachedDataBeforeFirstConnect() {
         guard accounts.isEmpty, transactions.isEmpty,
-              let context = persistedTransactionCacheContext()
+              let context = persistedTransactionCacheContext(),
+              let cacheDirectory = preconnectCacheDirectory(for: context)
         else { return }
 
         if let cachedAccounts = try? LocalDataStore.loadAccounts(
-            from: activeStorageDirectoryURL,
+            from: cacheDirectory,
             context: context
         ), !cachedAccounts.isEmpty {
             accounts = cachedAccounts
         }
         if let cachedTransactions = try? LocalDataStore.loadTransactions(
-            from: activeStorageDirectoryURL,
+            from: cacheDirectory,
             context: context
         ), !cachedTransactions.isEmpty {
             transactions = cachedTransactions
         }
+    }
+
+    private func preconnectCacheDirectory(for context: TransactionCacheContext) -> URL? {
+        let normalizedContext = normalizedCacheContext(context)
+        guard let currentHint = currentPreconnectCacheContextHint(),
+              normalizedCacheContext(currentHint) == normalizedContext
+        else { return nil }
+
+        return URL(fileURLWithPath: normalizedContext.storagePath, isDirectory: true)
+    }
+
+    private func currentPreconnectCacheContextHint() -> TransactionCacheContext? {
+        var environment = ProcessInfo.processInfo.environment
+        let configURL = LocalDataStore.storageDirectoryURL()
+            .appendingPathComponent(LocalDataStore.serverConfigFilename)
+        if let configContents = try? String(contentsOf: configURL, encoding: .utf8) {
+            for rawLine in configContents.components(separatedBy: .newlines) {
+                guard let entry = parseServerConfigLine(rawLine) else { continue }
+                environment[entry.key] = entry.value
+            }
+        }
+
+        let rawEnvironment = trimmedNonEmpty(environment["PLAID_ENV"]) ?? PlaidEnvironment.production.rawValue
+        guard let plaidEnvironment = PlaidEnvironment(rawValue: unquoteConfigValue(rawEnvironment)) else {
+            return nil
+        }
+
+        return TransactionCacheContext(
+            environment: plaidEnvironment,
+            storagePath: LocalDataStore.storageDirectoryURL(environment: environment).standardizedFileURL.path
+        )
+    }
+
+    private func normalizedCacheContext(_ context: TransactionCacheContext) -> TransactionCacheContext {
+        TransactionCacheContext(
+            environment: context.environment,
+            storagePath: URL(
+                fileURLWithPath: NSString(string: context.storagePath).expandingTildeInPath,
+                isDirectory: true
+            ).standardizedFileURL.path
+        )
+    }
+
+    private func parseServerConfigLine(_ rawLine: String) -> (key: String, value: String)? {
+        var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+        if line.hasPrefix("export ") {
+            line.removeFirst("export ".count)
+            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let separator = line.firstIndex(of: "=") else { return nil }
+        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return nil }
+        let value = String(line[line.index(after: separator)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (key, unquoteConfigValue(value))
+    }
+
+    private func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func unquoteConfigValue(_ value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              let last = value.last,
+              (first == "\"" && last == "\"") || (first == "'" && last == "'")
+        else {
+            return value
+        }
+        return String(value.dropFirst().dropLast())
     }
 
     private func persistedTransactionCacheContext() -> TransactionCacheContext? {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -22,6 +22,7 @@ final class AppState {
         static let notifyHighUtilization = "notifyHighUtilization"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
+        static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
     }
 
     // MARK: - State
@@ -35,6 +36,11 @@ final class AppState {
         }
     }
     var isLoading = false
+    /// True from launch until the first `loadInitialData()` pass completes.
+    /// While booting, data surfaces render loading/skeleton states instead
+    /// of offline or empty verdicts — the first connectivity check has not
+    /// delivered a verdict yet.
+    var isBooting = true
     var error: String? {
         didSet {
             guard let error else { return }
@@ -221,6 +227,36 @@ final class AppState {
 
     // MARK: - Computed
 
+    /// True while the launch handshake is still running for a real (non-demo)
+    /// session. Demo data loads synchronously and never boots into skeletons.
+    var isBootLoadInFlight: Bool {
+        isBooting && !isDemoMode
+    }
+
+    /// Load-phase presenter per data surface. Surfaces with content keep
+    /// rendering it; surfaces without content show a skeleton while the
+    /// first fetch is in flight instead of offline/empty copy.
+    func loadState(for surface: DashboardLoadSurface) -> DashboardLoadState {
+        DashboardLoadState.evaluate(
+            surface: surface,
+            isDemoMode: isDemoMode,
+            isBooting: isBooting,
+            isLoading: isLoading,
+            serverConnected: serverConnected,
+            hasContent: hasContent(for: surface),
+            errorMessage: error
+        )
+    }
+
+    private func hasContent(for surface: DashboardLoadSurface) -> Bool {
+        switch surface {
+        case .menuBarSummary, .summaryCards, .accounts, .credit:
+            accountCount > 0
+        case .transactions, .spending, .recurring, .activityHeatmap:
+            transactionCount > 0
+        }
+    }
+
     var netBalance: Double {
         MenuBarSummary.netCash(from: accounts)
     }
@@ -262,13 +298,15 @@ final class AppState {
             mode: menuBarSummaryMode,
             accounts: accounts,
             transactions: transactions,
-            currencyFormat: balanceFormat
+            currencyFormat: balanceFormat,
+            isInitialLoad: isBootLoadInFlight
         )
     }
 
     var menuBarStatusPresentation: MenuBarStatusPresentation {
         MenuBarStatusPresentation.evaluate(
             isDemoMode: isDemoMode,
+            isInitialLoad: isBootLoadInFlight,
             isLoading: isLoading,
             serverConnected: serverConnected,
             errorMessage: error,
@@ -445,6 +483,7 @@ final class AppState {
     private var serverConnectionPresentation: ServerConnectionPresentation {
         ServerConnectionPresentation.evaluate(
             isDemoMode: isDemoMode,
+            isInitialLoad: isBootLoadInFlight,
             isLoading: isLoading,
             serverConnected: serverConnected,
             errorMessage: error
@@ -479,6 +518,7 @@ final class AppState {
     var dashboardStatusReadiness: DashboardStatusReadiness {
         DashboardStatusReadiness.evaluate(
             isDemoMode: isDemoMode && !isDemoStatusRecoveryScenario,
+            isInitialLoad: isBootLoadInFlight,
             serverConnected: serverConnected,
             credentialsConfigured: serverCredentialsConfigured,
             linkedItemCount: statusItemCount,
@@ -518,12 +558,18 @@ final class AppState {
     }
 
     var isSyncStale: Bool {
+        // Staleness is a verdict about completed syncs. During the boot
+        // handshake the first sync is still in flight, so stale warnings
+        // (menu bar badge, row tints, status strip) stay reserved for real
+        // staleness measured after the check completes.
+        if isBootLoadInFlight { return false }
         guard let lastSyncDate else { return true }
         let staleAfter = max(refreshInterval * 2, PlaidBarConstants.transactionSyncInterval * 2)
         return Date().timeIntervalSince(lastSyncDate) > staleAfter
     }
 
     var statusSyncText: String {
+        if isBootLoadInFlight { return "Syncing" }
         guard let lastSyncRelative else { return "Never synced" }
         return isSyncStale ? "Stale \(lastSyncRelative)" : "Synced \(lastSyncRelative)"
     }
@@ -625,6 +671,7 @@ final class AppState {
             serverSyncReady = status.syncReady
             serverSyncedItemCount = status.syncedItemCount
             lastSyncDate = status.lastSync
+            persistTransactionCacheContext()
             refreshSetupCompletionForActiveContext()
             updateSetupCompletion()
             if !(await refreshItemStatuses()) {
@@ -996,6 +1043,7 @@ final class AppState {
 
         balanceHistory = []
         UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
+        UserDefaults.standard.removeObject(forKey: Keys.lastTransactionCacheContext)
         notificationService.resetDeduplicationState()
 
         return result
@@ -1046,6 +1094,10 @@ final class AppState {
     }
 
     func loadInitialData() async {
+        // The boot window ends when this pass returns, on every path: from
+        // then on, offline/empty verdicts are real and may render.
+        defer { isBooting = false }
+
         // Recheck notification permission at startup (user may have revoked in System Settings)
         if notificationsEnabled {
             _ = await notificationPermissionStatus()
@@ -1062,6 +1114,10 @@ final class AppState {
             }
             return
         }
+        // Returning users see cached last-known data immediately: the cache
+        // loads before the connectivity check (which can take seconds while
+        // a bundled server boots) instead of after it.
+        preloadCachedDataBeforeFirstConnect()
         await checkServerConnection()
         if !serverConnected {
             await startBundledServerIfAvailable()
@@ -1170,6 +1226,44 @@ final class AppState {
             await checkServerConnection()
             if serverConnected { break }
         }
+    }
+
+    /// Warm start for returning users: hydrate accounts/transactions from the
+    /// local cache saved under the last-known server context before the first
+    /// connectivity check runs. Opportunistic — failures and context
+    /// mismatches fall through to the normal post-connect cache path without
+    /// surfacing an error during boot.
+    private func preloadCachedDataBeforeFirstConnect() {
+        guard accounts.isEmpty, transactions.isEmpty,
+              let context = persistedTransactionCacheContext()
+        else { return }
+
+        if let cachedAccounts = try? LocalDataStore.loadAccounts(
+            from: activeStorageDirectoryURL,
+            context: context
+        ), !cachedAccounts.isEmpty {
+            accounts = cachedAccounts
+        }
+        if let cachedTransactions = try? LocalDataStore.loadTransactions(
+            from: activeStorageDirectoryURL,
+            context: context
+        ), !cachedTransactions.isEmpty {
+            transactions = cachedTransactions
+        }
+    }
+
+    private func persistedTransactionCacheContext() -> TransactionCacheContext? {
+        guard let data = UserDefaults.standard.data(forKey: Keys.lastTransactionCacheContext) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(TransactionCacheContext.self, from: data)
+    }
+
+    private func persistTransactionCacheContext() {
+        guard let transactionCacheContext,
+              let data = try? JSONEncoder().encode(transactionCacheContext)
+        else { return }
+        UserDefaults.standard.set(data, forKey: Keys.lastTransactionCacheContext)
     }
 
     // MARK: - Balance History
@@ -1400,6 +1494,8 @@ final class AppState {
 
     func loadDemoData() {
         isDemoMode = true
+        // Demo fixtures load synchronously: there is no boot handshake to wait for.
+        isBooting = false
         isDemoStatusRecoveryScenario = CommandLine.arguments.contains("--screenshot-status-recovery")
 
         let today = Self.dateString(daysAgo: 0)

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -370,6 +370,7 @@ struct AccountSettingsView: View {
     private var emptyPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.accounts(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .accounts).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount
         )

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -273,6 +273,7 @@ struct AccountDetailFlyout: View {
         AccountActivityEmptyState.evaluate(
             transactionCount: snapshot.transactionCount,
             isDemoMode: appState.usesDemoConnectionPresentation,
+            isInitialLoad: appState.loadState(for: .transactions).isInitialLoad,
             serverConnected: appState.serverConnected,
             connectionLevel: connection.level,
             accountDisplayName: AccountPresentation.displayName(for: account)
@@ -645,7 +646,7 @@ struct AccountActivityEmptyStateView: View {
         switch presentation.tone {
         case .brand:
             SemanticColors.brand
-        case .healthy, .offline, .secondary:
+        case .healthy, .loading, .offline, .secondary:
             .secondary
         case .warning:
             SemanticColors.warning

--- a/Sources/PlaidBar/Views/AccountsView.swift
+++ b/Sources/PlaidBar/Views/AccountsView.swift
@@ -8,6 +8,7 @@ struct AccountsView: View {
     private var emptyPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.accounts(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .accounts).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount
         )

--- a/Sources/PlaidBar/Views/CreditView.swift
+++ b/Sources/PlaidBar/Views/CreditView.swift
@@ -15,6 +15,7 @@ struct CreditView: View {
     private var emptyPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.credit(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .credit).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count

--- a/Sources/PlaidBar/Views/LoadingSkeletons.swift
+++ b/Sources/PlaidBar/Views/LoadingSkeletons.swift
@@ -1,0 +1,118 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Loading Redaction
+
+/// Redacts a populated surface into placeholder bars while its first data
+/// load is in flight. No-op outside the loading phase, so live and cached
+/// content always render normally.
+private struct LoadingRedaction: ViewModifier {
+    let state: DashboardLoadState
+
+    func body(content: Content) -> some View {
+        if state.showsSkeleton {
+            content
+                .redacted(reason: .placeholder)
+                .opacity(0.65)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(state.loadingAccessibilityLabel ?? "Loading")
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func loadingRedaction(_ state: DashboardLoadState) -> some View {
+        modifier(LoadingRedaction(state: state))
+    }
+}
+
+// MARK: - Skeleton Pulse
+
+/// Gentle opacity pulse for skeleton surfaces. Under Reduce Motion the
+/// skeleton stays static — redaction alone carries the loading meaning, so
+/// nothing depends on the movement.
+private struct SkeletonPulse: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isDimmed = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isDimmed ? 0.55 : 1)
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                    isDimmed = true
+                }
+            }
+    }
+}
+
+// MARK: - Account Row Skeletons
+
+/// Redacted placeholder rows shown in place of the account list while the
+/// first balances fetch is in flight. The placeholder copy never renders as
+/// text — `.redacted(reason: .placeholder)` replaces it with neutral bars
+/// sized like real rows, so boot reads as "loading" instead of "offline".
+struct DashboardAccountRowSkeletonList: View {
+    let loadState: DashboardLoadState
+    var rowCount = 3
+
+    private var accessibilityText: String {
+        loadState.loadingAccessibilityLabel
+            ?? "\(loadState.surface.loadingTitle). \(loadState.surface.loadingDetail)"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(0 ..< rowCount, id: \.self) { index in
+                SkeletonAccountRow(showsDivider: index < rowCount - 1)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel))
+        .modifier(SkeletonPulse())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .task {
+            // Mirror ErrorBanner's announcement pattern: yield once so the
+            // placeholder is mounted before VoiceOver speaks the load state.
+            await Task.yield()
+            AccessibilityNotification.Announcement(accessibilityText).post()
+        }
+    }
+}
+
+private struct SkeletonAccountRow: View {
+    let showsDivider: Bool
+
+    var body: some View {
+        HStack(spacing: Spacing.compactRowContentSpacing) {
+            RoundedRectangle(cornerRadius: Radius.control)
+                .fill(.quinary)
+                .frame(width: Sizing.iconChip, height: Sizing.iconChip)
+
+            VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
+                Text("Account placeholder")
+                    .font(.callout.weight(.medium))
+                Text("Checking ··0000 · Syncing")
+                    .detailText()
+            }
+            .redacted(reason: .placeholder)
+
+            Spacer(minLength: Spacing.compactRowContentSpacing)
+
+            Text("$0,000.00")
+                .dataText()
+                .redacted(reason: .placeholder)
+        }
+        .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+        .padding(.vertical, Spacing.compactRowVerticalPadding)
+        .overlay(alignment: .bottom) {
+            if showsDivider {
+                Divider()
+                    .opacity(0.4)
+            }
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -159,6 +159,7 @@ struct MainPopover: View {
                         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                             DashboardHeader()
                                 .environment(appState)
+                                .loadingRedaction(appState.loadState(for: .summaryCards))
 
                             DashboardChangeReceiptStrip()
                                 .environment(appState)
@@ -199,6 +200,7 @@ struct MainPopover: View {
                             LocalInsightsCard()
                                 .environment(appState)
                         }
+                        .loadingRedaction(appState.loadState(for: .summaryCards))
 
                         if shouldShowLowerStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
@@ -243,11 +245,14 @@ struct MainPopover: View {
     }
 
     private var shouldShowStatusReadinessPanel: Bool {
-        selectedFilter == .status || !appState.isSetupComplete || appState.dashboardStatusReadiness.level != .healthy
+        selectedFilter == .status || shouldElevateStatusReadinessPanel
     }
 
     private var shouldElevateStatusReadinessPanel: Bool {
-        !appState.isSetupComplete || appState.dashboardStatusReadiness.level != .healthy
+        // `.loading` stays quiet like `.healthy`: the boot handshake must not
+        // hoist an attention panel over the dashboard before any verdict.
+        let level = appState.dashboardStatusReadiness.level
+        return !appState.isSetupComplete || level == .warning || level == .blocked
     }
 
     private var shouldShowLowerStatusReadinessPanel: Bool {
@@ -604,6 +609,7 @@ private struct BalanceCompositionLegend: View {
 
 private struct BalanceActivityHeatmap: View {
     let transactions: [TransactionDTO]
+    var loadState: DashboardLoadState?
 
     @AppStorage("dashboard.heatmapMode") private var modeRawValue = SpendingHeatmapMode.spending.rawValue
 
@@ -650,9 +656,9 @@ private struct BalanceActivityHeatmap: View {
                 .controlSize(.mini)
                 .frame(width: 116)
 
-                Text(totalLabel(for: layout))
+                Text(isInitialLoad ? "—" : totalLabel(for: layout))
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(totalTint(for: layout))
+                    .foregroundStyle(isInitialLoad ? .secondary : totalTint(for: layout))
                     .monospacedDigit()
                     .lineLimit(1)
             }
@@ -696,6 +702,9 @@ private struct BalanceActivityHeatmap: View {
                 }
             }
             .frame(height: monthLabelHeight + 3 + 7 * 8 + 6 * spacing)
+            // First sync in flight: the empty grid dims so it reads as a
+            // placeholder, not as a year of zero activity.
+            .opacity(isInitialLoad ? 0.45 : 1)
 
             HStack(spacing: 5) {
                 if layout.mode == .spending {
@@ -723,7 +732,7 @@ private struct BalanceActivityHeatmap: View {
 
                 Spacer()
 
-                Text("\(layout.activeDayCount) active days")
+                Text(isInitialLoad ? "Loading activity" : "\(layout.activeDayCount) active days")
                     .microText()
                     .foregroundStyle(.secondary)
             }
@@ -732,8 +741,14 @@ private struct BalanceActivityHeatmap: View {
         .glassSurface(.raised)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(
-            "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
+            isInitialLoad
+                ? (loadState?.loadingAccessibilityLabel ?? "Loading activity heatmap.")
+                : "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
         )
+    }
+
+    private var isInitialLoad: Bool {
+        loadState?.isInitialLoad ?? false
     }
 
     private var modeBinding: Binding<SpendingHeatmapMode> {
@@ -1058,21 +1073,24 @@ private struct DashboardStatusReadinessPanel: View {
     private var icon: String {
         switch readiness.level {
         case .healthy: "checkmark.circle.fill"
+        case .loading: "arrow.triangle.2.circlepath"
         case .warning: "exclamationmark.triangle.fill"
         case .blocked: "xmark.octagon.fill"
         }
     }
 
     private var tint: Color {
+        // Warning/negative tints are reserved for actionable verdicts —
+        // an in-flight first load renders neutral.
         switch readiness.level {
-        case .healthy: .secondary
+        case .healthy, .loading: .secondary
         case .warning: SemanticColors.warning
         case .blocked: SemanticColors.negative
         }
     }
 
     private var readinessNeedsAttention: Bool {
-        readiness.level != .healthy
+        readiness.level == .warning || readiness.level == .blocked
     }
 
     private func perform(_ action: DashboardStatusReadinessAction) {
@@ -1249,7 +1267,10 @@ private struct DashboardOverviewStack: View {
             if let fallbackState {
                 DashboardOverviewFallbackBanner(presentation: fallbackState, onAction: onAddAccount)
             } else {
-                BalanceActivityHeatmap(transactions: transactions)
+                BalanceActivityHeatmap(
+                    transactions: transactions,
+                    loadState: appState.loadState(for: .activityHeatmap)
+                )
             }
 
             VStack(alignment: .leading, spacing: LayoutSpacing.controls) {
@@ -1330,6 +1351,10 @@ private struct AccountsSection: View {
     let onDeselect: () -> Void
     let onAddAccount: () -> Void
 
+    private var accountsLoadState: DashboardLoadState {
+        appState.loadState(for: .accounts)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
@@ -1340,13 +1365,20 @@ private struct AccountsSection: View {
                 Text("\(accounts.count)")
                     .sectionTitle()
                     .foregroundStyle(.secondary)
+                    .opacity(accountsLoadState.showsSkeleton ? 0 : 1)
             }
             .padding(.horizontal, Spacing.compactRowHorizontalPadding)
             .padding(.bottom, Spacing.xs)
 
             if accounts.isEmpty {
-                DashboardEmptyAccountState(filter: filter, onAddAccount: onAddAccount)
-                    .environment(appState)
+                if accountsLoadState.showsSkeleton {
+                    // First fetch in flight: redacted placeholder rows
+                    // instead of offline/empty copy.
+                    DashboardAccountRowSkeletonList(loadState: accountsLoadState)
+                } else {
+                    DashboardEmptyAccountState(filter: filter, onAddAccount: onAddAccount)
+                        .environment(appState)
+                }
             } else {
                 VStack(spacing: 0) {
                     ForEach(accounts) { account in
@@ -1443,6 +1475,7 @@ private struct DashboardEmptyAccountState: View {
         DashboardAccountEmptyState.evaluate(
             filter: filter,
             isDemoMode: appState.usesDemoConnectionPresentation,
+            isInitialLoad: appState.loadState(for: .accounts).isInitialLoad,
             serverConnected: appState.serverConnected,
             credentialsConfigured: appState.serverCredentialsConfigured,
             linkedItemCount: appState.statusItemCount,
@@ -1471,22 +1504,26 @@ private struct DashboardEmptyAccountState: View {
                 }
             }
 
-            HStack(spacing: 8) {
-                if showsAddAccount {
-                    Button(action: onAddAccount) {
-                        Label("Add Account", systemImage: "plus.circle")
+            // Loading is passive: no recovery actions until the first fetch
+            // delivers a verdict the user can act on.
+            if !presentation.isLoading {
+                HStack(spacing: 8) {
+                    if showsAddAccount {
+                        Button(action: onAddAccount) {
+                            Label("Add Account", systemImage: "plus.circle")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Button {
+                        performRecoveryAction()
+                    } label: {
+                        Label(actionTitle, systemImage: actionIcon)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
-
-                Button {
-                    performRecoveryAction()
-                } label: {
-                    Label(actionTitle, systemImage: actionIcon)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
             }
         }
         .padding(Spacing.md)
@@ -1510,7 +1547,7 @@ private struct DashboardEmptyAccountState: View {
         switch presentation.tone {
         case .brand:
             SemanticColors.brand
-        case .healthy:
+        case .healthy, .loading:
             .secondary
         case .offline, .secondary:
             .secondary
@@ -1523,7 +1560,7 @@ private struct DashboardEmptyAccountState: View {
         switch presentation.tone {
         case .brand, .warning:
             tint
-        case .healthy, .offline, .secondary:
+        case .healthy, .loading, .offline, .secondary:
             nil
         }
     }

--- a/Sources/PlaidBar/Views/RecurringView.swift
+++ b/Sources/PlaidBar/Views/RecurringView.swift
@@ -7,6 +7,7 @@ struct RecurringView: View {
     private var emptyPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.recurring(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .recurring).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -243,11 +243,20 @@ struct SecondaryUnavailableView: View {
             Text(presentation.detail)
                 .multilineTextAlignment(.center)
         } actions: {
-            actionButton
+            // Loading is passive: no recovery action until the first fetch
+            // delivers a verdict the user can act on.
+            if !presentation.isLoading {
+                actionButton
+            }
         }
         .padding()
         .frame(maxWidth: .infinity, minHeight: 180)
         .accessibilityElement(children: .contain)
+        .task(id: presentation.isLoading) {
+            guard presentation.isLoading else { return }
+            await Task.yield()
+            AccessibilityNotification.Announcement("\(presentation.title). \(presentation.detail)").post()
+        }
     }
 
     @ViewBuilder

--- a/Sources/PlaidBar/Views/SpendingView.swift
+++ b/Sources/PlaidBar/Views/SpendingView.swift
@@ -92,6 +92,7 @@ struct SpendingView: View {
     private var emptyActivityPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.spendingActivity(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .spending).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,

--- a/Sources/PlaidBar/Views/StatusView.swift
+++ b/Sources/PlaidBar/Views/StatusView.swift
@@ -398,6 +398,8 @@ struct StatusView: View {
         switch level {
         case .healthy:
             .accentColor
+        case .loading:
+            .secondary
         case .warning:
             SemanticColors.warning
         case .blocked:

--- a/Sources/PlaidBar/Views/TransactionsView.swift
+++ b/Sources/PlaidBar/Views/TransactionsView.swift
@@ -39,6 +39,7 @@ struct TransactionsView: View {
     private var emptyPresentation: SecondaryContentUnavailableState {
         SecondaryContentUnavailableState.transactions(
             isDemoMode: appState.isDemoMode,
+            isInitialLoad: appState.loadState(for: .transactions).isInitialLoad,
             serverConnected: appState.serverConnected,
             linkedItemCount: appState.statusItemCount,
             accountCount: appState.accounts.count,

--- a/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift
@@ -25,6 +25,7 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
     public static func evaluate(
         transactionCount: Int,
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         connectionLevel: AccountConnectionLevel,
         accountDisplayName: String
@@ -37,6 +38,17 @@ public struct AccountActivityEmptyState: Equatable, Sendable {
                 detail: "\(accountDisplayName) has no sample transactions in the local demo fixture.",
                 iconName: "play.circle",
                 tone: .secondary
+            )
+        }
+
+        // The first sync outranks offline/stale messaging: activity that has
+        // not arrived yet reads as loading, not as a degraded connection.
+        if isInitialLoad {
+            return AccountActivityEmptyState(
+                title: "Loading activity",
+                detail: "Syncing recent transactions for \(accountDisplayName).",
+                iconName: "arrow.triangle.2.circlepath",
+                tone: .loading
             )
         }
 

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -32,6 +32,7 @@ public enum DashboardAccountFilterKind: String, CaseIterable, Sendable {
 public enum DashboardAccountEmptyStateTone: String, Sendable {
     case brand
     case healthy
+    case loading
     case offline
     case secondary
     case warning
@@ -74,9 +75,17 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         self.actionIconName = actionIconName
     }
 
+    /// True while the first fetch is still in flight. Views prefer skeleton
+    /// rows over this panel, but any consumer that does render it must not
+    /// present loading as an actionable failure.
+    public var isLoading: Bool {
+        tone == .loading
+    }
+
     public static func evaluate(
         filter: DashboardAccountFilterKind,
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         credentialsConfigured: Bool? = nil,
         linkedItemCount: Int,
@@ -85,6 +94,21 @@ public struct DashboardAccountEmptyState: Equatable, Sendable {
         degradedItemRecoveryTitle: String? = nil,
         degradedItemRecoveryDetail: String? = nil
     ) -> DashboardAccountEmptyState {
+        // The first fetch outranks offline/empty messaging: boot must read
+        // as loading, not as a broken or offline app.
+        if !isDemoMode, isInitialLoad {
+            return DashboardAccountEmptyState(
+                title: "Loading accounts",
+                detail: "Fetching linked account balances from the local VaultPeek server. This usually takes a few seconds.",
+                iconName: "arrow.triangle.2.circlepath",
+                tone: .loading,
+                showsAddAccount: false,
+                action: .refresh,
+                actionTitle: "Refresh",
+                actionIconName: "arrow.clockwise"
+            )
+        }
+
         if !isDemoMode, !serverConnected {
             return DashboardAccountEmptyState(
                 title: "Server offline",

--- a/Sources/PlaidBarCore/Models/DashboardLoadState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardLoadState.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Load phase for a single data surface. Distinguishes "first data is still
+/// arriving" from the genuine offline/empty/error states so boot renders as
+/// loading instead of a broken or offline app.
+public enum DashboardLoadPhase: String, CaseIterable, Sendable {
+    /// Connected with no content and no fetch in flight — the surface's
+    /// regular empty-state evaluator owns the messaging.
+    case idle
+    /// A fetch is in flight and the surface has no content to show yet.
+    case loading
+    /// Content is available. A background refresh may still be running, but
+    /// the surface keeps rendering last-known data while it does.
+    case loaded
+    /// The connectivity check completed and the server is unreachable.
+    case offline
+    /// The last load failed with a user-facing error and left no content.
+    case error
+}
+
+/// Data surfaces that render a distinct loading treatment.
+public enum DashboardLoadSurface: String, CaseIterable, Sendable {
+    case menuBarSummary
+    case summaryCards
+    case accounts
+    case transactions
+    case spending
+    case credit
+    case recurring
+    case activityHeatmap
+
+    public var loadingTitle: String {
+        switch self {
+        case .menuBarSummary: "Loading summary"
+        case .summaryCards: "Loading balances"
+        case .accounts: "Loading accounts"
+        case .transactions: "Loading transactions"
+        case .spending: "Loading spending activity"
+        case .credit: "Loading credit accounts"
+        case .recurring: "Loading recurring charges"
+        case .activityHeatmap: "Loading activity"
+        }
+    }
+
+    public var loadingDetail: String {
+        switch self {
+        case .menuBarSummary:
+            "Fetching the menu bar summary from the local VaultPeek server."
+        case .summaryCards:
+            "Fetching the latest balances from the local VaultPeek server."
+        case .accounts:
+            "Fetching linked account balances from the local VaultPeek server."
+        case .transactions:
+            "Syncing recent transaction history from the local VaultPeek server."
+        case .spending:
+            "Syncing transactions to build spending and cashflow views."
+        case .credit:
+            "Fetching credit accounts and utilization from the local VaultPeek server."
+        case .recurring:
+            "Syncing transaction history to detect recurring charges."
+        case .activityHeatmap:
+            "Syncing transaction history to build the activity heatmap."
+        }
+    }
+}
+
+/// Pure presenter for the boot/refresh load-phase state machine. Views ask
+/// for the phase per surface and render skeletons/redacted placeholders only
+/// while the *first* data is in flight; cached or live content always wins.
+public struct DashboardLoadState: Equatable, Sendable {
+    public let surface: DashboardLoadSurface
+    public let phase: DashboardLoadPhase
+
+    public init(surface: DashboardLoadSurface, phase: DashboardLoadPhase) {
+        self.surface = surface
+        self.phase = phase
+    }
+
+    /// True while the first fetch is in flight with nothing to show —
+    /// surfaces render skeleton/redacted placeholders instead of offline or
+    /// empty copy.
+    public var isInitialLoad: Bool {
+        phase == .loading
+    }
+
+    /// Alias that reads better at skeleton call sites.
+    public var showsSkeleton: Bool {
+        isInitialLoad
+    }
+
+    /// VoiceOver copy for the loading placeholder. Nil outside the loading
+    /// phase so callers never announce loading over real content.
+    public var loadingAccessibilityLabel: String? {
+        guard isInitialLoad else { return nil }
+        return "\(surface.loadingTitle). \(surface.loadingDetail)"
+    }
+
+    public static func evaluate(
+        surface: DashboardLoadSurface,
+        isDemoMode: Bool,
+        isBooting: Bool,
+        isLoading: Bool,
+        serverConnected: Bool,
+        hasContent: Bool,
+        errorMessage: String?
+    ) -> DashboardLoadState {
+        // Demo fixtures load synchronously; demo never skeletons.
+        if isDemoMode {
+            return DashboardLoadState(surface: surface, phase: hasContent ? .loaded : .idle)
+        }
+
+        // Last-known data always wins over in-flight refreshes (T093):
+        // a surface with content never regresses to a skeleton.
+        if hasContent {
+            return DashboardLoadState(surface: surface, phase: .loaded)
+        }
+
+        if isBooting || isLoading {
+            return DashboardLoadState(surface: surface, phase: .loading)
+        }
+
+        let trimmedError = errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedError, !trimmedError.isEmpty {
+            return DashboardLoadState(surface: surface, phase: .error)
+        }
+
+        if !serverConnected {
+            return DashboardLoadState(surface: surface, phase: .offline)
+        }
+
+        return DashboardLoadState(surface: surface, phase: .idle)
+    }
+}

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum DashboardStatusReadinessLevel: String, Codable, Sendable {
     case healthy
+    case loading
     case warning
     case blocked
 
@@ -65,6 +66,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
 
     public static func evaluate(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         credentialsConfigured: Bool?,
         linkedItemCount: Int,
@@ -86,6 +88,17 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 primaryAction: .addAccount,
                 primaryActionTitle: "Connect Bank",
                 secondaryActions: [.openSettings]
+            )
+        }
+
+        // The boot handshake outranks offline/stale verdicts: warning and
+        // blocked tints are reserved for states the user can act on, not for
+        // an in-flight first load.
+        if isInitialLoad {
+            return DashboardStatusReadiness(
+                level: .loading,
+                title: "Loading financial data",
+                detail: "Connecting to the local VaultPeek server and fetching the latest balances and transactions."
             )
         }
 

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -12,7 +12,7 @@ public enum DashboardStatusReadinessLevel: String, Codable, Sendable {
     /// path and may use chrome-level alert treatments.
     public var errorSeverity: ErrorSeverity? {
         switch self {
-        case .healthy: nil
+        case .healthy, .loading: nil
         case .warning: .advisory
         case .blocked: .blocking
         }

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -28,6 +28,9 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
     public let actionTitle: String
     public let actionIconName: String
     public let actionAccessibilityHint: String?
+    /// True while the first fetch is in flight: views render the copy as a
+    /// passive loading state and hide the recovery action.
+    public let isLoading: Bool
 
     public init(
         title: String,
@@ -36,7 +39,8 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         action: SecondaryContentUnavailableAction,
         actionTitle: String,
         actionIconName: String,
-        actionAccessibilityHint: String? = nil
+        actionAccessibilityHint: String? = nil,
+        isLoading: Bool = false
     ) {
         self.title = title
         self.detail = detail
@@ -45,13 +49,22 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         self.actionTitle = actionTitle
         self.actionIconName = actionIconName
         self.actionAccessibilityHint = actionAccessibilityHint
+        self.isLoading = isLoading
     }
 
     public static func accounts(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         linkedItemCount: Int
     ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, isInitialLoad {
+            return loadingState(
+                title: "Loading accounts",
+                detail: "Fetching linked account balances from the local VaultPeek server."
+            )
+        }
+
         if !isDemoMode, !serverConnected {
             return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before account balances can load.")
         }
@@ -73,10 +86,18 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
     public static func credit(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         linkedItemCount: Int,
         accountCount: Int
     ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, isInitialLoad {
+            return loadingState(
+                title: "Loading credit accounts",
+                detail: "Fetching credit accounts and utilization from the local VaultPeek server."
+            )
+        }
+
         if !isDemoMode, !serverConnected {
             return serverOfflineState(detail: "Start the VaultPeek companion server, then check the connection before credit utilization can load.")
         }
@@ -118,6 +139,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
     public static func transactions(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         linkedItemCount: Int,
         accountCount: Int,
@@ -136,6 +158,13 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
                 actionTitle: "Clear Filters",
                 actionIconName: "xmark.circle",
                 actionAccessibilityHint: "Removes the current search text and filters."
+            )
+        }
+
+        if !isDemoMode, isInitialLoad {
+            return loadingState(
+                title: "Loading transactions",
+                detail: "Syncing recent transaction history from the local VaultPeek server."
             )
         }
 
@@ -188,6 +217,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
     public static func spendingActivity(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         linkedItemCount: Int,
         accountCount: Int,
@@ -195,6 +225,13 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         transactionCount: Int,
         errorMessage: String?
     ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, isInitialLoad {
+            return loadingState(
+                title: "Loading spending activity",
+                detail: "Syncing transactions to build spending and cashflow views."
+            )
+        }
+
         if let errorState = recentActionFailure(from: errorMessage) {
             return errorState
         }
@@ -251,6 +288,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
 
     public static func recurring(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         serverConnected: Bool,
         linkedItemCount: Int,
         accountCount: Int,
@@ -258,6 +296,13 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         transactionCount: Int,
         errorMessage: String?
     ) -> SecondaryContentUnavailableState {
+        if !isDemoMode, isInitialLoad {
+            return loadingState(
+                title: "Loading recurring charges",
+                detail: "Syncing transaction history to detect recurring charges."
+            )
+        }
+
         if let errorState = recentActionFailure(from: errorMessage) {
             return errorState
         }
@@ -302,6 +347,19 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
             actionTitle: "Sync Latest Transactions",
             actionIconName: "arrow.triangle.2.circlepath",
             actionAccessibilityHint: "Checks for newer transactions that may complete a recurring pattern."
+        )
+    }
+
+    private static func loadingState(title: String, detail: String) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState(
+            title: title,
+            detail: detail,
+            iconName: "arrow.triangle.2.circlepath",
+            action: .refresh,
+            actionTitle: "Refresh",
+            actionIconName: "arrow.clockwise",
+            actionAccessibilityHint: "Reloads the dashboard data.",
+            isLoading: true
         )
     }
 

--- a/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
@@ -22,6 +22,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
 
     public static func evaluate(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         isLoading: Bool,
         serverConnected: Bool,
         errorMessage: String?,
@@ -32,6 +33,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
     ) -> MenuBarStatusPresentation {
         let connection = ServerConnectionPresentation.evaluate(
             isDemoMode: isDemoMode,
+            isInitialLoad: isInitialLoad,
             isLoading: isLoading,
             serverConnected: serverConnected,
             errorMessage: errorMessage

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -150,7 +150,8 @@ public enum MenuBarSummary {
         mode: MenuBarSummaryMode,
         accounts: [AccountDTO],
         transactions: [TransactionDTO],
-        currencyFormat: CurrencyFormat
+        currencyFormat: CurrencyFormat,
+        isInitialLoad: Bool = false
     ) -> String {
         switch mode {
         case .netCash:
@@ -164,7 +165,11 @@ public enum MenuBarSummary {
             guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
             return Formatters.percent(utilization, decimals: 0)
         case .recentSpend:
-            guard !transactions.isEmpty else { return "No spend" }
+            // During the boot fetch an empty history is unknown, not zero:
+            // show the neutral app name instead of a "No spend" verdict.
+            guard !transactions.isEmpty else {
+                return isInitialLoad ? PlaidBarConstants.appName : "No spend"
+            }
             return Formatters.currency(recentSpend(from: transactions), format: currencyFormat)
         case .iconOnly:
             return ""

--- a/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift
@@ -49,6 +49,7 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
 
     public static func evaluate(
         isDemoMode: Bool,
+        isInitialLoad: Bool = false,
         isLoading: Bool,
         serverConnected: Bool,
         errorMessage: String?
@@ -63,6 +64,16 @@ public struct ServerConnectionPresentation: Sendable, Equatable {
 
         if let blockingIssue = blockingIssue(from: errorMessage) {
             return blockingIssue
+        }
+
+        // Boot handshake: the first connectivity check has not completed,
+        // so neither "Offline" nor an attention badge is a real verdict yet.
+        if isInitialLoad {
+            return ServerConnectionPresentation(
+                issue: .syncing,
+                statusText: "Connecting",
+                diagnosticsSummary: "Connecting to the local server"
+            )
         }
 
         if isLoading {

--- a/Tests/PlaidBarCoreTests/DashboardLoadStateTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardLoadStateTests.swift
@@ -1,0 +1,403 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("DashboardLoadState Tests")
+struct DashboardLoadStateTests {
+    private func evaluate(
+        surface: DashboardLoadSurface = .accounts,
+        isDemoMode: Bool = false,
+        isBooting: Bool = false,
+        isLoading: Bool = false,
+        serverConnected: Bool = false,
+        hasContent: Bool = false,
+        errorMessage: String? = nil
+    ) -> DashboardLoadState {
+        DashboardLoadState.evaluate(
+            surface: surface,
+            isDemoMode: isDemoMode,
+            isBooting: isBooting,
+            isLoading: isLoading,
+            serverConnected: serverConnected,
+            hasContent: hasContent,
+            errorMessage: errorMessage
+        )
+    }
+
+    @Test("Boot without content is loading and shows a skeleton, not offline")
+    func bootWithoutContentLoads() {
+        let state = evaluate(isBooting: true)
+
+        #expect(state.phase == .loading)
+        #expect(state.isInitialLoad)
+        #expect(state.showsSkeleton)
+        #expect(state
+            .loadingAccessibilityLabel ==
+            "Loading accounts. Fetching linked account balances from the local VaultPeek server.")
+    }
+
+    @Test("In-flight refresh without content is loading")
+    func refreshWithoutContentLoads() {
+        let state = evaluate(isLoading: true, serverConnected: true)
+
+        #expect(state.phase == .loading)
+        #expect(state.showsSkeleton)
+    }
+
+    @Test("Cached content wins over an in-flight boot — no skeleton regression")
+    func cachedContentWinsDuringBoot() {
+        let state = evaluate(isBooting: true, isLoading: true, hasContent: true)
+
+        #expect(state.phase == .loaded)
+        #expect(!state.showsSkeleton)
+        #expect(state.loadingAccessibilityLabel == nil)
+    }
+
+    @Test("Demo mode never skeletons")
+    func demoModeNeverSkeletons() {
+        let empty = evaluate(isDemoMode: true, isBooting: true)
+        let loaded = evaluate(isDemoMode: true, hasContent: true)
+
+        #expect(empty.phase == .idle)
+        #expect(!empty.showsSkeleton)
+        #expect(loaded.phase == .loaded)
+    }
+
+    @Test("Completed check without server is offline, with error is error")
+    func completedCheckVerdicts() {
+        #expect(evaluate().phase == .offline)
+        #expect(evaluate(serverConnected: true, errorMessage: "Recent action failed").phase == .error)
+        #expect(evaluate(errorMessage: "boom").phase == .error)
+    }
+
+    @Test("Whitespace-only error does not count as an error verdict")
+    func whitespaceErrorIgnored() {
+        #expect(evaluate(errorMessage: "  \n ").phase == .offline)
+        #expect(evaluate(serverConnected: true, errorMessage: "  ").phase == .idle)
+    }
+
+    @Test("Connected with no content and no fetch is idle")
+    func connectedEmptyIsIdle() {
+        let state = evaluate(serverConnected: true)
+
+        #expect(state.phase == .idle)
+        #expect(!state.showsSkeleton)
+    }
+
+    @Test("Every surface has loading copy")
+    func everySurfaceHasLoadingCopy() {
+        for surface in DashboardLoadSurface.allCases {
+            #expect(!surface.loadingTitle.isEmpty)
+            #expect(!surface.loadingDetail.isEmpty)
+            let state = DashboardLoadState(surface: surface, phase: .loading)
+            #expect(state.loadingAccessibilityLabel == "\(surface.loadingTitle). \(surface.loadingDetail)")
+        }
+    }
+}
+
+@Suite("Empty-state evaluator loading cases")
+struct EmptyStateLoadingCaseTests {
+    @Test("Dashboard account empty state renders loading before offline during the first fetch")
+    func dashboardAccountEmptyStateLoading() {
+        let state = DashboardAccountEmptyState.evaluate(
+            filter: .all,
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            degradedItemCount: 0
+        )
+
+        #expect(state.tone == .loading)
+        #expect(state.isLoading)
+        #expect(state.title == "Loading accounts")
+        #expect(!state.showsAddAccount)
+    }
+
+    @Test("Demo mode ignores the initial-load flag for the dashboard empty state")
+    func dashboardAccountEmptyStateDemoIgnoresLoading() {
+        let state = DashboardAccountEmptyState.evaluate(
+            filter: .all,
+            isDemoMode: true,
+            isInitialLoad: true,
+            serverConnected: true,
+            linkedItemCount: 0,
+            accountCount: 0,
+            degradedItemCount: 0
+        )
+
+        #expect(state.tone != .loading)
+        #expect(!state.isLoading)
+    }
+
+    @Test("Dashboard account empty state still reports offline once boot completes")
+    func dashboardAccountEmptyStateOfflineAfterBoot() {
+        let state = DashboardAccountEmptyState.evaluate(
+            filter: .all,
+            isDemoMode: false,
+            isInitialLoad: false,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            degradedItemCount: 0
+        )
+
+        #expect(state.tone == .offline)
+        #expect(state.title == "Server offline")
+    }
+
+    @Test("Secondary surfaces render passive loading states during the first fetch")
+    func secondarySurfacesLoading() {
+        let accounts = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0
+        )
+        let credit = SecondaryContentUnavailableState.credit(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0
+        )
+        let transactions = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            hasSearchText: false,
+            hasActiveFilters: false,
+            errorMessage: nil
+        )
+        let spending = SecondaryContentUnavailableState.spendingActivity(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            errorMessage: nil
+        )
+        let recurring = SecondaryContentUnavailableState.recurring(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            errorMessage: nil
+        )
+
+        for state in [accounts, credit, transactions, spending, recurring] {
+            #expect(state.isLoading)
+            #expect(state.title.hasPrefix("Loading"))
+            #expect(state.iconName == "arrow.triangle.2.circlepath")
+        }
+    }
+
+    @Test("Filtered-zero results beat the loading state — synced content exists")
+    func filteredZeroBeatsLoading() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            transactionCount: 12,
+            hasSearchText: true,
+            hasActiveFilters: false,
+            errorMessage: nil
+        )
+
+        #expect(!state.isLoading)
+        #expect(state.title == "No matching transactions")
+        #expect(state.action == .clearFilters)
+    }
+
+    @Test("Loading outranks a stale error message while the first fetch is in flight")
+    func loadingOutranksStaleError() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 0,
+            transactionCount: 0,
+            hasSearchText: false,
+            hasActiveFilters: false,
+            errorMessage: "Recent action failed"
+        )
+
+        #expect(state.isLoading)
+        #expect(state.title == "Loading transactions")
+    }
+
+    @Test("Secondary surfaces keep offline verdicts once boot completes")
+    func secondarySurfacesOfflineAfterBoot() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false,
+            isInitialLoad: false,
+            serverConnected: false,
+            linkedItemCount: 0
+        )
+
+        #expect(!state.isLoading)
+        #expect(state.title == "Server offline")
+    }
+
+    @Test("Account activity empty state loads before offline/stale verdicts")
+    func accountActivityLoading() {
+        let state = AccountActivityEmptyState.evaluate(
+            transactionCount: 0,
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            connectionLevel: .offline,
+            accountDisplayName: "Chase Checking"
+        )
+
+        #expect(state?.tone == .loading)
+        #expect(state?.title == "Loading activity")
+        #expect(state?.detail.contains("Chase Checking") == true)
+    }
+
+    @Test("Account activity returns nil when transactions exist, even mid-load")
+    func accountActivityContentWins() {
+        let state = AccountActivityEmptyState.evaluate(
+            transactionCount: 4,
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: true,
+            connectionLevel: .healthy,
+            accountDisplayName: "Chase Checking"
+        )
+
+        #expect(state == nil)
+    }
+}
+
+@Suite("Status readiness and connection loading states")
+struct StatusLoadingStateTests {
+    @Test("Readiness reports a neutral loading level with no action during boot")
+    func readinessLoadingLevel() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            isInitialLoad: true,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: nil
+        )
+
+        #expect(readiness.level == .loading)
+        #expect(readiness.title == "Loading financial data")
+        #expect(readiness.primaryAction == nil)
+    }
+
+    @Test("Demo readiness wins over the initial-load flag")
+    func readinessDemoWins() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: true,
+            isInitialLoad: true,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 2,
+            accountCount: 4,
+            syncedItemCount: 2,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: false,
+            lastSyncRelative: "just now",
+            errorMessage: nil
+        )
+
+        #expect(readiness.level == .healthy)
+        #expect(readiness.title == "Demo data ready")
+    }
+
+    @Test("Readiness keeps the blocked offline verdict once boot completes")
+    func readinessOfflineAfterBoot() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            isInitialLoad: false,
+            serverConnected: false,
+            credentialsConfigured: nil,
+            linkedItemCount: 0,
+            accountCount: 0,
+            syncedItemCount: 0,
+            needsLoginItemCount: 0,
+            erroredItemCount: 0,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: nil
+        )
+
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Server offline")
+    }
+
+    @Test("Server connection presents Connecting without an attention badge during boot")
+    func serverConnectionConnecting() {
+        let presentation = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isInitialLoad: true,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil
+        )
+
+        #expect(presentation.issue == .syncing)
+        #expect(presentation.statusText == "Connecting")
+        #expect(presentation.attentionText == nil)
+    }
+
+    @Test("Local auth issues outrank the boot connecting state")
+    func authIssueOutranksConnecting() {
+        let presentation = ServerConnectionPresentation.evaluate(
+            isDemoMode: false,
+            isInitialLoad: true,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: "The local app-server auth token is unavailable"
+        )
+
+        #expect(presentation.issue == .localAuthMissing)
+        #expect(presentation.attentionText == "Auth")
+    }
+
+    @Test("Menu bar recent spend shows the neutral app name during boot, not a zero verdict")
+    func menuBarRecentSpendNeutralDuringBoot() {
+        let booting = MenuBarSummary.text(
+            mode: .recentSpend,
+            accounts: [],
+            transactions: [],
+            currencyFormat: .abbreviated,
+            isInitialLoad: true
+        )
+        let settled = MenuBarSummary.text(
+            mode: .recentSpend,
+            accounts: [],
+            transactions: [],
+            currencyFormat: .abbreviated,
+            isInitialLoad: false
+        )
+
+        #expect(booting == PlaidBarConstants.appName)
+        #expect(settled == "No spend")
+    }
+}


### PR DESCRIPTION
## Summary

Boot rendered as offline/empty until the first server handshake completed (~4.8s with a bundled server), so launch looked like a broken or offline app. This PR models the load-phase state machine as a testable presenter in `PlaidBarCore` and renders proper loading/skeleton states across the dashboard data surfaces:

- **New `DashboardLoadState` presenter** (`Sources/PlaidBarCore/Models/DashboardLoadState.swift`): `idle / loading / loaded / offline / error` per surface (`menuBarSummary`, `summaryCards`, `accounts`, `transactions`, `spending`, `credit`, `recurring`, `activityHeatmap`). Content always wins over in-flight refreshes (preserves cached last-known data, PR-019 T093); skeletons appear only while the *first* fetch is in flight.
- **`.loading` cases in the empty-state evaluators**: `DashboardAccountEmptyState`, `SecondaryContentUnavailableState` (all five factories), and `AccountActivityEmptyState` accept `isInitialLoad` and return passive loading presentations (no recovery actions mid-load) instead of "Server offline".
- **Warning reserved for real staleness**: `DashboardStatusReadiness` gains a neutral `.loading` level; `isSyncStale`/`statusSyncText`/`menuBarAttentionText`/menu bar glyph stay quiet during the boot handshake; `ServerConnectionPresentation` reports "Connecting" without an attention badge. `SemanticColors.warning` in the status surfaces now means actual staleness, never an in-flight load.
- **Cache before connectivity check**: `AppState.loadInitialData()` hydrates accounts/transactions from the `LocalDataStore` cache (via a persisted last-known cache context) *before* the connectivity check, so returning users see data immediately.
- **Skeleton rendering** (`Sources/PlaidBar/Views/LoadingSkeletons.swift`): redacted (`.redacted(reason: .placeholder)`) account rows, a `loadingRedaction` modifier for the net-worth header and summary cards, and a dimmed heatmap with a "Loading activity" caption. No spinner-only surfaces. The skeleton pulse is disabled under Reduce Motion (static redaction carries the meaning); VoiceOver announces the loading state and placeholders carry accessibility labels.

Swift Testing coverage added for the full load-phase matrix and every evaluator loading case (`Tests/PlaidBarCoreTests/DashboardLoadStateTests.swift`); full suite is 416 tests green.

Note: repo-wide `swiftformat` (local 0.61.1) reformats 66 files at current `main` (including stripping explicit `Sendable` conformances, against repo conventions), so that churn was deliberately excluded; new code matches surrounding style. `swiftlint` is not installed on this machine.

## Autonomous task IDs

Task ID(s): AND-310
Backlog slice: PR-007 (Empty, Loading, And Error States) follow-up; aligns with PR-019 T093 (preserve cached last-known data during refresh)
Scope note: Loading/skeleton states for dashboard data surfaces only; no server/API changes. Settings `AttentionQueueView` rows during boot and `DashboardOverviewFallbackState` (setup-incomplete banner) left as-is — see Linear comment.

## Agent coordination

Builder agent: Claude Fable 5 (Claude Code session)
Builder branch/worktree: feat/and-310-loading-states in /Users/ftchvs/Developer/pb-worktrees/appui
Reviewer/merge steward: Felipe + Otto loop
Coordination note: review-only for other agents; do not push to this branch

## Changed files

- `Sources/PlaidBarCore/Models/DashboardLoadState.swift` (new)
- `Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift`
- `Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift`
- `Sources/PlaidBarCore/Models/AccountActivityEmptyState.swift`
- `Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift`
- `Sources/PlaidBarCore/Utilities/ServerConnectionPresentation.swift`
- `Sources/PlaidBarCore/Utilities/MenuBarSummary.swift`
- `Sources/PlaidBar/App/AppState.swift`
- `Sources/PlaidBar/Views/LoadingSkeletons.swift` (new)
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Sources/PlaidBar/Views/MenuBarLabel.swift`
- `Sources/PlaidBar/Views/AccountDetailFlyout.swift`
- `Sources/PlaidBar/Views/SharedModifiers.swift`
- `Sources/PlaidBar/Views/AccountsView.swift`
- `Sources/PlaidBar/Views/TransactionsView.swift`
- `Sources/PlaidBar/Views/SpendingView.swift`
- `Sources/PlaidBar/Views/CreditView.swift`
- `Sources/PlaidBar/Views/RecurringView.swift`
- `Sources/PlaidBar/Views/StatusView.swift`
- `Sources/PlaidBar/Settings/SettingsView.swift`
- `Tests/PlaidBarCoreTests/DashboardLoadStateTests.swift` (new)

## Local gates

- [x] `git diff --check` — clean, no whitespace errors
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — Build complete (all 3 targets, zero warnings)
- [x] `swift test` — 416 tests passed, 0 failures (includes new DashboardLoadState/evaluator loading-case suites)
- [x] `bash -n Scripts/*.sh` — all scripts parse cleanly (no scripts modified)
- [x] Secret scan over diff (`git diff main...HEAD | grep -iE 'client_secret|access-(sandbox|production)|api[_-]?key|BEGIN (RSA|EC|OPENSSH)'`) — no hits

## GitHub checks

- [ ] CI build (strict concurrency) green on PR head
- [ ] CI tests green on PR head
- [ ] Lint/format checks green on PR head
- [ ] No new warnings introduced in CI logs
- [ ] All required status checks passing before merge

GitHub Actions billing outage on 2026-06-12 — checks must be re-run once billing is restored; merge is held until green.

## Privacy and safety impact

- [x] No real credentials, access tokens, account IDs, or balances added to code, tests, or docs (all fixtures synthetic)
- [x] `/api/status` payload unchanged — still readiness metadata only
- [x] No new network calls or data egress; all data stays local (cache preload reads existing local files only)
- [x] No changes to credential storage or Keychain handling

## Reviewer local-first and secret-exposure checklist

- [x] App still talks only to `127.0.0.1` local server; no Plaid secrets in the app target
- [x] New persisted value (`cache.lastTransactionCacheContext` in UserDefaults) holds only environment name + local storage path, never tokens or account data
- [x] Cache preload validates the stored context against the cache file's embedded context before adopting rows
- [x] No telemetry, analytics, or cloud calls introduced
- [x] Error strings remain sanitized via existing `UserFacingError` paths

## UI and accessibility checks

- [x] Loading state never communicated by color alone: redacted placeholder geometry, loading icon (`arrow.triangle.2.circlepath`), and "Loading…" copy carry the meaning
- [x] Reduce Motion respected: skeleton pulse disabled under Reduce Motion (static redaction remains); no new unguarded animations
- [x] VoiceOver: skeleton list and loading unavailable-views post `AccessibilityNotification.Announcement`; redacted surfaces expose "Loading…" accessibility labels; heatmap label switches to loading copy
- [x] No spinner-only surfaces; recovery action buttons hidden while loading so users cannot fire refreshes into an in-flight boot

## Merge safety

- [x] Branch is up to date with the base branch at PR creation time
- [ ] PR head SHA was rechecked immediately before merge
- [x] Local gates above were run on the exact commit being proposed (f15c131)
- [ ] After merge: branch deleted and Linear issue moved to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)