### PR TITLE
fix: CLI safety — refuse non-loopback --server; drop unsafe --commit (AND-404)

### DIFF
--- a/Sources/PlaidBarCLI/PlaidBarCLI.swift
+++ b/Sources/PlaidBarCLI/PlaidBarCLI.swift
@@ -105,9 +105,6 @@ struct TransactionsList: AsyncParsableCommand {
     @Option(name: .long, help: "Restrict sync to one Plaid item ID.")
     var item: String?
 
-    @Flag(name: .long, help: "Commit returned sync cursors after a successful sync.")
-    var commit = false
-
     func run() async throws {
         let client = PlaidBarCLIHTTPClient(options: options)
         let response = try await fetchSync(client: client, item: item)
@@ -115,21 +112,14 @@ struct TransactionsList: AsyncParsableCommand {
         if options.json {
             try PlaidBarCLIOutput.write(response, json: true) { "" }
         } else {
-            // When committing, show every returned change so advancing the
-            // server cursor cannot hide transactions behind the table --count
-            // limit; otherwise honor the requested row cap.
-            let rowCount = commit ? transactions.count : count
-            print(PlaidBarCLITableFormatter.transactions(transactions, count: rowCount))
+            print(PlaidBarCLITableFormatter.transactions(transactions, count: count))
             if response.hasMore {
-                PlaidBarCLIOutput.writeError("More transactions are available; run again to continue syncing.")
+                PlaidBarCLIOutput.writeError("More transactions are available; open VaultPeek to sync them.")
             }
-            if !response.pendingCursors.isEmpty && !commit {
-                PlaidBarCLIOutput.writeError("Sync cursors were not committed. Re-run with --commit after reviewing results.")
+            if !response.pendingCursors.isEmpty {
+                PlaidBarCLIOutput.writeError(readOnlyCursorNote)
             }
         }
-        // Commit only after output succeeds, so a broken pipe or failed write
-        // never advances the cursor past transactions the user has not seen.
-        try await commitSyncIfRequested(client: client, response: response, commit: commit)
     }
 }
 
@@ -141,9 +131,6 @@ struct TransactionsSync: AsyncParsableCommand {
     @Option(name: .long, help: "Restrict sync to one Plaid item ID.")
     var item: String?
 
-    @Flag(name: .long, help: "Commit returned sync cursors after a successful sync.")
-    var commit = false
-
     func run() async throws {
         let client = PlaidBarCLIHTTPClient(options: options)
         let response = try await fetchSync(client: client, item: item)
@@ -152,15 +139,21 @@ struct TransactionsSync: AsyncParsableCommand {
             return PlaidBarCLITableFormatter.transactions(transactions, count: transactions.count)
         }
         if response.hasMore {
-            PlaidBarCLIOutput.writeError("More transactions are available; run again to continue syncing.")
+            PlaidBarCLIOutput.writeError("More transactions are available; open VaultPeek to sync them.")
         }
-        if !response.pendingCursors.isEmpty && !commit {
-            PlaidBarCLIOutput.writeError("Sync cursors were not committed. Re-run with --commit after reviewing results.")
+        if !response.pendingCursors.isEmpty {
+            PlaidBarCLIOutput.writeError(readOnlyCursorNote)
         }
-        // Commit only after the full response has been written to stdout.
-        try await commitSyncIfRequested(client: client, response: response, commit: commit)
     }
 }
+
+/// The CLI is a read-only diagnostic mirror: it fetches transactions from the
+/// server's sync endpoint but does NOT persist them. Only VaultPeek stores
+/// fetched transactions and advances the sync cursor, so the CLI must never
+/// commit cursors — doing so would advance the shared cursor past transactions
+/// the app has not stored, and the app's next sync would skip them (AND-404).
+private let readOnlyCursorNote =
+    "Read-only preview: VaultPeek stores these updates and advances the sync cursor when you open it. The CLI does not commit cursors."
 
 struct Link: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -197,15 +190,6 @@ private func fetchSync(
     try await client.get(.transactionsSync(itemId: item))
 }
 
-private func commitSyncIfRequested(
-    client: PlaidBarCLIHTTPClient,
-    response: SyncResponse,
-    commit: Bool
-) async throws {
-    guard commit, !response.pendingCursors.isEmpty else { return }
-    try await client.post(.commitCursors, body: SyncCursorCommitRequest(cursors: response.pendingCursors))
-}
-
 struct PlaidBarCLIHTTPClient: Sendable {
     let options: PlaidBarCLIOptions
 
@@ -222,14 +206,6 @@ struct PlaidBarCLIHTTPClient: Sendable {
         return try await decode(request)
     }
 
-    func post<T: Encodable & Sendable>(_ endpoint: PlaidBarCLIEndpoint, body: T) async throws {
-        var request = try request(endpoint: endpoint)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(body)
-        _ = try await PlaidBarURLSession.shared.data(for: request)
-    }
-
     private func request(endpoint: PlaidBarCLIEndpoint) throws -> URLRequest {
         // Tolerate a trailing slash on --server (e.g. http://127.0.0.1:8484/)
         // so it does not collapse into a double-slashed /api path the server
@@ -239,6 +215,11 @@ struct PlaidBarCLIHTTPClient: Sendable {
             : options.server
         guard let url = URL(string: base + endpoint.path) else {
             throw PlaidBarCLIError.invalidServerURL(options.server)
+        }
+        // Never attach the local bearer token (the local API secret) to a
+        // non-loopback server: that would leak it to a remote endpoint (AND-404).
+        guard PlaidBarCLIServer.isLoopback(base) else {
+            throw PlaidBarCLIError.nonLoopbackServer(options.server)
         }
         let token = try String(contentsOfFile: options.authTokenPath, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -323,6 +304,7 @@ enum PlaidBarCLIOutput {
 
 enum PlaidBarCLIError: Error, CustomStringConvertible, LocalizedError {
     case invalidServerURL(String)
+    case nonLoopbackServer(String)
     case missingAuthToken(String)
     case requestFailed(String)
 
@@ -330,6 +312,8 @@ enum PlaidBarCLIError: Error, CustomStringConvertible, LocalizedError {
         switch self {
         case .invalidServerURL(let value):
             "Invalid PlaidBar server URL: \(value)"
+        case .nonLoopbackServer(let value):
+            "Refusing to send the local auth token to a non-loopback server: \(value). PlaidBarServer binds to 127.0.0.1; use a loopback --server URL."
         case .missingAuthToken(let path):
             "PlaidBar auth token is missing at \(path). Start PlaidBarServer first."
         case .requestFailed(let message):

--- a/Sources/PlaidBarCore/Utilities/PlaidBarCLI.swift
+++ b/Sources/PlaidBarCore/Utilities/PlaidBarCLI.swift
@@ -38,6 +38,32 @@ public enum PlaidBarCLIEndpoint: Sendable, Equatable {
     }
 }
 
+/// Safety checks for the CLI's `--server` target. The CLI attaches the local
+/// API bearer token (the local secret) to every request, so it must only ever
+/// talk to a loopback address — otherwise a non-loopback `--server` would leak
+/// the token to a remote endpoint (AND-404).
+public enum PlaidBarCLIServer {
+    /// Whether `urlString`'s host is a loopback address the local bearer token
+    /// may be sent to: `localhost`, IPv6 `::1`, or any IPv4 in `127.0.0.0/8`.
+    public static func isLoopback(_ urlString: String) -> Bool {
+        guard var host = URLComponents(string: urlString)?.host?.lowercased() else {
+            return false
+        }
+        // IPv6 literals come back bracketed (e.g. "[::1]"); compare on the inner address.
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        if host == "localhost" || host == "::1" { return true }
+        // IPv4 loopback range 127.0.0.0/8 — require four numeric octets so a
+        // hostname like "127.evil.com" is not mistaken for a loopback IP.
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        if octets.count == 4, octets.first == "127", octets.allSatisfy({ UInt8($0) != nil }) {
+            return true
+        }
+        return false
+    }
+}
+
 public enum PlaidBarCLITableFormatter {
     public static func status(_ status: ServerStatus) -> String {
         rows([

--- a/Tests/PlaidBarCoreTests/PlaidBarCLIServerTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCLIServerTests.swift
@@ -1,0 +1,28 @@
+import PlaidBarCore
+import Testing
+
+@Suite("CLI server loopback safety")
+struct PlaidBarCLIServerTests {
+    @Test("Loopback hosts are allowed (token may be attached)")
+    func loopbackAllowed() {
+        #expect(PlaidBarCLIServer.isLoopback("http://127.0.0.1:8484"))
+        #expect(PlaidBarCLIServer.isLoopback("http://127.0.0.1:8484/")) // trailing slash
+        #expect(PlaidBarCLIServer.isLoopback("http://localhost:8484"))
+        #expect(PlaidBarCLIServer.isLoopback("http://LOCALHOST:8484")) // case-insensitive
+        #expect(PlaidBarCLIServer.isLoopback("http://[::1]:8484"))
+        #expect(PlaidBarCLIServer.isLoopback("http://127.5.6.7:8484")) // 127.0.0.0/8
+    }
+
+    @Test("Non-loopback hosts are rejected (token must not leak)")
+    func nonLoopbackRejected() {
+        #expect(!PlaidBarCLIServer.isLoopback("http://192.168.1.10:8484"))
+        #expect(!PlaidBarCLIServer.isLoopback("http://10.0.0.5:8484"))
+        #expect(!PlaidBarCLIServer.isLoopback("https://evil.example.com"))
+        #expect(!PlaidBarCLIServer.isLoopback("http://0.0.0.0:8484"))
+        // A hostname that merely starts with "127." is not a loopback IP.
+        #expect(!PlaidBarCLIServer.isLoopback("http://127.evil.com:8484"))
+        // 127 with the wrong octet count is not a valid loopback IPv4.
+        #expect(!PlaidBarCLIServer.isLoopback("http://127.0.0:8484"))
+        #expect(!PlaidBarCLIServer.isLoopback("not a url"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCLIServerTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCLIServerTests.swift
@@ -25,4 +25,22 @@ struct PlaidBarCLIServerTests {
         #expect(!PlaidBarCLIServer.isLoopback("http://127.0.0:8484"))
         #expect(!PlaidBarCLIServer.isLoopback("not a url"))
     }
+
+    @Test("Known loopback-allowlist bypass vectors are rejected")
+    func bypassVectorsRejected() {
+        // The classic "@"-in-authority SSRF bypass: the part before "@" is
+        // userinfo, so URLComponents parses the host as the remote — the token
+        // must not be sent there.
+        #expect(!PlaidBarCLIServer.isLoopback("http://127.0.0.1@evil.com"))
+        #expect(!PlaidBarCLIServer.isLoopback("http://localhost@evil.com"))
+        // A loopback label used as a subdomain prefix is not loopback.
+        #expect(!PlaidBarCLIServer.isLoopback("http://127.0.0.1.evil.com:8484"))
+        // Non-decimal / packed IPv4 encodings of 127.0.0.1 are not recognized.
+        #expect(!PlaidBarCLIServer.isLoopback("http://0x7f.0.0.1:8484"))   // hex octet
+        #expect(!PlaidBarCLIServer.isLoopback("http://0177.0.0.1:8484"))   // octal octet
+        #expect(!PlaidBarCLIServer.isLoopback("http://2130706433:8484"))   // packed decimal
+        // IPv4-mapped IPv6 and trailing-dot forms fail safe (rejected, not sent).
+        #expect(!PlaidBarCLIServer.isLoopback("http://[::ffff:127.0.0.1]:8484"))
+        #expect(!PlaidBarCLIServer.isLoopback("http://localhost.:8484"))
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the **Urgent** Codex safety review of the read-only `plaidbar-cli`. Closes **AND-404**.

## Fixes

**P2 — privacy/security: token leak to non-loopback `--server`**
The CLI attaches the local API bearer token (the local secret) to every request, but `--server` accepted any URL — a non-loopback target would leak the token to a remote endpoint. Added `PlaidBarCLIServer.isLoopback` (PlaidBarCore, unit-tested) and guarded the request builder: the token is only ever sent to a loopback host (`localhost`, `::1`, `127.0.0.0/8`); a non-loopback `--server` now **fails fast before the token is read**.

**P1 — data safety: `--commit` advanced the shared cursor without persisting**
The server's sync route does **not** persist transactions (it returns them; only the app stores them). So `transactions list/sync --commit` advanced the server's shared sync cursor past transactions the app hadn't stored → the app's next sync **skipped them (data loss)**. Removed `--commit` and the commit path entirely (`commitSyncIfRequested` + the now-unused encodable POST helper). Cursor advancement belongs to the app, which persists what it fetches. The `/api/transactions/sync/cursors` endpoint + `SyncCursorCommitRequest` stay for the app/server. The stderr note now explains this.

**P2 — docs: Homebrew/CLI claim** — already moot: Homebrew distribution was retired (README "installed build on your PATH" / drag-install DMG). No README change needed (also avoids conflicting with the open docs PR #313).

## Acceptance criteria
- [x] P1: read-only CLI can no longer advance the sync cursor past unstored transactions
- [x] P2: bearer token is never sent to a non-loopback `--server`
- [x] P2: README Homebrew claim verified already resolved (Homebrew retired)
- [x] Strict-concurrency build clean; no secrets/real data added

## Tests
`PlaidBarCLIServerTests` — loopback allowed (incl. trailing slash, IPv6 `[::1]`, `127.0.0.0/8`); non-loopback + spoofed `127.evil.com` + malformed URLs rejected. **572 → 574 passing.**

## Validation
```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test                                                                        # 574 passing
swift run plaidbar-cli status --server http://192.168.1.10:8484                   # refused, token not sent
swift run plaidbar-cli transactions list --help                                   # no --commit
```

## Risk / rollback
Low. Removing `--commit` is a deliberate behavior change (the flag was unsafe by design); the loopback guard only rejects configurations that were leaking the token. Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)