### PR TITLE
feat: add wealth summary flyout

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -56,20 +56,15 @@ struct MainPopover: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            if let selectedAccount, !shouldShowSetupScreen {
-                AccountDetailFlyout(
-                    account: selectedAccount,
-                    isStatusFilter: selectedFilter == .status,
-                    onClose: { selectedAccountId = "" }
-                )
-                .environment(appState)
-                .frame(width: Layout.flyoutWidth)
-                // Cap the fly-out to the same screen-bounded height as the
-                // dashboard scroll column so tall detail content scrolls
-                // inside the fly-out instead of growing the whole popover
-                // past the intended screen-bounded height.
-                .frame(maxHeight: dashboardScrollHeight)
-                .transition(.move(edge: .leading).combined(with: .opacity))
+            if !shouldShowSetupScreen {
+                leftFlyout
+                    .frame(width: Layout.flyoutWidth)
+                    // Cap the fly-out to the same screen-bounded height as the
+                    // dashboard scroll column so tall detail content scrolls
+                    // inside the fly-out instead of growing the whole popover
+                    // past the intended screen-bounded height.
+                    .frame(maxHeight: dashboardScrollHeight)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
 
                 Divider()
             }
@@ -91,7 +86,7 @@ struct MainPopover: View {
         // letting AppKit re-center the widened popover under the menu bar item.
         .background {
             PopoverTrailingEdgeAnchor(
-                isExpanded: selectedAccount != nil && !shouldShowSetupScreen,
+                isExpanded: !shouldShowSetupScreen,
                 collapsedWidth: Layout.dashboardWidth
             )
         }
@@ -143,7 +138,22 @@ struct MainPopover: View {
         // Setup renders at the dashboard's width so first run never snaps
         // between window sizes.
         guard !shouldShowSetupScreen else { return Layout.dashboardWidth }
-        return Layout.dashboardWidth + (selectedAccount == nil ? 0 : Layout.flyoutWidth + 1)
+        return Layout.dashboardWidth + Layout.flyoutWidth + 1
+    }
+
+    @ViewBuilder
+    private var leftFlyout: some View {
+        if let selectedAccount {
+            AccountDetailFlyout(
+                account: selectedAccount,
+                isStatusFilter: selectedFilter == .status,
+                onClose: { selectedAccountId = "" }
+            )
+            .environment(appState)
+        } else {
+            WealthSummaryFlyout(onAddAccount: openAccountSetup)
+                .environment(appState)
+        }
     }
 
     private var transparencySetting: PopoverTransparencySetting {

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -1,0 +1,547 @@
+import PlaidBarCore
+import SwiftUI
+
+struct WealthSummaryFlyout: View {
+    @Environment(AppState.self) private var appState
+    let onAddAccount: () -> Void
+
+    private var presentation: WealthSummaryPresentation {
+        WealthSummaryPresentation.evaluate(
+            accounts: appState.accounts,
+            transactions: appState.transactions,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
+            linkedItemCount: appState.statusItemCount,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            itemStatuses: appState.itemStatuses,
+            isSyncStale: appState.isSyncStale,
+            lastSyncRelative: appState.lastSyncRelative,
+            statusSyncText: appState.statusSyncText,
+            errorMessage: appState.error,
+            creditUtilizationThreshold: appState.creditUtilizationThreshold
+        )
+    }
+
+    var body: some View {
+        let presentation = presentation
+
+        VStack(spacing: 0) {
+            header(presentation)
+                .padding(Spacing.md)
+
+            Divider()
+                .opacity(0.4)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    WealthMetricGrid(presentation: presentation)
+                        .loadingRedaction(appState.loadState(for: .summaryCards))
+
+                    WealthBalanceMixSection(presentation: presentation)
+                        .loadingRedaction(appState.loadState(for: .summaryCards))
+
+                    WealthCashflowSection(cashflow: presentation.cashflow)
+                        .loadingRedaction(appState.loadState(for: .transactions))
+
+                    WealthCreditSection(
+                        summary: presentation.creditUtilization,
+                        threshold: appState.creditUtilizationThreshold
+                    )
+                        .loadingRedaction(appState.loadState(for: .credit))
+
+                    WealthAttentionSection(summary: presentation.attention)
+
+                    if presentation.accountCount == 0 {
+                        Button(action: onAddAccount) {
+                            Label("Connect Bank", systemImage: "plus.circle")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+                .padding(Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilitySummary(presentation))
+    }
+
+    private func header(_ presentation: WealthSummaryPresentation) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Wealth Summary")
+                    .font(.headline.weight(.semibold))
+                    .lineLimit(1)
+
+                Spacer(minLength: Spacing.sm)
+
+                WealthSyncPill(summary: presentation.syncHealth)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Net worth")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Text(Formatters.currency(presentation.netWorth, format: .full))
+                    .displayBalance()
+                    .contentTransition(.numericText())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+            }
+        }
+    }
+
+    private func accessibilitySummary(_ presentation: WealthSummaryPresentation) -> String {
+        let netWorth = Formatters.currency(presentation.netWorth, format: .full)
+        let netCashflow = cashflowText(presentation.cashflow.net, format: .full)
+        return "Wealth summary. Net worth \(netWorth). 30 day net cashflow \(netCashflow). \(presentation.syncHealth.title). \(presentation.attention.detail)"
+    }
+}
+
+private struct WealthSyncPill: View {
+    let summary: WealthSummaryPresentation.SyncHealthSummary
+
+    var body: some View {
+        Label {
+            Text(shortTitle)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+        } icon: {
+            Image(systemName: summary.iconName)
+        }
+        .font(.caption.weight(.medium))
+        .foregroundStyle(tint)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
+        .help("\(summary.title). \(summary.detail)")
+        .accessibilityLabel("\(summary.title). \(summary.detail)")
+    }
+
+    private var shortTitle: String {
+        switch summary.severity {
+        case .healthy:
+            summary.title
+        case .warning:
+            "Attention"
+        case .blocked:
+            "Blocked"
+        }
+    }
+
+    private var tint: Color {
+        switch summary.severity {
+        case .healthy:
+            .secondary
+        case .warning:
+            SemanticColors.warning
+        case .blocked:
+            SemanticColors.negative
+        }
+    }
+}
+
+private struct WealthMetricGrid: View {
+    let presentation: WealthSummaryPresentation
+
+    private var columns: [GridItem] {
+        [
+            GridItem(.flexible(minimum: 108), spacing: Spacing.sm),
+            GridItem(.flexible(minimum: 108), spacing: Spacing.sm),
+        ]
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: Spacing.sm) {
+            WealthMetricTile(
+                title: "Assets",
+                value: Formatters.currency(presentation.totalAssets, format: .compact),
+                detail: "\(presentation.accountCount) accounts",
+                systemImage: "building.columns.fill"
+            )
+
+            WealthMetricTile(
+                title: "Debt",
+                value: Formatters.currency(presentation.totalDebt, format: .compact),
+                detail: presentation.totalDebt > 0 ? "Credit and loans" : "No debt synced",
+                systemImage: "creditcard.fill",
+                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : .secondary
+            )
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct WealthMetricTile: View {
+    let title: String
+    let value: String
+    let detail: String
+    let systemImage: String
+    var tint: Color = .secondary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: systemImage)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(tint)
+                Text(title)
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Text(value)
+                .dataText()
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+
+            Text(detail)
+                .microText()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.sm)
+        .glassSurface(.inset, cornerRadius: Radius.control)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(value). \(detail)")
+    }
+}
+
+private struct WealthBalanceMixSection: View {
+    let presentation: WealthSummaryPresentation
+
+    private let segmentSpacing: CGFloat = 2
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            WealthFlyoutSectionLabel("Balance mix")
+
+            if presentation.balanceMix.segments.isEmpty {
+                Label("No balances loaded", systemImage: "chart.pie")
+                    .detailText()
+                    .foregroundStyle(.secondary)
+            } else {
+                GeometryReader { proxy in
+                    HStack(spacing: segmentSpacing) {
+                        ForEach(presentation.balanceMix.segments) { segment in
+                            RoundedRectangle(cornerRadius: Radius.cell)
+                                .fill(tint(for: segment.id).opacity(0.82))
+                                .frame(
+                                    width: segmentWidth(
+                                        segment,
+                                        totalWidth: proxy.size.width,
+                                        segmentCount: presentation.balanceMix.segments.count
+                                    )
+                                )
+                                .accessibilityLabel(segmentAccessibility(segment))
+                        }
+                    }
+                }
+                .frame(height: 8)
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    ForEach(presentation.balanceMix.segments) { segment in
+                        WealthMixLegendRow(segment: segment, tint: tint(for: segment.id))
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func segmentWidth(
+        _ segment: BalanceCompositionPresentation.Segment,
+        totalWidth: CGFloat,
+        segmentCount: Int
+    ) -> CGFloat {
+        let gaps = CGFloat(max(segmentCount - 1, 0)) * segmentSpacing
+        let availableWidth = max(totalWidth - gaps, 0)
+        return max(availableWidth * CGFloat(segment.share), 6)
+    }
+
+    private func tint(for id: String) -> Color {
+        switch id {
+        case "cash":
+            Color.secondary.opacity(0.6)
+        case "investments":
+            Color.primary.opacity(0.36)
+        case "credit":
+            SemanticColors.creditDebt
+        case "loans":
+            SemanticColors.warning
+        default:
+            Color.secondary.opacity(0.6)
+        }
+    }
+
+    private func segmentAccessibility(_ segment: BalanceCompositionPresentation.Segment) -> String {
+        "\(segment.title), \(Formatters.currency(segment.value, format: .full)), \(percentText(segment.share)) of balance mix"
+    }
+}
+
+private struct WealthMixLegendRow: View {
+    let segment: BalanceCompositionPresentation.Segment
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Circle()
+                .fill(tint)
+                .frame(width: 7, height: 7)
+                .accessibilityHidden(true)
+
+            Text(segment.title)
+                .microText()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer(minLength: Spacing.sm)
+
+            Text(Formatters.currency(segment.value, format: .compact))
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+
+            Text(percentText(segment.share))
+                .microText()
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(segment.title): \(Formatters.currency(segment.value, format: .full)), \(percentText(segment.share))"
+        )
+    }
+}
+
+private struct WealthCashflowSection: View {
+    let cashflow: WealthSummaryPresentation.CashflowSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack {
+                WealthFlyoutSectionLabel("\(cashflow.windowDays)D cashflow")
+                Spacer()
+                Text("\(cashflow.transactionCount) tx")
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(spacing: Spacing.xs) {
+                WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income)
+                WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending)
+                WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private enum WealthCashflowRole {
+    case income
+    case spending
+    case net
+}
+
+private struct WealthCashflowRow: View {
+    let title: String
+    let amount: Double
+    let role: WealthCashflowRole
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label(title, systemImage: iconName)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            Text(amountText)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(accessibilityAmountText)")
+    }
+
+    private var iconName: String {
+        switch role {
+        case .income:
+            "arrow.down.circle.fill"
+        case .spending:
+            "arrow.up.circle.fill"
+        case .net:
+            amount >= 0 ? "plus.circle.fill" : "minus.circle.fill"
+        }
+    }
+
+    private var amountText: String {
+        switch role {
+        case .income, .net:
+            cashflowText(amount, format: .compact)
+        case .spending:
+            Formatters.currency(amount, format: .compact)
+        }
+    }
+
+    private var accessibilityAmountText: String {
+        switch role {
+        case .income, .net:
+            cashflowText(amount, format: .full)
+        case .spending:
+            Formatters.currency(amount, format: .full)
+        }
+    }
+
+    private var tint: Color {
+        switch role {
+        case .income:
+            return SemanticColors.positive
+        case .spending:
+            return .primary
+        case .net:
+            if amount > 0 { return SemanticColors.positive }
+            if amount < 0 { return SemanticColors.negative }
+            return .secondary
+        }
+    }
+}
+
+private struct WealthCreditSection: View {
+    let summary: WealthSummaryPresentation.CreditUtilizationSummary?
+    let threshold: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            WealthFlyoutSectionLabel("Credit")
+
+            if let summary {
+                HStack(alignment: .top, spacing: Spacing.sm) {
+                    Image(systemName: SemanticColors.utilizationIcon(for: summary.percent, threshold: threshold))
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(tint(summary))
+                        .frame(width: Sizing.iconInline, height: Sizing.iconInline)
+
+                    VStack(alignment: .leading, spacing: Spacing.xxs) {
+                        Text("\(Formatters.percent(summary.percent, decimals: 0)) utilization, \(summary.statusLabel.lowercased())")
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+
+                        Text("\(Formatters.currency(summary.usedCredit, format: .compact)) used of \(Formatters.currency(summary.totalLimit, format: .compact)) limit")
+                            .detailText()
+                            .lineLimit(2)
+                    }
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(
+                    "Credit utilization \(Formatters.percent(summary.percent, decimals: 0)), \(summary.statusLabel). \(Formatters.currency(summary.usedCredit, format: .full)) used of \(Formatters.currency(summary.totalLimit, format: .full)) limit."
+                )
+            } else {
+                Label("No credit utilization available", systemImage: "creditcard")
+                    .detailText()
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func tint(_ summary: WealthSummaryPresentation.CreditUtilizationSummary) -> Color {
+        guard summary.exceedsThreshold else { return .secondary }
+        return SemanticColors.utilization(for: summary.percent, threshold: threshold)
+    }
+}
+
+private struct WealthAttentionSection: View {
+    let summary: WealthSummaryPresentation.AttentionSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            WealthFlyoutSectionLabel("Attention")
+
+            HStack(alignment: .top, spacing: Spacing.sm) {
+                Image(systemName: iconName)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: Sizing.iconInline, height: Sizing.iconInline)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text(summary.title)
+                        .font(.caption.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(detailText)
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(summary.title). \(detailText)")
+        }
+    }
+
+    private var detailText: String {
+        guard summary.visibleRowCount > 1 else { return summary.detail }
+        return "\(summary.detail) \(summary.visibleRowCount - 1) more item\(summary.visibleRowCount == 2 ? "" : "s") in Attention."
+    }
+
+    private var iconName: String {
+        switch summary.severity {
+        case .healthy:
+            "checkmark.circle.fill"
+        case .warning:
+            "exclamationmark.triangle.fill"
+        case .blocked:
+            "xmark.octagon.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch summary.severity {
+        case .healthy:
+            .secondary
+        case .warning:
+            SemanticColors.warning
+        case .blocked:
+            SemanticColors.negative
+        }
+    }
+}
+
+private struct WealthFlyoutSectionLabel: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title)
+            .sectionTitle()
+            .foregroundStyle(.secondary)
+    }
+}
+
+private func cashflowText(_ amount: Double, format: CurrencyFormat) -> String {
+    if amount > 0 {
+        return "+\(Formatters.currency(amount, format: format))"
+    }
+    if amount < 0 {
+        return "-\(Formatters.currency(abs(amount), format: format))"
+    }
+    return Formatters.currency(0, format: format)
+}
+
+private func percentText(_ share: Double) -> String {
+    "\(Int((share * 100).rounded()))%"
+}

