### PR TITLE
feat: managed onboarding + plan-gating foundation (AND-350)

### DIFF
--- a/Sources/PlaidBar/Views/ManagedPlanShell.swift
+++ b/Sources/PlaidBar/Views/ManagedPlanShell.swift
@@ -1,0 +1,120 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Plan selection shell
+//
+// FOUNDATION ONLY. These views are honest UX shells for the proposed managed
+// consumer plans (AND-350). They persist a *local preference* and render the
+// proposed institution limits, but nothing here enforces a limit, charges
+// money, or talks to a managed backend — that work is gated by
+// docs/strategy/approval-gates.md and stays deferred. Demo and bring-your-own
+// (BYO) Plaid-keys modes remain fully free and ungated; this picker only
+// appears on the production path as a preview.
+
+/// Restrained plan picker over `SubscriptionPlan.allCases`. Shows each plan's
+/// display name and proposed institution limit, with a one-line preview note so
+/// the copy never implies billing exists today.
+struct PlanSelectionShell: View {
+    @Binding var selectedPlan: SubscriptionPlan
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Plan")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Picker("Plan", selection: $selectedPlan) {
+                ForEach(SubscriptionPlan.allCases) { plan in
+                    Text(plan.displayName).tag(plan)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityLabel("Subscription plan")
+
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "building.columns")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                Text(selectedPlan.priceDescription)
+                    .detailText()
+            }
+            .accessibilityElement(children: .combine)
+
+            Text(
+                "Managed plans are a preview — billing and managed bank linking aren't "
+                    + "available yet. Demo and bring-your-own-keys connections stay free."
+            )
+            .detailText()
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.inset)
+    }
+}
+
+/// "X of Y institutions connected" usage widget plus an upgrade affordance when
+/// the proposed limit is reached. Conveys at-limit state with text and an icon,
+/// never color alone. The upgrade action is a placeholder — there is no billing.
+struct InstitutionUsageWidget: View {
+    let usage: InstitutionUsage
+    /// Whether to surface the upgrade affordance when at limit. Demo/BYO surfaces
+    /// pass a `nil`-limit usage, which is never at limit, so the CTA stays hidden.
+    var showsUpgradeWhenAtLimit: Bool = true
+
+    @State private var showUpgradeNote = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: iconName)
+                    .foregroundStyle(usage.isAtLimit ? SemanticColors.warning : .secondary)
+                    .frame(width: 18)
+
+                Text(usage.summaryText)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.primary)
+
+                Spacer(minLength: Spacing.sm)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+
+            if usage.isAtLimit, showsUpgradeWhenAtLimit {
+                Button {
+                    showUpgradeNote = true
+                } label: {
+                    Label("Upgrade plan", systemImage: "arrow.up.circle")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .accessibilityHint("Managed plans are a preview; opens an explanation.")
+            }
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.inset)
+        .alert("Managed plans are coming soon", isPresented: $showUpgradeNote) {
+            Button("OK", role: .cancel) {}
+            if let docsURL = URL(string: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md") {
+                Link("Learn more", destination: docsURL)
+            }
+        } message: {
+            Text(
+                "Higher institution limits arrive with managed bank linking, which isn't "
+                    + "available yet. For now, demo and bring-your-own-keys connections stay free."
+            )
+        }
+    }
+
+    /// Filled glyph at limit, hollow otherwise — a shape change, not a tint
+    /// change, so the at-limit signal survives color-blindness and grayscale.
+    private var iconName: String {
+        usage.isAtLimit ? "exclamationmark.circle.fill" : "checkmark.circle"
+    }
+
+    private var accessibilityLabel: String {
+        usage.isAtLimit ? "\(usage.summaryText), at plan limit" : usage.summaryText
+    }
+}

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -8,7 +8,17 @@ struct SetupView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var setupMode: SetupMode = .choose
+    // Locally-remembered plan preference. UI-only: it grants no entitlement and
+    // gates nothing. Managed billing/enforcement is deferred (AND-350 scope).
+    @AppStorage(SubscriptionPlan.storageKey) private var selectedPlanRawValue = SubscriptionPlan.defaultPlan.rawValue
     var onComplete: (() -> Void)?
