### PR TITLE
fix: respect reduce motion for loading affordances

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -129,9 +129,30 @@ enum MotionTokens {
     static let standard = Animation.easeInOut(duration: 0.2)
     /// Drill-in/fly-out expansion and number transitions.
     static let content = Animation.spring(response: 0.3, dampingFraction: 0.85)
+    /// Refresh spinner movement. Always pass through `animation`.
+    static let refreshSpin = Animation.linear(duration: 0.8).repeatForever(autoreverses: false)
+    /// Refresh spinner settle when loading ends.
+    static let refreshSettle = Animation.linear(duration: 0.3)
+    /// Loading skeleton pulse. Always pass through `animation`.
+    static let loadingPulse = Animation.easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+
+    static let staticLoadingOpacity = 0.62
+    static let loadingPulseOpacity = 0.55
 
     static func animation(_ animation: Animation, reduceMotion: Bool) -> Animation? {
         reduceMotion ? nil : animation
+    }
+
+    static func refreshSymbolName(isLoading: Bool, reduceMotion: Bool) -> String {
+        reduceMotion && isLoading ? "arrow.clockwise.circle.fill" : "arrow.clockwise"
+    }
+
+    static func refreshOpacity(isLoading: Bool, reduceMotion: Bool) -> Double {
+        reduceMotion && isLoading ? staticLoadingOpacity : 1
+    }
+
+    static func loadingOpacity(isDimmed: Bool, reduceMotion: Bool) -> Double {
+        reduceMotion ? 1 : (isDimmed ? loadingPulseOpacity : 1)
     }
 }
 

--- a/Sources/PlaidBar/Views/LoadingSkeletons.swift
+++ b/Sources/PlaidBar/Views/LoadingSkeletons.swift
@@ -39,13 +39,35 @@ private struct SkeletonPulse: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .opacity(isDimmed ? 0.55 : 1)
+            .opacity(MotionTokens.loadingOpacity(isDimmed: isDimmed, reduceMotion: reduceMotion))
             .onAppear {
-                guard !reduceMotion else { return }
-                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                    isDimmed = true
+                startPulseIfAllowed()
+            }
+            .onChange(of: reduceMotion) { _, shouldReduceMotion in
+                if shouldReduceMotion {
+                    stopPulse()
+                } else {
+                    startPulseIfAllowed()
                 }
             }
+    }
+
+    private func startPulseIfAllowed() {
+        guard !reduceMotion else {
+            stopPulse()
+            return
+        }
+
+        isDimmed = false
+        withAnimation(MotionTokens.animation(MotionTokens.loadingPulse, reduceMotion: reduceMotion)) {
+            isDimmed = true
+        }
+    }
+
+    private func stopPulse() {
+        withAnimation(nil) {
+            isDimmed = false
+        }
     }
 }
 

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -203,30 +203,53 @@ struct RefreshIcon: View {
     @State private var rotation: Double = 0
 
     var body: some View {
-        // Under Reduce Motion the infinite spin is replaced by a static
-        // dimmed state — loading is still visible, nothing moves.
-        Image(systemName: "arrow.clockwise")
-            .rotationEffect(.degrees(rotation))
-            .opacity(reduceMotion && isLoading ? 0.5 : 1)
+        // Under Reduce Motion the infinite spin is replaced by a filled static
+        // symbol plus accessibility value, so loading does not depend on motion.
+        Image(systemName: MotionTokens.refreshSymbolName(isLoading: isLoading, reduceMotion: reduceMotion))
+            .rotationEffect(.degrees(reduceMotion ? 0 : rotation))
+            .opacity(MotionTokens.refreshOpacity(isLoading: isLoading, reduceMotion: reduceMotion))
+            .accessibilityLabel(isLoading ? "Refreshing" : "Refresh")
+            .accessibilityValue(isLoading ? "In progress" : "Ready")
             .onChange(of: isLoading) { _, loading in
-                guard !reduceMotion else { return }
                 if loading {
-                    withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
-                        rotation = 360
-                    }
+                    startSpinIfAllowed()
                 } else {
-                    withAnimation(.linear(duration: 0.3)) {
-                        rotation = 0
-                    }
+                    stopSpin(animated: true)
+                }
+            }
+            .onChange(of: reduceMotion) { _, shouldReduceMotion in
+                if shouldReduceMotion {
+                    stopSpin(animated: false)
+                } else if isLoading {
+                    startSpinIfAllowed()
                 }
             }
             .onAppear {
-                if isLoading, !reduceMotion {
-                    withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
-                        rotation = 360
-                    }
-                }
+                guard isLoading else { return }
+                startSpinIfAllowed()
             }
+    }
+
+    private func startSpinIfAllowed() {
+        guard !reduceMotion else {
+            stopSpin(animated: false)
+            return
+        }
+
+        rotation = 0
+        withAnimation(MotionTokens.animation(MotionTokens.refreshSpin, reduceMotion: reduceMotion)) {
+            rotation = 360
+        }
+    }
+
+    private func stopSpin(animated: Bool) {
+        let animation = animated
+            ? MotionTokens.animation(MotionTokens.refreshSettle, reduceMotion: reduceMotion)
+            : nil
+
+        withAnimation(animation) {
+            rotation = 0
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Improve loading affordances so Reduce Motion uses static refresh and skeleton states instead of continuous movement.
- Keep the polish local to shared motion tokens and existing UI modifiers, without touching Plaid, server, provider, or data paths.

## Changes
- `Sources/PlaidBar/Theme/DesignTokens.swift`: centralizes refresh spin, refresh settle, skeleton pulse, and static loading fallback tokens.
- `Sources/PlaidBar/Views/SharedModifiers.swift`: makes `RefreshIcon` stop or restart when Reduce Motion changes and exposes a static filled loading state.
- `Sources/PlaidBar/Views/LoadingSkeletons.swift`: cancels the skeleton pulse when Reduce Motion is enabled.

## Test plan
- [x] `git diff --check`
- [x] `swift build --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] Targeted diff privacy scan for Plaid credentials, provider tokens, raw payloads, account or transaction IDs, SQLite, keychain, and screenshots
- [ ] Manual Reduce Motion UI QA in macOS

## Notes
- No app, server, provider credential, or local-data flow touched.
- No focused tests added because existing tests target PlaidBarCore and the changed motion utilities live in the executable SwiftUI target.