### PR TITLE
refactor: shared Reduce Motion-aware SF Symbol motion helper (AND-358)

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -111,7 +111,7 @@ private struct AttentionQueueRowView: View {
                 // the row never resizes. SeverityStatusBadge stays the primary,
                 // color-independent meaning carrier; this motion is decorative
                 // reinforcement only.
-                .symbolEffect(.bounce, options: .nonRepeating, isActive: hasAppeared && bouncesOnAppear)
+                .symbolMotion(.bounceOnce, isActive: hasAppeared && bouncesOnAppear, reduceMotion: reduceMotion)
                 .onAppear { hasAppeared = true }
                 .accessibilityHidden(true)
 
@@ -160,12 +160,12 @@ private struct AttentionQueueRowView: View {
         .accessibilityElement(children: .contain)
     }
 
-    /// Whether the leading status glyph should bounce once when this row view
-    /// appears. False under Reduce Motion or while healthy, so the effect stays
-    /// silent there and never fires when Reduce Motion is toggled on at runtime.
+    /// Whether this row's severity warrants the one-shot bounce when it appears
+    /// (warning/blocked, not healthy). The Reduce Motion gate is applied centrally
+    /// by `symbolMotion(.bounceOnce:reduceMotion:)` (AND-358), so this expresses
+    /// severity intent only.
     private var bouncesOnAppear: Bool {
-        guard !reduceMotion else { return false }
-        return row.severity != .healthy
+        row.severity != .healthy
     }
 
     private var tint: Color {

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -17,8 +17,8 @@ struct MenuBarLabel: View {
                 // One-shot Apple-native cross-fade when the status glyph
                 // changes; meaning still lives in the symbol shape + text, so
                 // this is purely calm polish. Disabled under Reduce Motion so
-                // the glyph swaps instantly with no animation.
-                .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
+                // the glyph swaps instantly with no animation (AND-358 helper).
+                .symbolMotion(.replace, reduceMotion: reduceMotion)
             if let attentionText = presentation.attentionText {
                 Text(attentionText)
                     .font(.caption.weight(.medium))

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -263,6 +263,41 @@ extension View {
     }
 }
 
+// MARK: - Symbol Motion (shared, Reduce Motion-aware)
+
+/// The status/state SF Symbol-motion patterns used across VaultPeek
+/// (refresh/sync, attention severity, menu-bar status swaps). Centralizes the
+/// native symbol APIs behind one Reduce Motion gate so future icon animation
+/// uses a single pattern instead of scattered per-call logic (AND-358). Meaning
+/// always survives motion loss via the symbol's shape/state — these effects are
+/// decorative reinforcement only.
+enum SymbolMotion {
+    /// Cross-fade between glyphs when the symbol name changes.
+    case replace
+    /// A single, non-repeating discrete effect when the view appears/activates.
+    case bounceOnce
+    /// A continuous effect that loops while active (e.g. an in-progress spinner).
+    case rotateContinuously
+}
+
+extension View {
+    /// Apply a `SymbolMotion` pattern, disabled under Reduce Motion (the symbol's
+    /// shape/state still conveys meaning). `isActive` gates the discrete and
+    /// continuous effects; it is ignored by `.replace`, which keys off the symbol
+    /// name change. Reduce Motion is gated here so call sites pass only intent.
+    @ViewBuilder
+    func symbolMotion(_ motion: SymbolMotion, isActive: Bool = true, reduceMotion: Bool) -> some View {
+        switch motion {
+        case .replace:
+            contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
+        case .bounceOnce:
+            symbolEffect(.bounce, options: .nonRepeating, isActive: isActive && !reduceMotion)
+        case .rotateContinuously:
+            symbolEffect(.rotate, options: .repeat(.continuous), isActive: isActive && !reduceMotion)
+        }
+    }
+}
+
 // MARK: - Refresh Icon (native continuous symbol effect)
 
 struct RefreshIcon: View {
@@ -275,11 +310,7 @@ struct RefreshIcon: View {
         // symbol helpers swap in the filled static glyph at a dimmed opacity and
         // the effect is gated inactive, so loading reads without any movement.
         Image(systemName: MotionTokens.refreshSymbolName(isLoading: isLoading, reduceMotion: reduceMotion))
-            .symbolEffect(
-                .rotate,
-                options: .repeat(.continuous),
-                isActive: isLoading && !reduceMotion
-            )
+            .symbolMotion(.rotateContinuously, isActive: isLoading, reduceMotion: reduceMotion)
             .opacity(MotionTokens.refreshOpacity(isLoading: isLoading, reduceMotion: reduceMotion))
             .accessibilityLabel(isLoading ? "Refreshing" : "Refresh")
             .accessibilityValue(isLoading ? "In progress" : "Ready")


### PR DESCRIPTION
## Summary

The SF Symbol effects from AND-359/360/361 used native APIs with per-call Reduce Motion gating scattered across three views. Consolidates them behind one helper so future icon animation uses a single pattern. Closes **AND-358**.

## What's included
- **`SymbolMotion`** enum (`.replace` / `.bounceOnce` / `.rotateContinuously`) + **`View.symbolMotion(_:isActive:reduceMotion:)`** in `SharedModifiers.swift`. It wraps `contentTransition(.symbolEffect(.replace))` and `symbolEffect(.bounce/.rotate)` and applies the Reduce Motion gate in **one place**; the symbol's shape/state still carries meaning when motion is off.
- Rewired the three call sites (behavior-identical):
  - `RefreshIcon` → `.rotateContinuously`
  - `MenuBarLabel` → `.replace`
  - `AttentionQueueView` → `.bounceOnce` (its `bouncesOnAppear` drops its own `!reduceMotion` guard now that the helper owns the gate — same resulting `isActive` expression)
- The only native symbol-effect call now lives inside the helper.

## Acceptance criteria
- [x] Helper compiles on the current macOS deployment target (14+)
- [x] Reduce Motion disables movement while the symbol shape/state still conveys meaning
- [x] No Plaid payloads/tokens/IDs/screenshots/local data introduced
- [x] Strict-concurrency build clean

## Risk / rollback
Low — behavior-preserving refactor (same effects, same gating), no new app behavior. No extractable non-trivial logic to unit-test beyond build/test (the gate is `isActive && !reduceMotion`). Rollback = revert.

## Validation
```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test                                                                        # 567 passing
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)