### PR TITLE
fix: render dashboard secondary recovery actions (#322)

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -895,33 +895,52 @@ private struct DashboardStatusReadinessPanel: View {
             StatusMetricGrid()
                 .environment(appState)
 
-            if let primaryAction = readiness.primaryAction {
+            if readiness.primaryAction != nil || !readiness.secondaryActions.isEmpty {
                 HStack(spacing: 8) {
-                    if readinessNeedsAttention {
-                        Button {
-                            perform(primaryAction)
-                        } label: {
-                            Label(
-                                primaryActionLabel(for: primaryAction),
-                                systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
-                            )
+                    if let primaryAction = readiness.primaryAction {
+                        if readinessNeedsAttention {
+                            Button {
+                                perform(primaryAction)
+                            } label: {
+                                Label(
+                                    primaryActionLabel(for: primaryAction),
+                                    systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                                )
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .tint(tint)
+                            .disabled(appState.isLoading)
+                        } else {
+                            Button {
+                                perform(primaryAction)
+                            } label: {
+                                Label(
+                                    primaryActionLabel(for: primaryAction),
+                                    systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                                )
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(appState.isLoading)
                         }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                        .tint(tint)
-                        .disabled(appState.isLoading)
-                    } else {
+                    }
+
+                    // Modeled recovery fallbacks (e.g. in-app Settings when the
+                    // primary action opens System Settings). Routed through the
+                    // same perform(_:) so the panel matches the readiness
+                    // presentation contract (#322).
+                    ForEach(readiness.secondaryActions, id: \.self) { action in
                         Button {
-                            perform(primaryAction)
+                            perform(action)
                         } label: {
-                            Label(
-                                primaryActionLabel(for: primaryAction),
-                                systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
-                            )
+                            Label(action.defaultTitle, systemImage: action.defaultIconName)
+                                .lineLimit(1)
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .disabled(appState.isLoading)
+                        .accessibilityLabel(action.defaultTitle)
                     }
                 }
             }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2026,6 +2026,9 @@ struct PlaidBarCoreTests {
         #expect(readiness.primaryAction == .addAccount)
         #expect(readiness.primaryActionTitle == "Connect Bank")
         #expect(readiness.primaryActionIconName == "plus.circle")
+        // The demo state offers an in-app Settings fallback the status panel
+        // must surface alongside the primary action (#322).
+        #expect(readiness.secondaryActions == [.openSettings])
     }
 
     @Test("Dashboard status readiness blocks on offline server")


### PR DESCRIPTION
## Problem
`DashboardStatusReadiness` models `secondaryActions`, but `DashboardStatusReadinessPanel` rendered only `readiness.primaryAction`. Modeled recovery fallbacks were silently unreachable in the dashboard status panel. Issue #322.

## Root Cause
The panel's action row was guarded on `if let primaryAction = readiness.primaryAction` and never iterated `readiness.secondaryActions`. The most user-visible loss: when macOS notification permission is denied, the model returns primary `.openNotificationSettings` **plus** secondary `.openSettings`, but the panel showed only the System Settings button — dropping the in-app Settings fallback.

## Solution
Render `secondaryActions` as bordered buttons beside the primary action, routed through the existing `perform(_:)` (which exhaustively handles all 7 action cases). Verified across every `evaluate` branch that no state pairs the same action as both primary and secondary, so no duplicate buttons appear. Each secondary button carries text + icon + explicit `accessibilityLabel` — no color-only meaning. Strengthened the demo-state model test to lock its `[.openSettings]` secondary contract.

## Validation
GitHub Actions disabled (#309) → validated locally:
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!**
- `swift test` → **575 tests passed**

The panel is a private SwiftUI view with no ViewInspector harness in this SPM setup, so it is covered indirectly via the model contract tests + strict build.

## Risk
Low, additive. Only renders actions the model already emits; primary-action rendering is byte-for-byte preserved.

## Rollback
Revert this commit; the panel returns to primary-only rendering.

## Linked Issues
Fixes #322