### PR TITLE
refactor: rewrite Settings as native Form(.grouped) across all four tabs (AND-311)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -324,7 +324,7 @@ reference for PR-005 follow-up work.
 
 ### NotificationSettingsView
 
-**Anatomy:** Form | Master toggle "Enable notifications" | Permission denied warning (if applicable): `exclamationmark.triangle` icon + explanation text | Section "Transaction Alerts": Large transactions toggle + threshold field ($), Low balance toggle + threshold field ($) | Section "Credit Alerts": High utilization toggle + reference to credit warning threshold from General
+**Anatomy:** `Form` + `.formStyle(.grouped)` + switch-style toggles | First section: macOS permission status row (icon + label + detail + optional recovery action) and master toggle "Enable notifications" | Section "Transaction alerts": Large transactions toggle + "Large transaction threshold" field ($), Low balance warning toggle + "Low balance threshold" field ($) | Section "Credit alerts": High utilization toggle + reference to credit warning threshold from General
 
 **Code reference:** `Sources/PlaidBar/Settings/SettingsView.swift`
 
@@ -332,8 +332,9 @@ reference for PR-005 follow-up work.
 |-------|----------|
 | Notifications off | Master toggle off; all sub-toggles and fields disabled |
 | Notifications enabled | Master toggle on; sub-toggles and threshold fields enabled |
-| Permission denied (macOS) | Warning banner: `exclamationmark.triangle` + "Enable in System Settings > Notifications"; master toggle forced off |
+| Permission denied (macOS) | Permission status row shows warning icon + "Denied" label, explanation text, and an "Open System Settings" recovery button; sub-controls disabled |
 | Individual trigger disabled | Specific toggle off; associated threshold field disabled |
+| Zero-dollar threshold | `InlineSettingsNotice` (`bell.badge` icon + warning tint + text) explains a $0 threshold alerts on every outgoing transaction |
 | High utilization reference | Shows "Uses credit warning threshold ({X}%)" in `.detailText()` — threshold set in General tab |
 
 ### SpendingComparison
@@ -398,7 +399,7 @@ Pattern for all empty states:
 | Selected account panel | Connection badge, balance metrics, pending/inflow/outflow/sync pills, recent transactions, reconnect/refresh actions | Inline recovery actions for stale or degraded items |
 | Spending activity | GitHub-style 365-day grid with month labels, Spend/Net toggle, intensity legend, and total header | Hover cells for day-level transaction count plus spend or net cashflow |
 | Legacy detail views | AccountsView, TransactionsView, SpendingView, CreditView, StatusView remain available as implementation surfaces and screenshot/reference components | Prefer dashboard-first entry unless adding a focused detail surface |
-| Settings | 4-tab TabView: General, Accounts, Notifications, About (480×380) | TabView |
+| Settings | 4-tab TabView: General, Accounts, Notifications, About; each tab is a native grouped `Form` with switch-style toggles and sentence-case section headers; resizable window (min 560×480) | TabView + `Form(.grouped)` |
 | Onboarding | Demo/Sandbox/Production choice with local-storage disclosure before Plaid Link | Mode choice, Back, Check Connection |
 
 ### Popover Surface Inventory
@@ -415,7 +416,7 @@ absolute paths when adding screenshot or review evidence.
 | Local insights | `LocalInsightsCard` and `InsightMetricPill` in `Sources/PlaidBar/Views/MainPopover.swift` | Optional local-only AI/status content is presented as a card with nested metric pills | Can feel like product/marketing chrome if it competes with financial rows | Prefer a compact disclosure or status row unless local insights become the selected detail focus |
 | Status and readiness | `DashboardStatusReadinessPanel` and `DashboardEmptyAccountState` in `Sources/PlaidBar/Views/MainPopover.swift` | Recovery and empty states use prominent rounded panels | Appropriate when degraded, but card-heavy if shown alongside several other panels | Keep panels exceptional for action-needed states; avoid duplicating status panels in normal healthy dashboard flow |
 | Legacy/detail surfaces | `AccountsView`, `TransactionsView`, `SpendingView`, `CreditView`, and `StatusView` | Older detail views include segmented controls, forms, grids, and diagnostic tiles | Tab-heavy if promoted back to first-level popover navigation | Treat as drill-ins or reference/screenshot surfaces; keep the main popover dashboard-first |
-| Settings | `SettingsView` | 4-tab macOS settings control plane | Tab-heavy by design, but outside the primary popover dashboard | Leave as settings unless a future settings-specific audit scopes a flatter layout |
+| Settings | `SettingsView` | 4-tab macOS settings window; each tab a native grouped `Form` (no hand-rolled card stacks since AND-311) | Tab-heavy by design, but outside the primary popover dashboard | Keep native `Form(.grouped)` idioms for new settings rows instead of reintroducing custom card containers |
 | Onboarding/setup | `SetupView` | Demo/Sandbox/Production choices, preflight rows, and local-storage disclosure use multiple callout blocks | First-run flow can feel card-heavy and marketing-like if choices duplicate each other | Keep boundary explanations, but consolidate duplicate choice surfaces before adding more setup panels |
 
 ## Extending the Design System

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1,7 +1,7 @@
-import SwiftUI
+import AppKit
 import PlaidBarCore
 import Sparkle
-import AppKit
+import SwiftUI
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -37,7 +37,14 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.about.rawValue)
         }
-        .frame(width: 620, height: 560)
+        .frame(
+            minWidth: 560,
+            idealWidth: 620,
+            maxWidth: .infinity,
+            minHeight: 480,
+            idealHeight: 560,
+            maxHeight: .infinity
+        )
     }
 }
 
