### PR TITLE
feat: add core notification trigger evaluation

### DIFF
--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -1,7 +1,13 @@
+import CryptoKit
+import Foundation
+
 public struct NotificationTriggers: Sendable {
     public var largeTransaction: Bool
     public var lowBalance: Bool
     public var highUtilization: Bool
+    public var staleSync: Bool
+    public var loginRequired: Bool
+    public var itemError: Bool
     public var largeTransactionThreshold: Double
     public var lowBalanceThreshold: Double
     public var creditUtilizationThreshold: Double
@@ -10,6 +16,9 @@ public struct NotificationTriggers: Sendable {
         largeTransaction: Bool = true,
         lowBalance: Bool = true,
         highUtilization: Bool = true,
+        staleSync: Bool = true,
+        loginRequired: Bool = true,
+        itemError: Bool = true,
         largeTransactionThreshold: Double = 500,
         lowBalanceThreshold: Double = 100,
         creditUtilizationThreshold: Double = 30
@@ -17,13 +26,160 @@ public struct NotificationTriggers: Sendable {
         self.largeTransaction = largeTransaction
         self.lowBalance = lowBalance
         self.highUtilization = highUtilization
+        self.staleSync = staleSync
+        self.loginRequired = loginRequired
+        self.itemError = itemError
         self.largeTransactionThreshold = largeTransactionThreshold
         self.lowBalanceThreshold = lowBalanceThreshold
         self.creditUtilizationThreshold = creditUtilizationThreshold
     }
 }
 
+public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
+    case itemError = "item-error"
+    case loginRequired = "login-required"
+    case syncStale = "sync-stale"
+    case highUtilization = "high-utilization"
+    case lowBalance = "low-balance"
+    case largeTransaction = "large-transaction"
+
+    public var clearsWhenResolved: Bool {
+        switch self {
+        case .itemError, .loginRequired, .syncStale, .highUtilization, .lowBalance:
+            true
+        case .largeTransaction:
+            false
+        }
+    }
+}
+
+public enum NotificationTriggerSeverity: String, Codable, Sendable {
+    case informational
+    case warning
+    case blocking
+}
+
+public struct NotificationTriggerDecision: Equatable, Identifiable, Sendable {
+    public var id: String { dedupKey }
+
+    public let kind: NotificationTriggerKind
+    public let dedupKey: String
+    public let title: String
+    public let body: String
+    public let severity: NotificationTriggerSeverity
+
+    public init(
+        kind: NotificationTriggerKind,
+        dedupKey: String,
+        title: String,
+        body: String,
+        severity: NotificationTriggerSeverity
+    ) {
+        self.kind = kind
+        self.dedupKey = dedupKey
+        self.title = title
+        self.body = body
+        self.severity = severity
+    }
+}
+
+public struct NotificationTriggerEvaluation: Equatable, Sendable {
+    public let decisions: [NotificationTriggerDecision]
+    public let activeDedupKeys: Set<String>
+    public let resolvedDedupKeys: Set<String>
+
+    public init(
+        decisions: [NotificationTriggerDecision],
+        activeDedupKeys: Set<String>,
+        resolvedDedupKeys: Set<String>
+    ) {
+        self.decisions = decisions
+        self.activeDedupKeys = activeDedupKeys
+        self.resolvedDedupKeys = resolvedDedupKeys
+    }
+}
+
 public enum NotificationTriggerSelection {
+    public static func evaluate(
+        transactions: [TransactionDTO] = [],
+        accounts: [AccountDTO] = [],
+        itemStatuses: [ItemStatus] = [],
+        isSyncStale: Bool = false,
+        config: NotificationTriggers = NotificationTriggers(),
+        deliveredDedupKeys: Set<String> = []
+    ) -> NotificationTriggerEvaluation {
+        var activeDecisions: [NotificationTriggerDecision] = []
+        var activeDedupKeys = Set<String>()
+
+        func append(_ decision: NotificationTriggerDecision) {
+            guard activeDedupKeys.insert(decision.dedupKey).inserted else { return }
+            activeDecisions.append(decision)
+        }
+
+        if config.itemError {
+            for item in itemStatuses where item.status == .error {
+                append(itemErrorDecision(for: item))
+            }
+        }
+
+        if config.loginRequired {
+            for item in itemStatuses where item.status == .loginRequired {
+                append(loginRequiredDecision(for: item))
+            }
+        }
+
+        if config.staleSync, isSyncStale {
+            append(syncStaleDecision())
+        }
+
+        if config.highUtilization {
+            for account in highUtilizationAccounts(
+                from: accounts,
+                threshold: config.creditUtilizationThreshold
+            ) {
+                append(highUtilizationDecision(for: account))
+            }
+        }
+
+        if config.lowBalance {
+            for account in lowBalanceAccounts(from: accounts, threshold: config.lowBalanceThreshold) {
+                append(lowBalanceDecision(for: account))
+            }
+        }
+
+        if config.largeTransaction {
+            for transaction in largeTransactions(
+                from: transactions,
+                threshold: config.largeTransactionThreshold
+            ) {
+                append(largeTransactionDecision(for: transaction))
+            }
+        }
+
+        let decisions = activeDecisions.filter { !deliveredDedupKeys.contains($0.dedupKey) }
+        let clearableDeliveredKeys = deliveredDedupKeys.filter { key in
+            guard let kind = kind(forDedupKey: key) else { return false }
+            return kind.clearsWhenResolved
+        }
+        let resolvedDedupKeys = Set(clearableDeliveredKeys).subtracting(activeDedupKeys)
+
+        return NotificationTriggerEvaluation(
+            decisions: decisions,
+            activeDedupKeys: activeDedupKeys,
+            resolvedDedupKeys: resolvedDedupKeys
+        )
+    }
+
+    public static func dedupKey(kind: NotificationTriggerKind, sourceID: String) -> String {
+        let normalizedSourceID = sourceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sourceID = normalizedSourceID.isEmpty ? "global" : normalizedSourceID
+        let digest = SHA256.hash(data: Data("\(kind.rawValue):\(sourceID)".utf8))
+            .prefix(16)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "\(kind.rawValue):\(digest)"
+    }
+
     public static func largeTransactions(
         from transactions: [TransactionDTO],
         threshold: Double,
@@ -52,5 +208,72 @@ public enum NotificationTriggerSelection {
         accounts.filter {
             $0.type == .credit && ($0.balances.utilizationPercent ?? 0) > threshold
         }
+    }
+
+    private static func itemErrorDecision(for item: ItemStatus) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .itemError,
+            dedupKey: dedupKey(kind: .itemError, sourceID: item.id),
+            title: "Institution needs attention",
+            body: "A linked institution reported a sync error. Reconnect, then refresh.",
+            severity: .blocking
+        )
+    }
+
+    private static func loginRequiredDecision(for item: ItemStatus) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .loginRequired,
+            dedupKey: dedupKey(kind: .loginRequired, sourceID: item.id),
+            title: "Bank login required",
+            body: "A linked institution needs a fresh login before sync can continue.",
+            severity: .warning
+        )
+    }
+
+    private static func syncStaleDecision() -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .syncStale,
+            dedupKey: dedupKey(kind: .syncStale, sourceID: "global"),
+            title: "Sync may be stale",
+            body: "VaultPeek has not refreshed recently. Open the app to refresh local data.",
+            severity: .warning
+        )
+    }
+
+    private static func highUtilizationDecision(for account: AccountDTO) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .highUtilization,
+            dedupKey: dedupKey(kind: .highUtilization, sourceID: account.id),
+            title: "Credit utilization alert",
+            body: "A credit account is above your configured utilization threshold.",
+            severity: .warning
+        )
+    }
+
+    private static func lowBalanceDecision(for account: AccountDTO) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .lowBalance,
+            dedupKey: dedupKey(kind: .lowBalance, sourceID: account.id),
+            title: "Low balance alert",
+            body: "A depository account is below your configured low-balance threshold.",
+            severity: .warning
+        )
+    }
+
+    private static func largeTransactionDecision(for transaction: TransactionDTO) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .largeTransaction,
+            dedupKey: dedupKey(kind: .largeTransaction, sourceID: transaction.id),
+            title: "Large transaction alert",
+            body: "A local transaction crossed your configured threshold.",
+            severity: .informational
+        )
+    }
+
+    private static func kind(forDedupKey dedupKey: String) -> NotificationTriggerKind? {
+        guard let rawKind = dedupKey.split(separator: ":", maxSplits: 1).first else {
+            return nil
+        }
+        return NotificationTriggerKind(rawValue: String(rawKind))
     }
 }

