### PR TITLE
feat: add provider abstraction foundation

### DIFF
--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -46,6 +46,7 @@ struct PlaidBarServer: AsyncParsableCommand {
 
         // Register migrations
         await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
         try await fluent.migrate()
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)

--- a/Sources/PlaidBarServer/Providers/BankDataProvider.swift
+++ b/Sources/PlaidBarServer/Providers/BankDataProvider.swift
@@ -1,0 +1,119 @@
+import Foundation
+import PlaidBarCore
+
+enum ProviderID: String, Codable, CaseIterable, Sendable {
+    case plaid
+    case teller
+    case fixture
+}
+
+enum ProviderSyncStrategy: String, Codable, Sendable {
+    case cursor
+    case windowedRescan
+}
+
+enum ProviderBalanceCost: String, Codable, Sendable {
+    case includedWithSync
+    case billedPerCall
+}
+
+struct ProviderCapabilities: Equatable, Sendable {
+    let accountTypes: [AccountType]
+    let syncStrategy: ProviderSyncStrategy
+    let balanceCost: ProviderBalanceCost
+    let providesCreditLimit: Bool
+    let supportsHostedLink: Bool
+    let supportsUpdateModeRepair: Bool
+    let multipleConnectionsPerLinkSession: Bool
+    let geography: Set<String>
+
+    static let plaid = ProviderCapabilities(
+        accountTypes: [.depository, .credit, .loan, .investment, .other],
+        syncStrategy: .cursor,
+        balanceCost: .includedWithSync,
+        providesCreditLimit: true,
+        supportsHostedLink: true,
+        supportsUpdateModeRepair: true,
+        multipleConnectionsPerLinkSession: true,
+        geography: ["US"]
+    )
+
+    static let teller = ProviderCapabilities(
+        accountTypes: [.depository, .credit],
+        syncStrategy: .windowedRescan,
+        balanceCost: .billedPerCall,
+        providesCreditLimit: false,
+        supportsHostedLink: false,
+        supportsUpdateModeRepair: true,
+        multipleConnectionsPerLinkSession: false,
+        geography: ["US"]
+    )
+
+    static let fixture = ProviderCapabilities(
+        accountTypes: [.depository, .credit, .loan, .investment, .other],
+        syncStrategy: .cursor,
+        balanceCost: .includedWithSync,
+        providesCreditLimit: true,
+        supportsHostedLink: false,
+        supportsUpdateModeRepair: false,
+        multipleConnectionsPerLinkSession: false,
+        geography: ["US"]
+    )
+}
+
+struct ProviderLinkRequest: Sendable {
+    let completionRedirectURI: String
+    let products: [String]
+}
+
+struct ProviderLinkSession: Sendable {
+    let sessionID: String
+    let url: String
+}
+
+struct ProviderLinkCompletion: Sendable {
+    let sessionID: String
+    let verifier: String
+}
+
+struct ProviderConnectionCredential: Sendable {
+    let storedToken: String
+}
+
+struct ProviderNewConnection: Sendable {
+    let providerConnectionID: String
+    let credential: ProviderConnectionCredential
+    let institutionID: String?
+    let institutionName: String?
+}
+
+struct ProviderSyncState: Sendable {
+    let rawValue: String?
+}
+
+struct ProviderSyncDelta: Sendable {
+    let added: [TransactionDTO]
+    let modified: [TransactionDTO]
+    let removed: [String]
+    let hasMore: Bool
+    let nextState: ProviderSyncState
+}
+
+protocol BankDataProvider: Sendable {
+    var id: ProviderID { get }
+    var capabilities: ProviderCapabilities { get }
+
+    func connectInstitution(_ request: ProviderLinkRequest) async throws -> ProviderLinkSession
+    func completeConnect(_ completion: ProviderLinkCompletion) async throws -> [ProviderNewConnection]
+    func listAccounts(credential: ProviderConnectionCredential) async throws -> [AccountDTO]
+    func getBalances(credential: ProviderConnectionCredential) async throws -> [AccountDTO]
+    func syncTransactions(
+        credential: ProviderConnectionCredential,
+        state: ProviderSyncState
+    ) async throws -> ProviderSyncDelta
+    func refreshConnection(
+        credential: ProviderConnectionCredential,
+        request: ProviderLinkRequest
+    ) async throws -> ProviderLinkSession
+    func disconnectInstitution(credential: ProviderConnectionCredential) async throws
+}

