### PR TITLE
ci: add Codex CI review workflow

### DIFF
--- a/.github/codex/prompts/pr-review.md
+++ b/.github/codex/prompts/pr-review.md
@@ -1,0 +1,48 @@
+# Codex CI PR Review
+
+You are running as Codex CI for PlaidBar. Review the checked-out pull request
+merge commit and decide whether it introduces concrete merge-blocking risk.
+
+Repository context:
+
+- PlaidBar is a local-first macOS menu bar app for Plaid financial data.
+- The SwiftUI app must never handle Plaid client secrets or access tokens.
+- The local Hummingbird server owns Plaid credentials and token storage.
+- SQLite stores only local metadata and keychain references for token bytes.
+- CI enforces Swift strict concurrency and warnings as errors.
+- Tests, screenshots, fixtures, and examples must use sandbox or synthetic data.
+
+Workflow context:
+
+- `PR_NUMBER` contains the pull request number.
+- `BASE_REF` contains the target branch.
+- The workflow fetched `origin/$BASE_REF` and the pull request head ref.
+
+Review process:
+
+1. Inspect the changed files and relevant surrounding code with read-only
+   commands such as `git diff --stat "origin/${BASE_REF:-main}"...HEAD`,
+   `git diff "origin/${BASE_REF:-main}"...HEAD`, `rg`, and `sed`.
+2. Focus only on likely P0/P1 issues that should block merge:
+   - real Plaid credentials, access tokens, account IDs, balances, logs, or
+     other sensitive local financial data committed to the repo
+   - app/server boundary regressions that expose Plaid secrets to the SwiftUI app
+   - localhost API authentication bypasses or token leakage
+   - Swift strict-concurrency, Sendable, or warnings-as-errors failures that are
+     likely from the diff
+   - missing tests for changed shared business logic, server auth/storage logic,
+     or security-sensitive behavior
+   - generated local artifacts, build products, databases, credentials, or logs
+   - release, Homebrew formula, or packaging changes that likely break CI
+3. Do not report style nits, speculative improvements, formatting preferences,
+   broad architecture suggestions, or minor documentation typos.
+4. Do not edit files. Do not run commands that resolve dependencies, build, test,
+   mutate package state, or create build products.
+5. Return only JSON matching the supplied schema.
+
+Verdict rules:
+
+- Use `"pass"` when you find no concrete P0/P1 blocking issue.
+- Use `"fail"` when at least one concrete blocking issue exists.
+- Every finding must include the most specific file path and line number you can
+  determine. If a line number is not available, set it to null and explain why.

