### PR TITLE
feat: sandbox reliability and production-readiness boundaries (AND-318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,27 @@ For a fast sandbox preflight without opening the menu bar app, export sandbox
 credentials and run `./Scripts/smoke-sandbox.sh`. It builds the server, starts
 it on `127.0.0.1:${PLAIDBAR_SMOKE_PORT:-18484}`, checks `/health`, and verifies
 that unauthenticated `/api` calls are rejected before checking `/api/status`
-with the generated local bearer token. The smoke script uses a temporary data
-directory by default; set `PLAIDBAR_DATA_DIR` when you intentionally want to
-point it at a specific local store.
+with the generated local bearer token. It then restarts the server against the
+same data directory to verify restart recovery (same auth token, same readiness
+state), and boots a second credential-less server on
+`127.0.0.1:${PLAIDBAR_SMOKE_SETUP_PORT:-18485}` to verify the setup state:
+`credentialsConfigured=false` on `/api/status` and a 503 on Plaid-backed routes
+whose body names the missing `PLAID_CLIENT_ID`/`PLAID_SECRET` variables. The
+smoke script uses temporary data directories by default; set
+`PLAIDBAR_DATA_DIR` when you intentionally want to point it at a specific local
+store.
+
+### Sandbox limitations
+
+Sandbox mode exercises the full local pipeline — server startup, local auth,
+Plaid Link, transaction sync, storage permissions — against Plaid's test
+institutions only. Passing sandbox (including the smoke script) does not
+demonstrate production readiness: production requires Plaid production
+approval, separate production credentials, and connects real financial data.
+Sandbox and production keep strictly separate SQLite stores and caches
+(`plaidbar-sandbox.sqlite` vs `plaidbar-production.sqlite`) in the same data
+directory, so switching modes never mixes test data with real data — and also
+means each mode starts empty until linked in that mode.
 
 ## Keyboard Shortcuts
 

--- a/Scripts/smoke-sandbox.sh
+++ b/Scripts/smoke-sandbox.sh
@@ -4,23 +4,57 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 PORT="${PLAIDBAR_SMOKE_PORT:-18484}"
+SETUP_PORT="${PLAIDBAR_SMOKE_SETUP_PORT:-$((PORT + 1))}"
 SERVER_LOG="$(mktemp -t plaidbar-smoke-server.XXXXXX.log)"
 CREATED_DATA_DIR=""
+SETUP_DATA_DIR=""
 SERVER_PID=""
+SETUP_SERVER_PID=""
 
 cd "$PROJECT_DIR"
 
 cleanup() {
-    if [[ -n "$SERVER_PID" ]]; then
-        kill "$SERVER_PID" 2>/dev/null || true
-        wait "$SERVER_PID" 2>/dev/null || true
-    fi
+    for pid in "$SERVER_PID" "$SETUP_SERVER_PID"; do
+        if [[ -n "$pid" ]]; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
     if [[ -n "$CREATED_DATA_DIR" ]]; then
         rm -rf "$CREATED_DATA_DIR"
+    fi
+    if [[ -n "$SETUP_DATA_DIR" ]]; then
+        rm -rf "$SETUP_DATA_DIR"
     fi
     rm -f "$SERVER_LOG"
 }
 trap cleanup EXIT INT TERM
+
+fail_with_log() {
+    echo "$1" >&2
+    echo "Server log: $SERVER_LOG" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+}
+
+# Waits until /health answers on the given port, or fails if the given
+# server process exits first.
+wait_for_health() {
+    local port="$1"
+    local pid="$2"
+    for _ in {1..30}; do
+        if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            fail_with_log "Server exited before health check passed."
+        fi
+        sleep 1
+    done
+    if ! curl -fsS "http://127.0.0.1:$port/health" >/dev/null; then
+        fail_with_log "Server did not become healthy before timeout."
+    fi
+}
 
 if [[ -z "${PLAID_CLIENT_ID:-}" || -z "${PLAID_SECRET:-}" ]]; then
     echo "Missing Plaid sandbox credentials."
@@ -46,31 +80,10 @@ echo "Starting sandbox server on http://127.0.0.1:$PORT..."
 swift run PlaidBarServer --sandbox --port "$PORT" >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
-for _ in {1..30}; do
-    if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
-        break
-    fi
-    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-        echo "Server exited before health check passed."
-        echo "Server log: $SERVER_LOG"
-        cat "$SERVER_LOG"
-        exit 1
-    fi
-    sleep 1
-done
-
-if ! curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null; then
-    echo "Server did not become healthy before timeout."
-    echo "Server log: $SERVER_LOG"
-    cat "$SERVER_LOG"
-    exit 1
-fi
+wait_for_health "$PORT" "$SERVER_PID"
 AUTH_TOKEN_PATH="$PLAIDBAR_DATA_DIR/auth-token"
 if [[ ! -r "$AUTH_TOKEN_PATH" ]]; then
-    echo "Smoke check failed: auth token is not readable at $AUTH_TOKEN_PATH" >&2
-    echo "Server log: $SERVER_LOG" >&2
-    cat "$SERVER_LOG" >&2
-    exit 1
+    fail_with_log "Smoke check failed: auth token is not readable at $AUTH_TOKEN_PATH"
 fi
 
 AUTH_TOKEN="$(tr -d '\r\n' < "$AUTH_TOKEN_PATH")"
@@ -194,5 +207,105 @@ print(f"  Items: {status['itemCount']}")
 print(f"  Storage: {status['storagePath']}")
 print(f"  Isolated data dir: {data_dir}")
 PY
+
+# Restart recovery: a second server boot against the same data directory must
+# reuse the same auth token (the app holds it across server restarts) and
+# report the same sandbox readiness state.
+echo "Restarting server to verify restart recovery..."
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+
+swift run PlaidBarServer --sandbox --port "$PORT" >>"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+wait_for_health "$PORT" "$SERVER_PID"
+
+RESTART_AUTH_TOKEN="$(tr -d '\r\n' < "$AUTH_TOKEN_PATH")"
+if [[ "$RESTART_AUTH_TOKEN" != "$AUTH_TOKEN" ]]; then
+    fail_with_log "Smoke check failed: auth token changed across a server restart"
+fi
+
+RESTART_STATUS_JSON="$(curl -fsS -H "Authorization: Bearer $AUTH_TOKEN" "http://127.0.0.1:$PORT/api/status")"
+
+python3 - "$STATUS_JSON" "$RESTART_STATUS_JSON" <<'PY'
+import json
+import sys
+
+first = json.loads(sys.argv[1])
+restarted = json.loads(sys.argv[2])
+errors = []
+
+if restarted.get("environment") != "sandbox":
+    errors.append(f"expected sandbox environment after restart, got {restarted.get('environment')!r}")
+if restarted.get("credentialsConfigured") is not True:
+    errors.append("expected credentialsConfigured=true after restart")
+for key in ["storagePath", "itemCount", "syncedItemCount"]:
+    if restarted.get(key) != first.get(key):
+        errors.append(
+            f"expected {key} to be preserved across restart: "
+            f"{first.get(key)!r} became {restarted.get(key)!r}"
+        )
+
+if errors:
+    for error in errors:
+        print(f"Smoke check failed: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("Restart recovery check passed.")
+PY
+
+# Setup-state readiness: a credential-less boot in a clean data directory
+# must stay reachable (/health, /api/status), report
+# credentialsConfigured=false, and answer Plaid-backed routes with a 503
+# whose body names the missing credential variables.
+echo "Verifying credential-less boot reports setup state on http://127.0.0.1:$SETUP_PORT..."
+SETUP_DATA_DIR="$(mktemp -d -t plaidbar-smoke-setup.XXXXXX)"
+PLAID_CLIENT_ID="" PLAID_SECRET="" PLAIDBAR_DATA_DIR="$SETUP_DATA_DIR" \
+    swift run PlaidBarServer --sandbox --port "$SETUP_PORT" >>"$SERVER_LOG" 2>&1 &
+SETUP_SERVER_PID=$!
+wait_for_health "$SETUP_PORT" "$SETUP_SERVER_PID"
+
+SETUP_AUTH_TOKEN_PATH="$SETUP_DATA_DIR/auth-token"
+if [[ ! -r "$SETUP_AUTH_TOKEN_PATH" ]]; then
+    fail_with_log "Smoke check failed: setup-state auth token is not readable at $SETUP_AUTH_TOKEN_PATH"
+fi
+SETUP_AUTH_TOKEN="$(tr -d '\r\n' < "$SETUP_AUTH_TOKEN_PATH")"
+
+SETUP_STATUS_JSON="$(curl -fsS -H "Authorization: Bearer $SETUP_AUTH_TOKEN" "http://127.0.0.1:$SETUP_PORT/api/status")"
+ACCOUNTS_HTTP_CODE="$(curl -sS -o /tmp/plaidbar-smoke-setup-body.$$ -w '%{http_code}' \
+    -H "Authorization: Bearer $SETUP_AUTH_TOKEN" "http://127.0.0.1:$SETUP_PORT/api/accounts")"
+ACCOUNTS_BODY="$(cat /tmp/plaidbar-smoke-setup-body.$$)"
+rm -f /tmp/plaidbar-smoke-setup-body.$$
+
+python3 - "$SETUP_STATUS_JSON" "$ACCOUNTS_HTTP_CODE" "$ACCOUNTS_BODY" <<'PY'
+import json
+import sys
+
+status = json.loads(sys.argv[1])
+accounts_http_code = sys.argv[2]
+accounts_body = sys.argv[3]
+errors = []
+
+if status.get("environment") != "sandbox":
+    errors.append(f"expected sandbox environment in setup state, got {status.get('environment')!r}")
+if status.get("credentialsConfigured") is not False:
+    errors.append("expected credentialsConfigured=false in setup state")
+if accounts_http_code != "503":
+    errors.append(f"expected Plaid-backed route to return 503 in setup state, got {accounts_http_code}")
+for variable in ["PLAID_CLIENT_ID", "PLAID_SECRET"]:
+    if variable not in accounts_body:
+        errors.append(f"expected setup-state 503 body to name {variable}")
+
+if errors:
+    for error in errors:
+        print(f"Smoke check failed: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("Setup-state readiness check passed.")
+PY
+
+kill "$SETUP_SERVER_PID" 2>/dev/null || true
+wait "$SETUP_SERVER_PID" 2>/dev/null || true
+SETUP_SERVER_PID=""
 
 echo "Server log: $SERVER_LOG"

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -35,7 +35,8 @@ struct SetupView: View {
                     environment: .production,
                     icon: "lock.shield",
                     title: "Connect Production",
-                    summary: "Real accounts with approved Plaid production credentials.",
+                    summary: "Real accounts and real financial data. Requires Plaid production "
+                        + "approval and production credentials.",
                     primaryTitle: "Open Link"
                 )
             case let .connecting(environment):
@@ -98,7 +99,7 @@ struct SetupView: View {
 
                 OnboardingChoiceButton(
                     title: "Connect Production",
-                    subtitle: "Approved Plaid access for real accounts.",
+                    subtitle: "Real financial data. Requires Plaid production approval.",
                     icon: "lock.shield",
                     color: SemanticColors.positive
                 ) {

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -75,7 +75,8 @@ struct PlaidBarServer: AsyncParsableCommand {
         let api = router.group("api")
         api.add(middleware: APITokenMiddleware(authToken: serverConfig.authToken))
         api.add(middleware: SetupStateMiddleware(
-            credentialsConfigured: serverConfig.credentialsConfigured
+            credentialDiagnosis: serverConfig.credentialDiagnosis,
+            plaidEnvironment: serverConfig.plaidEnvironment
         ))
         LinkRoutes(
             plaidClient: plaidClient,
@@ -111,13 +112,13 @@ struct PlaidBarServer: AsyncParsableCommand {
 
         logger.info("VaultPeek companion server starting on http://127.0.0.1:\(serverConfig.port)")
         logger.info("Environment: \(serverConfig.plaidEnvironment.rawValue)")
-        if !serverConfig.credentialsConfigured {
+        if let setupGuidance = serverConfig.credentialDiagnosis.setupGuidance(
+            environment: serverConfig.plaidEnvironment
+        ) {
             logger.warning(
                 """
-                Plaid credentials are not configured; starting in setup state. \
-                /health and /api/status stay available, Plaid-backed routes return 503. \
-                Add PLAID_CLIENT_ID and PLAID_SECRET to server.conf and restart \
-                (the menu bar app restarts its bundled server automatically).
+                Starting in setup state: \(setupGuidance) \
+                /health and /api/status stay available; Plaid-backed routes return 503.
                 """
             )
         }

--- a/Sources/PlaidBarServer/Config/CredentialSetupDiagnosis.swift
+++ b/Sources/PlaidBarServer/Config/CredentialSetupDiagnosis.swift
@@ -1,0 +1,71 @@
+import Foundation
+import PlaidBarCore
+
+/// Names exactly which Plaid credential is missing so the setup-state 503
+/// body and the server boot log can say "add PLAID_SECRET" instead of a
+/// generic "credentials are not configured" (PR-016 T077).
+///
+/// Partial configuration is the confusing failure: one variable was exported
+/// or written to `server.conf` and the other was forgotten, but a single
+/// `credentialsConfigured` bool reports it identically to a fresh install.
+/// The diagnosis carries variable *names* only — never credential values —
+/// so its guidance is always safe to log and to return to the local client.
+enum CredentialSetupDiagnosis: Sendable, Equatable, CaseIterable {
+    case configured
+    case missingClientId
+    case missingSecret
+    case missingBoth
+
+    static func diagnose(clientId: String, secret: String) -> CredentialSetupDiagnosis {
+        switch (clientId.isEmpty, secret.isEmpty) {
+        case (false, false): .configured
+        case (true, false): .missingClientId
+        case (false, true): .missingSecret
+        case (true, true): .missingBoth
+        }
+    }
+
+    var isConfigured: Bool {
+        self == .configured
+    }
+
+    var missingVariableNames: [String] {
+        switch self {
+        case .configured: []
+        case .missingClientId: ["PLAID_CLIENT_ID"]
+        case .missingSecret: ["PLAID_SECRET"]
+        case .missingBoth: ["PLAID_CLIENT_ID", "PLAID_SECRET"]
+        }
+    }
+
+    /// User-facing setup guidance for the 503 body and the boot log. `nil`
+    /// once both credentials are present.
+    ///
+    /// The guidance is environment-scoped on purpose (PR-017 T081): sandbox
+    /// copy never implies production readiness, and production copy is
+    /// explicit that it connects real financial accounts and requires Plaid
+    /// production approval.
+    func setupGuidance(environment: PlaidEnvironment) -> String? {
+        guard !isConfigured else { return nil }
+
+        let missing = missingVariableNames.joined(separator: " and ")
+        let lead = switch self {
+        case .configured, .missingBoth:
+            "Plaid \(environment.rawValue) credentials are not configured "
+                + "on the VaultPeek companion server."
+        case .missingClientId, .missingSecret:
+            "The VaultPeek companion server is missing \(missing); "
+                + "the other Plaid \(environment.rawValue) credential is set."
+        }
+        let fix = "Add \(missing) to server.conf; "
+            + "the menu bar app restarts its bundled server automatically."
+        let boundary = switch environment {
+        case .sandbox:
+            "Sandbox uses Plaid test institutions only and never touches real financial data."
+        case .production:
+            "Production connects real financial accounts and requires Plaid "
+                + "production approval; sandbox credentials will not work."
+        }
+        return "\(lead) \(fix) \(boundary)"
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -41,7 +41,13 @@ struct ServerConfig: Sendable {
     /// what lets a fresh DMG install auto-start its bundled server before
     /// `server.conf` exists.
     var credentialsConfigured: Bool {
-        !plaidClientId.isEmpty && !plaidSecret.isEmpty
+        credentialDiagnosis.isConfigured
+    }
+
+    /// Which credential is missing (if any), so setup-state responses and
+    /// the boot log can name the exact variable to fix.
+    var credentialDiagnosis: CredentialSetupDiagnosis {
+        .diagnose(clientId: plaidClientId, secret: plaidSecret)
     }
 
     static func load(

--- a/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
+++ b/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Hummingbird
 import NIOCore
+import PlaidBarCore
 
 /// Maps the credential-less setup state to a clear 503 on Plaid-backed
 /// routes, so clients can tell "server is up but awaiting credentials" apart
@@ -13,13 +14,27 @@ import NIOCore
 /// catch stays as a safety net for any Plaid call reached through a path the
 /// prefix list does not name.
 ///
+/// The 503 body names exactly which credential variable is missing and is
+/// scoped to the server's Plaid environment, so a partially configured
+/// `server.conf` (one variable set, the other forgotten) gets an actionable
+/// message instead of a generic "credentials are not configured".
+///
 /// The body is a flat `{"error": ...}` object because that is the shape the
 /// app's `ServerClient` extracts a user-facing message from.
 struct SetupStateMiddleware<Context: RequestContext>: RouterMiddleware {
-    let credentialsConfigured: Bool
+    let credentialDiagnosis: CredentialSetupDiagnosis
+    let plaidEnvironment: PlaidEnvironment
 
-    static var setupStateMessage: String {
-        "Plaid credentials are not configured on the VaultPeek companion server. "
+    var credentialsConfigured: Bool {
+        credentialDiagnosis.isConfigured
+    }
+
+    static func setupStateMessage(
+        diagnosis: CredentialSetupDiagnosis,
+        environment: PlaidEnvironment
+    ) -> String {
+        diagnosis.setupGuidance(environment: environment)
+            ?? "Plaid credentials are not configured on the VaultPeek companion server. "
             + "Add PLAID_CLIENT_ID and PLAID_SECRET to server.conf; "
             + "the menu bar app restarts its bundled server automatically."
     }
@@ -45,17 +60,21 @@ struct SetupStateMiddleware<Context: RequestContext>: RouterMiddleware {
         next: (Request, Context) async throws -> Response
     ) async throws -> Response {
         if !credentialsConfigured, Self.isPlaidBackedPath(request.uri.path) {
-            return try Self.setupStateResponse()
+            return try setupStateResponse()
         }
         do {
             return try await next(request, context)
         } catch PlaidError.credentialsNotConfigured {
-            return try Self.setupStateResponse()
+            return try setupStateResponse()
         }
     }
 
-    private static func setupStateResponse() throws -> Response {
-        let body = try JSONEncoder().encode(["error": setupStateMessage])
+    private func setupStateResponse() throws -> Response {
+        let message = Self.setupStateMessage(
+            diagnosis: credentialDiagnosis,
+            environment: plaidEnvironment
+        )
+        let body = try JSONEncoder().encode(["error": message])
         return Response(
             status: .serviceUnavailable,
             headers: [.contentType: "application/json"],

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -106,12 +106,11 @@ struct TransactionRoutes: Sendable {
     ) async throws -> HTTPResponse.Status {
         let commitRequest = try await request.decode(as: SyncCursorCommitRequest.self, context: context)
         for (itemId, cursor) in commitRequest.cursors {
-            let trimmedCursor = cursor.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedCursor.isEmpty else { continue }
+            guard let committableCursor = Self.normalizedCommittableCursor(cursor) else { continue }
             guard try await tokenStore.getItem(id: itemId) != nil else {
                 throw HTTPError(.badRequest, message: "Cannot commit cursor for unknown item")
             }
-            try await tokenStore.saveSyncCursor(itemId: itemId, cursor: trimmedCursor)
+            try await tokenStore.saveSyncCursor(itemId: itemId, cursor: committableCursor)
         }
         return .ok
     }
@@ -120,6 +119,14 @@ struct TransactionRoutes: Sendable {
 
     static func shouldFailSync(attemptedItemCount: Int, successfulItemCount: Int) -> Bool {
         attemptedItemCount > 0 && successfulItemCount == 0
+    }
+
+    /// Cursor-state preservation guard: an empty or whitespace-only cursor
+    /// must never overwrite a stored cursor, otherwise the next sync would
+    /// silently restart from the beginning of the item's history.
+    static func normalizedCommittableCursor(_ cursor: String) -> String? {
+        let trimmed = cursor.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func toDTO(_ plaidTx: PlaidTransaction, itemId: String) -> TransactionDTO {

--- a/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
+++ b/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
@@ -1,0 +1,350 @@
+import FluentKit
+import FluentSQLiteDriver
+import Foundation
+import Hummingbird
+import HTTPTypes
+import HummingbirdFluent
+import Logging
+import NIOCore
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+private struct ReliabilityTestRequestContextSource: RequestContextSource {
+    let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.sandbox-reliability")
+}
+
+private struct ReliabilityTestRequestContext: RequestContext {
+    typealias Source = ReliabilityTestRequestContextSource
+
+    var coreContext: CoreRequestContextStorage
+
+    init(source: ReliabilityTestRequestContextSource) {
+        coreContext = CoreRequestContextStorage(source: source)
+    }
+}
+
+/// Sandbox reliability and production-readiness boundaries (PR-016 T076-T078,
+/// PR-017 T082): clean-directory setup, missing-credential diagnosis,
+/// sync-cursor preservation across server restarts, and strict
+/// sandbox-vs-production storage separation.
+///
+/// All credentials in this suite are synthetic test strings; nothing here
+/// contacts Plaid, the network, or the macOS Keychain.
+@Suite("Sandbox reliability and production boundaries")
+struct SandboxReliabilityTests {
+    // MARK: - T076: clean temporary data directory
+
+    @Test("Sandbox setup succeeds from a clean temporary data directory")
+    func sandboxSetupSucceedsFromCleanTemporaryDataDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-clean-setup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // The data directory deliberately does not exist yet: a first
+        // sandbox run must provision everything from nothing.
+        let dataDirectory = directory.appendingPathComponent("fresh-data", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: dataDirectory.path))
+
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=test-sandbox-client
+        PLAID_SECRET=test-sandbox-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let config = try ServerConfig.load(from: configURL.path)
+        try ServerConfig.preparePrivateSQLiteStoreForOpen(at: config.databasePath)
+
+        #expect(config.plaidEnvironment == .sandbox)
+        #expect(config.credentialsConfigured)
+        #expect(config.credentialDiagnosis == .configured)
+        #expect(config.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(try posixPermissions(at: dataDirectory) == 0o700)
+        #expect(try posixPermissions(
+            at: dataDirectory.appendingPathComponent(LocalDataStore.authTokenFilename)
+        ) == 0o600)
+        #expect(FileManager.default.fileExists(atPath: config.databasePath))
+        #expect(try posixPermissions(at: URL(fileURLWithPath: config.databasePath)) == 0o600)
+    }
+
+    // MARK: - T077: missing-credential diagnosis
+
+    @Test("Credential diagnosis names exactly the missing variable")
+    func credentialDiagnosisNamesExactlyTheMissingVariable() {
+        #expect(CredentialSetupDiagnosis.diagnose(clientId: "", secret: "") == .missingBoth)
+        #expect(CredentialSetupDiagnosis.diagnose(clientId: "test-client", secret: "") == .missingSecret)
+        #expect(CredentialSetupDiagnosis.diagnose(clientId: "", secret: "test-secret") == .missingClientId)
+        #expect(CredentialSetupDiagnosis.diagnose(
+            clientId: "test-client",
+            secret: "test-secret"
+        ) == .configured)
+
+        #expect(CredentialSetupDiagnosis.missingBoth.missingVariableNames ==
+            ["PLAID_CLIENT_ID", "PLAID_SECRET"])
+        #expect(CredentialSetupDiagnosis.missingClientId.missingVariableNames == ["PLAID_CLIENT_ID"])
+        #expect(CredentialSetupDiagnosis.missingSecret.missingVariableNames == ["PLAID_SECRET"])
+        #expect(CredentialSetupDiagnosis.configured.missingVariableNames.isEmpty)
+        #expect(CredentialSetupDiagnosis.configured.setupGuidance(environment: .sandbox) == nil)
+        #expect(CredentialSetupDiagnosis.configured.setupGuidance(environment: .production) == nil)
+    }
+
+    @Test("Partial-credential guidance points at the single missing variable")
+    func partialCredentialGuidancePointsAtSingleMissingVariable() throws {
+        let guidance = try #require(
+            CredentialSetupDiagnosis.missingSecret.setupGuidance(environment: .sandbox)
+        )
+
+        #expect(guidance.contains("PLAID_SECRET"))
+        #expect(guidance.contains("Add PLAID_SECRET to server.conf"))
+        // The one configured variable must not be re-requested.
+        #expect(!guidance.contains("Add PLAID_CLIENT_ID"))
+
+        let clientGuidance = try #require(
+            CredentialSetupDiagnosis.missingClientId.setupGuidance(environment: .sandbox)
+        )
+        #expect(clientGuidance.contains("Add PLAID_CLIENT_ID to server.conf"))
+        #expect(!clientGuidance.contains("Add PLAID_SECRET"))
+    }
+
+    @Test("Sandbox guidance never implies production readiness")
+    func sandboxGuidanceNeverImpliesProductionReadiness() throws {
+        let guidance = try #require(
+            CredentialSetupDiagnosis.missingBoth.setupGuidance(environment: .sandbox)
+        )
+
+        #expect(guidance.contains("sandbox"))
+        #expect(guidance.contains("test institutions"))
+        #expect(guidance.contains("never touches real financial data"))
+        #expect(!guidance.contains("production approval"))
+    }
+
+    @Test("Production guidance is explicit about Plaid approval and real data")
+    func productionGuidanceIsExplicitAboutApprovalAndRealData() throws {
+        let guidance = try #require(
+            CredentialSetupDiagnosis.missingBoth.setupGuidance(environment: .production)
+        )
+
+        #expect(guidance.contains("production"))
+        #expect(guidance.contains("real financial accounts"))
+        #expect(guidance.contains("Plaid production approval"))
+        #expect(guidance.contains("sandbox credentials will not work"))
+    }
+
+    @Test("Guidance carries variable names only, never credential values")
+    func guidanceCarriesVariableNamesOnlyNeverCredentialValues() throws {
+        let configuredValue = "test-secret-value-\(UUID().uuidString)"
+        let diagnosis = CredentialSetupDiagnosis.diagnose(clientId: configuredValue, secret: "")
+        let guidance = try #require(diagnosis.setupGuidance(environment: .sandbox))
+
+        #expect(diagnosis == .missingSecret)
+        #expect(!guidance.contains(configuredValue))
+    }
+
+    @Test("Setup-state 503 body names the missing credential variable")
+    func setupState503BodyNamesMissingCredentialVariable() async throws {
+        let middleware = SetupStateMiddleware<ReliabilityTestRequestContext>(
+            credentialDiagnosis: .missingSecret,
+            plaidEnvironment: .sandbox
+        )
+        let context = ReliabilityTestRequestContext(source: ReliabilityTestRequestContextSource())
+
+        let response = try await middleware.handle(
+            Self.makeRequest(path: "/api/accounts"),
+            context: context
+        ) { _, _ in
+            Response(status: .ok)
+        }
+
+        #expect(response.status == .serviceUnavailable)
+        let message = SetupStateMiddleware<ReliabilityTestRequestContext>.setupStateMessage(
+            diagnosis: .missingSecret,
+            environment: .sandbox
+        )
+        #expect(message.contains("PLAID_SECRET"))
+
+        // Readiness metadata keeps flowing in the same setup state.
+        let statusResponse = try await middleware.handle(
+            Self.makeRequest(path: "/api/status"),
+            context: context
+        ) { _, _ in
+            Response(status: .ok)
+        }
+        #expect(statusResponse.status == .ok)
+    }
+
+    // MARK: - T078: sync-cursor preservation
+
+    @Test("Sync cursor state survives a server restart")
+    func syncCursorStateSurvivesServerRestart() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-cursor-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-sandbox.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.cursor")
+        let itemId = "test_item_\(UUID().uuidString)"
+
+        // First server lifetime: commit an initial cursor, then advance it.
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveSyncCursor(itemId: itemId, cursor: "cursor-page-1")
+            #expect(try await store.getSyncCursor(itemId: itemId) == "cursor-page-1")
+
+            try await store.saveSyncCursor(itemId: itemId, cursor: "cursor-page-2")
+            #expect(try await store.getSyncCursor(itemId: itemId) == "cursor-page-2")
+            #expect(try await store.syncedItemCount() == 1)
+        }
+
+        // Second server lifetime: the committed cursor must come back
+        // exactly, so the next sandbox sync resumes instead of refetching
+        // the item's full history.
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let restoredCursor = try await store.getSyncCursor(itemId: itemId)
+            let syncedCount = try await store.syncedItemCount()
+            let lastSync = try await store.lastSyncDate()
+            #expect(restoredCursor == "cursor-page-2")
+            #expect(syncedCount == 1)
+            #expect(lastSync != nil)
+        }
+    }
+
+    @Test("Empty cursor commits never clobber a stored cursor")
+    func emptyCursorCommitsNeverClobberStoredCursor() {
+        #expect(TransactionRoutes.normalizedCommittableCursor("") == nil)
+        #expect(TransactionRoutes.normalizedCommittableCursor("   ") == nil)
+        #expect(TransactionRoutes.normalizedCommittableCursor("\n\t") == nil)
+        #expect(TransactionRoutes.normalizedCommittableCursor("cursor-page-3") == "cursor-page-3")
+        #expect(TransactionRoutes.normalizedCommittableCursor("  cursor-page-3\n") == "cursor-page-3")
+    }
+
+    // MARK: - T082: sandbox/production storage separation
+
+    @Test("Sandbox and production modes use separate stores in one data directory")
+    func sandboxAndProductionModesUseSeparateStores() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-env-split-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=test-client
+        PLAID_SECRET=test-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let sandboxConfig = try ServerConfig.load(from: configURL.path, sandboxOverride: true)
+        let productionConfig = try ServerConfig.load(from: configURL.path, sandboxOverride: false)
+
+        #expect(sandboxConfig.plaidEnvironment == .sandbox)
+        #expect(productionConfig.plaidEnvironment == .production)
+        #expect(sandboxConfig.databasePath != productionConfig.databasePath)
+        #expect(sandboxConfig.databasePath.hasSuffix("/plaidbar-sandbox.sqlite"))
+        #expect(productionConfig.databasePath.hasSuffix("/plaidbar-production.sqlite"))
+        // Both stores share the data directory without sharing files.
+        #expect(sandboxConfig.dataDirectoryPath == productionConfig.dataDirectoryPath)
+
+        // Booting one environment must never create or touch the other's
+        // store file.
+        try ServerConfig.preparePrivateSQLiteStoreForOpen(at: sandboxConfig.databasePath)
+        try Data("sandbox-store".utf8).write(to: URL(fileURLWithPath: sandboxConfig.databasePath))
+        #expect(!FileManager.default.fileExists(atPath: productionConfig.databasePath))
+
+        try ServerConfig.preparePrivateSQLiteStoreForOpen(at: productionConfig.databasePath)
+        try Data("production-store".utf8).write(to: URL(fileURLWithPath: productionConfig.databasePath))
+
+        #expect(try Data(contentsOf: URL(fileURLWithPath: sandboxConfig.databasePath)) ==
+            Data("sandbox-store".utf8))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: productionConfig.databasePath)) ==
+            Data("production-store".utf8))
+    }
+
+    @Test("Transaction caches are scoped per environment store")
+    func transactionCachesAreScopedPerEnvironmentStore() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-cache-split-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sandboxContext = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: ServerConfig.databasePath(in: directory.path, environment: .sandbox)
+        )
+        let productionContext = TransactionCacheContext(
+            environment: .production,
+            storagePath: ServerConfig.databasePath(in: directory.path, environment: .production)
+        )
+
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(
+                id: "tx-sandbox",
+                accountId: "checking",
+                amount: 12,
+                date: "2026-06-01",
+                name: "Coffee"
+            )],
+            to: directory,
+            context: sandboxContext
+        )
+
+        #expect(try LocalDataStore.loadTransactions(
+            from: directory,
+            context: sandboxContext
+        ).map(\.id) == ["tx-sandbox"])
+        #expect(try LocalDataStore.loadTransactions(
+            from: directory,
+            context: productionContext
+        ).isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeRequest(path: String) -> Request {
+        Request(
+            head: HTTPRequest(
+                method: .get,
+                scheme: nil,
+                authority: nil,
+                path: path,
+                headerFields: HTTPFields()
+            ),
+            body: RequestBody(buffer: ByteBuffer())
+        )
+    }
+
+    /// Runs `body` against a TokenStore backed by a real SQLite file, and
+    /// always shuts the Fluent stack down so a follow-up store sees fully
+    /// persisted state — the same shape as a server restart.
+    private func withTokenStore(
+        databasePath: String,
+        logger: Logger,
+        _ body: (TokenStore) async throws -> Void
+    ) async throws {
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(CreateSyncCursors())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(TokenStore(fluent: fluent, logger: logger))
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+}

