### PR TITLE
fix: remove duplicate center net-worth hero when Wealth Summary visible (AND-376)

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -51,6 +51,15 @@ struct MainPopover: View {
         return accounts.first { $0.id == selectedAccountId }
     }
 
+    /// The left Wealth Summary rail is showing (vs. the account inspector).
+    /// While it is visible it owns the net-worth hero, so the center dashboard
+    /// drops its duplicate net-worth amount and keeps only a compact trend
+    /// (AND-376). Per the three-column contract the rail becomes always-on,
+    /// at which point this stays true for every non-setup state.
+    private var isWealthSummaryRailVisible: Bool {
+        selectedAccount == nil && !shouldShowSetupScreen
+    }
+
     private var filteredAccounts: [AccountDTO] {
         appState.accounts.filter { selectedFilter.includes($0, appState: appState) }
     }
@@ -189,7 +198,7 @@ struct MainPopover: View {
                     // within a group — spacing is the hierarchy.
                     VStack(alignment: .leading, spacing: Layout.groupSpacing) {
                         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-                            DashboardHeader()
+                            DashboardHeader(showsNetWorth: !isWealthSummaryRailVisible)
                                 .environment(appState)
                                 .loadingRedaction(appState.loadState(for: .summaryCards))
 
@@ -308,14 +317,29 @@ struct MainPopover: View {
 private struct DashboardHeader: View {
     @Environment(AppState.self) private var appState
 
+    /// When the left Wealth Summary rail already owns the net-worth hero, the
+    /// center header drops the duplicate amount and shows only a compact
+    /// net-worth trend so the chart cue survives without a second hero
+    /// (AND-376). Defaults to `true` for the swap-model selected-account state,
+    /// where the center is the only place net worth is shown.
+    var showsNetWorth: Bool = true
+
     private var trend: BalanceTrend? {
         BalanceTrend.evaluate(history: appState.balanceHistory)
     }
 
     var body: some View {
-        // One hero per surface: the net worth number is the only large text.
-        // Sync state lives in the footer; the app's own name does not belong
-        // inside its own popover.
+        if showsNetWorth {
+            heroHeader
+        } else {
+            compactTrendHeader
+        }
+    }
+
+    // One hero per surface: the net worth number is the only large text.
+    // Sync state lives in the footer; the app's own name does not belong
+    // inside its own popover.
+    private var heroHeader: some View {
         HStack(alignment: .firstTextBaseline) {
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Text("Net Worth")
@@ -332,23 +356,48 @@ private struct DashboardHeader: View {
             Spacer(minLength: Spacing.md)
 
             if let trend {
-                VStack(alignment: .trailing, spacing: Spacing.xxs) {
-                    BalanceTrendChart(trend: trend)
-                        .frame(width: 92, height: 21)
-
-                    Text("\(trend.deltaText) \(trend.spanText)")
-                        .font(.caption2.weight(.medium))
-                        .monospacedDigit()
-                        .foregroundStyle(deltaTint(for: trend.direction))
-                        .lineLimit(1)
-                }
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(trend.accessibilitySummary)
-                .help(trend.accessibilitySummary)
+                trendCluster(trend)
             }
         }
         .padding(Spacing.sm)
         .heroAccentSurface()
+    }
+
+    // The left rail owns the net-worth amount, so the center keeps only the
+    // trend chart cue (no duplicate hero number). Renders nothing when there is
+    // no history to chart, so the center column starts cleanly at the change
+    // receipt without an awkward empty gap.
+    @ViewBuilder
+    private var compactTrendHeader: some View {
+        if let trend {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Net Worth Trend")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: Spacing.md)
+
+                trendCluster(trend)
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.inset)
+        }
+    }
+
+    private func trendCluster(_ trend: BalanceTrend) -> some View {
+        VStack(alignment: .trailing, spacing: Spacing.xxs) {
+            BalanceTrendChart(trend: trend)
+                .frame(width: 92, height: 21)
+
+            Text("\(trend.deltaText) \(trend.spanText)")
+                .font(.caption2.weight(.medium))
+                .monospacedDigit()
+                .foregroundStyle(deltaTint(for: trend.direction))
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(trend.accessibilitySummary)
+        .help(trend.accessibilitySummary)
     }
 
     private func deltaTint(for direction: BalanceTrend.Direction) -> Color {


### PR DESCRIPTION
## AND-376 — Remove duplicate center net-worth hero when Wealth Summary is visible

When the left Wealth Summary rail is showing (the default no-selection popover
state), it already owns the one net-worth hero — yet the center `DashboardHeader`
rendered a *second* `Net Worth $…` hero. Two competing heroes, flagged in
`design-qa.md`.

### Change
- New `isWealthSummaryRailVisible` flag on `MainPopover`
  (`selectedAccount == nil && !setup`).
- `DashboardHeader` gains `showsNetWorth`. When the rail is visible the center
  header drops the duplicate amount and shows only a compact **"Net Worth Trend"**
  strip (sparkline + delta) — the chart cue survives without a second hero — and
  renders nothing when there's no history, so the center starts cleanly at the
  change receipt (no awkward gap).
- When an account is selected (rail replaced by the inspector in today's swap
  model), the center keeps the full hero — the only place net worth is shown.
- Forward-compatible with `docs/three-column-popover-contract.md` §7: once the
  rail is always-on (AND-369), the center never shows the duplicate hero.

### Visual evidence (demo data, light, headless render)
Left rail: single `NET WORTH $17,604.24` hero. Center: now opens with a compact
`NET WORTH TREND` strip instead of the duplicate big number. No top gap; trend
preserved. (Render captured via `Scripts/qa-appearance-matrix.sh`, kept out of
the commit — committing QA artifacts is AND-375's scope.)

### Acceptance criteria
- [x] The full net-worth amount appears only in the left Wealth Summary.
- [x] The center `Net Worth $17,604.24` hero is gone.
- [x] Center still communicates latest local changes, heatmap, filters, account rows, selected state, footer status.
- [x] Removing the center hero does not remove risk/utilization/sync/error/chart cues (trend cue kept; left rail unchanged).
- [x] Light visual QA confirms no awkward top gap or clipped content. (Dark render path hit a flaky flyout-capture exit; dashboard logic is appearance-independent. Full light+dark matrix is AND-375.)
- [x] No real account IDs, balances beyond demo fixtures, payloads, tokens, SQLite data, logs, or private screenshots committed.

### Tests
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean (64s).
- `swift test` — **545 tests pass**.
- No new unit test: the change is a view-presentation toggle (`selectedAccount == nil`); there is no pure logic to assert beyond what AND-375's visual QA covers. Validated by the strict build + the headless render above.

### Risks / rollback
Low. Single-file view change. The center balance-mix strip still partially echoes
the left rail — that broader trim is **AND-372**'s scope, intentionally not in
this PR. Rollback = revert the commit.

### Notes for reviewers
Design review: confirm the compact "Net Worth Trend" treatment (vs. removing the
trend entirely) reads correctly — see `design-qa.md` open question and contract §7.

Closes AND-376.