### PR TITLE
feat: native SF Symbol effects for refresh/sync state (AND-359)

### DIFF
--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -263,61 +263,26 @@ extension View {
     }
 }
 
-// MARK: - Refresh Icon (smooth spin via repeatForever)
+// MARK: - Refresh Icon (native continuous symbol effect)
 
 struct RefreshIcon: View {
     let isLoading: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var rotation: Double = 0
 
     var body: some View {
-        // Under Reduce Motion the infinite spin is replaced by a filled static
-        // symbol plus accessibility value, so loading does not depend on motion.
+        // The active refresh state is driven by a native SF Symbol effect that
+        // loops continuously while `isLoading` is true. Under Reduce Motion the
+        // symbol helpers swap in the filled static glyph at a dimmed opacity and
+        // the effect is gated inactive, so loading reads without any movement.
         Image(systemName: MotionTokens.refreshSymbolName(isLoading: isLoading, reduceMotion: reduceMotion))
-            .rotationEffect(.degrees(reduceMotion ? 0 : rotation))
+            .symbolEffect(
+                .rotate,
+                options: .repeat(.continuous),
+                isActive: isLoading && !reduceMotion
+            )
             .opacity(MotionTokens.refreshOpacity(isLoading: isLoading, reduceMotion: reduceMotion))
             .accessibilityLabel(isLoading ? "Refreshing" : "Refresh")
             .accessibilityValue(isLoading ? "In progress" : "Ready")
-            .onChange(of: isLoading) { _, loading in
-                if loading {
-                    startSpinIfAllowed()
-                } else {
-                    stopSpin(animated: true)
-                }
-            }
-            .onChange(of: reduceMotion) { _, shouldReduceMotion in
-                if shouldReduceMotion {
-                    stopSpin(animated: false)
-                } else if isLoading {
-                    startSpinIfAllowed()
-                }
-            }
-            .onAppear {
-                guard isLoading else { return }
-                startSpinIfAllowed()
-            }
-    }
-
-    private func startSpinIfAllowed() {
-        guard !reduceMotion else {
-            stopSpin(animated: false)
-            return
-        }
-
-        rotation = 0
-        withAnimation(MotionTokens.animation(MotionTokens.refreshSpin, reduceMotion: reduceMotion)) {
-            rotation = 360
-        }
-    }
-
-    private func stopSpin(animated: Bool) {
-        let animation = animated
-            ? MotionTokens.animation(MotionTokens.refreshSettle, reduceMotion: reduceMotion)
-            : nil
-
-        withAnimation(animation) {
-            rotation = 0
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces `RefreshIcon`'s manual `rotationEffect` spin (driven by `@State rotation` + `withAnimation(MotionTokens.refreshSpin)` and `onChange`/`onAppear` handlers) with a **native SF Symbol effect**:

```swift
Image(systemName: MotionTokens.refreshSymbolName(isLoading: isLoading, reduceMotion: reduceMotion))
    .symbolEffect(.rotate, options: .repeat(.continuous), isActive: isLoading && !reduceMotion)
```

The `arrow.clockwise` glyph now loops continuously while `isLoading` is true and stops at rest via the `isActive` gate — no continuous motion when not loading. The Reduce Motion fallback is preserved exactly: when `reduceMotion && isLoading`, the existing `MotionTokens.refreshSymbolName`/`refreshOpacity` helpers render the filled static `arrow.clockwise.circle.fill` at `staticLoadingOpacity`, and the symbol effect is gated inactive so there is no movement.

The now-dead manual-rotation machinery is removed: `@State rotation`, `rotationEffect`, `startSpinIfAllowed`/`stopSpin`, and the `onChange`/`onAppear` handlers that only drove rotation. `MotionTokens.refreshSpin`/`refreshSettle` remain defined (unused) in `DesignTokens.swift` per issue scope.

`RefreshIcon`'s public API (`isLoading:`) is unchanged; the sole callsite in `MainPopover.swift` is unaffected and icon sizing/layout do not shift.

## Acceptance criteria

- [x] Active refresh/sync state uses a native SF Symbol effect (`.symbolEffect(.rotate, options: .repeat(.continuous), isActive:)`) that loops continuously while loading
- [x] Reduce Motion fallback preserved exactly: filled static `arrow.clockwise.circle.fill` at `staticLoadingOpacity`, no motion; effect gated inactive under Reduce Motion
- [x] Accessibility label (`Refreshing`/`Refresh`) and value (`In progress`/`Ready`) unchanged
- [x] Dead manual-rotation machinery removed (`@State rotation`, `rotationEffect`, `startSpinIfAllowed`/`stopSpin`, rotation-only `onChange`/`onAppear`)
- [x] `MotionTokens.refreshSpin`/`refreshSettle` left defined even if unused
- [x] Refresh state stays visibly distinct without relying on color alone (glyph swap + motion + accessibility value)
- [x] Button/icon sizing and layout do not shift; no continuous motion when not loading
- [x] Strict-concurrency build clean (`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`)
- [x] Full test suite passes (516 tests)

Linear: https://linear.app/andeslab/issue/AND-359

---

_Note: CI may show queued or red due to a known GitHub Actions billing hold (infra, not a code problem). This PR is intentionally left **OPEN for review** — do not merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)