### PR TITLE
feat: calm menu bar status symbol replacement transition (AND-361)

### DIFF
--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MenuBarLabel: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         // State is carried by the symbol shape and attention text, not
@@ -13,6 +14,11 @@ struct MenuBarLabel: View {
         let presentation = appState.menuBarStatusPresentation
         HStack(spacing: Spacing.xs) {
             Image(systemName: presentation.symbolName)
+                // One-shot Apple-native cross-fade when the status glyph
+                // changes; meaning still lives in the symbol shape + text, so
+                // this is purely calm polish. Disabled under Reduce Motion so
+                // the glyph swaps instantly with no animation.
+                .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
             if let attentionText = presentation.attentionText {
                 Text(attentionText)
                     .font(.caption.weight(.medium))


### PR DESCRIPTION
## Summary

Adds an Apple-native symbol **replacement** transition to the menu bar status glyph in `Sources/PlaidBar/Views/MenuBarLabel.swift`. When `presentation.symbolName` changes (e.g. normal → warning → blocked), the glyph now cross-fades instead of hard-swapping, gated under Reduce Motion:

```swift
.contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
```

A new `@Environment(\.accessibilityReduceMotion) private var reduceMotion` drives the gate. The effect is **one-shot on change** — no indefinite animation in the menu bar.

Meaning still lives in the **symbol shape + attention text**, not color: no `foregroundStyle` tint is added, so the menu bar keeps its template-style monochrome rendering. The existing `.help(...)` and `.accessibilityLabel(...)` are untouched, and label width still tracks only actual content changes.

## Acceptance criteria

- [x] `.contentTransition(.symbolEffect(.replace))` applied to the status `Image`
- [x] Gated under Reduce Motion (`.identity` when Reduce Motion is on)
- [x] `@Environment(\.accessibilityReduceMotion)` added
- [x] No color-only status / no monochrome-breaking `foregroundStyle` tint
- [x] One-shot on change, no indefinite menu-bar animation
- [x] Width does not jitter beyond actual content changes
- [x] `.help(...)` and `.accessibilityLabel(...)` preserved
- [x] Normal / warning / blocked / attention-text states still render template-style and stay accessible
- [x] Strict-concurrency build clean (`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → Build complete!)

Linear: https://linear.app/andeslab/issue/AND-361

> Note: CI may show queued or red due to a known GitHub Actions billing hold (infra, not a code problem). This PR is intentionally left **OPEN for review** — please do not merge.