--- a/Sources/PlaidBarServer/Storage/Database.swift
+++ b/Sources/PlaidBarServer/Storage/Database.swift
@@ -21,6 +21,9 @@ final class ItemModel: Model, @unchecked Sendable {
     @Field(key: "status")
     var status: String
 
+    @OptionalField(key: "provider")
+    var provider: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
@@ -33,13 +36,19 @@ final class ItemModel: Model, @unchecked Sendable {
         id: String,
         accessToken: String,
         institutionId: String? = nil,
-        institutionName: String? = nil
+        institutionName: String? = nil,
+        providerID: ProviderID = .plaid
     ) {
         self.id = id
         self.accessToken = accessToken
         self.institutionId = institutionId
         self.institutionName = institutionName
         self.status = "connected"
+        self.provider = providerID.rawValue
+    }
+
+    var providerID: ProviderID {
+        ProviderID(rawValue: provider ?? "") ?? .plaid
     }
 }
 
@@ -96,5 +105,25 @@ struct CreateSyncCursors: AsyncMigration {
 
     func revert(on database: Database) async throws {
         try await database.schema("sync_cursors").delete()
+    }
+}
+
+struct AddProviderToItems: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("items")
+            .field("provider", .string)
+            .update()
+
+        let rows = try await ItemModel.query(on: database).all()
+        for row in rows where row.provider == nil {
+            row.provider = ProviderID.plaid.rawValue
+            try await row.save(on: database)
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("items")
+            .deleteField("provider")
+            .update()
     }
 }

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -18,7 +18,8 @@ actor TokenStore {
         id: String,
         accessToken: String,
         institutionId: String?,
-        institutionName: String?
+        institutionName: String?,
+        providerID: ProviderID = .plaid
     ) async throws {
         let storedAccessToken = try PlaidTokenVault.store(
             accessToken: accessToken,
@@ -28,7 +29,8 @@ actor TokenStore {
             id: id,
             accessToken: storedAccessToken,
             institutionId: institutionId,
-            institutionName: institutionName
+            institutionName: institutionName,
+            providerID: providerID
         )
         try await item.save(on: fluent.db())
     }
@@ -39,6 +41,12 @@ actor TokenStore {
 
     func getAllItems() async throws -> [ItemModel] {
         try await ItemModel.query(on: fluent.db()).all()
+    }
+
+    func getAllItems(providerID: ProviderID) async throws -> [ItemModel] {
+        try await ItemModel.query(on: fluent.db())
+            .filter(\.$provider == providerID.rawValue)
+            .all()
     }
 
     func deleteItem(id: String) async throws {

--- a/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
+++ b/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
@@ -328,6 +328,7 @@ struct SandboxReliabilityTests {
         let fluent = Fluent(logger: logger)
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?

--- a/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
+++ b/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
@@ -63,6 +63,8 @@ struct TokenStorageSafetyTests {
 
             let row = try #require(try await store.getItem(id: itemId))
             #expect(row.accessToken == "keychain:\(itemId)")
+            #expect(row.providerID == .plaid)
+            #expect(row.provider == ProviderID.plaid.rawValue)
             #expect(!row.accessToken.contains(rawToken))
             // The vault still resolves the reference back to the raw token.
             #expect(try store.accessToken(for: row) == rawToken)
@@ -95,6 +97,7 @@ struct TokenStorageSafetyTests {
         try await withTokenStore(databasePath: databasePath, logger: logger) { store in
             let restored = try #require(try await store.getItem(id: itemId))
             #expect(restored.accessToken == "keychain:\(itemId)")
+            #expect(restored.providerID == .plaid)
 
             try await store.deleteItem(id: itemId)
             #expect(try await store.getItem(id: itemId) == nil)
@@ -124,6 +127,68 @@ struct TokenStorageSafetyTests {
             storedToken: PlaidTokenVault.reference(for: itemId),
             fallbackItemId: itemId
         )
+    }
+
+    @Test(
+        "Provider-scoped item lookup isolates stored providers",
+        .enabled(if: tokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func providerScopedItemLookupIsolatesStoredProviders() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-provider-scope-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let plaidItemId = "test_item_plaid_\(UUID().uuidString)"
+        let fixtureItemId = "test_item_fixture_\(UUID().uuidString)"
+        defer {
+            for itemId in [plaidItemId, fixtureItemId] {
+                try? PlaidTokenVault.delete(
+                    storedToken: PlaidTokenVault.reference(for: itemId),
+                    fallbackItemId: itemId
+                )
+            }
+        }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-provider-scope.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.provider-scope")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(
+                id: plaidItemId,
+                accessToken: "access-sandbox-\(UUID().uuidString)",
+                institutionId: "ins_plaid",
+                institutionName: "Plaid Test Bank"
+            )
+            try await store.saveItem(
+                id: fixtureItemId,
+                accessToken: "access-sandbox-\(UUID().uuidString)",
+                institutionId: "ins_fixture",
+                institutionName: "Fixture Test Bank",
+                providerID: .fixture
+            )
+
+            let plaidItems = try await store.getAllItems(providerID: .plaid)
+            let fixtureItems = try await store.getAllItems(providerID: .fixture)
+
+            #expect(plaidItems.map(\.id).contains(plaidItemId))
+            #expect(!plaidItems.map(\.id).contains(fixtureItemId))
+            #expect(fixtureItems.map(\.id).contains(fixtureItemId))
+            #expect(!fixtureItems.map(\.id).contains(plaidItemId))
+        }
+    }
+
+    @Test("Missing item provider defaults to Plaid for legacy rows")
+    func missingItemProviderDefaultsToPlaid() {
+        let item = ItemModel(
+            id: "legacy_item",
+            accessToken: "keychain:legacy_item",
+            institutionId: nil,
+            institutionName: nil
+        )
+        item.provider = nil
+
+        #expect(item.providerID == .plaid)
     }
 
     @Test("Server config load keeps the data directory private")
@@ -205,6 +270,7 @@ struct TokenStorageSafetyTests {
         let fluent = Fluent(logger: logger)
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?


### PR DESCRIPTION
## Summary
- Adds a server-only bank-data provider contract and provider metadata foundation for future Plaid/Teller/fixture adapters.
- Adds an additive `items.provider` migration that defaults existing and newly saved rows to Plaid.
- Covers provider-scoped token-store lookup while keeping access tokens in the existing Keychain reference path.

## Changes
- `Sources/PlaidBarServer/Providers/BankDataProvider.swift`: provider IDs, capability metadata, and async provider protocol surface.
- `Sources/PlaidBarServer/Storage/Database.swift`: optional provider field, legacy Plaid default, and additive migration.
- `Sources/PlaidBarServer/Storage/TokenStore.swift`: provider-aware save and provider-scoped item lookup.
- `Tests/PlaidBarServerTests/*`: migration registration and token-storage safety coverage for provider defaults and provider-scoped lookup.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter TokenStorageSafetyTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test`
- [x] Targeted staged-diff scan for Plaid secrets, access/public tokens, raw payloads, account/transaction IDs, balances, SQLite/log/screenshot leaks

## Notes
- AND-346 foundation only. This does not implement Teller, Stripe entitlement checks, managed onboarding, broker calls, hosted Link lifecycle, or a blind proxy.
- Privacy promise remains local-first: provider credentials are represented only by stored server-side token references in the existing server storage path.
