### PR TITLE
docs: refresh PlaidBar public docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,12 +45,14 @@ User clicks "Refresh"
 Benefits:
 - **Security**: Secrets never in app memory
 - **Restartability**: Server and app restart independently
-- **Extensibility**: Future CLI tools or iOS app can use the same server
+- **Extensibility**: The source-built `plaidbar-cli` uses the same authenticated
+  localhost server without exposing Plaid credentials to terminal clients
 - **Testability**: Server API is testable with `curl`
 
 ### Process Lifecycle
 
-Both processes are started together via `Scripts/run.sh`:
+For source-based sandbox development, both processes can be started together via
+`Scripts/run.sh`:
 
 ```bash
 swift run PlaidBarServer --sandbox &   # Background
@@ -58,7 +60,9 @@ swift run PlaidBar &                    # Background
 wait                                    # Ctrl+C stops both
 ```
 
-In production, the server would run as a LaunchAgent for auto-start at login.
+For app-bundle style launches, PlaidBar can start its bundled companion server
+when needed. Source/developer checkouts can also run the server explicitly with
+`swift run PlaidBarServer`.
 
 ## Target Breakdown
 
@@ -75,6 +79,9 @@ Zero external dependencies. Contains:
 | `LinkResponse.swift` | Link token response + item status models |
 | `SyncResponse.swift` | Transaction sync response (added/modified/removed) |
 | `ServerStatus.swift` | Server health + `PlaidEnvironment` enum |
+| `LocalAIInsights.swift` | Local-only activity receipt and category-hint presentation models |
+| `AttentionQueue.swift` | Prioritized recovery prompts for dashboard/status surfaces |
+| `Dashboard*.swift` | Dashboard status, nav, change, empty, and drill-in presenters |
 | `Formatters.swift` | Currency (full/abbreviated/compact), date, percentage formatting |
 | `Constants.swift` | Ports, intervals, thresholds, keychain keys |
 
@@ -99,13 +106,13 @@ GET  /api/status                → ServerStatus
 GET  /api/items                 → [ItemStatus]
 ```
 
-**Storage (SQLite via Fluent):**
+**Storage (SQLite via Fluent + Keychain where available):**
 
 ```sql