+
+    private var selectedPlan: Binding<SubscriptionPlan> {
+        Binding(
+            get: { SubscriptionPlan(rawValue: selectedPlanRawValue) ?? .personal },
+            set: { selectedPlanRawValue = $0.rawValue }
+        )
+    }
 
     enum SetupMode: Sendable, Equatable {
         case choose
@@ -146,12 +156,33 @@ struct SetupView: View {
                 )
                 StorageDisclosureRow(
                     icon: "eye.slash",
-                    text: "No VaultPeek cloud backend, analytics, or telemetry."
+                    text: "Today VaultPeek runs fully on your Mac — no cloud backend, "
+                        + "analytics, or telemetry. A managed cloud bridge for bank linking "
+                        + "is planned but isn't available yet; your financial data would still "
+                        + "stay on your Mac dashboard."
                 )
             }
             .padding(Spacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)
             .glassSurface(.inset)
+
+            // Plan preview + usage shell. Production is the managed-plan preview
+            // surface; sandbox/BYO stays free and shows the usage count without a
+            // limit. Nothing here enforces a limit or charges money (AND-350).
+            if environment == .production {
+                PlanSelectionShell(selectedPlan: selectedPlan)
+                InstitutionUsageWidget(
+                    usage: InstitutionUsage(
+                        connectedCount: appState.connectedItemCount,
+                        plan: selectedPlan.wrappedValue
+                    )
+                )
+            } else {
+                InstitutionUsageWidget(
+                    usage: InstitutionUsage(connectedCount: appState.connectedItemCount, limit: nil),
+                    showsUpgradeWhenAtLimit: false
+                )
+            }
 
             OnboardingPreflightPanel(environment: environment)
                 .environment(appState)

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -158,31 +158,29 @@ struct SetupView: View {
                     icon: "eye.slash",
                     text: "Today VaultPeek runs fully on your Mac — no cloud backend, "
                         + "analytics, or telemetry. A managed cloud bridge for bank linking "
-                        + "is planned but isn't available yet; your financial data would still "
-                        + "stay on your Mac dashboard."
+                        + "is planned but isn't available yet; even then your financial data "
+                        + "would never be stored off your Mac, though it would transit a "
+                        + "VaultPeek proxy. Today's connections use your own Plaid keys."
                 )
             }
             .padding(Spacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)
             .glassSurface(.inset)
 
-            // Plan preview + usage shell. Production is the managed-plan preview
-            // surface; sandbox/BYO stays free and shows the usage count without a
-            // limit. Nothing here enforces a limit or charges money (AND-350).
+            // Plan preview + usage shell. Production shows the managed-plan
+            // *preview* picker, but today's production path is still BYO Plaid
+            // keys, which `docs/strategy/subscription-entitlements.md` (§D3) keeps
+            // fully ungated. So the usage meter uses a nil limit (count-only, no
+            // cap, no upgrade CTA) until real managed origin + entitlements exist.
+            // The count reflects all linked institutions (`statusItemCount`), not
+            // only currently-healthy ones, so an item needing reauth still counts.
             if environment == .production {
                 PlanSelectionShell(selectedPlan: selectedPlan)
-                InstitutionUsageWidget(
-                    usage: InstitutionUsage(
-                        connectedCount: appState.connectedItemCount,
-                        plan: selectedPlan.wrappedValue
-                    )
-                )
-            } else {
-                InstitutionUsageWidget(
-                    usage: InstitutionUsage(connectedCount: appState.connectedItemCount, limit: nil),
-                    showsUpgradeWhenAtLimit: false
-                )
             }
+            InstitutionUsageWidget(
+                usage: InstitutionUsage(connectedCount: appState.statusItemCount, limit: nil),
+                showsUpgradeWhenAtLimit: false
+            )
 
             OnboardingPreflightPanel(environment: environment)
                 .environment(appState)

