### PR TITLE
fix: add attention status accessibility backups

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -91,7 +91,7 @@ private struct AttentionQueueRowView: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: Spacing.sm) {
-            Image(systemName: iconName)
+            Image(systemName: row.severity.statusSymbolName)
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(tint)
                 .frame(width: 24, height: 24)
@@ -99,16 +99,23 @@ private struct AttentionQueueRowView: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text(row.title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.82)
+                HStack(spacing: Spacing.xs) {
+                    SeverityStatusBadge(severity: row.severity, tint: tint)
+
+                    Text(row.title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.82)
+                }
 
                 Text(row.detail)
                     .microText()
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(row.accessibilityLabel)
+            .accessibilityHint(row.accessibilityHint ?? "")
 
             Spacer(minLength: Spacing.xs)
 
@@ -133,17 +140,7 @@ private struct AttentionQueueRowView: View {
             fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: emphasizedTint)),
             stroke: panelStroke
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(row.accessibilityLabel)
-        .accessibilityHint(row.accessibilityHint ?? "")
-    }
-
-    private var iconName: String {
-        switch row.severity {
-        case .healthy: "checkmark.circle.fill"
-        case .warning: "exclamationmark.triangle.fill"
-        case .blocked: "xmark.octagon.fill"
-        }
+        .accessibilityElement(children: .contain)
     }
 
     private var tint: Color {
@@ -160,5 +157,31 @@ private struct AttentionQueueRowView: View {
 
     private var panelStroke: Color {
         row.severity == .healthy ? Color.primary.opacity(0.07) : tint.opacity(0.18)
+    }
+}
+
+private struct SeverityStatusBadge: View {
+    let severity: AttentionQueueSeverity
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: Spacing.xxs) {
+            Image(systemName: severity.statusSymbolName)
+                .font(.caption2.weight(.semibold))
+                .accessibilityHidden(true)
+
+            Text(severity.statusLabel)
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(tint.opacity(0.11), in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(tint.opacity(0.22), lineWidth: 1)
+        }
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
@@ -42,7 +42,8 @@ struct BalanceTrendChart: View {
                 revealFraction = 1
             }
         }
-        .accessibilityHidden(true)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(trend.accessibilitySummary)
     }
 
     private var tint: Color {

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -5,6 +5,24 @@ public enum AttentionQueueSeverity: String, Codable, Sendable {
     case warning
     case blocked
 
+    /// Short visible text that backs up the row's status icon and tint.
+    public var statusLabel: String {
+        switch self {
+        case .healthy: "Healthy"
+        case .warning: "Needs attention"
+        case .blocked: "Blocked"
+        }
+    }
+
+    /// SF Symbol selected for distinct shape, not just tint.
+    public var statusSymbolName: String {
+        switch self {
+        case .healthy: "checkmark.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        case .blocked: "xmark.octagon.fill"
+        }
+    }
+
     /// Severity tier of the failure this row represents; `nil` for healthy
     /// rows, which carry no error. Warnings are advisory (inline recovery),
     /// blocked rows gate the connection or credential path.
@@ -54,7 +72,7 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
         self.actionTitle = actionTitle ?? action?.defaultTitle
         self.actionIconName = actionIconName ?? action?.defaultIconName
         self.targetItemId = targetItemId
-        self.accessibilityLabel = accessibilityLabel ?? "\(title). \(detail)"
+        self.accessibilityLabel = accessibilityLabel ?? "\(severity.statusLabel). \(title). \(detail)"
         self.accessibilityHint = accessibilityHint
     }
 }

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -4,6 +4,42 @@ import Testing
 
 @Suite("AttentionQueue Tests")
 struct AttentionQueueTests {
+    @Test("Severity exposes status text and shaped symbols")
+    func severityExposesStatusTextAndSymbols() {
+        #expect(AttentionQueueSeverity.healthy.statusLabel == "Healthy")
+        #expect(AttentionQueueSeverity.healthy.statusSymbolName == "checkmark.circle.fill")
+        #expect(AttentionQueueSeverity.warning.statusLabel == "Needs attention")
+        #expect(AttentionQueueSeverity.warning.statusSymbolName == "exclamationmark.triangle.fill")
+        #expect(AttentionQueueSeverity.blocked.statusLabel == "Blocked")
+        #expect(AttentionQueueSeverity.blocked.statusSymbolName == "xmark.octagon.fill")
+    }
+
+    @Test("Queue row accessibility labels include status text backup")
+    func accessibilityLabelsIncludeStatusTextBackup() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-login-secret", institutionName: "Example Bank", status: .loginRequired),
+            ],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil
+        )
+
+        #expect(queue.rows.map(\.accessibilityLabel).contains {
+            $0.hasPrefix("Blocked. Server offline.")
+        })
+        #expect(queue.rows.map(\.accessibilityLabel).contains {
+            $0.hasPrefix("Needs attention. Example Bank needs login.")
+        })
+        #expect(queue.rows.allSatisfy { !$0.accessibilityLabel.contains("item-login-secret") })
+    }
+
     @Test("Queue prioritizes blocked recovery before login, stale sync, and healthy rows")
     func orderingPrioritizesBlockedRecovery() {
         let queue = AttentionQueue.evaluate(


### PR DESCRIPTION
## Summary
- Adds visible text and shaped symbol backups for attention queue severity states so status is not conveyed by color alone.
- Exposes balance trend chart summaries to VoiceOver using the existing accessibility summary.
- Extends AttentionQueue tests for severity labels, symbols, and redacted accessibility labels.

## Changes
- `Sources/PlaidBarCore/Models/AttentionQueue.swift`: severity label/symbol presentation and default accessibility labels.
- `Sources/PlaidBar/Views/AttentionQueueView.swift`: visible severity badge and contained row accessibility.
- `Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift`: chart accessibility label.
- `Tests/PlaidBarCoreTests/AttentionQueueTests.swift`: focused regression coverage.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter AttentionQueueTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`

## Notes
- Manual VoiceOver QA is still needed before marking ready for review.