--- items: stores Plaid access tokens
+-- items: stores Plaid item records and token references
 CREATE TABLE items (
-    id TEXT PRIMARY KEY,          -- Plaid item_id
-    access_token TEXT NOT NULL,
+    id TEXT PRIMARY KEY,
+    access_token TEXT NOT NULL,   -- keychain:<item_id> on macOS runtime builds
     institution_id TEXT,
     institution_name TEXT,
     status TEXT NOT NULL,         -- connected | login_required | error
@@ -120,6 +127,11 @@ CREATE TABLE sync_cursors (
     updated_at DATETIME
 );
 ```
+
+On macOS runtime builds with Security framework support, Plaid access-token
+bytes are stored in Keychain and SQLite stores `keychain:<item_id>` references.
+Fallback builds without Keychain support may store token bytes locally in the
+SQLite store; release and security docs call out that boundary explicitly.
 
 **Plaid Client:**
 
@@ -155,10 +167,13 @@ Single `@Observable` state object injected via SwiftUI `@Environment`. No Combin
 MenuBarExtra
 ├── MenuBarLabel (icon + balance text)
 └── MainPopover (dashboard-first surface)
-    ├── SetupView (if !isSetupComplete)
+    ├── SetupView (if setup is incomplete)
+    ├── status strip + latest change receipt
+    ├── 365-day spend/cashflow heatmap
     ├── DashboardNavBand (Cash/Credit/Savings/Debt/Status filters)
-    ├── AttentionQueueView (degraded-item recovery)
-    └── AccountDetailFlyout (per-account drill-in)
+    ├── compact account rows + selected account drill-in / AccountDetailFlyout
+    ├── AttentionQueueView (degraded-item recovery prompts)
+    └── local insight receipt
 ```
 
 **Background Refresh:**
@@ -266,13 +281,19 @@ Unit tests span 3 suites, all using Swift Testing framework:
 | PlaidBarServerTests | Plaid response decoding, config, type conversion |
 | PlaidBarTests | Business logic: net balance, spending aggregation, filtering |
 
-Server integration tests (starting Hummingbird, making HTTP calls) are planned for v0.2.
+Server tests cover config, status contracts, Plaid decoding, auth behavior, and
+route-adjacent reducers. Full end-to-end Plaid sandbox coverage remains a manual
+or smoke-test gate because it depends on external sandbox credentials.
 
 Suite size is not hard-coded in these docs; derive the current count with `swift test list` or a ripgrep over `Tests/` (`rg -n "@Test" Tests/`), which is the source of truth.
 
 ## Future Architecture Considerations
 
-- **LaunchAgent**: Ship a plist for auto-starting the server at login
-- **Webhooks**: Plaid can push updates instead of polling — requires a tunnel or relay service
-- **iOS Companion**: The server API is already REST; an iOS app could connect via Tailscale/local network
-- **Multiple providers**: Abstract the Plaid client behind a protocol to support Teller, MX, etc.
+- **Distribution**: Keep private DMG and source/developer paths stable; add
+  notarization and Sparkle appcast only after signing and Gatekeeper checks are
+  real
+- **Webhooks**: Plaid can push updates instead of polling, but a relay/tunnel
+  would need an explicit privacy review because PlaidBar has no hosted backend
+- **Multiple providers**: Abstract the Plaid client behind a protocol only if it
+  strengthens the local menu-bar instrument instead of becoming a generic
+  provider playground

--- a/PRD.md
+++ b/PRD.md
@@ -159,13 +159,14 @@ native RepoBar-style finance instrument before expanding finance scope.
 
 | # | Requirement | Acceptance Criteria |
 |---|-------------|-------------------|
-| P1.1 | Roadmap truth cleanup | **Given** a contributor reads README, PRD, release notes, release docs, and roadmap, **When** they compare release status, **Then** the docs agree that v1.0.0 has shipped and that notarized app/cask/Sparkle appcast distribution remains post-1.0 |
+| P1.1 | Roadmap truth cleanup | **Given** a contributor reads README, PRD, release notes, release docs, and roadmap, **When** they compare release status, **Then** the docs agree that v1.0.0 has shipped and that Developer ID notarization plus Sparkle appcast distribution remains post-1.0 |
 | P1.2 | Native material surface system | **Given** the dashboard renders on macOS 15+, **When** panels, filters, selected rows, and recovery states are visible, **Then** they use shared material/fill/stroke tokens instead of one-off saturated card fills |
 | P1.3 | Liquid Glass readiness | **Given** VaultPeek is built with a macOS 26+ SDK, **When** SwiftUI Liquid Glass APIs are available, **Then** native panel surfaces may opt into `glassEffect` while preserving the macOS 15 material fallback |
 | P1.4 | RepoBar-style dashboard density | **Given** the menu bar popover opens, **When** dashboard content is scanned, **Then** the status strip and 365-day heatmap appear before account rows, with compact filters and selected account detail actions in the same surface |
 | P1.5 | Recovery convergence | **Given** common failures occur, **When** the user views dashboard or settings, **Then** server offline, wrong mode, missing credentials, stale sync, login-required item, empty account data, filtered-zero transactions, and denied notifications each expose one clear recovery action |
-| P1.6 | Local AI activity summaries | **Given** a local AI runtime is configured, **When** the user opens the dashboard or an insights surface, **Then** VaultPeek summarizes financial activity for the last 7 days, last month, and year-over-year windows, including spending, income, balance changes, recurring charges, credit utilization, and notable anomalies without sending data to cloud models |
+| P1.6 | Local insight receipts | **Given** local transactions are available, **When** the user opens the dashboard, **Then** VaultPeek shows a local-only activity receipt with source-row count, time window, top category, recurring estimate, category hints, and disabled/no-runtime copy when no local model runtime is configured; future local model runtimes must not send data to cloud models |
 | P1.7 | Local AI categorization | **Given** synced transactions include Plaid categories, merchant names, raw names, amounts, dates, and account context, **When** local AI categorization is enabled, **Then** VaultPeek suggests smarter expense and income categories with confidence and evidence while preserving raw Plaid data and allowing user correction or fallback to Plaid categories |
+| P1.8 | Local CLI access | **Given** VaultPeekServer is running in a source/developer checkout, **When** a user or local agent runs `plaidbar-cli`, **Then** status, item, balance, transaction, and link commands use the localhost API and local bearer token without reading Plaid Dashboard credentials directly |
 
 ### Future (not committed)
 
@@ -261,5 +262,5 @@ native RepoBar-style finance instrument before expanding finance scope.
 | Filter usage rate | 0% (new feature) | >30% of sessions use ≥1 filter | 90 days post-v0.3 | Local UserDefaults counter (planned) |
 | Notification opt-in rate | 0% (new feature) | >50% of users who open Settings | 90 days post-v0.3 | Local counter: settings_opened / notifications_enabled |
 | Notification delivery latency | N/A | <10s after sync completes | Continuous | Timestamp delta: sync_complete → notification_shown |
-| Test suite size | 86 tests, 100% pass | Maintain 100% pass rate | Continuous | `swift test` in CI |
+| Test suite size | 353 Swift Testing cases, 100% pass | Maintain 100% pass rate | Continuous | `swift test` in CI |
 | Build time (clean) | ~45s M1 | <60s | Per release | GitHub Actions CI timing |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Personal finance data lives behind bank website logins. The closest thing to a m
 - **Credit Utilization** — Progress bars with configurable warning thresholds and gauge
 - **Smart Notifications** — Alerts for large transactions, low balances, and high credit utilization
 - **Balance History** — Sparkline showing net balance trend over time
+- **Local Insight Receipt** — Optional, local-only activity summary with source-row counts, time window, top category, recurring estimate, and explicit no-cloud fallback when no local AI runtime is configured
+- **Attention Queue** — Prioritized recovery prompts keep setup, server, notification, stale-sync, and item-login work visible without hiding the dashboard
 - **Diagnostics** — Popover status strip plus a dashboard readiness panel for server health, credential state, synced item count, active local data path, item recovery, and settings handoff
 - **Keyboard Shortcuts** — Cmd+R to refresh and Cmd+N to add an account
 - **Settings Persistence** — Preferences saved across launches
@@ -70,8 +72,11 @@ browser handoff.
 
 The current app is dashboard-first. The main popover answers the common
 questions first: cash on hand, credit exposure, savings, debt, sync health, and
-the last year of spending activity. Filtered states keep the same visual system
-while focusing the account list and drill-down controls.
+the last year of spending activity. The same dashboard surface also owns
+below-the-fold local-only activity insight receipts and priority attention
+prompts without sending private transactions to a cloud model. Filtered states
+keep the same visual system while focusing the account list and drill-down
+controls.
 
 | Overview | Cash |
 |----------|------|
@@ -85,8 +90,8 @@ while focusing the account list and drill-down controls.
 
 | Debt | Status |
 |------|--------|
-| <img src="Assets/dashboard-debt.png" width="380" alt="Dashboard debt filter showing debt-oriented accounts and selected credit account detail"> | <img src="Assets/dashboard-status.png" width="380" alt="Dashboard status filter showing linked item health, server sync state, synced item count, and recovery actions"> |
-| Debt view emphasizes owed balances and high-utilization cards so risk is visible at a glance. | Status view now acts as a compact recovery surface for server state, credentials, synced items, active local data path, stale sync, item login, reconnect, refresh, and settings handoff. |
+| <img src="Assets/dashboard-debt.png" width="380" alt="Dashboard debt filter showing debt-oriented accounts and selected credit account detail"> | <img src="Assets/dashboard-status.png" width="380" alt="Dashboard status filter showing linked item health, server sync state, synced item count, attention queue, and recovery actions"> |
+| Debt view emphasizes owed balances and high-utilization cards so risk is visible at a glance. | Status view acts as a compact recovery surface for server state, credentials, synced items, active local data path, stale sync, item login, prioritized attention prompts, reconnect, refresh, and settings handoff. |
 
 Generate fresh dashboard screenshots with demo data:
 
@@ -176,32 +181,33 @@ the server agree.
 
 VaultPeek is a proprietary product. Public Homebrew tap distribution has been
 discontinued; signed builds are distributed privately to licensed users. The
-commands below assume an installed build on your `PATH`.
+drag-install DMG installs `VaultPeek.app`; source/developer command examples
+below assume you are running from a checkout.
 
 Run local demo data without Plaid credentials:
 
 ```bash
-plaidbar --demo
+swift run PlaidBar --demo
 ```
 
-Available commands after installation:
+Available source/developer commands:
 
 | Command | Purpose |
 |---------|---------|
-| `plaidbar --demo` | Launch the menu bar app with local fixture data |
-| `plaidbar-cli status --json` | Query the running local server with agent-friendly JSON output |
-| `plaidbar-cli item list` | List linked Plaid Items stored by PlaidBarServer |
-| `plaidbar-cli balance` | Fetch current balances through PlaidBarServer |
-| `plaidbar-cli transactions list --count 5` | Fetch recent transaction updates through PlaidBarServer |
-| `plaidbar-cli link --no-open --json` | Create a Hosted Link URL without opening a browser |
-| `plaidbar-server --sandbox` | Start the local Plaid companion server in sandbox mode |
-| `plaidbar-server --version` | Print the installed VaultPeek version |
+| `swift run PlaidBar --demo` | Launch the menu bar app with local fixture data |
+| `swift run plaidbar-cli status --json` | Query the running local server with agent-friendly JSON output |
+| `swift run plaidbar-cli item list` | List linked Plaid Items stored by PlaidBarServer |
+| `swift run plaidbar-cli balance` | Fetch current balances through PlaidBarServer |
+| `swift run plaidbar-cli transactions list --count 5` | Fetch recent transaction updates through PlaidBarServer |
+| `swift run plaidbar-cli link --no-open --json` | Create a Hosted Link URL without opening a browser |
+| `swift run PlaidBarServer --sandbox` | Start the local Plaid companion server in sandbox mode |
+| `swift run PlaidBarServer --version` | Print the installed VaultPeek version |
 
-The `plaidbar` and `plaidbar-server` executable names are intentionally
-unchanged until the staged SwiftPM product rename lands. Source checkouts also
-include `Scripts/vaultpeek-run` and the deprecated `Scripts/plaidbar-run` alias
-for local sandbox testing, but those helper scripts are not installed by the
-DMG.
+The `PlaidBar`, `PlaidBarServer`, and `plaidbar-cli` SwiftPM product names are
+intentionally unchanged until the staged product rename lands. Source checkouts
+also include `Scripts/vaultpeek-run` and the deprecated `Scripts/plaidbar-run`
+alias for local sandbox testing, but those helper scripts are not installed by
+the DMG.
 
 ### Naming compatibility (PlaidBar → VaultPeek)
 
@@ -210,7 +216,7 @@ few technical surfaces for compatibility, and those are not bugs:
 
 | Surface | Still PlaidBar | Why |
 |---------|----------------|-----|
-| SwiftPM targets/products | `PlaidBar`, `PlaidBarServer`, `PlaidBarCore`; executables `plaidbar`, `plaidbar-server` | Staged rename; avoids breaking builds, scripts, and installed binaries at once |
+| SwiftPM targets/products | `PlaidBar`, `PlaidBarServer`, `PlaidBarCore`, `plaidbar-cli`; app-bundle executables `PlaidBar`, `PlaidBarServer` | Staged rename; avoids breaking builds, scripts, and bundled server launches at once |
 | Environment variables / config keys | `PLAID_*` plus `PLAIDBAR_SERVER_PORT`, `PLAIDBAR_DATA_DIR`, `PLAIDBAR_MIGRATE_LEGACY_DATABASE`, `PLAIDBAR_SMOKE_PORT` | Existing `server.conf` files and shell setups keep working |
 | Keychain service | `PlaidBar.PlaidAccessToken` | SQLite `keychain:<item_id>` references must keep resolving after the storage migration |
 | SQLite store filenames | `plaidbar-sandbox.sqlite`, `plaidbar-production.sqlite` | Renaming live database files is riskier than keeping them |
@@ -220,15 +226,19 @@ few technical surfaces for compatibility, and those are not bugs:
 Rename history and upgrade guidance live in
 [docs/release-notes.md](docs/release-notes.md) and [CHANGELOG.md](CHANGELOG.md).
 
-`plaidbar-cli` follows the official Plaid CLI's terminal/agent conventions where they fit VaultPeek: table output by default, `--json` for structured stdout, diagnostics on stderr, and local-server bearer auth from `~/.vaultpeek/auth-token` or `$PLAIDBAR_DATA_DIR/auth-token`. It does not read Plaid Dashboard credentials directly; Plaid secrets and access tokens stay in `PlaidBarServer`.
+In source/developer builds, `plaidbar-cli` follows the official Plaid CLI's
+terminal/agent conventions where they fit VaultPeek: table output by default,
+`--json` for structured stdout, diagnostics on stderr, and local-server bearer
+auth from `~/.vaultpeek/auth-token` or `$PLAIDBAR_DATA_DIR/auth-token`. It does
+not read Plaid Dashboard credentials directly; Plaid secrets and access tokens
+stay in `PlaidBarServer`.
 
-Run Plaid sandbox mode with the installed server and app:
+Run Plaid sandbox mode from a source checkout:
 
 ```bash
 export PLAID_CLIENT_ID=your_sandbox_client_id
 export PLAID_SECRET=your_sandbox_secret
-plaidbar-server --sandbox
-open /Applications/VaultPeek.app
+./Scripts/run.sh --sandbox
 ```
 
 ### Source build (licensed access only)
@@ -384,7 +394,8 @@ VaultPeek uses a **two-process architecture** — a SwiftUI menu bar app talks t
 2. Stores item records in local SQLite and Plaid access-token bytes in macOS Keychain when available
 3. Binds to `127.0.0.1` only — no LAN or cloud exposure
 4. Can be restarted independently of the UI
-5. Opens the door for future CLI tools or iOS companion
+5. Powers the source-built `plaidbar-cli` while keeping terminal access behind the
+   same local auth and server boundaries
 
 ### Technology Stack
 
@@ -423,8 +434,8 @@ PlaidBar/                            # repo checkout (repo rename pending)
 │   │   ├── Storage/                 # Fluent models + migrations
 │   │   └── Config/                  # Server configuration
 │   └── PlaidBarCore/                # Shared library
-│       ├── Models/                  # DTOs (Account, Transaction, etc.)
-│       └── Utilities/               # Currency formatters, constants
+│       ├── Models/                  # DTOs, dashboard presenters, local AI receipts
+│       └── Utilities/               # Currency formatters, constants, reducers
 ├── Tests/                           # Swift Testing suites for all 3 targets
 ├── Scripts/                         # build.sh, run.sh, screenshots.sh
 ├── Assets/                          # README screenshots
@@ -474,9 +485,9 @@ swift build
 # Build release
 swift build -c release
 
-# Run installed app bundle commands
-plaidbar --demo
-plaidbar-server --sandbox
+# Run source/developer commands
+swift run PlaidBar --demo
+swift run PlaidBarServer --sandbox
 
 # Run source-checkout helper scripts
 ./Scripts/vaultpeek-run --sandbox   # plaidbar-run remains a deprecated alias

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ executable names below intentionally keep the PlaidBar name; see
 | Module | Responsibility | Must Not Do |
 |--------|----------------|-------------|
 | `PlaidBar` | SwiftUI menu bar app, popover, setup flow, settings, local client calls, notification UX | Store Plaid secrets, call Plaid directly, contain server persistence logic |
-| `PlaidBarCore` | Shared DTOs, formatting, sync reducers, recurring detection, presentation helpers, local data path helpers | Depend on SwiftUI, Hummingbird, or Plaid network clients |
+| `PlaidBarCore` | Shared DTOs, formatting, sync reducers, recurring detection, dashboard presenters, attention queue models, local insight receipt models, local data path helpers | Depend on SwiftUI, Hummingbird, Plaid network clients, or cloud AI SDKs |
 | `PlaidBarServer` | Hummingbird localhost API, Plaid API client, SQLite storage, link flow, token vault, auth middleware | Render UI, depend on app state, expose secrets in status responses |
 
 ## Runtime Topology
@@ -57,6 +57,16 @@ The app talks to the server through `ServerClient`. The server exposes:
 
 `/health` and `/oauth/callback` are public on localhost. `/api/*` requires the
 local bearer token stored in the VaultPeek data directory.
+
+`plaidbar-cli` is a source/developer local client for this same contract. It
+reads the local bearer token, talks to `127.0.0.1`, and prints table or `--json`
+output; it does not read Plaid Dashboard credentials or bypass the companion
+server.
+
+Local insight receipts are intentionally app/core-side presentation artifacts.
+They summarize local transaction rows and can expose disabled/no-runtime state,
+source-row count, windows, top categories, recurring estimates, and category
+hints. They must not add a cloud AI path or send raw transaction data off-device.
 
 ## Configuration
 
@@ -114,8 +124,8 @@ VaultPeek was renamed from PlaidBar at the product level. The following
 surfaces intentionally keep the PlaidBar name and must not be renamed without
 an explicit migration plan:
 
-- SwiftPM targets/products and executables: `PlaidBar`, `PlaidBarServer`,
-  `PlaidBarCore`, `plaidbar`, `plaidbar-server` (staged rename, tracked
+- SwiftPM targets/products and app-bundle executables: `PlaidBar`,
+  `PlaidBarServer`, `PlaidBarCore`, `plaidbar-cli` (staged rename, tracked
   separately).
 - Environment variables and config keys: `PLAIDBAR_SERVER_PORT`,
   `PLAIDBAR_DATA_DIR`, `PLAIDBAR_MIGRATE_LEGACY_DATABASE`,
@@ -179,9 +189,8 @@ states if any later step fails.
 - Make each degraded state actionable: start server, check mode, add account,
   reconnect item, clear filters, or open Settings.
 
-## 1.0 Architecture Debt
+## Architecture Debt
 
-- Add a clean architecture diagram to README or docs.
 - Add endpoint-level documentation for request/response DTOs.
 - Add a clean duplicate-instance strategy and document expected behavior.
 - Ship 1.0 as a privately-distributed, ad-hoc-signed DMG unless Developer ID

--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -12,7 +12,7 @@ onboarding confidence.
 
 | Scenario | Fixture intent | Dashboard story | Expected status and recovery state | Screenshot list |
 |----------|----------------|-----------------|------------------------------------|-----------------|
-| `steady-household-overview` | Four local demo accounts across checking, savings, and two credit cards; deterministic balance history; recurring income, rent, subscriptions, travel, shopping, groceries, and utility transactions. | The first popover view should answer cash on hand, savings cushion, credit exposure, debt risk, recent activity, and 365-day spend/cashflow shape before a user opens details. | Demo mode is healthy. Local demo accounts are loaded, the server surface reports local demo readiness, and no Plaid network call is required. | `Assets/dashboard.png` |
+| `steady-household-overview` | Four local demo accounts across checking, savings, and two credit cards; deterministic balance history; recurring income, rent, subscriptions, travel, shopping, groceries, and utility transactions. | The first popover view should answer cash on hand, savings cushion, credit exposure, debt risk, recent activity, 365-day spend/cashflow shape, and local-only insight receipt before a user opens details. | Demo mode is healthy. Local demo accounts are loaded, the server surface reports local demo readiness, the local insight receipt may show deterministic/no-runtime status, and no Plaid network call is required. | `Assets/dashboard.png` |
 | `cash-runway-check` | Same synthetic household fixture with the checking account selected and the Cash filter active. | A user can confirm checking and savings balances, spot recent inflow/outflow, and inspect the selected checking account without leaving the dashboard surface. | Healthy demo state. Recovery controls should stay quiet because the scenario is about confidence, not failure. | `Assets/dashboard-cash.png`, `Assets/dashboard-savings.png` |
 | `credit-pressure-review` | Same synthetic fixture with one low-utilization card and one high-utilization card; the selected card is the pressure point. | A user can see owed balances, utilization, available credit, pending card activity, and debt emphasis without turning the app into a budgeting workflow. | Healthy demo state for the normal credit capture. The row and detail copy should identify credit risk with text or shape, not color alone. | `Assets/dashboard-credit.png`, `Assets/dashboard-debt.png` |
 | `reconnect-confidence-check` | Demo data plus `--screenshot-status-recovery`, which keeps one synthetic institution recovered and marks another synthetic institution as needing login. | A user can trust that VaultPeek preserves last-known local data while making item recovery visible and actionable. | Status should show one connected/recovered institution, one login-required institution, synced-item count context, stale or delayed sync context when applicable, and explicit reconnect/settings/refresh handoff. | `Assets/dashboard-status.png` |
@@ -21,7 +21,8 @@ onboarding confidence.
 ## Reduced-Noise Composition
 
 - Keep the first screenshot signal dense and product-shaped: heatmap, account
-  rows, selected-account detail, status strip, and one clear action path.
+  rows, selected-account detail, status strip, local insight receipt, and one
+  clear action path.
 - Use dashboard filters to focus the story instead of adding separate marketing
   or explanatory surfaces.
 - Prefer one selected account per scenario so screenshots show drill-in
@@ -38,6 +39,9 @@ onboarding confidence.
 
 - Demo mode must not call Plaid.
 - Screenshot data must be demo, sandbox, or synthetic only.
+- Local insight receipt content must remain deterministic/local-only unless a
+  configured local runtime is part of the explicit screenshot scenario; never
+  capture or imply cloud AI over private transactions.
 - Public screenshots must not include real balances, real transaction history,
   Plaid item IDs, account IDs, access tokens, local bearer tokens, or Plaid
   credentials.

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -38,8 +38,10 @@ local storage, notifications, and distribution.
 | Dashboard filters | All/Cash/Credit/Savings/Debt/Status | Rows and details match selected scope |
 | Dashboard Status | Select Status filter | Readiness panel shows mode, server state, credentials, linked/synced items, last sync, and one primary recovery action |
 | Dashboard stale sync | Last sync is beyond the configured stale window | Status panel shows stale sync and offers Refresh |
+| Attention queue | Trigger stale sync, denied notifications, missing credentials, or login-required fixture | Dashboard surfaces prioritized attention without hiding balances or account rows |
 | Account drill-down | Select account row | Account inspector opens on the RIGHT with balances, status, and actions; the left Wealth Summary rail and center dashboard stay in place (three-column) |
 | Inspector dismissal | Esc, the inspector ✕, re-click the row, or switch filters | Closes only the inspector and returns to the two-column state; focus returns to the row on Esc/✕/re-click |
+| Local insight receipt | Open demo dashboard with transactions | Receipt shows source rows, time window, top category, recurring estimate, local-only badge, and disabled/no-runtime copy when no local AI runtime is configured |
 | Transactions | Apply date/category/account filters | Matching rows update; zero state can clear filters |
 | Recurring | Open recurring view with insufficient history | Empty state explains history requirement |
 | Settings General | Local Data section | Path, reveal/copy, and reset controls are visible |
@@ -184,6 +186,7 @@ tech):
 | Status contract test | Encoded `ServerStatus` contains only release-approved keys |
 | Auth middleware | `/api/*` rejects missing/invalid bearer token |
 | Auth comparison | Bearer token comparison accepts only exact token strings |
+| CLI auth | Source/developer `plaidbar-cli status --json` reads the local bearer token and fails closed without exposing it |
 | Data directory | `~/.vaultpeek/` uses private user permissions where supported |
 | Legacy storage migration | Missing default files copy from `~/.plaidbar/` without overwriting newer `~/.vaultpeek/` files |
 | Auth token | `auth-token` uses private file permissions where supported |
@@ -191,6 +194,7 @@ tech):
 | Sandbox/production | Stores and transaction cache are scoped by environment |
 | Reset copy | UI explains local reset does not guarantee Plaid/bank revocation |
 | Screenshots | Assets contain demo/sandbox/synthetic data only |
