### PR TITLE
feat: live popover preview + transparency presets in Appearance (AND-364)

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -72,6 +72,12 @@ struct AppearanceSettingsView: View {
     var body: some View {
         Form {
             Section("Popover") {
+                // Live preview first: the popover material renders with the
+                // current setting over synthetic labels, so the slider and
+                // presets have immediate, privacy-safe feedback (AND-364).
+                AppearancePreviewCard(setting: transparencySetting)
+                    .padding(.vertical, Spacing.xxs)
+
                 // Full-width control block: the label/value row sits at the top,
                 // the slider spans the row, and the captions track the slider —
                 // so nothing clips at the minimum settings window width and
@@ -108,6 +114,26 @@ struct AppearanceSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                    // Quick-pick presets map to the anchor values; the active one
+                    // is filled. Reset returns to the recommended default.
+                    HStack(spacing: Spacing.sm) {
+                        ForEach(PopoverTransparencySetting.Preset.allCases) { preset in
+                            presetButton(preset)
+                        }
+
+                        Spacer(minLength: Spacing.sm)
+
+                        Button("Reset") {
+                            popoverTransparency = PopoverTransparencySetting.defaultValue
+                        }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .disabled(transparencySetting.value == PopoverTransparencySetting.defaultValue)
+                        .help("Reset transparency to the default (\(Int(PopoverTransparencySetting.defaultValue))%)")
+                    }
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel("Transparency presets")
+
                     Text("Adjusts the ultra-thin material overlay live. The range is capped to keep balances and status text legible on busy desktops.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
@@ -117,6 +143,87 @@ struct AppearanceSettingsView: View {
         }
         .formStyle(.grouped)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func presetButton(_ preset: PopoverTransparencySetting.Preset) -> some View {
+        let isActive = transparencySetting.matchingPreset == preset
+        Button(preset.title) {
+            popoverTransparency = preset.value
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(isActive ? Color.accentColor : Color.secondary)
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+}
+
+/// Privacy-safe live preview of the popover material at the current transparency.
+/// Reuses the real `PopoverMaterialBackground` and surface tokens over synthetic
+/// labels only — never real account names, balances, or data (AND-364).
+private struct AppearancePreviewCard: View {
+    let setting: PopoverTransparencySetting
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Net Worth")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                    Text("$12,345")
+                        .font(.title3.weight(.semibold))
+                        .monospacedDigit()
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                Label("Synced", systemImage: "checkmark.circle.fill")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, Spacing.chipVertical)
+                    .background(.quinary, in: Capsule())
+            }
+
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "building.columns.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Sample Checking")
+                        .font(.callout.weight(.medium))
+                    Text("Preview only")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                Text("$4,200.00")
+                    .font(.callout.weight(.medium))
+                    .monospacedDigit()
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.inset)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            PopoverMaterialBackground(transparencySetting: setting)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel))
+        .overlay {
+            RoundedRectangle(cornerRadius: Radius.panel)
+                .stroke(.separator, lineWidth: 1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "Live preview of the popover at \(setting.displayPercent) percent transparency, with sample data only."
+        )
     }
 }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -130,9 +130,10 @@ struct AppearanceSettingsView: View {
                         .controlSize(.small)
                         .disabled(transparencySetting.value == PopoverTransparencySetting.defaultValue)
                         .help("Reset transparency to the default (\(Int(PopoverTransparencySetting.defaultValue))%)")
+                        .accessibilityHint("Restores transparency to \(Int(PopoverTransparencySetting.defaultValue)) percent")
                     }
                     .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Transparency presets")
+                    .accessibilityLabel("Transparency presets and reset")
 
                     Text("Adjusts the ultra-thin material overlay live. The range is capped to keep balances and status text legible on busy desktops.")
                         .detailText()
@@ -147,14 +148,19 @@ struct AppearanceSettingsView: View {
 
     @ViewBuilder
     private func presetButton(_ preset: PopoverTransparencySetting.Preset) -> some View {
-        let isActive = transparencySetting.matchingPreset == preset
-        Button(preset.title) {
-            popoverTransparency = preset.value
+        // The active preset is filled (prominent) and inactive ones are bordered,
+        // so the current quick-pick reads as selected without relying on tint
+        // alone; VoiceOver also gets the selected trait.
+        if transparencySetting.matchingPreset == preset {
+            Button(preset.title) { popoverTransparency = preset.value }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityAddTraits(.isSelected)
+        } else {
+            Button(preset.title) { popoverTransparency = preset.value }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
         }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-        .tint(isActive ? Color.accentColor : Color.secondary)
-        .accessibilityAddTraits(isActive ? [.isSelected] : [])
     }
 }
 

--- a/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
+++ b/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
@@ -68,6 +68,8 @@ public struct PopoverTransparencySetting: Sendable, Equatable {
     /// The preset whose value matches the current setting, for highlighting the
     /// active quick-pick. Nil when the value was fine-tuned off a preset.
     public var matchingPreset: Preset? {
-        Preset.allCases.first { abs($0.value - value) < 0.5 }
+        // Slider steps and preset values are whole numbers, so an exact match is
+        // all that's needed; the small epsilon only guards Double comparison.
+        Preset.allCases.first { abs($0.value - value) < 0.01 }
     }
 }

--- a/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
+++ b/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
@@ -37,4 +37,37 @@ public struct PopoverTransparencySetting: Sendable, Equatable {
         let opacity = 0.32 - (progress * 0.26)
         return (opacity * 100).rounded() / 100
     }
+
+    /// Named quick-pick presets spanning the legible transparency range. They map
+    /// to the anchor values (most opaque / recommended default / most glass) so
+    /// the Appearance preset row stays in sync with the slider.
+    public enum Preset: String, CaseIterable, Sendable, Identifiable {
+        case solid
+        case balanced
+        case glass
+
+        public var id: String { rawValue }
+
+        public var title: String {
+            switch self {
+            case .solid: "Solid"
+            case .balanced: "Balanced"
+            case .glass: "Glass"
+            }
+        }
+
+        public var value: Double {
+            switch self {
+            case .solid: PopoverTransparencySetting.minimumValue
+            case .balanced: PopoverTransparencySetting.defaultValue
+            case .glass: PopoverTransparencySetting.maximumValue
+            }
+        }
+    }
+
+    /// The preset whose value matches the current setting, for highlighting the
+    /// active quick-pick. Nil when the value was fine-tuned off a preset.
+    public var matchingPreset: Preset? {
+        Preset.allCases.first { abs($0.value - value) < 0.5 }
+    }
 }