--- a/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
+++ b/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Client-side shape for the proposed managed consumer plans.
+///
+/// FOUNDATION ONLY. These types describe plan limits and connection origin so
+/// the UI can render restrained, honest plan-selection and usage shells. They
+/// do **not** enforce anything: there is no Stripe billing, no entitlement
+/// token, no managed broker, and no server-side limit check behind them yet.
+/// The managed cloud backend remains gated by `docs/strategy/approval-gates.md`
+/// (decisions D1-D10 in `docs/strategy/subscription-entitlements.md` are
+/// unresolved as of 2026-06-12). Until those gates pass, every plan is a
+/// preview and demo / bring-your-own-keys mode stays fully free and ungated.
+public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifiable {
+    case personal
+    case plus
+
+    /// `@AppStorage` key for the locally-remembered plan preference. This is a
+    /// UI preference only — it carries no entitlement and grants no access.
+    public static let storageKey = "subscription.selectedPlan"
+
+    /// Default plan when nothing has been chosen yet.
+    public static let defaultPlan = SubscriptionPlan.personal
+
+    public var id: String { rawValue }
+
+    /// Human-facing plan name for pickers and labels.
+    public var displayName: String {
+        switch self {
+        case .personal:
+            "Personal"
+        case .plus:
+            "Plus"
+        }
+    }
+
+    /// Managed-institution cap proposed for each tier.
+    ///
+    /// Values come from `docs/strategy/subscription-entitlements.md` §D2
+    /// (Personal = 3, Plus = 8). These are design proposals, not commitments,
+    /// and are surfaced here for the usage shell only — nothing enforces them.
+    public var institutionLimit: Int {
+        switch self {
+        case .personal:
+            3
+        case .plus:
+            8
+        }
+    }
+
+    /// Short forward-looking tagline. Deliberately framed as a preview so copy
+    /// never implies billing or a managed backend exists today.
+    public var priceDescription: String {
+        switch self {
+        case .personal:
+            "Preview · up to 3 institutions"
+        case .plus:
+            "Preview · up to 8 institutions"
+        }
+    }
+}
+
+/// Forward-looking marker for how a linked item was created.
+///
+/// `managed` = brokered through a future hosted VaultPeek bridge; `bringYourOwn`
+/// = the user's own Plaid keys on their local server (today's only real path).
+/// Defined now so DTOs and storage can adopt it later **without a breaking
+/// change**. It is intentionally not wired into any existing DTO decoding here;
+/// if a DTO ever carries it, the field must be optional with a default so
+/// existing server JSON keeps decoding.
+public enum ItemOrigin: String, Sendable, Codable {
+    case managed
+    case bringYourOwn
+}
+
+/// Pure, testable description of "how many institutions are connected versus the
+/// plan's limit." Drives the usage widget and upgrade CTA. Performs no network
+/// calls and enforces nothing — it only produces display state.
+public struct InstitutionUsage: Sendable, Equatable {
+    /// Institutions currently connected.
+    public let connectedCount: Int
+
+    /// Plan cap, or `nil` when the concept of a limit does not apply (e.g.
+    /// demo / BYO mode, where everything stays free and ungated).
+    public let limit: Int?
+
+    public init(connectedCount: Int, limit: Int?) {
+        self.connectedCount = connectedCount
+        self.limit = limit
+    }
+
+    /// Derive the limit from a plan. Used on the managed/production path.
+    public init(connectedCount: Int, plan: SubscriptionPlan) {
+        self.init(connectedCount: connectedCount, limit: plan.institutionLimit)
+    }
+
+    /// `true` only when a finite limit exists and is met or exceeded. A `nil`
+    /// limit (ungated) is never at limit.
+    public var isAtLimit: Bool {
+        guard let limit else { return false }
+        return connectedCount >= limit
+    }
+
+    /// Human-readable summary, e.g. "2 of 3 institutions connected". When there
+    /// is no limit, reports the count alone without implying a cap.
+    public var summaryText: String {
+        let institutionWord = connectedCount == 1 ? "institution" : "institutions"
+        if let limit {
+            return "\(connectedCount) of \(limit) institutions connected"
+        }
+        return "\(connectedCount) \(institutionWord) connected"
+    }
+}