+| Local AI boundary | Insight receipts and category hints stay local-only and do not send raw transaction data to cloud AI services |
 
 ## Release Candidate Exit Criteria
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -97,8 +97,9 @@ VaultPeek:
 
 Intentional, kept for compatibility:
 
-- Executables and SwiftPM targets: `plaidbar`, `plaidbar-server`, `PlaidBar`,
-  `PlaidBarServer`, `PlaidBarCore` (staged rename tracked separately).
+- SwiftPM targets/products and app-bundle executables: `PlaidBar`,
+  `PlaidBarServer`, `PlaidBarCore`, `plaidbar-cli` (staged rename tracked
+  separately).
 - Environment variables and config keys: `PLAIDBAR_SERVER_PORT`,
   `PLAIDBAR_DATA_DIR`, `PLAIDBAR_MIGRATE_LEGACY_DATABASE`,
   `PLAIDBAR_SMOKE_PORT`.
@@ -130,12 +131,16 @@ Intentional, kept for compatibility:
   macOS 15 material fallback.
 - Continue recovery convergence across dashboard, setup, settings, Plaid item
   health, local server state, notification permissions, and empty data states.
+- Keep source/developer CLI behavior, local insight receipts, the attention
+  queue, and README screenshot expectations documented as part of the public
+  product contract.
 
 ### Verification Targets
 
 - `git diff --check`
 - `swift build --target PlaidBar --skip-update --disable-keychain`
 - `./Scripts/screenshots.sh` after visual changes
