### PR TITLE
fix: count status attention by item

### DIFF
--- a/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
+++ b/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
@@ -75,7 +75,11 @@ public extension DashboardNavBarItem {
         guard kind == .status, showsAttentionBadge else { return nil }
         // Item-scoped, not row-scoped: a bank that exposes checking, savings,
         // and credit under one Plaid Item must announce one item, not three.
-        return "\(attentionItemCount) \(attentionItemCount == 1 ? "item needs" : "items need") attention"
+        // Fall back to `count` when a direct caller badged the segment without
+        // supplying an item-scoped count, preserving the prior wording for
+        // previews/tests/downstream code that omit `attentionItemCount`.
+        let attention = attentionItemCount > 0 ? attentionItemCount : count
+        return "\(attention) \(attention == 1 ? "item needs" : "items need") attention"
     }
 }
 

--- a/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
+++ b/Sources/PlaidBarCore/Models/DashboardNavBarModel.swift
@@ -12,6 +12,12 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
     public let title: String
     /// Number of accounts matching this filter.
     public let count: Int
+    /// Number of unique degraded Plaid Items represented by the matching
+    /// accounts. Nonzero only for `.status`. This is item-scoped, not
+    /// account-scoped: one degraded institution exposing several accounts
+    /// counts once, so recovery messaging never overstates how many
+    /// institutions are broken.
+    public let attentionItemCount: Int
     /// True only for `.status` when at least one account needs attention.
     /// Pair the badge with an icon or text — never color alone.
     public let showsAttentionBadge: Bool
@@ -30,6 +36,7 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
         kind: DashboardAccountFilterKind,
         title: String,
         count: Int,
+        attentionItemCount: Int = 0,
         showsAttentionBadge: Bool,
         shortcutOrdinal: Int,
         accessibilityLabel: String,
