### PR TITLE
fix: preserve hosted link institution names

### DIFF
--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -4,7 +4,26 @@ import PlaidBarCore
     import FoundationNetworking
 #endif
 
-actor PlaidClient {
+protocol PlaidClientProtocol: Sendable {
+    func createLinkToken(
+        userId: String,
+        completionRedirectUri: String
+    ) async throws -> PlaidLinkTokenResponse
+
+    func createUpdateLinkToken(
+        userId: String,
+        accessToken: String,
+        completionRedirectUri: String
+    ) async throws -> PlaidLinkTokenResponse
+
+    func getLinkToken(_ linkToken: String) async throws -> PlaidLinkTokenGetResponse
+
+    func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse
+
+    func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse
+}
+
+actor PlaidClient: PlaidClientProtocol {
     private let config: ServerConfig
     private let session: URLSession
     private let decoder: JSONDecoder

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -101,19 +101,43 @@ struct PlaidLinkTokenGetResponse: Decodable, Sendable {
     let results: PlaidLinkResults?
 
     var publicTokens: [String] {
+        publicTokenResults.map(\.publicToken)
+    }
+
+    var publicTokenResults: [PlaidPublicTokenResult] {
         let sessionTokens = linkSessions?
             .flatMap { $0.results?.itemAddResults ?? [] }
-            .map(\.publicToken) ?? []
+            .map(PlaidPublicTokenResult.init) ?? []
         if !sessionTokens.isEmpty {
             return sessionTokens
         }
         if let itemAddResults = results?.itemAddResults, !itemAddResults.isEmpty {
-            return itemAddResults.map(\.publicToken)
+            return itemAddResults.map(PlaidPublicTokenResult.init)
         }
         if let publicToken = onSuccess?.publicToken {
-            return [publicToken]
+            return [
+                PlaidPublicTokenResult(
+                    publicToken: publicToken,
+                    institution: onSuccess?.metadata?.institution
+                ),
+            ]
         }
         return []
+    }
+}
+
+struct PlaidPublicTokenResult: Sendable {
+    let publicToken: String
+    let institution: PlaidLinkInstitution?
+
+    init(publicToken: String, institution: PlaidLinkInstitution?) {
+        self.publicToken = publicToken
+        self.institution = institution
+    }
+
+    init(itemAddResult: PlaidLinkItemAddResult) {
+        publicToken = itemAddResult.publicToken
+        institution = itemAddResult.institution
     }
 }
 

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -4,7 +4,7 @@ import NIOCore
 import PlaidBarCore
 
 struct LinkRoutes: Sendable {
-    let plaidClient: PlaidClient
+    let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
     let pendingLinkSessions: PendingLinkSessionStore
     let config: ServerConfig
@@ -95,7 +95,7 @@ struct LinkRoutes: Sendable {
 // MARK: - OAuth Callback (top-level route, not under /api)
 
 struct OAuthCallbackRoute: Sendable {
-    let plaidClient: PlaidClient
+    let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
     let pendingLinkSessions: PendingLinkSessionStore
 
@@ -121,8 +121,8 @@ struct OAuthCallbackRoute: Sendable {
         }
 
         do {
-            let publicTokens = try await publicTokens(from: request, pendingSession: pendingSession)
-            if publicTokens.isEmpty, let updateItemId = pendingSession.updateItemId {
+            let publicTokenResults = try await publicTokenResults(from: request, pendingSession: pendingSession)
+            if publicTokenResults.isEmpty, let updateItemId = pendingSession.updateItemId {
                 try await tokenStore.updateItemStatus(id: updateItemId, status: ItemConnectionStatus.connected.rawValue)
                 return Response(
                     status: .ok,
@@ -131,7 +131,7 @@ struct OAuthCallbackRoute: Sendable {
                 )
             }
 
-            guard !publicTokens.isEmpty else {
+            guard !publicTokenResults.isEmpty else {
                 return Response(
                     status: .badRequest,
                     headers: [.contentType: "text/html"],
@@ -141,8 +141,8 @@ struct OAuthCallbackRoute: Sendable {
                 )
             }
 
-            for publicToken in publicTokens {
-                try await exchangeAndStore(publicToken: publicToken)
+            for publicTokenResult in publicTokenResults {
+                try await exchangeAndStore(publicTokenResult: publicTokenResult)
             }
 
             return Response(
@@ -161,30 +161,30 @@ struct OAuthCallbackRoute: Sendable {
         }
     }
 
-    private func publicTokens(
+    private func publicTokenResults(
         from request: Request,
         pendingSession: PendingLinkSession
-    ) async throws -> [String] {
+    ) async throws -> [PlaidPublicTokenResult] {
         if let publicToken = request.uri.queryParameters.get("public_token") {
-            return [String(publicToken)]
+            return [PlaidPublicTokenResult(publicToken: String(publicToken), institution: nil)]
         }
 
         let linkSession = try await plaidClient.getLinkToken(pendingSession.linkToken)
-        return linkSession.publicTokens
+        return linkSession.publicTokenResults
     }
 
-    private func exchangeAndStore(publicToken: String) async throws {
-        let exchangeResponse = try await plaidClient.exchangePublicToken(publicToken)
+    private func exchangeAndStore(publicTokenResult: PlaidPublicTokenResult) async throws {
+        let exchangeResponse = try await plaidClient.exchangePublicToken(publicTokenResult.publicToken)
         let accountsResponse = try await plaidClient.getAccounts(
             accessToken: exchangeResponse.accessToken
         )
-        let institutionId = accountsResponse.item?.institutionId
+        let institutionId = publicTokenResult.institution?.institutionId ?? accountsResponse.item?.institutionId
 
         try await tokenStore.saveItem(
             id: exchangeResponse.itemId,
             accessToken: exchangeResponse.accessToken,
             institutionId: institutionId,
-            institutionName: nil
+            institutionName: publicTokenResult.institution?.normalizedName
         )
     }
 
@@ -218,6 +218,14 @@ struct OAuthCallbackRoute: Sendable {
         </body>
         </html>
         """
+    }
+}
+
+private extension PlaidLinkInstitution {
+    var normalizedName: String? {
+        guard let name else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1,5 +1,8 @@
 import Foundation
+import FluentKit
+import FluentSQLiteDriver
 import Hummingbird
+import HummingbirdFluent
 import HTTPTypes
 import Logging
 import NIOCore
@@ -31,6 +34,67 @@ private let plaidTokenVaultKeychainAvailable: Bool = {
         return false
     }
 }()
+
+private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
+    private let linkTokenGetResponse: PlaidLinkTokenGetResponse
+    private let exchangeResponse: PlaidTokenExchangeResponse
+    private let accountsResponse: PlaidAccountsResponse
+    private var requestedLinkTokens: [String] = []
+    private var exchangedPublicTokens: [String] = []
+    private var requestedAccountAccessTokens: [String] = []
+
+    init(
+        linkTokenGetResponse: PlaidLinkTokenGetResponse,
+        exchangeResponse: PlaidTokenExchangeResponse,
+        accountsResponse: PlaidAccountsResponse
+    ) {
+        self.linkTokenGetResponse = linkTokenGetResponse
+        self.exchangeResponse = exchangeResponse
+        self.accountsResponse = accountsResponse
+    }
+
+    func createLinkToken(
+        userId _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func createUpdateLinkToken(
+        userId _: String,
+        accessToken _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getLinkToken(_ linkToken: String) async throws -> PlaidLinkTokenGetResponse {
+        requestedLinkTokens.append(linkToken)
+        return linkTokenGetResponse
+    }
+
+    func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse {
+        exchangedPublicTokens.append(publicToken)
+        return exchangeResponse
+    }
+
+    func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse {
+        requestedAccountAccessTokens.append(accessToken)
+        return accountsResponse
+    }
+
+    func recordedCalls() -> (
+        linkTokens: [String],
+        publicTokens: [String],
+        accountAccessTokens: [String]
+    ) {
+        (
+            requestedLinkTokens,
+            exchangedPublicTokens,
+            requestedAccountAccessTokens
+        )
+    }
+}
 
 @Suite("PlaidBarServer")
 struct PlaidBarServerTests {
@@ -500,6 +564,31 @@ struct PlaidBarServerTests {
         )
     }
 
+    /// Runs `body` against a TokenStore backed by a temporary SQLite file,
+    /// and always shuts Fluent down so the test does not hold database files.
+    private func withTokenStore(
+        databasePath: String,
+        logger: Logger,
+        _ body: (TokenStore) async throws -> Void
+    ) async throws {
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(CreateSyncCursors())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(TokenStore(fluent: fluent, logger: logger))
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+
     @Test func serverDatabasePathIsScopedByPlaidEnvironment() {
         let dataDir = "/tmp/plaidbar-test-data"
 
@@ -914,7 +1003,13 @@ struct PlaidBarServerTests {
               "link_session_id": "session-one",
               "results": {
                 "item_add_results": [
-                  { "public_token": "public-sandbox-one" },
+                  {
+                    "public_token": "public-sandbox-one",
+                    "institution": {
+                      "name": "Example Credit Union",
+                      "institution_id": "ins_example_credit_union"
+                    }
+                  },
                   { "public_token": "public-sandbox-two" }
                 ]
               }
@@ -928,6 +1023,99 @@ struct PlaidBarServerTests {
         let response = try decoder.decode(PlaidLinkTokenGetResponse.self, from: json)
 
         #expect(response.publicTokens == ["public-sandbox-one", "public-sandbox-two"])
+        #expect(response.publicTokenResults.first?.institution?.name == "Example Credit Union")
+        #expect(response.publicTokenResults.first?.institution?.institutionId == "ins_example_credit_union")
+    }
+
+    @Test(
+        "OAuth callback stores Hosted Link institution names",
+        .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func oauthCallbackStoresHostedLinkInstitutionName() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-callback-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let itemId = "test_item_\(UUID().uuidString)"
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+
+        let linkTokenJSON = """
+        {
+          "link_token": "test-link-token",
+          "link_sessions": [
+            {
+              "link_session_id": "test-link-session",
+              "results": {
+                "item_add_results": [
+                  {
+                    "public_token": "test-public-token",
+                    "institution": {
+                      "name": "Example Credit Union",
+                      "institution_id": "ins_example_credit_union"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let linkTokenGetResponse = try decoder.decode(PlaidLinkTokenGetResponse.self, from: linkTokenJSON)
+        let accessToken = "test-access-token-\(UUID().uuidString)"
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: accessToken,
+                itemId: itemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: itemId,
+                    institutionId: "ins_accounts_fallback",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: "test-link-token")
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-callback")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let savedItem = try #require(try await store.getItem(id: itemId))
+            let calls = await plaidClient.recordedCalls()
+
+            #expect(response.status == .ok)
+            #expect(savedItem.institutionName == "Example Credit Union")
+            #expect(savedItem.institutionId == "ins_example_credit_union")
+            #expect(calls.linkTokens == ["test-link-token"])
+            #expect(calls.publicTokens == ["test-public-token"])
+            #expect(calls.accountAccessTokens == [accessToken])
+        }
     }
 
     @Test func linkTokenGetResponseAllowsUpdateModeWithoutPublicToken() throws {


### PR DESCRIPTION
## Summary
- Fixes #290 by carrying Hosted Link public-token institution metadata through the OAuth callback instead of reducing results to token strings.
- Persists Link-provided `institution.name` when saving new Plaid items, while keeping `/accounts/get` in the existing exchange flow as the institution ID fallback.
- Adds route-level regression coverage with synthetic Plaid values proving the saved item keeps the institution name.

## Changes
- `Sources/PlaidBarServer/Plaid/PlaidModels.swift`: adds a richer public-token result that preserves Link institution metadata while retaining the existing token-only convenience.
- `Sources/PlaidBarServer/Routes/LinkRoutes.swift`: exchanges/stores the richer result and passes the normalized institution name into `TokenStore.saveItem`.
- `Sources/PlaidBarServer/Plaid/PlaidClient.swift`: introduces a small `Sendable` client protocol so route tests can exercise the callback without real Plaid calls.
- `Tests/PlaidBarServerTests/PlaidBarServerTests.swift`: covers Hosted Link metadata decoding and OAuth callback storage with synthetic tokens, item IDs, and institution values only.

## Test plan
- [x] `git diff --check` passed.
- [x] `swift test --filter PlaidBarServerTests/oauthCallbackStoresHostedLinkInstitutionName --skip-update --disable-keychain` passed: 1 test passed.
- [x] `swift test --filter PlaidBarServerTests/linkTokenGetResponseReadsHostedLinkSessionResults --skip-update --disable-keychain` passed: 1 test passed.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` passed.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` passed.
- [x] Targeted diff scan for Plaid secrets, access/public tokens, raw payloads, real account IDs, transaction IDs, balances, SQLite data, logs, and screenshots found only code identifiers plus synthetic test placeholders.

## Notes
- Privacy impact: no SwiftUI/app-target Plaid credential path changes, no raw Plaid payload dumps, no real financial identifiers, no logs/screenshots, and no new network calls beyond the existing token exchange plus accounts lookup.
- CI caveat: GitHub Actions may remain blocked by the account billing/spending-limit state described in the issue delegation; no billing or CI repair attempted.
- PR #283 interaction: it changes provider metadata/storage around `TokenStore.saveItem`; this branch does not edit those files, and a dry `git merge-tree --write-tree origin/pr-283 HEAD` completed successfully. If #283 lands first, this `saveItem` call should remain compatible with its defaulted `providerID` parameter.