+- Peekaboo window/UI validation for regenerated screenshots when available
 - Manual VoiceOver and keyboard checks for dashboard filters, footer actions,
   recovery buttons, and selected account detail surfaces
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -37,6 +37,14 @@ The script launches VaultPeek locally and captures:
 - Settings > Notifications
 - Settings > About
 
+The dashboard surface also includes a below-the-fold local insight receipt when
+demo transactions are available. Peekaboo/AX validation should see that receipt
+even when the public screenshot stays focused on the first-glance dashboard
+area. The receipt is intentionally local-only: it shows source-row count,
+window, top category, recurring estimate, category hints, and the
+disabled/no-runtime state when no local AI runtime is configured. It must not
+imply cloud AI processing or send transaction data off-device.
+
 The Status capture uses demo data with `--screenshot-status-recovery`. That
 fixture keeps the regular demo dashboard healthy, while the Status filter shows
 one recovered institution and one institution that needs login/reconnect.
@@ -65,7 +73,7 @@ fixture intent, dashboard story, and expected recovery state.
 
 | Scenario | Primary assets | Review focus |
 |----------|----------------|--------------|
-| `steady-household-overview` | `Assets/dashboard.png` | First-glance cash, credit, savings, debt, sync health, and heatmap context |
+| `steady-household-overview` | `Assets/dashboard.png` | First-glance cash, credit, savings, debt, sync health, and heatmap context; validate below-fold local insight receipt separately |
 | `cash-runway-check` | `Assets/dashboard-cash.png`, `Assets/dashboard-savings.png` | Depository balances, selected-account detail, and quiet healthy status |
 | `credit-pressure-review` | `Assets/dashboard-credit.png`, `Assets/dashboard-debt.png` | Utilization, available credit, owed balances, and non-budgeting debt emphasis |
 | `reconnect-confidence-check` | `Assets/dashboard-status.png` | Login-required item recovery without raw Plaid payloads or real errors |
