### PR TITLE
feat: add net worth menu bar mode

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -77,7 +77,7 @@ final class AppState {
     var notificationPermissionState: NotificationPermissionState = .notDetermined
 
     // MARK: - Settings (persisted to UserDefaults)
-    var menuBarSummaryMode: MenuBarSummaryMode = .netCash {
+    var menuBarSummaryMode: MenuBarSummaryMode = .netWorth {
         didSet {
             guard menuBarSummaryMode != oldValue else { return }
             UserDefaults.standard.set(menuBarSummaryMode.rawValue, forKey: Keys.menuBarSummaryMode)
@@ -323,6 +323,8 @@ final class AppState {
     var menuBarHelpText: String {
         let status = "Status: \(diagnosticsSummary)"
         switch menuBarSummaryMode {
+        case .netWorth:
+            return "VaultPeek - Net worth: \(menuBarText). \(status)"
         case .netCash:
             return "VaultPeek - Net cash: \(menuBarText). \(status)"
         case .totalCash:
@@ -339,6 +341,8 @@ final class AppState {
     var menuBarAccessibilityLabel: String {
         let status = "Status \(diagnosticsSummary)"
         switch menuBarSummaryMode {
+        case .netWorth:
+            return "VaultPeek net worth \(menuBarText). \(status)"
         case .netCash:
             return "VaultPeek net cash \(menuBarText). \(status)"
         case .totalCash:

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
+    case netWorth
     case netCash
     case totalCash
     case creditUtilization
@@ -9,6 +10,7 @@ public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
 
     public var displayName: String {
         switch self {
+        case .netWorth: return "Net worth"
         case .netCash: return "Net cash"
         case .totalCash: return "Total cash"
         case .creditUtilization: return "Credit utilization"
@@ -19,6 +21,10 @@ public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
 }
 
 public enum MenuBarSummary {
+    public static func netWorth(from accounts: [AccountDTO]) -> Double {
+        netCash(from: accounts)
+    }
+
     public static func netCash(from accounts: [AccountDTO]) -> Double {
         accounts.reduce(0) { total, account in
             switch account.type {
@@ -154,6 +160,9 @@ public enum MenuBarSummary {
         isInitialLoad: Bool = false
     ) -> String {
         switch mode {
+        case .netWorth:
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            return Formatters.currency(netWorth(from: accounts), format: currencyFormat)
         case .netCash:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             return Formatters.currency(netCash(from: accounts), format: currencyFormat)

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -469,6 +469,19 @@ struct PlaidBarCoreTests {
         #expect(abs(MenuBarSummary.netCash(from: accounts) - 12_449.32) < 0.01)
     }
 
+    @Test("Menu bar summary calculates net worth as the cockpit default")
+    func menuBarSummaryNetWorth() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 50_000)),
+            AccountDTO(id: "3", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -1_500, limit: 10_000)),
+            AccountDTO(id: "4", itemId: "i", name: "Auto Loan", type: .loan, balances: BalanceDTO(current: -7_250)),
+        ]
+
+        #expect(MenuBarSummary.netWorth(from: accounts) == 49_450)
+        #expect(MenuBarSummaryMode.allCases.first == .netWorth)
+    }
+
     @Test("Menu bar summary total cash uses depository accounts only")
     func menuBarSummaryTotalCash() {
         let accounts = [
@@ -1168,6 +1181,7 @@ struct PlaidBarCoreTests {
             TransactionDTO(id: "1", accountId: "a", amount: 25, date: Formatters.transactionDateString(Date()), name: "Coffee")
         ]
 
+        #expect(!MenuBarSummary.text(mode: .netWorth, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
         #expect(!MenuBarSummary.text(mode: .netCash, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
         #expect(!MenuBarSummary.text(mode: .totalCash, accounts: accounts, transactions: transactions, currencyFormat: .compact).isEmpty)
         #expect(MenuBarSummary.text(mode: .creditUtilization, accounts: accounts, transactions: transactions, currencyFormat: .compact) == "15%")


### PR DESCRIPTION
## Summary
- Adds a `Net worth` menu bar summary mode and makes it the default for new installs so the status item leads with overall portfolio posture.
- Keeps the existing `Net cash` mode and persisted `netCash` values working for current users.
- Adds explicit help and VoiceOver copy for the new menu bar mode.

## Changes
- `Sources/PlaidBarCore/Utilities/MenuBarSummary.swift` adds `MenuBarSummaryMode.netWorth`, a shared `netWorth(from:)` reducer, and text formatting for the mode.
- `Sources/PlaidBar/App/AppState.swift` defaults new installs to net worth and names that state in help/accessibility labels.
- `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift` covers net worth calculation, Settings ordering, and all summary-mode text output.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter menuBarSummaryNetWorth`
- [x] `swift test --filter menuBarSummaryTextModes`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test`
- [x] Zero-context diff scan for Plaid secrets, tokens, raw payloads, real IDs, SQLite data, logs, and screenshots

## Notes
- Manual menu bar QA across light/dark, VoiceOver, and degraded status glyph/text states still needs to run before marking ready.
- The first `swift test` compile in this fresh worktree emitted the existing `PendingLinkSessionStore` captured-var warning in `Tests/PlaidBarServerTests/PlaidBarServerTests.swift:845`; this PR does not touch that file.