@@ -38,6 +45,7 @@ public struct DashboardNavBarItem: Identifiable, Equatable, Sendable {
         self.kind = kind
         self.title = title
         self.count = count
+        self.attentionItemCount = attentionItemCount
         self.showsAttentionBadge = showsAttentionBadge
         self.shortcutOrdinal = shortcutOrdinal
         self.accessibilityLabel = accessibilityLabel
@@ -65,7 +73,9 @@ public extension DashboardNavBarItem {
     /// and for a healthy Status segment (no separate indicator is shown then).
     var statusIndicatorAccessibilityLabel: String? {
         guard kind == .status, showsAttentionBadge else { return nil }
-        return "\(count) \(count == 1 ? "item needs" : "items need") attention"
+        // Item-scoped, not row-scoped: a bank that exposes checking, savings,
+        // and credit under one Plaid Item must announce one item, not three.
+        return "\(attentionItemCount) \(attentionItemCount == 1 ? "item needs" : "items need") attention"
     }
 }
 
@@ -82,6 +92,11 @@ public enum DashboardNavBarModel {
         DashboardAccountFilterKind.allCases.enumerated().map { index, kind in
             let count = accounts.count { kind.includes($0, degradedItemIds: degradedItemIds) }
             let showsAttentionBadge = kind == .status && count > 0
+            // Collapse the matching account rows to the unique Plaid Items they
+            // belong to, so recovery messaging counts institutions, not rows.
+            let attentionItemCount = kind == .status
+                ? Set(accounts.lazy.filter { degradedItemIds.contains($0.itemId) }.map(\.itemId)).count
+                : 0
             var accessibilityValue = "\(count) matching \(accountWord(for: count))"
             if showsAttentionBadge {
                 // VoiceOver cannot see the warning icon; say it.
@@ -91,6 +106,7 @@ public enum DashboardNavBarModel {
                 kind: kind,
                 title: kind.rawValue,
                 count: count,
+                attentionItemCount: attentionItemCount,
                 showsAttentionBadge: showsAttentionBadge,
                 shortcutOrdinal: index + 1,
                 accessibilityLabel: "\(kind.rawValue) account filter",

--- a/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
@@ -230,19 +230,56 @@ struct DashboardNavBarModelTests {
         // Non-status segments never expose the indicator label.
         #expect(degraded.filter { $0.kind != .status }.allSatisfy { $0.statusIndicatorAccessibilityLabel == nil })
 
-        // Multiple degraded accounts -> plural wording.
+        // One degraded *item* that owns three account rows must still announce
+        // a single item needing attention — the indicator counts unique Plaid
+        // items, not matching account rows.
         let healthyItemDegraded = DashboardNavBarModel.items(
             accounts: Self.mixedAccounts,
             degradedItemIds: [Self.healthyItemId]
         )
+        let healthyItemStatus = healthyItemDegraded.first { $0.kind == .status }
+        // The Status filter row count stays account-based (three rows match)...
+        #expect(healthyItemStatus?.count == 3)
+        // ...but the recovery indicator speaks in items: one institution.
+        #expect(healthyItemStatus?.statusIndicatorAccessibilityLabel == "1 item needs attention")
+
+        // Two distinct degraded items -> plural item wording.
+        let twoItemsDegraded = DashboardNavBarModel.items(
+            accounts: Self.mixedAccounts,
+            degradedItemIds: [Self.degradedItemId, Self.healthyItemId]
+        )
         #expect(
-            healthyItemDegraded.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel
-                == "3 items need attention"
+            twoItemsDegraded.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel
+                == "2 items need attention"
         )
 
         // Healthy Status: no indicator label.
         let healthy = DashboardNavBarModel.items(accounts: Self.mixedAccounts)
         #expect(healthy.first { $0.kind == .status }?.statusIndicatorAccessibilityLabel == nil)
+    }
+
+    @Test("Status indicator counts unique degraded items, not matching account rows")
+    func statusIndicatorCountsUniqueDegradedItems() {
+        // One Plaid item exposing checking, savings, and credit — the common
+        // bank shape that previously over-reported as three items.
+        let sharedItemId = "item-shared"
+        let oneItemThreeAccounts = [
+            Self.makeAccount(id: "chk", itemId: sharedItemId, type: .depository, subtype: "checking"),
+            Self.makeAccount(id: "sav", itemId: sharedItemId, type: .depository, subtype: "savings"),
+            Self.makeAccount(id: "cc", itemId: sharedItemId, type: .credit, subtype: "credit card"),
+        ]
+
+        let items = DashboardNavBarModel.items(
+            accounts: oneItemThreeAccounts,
+            degradedItemIds: [sharedItemId]
+        )
+        let status = items.first { $0.kind == .status }
+
+        // Filtering still surfaces all three account rows...
+        #expect(status?.count == 3)
+        // ...while the unique degraded-item count drives the recovery wording.
+        #expect(status?.attentionItemCount == 1)
+        #expect(status?.statusIndicatorAccessibilityLabel == "1 item needs attention")
     }
 
     // MARK: - Summary


### PR DESCRIPTION
## Summary
- Fixes the dashboard Status attention indicator so it counts unique degraded Plaid Items, not matching account rows.
- Keeps the Status filter row count account-scoped, preserving the existing filtering behavior.
- Adds focused synthetic regression coverage for one degraded item with three accounts and plural item wording.

Related: #295

## Autonomous task IDs

- Task ID(s): Issue #295
- Backlog slice: Focused status accessibility/count regression
- Scope note: One narrow PlaidBarCore presenter/test fix; no server, storage, or network behavior changes.

## Agent coordination

- Builder agent: Codex
- Builder branch/worktree: `codex/fix-status-item-count` at `/Users/ftchvs/.codex/worktrees/7407/PlaidBar`
- Reviewer/merge steward: Owner/maintainer
- Coordination note: Draft PR only; no merge requested. No other threads were created, forked, steered, or assigned.

## Changed files

- `Sources/PlaidBarCore/Models/DashboardNavBarModel.swift`
- `Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift`

## Local gates

- [x] `git diff --check` passed.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` passed via repo-local review gate.
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` passed.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` not run; no server, shared DTO, storage, or package contract changes.
- [x] `swift test --filter DashboardNavBarModelTests --skip-update --disable-keychain` passed: 21 tests.
- [x] Diff secret/local-data scan completed: no matches for Plaid secrets, public/access tokens, raw Plaid payloads, real account IDs, transaction IDs, balances, local SQLite data, logs, or screenshots.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [x] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [x] Claude/Codex review auth/token/session/setup-only failures are documented as blocking unless Felipe explicitly grants a one-off override.

## Privacy and safety impact

- [x] Tests use synthetic item/account IDs only.
- [x] No real Plaid credentials, public tokens, access tokens, account IDs, transaction IDs, raw Plaid payloads, balances, local SQLite data, logs, screenshots, or generated artifacts were added.
- [x] The app still consumes existing local presenter data; no SwiftUI direct Plaid access or new network calls were introduced.
- [x] The local-first boundary is unchanged: no hosted backend, telemetry, cloud sync, multi-user accounts, or cloud AI over private transaction data.

## UI and accessibility checks

- [x] Status attention remains exposed through a warning symbol plus VoiceOver text, not color alone.
- [x] Focused accessibility wording was verified in `DashboardNavBarModelTests`.
- [x] No screenshots or docs were changed.

## Autoreview

- Repo-local serious review gate completed. No accepted/actionable findings remained.

## Residual risk

- GitHub CI/review checks were pending at PR creation.
- The filtered test command compiled the package test runner and emitted an existing Swift 6 sendability warning in `Tests/PlaidBarServerTests/PlaidBarServerTests.swift`; the required strict PlaidBar target build passed with warnings as errors.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] PR is within scoped PlaidBar/VaultPeek focused-work approval, but this draft PR should not be merged without owner direction and green required checks.
- [ ] PR head SHA must be rechecked immediately before any merge.
- [x] No other agent is actively mutating this branch/worktree to my knowledge.
