### PR TITLE
feat: polish wealth summary visuals

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -57,9 +57,11 @@ struct PlaidBarApp: App {
         MenuBarExtra {
             MainPopover()
                 .environment(appState)
+                .forcedAppColorScheme(Self.forcedColorScheme)
         } label: {
             MenuBarLabel()
                 .environment(appState)
+                .forcedAppColorScheme(Self.forcedColorScheme)
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented)
         .menuBarExtraStyle(.window)
@@ -67,6 +69,7 @@ struct PlaidBarApp: App {
         Settings {
             SettingsView(updater: updaterController.updater)
                 .environment(appState)
+                .forcedAppColorScheme(Self.forcedColorScheme)
         }
     }
 
@@ -84,6 +87,19 @@ struct PlaidBarApp: App {
             NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
         default:
             break
+        }
+    }
+
+    private static var forcedColorScheme: ColorScheme? {
+        guard let mode = CommandLineOptions.value(for: "--appearance") else { return nil }
+
+        switch mode.lowercased() {
+        case "light":
+            return .light
+        case "dark":
+            return .dark
+        default:
+            return nil
         }
     }
 
@@ -109,5 +125,23 @@ struct PlaidBarApp: App {
         if let settingsTab = CommandLineOptions.value(for: "--settings-tab") {
             UserDefaults.standard.set(settingsTab.lowercased(), forKey: "settings.selectedTab")
         }
+    }
+}
+
+private struct ForcedAppColorScheme: ViewModifier {
+    let colorScheme: ColorScheme?
+
+    func body(content: Content) -> some View {
+        if let colorScheme {
+            content.environment(\.colorScheme, colorScheme)
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    func forcedAppColorScheme(_ colorScheme: ColorScheme?) -> some View {
+        modifier(ForcedAppColorScheme(colorScheme: colorScheme))
     }
 }

--- a/Sources/PlaidBar/Theme/CategoryAccentTokens.swift
+++ b/Sources/PlaidBar/Theme/CategoryAccentTokens.swift
@@ -1,0 +1,41 @@
+import PlaidBarCore
+import SwiftUI
+
+enum CategoryAccentTokens {
+    static func color(for category: SpendingCategory) -> Color {
+        switch category {
+        case .foodAndDrink:
+            .pink
+        case .transportation:
+            .teal
+        case .shopping:
+            .cyan
+        case .entertainment:
+            .mint
+        case .personalCare:
+            .purple
+        case .healthAndFitness:
+            .red
+        case .billsAndUtilities:
+            .orange
+        case .homeImprovement:
+            .brown
+        case .travel:
+            .indigo
+        case .education:
+            .blue
+        case .subscriptions:
+            SemanticColors.recurring
+        case .income:
+            SemanticColors.positive
+        case .transfer, .transferOut:
+            .secondary
+        case .bankFees:
+            SemanticColors.negative
+        case .government:
+            SemanticColors.brandSecondary
+        case .other:
+            .secondary
+        }
+    }
+}

--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -7,7 +7,7 @@ enum SemanticColors {
 
     /// Money received — paycheck deposits, refunds, Venmo inflows.
     /// Used in transaction rows and Income vs Expense chart bars.
-    static let income = Color.green
+    static let income = Color(nsColor: .systemGreen)
 
     /// Default text color for outgoing transactions
     /// (uses `.primary` to follow system appearance).
@@ -15,54 +15,54 @@ enum SemanticColors {
 
     /// Outstanding credit card balance shown in account rows
     /// and credit utilization display.
-    static let creditDebt = Color.red
+    static let creditDebt = Color(nsColor: .systemRed)
 
     /// Available/spendable balance in depository account rows.
-    static let available = Color.green
+    static let available = Color(nsColor: .systemGreen)
 
     // MARK: - Status Indicators
 
     /// General caution indicator — credit utilization at or above the
     /// user's warning threshold (icon tint), stale sync badge.
-    static let warning = Color.orange
+    static let warning = Color(nsColor: .systemOrange)
 
     /// Favorable delta — spending decreased vs. prior period, balance increased.
-    static let positive = Color.green
+    static let positive = Color(nsColor: .systemGreen)
 
     /// Unfavorable delta — spending increased vs. prior period,
     /// "Remove" destructive actions.
-    static let negative = Color.red
+    static let negative = Color(nsColor: .systemRed)
 
     /// Uncommitted transactions that haven't cleared yet.
-    static let pending = Color.orange
+    static let pending = Color(nsColor: .systemOrange)
 
     // MARK: - Charts
 
     /// Balance history mini-chart and spending trend line/area fill.
-    static let sparkline = Color.blue
+    static let sparkline = Color(nsColor: .systemBlue)
 
     // MARK: - Brand Identity
 
     /// Primary app accent — hero icons, step dots, active controls.
-    static let brand = Color.blue
+    static let brand = Color(nsColor: .systemBlue)
 
     /// Secondary accent — sandbox mode icon, complementary highlights.
-    static let brandSecondary = Color.orange
+    static let brandSecondary = Color(nsColor: .systemOrange)
 
     // MARK: - Recurring
 
     /// Detected recurring charges badge and recurring transaction section header.
-    static let recurring = Color.indigo
+    static let recurring = Color(nsColor: .systemIndigo)
 
     /// Utilization thresholds. Yellow is excluded from the ramp: yellow text
     /// at caption size falls below 4.5:1 contrast in both appearances, so the
     /// 30-75% band shares orange and the icon ladder (below) carries the
     /// severity distinction.
     static func utilization(for percent: Double, threshold: Double = 30) -> Color {
-        guard percent >= threshold else { return .green }
+        guard percent >= threshold else { return Color(nsColor: .systemGreen) }
         switch percent {
-        case ..<75: return .orange
-        default: return .red
+        case ..<75: return Color(nsColor: .systemOrange)
+        default: return Color(nsColor: .systemRed)
         }
     }
 
@@ -73,6 +73,11 @@ enum SemanticColors {
         if percent < 75 { return "exclamationmark.triangle.fill" }
         return "xmark.octagon"
     }
+}
+
+enum AppearanceTextColors {
+    static let primary = Color(nsColor: .labelColor)
+    static let secondary = Color(nsColor: .secondaryLabelColor)
 }
 
 // MARK: - Spacing (8pt grid)
@@ -135,6 +140,8 @@ enum MotionTokens {
     static let refreshSettle = Animation.linear(duration: 0.3)
     /// Loading skeleton pulse. Always pass through `animation`.
     static let loadingPulse = Animation.easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+    /// Decorative background drift. Always pass through `animation`.
+    static let backgroundDrift = Animation.easeInOut(duration: 18).repeatForever(autoreverses: true)
 
     static let staticLoadingOpacity = 0.62
     static let loadingPulseOpacity = 0.55
@@ -159,6 +166,19 @@ enum MotionTokens {
 // MARK: - Native Surfaces
 
 enum SurfaceTokens {
+    struct SurfaceShadow: Sendable, Equatable {
+        let opacity: Double
+        let radius: CGFloat
+        let x: CGFloat
+        let y: CGFloat
+    }
+
+    struct SurfaceDepth: Sendable, Equatable {
+        let strokeOpacity: Double
+        let innerStrokeOpacity: Double
+        let shadow: SurfaceShadow?
+    }
+
     static let popoverCornerRadius: CGFloat = 12
     static let panelCornerRadius: CGFloat = 7
     static let compactCornerRadius: CGFloat = 6
@@ -170,6 +190,37 @@ enum SurfaceTokens {
 
     static let panelStrokeOpacity = 0.075
     static let emphasizedStrokeOpacity = 0.16
+
+    static let popoverTextureOpacity = 0.12
+    static let popoverTextureReduceTransparencyOpacity = 0.03
+
+    static let leftPanelDepth = SurfaceDepth(
+        strokeOpacity: 0.11,
+        innerStrokeOpacity: 0.045,
+        shadow: SurfaceShadow(opacity: 0.16, radius: 14, x: 0, y: 8)
+    )
+    static let raisedDepth = SurfaceDepth(
+        strokeOpacity: 0.08,
+        innerStrokeOpacity: 0.035,
+        shadow: SurfaceShadow(opacity: 0.11, radius: 10, x: 0, y: 5)
+    )
+    static let insetDepth = SurfaceDepth(
+        strokeOpacity: 0.055,
+        innerStrokeOpacity: 0.025,
+        shadow: SurfaceShadow(opacity: 0.055, radius: 5, x: 0, y: 2)
+    )
+    static let heroDepth = SurfaceDepth(
+        strokeOpacity: 0.10,
+        innerStrokeOpacity: 0.055,
+        shadow: SurfaceShadow(opacity: 0.12, radius: 12, x: 0, y: 6)
+    )
+    static let emphasizedDepth = SurfaceDepth(
+        strokeOpacity: emphasizedStrokeOpacity,
+        innerStrokeOpacity: 0.045,
+        shadow: SurfaceShadow(opacity: 0.08, radius: 8, x: 0, y: 4)
+    )
+
+    static let heroGlowOpacity = 0.10
 
     /// Liquid Glass is a progressive enhancement on macOS 26+.
     /// macOS 15 users keep the same layout with SwiftUI material/fill fallback.

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -162,17 +162,17 @@ struct AccountDetailFlyout: View {
             DetailValue(
                 title: summary.availableTitle,
                 value: Formatters.currency(summary.availableBalance, format: .compact),
-                tint: .primary
+                tint: AppearanceTextColors.primary
             )
             DetailValue(
                 title: summary.currentTitle,
                 value: Formatters.currency(summary.currentBalance, format: .compact),
-                tint: .primary
+                tint: AppearanceTextColors.primary
             )
 
-            // Utilization stays .primary here — risk severity is carried by
-            // the tinted icon ladder in the row and the Status section, not
-            // by tinting small data text below contrast thresholds.
+            // Utilization stays neutral here — risk severity is carried by the
+            // tinted icon ladder in the row and the Status section, not by
+            // tinting small data text below contrast thresholds.
             if account.balances.utilizationPercent != nil,
                let utilizationText = AccountPresentation.dashboardUtilizationDetailText(
                    for: account,
@@ -182,7 +182,7 @@ struct AccountDetailFlyout: View {
                 DetailValue(
                     title: "Utilization",
                     value: utilizationText,
-                    tint: .primary
+                    tint: AppearanceTextColors.primary
                 )
             }
         }
@@ -485,7 +485,7 @@ private struct CategorySliceRow: View {
             HStack(spacing: Spacing.sm) {
                 Image(systemName: slice.category.iconName)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(tint)
                     .frame(width: Sizing.iconInline)
 
                 Text(slice.category.displayName)
@@ -510,7 +510,7 @@ private struct CategorySliceRow: View {
                     .fill(.quaternary.opacity(0.5))
                     .overlay(alignment: .leading) {
                         Capsule()
-                            .fill(.secondary)
+                            .fill(tint.opacity(0.82))
                             .frame(width: max(proxy.size.width * slice.share, 2))
                     }
             }
@@ -526,6 +526,10 @@ private struct CategorySliceRow: View {
     private var shareText: String {
         "\(Int((slice.share * 100).rounded()))%"
     }
+
+    private var tint: Color {
+        CategoryAccentTokens.color(for: slice.category)
+    }
 }
 
 // MARK: - Shared Detail Components
@@ -533,7 +537,7 @@ private struct CategorySliceRow: View {
 func accountConnectionTint(for level: AccountConnectionLevel) -> Color {
     switch level {
     case .demo, .offline, .healthy, .unknown:
-        .secondary
+        AppearanceTextColors.secondary
     case .stale, .loginRequired:
         SemanticColors.warning
     case .error:
@@ -600,7 +604,9 @@ struct TransactionMiniRow: View {
 
             Text(amountText)
                 .dataText()
-                .foregroundStyle(transaction.isIncome ? SemanticColors.positive : .primary)
+                .foregroundStyle(
+                    transaction.isIncome ? SemanticColors.positive : AppearanceTextColors.primary
+                )
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
@@ -666,10 +672,16 @@ struct AccountDrillInActionBar: View {
                     onAction(action)
                 } label: {
                     Label(action.title, systemImage: action.iconName)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(action == .remove ? SemanticColors.negative : AppearanceTextColors.primary)
+                        .padding(.horizontal, Spacing.sm)
+                        .padding(.vertical, Spacing.chipVertical)
+                        .glassSurface(
+                            action == .remove ? .emphasized(SemanticColors.negative) : .inset,
+                            cornerRadius: Radius.control
+                        )
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .tint(action == .remove ? SemanticColors.negative : nil)
+                .buttonStyle(.plain)
                 .accessibilityLabel(action.accessibilityLabel(accountDisplayName: accountDisplayName))
                 .accessibilityHint(action.accessibilityHint)
             }

--- a/Sources/PlaidBar/Views/BalanceCompositionBar.swift
+++ b/Sources/PlaidBar/Views/BalanceCompositionBar.swift
@@ -1,0 +1,78 @@
+import PlaidBarCore
+import SwiftUI
+
+struct BalanceCompositionBarSegment: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: Double
+    let share: Double
+    let tint: Color
+
+    var fillColor: Color {
+        value > 0 ? tint.opacity(0.82) : Color.primary.opacity(0.08)
+    }
+}
+
+struct AnimatedBalanceCompositionBar: View {
+    let segments: [BalanceCompositionBarSegment]
+    var height: CGFloat = 8
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealProgress = 0.0
+
+    private let segmentSpacing: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { proxy in
+            HStack(spacing: segmentSpacing) {
+                ForEach(segments) { segment in
+                    RoundedRectangle(cornerRadius: Radius.cell)
+                        .fill(segment.fillColor)
+                        .frame(
+                            width: segmentWidth(
+                                segment,
+                                totalWidth: proxy.size.width,
+                                segmentCount: segments.count
+                            )
+                        )
+                        .accessibilityLabel(segmentAccessibility(segment))
+                }
+            }
+        }
+        .frame(height: height)
+        .onAppear(perform: reveal)
+        .onChange(of: segments) { _, _ in
+            reveal()
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func reveal() {
+        if reduceMotion {
+            revealProgress = 1
+        } else {
+            revealProgress = 0
+            withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+                revealProgress = 1
+            }
+        }
+    }
+
+    private func segmentWidth(
+        _ segment: BalanceCompositionBarSegment,
+        totalWidth: CGFloat,
+        segmentCount: Int
+    ) -> CGFloat {
+        let gaps = CGFloat(max(segmentCount - 1, 0)) * segmentSpacing
+        let availableWidth = max(totalWidth - gaps, 0)
+        return max(availableWidth * CGFloat(segment.share) * revealProgress, 6)
+    }
+
+    private func segmentAccessibility(_ segment: BalanceCompositionBarSegment) -> String {
+        "\(segment.title), \(Formatters.currency(segment.value, format: .full)), \(percentText(segment.share)) of balance mix"
+    }
+}
+
+private func percentText(_ share: Double) -> String {
+    "\(Int((share * 100).rounded()))%"
+}

--- a/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
@@ -14,6 +14,14 @@ struct BalanceTrendChart: View {
 
     var body: some View {
         Chart(trend.points, id: \.date) { snapshot in
+            AreaMark(
+                x: .value("Date", snapshot.date),
+                yStart: .value("Baseline", trend.chartBaseline),
+                yEnd: .value("Net worth", snapshot.balance)
+            )
+            .interpolationMethod(.monotone)
+            .foregroundStyle(areaGradient)
+
             LineMark(
                 x: .value("Date", snapshot.date),
                 y: .value("Net worth", snapshot.balance)
@@ -55,5 +63,16 @@ struct BalanceTrendChart: View {
         case .flat:
             .secondary
         }
+    }
+
+    private var areaGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                tint.opacity(0.22),
+                tint.opacity(0.035),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -6,6 +6,7 @@ struct MainPopover: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("dashboard.accountFilter") private var selectedFilterRawValue = DashboardAccountFilter.all.rawValue
     @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
     @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
@@ -64,22 +65,21 @@ struct MainPopover: View {
                     // inside the fly-out instead of growing the whole popover
                     // past the intended screen-bounded height.
                     .frame(maxHeight: dashboardScrollHeight)
+                    .leftPanelSurface()
                     .transition(.move(edge: .leading).combined(with: .opacity))
 
                 Divider()
+                    .opacity(0.35)
             }
 
             dashboardColumn
                 .frame(width: Layout.dashboardWidth)
         }
         .frame(width: popoverWidth)
-        // Stronger liquid-glass transparency: the thinnest system material
-        // lets the desktop read through the popover while the persisted
-        // overlay setting enforces a legibility floor.
+        .foregroundStyle(AppearanceTextColors.primary)
+        .environment(\.colorScheme, effectiveColorScheme)
         .background {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-                .overlay(Color(nsColor: .windowBackgroundColor).opacity(transparencySetting.materialOverlayOpacity))
+            PopoverMaterialBackground(transparencySetting: transparencySetting)
         }
         // Keep the dashboard stationary when the fly-out opens: pin the
         // window's right edge so the extra width grows leftward instead of
@@ -158,6 +158,18 @@ struct MainPopover: View {
 
     private var transparencySetting: PopoverTransparencySetting {
         PopoverTransparencySetting(value: popoverTransparency)
+    }
+
+    private var effectiveColorScheme: ColorScheme {
+        guard let mode = CommandLineOptions.value(for: "--appearance") else { return colorScheme }
+        switch mode.lowercased() {
+        case "light":
+            return .light
+        case "dark":
+            return .dark
+        default:
+            return colorScheme
+        }
     }
 
     private var dashboardColumn: some View {
@@ -335,6 +347,8 @@ private struct DashboardHeader: View {
                 .help(trend.accessibilitySummary)
             }
         }
+        .padding(Spacing.sm)
+        .heroAccentSurface()
     }
 
     private func deltaTint(for direction: BalanceTrend.Direction) -> Color {
@@ -344,7 +358,7 @@ private struct DashboardHeader: View {
         case .down:
             SemanticColors.negative
         case .flat:
-            .secondary
+            AppearanceTextColors.secondary
         }
     }
 }
@@ -473,7 +487,7 @@ private struct MetricCard: View {
                 .foregroundStyle(.secondary)
             Text(value)
                 .dataText()
-                .foregroundStyle(emphasizesTint ? tint : .primary)
+                .foregroundStyle(emphasizesTint ? tint : AppearanceTextColors.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
             Text(detail)
@@ -492,15 +506,14 @@ private struct MetricCard: View {
 private struct BalanceCompositionStrip: View {
     @Environment(AppState.self) private var appState
 
-    private let segmentSpacing: CGFloat = 2
-
     private var presentation: BalanceCompositionPresentation {
         BalanceCompositionPresentation(accounts: appState.accounts)
     }
 
-    private var activeSegments: [BalanceCompositionSegment] {
+    private var activeSegments: [BalanceCompositionBarSegment] {
         presentation.segments.map { segment in
-            BalanceCompositionSegment(
+            BalanceCompositionBarSegment(
+                id: segment.id,
                 title: segment.title,
                 value: segment.value,
                 share: segment.share,
@@ -537,25 +550,7 @@ private struct BalanceCompositionStrip: View {
                     .foregroundStyle(.secondary)
             }
 
-            GeometryReader { proxy in
-                HStack(spacing: segmentSpacing) {
-                    ForEach(activeSegments) { segment in
-                        RoundedRectangle(cornerRadius: Radius.cell)
-                            .fill(segment.fillColor)
-                            .frame(
-                                width: segmentWidth(
-                                    segment,
-                                    totalWidth: proxy.size.width,
-                                    segmentCount: activeSegments.count
-                                )
-                            )
-                            .accessibilityLabel(
-                                "\(segment.title), \(Formatters.currency(segment.value, format: .compact)), \(segmentPercentText(segment)) of balance mix"
-                            )
-                    }
-                }
-            }
-            .frame(height: 7)
+            AnimatedBalanceCompositionBar(segments: activeSegments, height: 7)
 
             HStack(spacing: Spacing.sm) {
                 ForEach(activeSegments) { segment in
@@ -567,39 +562,10 @@ private struct BalanceCompositionStrip: View {
         .glassSurface(.inset)
         .accessibilityElement(children: .contain)
     }
-
-    private func segmentWidth(
-        _ segment: BalanceCompositionSegment,
-        totalWidth: CGFloat,
-        segmentCount: Int
-    ) -> CGFloat {
-        let gaps = CGFloat(max(segmentCount - 1, 0)) * segmentSpacing
-        let availableWidth = max(totalWidth - gaps, 0)
-        return max(availableWidth * CGFloat(segment.share), 6)
-    }
-
-    private func segmentPercentText(_ segment: BalanceCompositionSegment) -> String {
-        "\(Int((segment.share * 100).rounded()))%"
-    }
-}
-
-private struct BalanceCompositionSegment: Identifiable {
-    let title: String
-    let value: Double
-    let share: Double
-    let tint: Color
-
-    var id: String {
-        title
-    }
-
-    var fillColor: Color {
-        value > 0 ? tint.opacity(0.82) : Color.primary.opacity(0.08)
-    }
 }
 
 private struct BalanceCompositionLegend: View {
-    let segment: BalanceCompositionSegment
+    let segment: BalanceCompositionBarSegment
 
     var body: some View {
         HStack(spacing: 5) {
@@ -675,7 +641,7 @@ private struct BalanceActivityHeatmap: View {
 
                 Text(isInitialLoad ? "—" : totalLabel(for: layout))
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(isInitialLoad ? .secondary : totalTint(for: layout))
+                    .foregroundStyle(isInitialLoad ? AppearanceTextColors.secondary : totalTint(for: layout))
                     .monospacedDigit()
                     .lineLimit(1)
             }
@@ -783,11 +749,11 @@ private struct BalanceActivityHeatmap: View {
     }
 
     private func totalTint(for layout: SpendingHeatmapLayout) -> Color {
-        guard layout.mode == .netCashflow else { return .secondary }
+        guard layout.mode == .netCashflow else { return AppearanceTextColors.primary }
         let displayAmount = SpendingHeatmap.displayCashflowAmount(layout.totalValue)
         if displayAmount > 0 { return SemanticColors.positive }
         if displayAmount < 0 { return SemanticColors.negative }
-        return .secondary
+        return AppearanceTextColors.secondary
     }
 
     private func cashflowText(for value: Double) -> String {
@@ -981,7 +947,7 @@ private struct LocalAIStatusPill: View {
     private var tint: Color {
         switch availability.state {
         case .available: SemanticColors.positive
-        case .disabled: .secondary
+        case .disabled: AppearanceTextColors.secondary
         case .unavailable: SemanticColors.warning
         }
     }
@@ -995,6 +961,7 @@ private struct LocalInsightEvidenceChip: View {
             HStack(spacing: 4) {
                 Image(systemName: chip.systemImage)
                     .font(.caption2.weight(.semibold))
+                    .foregroundStyle(accentTint)
                 Text(chip.label)
                     .lineLimit(1)
             }
@@ -1012,6 +979,11 @@ private struct LocalInsightEvidenceChip: View {
         .padding(.vertical, Spacing.rowVertical)
         .glassSurface(.inset, cornerRadius: Radius.control)
         .help("\(chip.label): \(chip.value)")
+    }
+
+    private var accentTint: Color {
+        guard let category = chip.accentCategory else { return AppearanceTextColors.secondary }
+        return CategoryAccentTokens.color(for: category)
     }
 }
 
@@ -1100,7 +1072,7 @@ private struct DashboardStatusReadinessPanel: View {
         // Warning/negative tints are reserved for actionable verdicts —
         // an in-flight first load renders neutral.
         switch readiness.level {
-        case .healthy, .loading: .secondary
+        case .healthy, .loading: AppearanceTextColors.secondary
         case .warning: SemanticColors.warning
         case .blocked: SemanticColors.negative
         }
@@ -1444,7 +1416,7 @@ private struct AccountRowWithDrilldown: View {
     }
 
     private var accountAccessibilityLabel: String {
-        AccountPresentation.rowAccessibilityLabel(
+        let label = AccountPresentation.rowAccessibilityLabel(
             for: account,
             amountText: AccountPresentation.rowAmountText(for: account),
             connectionLabel: connectionPresentation.rowLabel,
@@ -1452,6 +1424,12 @@ private struct AccountRowWithDrilldown: View {
             isSelected: isSelected,
             utilizationThreshold: appState.creditUtilizationThreshold
         )
+        guard let demoTrend else { return label }
+        return "\(label). \(accountTrendAccessibility(demoTrend))"
+    }
+
+    private var demoTrend: BalanceTrend? {
+        demoAccountTrend(for: account, appState: appState)
     }
 
     private var pendingCount: Int {
@@ -1650,13 +1628,19 @@ private struct DashboardAccountRow: View {
 
             Spacer(minLength: Spacing.compactRowContentSpacing)
 
+            if let demoTrend {
+                BalanceTrendChart(trend: demoTrend)
+                    .frame(width: 54, height: 16)
+                    .accessibilityHidden(true)
+            }
+
             VStack(alignment: .trailing, spacing: Spacing.xs) {
-                // Amounts are data, not verdicts: always .primary. Risk is
+                // Amounts are data, not verdicts: keep them neutral. Risk is
                 // carried by the utilization line below — icon + tint + text,
                 // and only once the user's own threshold is crossed.
                 Text(amountText)
                     .dataText()
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(AppearanceTextColors.primary)
                     .lineLimit(1)
 
                 if let utilization = account.balances.utilizationPercent {
@@ -1676,7 +1660,7 @@ private struct DashboardAccountRow: View {
                         }
                         Text(trailingDetailText)
                             .font(.caption.weight(.medium))
-                            .foregroundStyle(utilizationNeedsAttention ? AnyShapeStyle(.primary) :
+                            .foregroundStyle(utilizationNeedsAttention ? AnyShapeStyle(AppearanceTextColors.primary) :
                                 AnyShapeStyle(.secondary))
                     }
                     .lineLimit(1)
@@ -1766,6 +1750,29 @@ private struct DashboardAccountRow: View {
     private var statusTint: Color {
         accountConnectionTint(for: connectionPresentation.level)
     }
+
+    private var demoTrend: BalanceTrend? {
+        demoAccountTrend(for: account, appState: appState)
+    }
+}
+
+@MainActor
+private func demoAccountTrend(for account: AccountDTO, appState: AppState) -> BalanceTrend? {
+    guard appState.usesDemoConnectionPresentation else { return nil }
+    return BalanceTrend.evaluate(history: DemoFixtures.accountBalanceHistory(forAccountId: account.id))
+}
+
+private func accountTrendAccessibility(_ trend: BalanceTrend) -> String {
+    let change: String
+    switch trend.direction {
+    case .up:
+        change = "up \(Formatters.currency(abs(trend.delta), format: .full))"
+    case .down:
+        change = "down \(Formatters.currency(abs(trend.delta), format: .full))"
+    case .flat:
+        change = "unchanged"
+    }
+    return "Demo account balance trend \(change) over the last \(trend.spanDays) day\(trend.spanDays == 1 ? "" : "s")"
 }
 
 // MARK: - Footer

--- a/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
+++ b/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
@@ -1,0 +1,79 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+struct PopoverMaterialBackground: View {
+    let transparencySetting: PopoverTransparencySetting
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        ZStack {
+            PopoverMeshTexture(
+                opacity: reduceTransparency
+                    ? SurfaceTokens.popoverTextureReduceTransparencyOpacity
+                    : SurfaceTokens.popoverTextureOpacity,
+                reduceMotion: reduceMotion
+            )
+
+            Rectangle()
+                .fill(.ultraThinMaterial)
+
+            Color(nsColor: .windowBackgroundColor)
+                .opacity(transparencySetting.materialOverlayOpacity)
+        }
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
+    }
+}
+
+private struct PopoverMeshTexture: View {
+    let opacity: Double
+    let reduceMotion: Bool
+
+    @State private var isDrifted = false
+
+    var body: some View {
+        LinearGradient(
+            colors: [
+                SemanticColors.brand.opacity(opacity),
+                Color.primary.opacity(opacity * 0.35),
+                SemanticColors.brandSecondary.opacity(opacity * 0.82),
+                Color.clear,
+            ],
+            startPoint: isDrifted ? .topTrailing : .topLeading,
+            endPoint: isDrifted ? .bottomLeading : .bottomTrailing
+        )
+        .overlay {
+            LinearGradient(
+                colors: [
+                    Color.clear,
+                    Color.primary.opacity(opacity * 0.26),
+                    SemanticColors.brand.opacity(opacity * 0.48),
+                ],
+                startPoint: isDrifted ? .bottomTrailing : .leading,
+                endPoint: isDrifted ? .topLeading : .trailing
+            )
+            .blendMode(.softLight)
+        }
+        .onAppear {
+            guard !reduceMotion else {
+                isDrifted = false
+                return
+            }
+            withAnimation(MotionTokens.animation(MotionTokens.backgroundDrift, reduceMotion: reduceMotion)) {
+                isDrifted = true
+            }
+        }
+        .onChange(of: reduceMotion) { _, shouldReduceMotion in
+            if shouldReduceMotion {
+                isDrifted = false
+            } else {
+                withAnimation(MotionTokens.animation(MotionTokens.backgroundDrift, reduceMotion: shouldReduceMotion)) {
+                    isDrifted = true
+                }
+            }
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -10,10 +10,14 @@ import SwiftUI
 /// stroke — separation comes from spacing; hairlines are reserved for
 /// emphasized (attention) states.
 enum SurfaceRank {
+    /// Persistent left fly-out panel.
+    case leftPanel
     /// Primary content panels: account list, fly-out, heatmap.
     case raised
     /// Quiet secondary surfaces: metric strips, legends, chips.
     case inset
+    /// Decorative hero emphasis. Never carries finance meaning by itself.
+    case hero(Color)
     /// Attention states only: tinted fill plus hairline.
     case emphasized(Color)
 
@@ -23,26 +27,64 @@ enum SurfaceRank {
         // than over `.regularMaterial` to keep separation and keep `.secondary`
         // text legible over a busy wallpaper.
         switch self {
+        case .leftPanel: AnyShapeStyle(.quaternary.opacity(0.72))
         case .raised: AnyShapeStyle(.quaternary)
         case .inset: AnyShapeStyle(.quaternary.opacity(0.55))
+        case let .hero(tint):
+            AnyShapeStyle(
+                LinearGradient(
+                    colors: [
+                        tint.opacity(SurfaceTokens.heroGlowOpacity),
+                        Color.primary.opacity(0.035),
+                        Color.clear,
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
         case let .emphasized(tint): AnyShapeStyle(tint.opacity(0.12))
         }
     }
 
-    var stroke: Color? {
+    var depth: SurfaceTokens.SurfaceDepth {
         switch self {
-        case .raised, .inset: nil
-        case let .emphasized(tint): tint.opacity(0.16)
+        case .leftPanel:
+            SurfaceTokens.leftPanelDepth
+        case .raised:
+            SurfaceTokens.raisedDepth
+        case .inset:
+            SurfaceTokens.insetDepth
+        case .hero:
+            SurfaceTokens.heroDepth
+        case .emphasized:
+            SurfaceTokens.emphasizedDepth
         }
+    }
+
+    func stroke(multiplier: Double) -> Color {
+        switch self {
+        case let .emphasized(tint):
+            tint.opacity(min(depth.strokeOpacity * multiplier, 0.22))
+        case let .hero(tint):
+            tint.opacity(min(depth.strokeOpacity * multiplier, 0.16))
+        case .leftPanel, .raised, .inset:
+            Color.primary.opacity(min(depth.strokeOpacity * multiplier, 0.16))
+        }
+    }
+
+    func innerStroke(multiplier: Double) -> Color {
+        Color.white.opacity(min(depth.innerStrokeOpacity * multiplier, 0.10))
     }
 }
 
 private struct GlassSurface: ViewModifier {
     let rank: SurfaceRank
     let cornerRadius: CGFloat
+    @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        let multiplier = PopoverTransparencySetting(value: popoverTransparency).surfaceDepthMultiplier
 
         // Liquid Glass is a macOS 26+ progressive enhancement. Raised/inset
         // ranks carry no underlay fill so the material reads clean, but the
@@ -51,33 +93,40 @@ private struct GlassSurface: ViewModifier {
         #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
             if #available(macOS 26.0, *) {
                 content
-                    .background(emphasizedFill ?? AnyShapeStyle(.clear), in: shape)
+                    .background(liquidGlassFill, in: shape)
                     .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
-                    .overlay {
-                        if let stroke = rank.stroke {
-                            shape.stroke(stroke, lineWidth: 1)
-                        }
-                    }
+                    .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
+                    .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
             } else {
-                fallback(content: content, shape: shape)
+                fallback(content: content, shape: shape, multiplier: multiplier)
             }
         #else
-            fallback(content: content, shape: shape)
+            fallback(content: content, shape: shape, multiplier: multiplier)
         #endif
     }
 
-    private var emphasizedFill: AnyShapeStyle? {
-        guard case let .emphasized(tint) = rank else { return nil }
-        return AnyShapeStyle(tint.opacity(0.10))
+    private var liquidGlassFill: AnyShapeStyle {
+        switch rank {
+        case .raised, .inset:
+            AnyShapeStyle(.clear)
+        case .leftPanel, .hero, .emphasized:
+            rank.fill
+        }
     }
 
-    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
+    private func fallback(content: Content, shape: RoundedRectangle, multiplier: Double) -> some View {
         content
             .background(rank.fill, in: shape)
+            .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
+            .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
+    }
+
+    private func surfaceStroke(shape: RoundedRectangle, multiplier: Double) -> some View {
+        shape.stroke(rank.stroke(multiplier: multiplier), lineWidth: 1)
             .overlay {
-                if let stroke = rank.stroke {
-                    shape.stroke(stroke, lineWidth: 1)
-                }
+                shape
+                    .inset(by: 1)
+                    .stroke(rank.innerStroke(multiplier: multiplier), lineWidth: 0.5)
             }
     }
 }
@@ -88,6 +137,25 @@ extension View {
         cornerRadius: CGFloat = Radius.panel
     ) -> some View {
         modifier(GlassSurface(rank: rank, cornerRadius: cornerRadius))
+    }
+
+    func leftPanelSurface() -> some View {
+        glassSurface(.leftPanel, cornerRadius: SurfaceTokens.panelCornerRadius)
+    }
+
+    func heroAccentSurface(tint: Color = SemanticColors.brand) -> some View {
+        glassSurface(.hero(tint), cornerRadius: Radius.panel)
+    }
+}
+
+private extension View {
+    func surfaceShadow(_ shadow: SurfaceTokens.SurfaceShadow?, multiplier: Double) -> some View {
+        self.shadow(
+            color: Color.black.opacity((shadow?.opacity ?? 0) * multiplier),
+            radius: shadow?.radius ?? 0,
+            x: shadow?.x ?? 0,
+            y: shadow?.y ?? 0
+        )
     }
 }
 

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -19,7 +19,8 @@ struct WealthSummaryFlyout: View {
             lastSyncRelative: appState.lastSyncRelative,
             statusSyncText: appState.statusSyncText,
             errorMessage: appState.error,
-            creditUtilizationThreshold: appState.creditUtilizationThreshold
+            creditUtilizationThreshold: appState.creditUtilizationThreshold,
+            balanceHistory: appState.balanceHistory
         )
     }
 
@@ -92,7 +93,11 @@ struct WealthSummaryFlyout: View {
                     .contentTransition(.numericText())
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
+
+                WealthNetWorthTrendBlock(trend: presentation.netWorthTrend)
             }
+            .padding(Spacing.sm)
+            .heroAccentSurface()
         }
     }
 
@@ -100,6 +105,39 @@ struct WealthSummaryFlyout: View {
         let netWorth = Formatters.currency(presentation.netWorth, format: .full)
         let netCashflow = cashflowText(presentation.cashflow.net, format: .full)
         return "Wealth summary. Net worth \(netWorth). 30 day net cashflow \(netCashflow). \(presentation.syncHealth.title). \(presentation.attention.detail)"
+    }
+}
+
+private struct WealthNetWorthTrendBlock: View {
+    let trend: NetWorthTrendPresentation
+
+    var body: some View {
+        switch trend {
+        case let .available(balanceTrend):
+            HStack(alignment: .center, spacing: Spacing.sm) {
+                BalanceTrendChart(trend: balanceTrend)
+                    .frame(height: 38)
+
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(balanceTrend.deltaText)
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
+                    Text(balanceTrend.spanText)
+                        .microText()
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(balanceTrend.accessibilitySummary)
+            .help(balanceTrend.accessibilitySummary)
+        case let .insufficientHistory(pointCount, requiredPointCount):
+            Label(
+                "Trend pending · \(max(requiredPointCount - pointCount, 0)) more snapshot\(max(requiredPointCount - pointCount, 0) == 1 ? "" : "s")",
+                systemImage: "chart.line.uptrend.xyaxis"
+            )
+            .detailText()
+            .accessibilityLabel(trend.accessibilitySummary)
+        }
     }
 }
 
@@ -170,7 +208,7 @@ private struct WealthMetricGrid: View {
                 value: Formatters.currency(presentation.totalDebt, format: .compact),
                 detail: presentation.totalDebt > 0 ? "Credit and loans" : "No debt synced",
                 systemImage: "creditcard.fill",
-                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : .secondary
+                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : AppearanceTextColors.secondary
             )
         }
         .accessibilityElement(children: .contain)
@@ -198,7 +236,7 @@ private struct WealthMetricTile: View {
 
             Text(value)
                 .dataText()
-                .foregroundStyle(.primary)
+                .foregroundStyle(AppearanceTextColors.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.78)
 
@@ -219,7 +257,17 @@ private struct WealthMetricTile: View {
 private struct WealthBalanceMixSection: View {
     let presentation: WealthSummaryPresentation
 
-    private let segmentSpacing: CGFloat = 2
+    private var barSegments: [BalanceCompositionBarSegment] {
+        presentation.balanceMix.segments.map { segment in
+            BalanceCompositionBarSegment(
+                id: segment.id,
+                title: segment.title,
+                value: segment.value,
+                share: segment.share,
+                tint: tint(for: segment.id)
+            )
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -230,23 +278,7 @@ private struct WealthBalanceMixSection: View {
                     .detailText()
                     .foregroundStyle(.secondary)
             } else {
-                GeometryReader { proxy in
-                    HStack(spacing: segmentSpacing) {
-                        ForEach(presentation.balanceMix.segments) { segment in
-                            RoundedRectangle(cornerRadius: Radius.cell)
-                                .fill(tint(for: segment.id).opacity(0.82))
-                                .frame(
-                                    width: segmentWidth(
-                                        segment,
-                                        totalWidth: proxy.size.width,
-                                        segmentCount: presentation.balanceMix.segments.count
-                                    )
-                                )
-                                .accessibilityLabel(segmentAccessibility(segment))
-                        }
-                    }
-                }
-                .frame(height: 8)
+                AnimatedBalanceCompositionBar(segments: barSegments)
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     ForEach(presentation.balanceMix.segments) { segment in
@@ -256,16 +288,6 @@ private struct WealthBalanceMixSection: View {
             }
         }
         .accessibilityElement(children: .contain)
-    }
-
-    private func segmentWidth(
-        _ segment: BalanceCompositionPresentation.Segment,
-        totalWidth: CGFloat,
-        segmentCount: Int
-    ) -> CGFloat {
-        let gaps = CGFloat(max(segmentCount - 1, 0)) * segmentSpacing
-        let availableWidth = max(totalWidth - gaps, 0)
-        return max(availableWidth * CGFloat(segment.share), 6)
     }
 
     private func tint(for id: String) -> Color {
@@ -281,10 +303,6 @@ private struct WealthBalanceMixSection: View {
         default:
             Color.secondary.opacity(0.6)
         }
-    }
-
-    private func segmentAccessibility(_ segment: BalanceCompositionPresentation.Segment) -> String {
-        "\(segment.title), \(Formatters.currency(segment.value, format: .full)), \(percentText(segment.share)) of balance mix"
     }
 }
 
@@ -409,11 +427,11 @@ private struct WealthCashflowRow: View {
         case .income:
             return SemanticColors.positive
         case .spending:
-            return .primary
+            return AppearanceTextColors.primary
         case .net:
             if amount > 0 { return SemanticColors.positive }
             if amount < 0 { return SemanticColors.negative }
-            return .secondary
+            return AppearanceTextColors.secondary
         }
     }
 }
@@ -457,7 +475,7 @@ private struct WealthCreditSection: View {
     }
 
     private func tint(_ summary: WealthSummaryPresentation.CreditUtilizationSummary) -> Color {
-        guard summary.exceedsThreshold else { return .secondary }
+        guard summary.exceedsThreshold else { return AppearanceTextColors.secondary }
         return SemanticColors.utilization(for: summary.percent, threshold: threshold)
     }
 }

--- a/Sources/PlaidBarCore/Models/BalanceTrend.swift
+++ b/Sources/PlaidBarCore/Models/BalanceTrend.swift
@@ -4,17 +4,23 @@ import Foundation
 /// header sparkline: trend direction, signed delta, and the honest day span
 /// the data actually covers (which can be shorter than the requested window
 /// while history is still accumulating).
-public struct BalanceTrend: Sendable {
-    public enum Direction: Sendable {
+public struct BalanceTrend: Sendable, Equatable {
+    public enum Direction: Sendable, Equatable {
         case up
         case down
         case flat
     }
 
+    public static let requiredPointCount = 2
+
     public let direction: Direction
     public let delta: Double
     public let spanDays: Int
     public let points: [BalanceSnapshot]
+
+    public var chartBaseline: Double {
+        points.map(\.balance).min() ?? 0
+    }
 
     /// Signed compact delta, e.g. "+$1.2K", "-$420".
     public var deltaText: String {
@@ -60,7 +66,7 @@ public struct BalanceTrend: Sendable {
             .filter { $0.date >= windowStart && $0.date <= now }
             .sorted { $0.date < $1.date }
 
-        guard let first = points.first, let last = points.last, points.count >= 2 else {
+        guard let first = points.first, let last = points.last, points.count >= requiredPointCount else {
             return nil
         }
 

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -171,12 +171,20 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         public let label: String
         public let value: String
         public let systemImage: String
+        public let accentCategory: SpendingCategory?
 
-        public init(id: String, label: String, value: String, systemImage: String) {
+        public init(
+            id: String,
+            label: String,
+            value: String,
+            systemImage: String,
+            accentCategory: SpendingCategory? = nil
+        ) {
             self.id = id
             self.label = label
             self.value = value
             self.systemImage = systemImage
+            self.accentCategory = accentCategory
         }
     }
 
@@ -244,7 +252,8 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
                 id: "top-category",
                 label: "Top category",
                 value: topCategory.category.displayName,
-                systemImage: topCategory.category.iconName
+                systemImage: topCategory.category.iconName,
+                accentCategory: topCategory.category
             ))
         }
 

--- a/Sources/PlaidBarCore/Models/NetWorthTrendPresentation.swift
+++ b/Sources/PlaidBarCore/Models/NetWorthTrendPresentation.swift
@@ -1,0 +1,43 @@
+public enum NetWorthTrendPresentation: Sendable, Equatable {
+    case available(BalanceTrend)
+    case insufficientHistory(pointCount: Int, requiredPointCount: Int)
+
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        now: Date = Date(),
+        windowDays: Int = 90,
+        calendar: Calendar = .current
+    ) -> NetWorthTrendPresentation {
+        if let trend = BalanceTrend.evaluate(
+            history: history,
+            now: now,
+            windowDays: windowDays,
+            calendar: calendar
+        ) {
+            return .available(trend)
+        }
+
+        let windowStart = calendar.date(
+            byAdding: .day,
+            value: -(windowDays - 1),
+            to: calendar.startOfDay(for: now)
+        ) ?? calendar.startOfDay(for: now)
+        let pointCount = windowDays > 0
+            ? history.filter { $0.date >= windowStart && $0.date <= now }.count
+            : 0
+        return .insufficientHistory(
+            pointCount: pointCount,
+            requiredPointCount: BalanceTrend.requiredPointCount
+        )
+    }
+
+    public var accessibilitySummary: String {
+        switch self {
+        case let .available(trend):
+            return trend.accessibilitySummary
+        case let .insufficientHistory(pointCount, requiredPointCount):
+            let needed = max(requiredPointCount - pointCount, 0)
+            return "Net worth trend unavailable. Needs \(needed) more local balance snapshot\(needed == 1 ? "" : "s")."
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
+++ b/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
@@ -16,6 +16,18 @@ public struct PopoverTransparencySetting: Sendable, Equatable {
         Int(value.rounded())
     }
 
+    public var normalizedProgress: Double {
+        (value - Self.minimumValue) / (Self.maximumValue - Self.minimumValue)
+    }
+
+    /// Higher transparency needs slightly more surface separation so cards
+    /// remain readable over busy desktops. This is visual-only and does not
+    /// change the persisted transparency value.
+    public var surfaceDepthMultiplier: Double {
+        let multiplier = 0.86 + (normalizedProgress * 0.28)
+        return (multiplier * 100).rounded() / 100
+    }
+
     /// Solid fill layered over `.ultraThinMaterial`. Lower values produce a
     /// more opaque panel; higher values preserve more desktop read-through.
     /// The floor keeps text and numeric finance values legible at maximum

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -68,6 +68,29 @@ public enum DemoFixtures {
         }
     }
 
+    public static func accountBalanceHistory(
+        forAccountId accountId: String,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [BalanceSnapshot] {
+        guard let accountIndex = accounts.firstIndex(where: { $0.id == accountId }),
+              let currentBalance = accounts[accountIndex].balances.current ?? accounts[accountIndex].balances.available
+        else {
+            return []
+        }
+
+        let amplitude = max(abs(currentBalance) * 0.045, 120 + (Double(accountIndex) * 35))
+        let direction = accountIndex.isMultiple(of: 2) ? 1.0 : -1.0
+
+        return (0..<60).reversed().map { daysAgo in
+            let date = calendar.date(byAdding: .day, value: -daysAgo, to: now) ?? now
+            let progress = Double(59 - daysAgo) / 59
+            let drift = -direction * amplitude * (1 - progress)
+            let wobble = daysAgo == 0 ? 0 : sin((Double(daysAgo) + Double(accountIndex)) / 5.5) * (amplitude * 0.18)
+            return BalanceSnapshot(date: date, balance: currentBalance + drift + wobble)
+        }
+    }
+
     // MARK: - Explicit recent window
 
     private static func explicitTransactions(now: Date, calendar: Calendar) -> [TransactionDTO] {

--- a/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
@@ -92,6 +92,7 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
     public let totalAssets: Double
     public let totalDebt: Double
     public let balanceMix: BalanceCompositionPresentation
+    public let netWorthTrend: NetWorthTrendPresentation
     public let cashflow: CashflowSummary
     public let creditUtilization: CreditUtilizationSummary?
     public let attention: AttentionSummary
@@ -104,6 +105,10 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         totalAssets: Double,
         totalDebt: Double,
         balanceMix: BalanceCompositionPresentation,
+        netWorthTrend: NetWorthTrendPresentation = .insufficientHistory(
+            pointCount: 0,
+            requiredPointCount: BalanceTrend.requiredPointCount
+        ),
         cashflow: CashflowSummary,
         creditUtilization: CreditUtilizationSummary?,
         attention: AttentionSummary,
@@ -115,6 +120,7 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         self.totalAssets = totalAssets
         self.totalDebt = totalDebt
         self.balanceMix = balanceMix
+        self.netWorthTrend = netWorthTrend
         self.cashflow = cashflow
         self.creditUtilization = creditUtilization
         self.attention = attention
@@ -135,6 +141,7 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         statusSyncText: String,
         errorMessage: String?,
         creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        balanceHistory: [BalanceSnapshot] = [],
         windowDays: Int = 30,
         now: Date = Date(),
         calendar: Calendar = .current
@@ -160,6 +167,11 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
             totalAssets: totalAssets(from: accounts),
             totalDebt: MenuBarSummary.totalDebt(from: accounts),
             balanceMix: BalanceCompositionPresentation(accounts: accounts),
+            netWorthTrend: NetWorthTrendPresentation.evaluate(
+                history: balanceHistory,
+                now: now,
+                calendar: calendar
+            ),
             cashflow: cashflowSummary(
                 from: transactions,
                 windowDays: windowDays,

--- a/Tests/PlaidBarCoreTests/DemoFixturesTests.swift
+++ b/Tests/PlaidBarCoreTests/DemoFixturesTests.swift
@@ -119,4 +119,28 @@ struct DemoFixturesTests {
         }
         #expect(abs(total - DemoFixtures.netWorth) < 0.01)
     }
+
+    @Test("Demo account balance histories cover every synthetic account")
+    func accountBalanceHistoriesCoverEveryDemoAccount() {
+        for account in DemoFixtures.accounts {
+            let history = DemoFixtures.accountBalanceHistory(
+                forAccountId: account.id,
+                now: referenceDate
+            )
+
+            #expect(history.count == 60)
+            #expect(history == history.sorted { $0.date < $1.date })
+            #expect(history.last?.date == referenceDate)
+            #expect(abs((history.last?.balance ?? 0) - (account.balances.current ?? account.balances.available ?? 0)) < 0.01)
+        }
+    }
+
+    @Test("Demo account balance histories are deterministic and unknown ids stay empty")
+    func accountBalanceHistoriesAreDeterministic() {
+        let first = DemoFixtures.accountBalanceHistory(forAccountId: "demo_checking", now: referenceDate)
+        let second = DemoFixtures.accountBalanceHistory(forAccountId: "demo_checking", now: referenceDate)
+
+        #expect(first == second)
+        #expect(DemoFixtures.accountBalanceHistory(forAccountId: "accountSecretIdentifier", now: referenceDate).isEmpty)
+    }
 }

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -23,6 +23,7 @@ struct LocalAIInsightReceiptTests {
         #expect(receipt.evidenceChips.map(\.id).contains("transactions"))
         #expect(receipt.evidenceChips.contains { $0.id == "window" && $0.value == "2026-06-05 to 2026-06-11" })
         #expect(receipt.evidenceChips.map(\.id).contains("top-category"))
+        #expect(receipt.evidenceChips.first { $0.id == "top-category" }?.accentCategory == .foodAndDrink)
         #expect(receipt.confidence.contains("Deterministic confidence"))
         #expect(receipt.limitations.contains { $0.contains("raw IDs and Plaid payloads are excluded") })
         #expect(!receipt.headline.contains("accountSecretIdentifier"))

--- a/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
@@ -27,4 +27,16 @@ struct PopoverTransparencyTests {
         #expect(lessTransparent.materialOverlayOpacity == 0.32)
         #expect(moreTransparent.materialOverlayOpacity == 0.06)
     }
+
+    @Test("Higher transparency slightly strengthens depth separation")
+    func higherTransparencyStrengthensDepthSeparation() {
+        let lessTransparent = PopoverTransparencySetting(value: 20)
+        let defaultTransparency = PopoverTransparencySetting(value: PopoverTransparencySetting.defaultValue)
+        let moreTransparent = PopoverTransparencySetting(value: 85)
+
+        #expect(lessTransparent.normalizedProgress == 0)
+        #expect(moreTransparent.normalizedProgress == 1)
+        #expect(lessTransparent.surfaceDepthMultiplier < defaultTransparency.surfaceDepthMultiplier)
+        #expect(defaultTransparency.surfaceDepthMultiplier < moreTransparent.surfaceDepthMultiplier)
+    }
 }

--- a/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
@@ -63,6 +63,88 @@ struct WealthSummaryPresentationTests {
         #expect(presentation.creditUtilization?.exceedsThreshold == true)
     }
 
+    @Test("Surfaces an available net worth trend from local balance history")
+    func surfacesAvailableNetWorthTrend() {
+        let older = Calendar.current.date(byAdding: .day, value: -6, to: now)!
+        let presentation = makePresentation(
+            balanceHistory: [
+                BalanceSnapshot(date: older, balance: 1_000),
+                BalanceSnapshot(date: now, balance: 1_250),
+            ]
+        )
+
+        guard case let .available(trend) = presentation.netWorthTrend else {
+            Issue.record("Expected available trend")
+            return
+        }
+
+        #expect(trend.delta == 250)
+        #expect(trend.direction == .up)
+        #expect(trend.spanDays == 6)
+        #expect(trend.accessibilitySummary.contains("up $250.00"))
+    }
+
+    @Test("Surfaces insufficient history when local snapshots are unavailable")
+    func surfacesInsufficientNetWorthHistory() {
+        let presentation = makePresentation(balanceHistory: [])
+
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation.netWorthTrend else {
+            Issue.record("Expected insufficient trend history")
+            return
+        }
+
+        #expect(pointCount == 0)
+        #expect(requiredPointCount == 2)
+        #expect(presentation.netWorthTrend.accessibilitySummary.contains("Needs 2 more local balance snapshots"))
+    }
+
+    @Test("Insufficient net worth trend counts only snapshots inside the trend window")
+    func insufficientNetWorthTrendCountsOnlyWindowSnapshots() {
+        let oldFirst = Calendar.current.date(byAdding: .day, value: -130, to: now)!
+        let oldSecond = Calendar.current.date(byAdding: .day, value: -120, to: now)!
+        let recent = Calendar.current.date(byAdding: .day, value: -3, to: now)!
+        let presentation = makePresentation(
+            balanceHistory: [
+                BalanceSnapshot(date: oldFirst, balance: 900),
+                BalanceSnapshot(date: oldSecond, balance: 950),
+                BalanceSnapshot(date: recent, balance: 1_000),
+            ]
+        )
+
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation.netWorthTrend else {
+            Issue.record("Expected insufficient trend history")
+            return
+        }
+
+        #expect(pointCount == 1)
+        #expect(requiredPointCount == 2)
+        #expect(presentation.netWorthTrend.accessibilitySummary.contains("Needs 1 more local balance snapshot"))
+    }
+
+    @Test("Net worth trend summary does not expose account or item identifiers")
+    func netWorthTrendSummaryExcludesIdentifiers() {
+        let older = Calendar.current.date(byAdding: .day, value: -2, to: now)!
+        let presentation = makePresentation(
+            accounts: [
+                AccountDTO(
+                    id: "accountSecretIdentifier",
+                    itemId: "itemSecretIdentifier",
+                    name: "Checking",
+                    type: .depository,
+                    balances: BalanceDTO(current: 1_250)
+                ),
+            ],
+            balanceHistory: [
+                BalanceSnapshot(date: older, balance: 1_000),
+                BalanceSnapshot(date: now, balance: 1_250),
+            ]
+        )
+
+        let summary = presentation.netWorthTrend.accessibilitySummary
+        #expect(!summary.contains("accountSecretIdentifier"))
+        #expect(!summary.contains("itemSecretIdentifier"))
+    }
+
     @Test("Uses existing attention and sync status inputs")
     func derivesAttentionAndSyncHealthFromStatusInputs() {
         let presentation = makePresentation(
@@ -117,7 +199,8 @@ struct WealthSummaryPresentationTests {
         lastSyncRelative: String? = "now",
         statusSyncText: String = "Synced now",
         errorMessage: String? = nil,
-        creditUtilizationThreshold: Double = 30
+        creditUtilizationThreshold: Double = 30,
+        balanceHistory: [BalanceSnapshot] = []
     ) -> WealthSummaryPresentation {
         WealthSummaryPresentation.evaluate(
             accounts: accounts,
@@ -133,6 +216,7 @@ struct WealthSummaryPresentationTests {
             statusSyncText: statusSyncText,
             errorMessage: errorMessage,
             creditUtilizationThreshold: creditUtilizationThreshold,
+            balanceHistory: balanceHistory,
             now: now
         )
     }


### PR DESCRIPTION
## Summary

- Adds a cohesive visual depth, hero accent, and material texture pass for the dashboard and Wealth Summary without changing server, storage, or Plaid data boundaries.
- Reuses existing aggregate balance history for net-worth trend presentation and adds demo-only synthetic account histories for row sparklines.
- Keeps finance/risk meaning backed by text, icons, legends, and accessibility summaries rather than color alone.

## Autonomous task IDs

- Task ID(s): AND-340, AND-341, AND-342
- Backlog slice: Wealth Summary visual polish tranche
- Scope note: One focused app/core presentation PR; no PlaidBarServer routes, storage, token handling, SQLite, Plaid payload, or real financial artifact changes.

## Agent coordination

- Builder agent: Codex
- Builder branch/worktree: `codex/and-340-341-342-visual-polish-v2` at `/Users/ftchvs/Developer/pb-worktrees/and-340-342-visual-polish-v2`
- Reviewer/merge steward: Otto / GitHub required checks
- Coordination note: Use this branch for review only unless coordinated. Requested branch `codex/and-340-341-342-visual-polish` already backs open PR #293 for unrelated menu-bar context-menu work, so this PR uses the `-v2` branch to avoid overwriting it.

## Changed files

- `Sources/PlaidBar/Theme`, `Views/SharedModifiers.swift`, `PopoverMaterialBackground.swift`: depth-ranked glass surfaces, app text tokens, category accents, and subtle material texture.
- `Sources/PlaidBar/Views/MainPopover.swift`, `WealthSummaryFlyout.swift`, `BalanceTrendChart.swift`, `BalanceCompositionBar.swift`: hero net-worth accents, area-filled trend charts, animated balance mix, and demo-only account sparklines.
- `Sources/PlaidBarCore/Models`, `Utilities/WealthSummaryPresentation.swift`, `DemoFixtures.swift`: `NetWorthTrendPresentation`, `BalanceTrend: Equatable`, balance-history presentation input, deterministic demo account balance history.
- `Tests/PlaidBarCoreTests`: trend-state, stale-history, demo fixture, transparency-depth, and local insight accent coverage.

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain`
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain`
- [x] `swift test --filter PlaidBarCoreTests --skip-update --disable-keychain` — 416 tests passed. Existing compile warning observed in `Tests/PlaidBarServerTests/PlaidBarServerTests.swift:935` while dependency tests compile; not introduced by this diff.
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `./Scripts/qa-appearance-matrix.sh /tmp/plaidbar-and-340-342-qa-clean` — light/dark dashboard and flyout rendered with demo data only.
- [x] Secret scan completed for docs, source, tests, commands, workflows, and agent prompt files. Hits were existing placeholder/config/redaction references only; no real secrets or raw financial artifacts added.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude/Codex review auth/token/session/setup-only failures are documented as blocking unless Felipe explicitly grants a one-off override.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed. No docs/screenshots were committed; QA artifacts are demo-only under `/tmp`.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.