@@ -57,140 +64,137 @@ struct GeneralSettingsView: View {
     var body: some View {
         @Bindable var state = appState
 
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.lg) {
-                SettingsCard {
-                    settingsRow("Menu bar shows") {
-                        Picker("Menu bar shows", selection: $state.menuBarSummaryMode) {
-                            ForEach(MenuBarSummaryMode.allCases, id: \.self) { mode in
-                                Text(mode.displayName).tag(mode)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 230)
+        Form {
+            Section {
+                Picker("Menu bar shows", selection: $state.menuBarSummaryMode) {
+                    ForEach(MenuBarSummaryMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
                     }
-
-                    settingsRow("Balance format") {
-                        Picker("Balance format", selection: $state.balanceFormat) {
-                            Text("$12,450.32").tag(CurrencyFormat.full)
-                            Text("$12.4K").tag(CurrencyFormat.abbreviated)
-                            Text("$12,450").tag(CurrencyFormat.compact)
-                        }
-                        .labelsHidden()
-                        .frame(width: 230)
-                        .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
-                    }
-
-                    settingsRow("Refresh interval") {
-                        Picker("Refresh interval", selection: $state.refreshInterval) {
-                            Text("5 minutes").tag(TimeInterval(5 * 60))
-                            Text("15 minutes").tag(TimeInterval(15 * 60))
-                            Text("30 minutes").tag(TimeInterval(30 * 60))
-                            Text("1 hour").tag(TimeInterval(60 * 60))
-                        }
-                        .labelsHidden()
-                        .frame(width: 230)
-                    }
-
-                    settingsRow("Credit warning") {
-                        HStack(spacing: Spacing.sm) {
-                            TextField(
-                                "",
-                                value: $state.creditUtilizationThreshold,
-                                format: .number.precision(.fractionLength(0))
-                            )
-                            .frame(width: 72)
-                            .textFieldStyle(.roundedBorder)
-                            Text("%")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .help("Credit cards above this utilization threshold show warning colors")
-
-                    Toggle("Launch at login", isOn: $state.launchAtLogin)
-                        .padding(.top, Spacing.xs)
                 }
 
-                SettingsCard(title: "Local AI") {
-                    settingsRow("Availability") {
-                        HStack(spacing: Spacing.xs) {
-                            Image(systemName: localAIAvailabilityIcon)
-                                .foregroundStyle(localAIAvailabilityTint)
-                            Text(appState.localAIAvailability.state.displayName)
-                                .font(.body.weight(.medium))
-                        }
-                    }
+                Picker("Balance format", selection: $state.balanceFormat) {
+                    Text("$12,450.32").tag(CurrencyFormat.full)
+                    Text("$12.4K").tag(CurrencyFormat.abbreviated)
+                    Text("$12,450").tag(CurrencyFormat.compact)
+                }
+                .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
 
-                    settingsRow("Runtime") {
-                        Text(appState.localAIAvailability.runtimeName ?? "None configured")
+                Picker("Refresh interval", selection: $state.refreshInterval) {
+                    Text("5 minutes").tag(TimeInterval(5 * 60))
+                    Text("15 minutes").tag(TimeInterval(15 * 60))
+                    Text("30 minutes").tag(TimeInterval(30 * 60))
+                    Text("1 hour").tag(TimeInterval(60 * 60))
+                }
+
+                LabeledContent("Credit warning") {
+                    HStack(spacing: Spacing.xs) {
+                        TextField(
+                            "Credit warning threshold",
+                            value: $state.creditUtilizationThreshold,
+                            format: .number.precision(.fractionLength(0))
+                        )
+                        .labelsHidden()
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 64)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Credit warning threshold")
+
+                        Text("%")
                             .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
                     }
+                }
+                .help("Credit cards above this utilization threshold show warning colors")
 
-                    Text(appState.localAIAvailability.detail)
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
+                Toggle("Launch at login", isOn: $state.launchAtLogin)
+            }
 
-                    Text("VaultPeek does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged.")
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
+            Section("Local AI") {
+                LabeledContent("Availability") {
+                    HStack(spacing: Spacing.xs) {
+                        Image(systemName: LocalAIAvailabilityPresentation
+                            .iconName(for: appState.localAIAvailability.state))
+                            .foregroundStyle(localAIAvailabilityTint)
+                            .accessibilityHidden(true)
+                        Text(appState.localAIAvailability.state.displayName)
+                            .font(.body.weight(.medium))
+                    }
+                }
+                .accessibilityElement(children: .combine)
+
+                LabeledContent("Runtime") {
+                    Text(appState.localAIAvailability.runtimeName ?? "None configured")
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
                 }
 
-                SettingsCard(title: "Local Data") {
-                    settingsRow("Storage path", alignment: .top) {
-                        VStack(alignment: .trailing, spacing: Spacing.xs) {
-                            Text(appState.activeStorageDirectoryDisplayText)
-                                .font(.system(.body, design: .monospaced))
-                                .lineLimit(2)
-                                .multilineTextAlignment(.trailing)
-                                .textSelection(.enabled)
+                Text(appState.localAIAvailability.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
 
-                            Text(storageDetailText)
-                                .detailText()
-                                .lineLimit(2)
-                                .multilineTextAlignment(.trailing)
-                                .textSelection(.enabled)
-                        }
+                Text(
+                    "VaultPeek does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged."
+                )
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Local data") {
+                LabeledContent("Storage path") {
+                    VStack(alignment: .trailing, spacing: Spacing.xs) {
+                        Text(appState.activeStorageDirectoryDisplayText)
+                            .font(.system(.body, design: .monospaced))
+                            .lineLimit(2)
+                            .multilineTextAlignment(.trailing)
+                            .textSelection(.enabled)
+
+                        Text(storageDetailText)
+                            .detailText()
+                            .lineLimit(2)
+                            .multilineTextAlignment(.trailing)
+                            .textSelection(.enabled)
                     }
+                }
 
-                    LocalTrustReceiptView(receipt: localTrustReceipt)
+                LocalTrustReceiptView(receipt: localTrustReceipt)
 
-                    HStack(alignment: .center, spacing: Spacing.sm) {
-                        Button {
-                            revealStorageDirectory()
-                        } label: {
-                            Label("Open Folder", systemImage: "folder")
-                        }
-                        .controlSize(.small)
-
-                        Button {
-                            copyStoragePath()
-                        } label: {
-                            Label("Copy Path", systemImage: "doc.on.doc")
-                        }
-                        .controlSize(.small)
-
-                        Button {
-                            isShowingResetConfirmation = true
-                        } label: {
-                            Label("Reset Local Data", systemImage: "trash")
-                        }
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                        .foregroundStyle(.secondary)
+                HStack(alignment: .center, spacing: Spacing.sm) {
+                    Button {
+                        revealStorageDirectory()
+                    } label: {
+                        Label("Open Folder", systemImage: "folder")
                     }
+                    .controlSize(.small)
+
+                    Button {
+                        copyStoragePath()
+                    } label: {
+                        Label("Copy Path", systemImage: "doc.on.doc")
+                    }
+                    .controlSize(.small)
+
+                    Button {
+                        isShowingResetConfirmation = true
+                    } label: {
+                        Label("Reset Local Data", systemImage: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .foregroundStyle(.secondary)
                 }
             }
-            .padding(Spacing.lg)
         }
+        .formStyle(.grouped)
+        .toggleStyle(.switch)
         .alert("Reset Local Data?", isPresented: $isShowingResetConfirmation) {
             Button("Reset Local Data", role: .destructive) {
                 resetLocalData()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Deletes the SQLite database, account and transaction caches, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart the VaultPeek companion server after resetting.")
+            Text(
+                "Deletes the SQLite database, account and transaction caches, stored Plaid access tokens, sync cursors, and loaded account data under \(appState.activeStorageDirectoryDisplayText). Keeps server.conf, app/server auth, Plaid dashboard Items, shell credentials, and app preferences. Restart the VaultPeek companion server after resetting."
+            )
         }
         .alert("Local Data Reset", isPresented: Binding(
             get: { resetResultMessage != nil },
@@ -224,81 +228,33 @@ struct GeneralSettingsView: View {
     private func resetLocalData() {
         do {
             let result = try appState.resetLocalData()
-            let preservationText = preservedEntriesText(for: result)
-            if result.removedEntryCount == 0 {
-                resetResultMessage = "No local data found. \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))) is ready. \(keychainResetText(for: result))\(preservationText)"
-            } else {
-                resetResultMessage = "Removed \(result.removedEntryCount) VaultPeek data item\(result.removedEntryCount == 1 ? "" : "s") from \(LocalDataStore.displayPath(for: URL(fileURLWithPath: result.directoryPath, isDirectory: true))). \(keychainResetText(for: result))\(preservationText) Restart the VaultPeek companion server."
-            }
+            resetResultMessage = LocalDataResetPresentation.successMessage(for: result)
         } catch {
             resetErrorMessage = error.localizedDescription
         }
     }
 
     private var storageDetailText: String {
-        if let serverStoragePath = appState.serverStoragePath {
-            return "Server: \(LocalDataStore.displayPath(for: URL(fileURLWithPath: NSString(string: serverStoragePath).expandingTildeInPath)))"
-        }
-
-        return "Default: \(appState.localStorageResolvedDisplayPathText)"
+        LocalDataResetPresentation.storageDetail(
+            serverStoragePath: appState.serverStoragePath,
+            defaultResolvedDisplayPath: appState.localStorageResolvedDisplayPathText
+        )
     }
 
     private var localTrustReceipt: LocalTrustReceipt {
         LocalTrustReceipt.settingsReceipt(storagePath: appState.activeStorageDirectoryDisplayText)
     }
 
-    private var localAIAvailabilityIcon: String {
-        switch appState.localAIAvailability.state {
-        case .available: "cpu.fill"
-        case .disabled: "pause.circle.fill"
-        case .unavailable: "exclamationmark.triangle.fill"
-        }
-    }
-
     private var localAIAvailabilityTint: Color {
-        switch appState.localAIAvailability.state {
-        case .available: SemanticColors.positive
-        case .disabled: .secondary
-        case .unavailable: SemanticColors.warning
+        color(for: LocalAIAvailabilityPresentation.tone(for: appState.localAIAvailability.state))
+    }
+
+    private func color(for tone: SettingsStatusTone) -> Color {
+        switch tone {
+        case .positive: SemanticColors.positive
+        case .warning: SemanticColors.warning
+        case .secondary: .secondary
         }
-    }
-
-    private func keychainResetText(for result: LocalDataResetResult) -> String {
-        result.keychainTokensCleared
-            ? "Keychain token entries were cleared when present."
-            : "Keychain token entries were not cleared."
-    }
-
-    private func preservedEntriesText(for result: LocalDataResetResult) -> String {
-        guard result.preservedEntryCount > 0 else { return "" }
-        return " Left \(result.preservedEntryCount) config or unrelated item\(result.preservedEntryCount == 1 ? "" : "s") untouched."
-    }
-}
-
-private struct SettingsCard<Content: View>: View {
-    let title: String?
-    @ViewBuilder let content: Content
-
-    init(title: String? = nil, @ViewBuilder content: () -> Content) {
-        self.title = title
-        self.content = content()
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
-            if let title {
-                Text(title)
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: Spacing.md) {
-                content
-            }
-        }
-        .padding(Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
     }
 }
 
@@ -343,25 +299,6 @@ private struct LocalTrustReceiptView: View {
     }
 }
 
-@ViewBuilder
-@MainActor
-private func settingsRow<Content: View>(
-    _ title: String,
-    alignment: VerticalAlignment = .center,
-    @ViewBuilder content: () -> Content
-) -> some View {
-    HStack(alignment: alignment, spacing: Spacing.md) {
-        Text(title)
-            .foregroundStyle(.secondary)
-            .frame(width: 150, alignment: .leading)
-
-        Spacer(minLength: Spacing.md)
-
-        content()
-            .frame(maxWidth: 330, alignment: .trailing)
-    }
-}
-
 struct AccountSettingsView: View {
     @Environment(AppState.self) private var appState
     @State private var isShowingAccountSetup = false
@@ -377,124 +314,58 @@ struct AccountSettingsView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            AttentionQueueView(
-                title: "ATTENTION",
-                showsHealthyRow: false,
-                onAddAccount: handleAddAccount
-            )
-            .environment(appState)
-            .padding([.horizontal, .top], Spacing.md)
-
+        Group {
             if appState.accounts.isEmpty {
-                SecondaryUnavailableView(presentation: emptyPresentation) {
-                    performEmptyAction(emptyPresentation.action)
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    AttentionQueueView(
+                        title: "Attention",
+                        showsHealthyRow: false,
+                        onAddAccount: handleAddAccount
+                    )
+                    .environment(appState)
+                    .padding([.horizontal, .top], Spacing.md)
+
+                    SecondaryUnavailableView(presentation: emptyPresentation) {
+                        performEmptyAction(emptyPresentation.action)
+                    }
                 }
             } else {
-                List {
+                Form {
+                    AttentionQueueView(
+                        title: "Attention",
+                        showsHealthyRow: false,
+                        onAddAccount: handleAddAccount
+                    )
+                    .environment(appState)
+
                     ForEach(accountGroups) { group in
-                        VStack(alignment: .leading, spacing: Spacing.sm) {
-                            HStack(alignment: .top) {
-                                VStack(alignment: .leading, spacing: Spacing.xxs) {
-                                    Text(group.institutionName)
-                                        .font(.headline)
-
-                                    HStack(spacing: Spacing.xs) {
-                                        Image(systemName: group.connection.iconName)
-                                            .foregroundStyle(color(for: group.connection.level))
-                                        Text(group.connection.signalLabel)
-                                            .foregroundStyle(color(for: group.connection.level))
-                                        Text("\u{00B7}")
-                                            .foregroundStyle(.tertiary)
-                                        Text("\(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")")
-                                            .foregroundStyle(.secondary)
-                                        if let itemSyncLabel = group.connection.itemSyncLabel {
-                                            Text("\u{00B7}")
-                                                .foregroundStyle(.tertiary)
-                                            Text(itemSyncLabel)
-                                                .foregroundStyle(.secondary)
-                                        }
-                                    }
-                                    .detailText()
-
-                                    if let recoveryDetailLabel = group.connection.recoveryDetailLabel {
-                                        Text(recoveryDetailLabel)
-                                            .detailText()
-                                            .foregroundStyle(.secondary)
-                                            .fixedSize(horizontal: false, vertical: true)
-                                    }
-                                }
-
-                                Spacer()
-
-                                if group.connection.showsRecoveryActions,
-                                   let recoveryActionTitle = group.connection.recoveryActionTitle {
-                                    Button {
-                                        performRecoveryAction(for: group)
-                                    } label: {
-                                        Label(recoveryActionTitle, systemImage: group.connection.level == .stale ? "arrow.clockwise" : "link.badge.plus")
-                                    }
-                                    .buttonStyle(.bordered)
-                                }
-
-                                Button(role: .destructive) {
-                                    pendingRemoval = PendingAccountRemoval(
-                                        itemId: group.id,
-                                        institutionName: group.institutionName,
-                                        accountCount: group.accounts.count
-                                    )
-                                } label: {
-                                    Label("Remove", systemImage: "trash")
-                                }
-                                .buttonStyle(.bordered)
-                            }
+                        Section {
+                            groupHeaderRow(for: group)
 
                             ForEach(group.accounts) { account in
-                                HStack {
-                                    Image(systemName: AccountPresentation.iconName(for: account))
-                                        .foregroundStyle(accountIconTint(for: account))
-                                        .frame(width: 18)
-
-                                    VStack(alignment: .leading, spacing: Spacing.xxs) {
-                                        Text(account.name)
-                                        Text(account.type.rawValue.capitalized)
-                                            .detailText()
-                                    }
-
-                                    Spacer()
-
-                                    Text(balanceText(for: account))
-                                        .monospacedDigit()
-                                        .foregroundStyle(balanceTint(for: account))
-                                }
-                                .padding(.leading, Spacing.md)
-                                .accessibilityElement(children: .combine)
-                                .accessibilityLabel(accountAccessibilityLabel(for: account))
+                                accountRow(for: account)
                             }
                         }
-                        .padding(.vertical, Spacing.xs)
-                        .accessibilityElement(children: .contain)
-                        .accessibilityLabel(groupAccessibilityLabel(for: group))
                     }
-                }
-            }
 
-            if !appState.accounts.isEmpty {
-                HStack {
-                    Spacer()
-                    Button("Add Account") {
-                        handleAddAccount()
+                    Section {
+                        HStack {
+                            Spacer()
+                            Button("Add Account") {
+                                handleAddAccount()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
                     }
-                    .buttonStyle(.borderedProminent)
                 }
-                .padding()
+                .formStyle(.grouped)
             }
         }
         .sheet(isPresented: $isShowingAccountSetup) {
             SetupView {
                 isShowingAccountSetup = false
             }
-                .environment(appState)
+            .environment(appState)
         }
         .onChange(of: appState.isSetupComplete) { _, isComplete in
             if isComplete {
@@ -504,13 +375,102 @@ struct AccountSettingsView: View {
         .alert(item: $pendingRemoval) { removal in
             Alert(
                 title: Text("Remove \(removal.institutionName)?"),
-                message: Text("This removes \(removal.accountCount) linked account\(removal.accountCount == 1 ? "" : "s") from VaultPeek and clears matching cached transactions from this Mac. It does not delete the institution from Plaid's dashboard."),
+                message: Text(
+                    "This removes \(removal.accountCount) linked account\(removal.accountCount == 1 ? "" : "s") from VaultPeek and clears matching cached transactions from this Mac. It does not delete the institution from Plaid's dashboard."
+                ),
                 primaryButton: .destructive(Text("Remove")) {
                     Task { await appState.removeAccount(itemId: removal.itemId) }
                 },
                 secondaryButton: .cancel()
             )
         }
+    }
+
+    private func groupHeaderRow(for group: AccountItemGroup) -> some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(group.institutionName)
+                    .font(.headline)
+
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: group.connection.iconName)
+                        .foregroundStyle(color(for: group.connection.level))
+                    Text(group.connection.signalLabel)
+                        .foregroundStyle(color(for: group.connection.level))
+                    Text("\u{00B7}")
+                        .foregroundStyle(.tertiary)
+                    Text("\(group.accounts.count) account\(group.accounts.count == 1 ? "" : "s")")
+                        .foregroundStyle(.secondary)
+                    if let itemSyncLabel = group.connection.itemSyncLabel {
+                        Text("\u{00B7}")
+                            .foregroundStyle(.tertiary)
+                        Text(itemSyncLabel)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .detailText()
+
+                if let recoveryDetailLabel = group.connection.recoveryDetailLabel {
+                    Text(recoveryDetailLabel)
+                        .detailText()
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(groupAccessibilityLabel(for: group))
+
+            Spacer()
+
+            if group.connection.showsRecoveryActions,
+               let recoveryActionTitle = group.connection.recoveryActionTitle
+            {
+                Button {
+                    performRecoveryAction(for: group)
+                } label: {
+                    Label(
+                        recoveryActionTitle,
+                        systemImage: group.connection.level == .stale ? "arrow.clockwise" : "link.badge.plus"
+                    )
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Button(role: .destructive) {
+                pendingRemoval = PendingAccountRemoval(
+                    itemId: group.id,
+                    institutionName: group.institutionName,
+                    accountCount: group.accounts.count
+                )
+            } label: {
+                Label("Remove", systemImage: "trash")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Remove \(group.institutionName)")
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    private func accountRow(for account: AccountDTO) -> some View {
+        HStack {
+            Image(systemName: AccountPresentation.iconName(for: account))
+                .foregroundStyle(accountIconTint(for: account))
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(account.name)
+                Text(account.type.rawValue.capitalized)
+                    .detailText()
+            }
+
+            Spacer()
+
+            Text(balanceText(for: account))
+                .monospacedDigit()
+                .foregroundStyle(balanceTint(for: account))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accountAccessibilityLabel(for: account))
     }
 
     private func handleAddAccount() {
@@ -620,7 +580,6 @@ struct AccountSettingsView: View {
     private func accountAccessibilityLabel(for account: AccountDTO) -> String {
         "\(account.name), \(account.type.rawValue.capitalized), \(balanceText(for: account))"
     }
-
 }
 
 private struct AccountItemGroup: Identifiable {
@@ -635,7 +594,9 @@ private struct PendingAccountRemoval: Identifiable {
     let institutionName: String
     let accountCount: Int
 
-    var id: String { itemId }
+    var id: String {
+        itemId
+    }
 }
 
 struct NotificationSettingsView: View {
@@ -652,86 +613,95 @@ struct NotificationSettingsView: View {
     var body: some View {
         @Bindable var state = appState
 
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.lg) {
-                SettingsCard {
-                    permissionStatusRow
+        Form {
+            Section {
+                permissionStatusRow
 
-                    Toggle("Enable notifications", isOn: $state.notificationsEnabled)
-                        .onChange(of: appState.notificationsEnabled) { _, enabled in
-                            if enabled {
-                                Task {
-                                    let granted = await appState.requestNotificationPermission()
-                                    await refreshPermissionStatus()
-                                    guard granted else {
-                                        return
-                                    }
+                Toggle("Enable notifications", isOn: $state.notificationsEnabled)
+                    .onChange(of: appState.notificationsEnabled) { _, enabled in
+                        if enabled {
+                            Task {
+                                let granted = await appState.requestNotificationPermission()
+                                await refreshPermissionStatus()
+                                guard granted else {
+                                    return
                                 }
-                            } else {
-                                Task { await refreshPermissionStatus() }
                             }
-                        }
-                        .disabled(permissionPresentation.isNotificationToggleDisabled)
-                }
-
-                SettingsCard(title: "Transaction Alerts") {
-                    Toggle("Large transactions", isOn: $state.notifyLargeTransaction)
-                        .disabled(areNotificationControlsDisabled)
-
-                    settingsRow("Threshold") {
-                        HStack(spacing: Spacing.sm) {
-                            Text("$")
-                                .foregroundStyle(.secondary)
-                            TextField(
-                                "",
-                                value: $state.largeTransactionThreshold,
-                                format: .number.precision(.fractionLength(0))
-                            )
-                            .frame(width: 72)
-                            .textFieldStyle(.roundedBorder)
+                        } else {
+                            Task { await refreshPermissionStatus() }
                         }
                     }
-                    .disabled(areNotificationControlsDisabled || !appState.notifyLargeTransaction)
-
-                    if !areNotificationControlsDisabled,
-                       appState.notifyLargeTransaction,
-                       appState.largeTransactionThreshold <= 0 {
-                        InlineSettingsNotice(
-                            text: "A $0 threshold sends an alert for every outgoing transaction.",
-                            icon: "bell.badge",
-                            tint: SemanticColors.warning
-                        )
-                    }
-
-                    Toggle("Low balance warning", isOn: $state.notifyLowBalance)
-                        .disabled(areNotificationControlsDisabled)
-
-                    settingsRow("Threshold") {
-                        HStack(spacing: Spacing.sm) {
-                            Text("$")
-                                .foregroundStyle(.secondary)
-                            TextField(
-                                "",
-                                value: $state.lowBalanceThreshold,
-                                format: .number.precision(.fractionLength(0))
-                            )
-                            .frame(width: 72)
-                            .textFieldStyle(.roundedBorder)
-                        }
-                    }
-                    .disabled(areNotificationControlsDisabled || !appState.notifyLowBalance)
-                }
-
-                SettingsCard(title: "Credit Alerts") {
-                    Toggle("High utilization", isOn: $state.notifyHighUtilization)
-                        .disabled(areNotificationControlsDisabled)
-                    Text("Uses credit warning threshold (\(Formatters.percent(appState.creditUtilizationThreshold, decimals: 0)))")
-                        .detailText()
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                    .disabled(permissionPresentation.isNotificationToggleDisabled)
             }
-            .padding(Spacing.lg)
+
+            Section("Transaction alerts") {
+                Toggle("Large transactions", isOn: $state.notifyLargeTransaction)
+                    .disabled(areNotificationControlsDisabled)
+
+                LabeledContent("Large transaction threshold") {
+                    HStack(spacing: Spacing.xs) {
+                        Text("$")
+                            .foregroundStyle(.secondary)
+                        TextField(
+                            "Large transaction threshold",
+                            value: $state.largeTransactionThreshold,
+                            format: .number.precision(.fractionLength(0))
+                        )
+                        .labelsHidden()
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Large transaction threshold in dollars")
+                    }
+                }
+                .disabled(areNotificationControlsDisabled || !appState.notifyLargeTransaction)
+
+                if !areNotificationControlsDisabled,
+                   appState.notifyLargeTransaction,
+                   appState.largeTransactionThreshold <= 0
+                {
+                    InlineSettingsNotice(
+                        text: "A $0 threshold sends an alert for every outgoing transaction.",
+                        icon: "bell.badge",
+                        tint: SemanticColors.warning
+                    )
+                }
+
+                Toggle("Low balance warning", isOn: $state.notifyLowBalance)
+                    .disabled(areNotificationControlsDisabled)
+
+                LabeledContent("Low balance threshold") {
+                    HStack(spacing: Spacing.xs) {
+                        Text("$")
+                            .foregroundStyle(.secondary)
+                        TextField(
+                            "Low balance threshold",
+                            value: $state.lowBalanceThreshold,
+                            format: .number.precision(.fractionLength(0))
+                        )
+                        .labelsHidden()
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Low balance threshold in dollars")
+                    }
+                }
+                .disabled(areNotificationControlsDisabled || !appState.notifyLowBalance)
+            }
+
+            Section("Credit alerts") {
+                Toggle("High utilization", isOn: $state.notifyHighUtilization)
+                    .disabled(areNotificationControlsDisabled)
+
+                Text(
+                    "Uses credit warning threshold (\(Formatters.percent(appState.creditUtilizationThreshold, decimals: 0)))"
+                )
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
+        .formStyle(.grouped)
+        .toggleStyle(.switch)
         .task {
             await refreshPermissionStatus()
         }
@@ -772,7 +742,8 @@ struct NotificationSettingsView: View {
     }
 
     private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension")
+        else { return }
         NSWorkspace.shared.open(url)
     }
 
@@ -878,12 +849,12 @@ struct AboutView: View {
     let updater: SPUUpdater
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.lg) {
-                HStack(alignment: .top, spacing: Spacing.md) {
-                    Image(systemName: "dollarsign.circle.fill")
-                        .font(.system(size: 46))
-                        .foregroundStyle(SemanticColors.brand)
+        Form {
+            Section {
+                HStack(alignment: .center, spacing: Spacing.md) {
+                    Image(nsImage: appIconImage)
+                        .resizable()
+                        .frame(width: 64, height: 64)
                         .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -901,53 +872,56 @@ struct AboutView: View {
 
                     Spacer()
                 }
+                .padding(.vertical, Spacing.xs)
+            }
 
-                SettingsCard(title: "Support") {
-                    supportLink(
-                        "Troubleshooting",
-                        systemImage: "wrench.and.screwdriver",
-                        url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/troubleshooting.md",
-                        detail: "Setup, server, Plaid Link, notifications, and screenshot fixes."
-                    )
+            Section("Support") {
+                supportLink(
+                    "Troubleshooting",
+                    systemImage: "wrench.and.screwdriver",
+                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/troubleshooting.md",
+                    detail: "Setup, server, Plaid Link, notifications, and screenshot fixes."
+                )
 
-                    supportLink(
-                        "Privacy",
-                        systemImage: "lock.shield",
-                        url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md",
-                        detail: "What stays local, what calls Plaid, and what not to share."
-                    )
+                supportLink(
+                    "Privacy",
+                    systemImage: "lock.shield",
+                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md",
+                    detail: "What stays local, what calls Plaid, and what not to share."
+                )
 
-                    supportLink(
-                        "Security",
-                        systemImage: "exclamationmark.shield",
-                        url: "https://github.com/ftchvs/PlaidBar/blob/main/SECURITY.md",
-                        detail: "Private reporting path for token, credential, or data exposure."
-                    )
-                }
+                supportLink(
+                    "Security",
+                    systemImage: "exclamationmark.shield",
+                    url: "https://github.com/ftchvs/PlaidBar/blob/main/SECURITY.md",
+                    detail: "Private reporting path for token, credential, or data exposure."
+                )
+            }
 
-                SettingsCard(title: "Project") {
-                    supportLink(
-                        "GitHub Repository",
-                        systemImage: "chevron.left.forwardslash.chevron.right",
-                        url: "https://github.com/ftchvs/PlaidBar",
-                        detail: "Source, issues, and releases (private repository)."
-                    )
+            Section("Project") {
+                supportLink(
+                    "GitHub Repository",
+                    systemImage: "chevron.left.forwardslash.chevron.right",
+                    url: "https://github.com/ftchvs/PlaidBar",
+                    detail: "Source, issues, and releases (private repository)."
+                )
 
-                    supportLink(
-                        "1.0 Roadmap",
-                        systemImage: "map",
-                        url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/v1.0-roadmap.md",
-                        detail: "Product, design, system, security, and release plan."
-                    )
+                supportLink(
+                    "1.0 Roadmap",
+                    systemImage: "map",
+                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/v1.0-roadmap.md",
+                    detail: "Product, design, system, security, and release plan."
+                )
 
-                    supportLink(
-                        "Release Notes",
-                        systemImage: "doc.text",
-                        url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/release-notes.md",
-                        detail: "Curated release summary for current and upcoming versions."
-                    )
-                }
+                supportLink(
+                    "Release Notes",
+                    systemImage: "doc.text",
+                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/release-notes.md",
+                    detail: "Curated release summary for current and upcoming versions."
+                )
+            }
 
+            Section {
                 HStack {
                     Button {
                         updater.checkForUpdates()
@@ -962,8 +936,13 @@ struct AboutView: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            .padding(Spacing.lg)
         }
+        .formStyle(.grouped)
+    }
+
+    @MainActor
+    private var appIconImage: NSImage {
+        NSImage(named: NSImage.applicationIconName) ?? NSApp.applicationIconImage
     }
 
     @ViewBuilder

--- a/Sources/PlaidBarCore/Utilities/SettingsPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/SettingsPresentation.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Tone for settings status indicators.
+///
+/// Always paired with an icon and visible text so meaning never relies on
+/// color alone (see `ACCESSIBILITY.md`).
+public enum SettingsStatusTone: String, Sendable {
+    case positive
+    case warning
+    case secondary
+}
+
+/// Maps local AI availability to settings status iconography.
+public enum LocalAIAvailabilityPresentation {
+    public static func iconName(for state: LocalAIAvailabilityState) -> String {
+        switch state {
+        case .available: "cpu.fill"
+        case .disabled: "pause.circle.fill"
+        case .unavailable: "exclamationmark.triangle.fill"
+        }
+    }
+
+    public static func tone(for state: LocalAIAvailabilityState) -> SettingsStatusTone {
+        switch state {
+        case .available: .positive
+        case .disabled: .secondary
+        case .unavailable: .warning
+        }
+    }
+}
+
+/// Builds user-facing copy for the Settings "Local data" section.
+public enum LocalDataResetPresentation {
+    /// Secondary line under the storage path row: prefers the server-reported
+    /// storage path, falling back to the locally resolved default.
+    public static func storageDetail(
+        serverStoragePath: String?,
+        defaultResolvedDisplayPath: String,
+        homeDirectory: URL = LocalDataStore.accountHomeDirectoryURL()
+    ) -> String {
+        if let serverStoragePath {
+            let expandedPath = NSString(string: serverStoragePath).expandingTildeInPath
+            let displayPath = LocalDataStore.displayPath(
+                for: URL(fileURLWithPath: expandedPath),
+                homeDirectory: homeDirectory
+            )
+            return "Server: \(displayPath)"
+        }
+
+        return "Default: \(defaultResolvedDisplayPath)"
+    }
+
+    /// Result-alert message after a local data reset completes.
+    public static func successMessage(
+        for result: LocalDataResetResult,
+        homeDirectory: URL = LocalDataStore.accountHomeDirectoryURL()
+    ) -> String {
+        let directoryDisplayPath = LocalDataStore.displayPath(
+            for: URL(fileURLWithPath: result.directoryPath, isDirectory: true),
+            homeDirectory: homeDirectory
+        )
+        let keychainText = result.keychainTokensCleared
+            ? "Keychain token entries were cleared when present."
+            : "Keychain token entries were not cleared."
+        let preservationText = result.preservedEntryCount > 0
+            ? " Left \(result.preservedEntryCount) config or unrelated item\(result.preservedEntryCount == 1 ? "" : "s") untouched."
+            : ""
+
+        if result.removedEntryCount == 0 {
+            return "No local data found. \(directoryDisplayPath) is ready. \(keychainText)\(preservationText)"
+        }
+
+        return "Removed \(result.removedEntryCount) VaultPeek data item\(result.removedEntryCount == 1 ? "" : "s") from \(directoryDisplayPath). \(keychainText)\(preservationText) Restart the VaultPeek companion server."
+    }
+}

--- a/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Settings Presentation Tests")
+struct SettingsPresentationTests {
+    private let homeDirectory = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+    @Test("Local AI availability maps every state to a distinct icon")
+    func localAIAvailabilityIconMapping() {
+        #expect(LocalAIAvailabilityPresentation.iconName(for: .available) == "cpu.fill")
+        #expect(LocalAIAvailabilityPresentation.iconName(for: .disabled) == "pause.circle.fill")
+        #expect(LocalAIAvailabilityPresentation.iconName(for: .unavailable) == "exclamationmark.triangle.fill")
+
+        let iconNames = [
+            LocalAIAvailabilityPresentation.iconName(for: .available),
+            LocalAIAvailabilityPresentation.iconName(for: .disabled),
+            LocalAIAvailabilityPresentation.iconName(for: .unavailable),
+        ]
+        #expect(Set(iconNames).count == iconNames.count, "States must stay distinguishable without color")
+    }
+
+    @Test("Local AI availability maps states to tones")
+    func localAIAvailabilityToneMapping() {
+        #expect(LocalAIAvailabilityPresentation.tone(for: .available) == .positive)
+        #expect(LocalAIAvailabilityPresentation.tone(for: .disabled) == .secondary)
+        #expect(LocalAIAvailabilityPresentation.tone(for: .unavailable) == .warning)
+    }
+
+    @Test("Storage detail prefers the server path and abbreviates the home directory")
+    func storageDetailPrefersServerPath() {
+        let detail = LocalDataResetPresentation.storageDetail(
+            serverStoragePath: "/Users/example/.vaultpeek",
+            defaultResolvedDisplayPath: "~/.vaultpeek",
+            homeDirectory: homeDirectory
+        )
+
+        #expect(detail == "Server: ~/.vaultpeek")
+    }
+
+    @Test("Storage detail keeps non-home server paths absolute")
+    func storageDetailKeepsAbsoluteServerPath() {
+        let detail = LocalDataResetPresentation.storageDetail(
+            serverStoragePath: "/private/var/data/vaultpeek",
+            defaultResolvedDisplayPath: "~/.vaultpeek",
+            homeDirectory: homeDirectory
+        )
+
+        #expect(detail == "Server: /private/var/data/vaultpeek")
+    }
+
+    @Test("Storage detail falls back to the default resolved path")
+    func storageDetailFallsBackToDefault() {
+        let detail = LocalDataResetPresentation.storageDetail(
+            serverStoragePath: nil,
+            defaultResolvedDisplayPath: "~/.vaultpeek",
+            homeDirectory: homeDirectory
+        )
+
+        #expect(detail == "Default: ~/.vaultpeek")
+    }
+
+    @Test("Reset message explains a no-op reset and keychain outcome")
+    func resetMessageForNoRemovedEntries() {
+        let result = LocalDataResetResult(
+            directoryPath: "/Users/example/.vaultpeek",
+            removedEntries: [],
+            keychainTokensCleared: false
+        )
+
+        let message = LocalDataResetPresentation.successMessage(for: result, homeDirectory: homeDirectory)
+
+        #expect(message == "No local data found. ~/.vaultpeek is ready. Keychain token entries were not cleared.")
+    }
+
+    @Test("Reset message pluralizes removed entries and asks for a server restart")
+    func resetMessageForRemovedEntries() {
+        let result = LocalDataResetResult(
+            directoryPath: "/Users/example/.vaultpeek",
+            removedEntries: ["plaidbar.sqlite", "transactions-cache.json"],
+            keychainTokensCleared: true
+        )
+
+        let message = LocalDataResetPresentation.successMessage(for: result, homeDirectory: homeDirectory)
+
+        #expect(message.contains("Removed 2 VaultPeek data items from ~/.vaultpeek."))
+        #expect(message.contains("Keychain token entries were cleared when present."))
+        #expect(message.contains("Restart the VaultPeek companion server."))
+    }
+
+    @Test("Reset message uses singular copy for one removed entry")
+    func resetMessageForSingleRemovedEntry() {
+        let result = LocalDataResetResult(
+            directoryPath: "/Users/example/.vaultpeek",
+            removedEntries: ["plaidbar.sqlite"],
+            keychainTokensCleared: true
+        )
+
+        let message = LocalDataResetPresentation.successMessage(for: result, homeDirectory: homeDirectory)
+
+        #expect(message.contains("Removed 1 VaultPeek data item from ~/.vaultpeek."))
+    }
+
+    @Test("Reset message reports preserved config entries")
+    func resetMessageReportsPreservedEntries() {
+        let result = LocalDataResetResult(
+            directoryPath: "/Users/example/.vaultpeek",
+            removedEntries: ["plaidbar.sqlite"],
+            preservedEntries: ["server.conf"],
+            keychainTokensCleared: true
+        )
+
+        let message = LocalDataResetPresentation.successMessage(for: result, homeDirectory: homeDirectory)
+
+        #expect(message.contains("Left 1 config or unrelated item untouched."))
+    }
+}


### PR DESCRIPTION
## Summary

- **Stacked PR:** this PR is stacked on `feat/and-310-loading-states` (AND-310) and will auto-retarget to `main` when the parent merges.
- Rewrites all four Settings tabs (General, Accounts, Notifications, About) as native SwiftUI `Form` with `.formStyle(.grouped)`, removing the hand-rolled `SettingsCard` stacks and the 150pt label-column `settingsRow` helper (web-dashboard idiom).
- Drops the fixed 620×560 frame: the Settings window is now resizable with a 560×480 minimum (ideal 620×560).
- Switch-style toggles (`.toggleStyle(.switch)`) and sentence-case section headers ("Local data", "Transaction alerts", "Credit alerts") per macOS conventions.
- Labels the two notification threshold fields ("Large transaction threshold" / "Low balance threshold" instead of two bare "Threshold"s), each with an explicit VoiceOver label.
- About now shows the real app icon (`NSImage(named: NSImage.applicationIconName)` with `NSApp.applicationIconImage` fallback) instead of the 46pt `dollarsign.circle.fill` SF Symbol. In the packaged VaultPeek.app this is the bundled `AppIcon.icns`; under bare `swift run` macOS supplies the generic executable icon.
- Extracts non-trivial presentation logic into `PlaidBarCore`: `LocalDataResetPresentation` (reset result-alert copy + storage path detail line) and `LocalAIAvailabilityPresentation` (icon/tone mapping), covered by a new 9-test Swift Testing suite.
- Updates the DESIGN.md settings documentation (NotificationSettingsView anatomy, screen-level patterns table, popover surface inventory) to match the Form-based implementation.
- Accessibility verification was code-level (labels, focus order, non-color meaning audited per control, see inventory below); no live VoiceOver pass was run in this autonomous session.

### Settings inventory (verify nothing dropped)

**Window:** 4-tab `TabView` (General / Accounts / Notifications / About), persisted tab selection via `@AppStorage("settings.selectedTab")` — preserved. Fixed 620×560 frame → resizable, min 560×480 (intentional change per AND-311).

**General tab — all preserved:**
1. "Menu bar shows" picker (`menuBarSummaryMode`, all `MenuBarSummaryMode` cases)
2. "Balance format" picker (full / abbreviated / compact), still disabled for `creditUtilization`/`iconOnly` summary modes
3. "Refresh interval" picker (5/15/30 min, 1 hour)
4. "Credit warning" % threshold field + `.help` tooltip (VoiceOver label "Credit warning threshold" added)
5. "Launch at login" toggle (now switch style)
6. Local AI: Availability row (icon + tone + state name, icon mapping moved to core, marked decorative for VoiceOver since the text carries the state), Runtime row ("None configured" fallback), availability detail text, cloud-AI privacy sentence — all verbatim
7. Local data (PR-011 copy preserved verbatim): storage path row (monospaced, text-selectable) + server/default detail line (logic moved to core), `LocalTrustReceiptView` with per-row combined a11y labels, "Open Folder" / "Copy Path" / "Reset Local Data" buttons
8. Reset confirmation alert (destructive + cancel, full deletes/keeps copy), reset result alert (copy moved to core, byte-identical strings under test), reset error alert

**Accounts tab — all preserved:**
1. `AttentionQueueView` (title now sentence-case "Attention"; `showsHealthyRow: false`, add-account routing)
2. Empty state via `SecondaryUnavailableView` + `SecondaryContentUnavailableState.accounts(...)` with all action routings (checkServer/addAccount/refreshAccounts/syncTransactions/refresh)
3. Institution groups → one `Form` `Section` per institution: header row (name, connection icon+signal label in level color, account count, sync label, recovery detail) with combined a11y label; recovery action button (stale → refresh, loginRequired/error → reconnect); destructive Remove button (a11y label now names the institution)
4. Account rows: type icon + tint, name, type, compact balance with debt tint, combined a11y label — verbatim
5. "Add Account" prominent button, `SetupView` sheet, `isSetupComplete` auto-dismiss, removal confirmation alert with full copy — verbatim

**Notifications tab — all preserved:**
1. macOS permission status row (icon, label, detail, recovery action button/non-interactive label, a11y label + hint + per-action hints) — verbatim
2. "Enable notifications" master toggle with permission request `onChange` flow and presentation-driven disabling
3. "Large transactions" toggle; threshold field relabeled "Large transaction threshold" (a11y: "Large transaction threshold in dollars"), same disable conditions
4. $0-threshold `InlineSettingsNotice` (icon + warning tint + text; not color-only)
5. "Low balance warning" toggle; threshold field relabeled "Low balance threshold" (a11y: "Low balance threshold in dollars"), same disable conditions
6. "High utilization" toggle + "Uses credit warning threshold (X%)" reference text
7. `.task` permission refresh on appear

**About tab — all preserved:**
1. App identity block: name, version, tagline (icon swapped to real app icon, decorative/a11y-hidden as before)
2. All 6 GitHub URLs byte-identical (Troubleshooting, Privacy, Security, GitHub Repository, 1.0 Roadmap, Release Notes) with the same SF Symbols and detail copy; the other 3 of the repo's 9 hardcoded GitHub URLs live in `SetupView.swift` and are untouched
3. "Check for Updates" Sparkle button; copyright line

## Autonomous task IDs

- Task ID(s): AND-311
- Backlog slice: Product Experience Hardening — Settings native Form(.grouped) rewrite; preserves PR-011 (Local Data Controls) destructive-action and storage-path copy
- Scope note: one focused slice — Settings UI rewrite + core presenter extraction + DESIGN.md sync; no server, storage, or popover changes

## Agent coordination

- Builder agent: Claude Fable 5 (Claude Code session)
- Builder branch/worktree: refactor/and-311-settings-grouped-form in /Users/ftchvs/Developer/pb-worktrees/appui
- Reviewer/merge steward: Felipe + Otto loop
- Coordination note: review-only for other agents; do not push to this branch

## Changed files

- `Sources/PlaidBar/Settings/SettingsView.swift` — Form(.grouped) rewrite of all four tabs
- `Sources/PlaidBarCore/Utilities/SettingsPresentation.swift` — new: `SettingsStatusTone`, `LocalAIAvailabilityPresentation`, `LocalDataResetPresentation`
- `Tests/PlaidBarCoreTests/SettingsPresentationTests.swift` — new: 9 tests for the extracted presenters
- `DESIGN.md` — settings sections updated to match the Form-based implementation

## Local gates

- [x] `git diff --check` — clean, no whitespace errors
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` or documented why not needed. — superseded by full `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`: Build complete, zero warnings (builds all three targets including PlaidBar)
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` when server/shared DTO/package code changed, or documented why not needed. — PlaidBarCore changed, so the same strict-concurrency build above compiled and linked PlaidBarServer successfully
- [x] Focused tests or `swift test` when core/server logic changed, or documented the local Swift Testing limitation. — full `swift test`: 425 tests passed, 0 failures (includes the new 9-test Settings Presentation suite, also verified via `--filter SettingsPresentationTests`)
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files. — `git diff feat/and-310-loading-states...HEAD | grep -iE 'client_secret|access-(sandbox|production)|api[_-]?key|BEGIN (RSA|EC|OPENSSH)'` returned no hits; `bash -n Scripts/*.sh` also clean (no scripts touched); swiftformat run, swiftlint not installed on this machine

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

GitHub Actions billing outage on 2026-06-12 — checks must be re-run once billing is restored; merge is held until green

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes. — code-level: every interactive control is a standard focusable Form control in linear top-to-bottom section order; no focus traps or custom hit areas introduced
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes. — code-level audit per the inventory above: all existing labels/hints preserved; new explicit labels added to the three relabeled threshold fields and the per-institution Remove button; decorative icons marked hidden
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone. — every status keeps icon + text alongside tint (Local AI availability, connection signal, permission status, $0-threshold notice); new core test asserts the three Local AI states map to distinct icons
- [x] I updated docs or screenshots if user-facing behavior changed. — DESIGN.md settings sections updated; screenshots unchanged (no settings screenshots in README set)

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
