### PR TITLE
fix: add menu bar right-click quit menu

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -7,6 +7,7 @@ import SwiftUI
 @main
 struct PlaidBarApp: App {
     @State private var appState: AppState
+    @Environment(\.openSettings) private var openSettings
     private let updaterController: SPUStandardUpdaterController
     private let statusItemContextMenuController = StatusItemContextMenuController()
 
@@ -63,9 +64,30 @@ struct PlaidBarApp: App {
                 .environment(appState)
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
-            statusItemContextMenuController.configure(statusItem: statusItem) {
-                appState.isPopoverPresented = false
-            }
+            statusItemContextMenuController.configure(
+                statusItem: statusItem,
+                actions: StatusItemContextMenuActions(
+                    showDashboard: {
+                        appState.isPopoverPresented = true
+                    },
+                    refreshDashboard: {
+                        Task { await appState.refreshDashboard() }
+                    },
+                    openSettings: {
+                        SettingsWindowActivationRestorer.shared.open(openSettings: openSettings)
+                    },
+                    checkForUpdates: {
+                        updaterController.updater.checkForUpdates()
+                    },
+                    showAbout: {
+                        NSApplication.shared.orderFrontStandardAboutPanel(nil)
+                        NSApplication.shared.activate(ignoringOtherApps: true)
+                    },
+                    dismissPopover: {
+                        appState.isPopoverPresented = false
+                    }
+                )
+            )
         }
         .menuBarExtraStyle(.window)
 

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct PlaidBarApp: App {
     @State private var appState: AppState
     private let updaterController: SPUStandardUpdaterController
+    private let statusItemContextMenuController = StatusItemContextMenuController()
 
     init() {
         Self.applyForcedAppearance()
@@ -61,7 +62,11 @@ struct PlaidBarApp: App {
             MenuBarLabel()
                 .environment(appState)
         }
-        .menuBarExtraAccess(isPresented: $appState.isPopoverPresented)
+        .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
+            statusItemContextMenuController.configure(statusItem: statusItem) {
+                appState.isPopoverPresented = false
+            }
+        }
         .menuBarExtraStyle(.window)
 
         Settings {

--- a/Sources/PlaidBar/App/StatusItemContextMenuController.swift
+++ b/Sources/PlaidBar/App/StatusItemContextMenuController.swift
@@ -1,15 +1,24 @@
 import AppKit
 
+struct StatusItemContextMenuActions {
+    let showDashboard: @MainActor () -> Void
+    let refreshDashboard: @MainActor () -> Void
+    let openSettings: @MainActor () -> Void
+    let checkForUpdates: @MainActor () -> Void
+    let showAbout: @MainActor () -> Void
+    let dismissPopover: @MainActor () -> Void
+}
+
 @MainActor
 final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
     private weak var statusItem: NSStatusItem?
     private weak var highlightedButton: NSStatusBarButton?
     private var localEventMonitor: Any?
-    private var dismissPopover: (() -> Void)?
+    private var actions: StatusItemContextMenuActions?
 
-    func configure(statusItem: NSStatusItem, dismissPopover: @escaping () -> Void) {
+    func configure(statusItem: NSStatusItem, actions: StatusItemContextMenuActions) {
         self.statusItem = statusItem
-        self.dismissPopover = dismissPopover
+        self.actions = actions
         installLocalEventMonitorIfNeeded()
     }
 
@@ -30,7 +39,7 @@ final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
             return false
         }
 
-        dismissPopover?()
+        actions?.dismissPopover()
         showMenu(from: button, with: event)
         return true
     }
@@ -40,13 +49,14 @@ final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
         menu.autoenablesItems = false
         menu.delegate = self
 
-        let quitItem = NSMenuItem(
-            title: "Quit VaultPeek",
-            action: #selector(quitApplication),
-            keyEquivalent: "q"
-        )
-        quitItem.target = self
-        menu.addItem(quitItem)
+        menu.addActionItem("Open VaultPeek", action: #selector(showDashboard), target: self)
+        menu.addActionItem("Refresh Dashboard", action: #selector(refreshDashboard), target: self)
+        menu.addItem(.separator())
+        menu.addActionItem("Settings...", action: #selector(openSettings), target: self)
+        menu.addActionItem("Check for Updates...", action: #selector(checkForUpdates), target: self)
+        menu.addActionItem("About VaultPeek", action: #selector(showAbout), target: self)
+        menu.addItem(.separator())
+        menu.addActionItem("Quit VaultPeek", action: #selector(quitApplication), target: self, keyEquivalent: "q")
 
         highlightedButton = button
         button.isHighlighted = true
@@ -58,8 +68,41 @@ final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
         highlightedButton = nil
     }
 
+    @objc private func showDashboard() {
+        actions?.showDashboard()
+    }
+
+    @objc private func refreshDashboard() {
+        actions?.refreshDashboard()
+    }
+
+    @objc private func openSettings() {
+        actions?.openSettings()
+    }
+
+    @objc private func checkForUpdates() {
+        actions?.checkForUpdates()
+    }
+
+    @objc private func showAbout() {
+        actions?.showAbout()
+    }
+
     @objc private func quitApplication() {
         NSApplication.shared.terminate(nil)
+    }
+}
+
+private extension NSMenu {
+    func addActionItem(
+        _ title: String,
+        action: Selector,
+        target: AnyObject,
+        keyEquivalent: String = ""
+    ) {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+        item.target = target
+        addItem(item)
     }
 }
 

--- a/Sources/PlaidBar/App/StatusItemContextMenuController.swift
+++ b/Sources/PlaidBar/App/StatusItemContextMenuController.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+@MainActor
+final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
+    private weak var statusItem: NSStatusItem?
+    private weak var highlightedButton: NSStatusBarButton?
+    private var localEventMonitor: Any?
+    private var dismissPopover: (() -> Void)?
+
+    func configure(statusItem: NSStatusItem, dismissPopover: @escaping () -> Void) {
+        self.statusItem = statusItem
+        self.dismissPopover = dismissPopover
+        installLocalEventMonitorIfNeeded()
+    }
+
+    private func installLocalEventMonitorIfNeeded() {
+        guard localEventMonitor == nil else { return }
+
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+            let didHandleEvent = MainActor.assumeIsolated {
+                guard let self else { return false }
+                return self.handleRightMouseDown(event)
+            }
+            return didHandleEvent ? nil : event
+        }
+    }
+
+    private func handleRightMouseDown(_ event: NSEvent) -> Bool {
+        guard let button = statusItem?.button, event.isInside(button: button) else {
+            return false
+        }
+
+        dismissPopover?()
+        showMenu(from: button, with: event)
+        return true
+    }
+
+    private func showMenu(from button: NSStatusBarButton, with event: NSEvent) {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        menu.delegate = self
+
+        let quitItem = NSMenuItem(
+            title: "Quit VaultPeek",
+            action: #selector(quitApplication),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        highlightedButton = button
+        button.isHighlighted = true
+        NSMenu.popUpContextMenu(menu, with: event, for: button)
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        highlightedButton?.isHighlighted = false
+        highlightedButton = nil
+    }
+
+    @objc private func quitApplication() {
+        NSApplication.shared.terminate(nil)
+    }
+}
+
+private extension NSEvent {
+    @MainActor
+    func isInside(button: NSStatusBarButton) -> Bool {
+        guard window === button.window else { return false }
+
+        let locationInButton = button.convert(locationInWindow, from: nil)
+        return button.bounds.contains(locationInButton)
+    }
+}


### PR DESCRIPTION
## Summary
- Right-clicking the menu bar status item now opens a native context menu.
- Adds quick actions for opening VaultPeek, refreshing the dashboard, Settings, Sparkle updates, About, and Quit.
- Keeps the existing left-click window popover behavior unchanged.

## Changes
- Wires `MenuBarExtraAccess` status-item introspection into the app entrypoint.
- Adds a main-actor AppKit controller for secondary-click handling, menu highlighting, and app termination.
- Routes menu actions through existing app paths, including `AppState.refreshDashboard()` and the Settings activation restorer.

## Test plan
- [x] `swift build`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [ ] Manual menu-bar right-click and action smoke test

## Notes
- Manual status-item clicking was not automated from this environment.