--- a/Tests/PlaidBarCoreTests/PopoverTransparencyPresetTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverTransparencyPresetTests.swift
@@ -1,0 +1,36 @@
+import PlaidBarCore
+import Testing
+
+@Suite("Popover transparency presets")
+struct PopoverTransparencyPresetTests {
+    @Test("Presets map to the anchor values within the legible range")
+    func presetValues() {
+        #expect(PopoverTransparencySetting.Preset.solid.value == PopoverTransparencySetting.minimumValue)
+        #expect(PopoverTransparencySetting.Preset.balanced.value == PopoverTransparencySetting.defaultValue)
+        #expect(PopoverTransparencySetting.Preset.glass.value == PopoverTransparencySetting.maximumValue)
+        for preset in PopoverTransparencySetting.Preset.allCases {
+            #expect(preset.value >= PopoverTransparencySetting.minimumValue)
+            #expect(preset.value <= PopoverTransparencySetting.maximumValue)
+        }
+    }
+
+    @Test("A value on a preset highlights that preset")
+    func matchingPresetOnAnchor() {
+        #expect(PopoverTransparencySetting(value: PopoverTransparencySetting.minimumValue).matchingPreset == .solid)
+        #expect(PopoverTransparencySetting(value: PopoverTransparencySetting.defaultValue).matchingPreset == .balanced)
+        #expect(PopoverTransparencySetting(value: PopoverTransparencySetting.maximumValue).matchingPreset == .glass)
+    }
+
+    @Test("A fine-tuned value off any preset highlights none")
+    func noMatchingPresetOffAnchor() {
+        // 50 sits between solid (20) and balanced (70) — a custom, non-preset value.
+        #expect(PopoverTransparencySetting(value: 50).matchingPreset == nil)
+    }
+
+    @Test("Preset titles are stable and human-readable")
+    func presetTitles() {
+        #expect(PopoverTransparencySetting.Preset.solid.title == "Solid")
+        #expect(PopoverTransparencySetting.Preset.balanced.title == "Balanced")
+        #expect(PopoverTransparencySetting.Preset.glass.title == "Glass")
+    }
+}


### PR DESCRIPTION
## Summary

Settings → Appearance previously showed only a raw transparency % with no in-pane feedback. Adds immediate, privacy-safe feedback. Closes **AND-364**.

- **Live preview** (`AppearancePreviewCard`) — renders the real `PopoverMaterialBackground` + surface tokens at the current transparency over **synthetic labels only** (sample net worth, a Synced status pill, one sample account row). Updates live as the slider/presets change. No real account names, balances, IDs, payloads, paths, or screenshots.
- **Presets** — Solid / Balanced / Glass quick-picks mapping to the anchor values via `PopoverTransparencySetting.Preset` (min / default / max); the active preset is highlighted (`matchingPreset`).
- **Reset** — returns to `defaultValue`, disabled when already default.
- `PopoverTransparencySetting` gains `Preset` + `matchingPreset` (pure, Sendable, unit-tested).

## Acceptance criteria
- [x] Moving the slider updates the % value and the preview immediately
- [x] Selecting a preset updates the same persisted AppStorage value the popover uses
- [x] Reset returns to `PopoverTransparencySetting.defaultValue`
- [x] Color in the preview is reinforcement only (status pill = checkmark + "Synced" text)
- [x] Strict-concurrency build clean
- [ ] Preview readable in light/dark/Reduce Transparency — reuses the proven `PopoverMaterialBackground`; the **headless Settings→Appearance capture lands in AND-366** (next), which renders this in light/dark for the QA matrix

## Tests
`PopoverTransparencyPresetTests` — preset values within range, anchor matches, off-anchor matches none, titles. Full suite green.

## Risk / rollback
Low — additive UI reusing proven components + a pure tested Core enum. Rollback = revert.

## Validation
```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test                                                                        # passing
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)