--- a/docs/autonomous-loop-backlog.md
+++ b/docs/autonomous-loop-backlog.md
@@ -196,21 +196,21 @@ and `docs/autonomous-roadmap.md`.
 
 ### PR-016: Sandbox Reliability
 
-- [ ] T076: Verify sandbox setup succeeds from a clean temporary data directory.
-- [ ] T077: Add clearer failure handling for missing sandbox credentials.
-- [ ] T078: Verify sandbox transaction sync preserves cursor state.
-- [ ] T079: Add smoke-script coverage for one new sandbox readiness assertion.
-- [ ] T080: Document any remaining sandbox limitation without implying
+- [x] T076: Verify sandbox setup succeeds from a clean temporary data directory.
+- [x] T077: Add clearer failure handling for missing sandbox credentials.
+- [x] T078: Verify sandbox transaction sync preserves cursor state.
+- [x] T079: Add smoke-script coverage for one new sandbox readiness assertion.
+- [x] T080: Document any remaining sandbox limitation without implying
   production readiness.
 
 ### PR-017: Production Readiness Boundaries
 
-- [ ] T081: Keep production setup copy explicit about Plaid approval and real
+- [x] T081: Keep production setup copy explicit about Plaid approval and real
   financial data.
-- [ ] T082: Verify production mode uses separate storage from sandbox.
-- [ ] T083: Add a release checklist item for clean-profile production setup.
-- [ ] T084: Avoid notarization, appcast, or distribution claims until verified.
-- [ ] T085: Update troubleshooting for one production credential or mode failure.
+- [x] T082: Verify production mode uses separate storage from sandbox.
+- [x] T083: Add a release checklist item for clean-profile production setup.
+- [x] T084: Avoid notarization, appcast, or distribution claims until verified.
+- [x] T085: Update troubleshooting for one production credential or mode failure.
 
 ### PR-018: Accessibility And Keyboard Flow
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,6 +92,23 @@ Clean-install verification (required before distributing):
 3. Confirm the menu bar item appears and the bundled server reports healthy
    in the Status view before distributing.
 
