### PR TITLE
fix: gate AttentionQueue #Preview out of SwiftPM builds (#314)

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -216,6 +216,12 @@ private struct SeverityStatusBadge: View {
 // animation manually, run `swift run PlaidBar --demo` and toggle a row into a
 // non-healthy state; with Reduce Motion on, the glyph must stay still while the
 // badge text/icon still distinguishes severity without color.
+//
+// Gated behind `!SWIFT_PACKAGE`: the `#Preview` macro is supplied by Xcode's
+// `PreviewsMacros` plugin, which is absent in plain SwiftPM (`swift build`/
+// `swift test`). Without this guard the whole package fails to compile, taking
+// the test suite down with it (#314).
+#if !SWIFT_PACKAGE
 #Preview("Attention rows") {
     VStack(spacing: Spacing.xs) {
         AttentionQueueRowView(
@@ -245,3 +251,4 @@ private struct SeverityStatusBadge: View {
     .padding()
     .frame(width: 360)
 }
+#endif


### PR DESCRIPTION
## Problem
`swift test` / `swift build` on `main` fail to compile the `PlaidBar` app target, taking the entire package test suite down. Issue #314.

## Root Cause
`Sources/PlaidBar/Views/AttentionQueueView.swift` contains an unconditional `#Preview("Attention rows")`. The `#Preview` macro is supplied by Xcode's `PreviewsMacros` plugin, which is **not** available in plain SwiftPM. The package cannot compile far enough to run tests, hiding regressions in server privacy/storage boundaries and dashboard-state logic.

## Solution
Wrap the preview block in `#if !SWIFT_PACKAGE` — the standard SwiftPM idiom for Xcode-canvas-only preview code. The preview source is retained for Xcode; CLI package builds skip it. One-file, behavior-preserving change.

## Validation
GitHub Actions are disabled (#309), so validated locally:
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!**
- `swift test` → **575 tests passed**

## Risk
Minimal. The guarded code is preview-only and never participated in a successful CLI build. No production code path changes.

## Rollback
Revert this commit; `main` returns to the broken-test state.

## Linked Issues
Fixes #314