@@ -108,6 +116,9 @@ when the menu-bar popover is positioned outside the active display bounds.
 - No real personal finance data appears.
 - Empty/degraded states are represented where relevant.
 - `dashboard-status.png` shows the recovery fixture, not a real Plaid error.
+- Peekaboo/AX validation can find local insight receipt text saying
+  local-only/disabled when no local runtime is configured; it must not mention
+  cloud AI fallback.
 - Button labels and status copy match the current app.
 - Settings screenshots show useful controls, not blank tabs.
 - Screenshots do not include unrelated desktop windows or notifications.
@@ -119,6 +130,7 @@ Regenerate screenshots when a change affects:
 - dashboard layout
 - setup/onboarding
 - status/recovery states
+- local insight receipt or attention queue copy
 - settings tabs
 - local data copy
 - notification controls

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,18 +2,12 @@
 
 This guide covers the common problems a new VaultPeek user or contributor
 should be able to solve without reading the source. (VaultPeek was renamed from
-PlaidBar; the `plaidbar`/`plaidbar-server` executable names and `PLAIDBAR_*`
+PlaidBar; SwiftPM targets, app-bundle executable names, and `PLAIDBAR_*`
 environment variables are intentionally unchanged.)
 
 ## Demo Mode Shows No Data
 
-Expected command:
-
-```bash
-plaidbar --demo
-```
-
-or from source:
+Expected source/developer command:
 
 ```bash
 swift run PlaidBar --demo
@@ -101,7 +95,7 @@ data never mix. Each mode starts empty until accounts are linked in that mode.
 
 Checks:
 
-- Start the local server with `plaidbar-server --sandbox` or
+- Start the local server with `swift run PlaidBarServer --sandbox` or
   `./Scripts/run.sh --sandbox`.
 - Confirm the port matches the app configuration.
 - Visit `http://127.0.0.1:8484/health` if using the default port.
