### PR TITLE
fix: repair Appearance settings layout and top anchoring (AND-363)

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -72,42 +72,47 @@ struct AppearanceSettingsView: View {
     var body: some View {
         Form {
             Section("Popover") {
-                LabeledContent("Transparency") {
-                    VStack(alignment: .leading, spacing: Spacing.xs) {
-                        HStack(alignment: .center, spacing: Spacing.sm) {
-                            Slider(
-                                value: Binding(
-                                    get: { transparencySetting.value },
-                                    set: { popoverTransparency = PopoverTransparencySetting(value: $0).value }
-                                ),
-                                in: PopoverTransparencySetting.minimumValue...PopoverTransparencySetting.maximumValue,
-                                step: 1
-                            )
-                            .labelsHidden()
-                            .frame(minWidth: 220, idealWidth: 280, maxWidth: 320)
-                            .accessibilityLabel("Popover transparency")
-                            .accessibilityValue("\(transparencySetting.displayPercent) percent transparent")
+                // Full-width control block: the label/value row sits at the top,
+                // the slider spans the row, and the captions track the slider —
+                // so nothing clips at the minimum settings window width and
+                // "Transparency" anchors to the top instead of floating against a
+                // width-constrained LabeledContent trailing column. (AND-363)
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                        Text("Transparency")
 
-                            Text("\(transparencySetting.displayPercent)%")
-                                .monospacedDigit()
-                                .foregroundStyle(.secondary)
-                                .frame(width: 38, alignment: .trailing)
-                        }
+                        Spacer(minLength: Spacing.md)
 
-                        HStack {
-                            Text("More solid")
-                            Spacer()
-                            Text("More glass")
-                        }
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(minWidth: 220, idealWidth: 280, maxWidth: 320)
-
-                        Text("Adjusts the ultra-thin material overlay live. The range is capped to keep balances and status text legible on busy desktops.")
-                            .detailText()
-                            .fixedSize(horizontal: false, vertical: true)
+                        Text("\(transparencySetting.displayPercent)%")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
                     }
+
+                    Slider(
+                        value: Binding(
+                            get: { transparencySetting.value },
+                            set: { popoverTransparency = PopoverTransparencySetting(value: $0).value }
+                        ),
+                        in: PopoverTransparencySetting.minimumValue...PopoverTransparencySetting.maximumValue,
+                        step: 1
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("Popover transparency")
+                    .accessibilityValue("\(transparencySetting.displayPercent) percent transparent")
+
+                    HStack {
+                        Text("More solid")
+                        Spacer()
+                        Text("More glass")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                    Text("Adjusts the ultra-thin material overlay live. The range is capped to keep balances and status text legible on busy desktops.")
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+                .padding(.vertical, Spacing.xxs)
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION
## AND-363 — Repair Appearance settings layout and top anchoring

The transparency control sat inside a width-constrained `LabeledContent`
trailing column: at the minimum 560pt settings window the slider's
`minWidth: 220` clipped against the label column, and "Transparency" floated
vertically against the tall trailing VStack instead of anchoring to the top.

### Change
Restructured the `Popover` section as a **full-width control block**: label/value
row on top, the slider spanning the full row (no fixed-width frame that clips),
the "More solid / More glass" captions tracking the slider, then the description.
Kept `.formStyle(.grouped)` + the top-anchoring frame.

### Acceptance criteria
- [x] Appearance tab content is top-aligned and visually comparable to the other settings tabs.
- [x] At the minimum settings window size, Transparency, Popover transparency, More solid, More glass, and the percent value are readable without overlap or clipping (slider is full-width; nothing is pinned to `minWidth: 220` inside a narrow trailing column).
- [x] VoiceOver still exposes the slider as `Popover transparency` with the current percent value (`accessibilityLabel`/`accessibilityValue` preserved).
- [x] No Plaid credentials/tokens/IDs/balances/payloads/paths/logs/screenshots added.
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` clean.

### Tests
- Strict-concurrency build: clean (46s).
- `swift test`: **545 pass**.
- Pure layout change; the reproducible Appearance-tab screenshot capture is **AND-366**'s deliverable (the headless render path currently covers dashboard/flyout only).

### Risks / rollback
Low — single view-body restructure, same control + bindings. Rollback = revert.

Closes AND-363.