### PR TITLE
perf: cache balance composition presentation

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -474,49 +474,29 @@ private struct BalanceCompositionStrip: View {
 
     private let segmentSpacing: CGFloat = 2
 
-    private var segments: [BalanceCompositionSegment] {
-        [
-            BalanceCompositionSegment(
-                title: "Cash",
-                value: AccountPresentation.positiveBalanceTotal(
-                    from: appState.accounts,
-                    type: .depository
-                ),
-                tint: Color.secondary.opacity(0.6)
-            ),
-            BalanceCompositionSegment(
-                title: "Investments",
-                value: AccountPresentation.positiveBalanceTotal(
-                    from: appState.accounts,
-                    type: .investment
-                ),
-                tint: Color.primary.opacity(0.36)
-            ),
-            BalanceCompositionSegment(
-                title: "Credit",
-                value: AccountPresentation.debtBalanceTotal(
-                    from: appState.accounts,
-                    type: .credit
-                ),
-                tint: SemanticColors.creditDebt
-            ),
-            BalanceCompositionSegment(
-                title: "Loans",
-                value: AccountPresentation.debtBalanceTotal(
-                    from: appState.accounts,
-                    type: .loan
-                ),
-                tint: SemanticColors.warning
-            ),
-        ]
+    private var presentation: BalanceCompositionPresentation {
+        BalanceCompositionPresentation(accounts: appState.accounts)
     }
 
     private var activeSegments: [BalanceCompositionSegment] {
-        segments.filter { $0.value > 0 }
+        presentation.segments.map { segment in
+            BalanceCompositionSegment(
+                title: segment.title,
+                value: segment.value,
+                share: segment.share,
+                tint: tint(for: segment.id)
+            )
+        }
     }
 
-    private var total: Double {
-        max(activeSegments.reduce(0) { $0 + $1.value }, 1)
+    private func tint(for id: String) -> Color {
+        switch id {
+        case "cash": Color.secondary.opacity(0.6)
+        case "investments": Color.primary.opacity(0.36)
+        case "credit": SemanticColors.creditDebt
+        case "loans": SemanticColors.warning
+        default: Color.secondary.opacity(0.6)
+        }
     }
 
     var body: some View {
@@ -546,7 +526,7 @@ private struct BalanceCompositionStrip: View {
             .frame(height: 7)
 
             HStack(spacing: Spacing.sm) {
-                ForEach(segments) { segment in
+                ForEach(activeSegments) { segment in
                     BalanceCompositionLegend(segment: segment)
                 }
             }
@@ -559,17 +539,18 @@ private struct BalanceCompositionStrip: View {
     private func segmentWidth(_ segment: BalanceCompositionSegment, totalWidth: CGFloat) -> CGFloat {
         let gaps = CGFloat(max(activeSegments.count - 1, 0)) * segmentSpacing
         let availableWidth = max(totalWidth - gaps, 0)
-        return max(availableWidth * CGFloat(segment.value / total), 6)
+        return max(availableWidth * CGFloat(segment.share), 6)
     }
 
     private func segmentPercentText(_ segment: BalanceCompositionSegment) -> String {
-        "\(Int((segment.value / total * 100).rounded()))%"
+        "\(Int((segment.share * 100).rounded()))%"
     }
 }
 
 private struct BalanceCompositionSegment: Identifiable {
     let title: String
     let value: Double
+    let share: Double
     let tint: Color
 
     var id: String {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -510,7 +510,13 @@ private struct BalanceCompositionStrip: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        // Derive the active segments once per render: rebuilding the
+        // presentation re-filters the account list, so computing it here and
+        // threading the result (and its count) through the helpers avoids
+        // re-running that work for every segment in the strip and legend.
+        let activeSegments = activeSegments
+
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
                 Text("Balance Mix")
                     .sectionTitle()
@@ -526,7 +532,13 @@ private struct BalanceCompositionStrip: View {
                     ForEach(activeSegments) { segment in
                         RoundedRectangle(cornerRadius: Radius.cell)
                             .fill(segment.fillColor)
-                            .frame(width: segmentWidth(segment, totalWidth: proxy.size.width))
+                            .frame(
+                                width: segmentWidth(
+                                    segment,
+                                    totalWidth: proxy.size.width,
+                                    segmentCount: activeSegments.count
+                                )
+                            )
                             .accessibilityLabel(
                                 "\(segment.title), \(Formatters.currency(segment.value, format: .compact)), \(segmentPercentText(segment)) of balance mix"
                             )
@@ -546,8 +558,12 @@ private struct BalanceCompositionStrip: View {
         .accessibilityElement(children: .contain)
     }
 
-    private func segmentWidth(_ segment: BalanceCompositionSegment, totalWidth: CGFloat) -> CGFloat {
-        let gaps = CGFloat(max(activeSegments.count - 1, 0)) * segmentSpacing
+    private func segmentWidth(
+        _ segment: BalanceCompositionSegment,
+        totalWidth: CGFloat,
+        segmentCount: Int
+    ) -> CGFloat {
+        let gaps = CGFloat(max(segmentCount - 1, 0)) * segmentSpacing
         let availableWidth = max(totalWidth - gaps, 0)
         return max(availableWidth * CGFloat(segment.share), 6)
     }

--- a/Sources/PlaidBarCore/Utilities/BalanceCompositionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/BalanceCompositionPresentation.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public struct BalanceCompositionPresentation: Sendable, Equatable {
+    public struct Segment: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let title: String
+        public let value: Double
+        public let share: Double
+
+        public init(id: String, title: String, value: Double, share: Double) {
+            self.id = id
+            self.title = title
+            self.value = value
+            self.share = share
+        }
+    }
+
+    public let segments: [Segment]
+    public let accountCount: Int
+    public let total: Double
+
+    public init(accounts: [AccountDTO]) {
+        let rawSegments: [(id: String, title: String, value: Double)] = [
+            (
+                id: "cash",
+                title: "Cash",
+                value: AccountPresentation.positiveBalanceTotal(from: accounts, type: .depository)
+            ),
+            (
+                id: "investments",
+                title: "Investments",
+                value: AccountPresentation.positiveBalanceTotal(from: accounts, type: .investment)
+            ),
+            (
+                id: "credit",
+                title: "Credit",
+                value: AccountPresentation.debtBalanceTotal(from: accounts, type: .credit)
+            ),
+            (
+                id: "loans",
+                title: "Loans",
+                value: AccountPresentation.debtBalanceTotal(from: accounts, type: .loan)
+            ),
+        ]
+
+        let activeValues = rawSegments.filter { $0.value > 0 }
+        let total = activeValues.reduce(0) { $0 + $1.value }
+        let denominator = max(total, 1)
+
+        self.segments = activeValues.map { raw in
+            Segment(
+                id: raw.id,
+                title: raw.title,
+                value: raw.value,
+                share: raw.value / denominator
+            )
+        }
+        self.accountCount = accounts.count
+        self.total = total
+    }
+}

--- a/Tests/PlaidBarCoreTests/BalanceCompositionPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceCompositionPresentationTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Balance composition presentation")
+struct BalanceCompositionPresentationTests {
+    @Test("Computes active balance-mix segments in one reusable pass")
+    func computesActiveSegments() {
+        let accounts = [
+            AccountDTO(id: "checking", itemId: "item", name: "Checking", type: .depository, balances: BalanceDTO(available: 800, current: 900)),
+            AccountDTO(id: "brokerage", itemId: "item", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 1_200)),
+            AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -300, limit: 2_000)),
+            AccountDTO(id: "loan", itemId: "item", name: "Loan", type: .loan, balances: BalanceDTO(current: -700)),
+        ]
+
+        let presentation = BalanceCompositionPresentation(accounts: accounts)
+
+        #expect(presentation.accountCount == 4)
+        #expect(presentation.total == 3_000)
+        #expect(presentation.segments.map(\.id) == ["cash", "investments", "credit", "loans"])
+        #expect(presentation.segments.map(\.title) == ["Cash", "Investments", "Credit", "Loans"])
+        #expect(presentation.segments.map(\.value) == [800, 1_200, 300, 700])
+        #expect(presentation.segments.map { Int(($0.share * 100).rounded()) } == [27, 40, 10, 23])
+    }
+
+    @Test("Suppresses zero and negative asset segments")
+    func suppressesInactiveSegments() {
+        let accounts = [
+            AccountDTO(id: "checking", itemId: "item", name: "Checking", type: .depository, balances: BalanceDTO(current: -50)),
+            AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -125)),
+        ]
+
+        let presentation = BalanceCompositionPresentation(accounts: accounts)
+
+        #expect(presentation.total == 125)
+        #expect(presentation.segments.map(\.id) == ["credit"])
+        #expect(presentation.segments.first?.share == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Moves balance-mix segment derivation out of the SwiftUI view into PlaidBarCore
- Computes active segment values and shares once per render instead of re-filtering accounts in the popover view
- Adds focused tests for the reusable presentation model

## Linear
- AND-320

## Local gates
- [x] `swift test --filter BalanceCompositionPresentationTests` (2 tests)
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `git diff --check`
- [x] changed-line secret scan clean

@codex review