@@ -125,6 +119,11 @@ Checks:
   available.
 - Restart both the app and server after changing the data directory.
 - Avoid copying `auth-token` into public logs or issues.
+
+The same local token boundary applies to the source/developer `plaidbar-cli`.
+If CLI commands fail with unauthorized, first verify the server is running and
+that the CLI is using the same `PLAIDBAR_DATA_DIR` as the app/server. Do not
+paste the token value in issues or support logs.
 
 ## Default Storage Did Not Migrate
 
@@ -152,6 +151,20 @@ Recovery checks:
   VaultPeek file is not already present.
 - To roll back temporarily, set `PLAIDBAR_DATA_DIR=~/.plaidbar` before starting
   both the app and server.
+
+## Local Insight Receipt Says Local AI Is Disabled
+
+That is expected when no local model runtime is configured. VaultPeek still
+shows a deterministic local receipt using on-device transaction summaries:
+source-row count, time window, top category, recurring estimate, and category
+hints. It does not fall back to a cloud model.
+
+Checks:
+
+- Confirm the dashboard still renders balances, activity, and account rows.
+- Treat the disabled/no-runtime badge as an availability note, not a sync error.
+- Do not enter cloud AI API keys for private transaction data; local insight
+  work must stay on-device.
 
 ## Accounts Are Linked But Transactions Are Empty
 