--- a/.github/codex/schemas/pr-review.schema.json
+++ b/.github/codex/schemas/pr-review.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Codex CI PR Review",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["verdict", "summary", "findings"],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"],
+      "description": "Use fail only when concrete P0/P1 blocking findings exist."
+    },
+    "summary": {
+      "type": "string",
+      "description": "A concise summary of the reviewed diff and final judgment."
+    },
+    "findings": {
+      "type": "array",
+      "description": "Concrete P0/P1 blocking findings. Empty when verdict is pass.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "title", "path", "line", "details", "recommendation"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["P0", "P1"]
+          },
+          "title": {
+            "type": "string"
+          },
+          "path": {
+            "type": ["string", "null"]
+          },
+          "line": {
+            "type": ["integer", "null"],
+            "minimum": 1
+          },
+          "details": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,0 +1,253 @@
+name: Codex CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-ci-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.context.outputs.pr_number }}
+      verdict: ${{ steps.normalize.outputs.verdict }}
+      has_output: ${{ steps.normalize.outputs.has_output }}
+      markdown: ${{ steps.normalize.outputs.markdown }}
+    steps:
+      - name: Resolve pull request context
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr_number="$INPUT_PR_NUMBER"
+          else
+            pr_number="$EVENT_PR_NUMBER"
+          fi
+
+          if [ -z "$pr_number" ]; then
+            echo "::error::No pull request number was provided."
+            exit 1
+          fi
+
+          base_ref="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
+          head_ref="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)"
+          head_sha="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
+
+          {
+            echo "pr_number=$pr_number"
+            echo "base_ref=$base_ref"
+            echo "head_ref=$head_ref"
+            echo "head_sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out pull request merge commit
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ steps.context.outputs.pr_number }}/merge
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch review refs
+        env:
+          BASE_REF: ${{ steps.context.outputs.base_ref }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head:refs/remotes/origin/pr/$PR_NUMBER/head"
+          {
+            echo "BASE_REF=$BASE_REF"
+            echo "PR_NUMBER=$PR_NUMBER"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Codex review
+        id: run_codex
+        uses: openai/codex-action@v1
+        continue-on-error: true
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/pr-review.md
+          output-file: codex-review.json
+          sandbox: read-only
+          safety-strategy: drop-sudo
+          codex-args: >-
+            ["--ephemeral","--ignore-user-config","--output-schema",".github/codex/schemas/pr-review.schema.json"]
+
+      - name: Normalize Codex result
+        id: normalize
+        if: always()
+        env:
+          CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
+          CODEX_OUTCOME: ${{ steps.run_codex.outcome }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const rawFromOutput = process.env.CODEX_FINAL_MESSAGE || "";
+          const rawFromFile = fs.existsSync("codex-review.json")
+            ? fs.readFileSync("codex-review.json", "utf8")
+            : "";
+          const raw = rawFromOutput.trim() || rawFromFile.trim();
+
+          let result = {
+            verdict: "fail",
+            summary: "Codex CI did not produce a valid structured review.",
+            findings: [
+              {
+                severity: "P1",
+                title: "Codex review did not complete cleanly",
+                path: null,
+                line: null,
+                details: "The Codex Action outcome was not success or its output could not be parsed as JSON.",
+                recommendation: "Open the Codex CI job logs, fix the workflow or Codex runtime failure, then rerun Codex CI."
+              }
+            ]
+          };
+
+          if (process.env.CODEX_OUTCOME === "success" && raw) {
+            try {
+              const parsed = JSON.parse(raw);
+              if (parsed && (parsed.verdict === "pass" || parsed.verdict === "fail")) {
+                result = {
+                  verdict: parsed.verdict,
+                  summary: String(parsed.summary || "Codex CI completed."),
+                  findings: Array.isArray(parsed.findings) ? parsed.findings : []
+                };
+              }
+            } catch (error) {
+              result.findings[0].details = `Codex returned output, but JSON parsing failed: ${error.message}`;
+            }
+          }
+
+          const findingLines = result.findings.map((finding) => {
+            const severity = finding.severity || "P1";
+            const title = finding.title || "Blocking finding";
+            const location = finding.path
+              ? `\`${finding.path}${finding.line ? `:${finding.line}` : ""}\``
+              : "repository";
+            const details = finding.details || "No details provided.";
+            const recommendation = finding.recommendation || "Address the finding before merging.";
+            return [
+              `- **${severity}: ${title}**`,
+              `  - Location: ${location}`,
+              `  - Details: ${details}`,
+              `  - Recommendation: ${recommendation}`
+            ].join("\n");
+          });
+
+          const markdown = [
+            "<!-- codex-ci-review -->",
+            "## Codex CI",
+            "",
+            `**Verdict:** ${result.verdict === "pass" ? "Pass" : "Needs attention"}`,
+            "",
+            result.summary,
+            "",
+            ...(findingLines.length > 0 ? ["### Findings", "", findingLines.join("\n")] : ["No blocking P0/P1 findings."])
+          ].join("\n");
+
+          fs.writeFileSync("codex-review.normalized.json", `${JSON.stringify(result, null, 2)}\n`);
+          fs.writeFileSync("codex-review.md", `${markdown}\n`);
+
+          function setOutput(name, value) {
+            const delimiter = `EOF_${name}_${Date.now()}`;
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}<<${delimiter}\n${value}\n${delimiter}\n`);
+          }
+
+          setOutput("verdict", result.verdict);
+          setOutput("has_output", "true");
+          setOutput("markdown", markdown);
+          NODE
+
+      - name: Upload Codex review artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-ci-review
+          path: |
+            codex-review.json
+            codex-review.normalized.json
+            codex-review.md
+          if-no-files-found: ignore
+
+  post-feedback:
+    needs: review
+    if: ${{ always() && needs.review.outputs.has_output == 'true' && needs.review.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Post or update Codex CI comment
+        uses: actions/github-script@v7
+        env:
+          CODEX_MARKDOWN: ${{ needs.review.outputs.markdown }}
+          PR_NUMBER: ${{ needs.review.outputs.pr_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = "<!-- codex-ci-review -->";
+            const issue_number = Number(process.env.PR_NUMBER);
+            const body = process.env.CODEX_MARKDOWN;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
+
+  gate:
+    needs: [review, post-feedback]
+    if: ${{ always() && needs.review.outputs.verdict == 'fail' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on blocking Codex findings
+        run: |
+          echo "::error::Codex CI reported blocking findings or did not complete cleanly."
+          exit 1

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -118,12 +118,12 @@ jobs:
         id: run_codex
         continue-on-error: true
         env:
-          CODEX_ACCESS_TOKEN: ${{ secrets.CODEX_ACCESS_TOKEN }}
+          CODEX_ACCESS_TOKEN: ${{ secrets.CODEX_OAUTH_TOKEN }}
         run: |
           set +e
 
           if [ -z "${CODEX_ACCESS_TOKEN:-}" ]; then
-            echo "::error::Missing CODEX_ACCESS_TOKEN repository secret."
+            echo "::error::Missing CODEX_OAUTH_TOKEN repository secret."
             echo "exit_code=1" >> "$GITHUB_OUTPUT"
             exit 1
           fi

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -20,7 +20,15 @@ concurrency:
 
 jobs:
   review:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.draft == false &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -85,34 +93,69 @@ jobs:
             echo "PR_NUMBER=$PR_NUMBER"
           } >> "$GITHUB_ENV"
 
+      - name: Install Codex CLI
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+        run: npm install -g @openai/codex
+
+      - name: Prepare Linux sandbox
+        if: ${{ runner.os == 'Linux' && runner.environment == 'github-hosted' }}
+        run: |
+          set -euo pipefail
+
+          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [ -n "$current_userns" ] && [ "$current_userns" != "1" ]; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+
+          current_apparmor="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+          if [ -n "$current_apparmor" ] && [ "$current_apparmor" != "0" ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       - name: Run Codex review
         id: run_codex
-        uses: openai/codex-action@v1
         continue-on-error: true
-        with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          prompt-file: .github/codex/prompts/pr-review.md
-          output-file: codex-review.json
-          sandbox: read-only
-          safety-strategy: drop-sudo
-          codex-args: >-
-            ["--ephemeral","--ignore-user-config","--output-schema",".github/codex/schemas/pr-review.schema.json"]
+        env:
+          CODEX_ACCESS_TOKEN: ${{ secrets.CODEX_ACCESS_TOKEN }}
+        run: |
+          set +e
+
+          if [ -z "${CODEX_ACCESS_TOKEN:-}" ]; then
+            echo "::error::Missing CODEX_ACCESS_TOKEN repository secret."
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          codex exec \
+            --ephemeral \
+            --ignore-user-config \
+            --output-schema .github/codex/schemas/pr-review.schema.json \
+            --sandbox read-only \
+            -C "$GITHUB_WORKSPACE" \
+            -o codex-review.json \
+            --json \
+            - < .github/codex/prompts/pr-review.md > codex-events.jsonl
+
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
 
       - name: Normalize Codex result
         id: normalize
         if: always()
         env:
-          CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs.final-message }}
           CODEX_OUTCOME: ${{ steps.run_codex.outcome }}
+          CODEX_EXIT_CODE: ${{ steps.run_codex.outputs.exit_code }}
         run: |
           node <<'NODE'
           const fs = require("fs");
 
-          const rawFromOutput = process.env.CODEX_FINAL_MESSAGE || "";
           const rawFromFile = fs.existsSync("codex-review.json")
             ? fs.readFileSync("codex-review.json", "utf8")
             : "";
-          const raw = rawFromOutput.trim() || rawFromFile.trim();
+          const raw = rawFromFile.trim();
 
           let result = {
             verdict: "fail",
@@ -123,8 +166,8 @@ jobs:
                 title: "Codex review did not complete cleanly",
                 path: null,
                 line: null,
-                details: "The Codex Action outcome was not success or its output could not be parsed as JSON.",
-                recommendation: "Open the Codex CI job logs, fix the workflow or Codex runtime failure, then rerun Codex CI."
+                details: `Codex exited with status ${process.env.CODEX_EXIT_CODE || "unknown"} or its output could not be parsed as JSON.`,
+                recommendation: "Open the Codex CI job logs, fix the workflow, token, or Codex runtime failure, then rerun Codex CI."
               }
             ]
           };
@@ -193,6 +236,7 @@ jobs:
             codex-review.json
             codex-review.normalized.json
             codex-review.md
+            codex-events.jsonl
           if-no-files-found: ignore
 
   post-feedback:


### PR DESCRIPTION
## Summary

- Add a PlaidBar Codex CI workflow using Codex CLI non-interactive mode.
- Run a read-only, structured Codex PR review on trusted same-repository pull requests and manual dispatch using a `CODEX_OAUTH_TOKEN` repository secret.
- Post or update one Codex CI PR comment, upload review artifacts, and fail the gate only for concrete P0/P1 findings or Codex runtime failures.

## Autonomous task IDs

- Task ID(s): codex-ci-oauth-ad-hoc
- Backlog slice: PlaidBar CI workflow automation
- Scope note: One focused workflow-only slice for Codex CI review gating.

## Agent coordination

- Builder agent: Codex
- Builder branch/worktree: feature/codex-ci in /Users/otto/workspace/maintainer/PlaidBar
- Reviewer/merge steward: Otto
- Coordination note: No other agent should mutate this branch while review is pending.

## Changed files

- `.github/workflows/codex-ci.yml`
- `.github/codex/prompts/pr-review.md`
- `.github/codex/schemas/pr-review.schema.json`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` not needed; workflow/prompt/schema-only change with no Swift source or package changes.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` not needed; workflow/prompt/schema-only change with no server/shared DTO/package changes.
- [x] Focused tests or `swift test` not needed; no core/server logic changed.
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files. Targeted scan only found the intentional `${{ secrets.CODEX_OAUTH_TOKEN }}` workflow reference and prompt text describing forbidden secret classes.

Additional local validation:

- [x] Parsed `.github/workflows/codex-ci.yml` with Ruby YAML.
- [x] Parsed `.github/codex/schemas/pr-review.schema.json` with `jq`.
- [x] Checked embedded workflow JavaScript with `node --check`.
- [x] `actionlint` was not installed locally.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [x] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude review auth/token/session/setup-only failures are documented as non-blocking, or there are no such failures.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.
