### PR TITLE
fix: cover local ai readiness presentation

### DIFF
--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -73,12 +73,42 @@ struct LocalAIInsightReceiptTests {
         #expect(receipt.reversibleActionCopy.contains("No insight action is available yet"))
     }
 
+    @Test("Receipt explains configured but unverified local runtime")
+    func receiptExplainsConfiguredButUnverifiedLocalRuntime() {
+        let availability = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        let input = makeInput(transactionCount: 2, includeCategorySuggestion: false)
+        let summary = LocalAIActivitySummary(
+            window: .last7days,
+            availability: availability,
+            input: input,
+            generatedSummary: "Last 7D: deterministic fallback summary.",
+            generatedBullets: [],
+            evidence: input.evidence
+        )
+
+        let receipt = LocalAIInsightReceipt.make(summary: summary, availability: availability)
+
+        #expect(receipt.confidence.contains("Deterministic confidence"))
+        #expect(receipt.limitations.contains { $0.contains("Verifying the local runtime") })
+        #expect(receipt.unavailableState == nil)
+        #expect(receipt.accessibilitySummary.contains("Checking"))
+    }
+
     @Test("Receipt surfaces configured runtime fallback details")
     func receiptSurfacesConfiguredRuntimeFallbackDetails() {
-        let fallbackAvailability = LocalAIAvailability(
-            state: .unavailable,
-            runtimeName: "local-runtime",
-            detail: "Local runtime 'local-runtime' timed out before producing output. VaultPeek used deterministic local summaries and did not call cloud AI."
+        let base = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        let fallbackAvailability = LocalAIRuntimeResolution.resolved(
+            base: base,
+            usedModelOutput: false,
+            fallbackReason: .timeout
         )
         let input = makeInput(transactionCount: 2, includeCategorySuggestion: false)
         let summary = LocalAIActivitySummary(

--- a/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
@@ -26,6 +26,61 @@ struct SettingsPresentationTests {
         #expect(LocalAIAvailabilityPresentation.tone(for: .checking) == .secondary)
     }
 
+    @Test("Configured but unverified local AI is not presented as available")
+    func configuredButUnverifiedLocalAIIsNotPresentedAsAvailable() {
+        let availability = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+
+        #expect(availability.state == .checking)
+        #expect(availability.runtimeName == "ollama")
+        #expect(availability.detail.contains("Verifying local runtime"))
+        #expect(LocalAIAvailabilityPresentation.iconName(for: availability.state) == "hourglass")
+        #expect(LocalAIAvailabilityPresentation.tone(for: availability.state) == .secondary)
+    }
+
+    @Test("Verified local AI uses the positive available presentation")
+    func verifiedLocalAIUsesAvailablePresentation() {
+        let base = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        let availability = LocalAIRuntimeResolution.resolved(
+            base: base,
+            usedModelOutput: true,
+            fallbackReason: nil
+        )
+
+        #expect(availability.state == .available)
+        #expect(availability.runtimeName == "ollama")
+        #expect(availability.detail.contains("produced this summary on-device"))
+        #expect(LocalAIAvailabilityPresentation.iconName(for: availability.state) == "cpu.fill")
+        #expect(LocalAIAvailabilityPresentation.tone(for: availability.state) == .positive)
+    }
+
+    @Test("Local AI fallback remains unavailable after generation failure")
+    func localAIFallbackAfterGenerationFailureIsUnavailable() {
+        let base = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        let availability = LocalAIRuntimeResolution.resolved(
+            base: base,
+            usedModelOutput: false,
+            fallbackReason: .runtimeUnavailable
+        )
+
+        #expect(availability.state == .unavailable)
+        #expect(availability.runtimeName == "ollama")
+        #expect(availability.detail.contains("is not reachable on this Mac"))
+        #expect(availability.detail.contains("did not call cloud AI"))
+        #expect(LocalAIAvailabilityPresentation.tone(for: availability.state) == .warning)
+    }
+
     @Test("Storage detail prefers the server path and abbreviates the home directory")
     func storageDetailPrefersServerPath() {
         let detail = LocalDataResetPresentation.storageDetail(


### PR DESCRIPTION
## Summary
- Fixes #302 by locking in regression coverage for Local AI readiness presentation after the source fix landed in `main` via #305.
- Verifies configured-but-unverified local runtimes present as neutral `Checking...`, not positive `Available`.
- Verifies successful generation promotes to `Available`, while generation/probe fallback remains `Unavailable` with deterministic local-only copy.

## Changes
- `Tests/PlaidBarCoreTests/SettingsPresentationTests.swift`: covers checking, verified, and fallback presentation tone/icon/copy for the Settings/dashboard availability contract.
- `Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift`: covers configured-but-unverified receipt copy and fallback receipt details with synthetic-only data.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter LocalInsightModelRuntimeTests --skip-update --disable-keychain` (12 tests passed)
- [x] `swift test --filter LocalAIRuntimeResolutionTests --skip-update --disable-keychain` (10 tests passed)
- [x] `swift test --filter SettingsPresentationTests --skip-update --disable-keychain` (12 tests passed)
- [x] `swift test --filter LocalAIInsightReceiptTests --skip-update --disable-keychain` (6 tests passed)
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] Targeted diff scan for Plaid secrets/tokens/raw payloads/real IDs/balances/local SQLite/logs/screenshots/generated artifacts/local-first boundary violations
- [x] Repo-local autoreview gate: no serious actionable findings

## Notes
- Privacy/security: no cloud AI, telemetry, hosted backend, Plaid credential movement, raw Plaid payloads, real account IDs, transaction IDs, balances, SQLite data, logs, screenshots, or generated artifacts added.
- Residual risk: this PR is regression coverage only because the implementation fix is already present on current `main`; CI is still required before merge.
- CI status: pending after branch update.