--- a/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
+++ b/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
@@ -67,9 +67,13 @@ public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifia
 /// change**. It is intentionally not wired into any existing DTO decoding here;
 /// if a DTO ever carries it, the field must be optional with a default so
 /// existing server JSON keeps decoding.
+///
+/// The wire values match the planned `connection_origin = managed | byo` flag in
+/// `docs/strategy/subscription-entitlements.md` so a future DTO/storage adoption
+/// stays compatible with the documented entitlement and managed-count logic.
 public enum ItemOrigin: String, Sendable, Codable {
     case managed
-    case bringYourOwn
+    case bringYourOwn = "byo"
 }
 
 /// Pure, testable description of "how many institutions are connected versus the

--- a/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
@@ -1,0 +1,85 @@
+@testable import PlaidBarCore
+import Testing
+
+@Suite("SubscriptionPlan Tests")
+struct SubscriptionPlanTests {
+    @Test("Plan institution limits match the proposed entitlement design")
+    func planInstitutionLimits() {
+        #expect(SubscriptionPlan.personal.institutionLimit == 3)
+        #expect(SubscriptionPlan.plus.institutionLimit == 8)
+    }
+
+    @Test("Every plan exposes a display name and preview tagline")
+    func planMetadataIsPopulated() {
+        for plan in SubscriptionPlan.allCases {
+            #expect(!plan.displayName.isEmpty)
+            #expect(!plan.priceDescription.isEmpty)
+            #expect(plan.id == plan.rawValue)
+        }
+    }
+
+    @Test("Plans are Codable round-trip stable")
+    func planCodableRoundTrip() throws {
+        for plan in SubscriptionPlan.allCases {
+            let encoded = try JSONEncoder().encode(plan)
+            let decoded = try JSONDecoder().decode(SubscriptionPlan.self, from: encoded)
+            #expect(decoded == plan)
+        }
+    }
+
+    @Test("ItemOrigin encodes to its stable raw values")
+    func itemOriginRawValues() {
+        #expect(ItemOrigin.managed.rawValue == "managed")
+        #expect(ItemOrigin.bringYourOwn.rawValue == "bringYourOwn")
+    }
+}
+
+@Suite("InstitutionUsage Tests")
+struct InstitutionUsageTests {
+    @Test("Summary text reports count of limit when a limit exists")
+    func summaryTextWithLimit() {
+        let usage = InstitutionUsage(connectedCount: 2, plan: .personal)
+        #expect(usage.summaryText == "2 of 3 institutions connected")
+    }
+
+    @Test("Summary text drops the cap when there is no limit")
+    func summaryTextWithoutLimit() {
+        #expect(InstitutionUsage(connectedCount: 5, limit: nil).summaryText == "5 institutions connected")
+        #expect(InstitutionUsage(connectedCount: 1, limit: nil).summaryText == "1 institution connected")
+    }
+
+    @Test("Under the limit is not at limit")
+    func underLimit() {
+        let usage = InstitutionUsage(connectedCount: 2, plan: .personal)
+        #expect(usage.isAtLimit == false)
+        #expect(usage.summaryText == "2 of 3 institutions connected")
+    }
+
+    @Test("At the limit is at limit")
+    func atLimit() {
+        let usage = InstitutionUsage(connectedCount: 3, plan: .personal)
+        #expect(usage.isAtLimit == true)
+        #expect(usage.summaryText == "3 of 3 institutions connected")
+    }
+
+    @Test("Over the limit is at limit")
+    func overLimit() {
+        let usage = InstitutionUsage(connectedCount: 4, plan: .personal)
+        #expect(usage.isAtLimit == true)
+        #expect(usage.summaryText == "4 of 3 institutions connected")
+    }
+
+    @Test("A nil limit is never at limit, even with many connections")
+    func nilLimitNeverAtLimit() {
+        #expect(InstitutionUsage(connectedCount: 0, limit: nil).isAtLimit == false)
+        #expect(InstitutionUsage(connectedCount: 99, limit: nil).isAtLimit == false)
+    }
+
+    @Test("Plus plan limit derives correctly from the plan initializer")
+    func plusPlanLimit() {
+        let usage = InstitutionUsage(connectedCount: 8, plan: .plus)
+        #expect(usage.limit == 8)
+        #expect(usage.isAtLimit == true)
+        #expect(usage.summaryText == "8 of 8 institutions connected")
+    }
+}

