### PR TITLE
refactor: standardize balance trend reveal via MotionTokens (AND-362)

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -142,6 +142,8 @@ enum MotionTokens {
     static let loadingPulse = Animation.easeInOut(duration: 0.9).repeatForever(autoreverses: true)
     /// Decorative background drift. Always pass through `animation`.
     static let backgroundDrift = Animation.easeInOut(duration: 18).repeatForever(autoreverses: true)
+    /// Once-per-appearance left-to-right reveal for glance charts.
+    static let chartReveal = Animation.easeOut(duration: 0.55)
 
     static let staticLoadingOpacity = 0.62
     static let loadingPulseOpacity = 0.55

--- a/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
@@ -46,7 +46,7 @@ struct BalanceTrendChart: View {
                 return
             }
             revealFraction = 0
-            withAnimation(.easeOut(duration: 0.55).delay(0.1)) {
+            withAnimation(MotionTokens.chartReveal.delay(0.1)) {
                 revealFraction = 1
             }
         }


### PR DESCRIPTION
## Summary

Standardizes the `BalanceTrendChart` once-per-appearance reveal animation by routing it through a named `MotionTokens` token instead of a hardcoded `easeOut`.

- Adds `MotionTokens.chartReveal = Animation.easeOut(duration: 0.55)` with a doc comment ("Once-per-appearance left-to-right reveal for glance charts").
- Replaces the hardcoded `.easeOut(duration: 0.55).delay(0.1)` in `BalanceTrendChart.body.onAppear` with `MotionTokens.chartReveal.delay(0.1)`.

Behavior is identical: same 0.55s easeOut, same 0.1s delay, same left-to-right mask reveal. The existing Reduce Motion early-return guard (`guard !reduceMotion { revealFraction = 1; return }`) is preserved, so under Reduce Motion the full chart still renders immediately and `withAnimation` is never reached. No unrelated `MotionTokens` were changed, and tint / areaGradient / signed-delta and accessibility summary logic are untouched.

## Acceptance criteria

- [x] New named `MotionTokens.chartReveal` token added matching the current feel (`easeOut` duration 0.55)
- [x] `BalanceTrendChart` reveal now flows through `MotionTokens` (no hardcoded animation literal)
- [x] Reveal runs once per appearance when Reduce Motion is off
- [x] Reduce Motion renders the full chart immediately (early-return guard preserved)
- [x] Left-to-right mask reveal preserved
- [x] Accessibility summary and signed-delta / non-color tint reinforcement untouched
- [x] No unrelated `MotionTokens` changed
- [x] Strict-concurrency build clean (`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`)

Linear: https://linear.app/andeslab/issue/AND-362

> Note: CI may show queued or red due to a known GitHub Actions billing hold (infrastructure, not a code problem). This PR is intentionally left OPEN for review — please do not merge.