### PR TITLE
feat: add popover transparency setting

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -24,6 +24,12 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.accounts.rawValue)
 
+            AppearanceSettingsView()
+                .tabItem {
+                    Label("Appearance", systemImage: "paintbrush")
+                }
+                .tag(SettingsTab.appearance.rawValue)
+
             NotificationSettingsView()
                 .environment(appState)
                 .tabItem {
@@ -51,8 +57,54 @@ struct SettingsView: View {
 private enum SettingsTab: String {
     case general
     case accounts
+    case appearance
     case notifications
     case about
+}
+
+struct AppearanceSettingsView: View {
+    @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
+
+    private var transparencySetting: PopoverTransparencySetting {
+        PopoverTransparencySetting(value: popoverTransparency)
+    }
+
+    var body: some View {
+        Form {
+            Section("Popover") {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    HStack {
+                        Text("Transparency")
+                        Spacer()
+                        Text("\(transparencySetting.displayPercent)%")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Slider(
+                        value: Binding(
+                            get: { transparencySetting.value },
+                            set: { popoverTransparency = PopoverTransparencySetting(value: $0).value }
+                        ),
+                        in: PopoverTransparencySetting.minimumValue...PopoverTransparencySetting.maximumValue,
+                        step: 1
+                    ) {
+                        Text("Popover transparency")
+                    } minimumValueLabel: {
+                        Text("More solid")
+                    } maximumValueLabel: {
+                        Text("More glass")
+                    }
+                    .accessibilityValue("\(transparencySetting.displayPercent) percent transparent")
+
+                    Text("Adjusts the ultra-thin material overlay live. The range is capped to keep balances and status text legible on busy desktops.")
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(.top, Spacing.sm)
+    }
 }
 
 struct GeneralSettingsView: View {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -8,6 +8,7 @@ struct MainPopover: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage("dashboard.accountFilter") private var selectedFilterRawValue = DashboardAccountFilter.all.rawValue
     @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
+    @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
     @State private var dashboardContentHeight: CGFloat = 0
@@ -78,8 +79,13 @@ struct MainPopover: View {
         }
         .frame(width: popoverWidth)
         // Stronger liquid-glass transparency: the thinnest system material
-        // lets the desktop read through the popover while staying legible.
-        .background(.ultraThinMaterial)
+        // lets the desktop read through the popover while the persisted
+        // overlay setting enforces a legibility floor.
+        .background {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .overlay(Color(nsColor: .windowBackgroundColor).opacity(transparencySetting.materialOverlayOpacity))
+        }
         // Keep the dashboard stationary when the fly-out opens: pin the
         // window's right edge so the extra width grows leftward instead of
         // letting AppKit re-center the widened popover under the menu bar item.
@@ -138,6 +144,10 @@ struct MainPopover: View {
         // between window sizes.
         guard !shouldShowSetupScreen else { return Layout.dashboardWidth }
         return Layout.dashboardWidth + (selectedAccount == nil ? 0 : Layout.flyoutWidth + 1)
+    }
+
+    private var transparencySetting: PopoverTransparencySetting {
+        PopoverTransparencySetting(value: popoverTransparency)
     }
 
     private var dashboardColumn: some View {

--- a/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
+++ b/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public struct PopoverTransparencySetting: Sendable, Equatable {
+    public static let storageKey = "appearance.popoverTransparency"
+    public static let defaultValue = 70.0
+    public static let minimumValue = 20.0
+    public static let maximumValue = 85.0
+
+    public let value: Double
+
+    public init(value: Double) {
+        self.value = min(Self.maximumValue, max(Self.minimumValue, value))
+    }
+
+    public var displayPercent: Int {
+        Int(value.rounded())
+    }
+
+    /// Solid fill layered over `.ultraThinMaterial`. Lower values produce a
+    /// more opaque panel; higher values preserve more desktop read-through.
+    /// The floor keeps text and numeric finance values legible at maximum
+    /// transparency.
+    public var materialOverlayOpacity: Double {
+        let progress = (value - Self.minimumValue) / (Self.maximumValue - Self.minimumValue)
+        let opacity = 0.32 - (progress * 0.26)
+        return (opacity * 100).rounded() / 100
+    }
+}

--- a/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Popover transparency settings")
+struct PopoverTransparencyTests {
+    @Test("Defaults preserve the current legible glass opacity")
+    func defaultOpacityPreservesCurrentLook() {
+        let setting = PopoverTransparencySetting(value: PopoverTransparencySetting.defaultValue)
+
+        #expect(setting.value == 70)
+        #expect(setting.materialOverlayOpacity == 0.12)
+        #expect(setting.displayPercent == 70)
+    }
+
+    @Test("Values are clamped to the legibility floor and opacity ceiling")
+    func valuesClampToLegibilityRange() {
+        #expect(PopoverTransparencySetting(value: -50).value == 20)
+        #expect(PopoverTransparencySetting(value: 150).value == 85)
+    }
+
+    @Test("Higher transparency lowers the solid overlay")
+    func higherTransparencyLowersSolidOverlay() {
+        let lessTransparent = PopoverTransparencySetting(value: 20)
+        let moreTransparent = PopoverTransparencySetting(value: 85)
+
+        #expect(lessTransparent.materialOverlayOpacity > moreTransparent.materialOverlayOpacity)
+        #expect(lessTransparent.materialOverlayOpacity == 0.32)
+        #expect(moreTransparent.materialOverlayOpacity == 0.06)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a persisted Appearance tab slider for popover transparency
- Drives the menu popover material overlay live from the saved setting
- Keeps a tested legibility range so max transparency is not fully see-through

## Linear
- AND-338

## Local gates
- [x] `swift test --filter PopoverTransparencyTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `git diff --check`
- [x] changed-line secret scan clean

@codex review