--- a/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
@@ -1,0 +1,228 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Notification Trigger Evaluation Tests")
+struct NotificationTriggerEvaluationTests {
+    @Test("Evaluator emits threshold and status decisions in stable priority order")
+    func emitsThresholdAndStatusDecisions() {
+        let evaluation = NotificationTriggerSelection.evaluate(
+            transactions: [
+                transaction(id: "tx-large", amount: 650),
+                transaction(id: "tx-at-threshold", amount: 500),
+                transaction(id: "tx-income", amount: -1_000),
+                transaction(id: "tx-small", amount: 20),
+            ],
+            accounts: [
+                depository(id: "acct-low", balance: 50),
+                depository(id: "acct-at-threshold", balance: 100),
+                credit(id: "acct-high-util", current: -4_500, limit: 5_000),
+                credit(id: "acct-at-util-threshold", current: -300, limit: 1_000),
+            ],
+            itemStatuses: [
+                ItemStatus(id: "item-login", institutionName: "Example Bank", status: .loginRequired),
+                ItemStatus(id: "item-error", institutionName: "City Credit", status: .error),
+                ItemStatus(id: "item-ok", institutionName: "Healthy Bank", status: .connected),
+            ],
+            isSyncStale: true,
+            config: testConfig
+        )
+
+        let kinds = evaluation.decisions.map(\NotificationTriggerDecision.kind)
+        #expect(kinds == [
+            NotificationTriggerKind.itemError,
+            NotificationTriggerKind.loginRequired,
+            NotificationTriggerKind.syncStale,
+            NotificationTriggerKind.highUtilization,
+            NotificationTriggerKind.lowBalance,
+            NotificationTriggerKind.largeTransaction,
+            NotificationTriggerKind.largeTransaction,
+        ])
+        let severities = evaluation.decisions.map(\NotificationTriggerDecision.severity)
+        #expect(severities == [
+            NotificationTriggerSeverity.blocking,
+            NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.informational,
+            NotificationTriggerSeverity.informational,
+        ])
+        #expect(evaluation.activeDedupKeys == Set(evaluation.decisions.map(\NotificationTriggerDecision.dedupKey)))
+        #expect(evaluation.resolvedDedupKeys.isEmpty)
+    }
+
+    @Test("Delivered dedup keys suppress active decisions and clear when stateful alerts resolve")
+    func deliveredDedupKeysSuppressAndResolveStatefulAlerts() {
+        let active = NotificationTriggerSelection.evaluate(
+            transactions: [transaction(id: "tx-large", amount: 650)],
+            accounts: [
+                depository(id: "acct-low", balance: 50),
+                credit(id: "acct-high-util", current: -4_500, limit: 5_000),
+            ],
+            itemStatuses: [
+                ItemStatus(id: "item-login", status: .loginRequired),
+                ItemStatus(id: "item-error", status: .error),
+            ],
+            isSyncStale: true,
+            config: testConfig
+        )
+        let deliveredKeys = active.activeDedupKeys
+
+        let repeated = NotificationTriggerSelection.evaluate(
+            transactions: [transaction(id: "tx-large", amount: 650)],
+            accounts: [
+                depository(id: "acct-low", balance: 50),
+                credit(id: "acct-high-util", current: -4_500, limit: 5_000),
+            ],
+            itemStatuses: [
+                ItemStatus(id: "item-login", status: .loginRequired),
+                ItemStatus(id: "item-error", status: .error),
+            ],
+            isSyncStale: true,
+            config: testConfig,
+            deliveredDedupKeys: deliveredKeys
+        )
+
+        #expect(repeated.decisions.isEmpty)
+        #expect(repeated.activeDedupKeys == deliveredKeys)
+        #expect(repeated.resolvedDedupKeys.isEmpty)
+
+        let resolved = NotificationTriggerSelection.evaluate(
+            transactions: [],
+            accounts: [
+                depository(id: "acct-low", balance: 500),
+                credit(id: "acct-high-util", current: -200, limit: 5_000),
+            ],
+            itemStatuses: [
+                ItemStatus(id: "item-login", status: .connected),
+                ItemStatus(id: "item-error", status: .connected),
+            ],
+            isSyncStale: false,
+            config: testConfig,
+            deliveredDedupKeys: deliveredKeys
+        )
+
+        let stickyLargeTransactionKey = NotificationTriggerSelection.dedupKey(
+            kind: .largeTransaction,
+            sourceID: "tx-large"
+        )
+
+        #expect(resolved.decisions.isEmpty)
+        #expect(resolved.activeDedupKeys.isEmpty)
+        #expect(resolved.resolvedDedupKeys == deliveredKeys.subtracting([stickyLargeTransactionKey]))
+        #expect(resolved.resolvedDedupKeys.contains(stickyLargeTransactionKey) == false)
+    }
+
+    @Test("Dedup keys are stable and do not expose source identifiers")
+    func dedupKeysAreStableAndOpaque() {
+        let key = NotificationTriggerSelection.dedupKey(
+            kind: .lowBalance,
+            sourceID: "  acct_synthetic_private_abcdef  "
+        )
+        let repeatedKey = NotificationTriggerSelection.dedupKey(
+            kind: .lowBalance,
+            sourceID: "acct_synthetic_private_abcdef"
+        )
+
+        #expect(key == repeatedKey)
+        #expect(key.hasPrefix("low-balance:"))
+        #expect(key.contains("acct_synthetic_private_abcdef") == false)
+        #expect(key.count == "low-balance:".count + 32)
+    }
+
+    @Test("Notification copy avoids identifiers, account names, merchants, institutions, and amounts")
+    func notificationCopyAvoidsPrivateDetails() {
+        let rawAccountID = "acct_synthetic_private_abcdef"
+        let rawTransactionID = "tx_synthetic_private_abcdef"
+        let rawItemID = "item_synthetic_private_abcdef"
+        let accountName = "Sensitive Checking 4321"
+        let merchantName = "Sensitive Merchant"
+        let institutionName = "Sensitive Bank"
+
+        let evaluation = NotificationTriggerSelection.evaluate(
+            transactions: [
+                TransactionDTO(
+                    id: rawTransactionID,
+                    accountId: rawAccountID,
+                    amount: 9_876.54,
+                    date: "2026-06-12",
+                    name: "Raw Sensitive Merchant",
+                    merchantName: merchantName
+                ),
+            ],
+            accounts: [
+                AccountDTO(
+                    id: rawAccountID,
+                    itemId: rawItemID,
+                    name: accountName,
+                    type: .depository,
+                    balances: BalanceDTO(available: 12.34),
+                    institutionName: institutionName
+                ),
+            ],
+            itemStatuses: [
+                ItemStatus(id: rawItemID, institutionName: institutionName, status: .error),
+            ],
+            isSyncStale: true,
+            config: testConfig
+        )
+
+        let renderedCopy = evaluation.decisions
+            .flatMap { [$0.title, $0.body, $0.dedupKey] }
+            .joined(separator: " ")
+
+        for privateText in [
+            rawAccountID,
+            rawTransactionID,
+            rawItemID,
+            accountName,
+            merchantName,
+            institutionName,
+            "Raw Sensitive Merchant",
+            "9876.54",
+            "12.34",
+        ] {
+            #expect(renderedCopy.contains(privateText) == false)
+        }
+
+        #expect(evaluation.decisions.allSatisfy { !$0.body.contains("$") })
+    }
+
+    private var testConfig: NotificationTriggers {
+        NotificationTriggers(
+            largeTransactionThreshold: 500,
+            lowBalanceThreshold: 100,
+            creditUtilizationThreshold: 30
+        )
+    }
+
+    private func transaction(id: String, amount: Double) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acct-\(id)",
+            amount: amount,
+            date: "2026-06-12",
+            name: "Synthetic Transaction"
+        )
+    }
+
+    private func depository(id: String, balance: Double) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item-\(id)",
+            name: "Synthetic Checking",
+            type: .depository,
+            balances: BalanceDTO(available: balance)
+        )
+    }
+
+    private func credit(id: String, current: Double, limit: Double) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item-\(id)",
+            name: "Synthetic Credit",
+            type: .credit,
+            balances: BalanceDTO(current: current, limit: limit)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add a pure PlaidBarCore notification trigger evaluator for threshold, stale sync, login-required, and item-error decisions.
- Use opaque stable dedup keys so local notification state does not store raw Plaid identifiers.
- Keep generated notification title/body copy generic for private lock-screen display.

## Changes
- `Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift`: adds trigger decision models, status trigger config flags, stable SHA-256 dedup key generation, active/resolved dedup evaluation, and privacy-safe copy.
- `Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift`: covers threshold selection, status decisions, delivered-key suppression, resolved-key clearing, stable opaque keys, and private copy.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter NotificationTriggerEvaluationTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] Targeted staged diff privacy scan for Plaid tokens, raw ID fields, SQLite paths, and screenshots

## Notes
- Manual UI QA skipped; this slice is core-only and does not wire the evaluator into Settings or notification delivery yet.