@@ -220,6 +233,9 @@ Checks:
 - Terminal has macOS Accessibility permission for UI automation.
 - No other VaultPeek window is blocking the scripted flow.
 - Run from the repository root.
+- If you are validating with Peekaboo, `peekaboo list windows --app PlaidBar`
+  should show the popover/settings window and `mcp_peekaboo_inspect_ui` should
+  expose dashboard text such as `365D SPEND`, filters, and local insight receipt.
 
 Screenshots should use demo or sandbox data only.
 

--- a/docs/v1.0-roadmap.md
+++ b/docs/v1.0-roadmap.md
@@ -24,8 +24,8 @@ storage and local databases documented in the repository.
 The near-term design direction is inspired by RepoBar: a compact menu bar
 utility that feels native, dense, glanceable, and status-rich. For VaultPeek, the
 equivalent product surface is a finance instrument: heatmap first, account rows
-second, recovery states always visible, and settings as a clear local control
-plane.
+second, recovery states always visible, local-only insight receipts explicit,
+and settings as a clear local control plane.
 
 Liquid Glass is a progressive enhancement, not a minimum requirement. VaultPeek
 targets macOS 15+ with SwiftUI material fallback. macOS 26+ Liquid Glass APIs
@@ -256,6 +256,10 @@ VaultPeek should prioritize:
 - Account health and sync health.
 - Local data controls.
 - Notifications for simple thresholds and account attention.