--- a/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+public struct WealthSummaryPresentation: Sendable, Equatable {
+    public struct CashflowSummary: Sendable, Equatable {
+        public let windowDays: Int
+        public let income: Double
+        public let spending: Double
+        public let net: Double
+        public let transactionCount: Int
+
+        public init(
+            windowDays: Int,
+            income: Double,
+            spending: Double,
+            net: Double,
+            transactionCount: Int
+        ) {
+            self.windowDays = windowDays
+            self.income = income
+            self.spending = spending
+            self.net = net
+            self.transactionCount = transactionCount
+        }
+    }
+
+    public struct CreditUtilizationSummary: Sendable, Equatable {
+        public let percent: Double
+        public let usedCredit: Double
+        public let totalLimit: Double
+        public let statusLabel: String
+        public let exceedsThreshold: Bool
+
+        public init(
+            percent: Double,
+            usedCredit: Double,
+            totalLimit: Double,
+            statusLabel: String,
+            exceedsThreshold: Bool
+        ) {
+            self.percent = percent
+            self.usedCredit = usedCredit
+            self.totalLimit = totalLimit
+            self.statusLabel = statusLabel
+            self.exceedsThreshold = exceedsThreshold
+        }
+    }
+
+    public struct AttentionSummary: Sendable, Equatable {
+        public let severity: AttentionQueueSeverity
+        public let title: String
+        public let detail: String
+        public let visibleRowCount: Int
+
+        public init(
+            severity: AttentionQueueSeverity,
+            title: String,
+            detail: String,
+            visibleRowCount: Int
+        ) {
+            self.severity = severity
+            self.title = title
+            self.detail = detail
+            self.visibleRowCount = visibleRowCount
+        }
+    }
+
+    public struct SyncHealthSummary: Sendable, Equatable {
+        public let severity: AttentionQueueSeverity
+        public let title: String
+        public let detail: String
+        public let statusText: String
+        public let iconName: String
+
+        public init(
+            severity: AttentionQueueSeverity,
+            title: String,
+            detail: String,
+            statusText: String,
+            iconName: String
+        ) {
+            self.severity = severity
+            self.title = title
+            self.detail = detail
+            self.statusText = statusText
+            self.iconName = iconName
+        }
+    }
+
+    public let accountCount: Int
+    public let transactionCount: Int
+    public let netWorth: Double
+    public let totalAssets: Double
+    public let totalDebt: Double
+    public let balanceMix: BalanceCompositionPresentation
+    public let cashflow: CashflowSummary
+    public let creditUtilization: CreditUtilizationSummary?
+    public let attention: AttentionSummary
+    public let syncHealth: SyncHealthSummary
+
+    public init(
+        accountCount: Int,
+        transactionCount: Int,
+        netWorth: Double,
+        totalAssets: Double,
+        totalDebt: Double,
+        balanceMix: BalanceCompositionPresentation,
+        cashflow: CashflowSummary,
+        creditUtilization: CreditUtilizationSummary?,
+        attention: AttentionSummary,
+        syncHealth: SyncHealthSummary
+    ) {
+        self.accountCount = accountCount
+        self.transactionCount = transactionCount
+        self.netWorth = netWorth
+        self.totalAssets = totalAssets
+        self.totalDebt = totalDebt
+        self.balanceMix = balanceMix
+        self.cashflow = cashflow
+        self.creditUtilization = creditUtilization
+        self.attention = attention
+        self.syncHealth = syncHealth
+    }
+
+    public static func evaluate(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        credentialsConfigured: Bool?,
+        linkedItemCount: Int,
+        syncedItemCount: Int,
+        itemStatuses: [ItemStatus],
+        isSyncStale: Bool,
+        lastSyncRelative: String?,
+        statusSyncText: String,
+        errorMessage: String?,
+        creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        windowDays: Int = 30,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> WealthSummaryPresentation {
+        let attentionQueue = AttentionQueue.evaluate(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            credentialsConfigured: credentialsConfigured,
+            linkedItemCount: linkedItemCount,
+            accountCount: accounts.count,
+            syncedItemCount: syncedItemCount,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            errorMessage: errorMessage
+        )
+        let attention = attentionSummary(from: attentionQueue)
+
+        return WealthSummaryPresentation(
+            accountCount: accounts.count,
+            transactionCount: transactions.count,
+            netWorth: MenuBarSummary.netCash(from: accounts),
+            totalAssets: totalAssets(from: accounts),
+            totalDebt: MenuBarSummary.totalDebt(from: accounts),
+            balanceMix: BalanceCompositionPresentation(accounts: accounts),
+            cashflow: cashflowSummary(
+                from: transactions,
+                windowDays: windowDays,
+                now: now,
+                calendar: calendar
+            ),
+            creditUtilization: creditUtilizationSummary(
+                from: accounts,
+                threshold: creditUtilizationThreshold
+            ),
+            attention: attention,
+            syncHealth: syncHealthSummary(
+                from: attention,
+                isDemoMode: isDemoMode,
+                statusSyncText: statusSyncText
+            )
+        )
+    }
+
+    private static func totalAssets(from accounts: [AccountDTO]) -> Double {
+        accounts.reduce(0) { total, account in
+            guard !AccountPresentation.isDebt(account) else { return total }
+            return total + max(account.balances.effectiveBalance, 0)
+        }
+    }
+
+    private static func cashflowSummary(
+        from transactions: [TransactionDTO],
+        windowDays: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> CashflowSummary {
+        let normalizedWindowDays = max(windowDays, 1)
+        let referenceDate = calendar.startOfDay(for: now)
+        let currentStart = calendar.startOfDay(
+            for: calendar.date(byAdding: .day, value: -(normalizedWindowDays - 1), to: referenceDate)
+                ?? referenceDate
+        )
+
+        var income = 0.0
+        var spending = 0.0
+        var transactionCount = 0
+
+        for transaction in transactions {
+            guard !transaction.isCashflowTransfer,
+                  let date = Formatters.parseTransactionDate(transaction.date),
+                  date >= currentStart,
+                  date <= referenceDate
+            else {
+                continue
+            }
+
+            transactionCount += 1
+            if transaction.isIncome {
+                income += transaction.displayAmount
+            } else {
+                spending += transaction.displayAmount
+            }
+        }
+
+        return CashflowSummary(
+            windowDays: normalizedWindowDays,
+            income: income,
+            spending: spending,
+            net: income - spending,
+            transactionCount: transactionCount
+        )
+    }
+
+    private static func creditUtilizationSummary(
+        from accounts: [AccountDTO],
+        threshold: Double
+    ) -> CreditUtilizationSummary? {
+        let creditBalances = accounts
+            .filter { $0.type == .credit }
+            .map(\.balances)
+
+        let totalLimit = creditBalances.reduce(0) { $0 + max($1.limit ?? 0, 0) }
+        guard totalLimit > 0 else { return nil }
+
+        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
+        let percent = (usedCredit / totalLimit) * 100
+
+        return CreditUtilizationSummary(
+            percent: percent,
+            usedCredit: usedCredit,
+            totalLimit: totalLimit,
+            statusLabel: AccountPresentation.utilizationStatusLabel(
+                for: percent,
+                threshold: threshold
+            ),
+            exceedsThreshold: percent >= threshold
+        )
+    }
+
+    private static func attentionSummary(from queue: AttentionQueue) -> AttentionSummary {
+        let row = queue.rows.first
+        return AttentionSummary(
+            severity: row?.severity ?? .healthy,
+            title: row?.title ?? "Sync healthy",
+            detail: row?.detail ?? "No attention items.",
+            visibleRowCount: queue.rows.count
+        )
+    }
+
+    private static func syncHealthSummary(
+        from attention: AttentionSummary,
+        isDemoMode: Bool,
+        statusSyncText: String
+    ) -> SyncHealthSummary {
+        guard attention.severity != .healthy else {
+            return SyncHealthSummary(
+                severity: .healthy,
+                title: isDemoMode ? "Demo data ready" : "Sync healthy",
+                detail: statusSyncText,
+                statusText: statusSyncText,
+                iconName: isDemoMode ? "play.circle.fill" : "checkmark.circle.fill"
+            )
+        }
+
+        return SyncHealthSummary(
+            severity: attention.severity,
+            title: attention.title,
+            detail: attention.detail,
+            statusText: statusSyncText,
+            iconName: attention.severity == .blocked ? "xmark.octagon.fill" : "exclamationmark.triangle.fill"
+        )
+    }
+}
+
+private extension TransactionDTO {
+    var isCashflowTransfer: Bool {
+        category == .transfer || category == .transferOut
+    }
+}

--- a/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
@@ -1,0 +1,171 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Wealth summary presentation")
+struct WealthSummaryPresentationTests {
+    private let now = Formatters.parseTransactionDate("2026-06-11")!
+
+    @Test("Computes net worth, assets, debt, and active balance mix")
+    func computesBalanceOverview() {
+        let presentation = makePresentation(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(current: 900)),
+                AccountDTO(id: "brokerage", itemId: "item-a", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 1_500)),
+                AccountDTO(id: "card", itemId: "item-b", name: "Card", type: .credit, balances: BalanceDTO(current: -400, limit: 2_000)),
+                AccountDTO(id: "loan", itemId: "item-c", name: "Loan", type: .loan, balances: BalanceDTO(current: -700)),
+            ],
+            linkedItemCount: 3,
+            syncedItemCount: 3
+        )
+
+        #expect(presentation.accountCount == 4)
+        #expect(presentation.netWorth == 1_300)
+        #expect(presentation.totalAssets == 2_400)
+        #expect(presentation.totalDebt == 1_100)
+        #expect(presentation.balanceMix.segments.map(\.id) == ["cash", "investments", "credit", "loans"])
+        #expect(presentation.balanceMix.segments.map(\.value) == [900, 1_500, 400, 700])
+    }
+
+    @Test("Computes 30 day cashflow and excludes transfers")
+    func computesCashflowWindow() {
+        let presentation = makePresentation(
+            transactions: [
+                expense("current-spend", amount: 80, date: "2026-06-10"),
+                income("current-income", amount: 500, date: "2026-06-09"),
+                expense("boundary-spend", amount: 20, date: "2026-05-13"),
+                expense("previous-spend", amount: 40, date: "2026-05-12"),
+                expense("transfer-out", amount: 900, date: "2026-06-10", category: .transferOut),
+                income("transfer-in", amount: 900, date: "2026-06-10", category: .transfer),
+            ]
+        )
+
+        #expect(presentation.cashflow.windowDays == 30)
+        #expect(presentation.cashflow.spending == 100)
+        #expect(presentation.cashflow.income == 500)
+        #expect(presentation.cashflow.net == 400)
+        #expect(presentation.cashflow.transactionCount == 3)
+    }
+
+    @Test("Computes credit utilization against the configured threshold")
+    func computesCreditUtilization() {
+        let presentation = makePresentation(
+            accounts: [
+                AccountDTO(id: "card-a", itemId: "item-a", name: "Card A", type: .credit, balances: BalanceDTO(current: -400, limit: 1_000)),
+                AccountDTO(id: "card-b", itemId: "item-b", name: "Card B", type: .credit, balances: BalanceDTO(current: -200, limit: 1_000)),
+            ],
+            creditUtilizationThreshold: 25
+        )
+
+        #expect(presentation.creditUtilization?.usedCredit == 600)
+        #expect(presentation.creditUtilization?.totalLimit == 2_000)
+        #expect(presentation.creditUtilization?.percent == 30)
+        #expect(presentation.creditUtilization?.statusLabel == "Warning")
+        #expect(presentation.creditUtilization?.exceedsThreshold == true)
+    }
+
+    @Test("Uses existing attention and sync status inputs")
+    func derivesAttentionAndSyncHealthFromStatusInputs() {
+        let presentation = makePresentation(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(current: 100)),
+            ],
+            linkedItemCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-a", institutionName: "Example Bank", status: .loginRequired),
+            ],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            statusSyncText: "Stale 3 days ago"
+        )
+
+        #expect(presentation.attention.severity == .warning)
+        #expect(presentation.attention.title == "Example Bank needs login")
+        #expect(presentation.syncHealth.severity == .warning)
+        #expect(presentation.syncHealth.title == "Example Bank needs login")
+        #expect(presentation.syncHealth.statusText == "Stale 3 days ago")
+        #expect(presentation.syncHealth.iconName == "exclamationmark.triangle.fill")
+    }
+
+    @Test("Demo mode renders as healthy local data")
+    func demoModeRendersHealthy() {
+        let presentation = makePresentation(
+            isDemoMode: true,
+            serverConnected: true,
+            linkedItemCount: 2,
+            syncedItemCount: 2,
+            statusSyncText: "Synced now"
+        )
+
+        #expect(presentation.attention.severity == .healthy)
+        #expect(presentation.attention.title == "Demo data ready")
+        #expect(presentation.syncHealth.severity == .healthy)
+        #expect(presentation.syncHealth.title == "Demo data ready")
+        #expect(presentation.syncHealth.iconName == "play.circle.fill")
+    }
+
+    private func makePresentation(
+        accounts: [AccountDTO] = [],
+        transactions: [TransactionDTO] = [],
+        isDemoMode: Bool = false,
+        serverConnected: Bool = true,
+        credentialsConfigured: Bool? = true,
+        linkedItemCount: Int = 0,
+        syncedItemCount: Int = 0,
+        itemStatuses: [ItemStatus] = [],
+        isSyncStale: Bool = false,
+        lastSyncRelative: String? = "now",
+        statusSyncText: String = "Synced now",
+        errorMessage: String? = nil,
+        creditUtilizationThreshold: Double = 30
+    ) -> WealthSummaryPresentation {
+        WealthSummaryPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            credentialsConfigured: credentialsConfigured,
+            linkedItemCount: linkedItemCount,
+            syncedItemCount: syncedItemCount,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            statusSyncText: statusSyncText,
+            errorMessage: errorMessage,
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            now: now
+        )
+    }
+
+    private func expense(
+        _ id: String,
+        amount: Double,
+        date: String,
+        category: SpendingCategory? = nil
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: amount,
+            date: date,
+            name: id,
+            category: category
+        )
+    }
+
+    private func income(
+        _ id: String,
+        amount: Double,
+        date: String,
+        category: SpendingCategory? = .income
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: -amount,
+            date: date,
+            name: id,
+            category: category
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a left-side Wealth Summary flyout so the popover opens with portfolio context before a specific account is selected.
- Reuses existing local app state and core presentation models to surface net worth, balance mix, 30-day cashflow, credit utilization, and sync attention without new network calls.
- Keeps finance status backed by labels, icons, and accessibility copy instead of color-only signals.

## Changes
- `Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift` centralizes wealth, cashflow, credit, attention, and sync-health presentation.
- `Sources/PlaidBar/Views/WealthSummaryFlyout.swift` adds the SwiftUI flyout and accessibility labels.
- `Sources/PlaidBar/Views/MainPopover.swift` mounts the Wealth Summary flyout when no account row is selected and keeps the existing account detail flyout for selected rows.
- `Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift` covers synthetic net worth, balance mix, cashflow windowing, credit utilization, and sync attention states.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter WealthSummaryPresentationTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test`
- [x] Targeted diff privacy scan for Plaid secrets, tokens, raw payloads, real IDs, SQLite data, logs, and screenshots

## Notes
- Manual demo-mode, light/dark, Reduce Motion/Transparency, and VoiceOver QA still need to be completed before marking ready for review.
- Full `swift test` still emits the existing `PendingLinkSessionStore` captured-var warning in `Tests/PlaidBarServerTests/PlaidBarServerTests.swift:845`; this PR does not touch that file.
