### PR TITLE
test: register AddProviderToItems migration in PlaidBarServerTests

### DIFF
--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -574,6 +574,7 @@ struct PlaidBarServerTests {
         let fluent = Fluent(logger: logger)
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?


### PR DESCRIPTION
## Summary
- Cross-PR integration fix surfaced while merging the open PR batch (#279-#291).
- #283 (provider abstraction) added the `provider` column + `AddProviderToItems` migration and `ItemModel.provider`; #291 (Hosted Link institution names) added a test whose in-memory DB helper only registered `CreateItems` + `CreateSyncCursors`.
- Each PR passed in isolation, but once both were on `main` the test `OAuth callback stores Hosted Link institution names` failed with `no such column: items.provider`.

## Fix
- Register `AddProviderToItems()` between `CreateItems()` and `CreateSyncCursors()` in `PlaidBarServerTests.swift`, matching the already-correct ordering in `SandboxReliabilityTests` and `TokenStorageSafetyTests`.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` — full suite green (508 tests)
- [x] Previously-failing `OAuth callback stores Hosted Link institution names` now passes

Note: GitHub Actions review gates are billing-blocked on this repo, so the local strict-concurrency build + test suite is the gate (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)