+- Source/developer local CLI access through the same authenticated localhost
+  server.
+- Local-only insight receipts and category-hint evidence that degrade clearly
+  when no local model runtime is configured.
 - Clear recovery actions.
 - Product docs and release clarity.
 
@@ -266,8 +270,9 @@ These ideas may fit if the core experience is stable:
 - Redacted CSV or JSON export.
 - Better recurring charge explanation.
 - Category-level budget alerts.
-- Local AI summaries for the last 7 days, last month, and year-over-year
-  financial activity, provided transaction data never leaves the Mac.
+- Expanded local AI summaries for the last 7 days, last month, and
+  year-over-year financial activity, provided transaction data never leaves the
+  Mac and deterministic/no-runtime receipts remain understandable.
 - Local AI categorization suggestions for expenses and income, provided Plaid
   categories remain the auditable fallback and corrections are reversible.
 - Signed app bundle distribution (Developer ID + notarization; Homebrew


### PR DESCRIPTION
## Summary
- Refresh README and public docs for local insight receipts, the attention queue, local-first AI boundaries, storage migration, and current architecture state.
- Scope `plaidbar-cli` documentation to source/developer builds and the authenticated localhost API, avoiding package/install claims the DMG does not satisfy.
- Add screenshot, QA, and troubleshooting guidance for local-only receipt behavior without changing generated PNG assets.

## Local gates
- [x] `git diff --check origin/main...HEAD`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 578 Swift Testing cases passed

## Notes
- Final diff is markdown-only: no source, test, generated PNG, or screenshot asset changes.
- `./Scripts/screenshots.sh` was attempted during cleanup; the release build succeeded, but UI automation could not find the setup window in this environment. Because stale PNG updates were removed from the PR, screenshot regeneration is intentionally left out of this merge.
- Recent main already includes #323, #324, #325, and #326, so CLI safety, SwiftPM preview gating, secondary recovery actions, and three-column geometry fixes are dependencies from main rather than duplicated in this PR.
