### PR TITLE
feat: add first-run snapshot model

### DIFF
--- a/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+public enum FirstRunSnapshotTransactionState: String, Codable, Sendable {
+    case ready
+    case syncing
+    case empty
+}
+
+/// Display-safe first-run money snapshot computed entirely from local DTOs.
+///
+/// The presentation intentionally omits raw account IDs, item IDs, transaction
+/// IDs, and raw provider payloads. Transaction rows carry only the user-visible
+/// merchant/name, date, and amount needed for the first-run "aha" surface.
+public struct FirstRunSnapshot: Equatable, Sendable {
+    public struct LargeTransaction: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let displayName: String
+        public let amount: Double
+        public let date: String
+
+        public init(id: String, displayName: String, amount: Double, date: String) {
+            self.id = id
+            self.displayName = displayName
+            self.amount = amount
+            self.date = date
+        }
+    }
+
+    public let accountCount: Int
+    public let transactionCount: Int
+    public let netWorth: Double
+    public let cashAvailable: Double
+    public let debtTotal: Double
+    public let creditUtilization: Double?
+    public let monthToDateSpend: Double?
+    public let transactionState: FirstRunSnapshotTransactionState
+    public let largeTransactions: [LargeTransaction]
+    public let hasCreditAccounts: Bool
+    public let hasDebtAccounts: Bool
+    public let accessibilitySummary: String
+
+    public init(
+        accountCount: Int,
+        transactionCount: Int,
+        netWorth: Double,
+        cashAvailable: Double,
+        debtTotal: Double,
+        creditUtilization: Double?,
+        monthToDateSpend: Double?,
+        transactionState: FirstRunSnapshotTransactionState,
+        largeTransactions: [LargeTransaction],
+        hasCreditAccounts: Bool,
+        hasDebtAccounts: Bool,
+        accessibilitySummary: String
+    ) {
+        self.accountCount = accountCount
+        self.transactionCount = transactionCount
+        self.netWorth = netWorth
+        self.cashAvailable = cashAvailable
+        self.debtTotal = debtTotal
+        self.creditUtilization = creditUtilization
+        self.monthToDateSpend = monthToDateSpend
+        self.transactionState = transactionState
+        self.largeTransactions = largeTransactions
+        self.hasCreditAccounts = hasCreditAccounts
+        self.hasDebtAccounts = hasDebtAccounts
+        self.accessibilitySummary = accessibilitySummary
+    }
+
+    public static func evaluate(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        completionState: FirstRunCompletionState,
+        largeTransactionThreshold: Double = 500,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> FirstRunSnapshot {
+        let transactionState = transactionState(
+            transactionCount: transactions.count,
+            completionState: completionState
+        )
+        let monthToDateSpend = transactions.isEmpty
+            ? nil
+            : MenuBarSummary.monthToDateSpend(from: transactions, now: now, calendar: calendar)
+        let largeTransactions = largeTransactions(
+            from: transactions,
+            threshold: largeTransactionThreshold,
+            now: now,
+            calendar: calendar
+        )
+        let netWorth = MenuBarSummary.netCash(from: accounts)
+        let cashAvailable = MenuBarSummary.totalCash(from: accounts)
+        let debtTotal = MenuBarSummary.totalDebt(from: accounts)
+        let creditUtilization = MenuBarSummary.creditUtilization(from: accounts)
+
+        return FirstRunSnapshot(
+            accountCount: accounts.count,
+            transactionCount: transactions.count,
+            netWorth: netWorth,
+            cashAvailable: cashAvailable,
+            debtTotal: debtTotal,
+            creditUtilization: creditUtilization,
+            monthToDateSpend: monthToDateSpend,
+            transactionState: transactionState,
+            largeTransactions: largeTransactions,
+            hasCreditAccounts: accounts.contains { $0.type == .credit },
+            hasDebtAccounts: accounts.contains(where: AccountPresentation.isDebt),
+            accessibilitySummary: accessibilitySummary(
+                netWorth: netWorth,
+                cashAvailable: cashAvailable,
+                debtTotal: debtTotal,
+                creditUtilization: creditUtilization,
+                monthToDateSpend: monthToDateSpend,
+                transactionState: transactionState,
+                largeTransactionCount: largeTransactions.count
+            )
+        )
+    }
+
+    private static func transactionState(
+        transactionCount: Int,
+        completionState: FirstRunCompletionState
+    ) -> FirstRunSnapshotTransactionState {
+        if transactionCount > 0 { return .ready }
+        return completionState.step == .syncTransactions ? .syncing : .empty
+    }
+
+    private static func largeTransactions(
+        from transactions: [TransactionDTO],
+        threshold: Double,
+        now: Date,
+        calendar: Calendar
+    ) -> [LargeTransaction] {
+        let currentDay = calendar.startOfDay(for: now)
+        return Array(NotificationTriggerSelection.largeTransactions(
+            from: transactions,
+            threshold: threshold
+        )
+        .filter {
+            guard $0.category != .transfer,
+                  $0.category != .transferOut,
+                  let date = Formatters.parseTransactionDate($0.date)
+            else {
+                return false
+            }
+            return calendar.startOfDay(for: date) <= currentDay
+        }
+        .sorted {
+            if $0.date != $1.date { return $0.date > $1.date }
+            if $0.displayAmount != $1.displayAmount { return $0.displayAmount > $1.displayAmount }
+            return $0.displayName < $1.displayName
+        }
+        .prefix(3)
+        .map { transaction in
+            LargeTransaction(
+                id: displaySafeLargeTransactionID(for: transaction),
+                displayName: transaction.displayName,
+                amount: transaction.displayAmount,
+                date: transaction.date
+            )
+        })
+    }
+
+    private static func displaySafeLargeTransactionID(for transaction: TransactionDTO) -> String {
+        let amountCents = Int((transaction.displayAmount * 100).rounded())
+        return "\(transaction.date)-\(transaction.displayName)-\(amountCents)"
+    }
+
+    private static func accessibilitySummary(
+        netWorth: Double,
+        cashAvailable: Double,
+        debtTotal: Double,
+        creditUtilization: Double?,
+        monthToDateSpend: Double?,
+        transactionState: FirstRunSnapshotTransactionState,
+        largeTransactionCount: Int
+    ) -> String {
+        var parts = [
+            "First-run money snapshot.",
+            "Net worth \(Formatters.currency(netWorth, format: .full)).",
+            "Cash available \(Formatters.currency(cashAvailable, format: .full)).",
+            "Debt \(Formatters.currency(debtTotal, format: .full)).",
+        ]
+
+        if let creditUtilization {
+            parts.append("Credit utilization \(Formatters.percent(creditUtilization, decimals: 0)).")
+        } else {
+            parts.append("No credit utilization available.")
+        }
+
+        switch (monthToDateSpend, transactionState) {
+        case let (.some(spend), _):
+            parts.append("Month-to-date spend \(Formatters.currency(spend, format: .full)).")
+        case (.none, .syncing):
+            parts.append("Transactions are still syncing.")
+        case (.none, .empty):
+            parts.append("No transactions synced yet.")
+        case (.none, .ready):
+            parts.append("No month-to-date spend.")
+        }
+
+        if largeTransactionCount > 0 {
+            parts.append("\(largeTransactionCount) recent large transaction\(largeTransactionCount == 1 ? "" : "s").")
+        }
+
+        return parts.joined(separator: " ")
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -85,6 +85,31 @@ public enum MenuBarSummary {
         }
     }
 
+    public static func monthToDateSpend(
+        from transactions: [TransactionDTO],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Double {
+        let currentDay = calendar.startOfDay(for: now)
+        let components = calendar.dateComponents([.year, .month], from: currentDay)
+        let startDate = calendar.date(from: components) ?? currentDay
+        let startKey = transactionDateKey(for: startDate, calendar: calendar)
+        let endKey = transactionDateKey(for: currentDay, calendar: calendar)
+
+        return transactions.reduce(0) { total, transaction in
+            guard !transaction.isIncome,
+                  transaction.category != .transfer,
+                  transaction.category != .transferOut,
+                  Formatters.isCanonicalTransactionDateKey(transaction.date),
+                  transaction.date >= startKey,
+                  transaction.date <= endKey
+            else {
+                return total
+            }
+            return total + transaction.displayAmount
+        }
+    }
+
     private static func transactionDateKey(for date: Date, calendar: Calendar) -> String {
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         guard let year = components.year,

--- a/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("First-run snapshot")
+struct FirstRunSnapshotTests {
+    private let now = Formatters.parseTransactionDate("2026-06-12")!
+
+    @Test("Evaluates full first-run money snapshot")
+    func evaluatesFullSnapshot() {
+        let snapshot = FirstRunSnapshot.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+                AccountDTO(id: "brokerage", itemId: "item-a", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 50_000)),
+                AccountDTO(id: "card", itemId: "item-b", name: "Visa", type: .credit, balances: BalanceDTO(current: -1_500, limit: 10_000)),
+                AccountDTO(id: "loan", itemId: "item-c", name: "Auto Loan", type: .loan, balances: BalanceDTO(current: -7_250)),
+            ],
+            transactions: [
+                expense("rent-internal", amount: 1_200, date: "2026-06-02", name: "Rent"),
+                expense("dental-internal", amount: 900, date: "2026-06-12", name: "Dental"),
+                expense("laptop-internal", amount: 750, date: "2026-06-11", name: "Laptop"),
+                expense("grocery-internal", amount: 120, date: "2026-06-10", name: "Groceries"),
+                expense("old-internal", amount: 300, date: "2026-05-31", name: "Old"),
+                expense("future-internal", amount: 2_000, date: "2026-07-01", name: "Future"),
+                income("payroll-internal", amount: 5_000, date: "2026-06-05", name: "Payroll"),
+                expense("transfer-internal", amount: 1_000, date: "2026-06-07", name: "Transfer", category: .transfer),
+            ],
+            completionState: readyCompletion(transactionCount: 8),
+            now: now
+        )
+
+        #expect(snapshot.accountCount == 4)
+        #expect(snapshot.transactionCount == 8)
+        #expect(snapshot.netWorth == 49_450)
+        #expect(snapshot.cashAvailable == 8_200)
+        #expect(snapshot.debtTotal == 8_750)
+        #expect(snapshot.creditUtilization == 15)
+        #expect(snapshot.monthToDateSpend == 2_970)
+        #expect(snapshot.transactionState == .ready)
+        #expect(snapshot.hasCreditAccounts)
+        #expect(snapshot.hasDebtAccounts)
+        #expect(snapshot.largeTransactions.map(\.displayName) == ["Dental", "Laptop", "Rent"])
+        #expect(snapshot.largeTransactions.map(\.amount) == [900, 750, 1_200])
+        #expect(snapshot.largeTransactions.allSatisfy { !$0.id.contains("internal") })
+        #expect(snapshot.accessibilitySummary.contains("Net worth $49,450.00"))
+        #expect(snapshot.accessibilitySummary.contains("3 recent large transactions"))
+    }
+
+    @Test("Handles no credit and no liabilities")
+    func handlesNoCreditAndNoLiabilities() {
+        let snapshot = FirstRunSnapshot.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 1_200)),
+            ],
+            transactions: [
+                expense("coffee", amount: 8, date: "2026-06-12", name: "Coffee"),
+            ],
+            completionState: readyCompletion(transactionCount: 1),
+            now: now
+        )
+
+        #expect(snapshot.netWorth == 1_200)
+        #expect(snapshot.debtTotal == 0)
+        #expect(snapshot.creditUtilization == nil)
+        #expect(!snapshot.hasCreditAccounts)
+        #expect(!snapshot.hasDebtAccounts)
+        #expect(snapshot.accessibilitySummary.contains("No credit utilization available"))
+    }
+
+    @Test("Marks empty transactions as syncing while first sync is incomplete")
+    func marksTransactionsSyncing() {
+        let snapshot = FirstRunSnapshot.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 1_200)),
+            ],
+            transactions: [],
+            completionState: FirstRunCompletionState(
+                step: .syncTransactions,
+                title: "Accounts loaded",
+                detail: "Run the first transaction sync check to finish setup.",
+                isReady: false,
+                canRetry: true
+            ),
+            now: now
+        )
+
+        #expect(snapshot.transactionState == .syncing)
+        #expect(snapshot.monthToDateSpend == nil)
+        #expect(snapshot.largeTransactions.isEmpty)
+        #expect(snapshot.accessibilitySummary.contains("Transactions are still syncing"))
+    }
+
+    @Test("Month-to-date spend is calendar anchored")
+    func monthToDateSpendIsCalendarAnchored() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Pacific/Kiritimati")!
+        let localNow = calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 6,
+            day: 1,
+            hour: 0,
+            minute: 30
+        ))!
+        let transactions = [
+            expense("month-start", amount: 40, date: "2026-06-01", name: "Month Start"),
+            expense("previous-month", amount: 80, date: "2026-05-31", name: "Previous Month"),
+            income("income", amount: 100, date: "2026-06-01", name: "Income"),
+        ]
+
+        #expect(MenuBarSummary.monthToDateSpend(from: transactions, now: localNow, calendar: calendar) == 40)
+    }
+
+    private func readyCompletion(transactionCount: Int) -> FirstRunCompletionState {
+        FirstRunCompletionState(
+            step: .ready,
+            title: "Dashboard ready",
+            detail: "\(transactionCount) transactions synced. VaultPeek is ready.",
+            isReady: true,
+            canRetry: false
+        )
+    }
+
+    private func expense(
+        _ id: String,
+        amount: Double,
+        date: String,
+        name: String,
+        category: SpendingCategory? = nil
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: amount,
+            date: date,
+            name: name,
+            category: category
+        )
+    }
+
+    private func income(
+        _ id: String,
+        amount: Double,
+        date: String,
+        name: String
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: -amount,
+            date: date,
+            name: name,
+            category: .income
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the pure Core presentation model for the first-run money snapshot so the UI can mount a one-time post-sync snapshot in a follow-up PR.
- Adds calendar-anchored month-to-date spend logic separate from existing rolling-window spend.
- Keeps snapshot output display-safe: no raw account IDs, item IDs, transaction IDs, raw Plaid payloads, logs, or screenshots.

## Changes
- `Sources/PlaidBarCore/Models/FirstRunSnapshot.swift` evaluates local accounts, transactions, and first-run completion state into net worth, cash, debt, credit utilization, month-to-date spend, transaction sync state, and up to 3 display-safe large-transaction rows.
- `Sources/PlaidBarCore/Utilities/MenuBarSummary.swift` adds `monthToDateSpend(from:now:calendar:)`.
- `Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift` covers full data, no-credit/no-liability partial data, sync-in-progress with no transactions, and calendar month boundaries.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter FirstRunSnapshotTests`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test`
- [x] Staged diff privacy scan for Plaid secrets, tokens, raw payloads, real IDs, SQLite data, logs, and screenshots

## Notes
- This PR intentionally stops at the Core model. `FirstRunSnapshotView`, one-time dismissal, local persistence, and screenshot/VoiceOver QA should land as smaller follow-up PRs.
- The first focused test compile emitted the existing `PendingLinkSessionStore` captured-var warning in `Tests/PlaidBarServerTests/PlaidBarServerTests.swift:845`; this PR does not touch that file.
