### PR TITLE
feat: add local insight runtime shell

### DIFF
--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -86,6 +86,8 @@ struct LocalAIInsightsService {
 
         var summaries: [LocalAIActivitySummary] = []
         summaries.reserveCapacity(inputs.count)
+        let currentAvailability = availability
+        let configuredModel = currentAvailability.state == .available ? model : nil
 
         for input in inputs {
             let fallbackSummary: @Sendable (LocalAIActivitySummaryInput) -> String = { input in
@@ -93,14 +95,18 @@ struct LocalAIInsightsService {
             }
             let generated = await LocalInsightModelRuntime.generateSummary(
                 input: input,
-                model: model,
+                model: configuredModel,
                 fallbackSummary: fallbackSummary,
                 configuration: generationConfiguration
+            )
+            let summaryAvailability = Self.summaryAvailability(
+                baseAvailability: currentAvailability,
+                generationResult: generated
             )
             summaries.append(
                 LocalAIActivitySummary(
                     window: input.window,
-                    availability: availability,
+                    availability: summaryAvailability,
                     input: input,
                     generatedSummary: generated.summary,
                     generatedBullets: Self.bullets(for: input),
@@ -115,6 +121,42 @@ struct LocalAIInsightsService {
     private static func isDisabledRuntimeValue(_ rawValue: String) -> Bool {
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return normalized.isEmpty || ["disabled", "off", "false", "none"].contains(normalized)
+    }
+
+    private static func summaryAvailability(
+        baseAvailability: LocalAIAvailability,
+        generationResult: LocalInsightModelGenerationResult
+    ) -> LocalAIAvailability {
+        guard baseAvailability.state == .available,
+              generationResult.usedModelOutput == false,
+              let fallbackReason = generationResult.fallbackReason
+        else {
+            return baseAvailability
+        }
+
+        return LocalAIAvailability(
+            state: .unavailable,
+            runtimeName: baseAvailability.runtimeName,
+            detail: fallbackDetail(runtimeName: baseAvailability.runtimeName, reason: fallbackReason)
+        )
+    }
+
+    private static func fallbackDetail(
+        runtimeName: String?,
+        reason: LocalInsightModelFallbackReason
+    ) -> String {
+        let runtime = runtimeName.map { "Local runtime '\($0)'" } ?? "The configured local runtime"
+        let reasonText = switch reason {
+        case .noModel:
+            "has no model adapter"
+        case .timeout:
+            "timed out before producing output"
+        case .modelError:
+            "returned an error"
+        case .invalidOutput:
+            "returned invalid output"
+        }
+        return "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
     }
 
     private static func summaryText(for input: LocalAIActivitySummaryInput) -> String {

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -6,21 +6,43 @@ struct LocalAIInsightsService {
         static let localRuntime = "PLAIDBAR_LOCAL_AI_RUNTIME"
     }
 
+    private let model: (any LocalInsightModel)?
+    private let environment: [String: String]
+    private let generationConfiguration: LocalInsightModelGenerationConfiguration
+
+    init(
+        model: (any LocalInsightModel)? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        generationConfiguration: LocalInsightModelGenerationConfiguration = .default
+    ) {
+        self.model = model
+        self.environment = environment
+        self.generationConfiguration = generationConfiguration
+    }
+
     var availability: LocalAIAvailability {
-        let runtime = ProcessInfo.processInfo.environment[EnvironmentKeys.localRuntime]?
+        let runtime = environment[EnvironmentKeys.localRuntime]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard let runtime, !runtime.isEmpty, runtime.lowercased() != "disabled" else {
+        guard let runtime, !Self.isDisabledRuntimeValue(runtime) else {
             return LocalAIAvailability(
                 state: .disabled,
                 detail: "No local AI runtime is configured. VaultPeek is using deterministic local summaries and category hints only."
             )
         }
 
+        if model != nil {
+            return LocalAIAvailability(
+                state: .available,
+                runtimeName: runtime,
+                detail: "Local runtime '\(runtime)' is configured. Summaries run on this Mac with a short timeout, output validation, and deterministic fallback."
+            )
+        }
+
         return LocalAIAvailability(
             state: .unavailable,
             runtimeName: runtime,
-            detail: "Local runtime '\(runtime)' is configured, but this build has no model adapter yet. Cloud models are not supported."
+            detail: "Local runtime '\(runtime)' is configured, but this build has no model adapter yet. Deterministic summaries remain active; cloud models are not supported."
         )
     }
 
@@ -42,21 +64,67 @@ struct LocalAIInsightsService {
                 window: input.window,
                 availability: availability,
                 input: input,
-                generatedSummary: summaryText(for: input),
-                generatedBullets: bullets(for: input),
+                generatedSummary: Self.summaryText(for: input),
+                generatedBullets: Self.bullets(for: input),
                 evidence: input.evidence
             )
         }
     }
 
-    private func summaryText(for input: LocalAIActivitySummaryInput) -> String {
+    func generatedActivitySummaries(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        recurringTransactions: [RecurringTransaction],
+        anchorDate: Date = Date()
+    ) async -> [LocalAIActivitySummary] {
+        let inputs = LocalAIInsightInputBuilder.buildInputs(
+            accounts: accounts,
+            transactions: transactions,
+            recurringTransactions: recurringTransactions,
+            anchorDate: anchorDate
+        )
+
+        var summaries: [LocalAIActivitySummary] = []
+        summaries.reserveCapacity(inputs.count)
+
+        for input in inputs {
+            let fallbackSummary: @Sendable (LocalAIActivitySummaryInput) -> String = { input in
+                Self.summaryText(for: input)
+            }
+            let generated = await LocalInsightModelRuntime.generateSummary(
+                input: input,
+                model: model,
+                fallbackSummary: fallbackSummary,
+                configuration: generationConfiguration
+            )
+            summaries.append(
+                LocalAIActivitySummary(
+                    window: input.window,
+                    availability: availability,
+                    input: input,
+                    generatedSummary: generated.summary,
+                    generatedBullets: Self.bullets(for: input),
+                    evidence: input.evidence
+                )
+            )
+        }
+
+        return summaries
+    }
+
+    private static func isDisabledRuntimeValue(_ rawValue: String) -> Bool {
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty || ["disabled", "off", "false", "none"].contains(normalized)
+    }
+
+    private static func summaryText(for input: LocalAIActivitySummaryInput) -> String {
         let expenseText = Formatters.currency(input.current.expenseTotal, format: .compact)
         let incomeText = Formatters.currency(input.current.incomeTotal, format: .compact)
         let netText = signedCurrency(input.current.netCashflow)
         return "\(input.window.displayName): \(expenseText) expenses, \(incomeText) income, \(netText) net cashflow."
     }
 
-    private func bullets(for input: LocalAIActivitySummaryInput) -> [String] {
+    private static func bullets(for input: LocalAIActivitySummaryInput) -> [String] {
         var bullets: [String] = []
 
         if let topCategory = input.current.categoryTotals.first {
@@ -100,7 +168,7 @@ struct LocalAIInsightsService {
         return Array(bullets.prefix(4))
     }
 
-    private func signedCurrency(_ amount: Double) -> String {
+    private static func signedCurrency(_ amount: Double) -> String {
         let prefix = amount > 0 ? "+" : amount < 0 ? "-" : ""
         return "\(prefix)\(Formatters.currency(abs(amount), format: .compact))"
     }

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -346,7 +346,9 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         if availability.state == .disabled {
             result.append("Local AI is off; this receipt uses deterministic local totals and heuristics.")
         } else if availability.state == .unavailable {
-            result.append("The configured local runtime is unavailable; VaultPeek does not fall back to cloud AI.")
+            result.append(availability.detail.isEmpty
+                ? "The configured local runtime is unavailable; VaultPeek does not fall back to cloud AI."
+                : availability.detail)
         }
 
         if input.current.transactionCount == 0 {

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+public struct LocalInsightModelGenerationConfiguration: Sendable, Equatable {
+    public static let `default` = LocalInsightModelGenerationConfiguration()
+
+    public let maxTokens: Int
+    public let maxOutputCharacters: Int
+    public let timeoutNanoseconds: UInt64
+
+    public init(
+        maxTokens: Int = 96,
+        maxOutputCharacters: Int = 320,
+        timeoutNanoseconds: UInt64 = 1_500_000_000
+    ) {
+        self.maxTokens = max(1, maxTokens)
+        self.maxOutputCharacters = max(80, maxOutputCharacters)
+        self.timeoutNanoseconds = max(1_000_000, timeoutNanoseconds)
+    }
+}
+
+public enum LocalInsightModelFallbackReason: String, Sendable, Hashable {
+    case noModel
+    case timeout
+    case modelError
+    case invalidOutput
+}
+
+public struct LocalInsightModelGenerationResult: Sendable, Equatable {
+    public let summary: String
+    public let usedModelOutput: Bool
+    public let fallbackReason: LocalInsightModelFallbackReason?
+
+    public init(
+        summary: String,
+        usedModelOutput: Bool,
+        fallbackReason: LocalInsightModelFallbackReason?
+    ) {
+        self.summary = summary
+        self.usedModelOutput = usedModelOutput
+        self.fallbackReason = fallbackReason
+    }
+}
+
+public enum LocalInsightModelOutputRejectionReason: String, Sendable, Hashable {
+    case empty
+    case echoedPrompt
+    case garbage
+}
+
+public enum LocalInsightModelOutputValidationResult: Sendable, Equatable {
+    case accepted(String)
+    case rejected(LocalInsightModelOutputRejectionReason)
+}
+
+public enum LocalInsightModelOutputValidator {
+    public static func validate(
+        _ output: String,
+        prompt: LocalInsightModelPrompt,
+        maxCharacters: Int = LocalInsightModelGenerationConfiguration.default.maxOutputCharacters
+    ) -> LocalInsightModelOutputValidationResult {
+        let normalized = normalizedDisplayText(output)
+
+        guard !normalized.isEmpty else {
+            return .rejected(.empty)
+        }
+
+        guard !looksLikePromptEcho(normalized, prompt: prompt) else {
+            return .rejected(.echoedPrompt)
+        }
+
+        guard !looksLikeGarbage(normalized) else {
+            return .rejected(.garbage)
+        }
+
+        let capped = String(normalized.prefix(max(1, maxCharacters)))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !capped.isEmpty else {
+            return .rejected(.empty)
+        }
+
+        return .accepted(capped)
+    }
+
+    private static func normalizedDisplayText(_ output: String) -> String {
+        output
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func looksLikePromptEcho(
+        _ output: String,
+        prompt: LocalInsightModelPrompt
+    ) -> Bool {
+        let normalizedOutput = normalizedForComparison(output)
+        let promptParts = [prompt.system, prompt.user]
+            + prompt.system.components(separatedBy: .newlines)
+            + prompt.user.components(separatedBy: .newlines)
+
+        for part in promptParts {
+            let normalizedPart = normalizedForComparison(part)
+            if normalizedPart.count >= 24, normalizedOutput.contains(normalizedPart) {
+                return true
+            }
+        }
+
+        let lowercasedOutput = output.lowercased()
+        if lowercasedOutput.hasPrefix("period:") || lowercasedOutput.hasPrefix("totals:") {
+            return true
+        }
+
+        let promptMarkers = [
+            "period:",
+            "totals:",
+            "top categories:",
+            "largest expenses:",
+            "versus the prior period:",
+            "estimated recurring monthly cost:",
+            "you are vaultpeek",
+            "rules:",
+        ]
+        let markerCount = promptMarkers.reduce(0) { count, marker in
+            lowercasedOutput.contains(marker) ? count + 1 : count
+        }
+        return markerCount >= 2
+    }
+
+    private static func looksLikeGarbage(_ output: String) -> Bool {
+        if output.contains("\u{FFFD}") {
+            return true
+        }
+
+        let scalars = output.unicodeScalars
+        if scalars.contains(where: { scalar in
+            scalar.value < 32 && scalar.value != 9 && scalar.value != 10 && scalar.value != 13
+        }) {
+            return true
+        }
+
+        let nonWhitespace = Array(scalars.filter { !CharacterSet.whitespacesAndNewlines.contains($0) })
+        guard !nonWhitespace.isEmpty else {
+            return true
+        }
+
+        let alphanumericCount = nonWhitespace.filter { CharacterSet.alphanumerics.contains($0) }.count
+        if alphanumericCount < 12 {
+            return true
+        }
+
+        let alphanumericRatio = Double(alphanumericCount) / Double(nonWhitespace.count)
+        if alphanumericRatio < 0.35 {
+            return true
+        }
+
+        return longestRepeatedScalarRun(in: nonWhitespace) >= 16
+    }
+
+    private static func longestRepeatedScalarRun(in scalars: [UnicodeScalar]) -> Int {
+        var longest = 0
+        var currentRun = 0
+        var previous: UnicodeScalar?
+
+        for scalar in scalars {
+            if scalar == previous {
+                currentRun += 1
+            } else {
+                currentRun = 1
+                previous = scalar
+            }
+            longest = max(longest, currentRun)
+        }
+
+        return longest
+    }
+
+    private static func normalizedForComparison(_ text: String) -> String {
+        text
+            .lowercased()
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+public enum LocalInsightModelRuntime {
+    public static func generateSummary(
+        input: LocalAIActivitySummaryInput,
+        model: (any LocalInsightModel)?,
+        fallbackSummary: @Sendable (LocalAIActivitySummaryInput) -> String,
+        configuration: LocalInsightModelGenerationConfiguration = .default
+    ) async -> LocalInsightModelGenerationResult {
+        let fallback = fallbackSummary(input)
+        guard let model else {
+            return LocalInsightModelGenerationResult(
+                summary: fallback,
+                usedModelOutput: false,
+                fallbackReason: .noModel
+            )
+        }
+
+        let prompt = LocalInsightPromptBuilder.make(from: input)
+        let rawOutput: String
+
+        do {
+            rawOutput = try await withTimeout(nanoseconds: configuration.timeoutNanoseconds) {
+                try await model.summarize(prompt, maxTokens: configuration.maxTokens)
+            }
+        } catch is LocalInsightModelTimeoutError {
+            return LocalInsightModelGenerationResult(
+                summary: fallback,
+                usedModelOutput: false,
+                fallbackReason: .timeout
+            )
+        } catch {
+            return LocalInsightModelGenerationResult(
+                summary: fallback,
+                usedModelOutput: false,
+                fallbackReason: .modelError
+            )
+        }
+
+        switch LocalInsightModelOutputValidator.validate(
+            rawOutput,
+            prompt: prompt,
+            maxCharacters: configuration.maxOutputCharacters
+        ) {
+        case .accepted(let summary):
+            return LocalInsightModelGenerationResult(
+                summary: summary,
+                usedModelOutput: true,
+                fallbackReason: nil
+            )
+        case .rejected:
+            return LocalInsightModelGenerationResult(
+                summary: fallback,
+                usedModelOutput: false,
+                fallbackReason: .invalidOutput
+            )
+        }
+    }
+
+    private static func withTimeout<T: Sendable>(
+        nanoseconds: UInt64,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: nanoseconds)
+                throw LocalInsightModelTimeoutError()
+            }
+
+            guard let result = try await group.next() else {
+                group.cancelAll()
+                throw LocalInsightModelTimeoutError()
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
+private struct LocalInsightModelTimeoutError: Error {}

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
@@ -244,22 +244,94 @@ public enum LocalInsightModelRuntime {
         nanoseconds: UInt64,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
+        try await withCheckedThrowingContinuation { continuation in
+            let race = LocalInsightModelTimeoutRace(continuation: continuation)
+            let operationTask = Task {
+                do {
+                    let result = try await operation()
+                    race.complete(.success(result))
+                } catch {
+                    race.complete(.failure(error))
+                }
             }
-            group.addTask {
-                try await Task.sleep(nanoseconds: nanoseconds)
-                throw LocalInsightModelTimeoutError()
+            let timeoutTask = Task {
+                do {
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                    race.complete(.failure(LocalInsightModelTimeoutError()))
+                } catch {
+                    race.cancelTimeout()
+                }
             }
-
-            guard let result = try await group.next() else {
-                group.cancelAll()
-                throw LocalInsightModelTimeoutError()
-            }
-            group.cancelAll()
-            return result
+            race.setTasks(operationTask: operationTask, timeoutTask: timeoutTask)
         }
+    }
+}
+
+private final class LocalInsightModelTimeoutRace<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func setTasks(operationTask: Task<Void, Never>, timeoutTask: Task<Void, Never>) {
+        var shouldCancel = false
+        lock.lock()
+        if continuation == nil {
+            shouldCancel = true
+        } else {
+            self.operationTask = operationTask
+            self.timeoutTask = timeoutTask
+        }
+        lock.unlock()
+
+        if shouldCancel {
+            operationTask.cancel()
+            timeoutTask.cancel()
+        }
+    }
+
+    func complete(_ result: Result<T, Error>) {
+        let continuationToResume: CheckedContinuation<T, Error>?
+        let operationTaskToCancel: Task<Void, Never>?
+        let timeoutTaskToCancel: Task<Void, Never>?
+
+        lock.lock()
+        continuationToResume = continuation
+        continuation = nil
+        operationTaskToCancel = operationTask
+        timeoutTaskToCancel = timeoutTask
+        operationTask = nil
+        timeoutTask = nil
+        lock.unlock()
+
+        guard let continuationToResume else {
+            return
+        }
+
+        operationTaskToCancel?.cancel()
+        timeoutTaskToCancel?.cancel()
+
+        switch result {
+        case .success(let value):
+            continuationToResume.resume(returning: value)
+        case .failure(let error):
+            continuationToResume.resume(throwing: error)
+        }
+    }
+
+    func cancelTimeout() {
+        let timeoutTaskToCancel: Task<Void, Never>?
+
+        lock.lock()
+        timeoutTaskToCancel = timeoutTask
+        timeoutTask = nil
+        lock.unlock()
+
+        timeoutTaskToCancel?.cancel()
     }
 }
 

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -72,6 +72,30 @@ struct LocalAIInsightReceiptTests {
         #expect(receipt.reversibleActionCopy.contains("No insight action is available yet"))
     }
 
+    @Test("Receipt surfaces configured runtime fallback details")
+    func receiptSurfacesConfiguredRuntimeFallbackDetails() {
+        let fallbackAvailability = LocalAIAvailability(
+            state: .unavailable,
+            runtimeName: "local-runtime",
+            detail: "Local runtime 'local-runtime' timed out before producing output. VaultPeek used deterministic local summaries and did not call cloud AI."
+        )
+        let input = makeInput(transactionCount: 2, includeCategorySuggestion: false)
+        let summary = LocalAIActivitySummary(
+            window: .last7days,
+            availability: fallbackAvailability,
+            input: input,
+            generatedSummary: "Last 7D: deterministic fallback summary.",
+            generatedBullets: [],
+            evidence: input.evidence
+        )
+
+        let receipt = LocalAIInsightReceipt.make(summary: summary, availability: fallbackAvailability)
+
+        #expect(receipt.confidence.contains("Deterministic confidence"))
+        #expect(receipt.limitations.contains { $0.contains("timed out before producing output") })
+        #expect(receipt.limitations.contains { $0.contains("did not call cloud AI") })
+    }
+
     @Test("Receipt makes category hint action reversible and non-mutating")
     func receiptExplainsReversibleCategoryHintAction() {
         let input = makeInput(transactionCount: 1, includeCategorySuggestion: true)

--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -105,6 +105,28 @@ struct LocalInsightModelRuntimeTests {
         #expect(result.fallbackReason == .timeout)
     }
 
+    @Test("Runtime timeout returns without waiting for cancellation-ignoring models")
+    func runtimeTimeoutDoesNotWaitForCancellationIgnoringModel() async {
+        let model = CancellationIgnoringLocalInsightModel(
+            output: "Food spending was the largest driver this month.",
+            delaySeconds: 0.2
+        )
+        let startedAt = Date()
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" },
+            configuration: LocalInsightModelGenerationConfiguration(timeoutNanoseconds: 1_000_000)
+        )
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .timeout)
+        #expect(elapsed < 0.15)
+    }
+
     private func input() -> LocalAIActivitySummaryInput {
         let current = LocalAIActivityMetrics(
             transactionCount: 4,
@@ -173,6 +195,19 @@ private struct DelayedLocalInsightModel: LocalInsightModel {
 
     func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
         try await Task.sleep(nanoseconds: delayNanoseconds)
+        return output
+    }
+}
+
+private struct CancellationIgnoringLocalInsightModel: LocalInsightModel {
+    let output: String
+    let delaySeconds: TimeInterval
+
+    func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
+        let deadline = Date().addingTimeInterval(delaySeconds)
+        while Date() < deadline {
+            _ = 1 + 1
+        }
         return output
     }
 }

--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Local Insight Model Runtime Tests")
+struct LocalInsightModelRuntimeTests {
+    @Test("Output validator accepts clean summaries and caps length")
+    func validatorAcceptsAndCapsCleanSummary() {
+        let prompt = LocalInsightPromptBuilder.make(from: input())
+        let output = "Dining led spending this month, with groceries close behind. Net cashflow stayed positive after income."
+
+        let result = LocalInsightModelOutputValidator.validate(
+            output,
+            prompt: prompt,
+            maxCharacters: 42
+        )
+
+        #expect(result == .accepted(String(output.prefix(42))))
+    }
+
+    @Test("Output validator rejects empty, garbage, and echoed prompt output")
+    func validatorRejectsUnsafeOutput() {
+        let prompt = LocalInsightPromptBuilder.make(from: input())
+
+        #expect(LocalInsightModelOutputValidator.validate("   ", prompt: prompt) == .rejected(.empty))
+        #expect(LocalInsightModelOutputValidator.validate("!!!!!!!!!?????", prompt: prompt) == .rejected(.garbage))
+        #expect(LocalInsightModelOutputValidator.validate(prompt.user, prompt: prompt) == .rejected(.echoedPrompt))
+        #expect(LocalInsightModelOutputValidator.validate("Period: Last Month. Totals: expenses are listed.", prompt: prompt) == .rejected(.echoedPrompt))
+    }
+
+    @Test("Runtime falls back when no model is configured")
+    func runtimeFallsBackWithoutModel() async {
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: nil,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .noModel)
+    }
+
+    @Test("Runtime accepts valid model output")
+    func runtimeAcceptsValidModelOutput() async {
+        let model = StubLocalInsightModel(result: .success("Food spending was the largest driver this month. Net cashflow stayed positive."))
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "Food spending was the largest driver this month. Net cashflow stayed positive.")
+        #expect(result.usedModelOutput == true)
+        #expect(result.fallbackReason == nil)
+    }
+
+    @Test("Runtime falls back when model output is invalid")
+    func runtimeFallsBackForInvalidModelOutput() async {
+        let model = StubLocalInsightModel(result: .success("Period: Last Month. Totals: expenses were listed."))
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .invalidOutput)
+    }
+
+    @Test("Runtime falls back on model error")
+    func runtimeFallsBackForModelError() async {
+        let model = StubLocalInsightModel(result: .failure(StubModelError()))
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .modelError)
+    }
+
+    @Test("Runtime falls back when model exceeds timeout")
+    func runtimeFallsBackForTimeout() async {
+        let model = DelayedLocalInsightModel(
+            output: "Food spending was the largest driver this month.",
+            delayNanoseconds: 20_000_000
+        )
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" },
+            configuration: LocalInsightModelGenerationConfiguration(timeoutNanoseconds: 1_000_000)
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .timeout)
+    }
+
+    private func input() -> LocalAIActivitySummaryInput {
+        let current = LocalAIActivityMetrics(
+            transactionCount: 4,
+            incomeTotal: 3000,
+            expenseTotal: 420,
+            netCashflow: 2580,
+            incomeTransactionIds: [],
+            expenseTransactionIds: [],
+            transferTransactionIds: [],
+            categoryTotals: [
+                LocalAICategoryTotal(
+                    category: .foodAndDrink,
+                    totalAmount: 240,
+                    transactionCount: 2,
+                    transactionIds: [],
+                    evidence: []
+                ),
+            ],
+            topExpenses: [
+                LocalAITransactionInsightItem(
+                    transactionId: "redacted-test-transaction",
+                    accountId: "redacted-test-account",
+                    date: "2026-06-10",
+                    displayName: "Grocery Demo",
+                    amount: 120,
+                    effectiveCategory: .foodAndDrink,
+                    plaidCategory: .foodAndDrink,
+                    categorySource: .plaidCategory,
+                    pending: false,
+                    evidence: []
+                ),
+            ],
+            topIncome: []
+        )
+
+        return LocalAIActivitySummaryInput(
+            window: .lastMonth,
+            currentRange: LocalAIInsightDateRange(startDate: "2026-05-13", endDate: "2026-06-11"),
+            priorRange: nil,
+            accountSnapshot: LocalAIAccountSnapshot(
+                accountCount: 1,
+                accountIds: [],
+                cashTotal: 3000,
+                debtTotal: 0,
+                creditUtilization: nil
+            ),
+            current: current,
+            prior: nil,
+            recurringSnapshot: LocalAIRecurringSnapshot(estimatedMonthlyTotal: 0, items: []),
+            evidence: []
+        )
+    }
+}
+
+private struct StubLocalInsightModel: LocalInsightModel {
+    let result: Result<String, Error>
+
+    func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
+        try result.get()
+    }
+}
+
+private struct DelayedLocalInsightModel: LocalInsightModel {
+    let output: String
+    let delayNanoseconds: UInt64
+
+    func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
+        try await Task.sleep(nanoseconds: delayNanoseconds)
+        return output
+    }
+}
+
+private struct StubModelError: Error {}


### PR DESCRIPTION
## Summary
- Adds a local model runtime shell for activity summaries with timeout, output validation, and deterministic fallback behavior.
- Keeps the default app behavior local and deterministic unless an in-process model adapter is explicitly supplied.
- Documents configured runtime states without adding MLX, cloud AI, network calls, or model dependencies.

## Changes
- `Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift`: prompt execution wrapper, fallback reasons, output validator, and timeout handling.
- `Sources/PlaidBar/Services/LocalAIInsightsService.swift`: injectable runtime environment/model hook and async generated-summary path while preserving existing sync deterministic summaries.
- `Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift`: validation, fallback, model-error, and timeout coverage.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter LocalInsightModelRuntimeTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] Targeted scan of changed Local AI files for secrets, Plaid tokens, raw payload, account/transaction identifier, screenshot, and SQLite terms
- [ ] Manual Apple Silicon model generation proof after the MLX adapter PR exists

## Notes
- AND-322 runtime-shell slice only. The MLX Gemma adapter remains a separate PR.
- No app-target MLX dependency is introduced here, and `PlaidBarCore`/`PlaidBarServer` remain model-free.