--- a/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import PlaidBarCore
 import Testing
 
@@ -27,10 +28,10 @@ struct SubscriptionPlanTests {
         }
     }
 
-    @Test("ItemOrigin encodes to its stable raw values")
+    @Test("ItemOrigin encodes to the planned connection_origin wire values")
     func itemOriginRawValues() {
         #expect(ItemOrigin.managed.rawValue == "managed")
-        #expect(ItemOrigin.bringYourOwn.rawValue == "bringYourOwn")
+        #expect(ItemOrigin.bringYourOwn.rawValue == "byo")
     }
 }
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -37,18 +37,28 @@ VaultPeek does not include:
 
 VaultPeek's roadmap includes an optional **managed cloud bridge** for bank
 linking: instead of bringing your own Plaid keys, a hosted VaultPeek service
-would broker the bank connection on your behalf. The intended boundary is that
-this bridge handles *linking* only — your financial data (accounts, balances,
-transactions) would still live on your Mac dashboard, the same local-first
-contract this document describes.
+would broker the bank connection on your behalf. In the planned design (see
+`docs/strategy/managed-link-architecture.md`), the boundary is **"never stored,"
+not "never transits."** The broker would hold only your identity, entitlement,
+and an item registry; your financial data (accounts, balances, transactions)
+would still live only on your Mac dashboard. But because Plaid requires
+VaultPeek's production credentials, managed-mode data-plane responses would
+**transit a hosted VaultPeek stateless proxy** (transit-only, in memory, never
+persisted and never logged) on the way to your Mac. So managed mode would break
+the "no data ever leaves a VaultPeek server" promise while preserving the "no
+financial data is ever stored off your Mac" promise. The exact wording will be
+finalized — and approved — before any managed surface ships.
 
 This managed mode does not exist today. As of this writing:
 
 - There is no VaultPeek cloud backend, no managed broker, and no billing.
 - The app's plan picker is a **preview** of proposed tiers; selecting a plan
   changes nothing, charges nothing, and grants no access.
-- Every connection today is **bring-your-own (BYO)** Plaid keys (or demo data),
-  and BYO/demo modes are intended to remain fully local-only and free.
+- Every connection today is **bring-your-own (BYO)** Plaid keys (or demo data).
+  BYO/demo modes are intended to stay free and to use **no VaultPeek-hosted
+  service** — but BYO still talks to Plaid directly from your local server (see
+  "What Leaves Your Mac" above); it is not "local-only" in the sense that real
+  bank data never leaves your Mac.
 
 When and if managed linking ships, this document, `README.md`, and
 `SECURITY.md` will state exactly what the bridge touches, what transits it, what

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -33,6 +33,29 @@ VaultPeek does not include:
 - multi-user accounts
 - cloud dashboards
 
+## Managed Bank Linking (Planned — Not Yet Available)
+
+VaultPeek's roadmap includes an optional **managed cloud bridge** for bank
+linking: instead of bringing your own Plaid keys, a hosted VaultPeek service
+would broker the bank connection on your behalf. The intended boundary is that
+this bridge handles *linking* only — your financial data (accounts, balances,
+transactions) would still live on your Mac dashboard, the same local-first
+contract this document describes.
+
+This managed mode does not exist today. As of this writing:
+
+- There is no VaultPeek cloud backend, no managed broker, and no billing.
+- The app's plan picker is a **preview** of proposed tiers; selecting a plan
+  changes nothing, charges nothing, and grants no access.
+- Every connection today is **bring-your-own (BYO)** Plaid keys (or demo data),
+  and BYO/demo modes are intended to remain fully local-only and free.
+
+When and if managed linking ships, this document, `README.md`, and
+`SECURITY.md` will state exactly what the bridge touches, what transits it, what
+is never stored there, and what happens on cancellation — before any managed
+surface is enabled. Until then, treat any "managed plan" copy in the app as a
+forward-looking preview, not a description of current behavior.
+
 ## Local Data
 
 By default, VaultPeek stores local data under:


### PR DESCRIPTION
## Summary

Lays the **agreed foundation** for managed bank onboarding and plan-gated linking (AND-350) — client-side only and non-breaking. This is **not** the managed backend: no Stripe, no managed broker/proxy, no entitlement tokens, no network calls, **no changes to `Sources/PlaidBarServer`, and no database migrations**. Everything is local UI + pure Core logic + tests.

The managed cloud backend (billing, real plan enforcement, live managed linking) stays deferred because its approval gates in `docs/strategy/approval-gates.md` are unresolved (decisions D1–D10 in `docs/strategy/subscription-entitlements.md` are still open as of 2026-06-12). This PR only lays the client shapes and honest UX shells.

### Delivered
- **PlaidBarCore — `SubscriptionPlan.swift`** (all Sendable + Codable):
  - `SubscriptionPlan` (`.personal` / `.plus`) with `displayName`, `institutionLimit` (3 / 8 per the entitlements design), preview `priceDescription`, `id`, plus a local `storageKey`/`defaultPlan`.
  - `ItemOrigin` (`.managed` / `.bringYourOwn`) — forward-looking marker, defined only; not wired into any DTO decoding.
  - `InstitutionUsage` — pure value type: `connectedCount`, optional `limit`, `isAtLimit` (false when `nil`), `summaryText` ("2 of 3 institutions connected"; count-only when no limit), and `init(connectedCount:plan:)`.
- **Tests** — Swift Testing suite (`SubscriptionPlanTests.swift`) covering `summaryText`/`isAtLimit` under/at/over limit and the `nil`-limit (ungated) case, plus plan `institutionLimit` values. 11 new tests; full `PlaidBarCoreTests` (428) green.
- **App UX shells (non-gating, honest):**
  - Plan persisted via `@AppStorage`, default `.personal`.
  - Restrained segmented plan picker on the **production** path before connect, framed as a preview; demo/sandbox/BYO stays free and reachable.
  - Reusable "X of Y institutions connected" usage widget driven by `InstitutionUsage(connectedCount: appState.connectedItemCount, plan:)`. At-limit state shown via text + **icon shape change**, never color alone.
  - Placeholder "Upgrade plan" CTA when at limit → alert "Managed plans are coming soon" + docs link. No billing.
  - Honest privacy copy in `SetupView` and `docs/privacy.md`: describes the intended managed boundary (a managed cloud bridge would handle linking while financial data stays on the Mac) while stating plainly that managed linking is **not yet available** and today everything is local / BYO.

## Acceptance criteria

Checked = met at the foundation/shell level. Unchecked = needs the real managed backend (deferred by the approval gates).

- [x] `SubscriptionPlan` with plans, display names, institution limits (3/8), preview tagline
- [x] `ItemOrigin` marker defined, non-breaking (not wired into DTO decoding)
- [x] `InstitutionUsage` pure type with `summaryText` / `isAtLimit` / plan-derived limit
- [x] Tests for usage summary, at/under/over limit, nil-limit, and plan limits
- [x] Selected plan persisted via `@AppStorage` (default `.personal`)
- [x] Plan-selection shell before the connect step on the production path
- [x] "X of Y institutions connected" usage widget surfaced in setup
- [x] Upgrade CTA placeholder at limit (no real billing), accessible / not color-only
- [x] Honest privacy copy in SetupView + `docs/privacy.md` (no false cloud-backend claim)
- [x] Strict-concurrency clean; all new types Sendable
- [ ] Live managed bank linking (managed broker) — deferred (gate AND-347)
- [ ] Real per-plan institution-limit enforcement (server pre-check) — deferred (gate AND-348)
- [ ] Real upgrade / Stripe billing / entitlement tokens — deferred (gate AND-348)

## Verification
- Gate build: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **green**.
- `swift test --filter PlaidBarCoreTests` — **428 passed** (incl. 11 new).

Linear: https://linear.app/andeslab/issue/AND-350

> CI may show queued or red due to a known GitHub Actions billing hold (infrastructure, not a code problem). This PR is intentionally left **OPEN for review — do not merge**.
