### PR TITLE
perf: move local cache I/O off app state

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -159,6 +159,7 @@ final class AppState {
 
     // MARK: - Services
     private let serverClient = ServerClient()
+    private let localDataCache = LocalDataCacheService()
     private let localAIInsightsService = LocalAIInsightsService()
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
@@ -781,11 +782,10 @@ final class AppState {
             accounts = itemStatusesAvailable
                 ? accountsPreservingUnavailableItems(refreshedAccounts)
                 : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
-            try LocalDataStore.saveAccounts(
-                accounts,
-                to: activeStorageDirectoryURL,
-                context: transactionCacheContext
-            )
+            let cacheAccounts = accounts
+            let cacheDirectory = activeStorageDirectoryURL
+            let cacheContext = transactionCacheContext
+            try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
             serverItemCount = Set(accounts.map(\.itemId)).count
             serverSyncReady = (serverItemCount ?? 0) > 0
             recordBalanceSnapshot()
@@ -808,11 +808,10 @@ final class AppState {
             accounts = itemStatusesAvailable
                 ? accountsPreservingUnavailableItems(refreshedAccounts)
                 : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
-            try LocalDataStore.saveAccounts(
-                accounts,
-                to: activeStorageDirectoryURL,
-                context: transactionCacheContext
-            )
+            let cacheAccounts = accounts
+            let cacheDirectory = activeStorageDirectoryURL
+            let cacheContext = transactionCacheContext
+            try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
             lastSyncDate = Date()
             recordBalanceSnapshot()
         } catch {
@@ -837,10 +836,12 @@ final class AppState {
                 }
                 let response = try await serverClient.syncTransactions()
                 let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
-                try LocalDataStore.saveTransactions(
+                let cacheDirectory = activeStorageDirectoryURL
+                let cacheContext = transactionCacheContext
+                try await localDataCache.saveTransactions(
                     updatedTransactions,
-                    to: activeStorageDirectoryURL,
-                    context: transactionCacheContext
+                    to: cacheDirectory,
+                    context: cacheContext
                 )
                 transactions = updatedTransactions
                 try await serverClient.commitSyncCursors(response.pendingCursors)
@@ -1048,15 +1049,15 @@ final class AppState {
                     (transaction.itemId == nil && removedAccountIds.contains(transaction.accountId))
             }
             do {
-                try LocalDataStore.saveAccounts(
-                    accounts,
-                    to: activeStorageDirectoryURL,
-                    context: transactionCacheContext
-                )
-                try LocalDataStore.saveTransactions(
-                    transactions,
-                    to: activeStorageDirectoryURL,
-                    context: transactionCacheContext
+                let cacheAccounts = accounts
+                let cacheTransactions = transactions
+                let cacheDirectory = activeStorageDirectoryURL
+                let cacheContext = transactionCacheContext
+                try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
+                try await localDataCache.saveTransactions(
+                    cacheTransactions,
+                    to: cacheDirectory,
+                    context: cacheContext
                 )
             } catch {
                 self.error = "Local cache failed to save: \(error.localizedDescription)"
@@ -1067,11 +1068,12 @@ final class AppState {
     }
 
     @discardableResult
-    func resetLocalData() throws -> LocalDataResetResult {
+    func resetLocalData() async throws -> LocalDataResetResult {
         stopBackgroundRefresh()
 
         let resetSetupCompletionDefaultsKey = setupCompletionDefaultsKey
-        let result = try LocalDataStore.resetLocalData(at: activeStorageDirectoryURL)
+        let resetDirectory = activeStorageDirectoryURL
+        let result = try await localDataCache.resetLocalData(at: resetDirectory)
 
         accounts = []
         transactions = []
@@ -1158,7 +1160,7 @@ final class AppState {
         // Returning users see cached last-known data immediately: the cache
         // loads before the connectivity check (which can take seconds while
         // a bundled server boots) instead of after it.
-        preloadCachedDataBeforeFirstConnect()
+        await preloadCachedDataBeforeFirstConnect()
         await checkServerConnection()
         if !serverConnected {
             await startBundledServerIfAvailable()
@@ -1170,11 +1172,11 @@ final class AppState {
             // restart the managed server.
             if serverCredentialsConfigured != false {
                 if statusItemCount > 0 {
-                    loadCachedAccounts()
-                    loadCachedTransactions()
+                    await loadCachedAccounts()
+                    await loadCachedTransactions()
                 } else {
-                    clearCachedAccounts()
-                    clearCachedTransactions()
+                    await clearCachedAccounts()
+                    await clearCachedTransactions()
                 }
                 await refreshAccounts()
                 await syncTransactions()
@@ -1282,19 +1284,19 @@ final class AppState {
     /// connectivity check runs. Opportunistic — failures and context
     /// mismatches fall through to the normal post-connect cache path without
     /// surfacing an error during boot.
-    private func preloadCachedDataBeforeFirstConnect() {
+    private func preloadCachedDataBeforeFirstConnect() async {
         guard accounts.isEmpty, transactions.isEmpty,
               let context = persistedTransactionCacheContext(),
               let cacheDirectory = preconnectCacheDirectory(for: context)
         else { return }
 
-        if let cachedAccounts = try? LocalDataStore.loadAccounts(
+        if let cachedAccounts = try? await localDataCache.loadAccounts(
             from: cacheDirectory,
             context: context
         ), !cachedAccounts.isEmpty {
             accounts = cachedAccounts
         }
-        if let cachedTransactions = try? LocalDataStore.loadTransactions(
+        if let cachedTransactions = try? await localDataCache.loadTransactions(
             from: cacheDirectory,
             context: context
         ), !cachedTransactions.isEmpty {
@@ -1391,9 +1393,9 @@ final class AppState {
 
     // MARK: - Balance History
 
-    private func loadCachedAccounts() {
+    private func loadCachedAccounts() async {
         do {
-            accounts = try LocalDataStore.loadAccounts(
+            accounts = try await localDataCache.loadAccounts(
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
@@ -1402,10 +1404,10 @@ final class AppState {
         }
     }
 
-    private func clearCachedAccounts() {
+    private func clearCachedAccounts() async {
         accounts = []
         do {
-            try LocalDataStore.saveAccounts(
+            try await localDataCache.saveAccounts(
                 accounts,
                 to: activeStorageDirectoryURL,
                 context: transactionCacheContext
@@ -1415,9 +1417,9 @@ final class AppState {
         }
     }
 
-    private func loadCachedTransactions() {
+    private func loadCachedTransactions() async {
         do {
-            transactions = try LocalDataStore.loadTransactions(
+            transactions = try await localDataCache.loadTransactions(
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
@@ -1426,10 +1428,10 @@ final class AppState {
         }
     }
 
-    private func clearCachedTransactions() {
+    private func clearCachedTransactions() async {
         transactions = []
         do {
-            try LocalDataStore.saveTransactions(
+            try await localDataCache.saveTransactions(
                 transactions,
                 to: activeStorageDirectoryURL,
                 context: transactionCacheContext

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -836,6 +836,13 @@ final class AppState {
                 }
                 let response = try await serverClient.syncTransactions()
                 let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
+                // Assign before awaiting the cache write so a concurrent
+                // reentrant mutation (e.g. removeAccount filtering
+                // `transactions`) cannot be clobbered by the resumed sync
+                // overwriting it with a value reduced from the pre-suspension
+                // array. The cursor is still committed only after the cache
+                // write succeeds, preserving local-first durability.
+                transactions = updatedTransactions
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
                 try await localDataCache.saveTransactions(
@@ -843,7 +850,6 @@ final class AppState {
                     to: cacheDirectory,
                     context: cacheContext
                 )
-                transactions = updatedTransactions
                 try await serverClient.commitSyncCursors(response.pendingCursors)
                 hasMore = response.hasMore
             }

--- a/Sources/PlaidBar/Services/LocalDataCacheService.swift
+++ b/Sources/PlaidBar/Services/LocalDataCacheService.swift
@@ -1,0 +1,38 @@
+import Foundation
+import PlaidBarCore
+
+actor LocalDataCacheService {
+    func loadAccounts(
+        from directory: URL,
+        context: TransactionCacheContext?
+    ) throws -> [AccountDTO] {
+        try LocalDataStore.loadAccounts(from: directory, context: context)
+    }
+
+    func saveAccounts(
+        _ accounts: [AccountDTO],
+        to directory: URL,
+        context: TransactionCacheContext?
+    ) throws {
+        try LocalDataStore.saveAccounts(accounts, to: directory, context: context)
+    }
+
+    func loadTransactions(
+        from directory: URL,
+        context: TransactionCacheContext?
+    ) throws -> [TransactionDTO] {
+        try LocalDataStore.loadTransactions(from: directory, context: context)
+    }
+
+    func saveTransactions(
+        _ transactions: [TransactionDTO],
+        to directory: URL,
+        context: TransactionCacheContext?
+    ) throws {
+        try LocalDataStore.saveTransactions(transactions, to: directory, context: context)
+    }
+
+    func resetLocalData(at directory: URL) throws -> LocalDataResetResult {
+        try LocalDataStore.resetLocalData(at: directory)
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -248,7 +248,7 @@ struct GeneralSettingsView: View {
         .toggleStyle(.switch)
         .alert("Reset Local Data?", isPresented: $isShowingResetConfirmation) {
             Button("Reset Local Data", role: .destructive) {
-                resetLocalData()
+                Task { await resetLocalData() }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -285,9 +285,9 @@ struct GeneralSettingsView: View {
         NSPasteboard.general.setString(appState.activeStorageDirectoryURL.path, forType: .string)
     }
 
-    private func resetLocalData() {
+    private func resetLocalData() async {
         do {
-            let result = try appState.resetLocalData()
+            let result = try await appState.resetLocalData()
             resetResultMessage = LocalDataResetPresentation.successMessage(for: result)
         } catch {
             resetErrorMessage = error.localizedDescription

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -24,6 +24,27 @@ private struct TestRequestContext: RequestContext {
     }
 }
 
+private final class ManualDateClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    init(_ value: Date) {
+        self.value = value
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        value = value.addingTimeInterval(interval)
+        lock.unlock()
+    }
+}
+
 private let plaidTokenVaultKeychainAvailable: Bool = {
     let itemId = "test_keychain_probe_\(UUID().uuidString)"
     do {
@@ -931,12 +952,12 @@ struct PlaidBarServerTests {
     }
 
     @Test func pendingLinkSessionExpires() async {
-        var currentDate = Date(timeIntervalSince1970: 1000)
-        let store = PendingLinkSessionStore(ttl: 60) { currentDate }
+        let clock = ManualDateClock(Date(timeIntervalSince1970: 1000))
+        let store = PendingLinkSessionStore(ttl: 60, now: { @Sendable in clock.now() })
         let state = await store.issueState()
         await store.save(state: state, linkToken: "link-token")
 
-        currentDate = currentDate.addingTimeInterval(61)
+        clock.advance(by: 61)
 
         let expired = await store.consume(state: state)
         #expect(expired == nil)


### PR DESCRIPTION
## Summary
- Move app cache load/save/reset operations behind a local actor so AppState no longer performs JSON/file I/O directly on the main actor.
- Keep transaction cursor safety and local-first storage boundaries intact while preserving existing UI state transitions.
- Fix the pending link session expiry test so strict Sendable checks pass for tests too.

## Changes
- Added `LocalDataCacheService` as an app-target actor around `LocalDataStore`.
- Converted AppState warm-start cache hydration, refresh saves, account removal saves, and reset flow to await the cache actor.
- Updated Settings reset action for the async reset path and replaced mutable date capture in `PlaidBarServerTests`.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `PLAIDBAR_PACKAGE_SMOKE_LAUNCH=1 ./Scripts/package-app.sh`
- [x] `PLAID_CLIENT_ID=ci_smoke_client PLAID_SECRET=ci_smoke_secret PLAIDBAR_SMOKE_PORT=18492 ./Scripts/smoke-sandbox.sh`
