### PR TITLE
fix: count unique degraded items in status indicator (#295)

### DIFF
--- a/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
+++ b/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
@@ -12,6 +12,12 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
     public let title: String
     /// Number of accounts matching this filter.
     public let count: Int
+    /// Number of unique degraded Plaid Items represented by the matching
+    /// accounts. Nonzero only for `.status`. This is item-scoped, not
+    /// account-scoped: one degraded institution exposing several accounts
+    /// counts once, so recovery messaging never overstates how many
+    /// institutions are broken.
+    public let attentionItemCount: Int
     /// True only for `.status` when at least one account needs attention.
     /// Pair the badge with an icon or text — never color alone.
     public let showsAttentionBadge: Bool
@@ -30,6 +36,7 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
         kind: DashboardAccountFilterKind,
         title: String,
         count: Int,
+        attentionItemCount: Int = 0,
         showsAttentionBadge: Bool,
         shortcutOrdinal: Int,
         accessibilityLabel: String,
@@ -38,6 +45,7 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
         self.kind = kind
         self.title = title
         self.count = count
+        self.attentionItemCount = attentionItemCount
         self.showsAttentionBadge = showsAttentionBadge
         self.shortcutOrdinal = shortcutOrdinal
         self.accessibilityLabel = accessibilityLabel
@@ -65,7 +73,9 @@ public extension DashboardNavBarItem {
     /// and for a healthy Status segment (no separate indicator is shown then).
     var statusIndicatorAccessibilityLabel: String? {
         guard kind == .status, showsAttentionBadge else { return nil }
-        return "\(count) \(count == 1 ? "item needs" : "items need") attention"
+        // Item-scoped, not row-scoped: a bank that exposes checking, savings,
+        // and credit under one Plaid Item must announce one item, not three.
+        return "\(attentionItemCount) \(attentionItemCount == 1 ? "item needs" : "items need") attention"
     }
 }
 
@@ -82,6 +92,11 @@ public enum DashboardNavBarModel {
         DashboardAccountFilterKind.allCases.enumerated().map { index, kind in
             let count = accounts.count { kind.includes($0, degradedItemIds: degradedItemIds) }
             let showsAttentionBadge = kind == .status && count > 0
+            // Collapse the matching account rows to the unique Plaid Items they
+            // belong to, so recovery messaging counts institutions, not rows.
+            let attentionItemCount = kind == .status
+                ? Set(accounts.lazy.filter { degradedItemIds.contains($0.itemId) }.map(\.itemId)).count
+                : 0
             var accessibilityValue = "\(count) matching \(accountWord(for: count))"
             if showsAttentionBadge {
                 // VoiceOver cannot see the warning icon; say it.
@@ -91,6 +106,7 @@ public enum DashboardNavBarModel {
                 kind: kind,
                 title: kind.rawValue,
                 count: count,
+                attentionItemCount: attentionItemCount,
                 showsAttentionBadge: showsAttentionBadge,
                 shortcutOrdinal: index + 1,
                 accessibilityLabel: "\(kind.rawValue) account filter",

--- a/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
@@ -230,19 +230,56 @@ struct DashboardNavBarModelTests {
         // Non-status segments never expose the indicator label.
         #expect(degraded.filter { $0.kind != .status }.allSatisfy { $0.statusIndicatorAccessibilityLabel == nil })
 
-        // Multiple degraded accounts -> plural wording.
+        // One degraded *item* that owns three account rows must still announce
+        // a single item needing attention — the indicator counts unique Plaid
+        // items, not matching account rows.
         let healthyItemDegraded = DashboardNavBarModel.items(
             accounts: Self.mixedAccounts,
             degradedItemIds: [Self.healthyItemId]
         )
+        let healthyItemStatus = healthyItemDegraded.first { $0.kind == .status }
+        // The Status filter row count stays account-based (three rows match)...
+        #expect(healthyItemStatus?.count == 3)
+        // ...but the recovery indicator speaks in items: one institution.
+        #expect(healthyItemStatus?.statusIndicatorAccessibilityLabel == "1 item needs attention")
+
+        // Two distinct degraded items -> plural item wording.
+        let twoItemsDegraded = DashboardNavBarModel.items(
+            accounts: Self.mixedAccounts,
+            degradedItemIds: [Self.degradedItemId, Self.healthyItemId]
+        )
         #expect(
-            healthyItemDegraded.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel
-                == "3 items need attention"
+            twoItemsDegraded.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel
+                == "2 items need attention"
         )
 
         // Healthy Status: no indicator label.
         let healthy = DashboardNavBarModel.items(accounts: Self.mixedAccounts)
         #expect(healthy.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel == nil)
+    }
+
+    @Test("Status indicator counts unique degraded items, not matching account rows")
+    func statusIndicatorCountsUniqueDegradedItems() {
+        // One Plaid item exposing checking, savings, and credit — the common
+        // bank shape that previously over-reported as three items.
+        let sharedItemId = "item-shared"
+        let oneItemThreeAccounts = [
+            Self.makeAccount(id: "chk", itemId: sharedItemId, type: .depository, subtype: "checking"),
+            Self.makeAccount(id: "sav", itemId: sharedItemId, type: .depository, subtype: "savings"),
+            Self.makeAccount(id: "cc", itemId: sharedItemId, type: .credit, subtype: "credit card"),
+        ]
+
+        let items = DashboardNavBarModel.items(
+            accounts: oneItemThreeAccounts,
+            degradedItemIds: [sharedItemId]
+        )
+        let status = items.first { $0.kind == .status }
+
+        // Filtering still surfaces all three account rows...
+        #expect(status?.count == 3)
+        // ...while the unique degraded-item count drives the recovery wording.
+        #expect(status?.attentionItemCount == 1)
+        #expect(status?.statusIndicatorAccessibilityLabel == "1 item needs attention")
     }
 
     // MARK: - Summary


### PR DESCRIPTION
## Summary

Fixes #295. The dashboard Status filter's count is account-row based — `DashboardAccountFilterKind.status.includes` returns true for every account whose `itemId` is degraded. But `DashboardNavBarItem.statusIndicatorAccessibilityLabel` rendered that row count with **item** wording (`"N items need attention"`), so one degraded institution exposing checking + savings + credit announced *"3 items need attention"* to VoiceOver users — overstating how many banks are actually broken.

## Change

- Add an item-scoped `attentionItemCount` to `DashboardNavBarItem`: the count of **unique** degraded Plaid Items among the matching accounts (`Set(...map(\.itemId)).count`), nonzero only for `.status`.
- `statusIndicatorAccessibilityLabel` now counts items, not rows.
- The Status filter row `count` stays account-based for filtering (the issue explicitly recommended keeping it), so the filter still surfaces all matching account rows. This brings the indicator in line with the already item-based wording in `DashboardAccountEmptyState.evaluate` (`degradedItemCount`).

No view changes needed — `DashboardNavBand` already feeds `statusIndicatorAccessibilityLabel` straight to the indicator's `.help`/`.accessibilityLabel`.

## Tests

- Replaced the fixture that *encoded* the bug (`"3 items need attention"`) with assertions that one item / three accounts announces `"1 item needs attention"` while `count` stays `3`.
- Added coverage for two distinct degraded items → `"2 items need attention"`.
- Added a dedicated regression test (`statusIndicatorCountsUniqueDegradedItems`) mirroring the issue's exact scenario.

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (the CI gate) — passes.
- `swift test` — 517 tests pass.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)