### PR TITLE
feat: flag recurring stream changes

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -618,7 +618,7 @@ final class AppState {
 
     /// Monthly equivalent of all recurring charges (normalizes weekly/annual to monthly)
     var estimatedMonthlyRecurring: Double {
-        RecurringSummary.estimatedMonthlyTotal(from: recurringTransactions)
+        RecurringSummary.estimatedMonthlyTotal(from: recurringTransactions, asOf: Date())
     }
 
     var localAIAvailability: LocalAIAvailability {

--- a/Sources/PlaidBarCore/Models/RecurringTransaction.swift
+++ b/Sources/PlaidBarCore/Models/RecurringTransaction.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 public struct RecurringTransaction: Sendable, Identifiable, Hashable {
+    public static let priceIncreaseConfidenceThreshold = 0.6
+    public static let priceIncreaseRelativeThreshold = 0.10
+    public static let priceIncreaseAbsoluteThreshold = 1.0
+
     public let id: String
     public let merchantName: String
     public let frequency: RecurringFrequency
     public let averageAmount: Double
+    public let latestAmount: Double
+    public let trailingAverageAmount: Double?
     public let lastDate: String
     public let nextExpectedDate: String
     public let category: SpendingCategory?
@@ -15,6 +21,8 @@ public struct RecurringTransaction: Sendable, Identifiable, Hashable {
         merchantName: String,
         frequency: RecurringFrequency,
         averageAmount: Double,
+        latestAmount: Double? = nil,
+        trailingAverageAmount: Double? = nil,
         lastDate: String,
         nextExpectedDate: String,
         category: SpendingCategory?,
@@ -25,12 +33,86 @@ public struct RecurringTransaction: Sendable, Identifiable, Hashable {
         self.merchantName = merchantName
         self.frequency = frequency
         self.averageAmount = averageAmount
+        self.latestAmount = latestAmount ?? averageAmount
+        self.trailingAverageAmount = trailingAverageAmount
         self.lastDate = lastDate
         self.nextExpectedDate = nextExpectedDate
         self.category = category
         self.transactionCount = transactionCount
         self.confidence = confidence
     }
+
+    public var priceIncrease: RecurringPriceIncrease? {
+        guard confidence >= Self.priceIncreaseConfidenceThreshold,
+              let trailingAverageAmount,
+              trailingAverageAmount > 0
+        else { return nil }
+
+        let absoluteIncrease = latestAmount - trailingAverageAmount
+        let relativeIncrease = absoluteIncrease / trailingAverageAmount
+        guard absoluteIncrease >= Self.priceIncreaseAbsoluteThreshold,
+              relativeIncrease >= Self.priceIncreaseRelativeThreshold
+        else { return nil }
+
+        return RecurringPriceIncrease(
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            absoluteIncrease: absoluteIncrease,
+            relativeIncrease: relativeIncrease
+        )
+    }
+
+    public var hasPriceIncrease: Bool {
+        priceIncrease != nil
+    }
+
+    public func isStale(asOf date: Date, calendar: Calendar = .current) -> Bool {
+        guard let lastChargeDate = Formatters.parseTransactionDate(lastDate) else { return false }
+        let lastChargeStart = calendar.startOfDay(for: lastChargeDate)
+        let asOfStart = calendar.startOfDay(for: date)
+        guard let daysSinceLastCharge = calendar.dateComponents(
+            [.day],
+            from: lastChargeStart,
+            to: asOfStart
+        ).day else { return false }
+
+        return daysSinceLastCharge > frequency.estimatedDays * 2
+    }
+
+    public func isStale(asOf dateString: String, calendar: Calendar = .current) -> Bool {
+        guard let date = Formatters.parseTransactionDate(dateString) else { return false }
+        return isStale(asOf: date, calendar: calendar)
+    }
+
+    public func flags(asOf date: Date, calendar: Calendar = .current) -> Set<RecurringStreamFlag> {
+        var flags: Set<RecurringStreamFlag> = []
+        if hasPriceIncrease {
+            flags.insert(.priceIncrease)
+        }
+        if isStale(asOf: date, calendar: calendar) {
+            flags.insert(.stale)
+        }
+        return flags
+    }
+
+    public func flags(asOf dateString: String, calendar: Calendar = .current) -> Set<RecurringStreamFlag> {
+        guard let date = Formatters.parseTransactionDate(dateString) else {
+            return hasPriceIncrease ? [.priceIncrease] : []
+        }
+        return flags(asOf: date, calendar: calendar)
+    }
+}
+
+public struct RecurringPriceIncrease: Sendable, Hashable {
+    public let latestAmount: Double
+    public let trailingAverageAmount: Double
+    public let absoluteIncrease: Double
+    public let relativeIncrease: Double
+}
+
+public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
+    case priceIncrease
+    case stale
 }
 
 public enum RecurringFrequency: String, Codable, Sendable, CaseIterable, Hashable {

--- a/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
@@ -201,7 +201,7 @@ public enum LocalAIInsightInputBuilder {
             )
         }
         let accountSnapshot = accountSnapshot(from: accounts)
-        let recurringSnapshot = recurringSnapshot(from: recurringTransactions)
+        let recurringSnapshot = recurringSnapshot(from: recurringTransactions, asOf: anchorDate, calendar: calendar)
 
         var evidence: [LocalAIInsightEvidence] = [
             LocalAIInsightEvidence(
@@ -266,7 +266,11 @@ public enum LocalAIInsightInputBuilder {
         )
     }
 
-    public static func recurringSnapshot(from recurringTransactions: [RecurringTransaction])
+    public static func recurringSnapshot(
+        from recurringTransactions: [RecurringTransaction],
+        asOf date: Date? = nil,
+        calendar: Calendar = .current
+    )
         -> LocalAIRecurringSnapshot
     {
         let items = recurringTransactions.map { recurring in
@@ -292,7 +296,11 @@ public enum LocalAIInsightInputBuilder {
         .sorted { $0.estimatedMonthlyAmount > $1.estimatedMonthlyAmount }
 
         return LocalAIRecurringSnapshot(
-            estimatedMonthlyTotal: RecurringSummary.estimatedMonthlyTotal(from: recurringTransactions),
+            estimatedMonthlyTotal: RecurringSummary.estimatedMonthlyTotal(
+                from: recurringTransactions,
+                asOf: date,
+                calendar: calendar
+            ),
             items: items
         )
     }

--- a/Sources/PlaidBarCore/Utilities/RecurringDetector.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringDetector.swift
@@ -35,6 +35,11 @@ public enum RecurringDetector {
             guard confidence >= 0.3 else { continue }
 
             let averageAmount = sorted.reduce(0.0) { $0 + $1.displayAmount } / Double(sorted.count)
+            let previousTransactions = sorted.dropLast()
+            let trailingAverageAmount = previousTransactions.isEmpty
+                ? nil
+                : previousTransactions.reduce(0.0) { $0 + $1.displayAmount } / Double(previousTransactions.count)
+            let latestAmount = sorted.last!.displayAmount
             let lastDate = sorted.last!.date
             let nextExpected = computeNextDate(from: lastDate, frequency: frequency)
             let category = sorted.last!.category
@@ -43,6 +48,8 @@ public enum RecurringDetector {
                 merchantName: merchant,
                 frequency: frequency,
                 averageAmount: averageAmount,
+                latestAmount: latestAmount,
+                trailingAverageAmount: trailingAverageAmount,
                 lastDate: lastDate,
                 nextExpectedDate: nextExpected,
                 category: category,

--- a/Sources/PlaidBarCore/Utilities/RecurringSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringSummary.swift
@@ -2,9 +2,16 @@ import Foundation
 
 public enum RecurringSummary {
     public static func estimatedMonthlyTotal(
-        from recurringTransactions: [RecurringTransaction]
+        from recurringTransactions: [RecurringTransaction],
+        asOf date: Date? = nil,
+        calendar: Calendar = .current
     ) -> Double {
-        recurringTransactions.reduce(0) {
+        recurringTransactions
+            .filter { recurring in
+                guard let date else { return true }
+                return !recurring.isStale(asOf: date, calendar: calendar)
+            }
+            .reduce(0) {
             $0 + $1.averageAmount * $1.frequency.monthlyMultiplier
         }
     }

--- a/Tests/PlaidBarCoreTests/RecurringStreamFlagTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringStreamFlagTests.swift
@@ -1,0 +1,125 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Recurring stream flags")
+struct RecurringStreamFlagTests {
+    @Test("Detector marks price increase at the relative and absolute thresholds")
+    func detectorMarksPriceIncreaseAtThresholds() throws {
+        let recurring = try #require(RecurringDetector.detect(from: [
+            Self.transaction(id: "one", amount: 10, date: "2026-01-15"),
+            Self.transaction(id: "two", amount: 10, date: "2026-02-15"),
+            Self.transaction(id: "three", amount: 11, date: "2026-03-15"),
+        ]).first)
+
+        #expect(recurring.latestAmount == 11)
+        #expect(recurring.trailingAverageAmount == 10)
+        #expect(recurring.hasPriceIncrease)
+        #expect(recurring.flags(asOf: "2026-03-16") == [RecurringStreamFlag.priceIncrease])
+        #expect(abs((recurring.priceIncrease?.absoluteIncrease ?? 0) - 1) < 0.001)
+        #expect(abs((recurring.priceIncrease?.relativeIncrease ?? 0) - 0.10) < 0.001)
+    }
+
+    @Test("Price increase requires confidence, relative, and absolute thresholds")
+    func priceIncreaseRequiresAllThresholds() {
+        let lowConfidence = Self.recurring(
+            latestAmount: 11,
+            trailingAverageAmount: 10,
+            confidence: 0.59
+        )
+        let lowRelativeIncrease = Self.recurring(
+            latestAmount: 21.50,
+            trailingAverageAmount: 20,
+            confidence: 0.9
+        )
+        let lowAbsoluteIncrease = Self.recurring(
+            latestAmount: 5.50,
+            trailingAverageAmount: 5,
+            confidence: 0.9
+        )
+
+        #expect(!lowConfidence.hasPriceIncrease)
+        #expect(!lowRelativeIncrease.hasPriceIncrease)
+        #expect(!lowAbsoluteIncrease.hasPriceIncrease)
+    }
+
+    @Test("Stale stream starts after twice the expected interval")
+    func staleStreamStartsAfterTwiceExpectedInterval() {
+        let monthly = Self.recurring(lastDate: "2026-03-15")
+
+        #expect(!monthly.isStale(asOf: "2026-05-14"))
+        #expect(monthly.isStale(asOf: "2026-05-15"))
+    }
+
+    @Test("Flags combine stale and price increase")
+    func flagsCombineStaleAndPriceIncrease() {
+        let stream = Self.recurring(
+            latestAmount: 12,
+            trailingAverageAmount: 10,
+            lastDate: "2026-03-15",
+            confidence: 0.95
+        )
+
+        #expect(stream.flags(asOf: "2026-05-15") == [
+            RecurringStreamFlag.priceIncrease,
+            RecurringStreamFlag.stale,
+        ])
+    }
+
+    @Test("Estimated monthly total can exclude stale streams")
+    func estimatedMonthlyTotalCanExcludeStaleStreams() {
+        let active = Self.recurring(
+            averageAmount: 30,
+            lastDate: "2026-04-15"
+        )
+        let stale = Self.recurring(
+            merchantName: "Dormant Gym",
+            averageAmount: 50,
+            lastDate: "2026-03-01"
+        )
+
+        let asOf = Formatters.parseTransactionDate("2026-05-01")
+
+        #expect(RecurringSummary.estimatedMonthlyTotal(from: [active, stale]) == 80)
+        #expect(RecurringSummary.estimatedMonthlyTotal(from: [active, stale], asOf: asOf) == 30)
+    }
+
+    private static func transaction(
+        id: String,
+        amount: Double,
+        date: String,
+        merchantName: String = "StreamCo"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: amount,
+            date: date,
+            name: merchantName,
+            merchantName: merchantName,
+            category: .subscriptions
+        )
+    }
+
+    private static func recurring(
+        merchantName: String = "StreamCo",
+        frequency: RecurringFrequency = .monthly,
+        averageAmount: Double = 10,
+        latestAmount: Double? = nil,
+        trailingAverageAmount: Double? = nil,
+        lastDate: String = "2026-03-15",
+        confidence: Double = 0.9
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchantName,
+            frequency: frequency,
+            averageAmount: averageAmount,
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            lastDate: lastDate,
+            nextExpectedDate: "2026-04-15",
+            category: .subscriptions,
+            transactionCount: 3,
+            confidence: confidence
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds recurring-stream price increase and stale-state flags from local transaction history.
- Lets monthly recurring totals exclude stale streams when an evaluation date is provided.
- Updates local app and Local AI recurring snapshots to use stale-aware recurring totals.

## Changes
- `RecurringTransaction` now carries latest/trailing amount metadata and exposes price-increase/stale flags.
- `RecurringDetector` computes latest and trailing averages from detected streams.
- `RecurringSummary` can exclude stale streams for date-aware totals.
- `AppState` and `LocalAIInsightInputBuilder` use stale-aware totals from local data only.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter RecurringStreamFlagTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`

## Notes
- This does not implement alert notifications or promote the recurring SwiftUI surface; those remain separate PRs.
- No new network calls or provider products are introduced.