+Verify clean-profile production setup before distributing — on a clean macOS
+user profile (or with `PLAIDBAR_DATA_DIR` pointed at an empty directory):
+
+1. Launch the app with no existing local data; the server must boot into the
+   credential-less setup state (app reachable, `/api/status` reports
+   `credentialsConfigured=false`, setup surfaces show guidance — no crash, no
+   silent failure).
+2. Add production credentials to `server.conf` and restart; the setup
+   preflight must show production mode with credentials configured.
+3. Confirm the storage path uses the production store
+   (`plaidbar-production.sqlite`) and that no sandbox store or sandbox data is
+   created or read.
+
+This step requires Plaid production approval and real production credentials;
+it cannot be simulated with sandbox credentials. If production approval is not
+in place, record the step as not verified rather than skipping it silently.
+
 Distribute the resulting DMG privately to licensed users.
 
 ## Distribution Scope

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,6 +68,35 @@ Checks:
 
 Do not reuse sandbox credentials in production mode.
 
+## Production Mode Reports Missing Credentials (503)
+
+The server boots without credentials into a setup state: `/health` and
+`/api/status` keep working, and Plaid-backed routes return `503` until both
+credentials are present and the server restarts.
+
+The `503` body and the server boot log name exactly which variable is missing.
+A partially configured `server.conf` (for example `PLAID_CLIENT_ID` set but
+`PLAID_SECRET` forgotten) is the most common cause and reports the single
+missing variable instead of a generic credentials message.
+
+Checks:
+
+- Read the `503` error body or server log line: it says whether
+  `PLAID_CLIENT_ID`, `PLAID_SECRET`, or both are missing.
+- Confirm both values are in `server.conf` (or exported in the server's
+  environment) with no empty values — blank assignments count as missing.
+- Restart the server after fixing `server.conf`; credentials are read at boot.
+- For production, confirm the values are production credentials from an
+  approved Plaid application. Sandbox credentials will not work in production
+  mode.
+
+## Production Mode Shows No Linked Accounts After Sandbox Testing
+
+That is expected, not data loss. Sandbox and production use strictly separate
+local stores (`plaidbar-sandbox.sqlite` vs `plaidbar-production.sqlite`) and
+separate caches in the same data directory, so real financial data and test
+data never mix. Each mode starts empty until accounts are linked in that mode.
+
 ## App Says Server Is Offline
 
 Checks:


### PR DESCRIPTION
## Summary

- **Stacked PR:** based on `feat/and-315-316-error-severity-token-safety` (PR for AND-315/316); will auto-retarget to `main` when the parent merges. The diff here contains only the AND-318 slice.
- Implements PR-016 (T076–T080) and PR-017 (T081–T085): sandbox reliability and honest production-readiness boundaries.
- New `CredentialSetupDiagnosis` (server-only) names exactly which credential variable is missing (`PLAID_CLIENT_ID`, `PLAID_SECRET`, or both). The setup-state 503 body and the server boot log now carry that named, environment-scoped guidance — a partially configured `server.conf` is no longer indistinguishable from a fresh install. The diagnosis carries variable names only, never values.
- Sandbox guidance copy never implies production readiness; production guidance (and the SetupView production chooser/connect copy) is explicit about Plaid production approval and real financial data.
- `TransactionRoutes.normalizedCommittableCursor` extracts the cursor-commit guard so whitespace-only commits can never clobber a stored sync cursor; tests prove cursor state survives a server restart.
- `Scripts/smoke-sandbox.sh` gains two headless assertions: (a) restart recovery — same data dir must reuse the same auth token and preserve readiness state (environment, storagePath, itemCount, syncedItemCount); (b) credential-less boot — `credentialsConfigured=false` on `/api/status` and a 503 on Plaid-backed routes whose body names the missing variables. It never opens Plaid Link.
- New `SandboxReliabilityTests` suite (10 tests) covers clean-temp-dir setup, the diagnosis matrix, 503 behavior, cursor preservation, and sandbox/production storage separation. `/api/status` payload contract is unchanged.
- Docs: README sandbox-limitations section, troubleshooting entries for the production missing-credential 503 and the expected empty-production-store case, release runbook clean-profile production setup verification step (explicitly recorded as not verified when production approval is absent). No notarization/appcast/distribution claims added.
- Descoped: live production-credential verification (T083's actual execution) requires Plaid production approval and real credentials — the runbook step documents it instead. Note: local `swiftformat` 0.61.1 reformats 66 pre-existing files (including stripping explicit `Sendable` conformances) inconsistently with committed style, so it was deliberately not applied; `swiftlint` is not installed on this machine.

## Autonomous task IDs

- Task ID(s): T076, T077, T078, T079, T080, T081, T082, T083, T084, T085
- Backlog slice: PR-016: Sandbox Reliability + PR-017: Production Readiness Boundaries
- Scope note: one focused slice covering both Plaid-mode boundary backlog groups (AND-318); code + tests + smoke script + docs, no API contract changes.

## Agent coordination

- Builder agent: Claude Fable 5 (Claude Code session)
- Builder branch/worktree: feat/and-318-sandbox-reliability in /Users/ftchvs/Developer/pb-worktrees/core
- Reviewer/merge steward: Felipe + Otto loop
- Coordination note: review-only for other agents; do not push to this branch

## Changed files

- `Sources/PlaidBarServer/Config/CredentialSetupDiagnosis.swift` (new)
- `Sources/PlaidBarServer/Config/ServerConfig.swift`
- `Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift`
- `Sources/PlaidBarServer/App.swift`
- `Sources/PlaidBarServer/Routes/TransactionRoutes.swift`
- `Sources/PlaidBar/Views/SetupView.swift`
- `Tests/PlaidBarServerTests/SandboxReliabilityTests.swift` (new)
- `Scripts/smoke-sandbox.sh`
- `README.md`
- `docs/troubleshooting.md`
- `docs/release.md`
- `docs/autonomous-loop-backlog.md`

## Local gates

- [x] `git diff --check` — ran clean, no whitespace/conflict-marker errors.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` or documented why not needed. — ran the stricter superset: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` builds all three targets; Build complete, zero warnings.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` when server/shared DTO/package code changed, or documented why not needed. — covered by the same strict-concurrency all-targets build; PlaidBarServer also rebuilt by `Scripts/smoke-sandbox.sh` with `--disable-keychain`.
- [x] Focused tests or `swift test` when core/server logic changed, or documented the local Swift Testing limitation. — full `swift test`: 425 tests passed (10 new in SandboxReliabilityTests); plus `bash -n Scripts/*.sh Scripts/plaidbar-run` and a full `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret ./Scripts/smoke-sandbox.sh` run on the final code state — all three smoke phases passed.
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files. — `git diff HEAD | grep -iE 'client_secret|access-(sandbox|production)|api[_-]?key|BEGIN (RSA|EC|OPENSSH)'` over the full diff: zero hits; all credentials in tests/scripts are synthetic `test-*`/`ci_smoke_*` strings.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

GitHub Actions billing outage on 2026-06-12 — checks must be re-run once billing is restored; merge is held until green

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers — the new 503/boot-log guidance carries credential variable *names* only, never values (pinned by a test).
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured. (No AI behavior touched by this PR.)
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes. — the only UI change is static copy on existing SetupView `Text` elements; no controls, focus order, or interaction targets changed.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes. — the changed strings are plain `Text` content whose VoiceOver announcement is the text itself; the new copy states the production boundary explicitly.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone — the production/real-data distinction is carried by the words, not the existing icon/tint.
- [x] I updated docs or screenshots if user-facing behavior changed. — README, troubleshooting, and release runbook updated; no screenshot surfaces changed.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
