### PR TITLE
fix: three-column popover geometry on narrow displays + persisted-selection open (AND-405)

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -13,6 +13,10 @@ struct MainPopover: View {
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
     @State private var dashboardContentHeight: CGFloat = 0
+    /// True after the first render. Gates the inspector's trailing slide-in so a
+    /// popover opened with a persisted selection appears directly in three-column
+    /// geometry (no slide on restore); in-session selections still slide (AND-405).
+    @State private var hasAppeared = false
 
     private enum Layout {
         // Column widths and the screen-edge margin are owned by the shared,
@@ -116,6 +120,11 @@ struct MainPopover: View {
             .task {
                 await appState.loadInitialData()
             }
+            .onAppear { hasAppeared = true }
+            // Also self-heals the first-open edge where a persisted selection
+            // doesn't survive the active filter: at mount accounts are empty, so
+            // this fires once when they first populate and clears a now-invalid
+            // id, collapsing the reserved three-column back to two (AND-405).
             .onChange(of: filteredAccounts.map(\.id)) { _, ids in
                 guard !selectedAccountId.isEmpty, !ids.contains(selectedAccountId) else { return }
                 selectedAccountId = ""
@@ -243,8 +252,17 @@ struct MainPopover: View {
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: dashboardScrollHeight)
             .leftPanelSurface()
-            .transition(.move(edge: .trailing).combined(with: .opacity))
+            // Slide in only for an in-session selection; a popover opened with a
+            // persisted selection appears directly in three-column (AND-405).
+            .transition(.asymmetric(
+                insertion: inspectorInsertionTransition,
+                removal: .move(edge: .trailing).combined(with: .opacity)
+            ))
         }
+    }
+
+    private var inspectorInsertionTransition: AnyTransition {
+        hasAppeared ? .move(edge: .trailing).combined(with: .opacity) : .identity
     }
 
     private var inspectorLoadingPlaceholder: some View {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -62,11 +62,24 @@ struct MainPopover: View {
         return accounts.first { $0.id == id }
     }
 
-    /// The trailing account inspector is open (an account is selected and we are
-    /// past setup). Drives the third column, the popover width, the leading-edge
-    /// anchor, and Esc precedence.
+    /// The trailing account inspector is reserved: a selection is persisted and
+    /// we are past setup. Derived from the persisted `selectedAccountId`
+    /// (`@AppStorage`) rather than the resolved `selectedAccount`, so a popover
+    /// opened with a persisted selection reserves the three-column width and
+    /// anchor immediately — before `loadInitialData()` populates accounts —
+    /// instead of opening two-column and jumping to three-column once accounts
+    /// arrive (AND-405). The inspector column shows a brief loading placeholder
+    /// until `selectedAccount` resolves. Also drives the popover width, the
+    /// leading-edge anchor, and Esc precedence.
     private var isAccountInspectorOpen: Bool {
-        selectedAccount != nil && !shouldShowSetupScreen
+        !selectedAccountId.isEmpty && !shouldShowSetupScreen
+    }
+
+    /// The width available for the popover on the active screen, or effectively
+    /// unbounded when there is no screen (headless renders) so the full geometry
+    /// is used.
+    private var availableScreenWidth: CGFloat {
+        NSScreen.main?.visibleFrame.width ?? .greatestFiniteMagnitude
     }
 
     /// Two-column base width: Wealth Summary rail + divider + dashboard. This is
@@ -174,8 +187,12 @@ struct MainPopover: View {
                     .opacity(0.35)
             }
 
+            // The center flexes: the rail and inspector keep their fixed widths,
+            // so when the popover is capped on a narrow/scaled display the center
+            // absorbs the difference (down to a floor) and the trailing inspector
+            // + its close control stay on-screen (AND-405).
             dashboardColumn
-                .frame(width: Layout.dashboardWidth)
+                .frame(minWidth: PopoverGeometry.minDashboardWidth, maxWidth: .infinity)
 
             accountInspectorColumn
         }
@@ -204,16 +221,25 @@ struct MainPopover: View {
     // dismissible.
     @ViewBuilder
     private var accountInspectorColumn: some View {
-        if isAccountInspectorOpen, let selectedAccount {
+        if isAccountInspectorOpen {
             Divider()
                 .opacity(0.35)
 
-            AccountInspector(
-                account: selectedAccount,
-                isStatusFilter: selectedFilter == .status,
-                onClose: deselectAccount
-            )
-            .environment(appState)
+            Group {
+                if let selectedAccount {
+                    AccountInspector(
+                        account: selectedAccount,
+                        isStatusFilter: selectedFilter == .status,
+                        onClose: deselectAccount
+                    )
+                    .environment(appState)
+                } else {
+                    // A persisted selection reserves the column before accounts
+                    // load; show a brief placeholder so the width is correct
+                    // immediately and fills in without a resize jump (AND-405).
+                    inspectorLoadingPlaceholder
+                }
+            }
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: dashboardScrollHeight)
             .leftPanelSurface()
@@ -221,13 +247,23 @@ struct MainPopover: View {
         }
     }
 
+    private var inspectorLoadingPlaceholder: some View {
+        ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityLabel("Loading account details")
+    }
+
     private var popoverWidth: CGFloat {
-        // The true geometry is reported here (fixed columns must not be clipped);
-        // the window anchor shifts the window on-screen when the three-column
-        // width exceeds the available width near a display edge (AND-370/374).
-        // Setup renders at the dashboard width so first run never snaps sizes.
+        // Cap the content to the available screen width so the popover never
+        // renders off-screen; the center dashboard flexes to absorb the cap so
+        // the rail and the trailing inspector + close control stay visible on
+        // narrow/scaled displays (AND-405). Setup renders at the dashboard width.
         guard !shouldShowSetupScreen else { return PopoverGeometry.width(for: .setup) }
-        return PopoverGeometry.width(for: isAccountInspectorOpen ? .threeColumn : .twoColumn)
+        return PopoverGeometry.fittedWidth(
+            for: isAccountInspectorOpen ? .threeColumn : .twoColumn,
+            availableWidth: availableScreenWidth
+        )
     }
 
     private var transparencySetting: PopoverTransparencySetting {

--- a/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
+++ b/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
@@ -18,6 +18,12 @@ public enum PopoverGeometry {
     /// Default gap kept between the widened popover and the screen's visible
     /// edges when it is clamped on-screen.
     public static let screenEdgeMargin: CGFloat = 12
+    /// The minimum width the flexible center dashboard keeps when the popover is
+    /// capped on a narrow/scaled display. The rail and inspector stay fixed at
+    /// `railWidth`, so the center absorbs the difference down to this floor. Set
+    /// so a scaled 1024-wide display (center ≈ 358pt) still fits the full
+    /// three-column layout without overflow (AND-405).
+    public static let minDashboardWidth: CGFloat = 340
 
     /// The three popover layout states and their column composition.
     public enum Layout: Sendable, CaseIterable {
@@ -39,6 +45,27 @@ public enum PopoverGeometry {
         case .threeColumn:
             railWidth + dividerWidth + dashboardWidth + dividerWidth + railWidth
         }
+    }
+
+    /// The popover's content width capped to fit the available screen width.
+    ///
+    /// When the full layout width exceeds the available width (minus a margin on
+    /// each side), the popover is capped so it never renders off-screen — the
+    /// rail and inspector keep their fixed widths and the center dashboard flexes
+    /// to absorb the difference (down to `minDashboardWidth`), keeping the
+    /// trailing inspector and its close control on-screen on narrow/scaled
+    /// displays (AND-405). Pass a very large `availableWidth` (e.g. headless,
+    /// where no screen exists) to get the full, uncapped width.
+    public static func fittedWidth(
+        for layout: Layout,
+        availableWidth: CGFloat,
+        margin: CGFloat = screenEdgeMargin
+    ) -> CGFloat {
+        let full = width(for: layout)
+        guard availableWidth.isFinite, availableWidth > 0 else { return full }
+        let usable = availableWidth - (2 * margin)
+        guard usable > 0 else { return full }
+        return min(full, usable)
     }
 
     /// Clamp a desired leading-edge X so a popover of `width` stays within a

--- a/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
+++ b/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
@@ -62,6 +62,9 @@ public enum PopoverGeometry {
         margin: CGFloat = screenEdgeMargin
     ) -> CGFloat {
         let full = width(for: layout)
+        // Guards the degenerate inputs; the headless sentinel is a large *finite*
+        // value (e.g. .greatestFiniteMagnitude), which passes through to a no-op
+        // min() below — `subtracting 2*margin from it stays effectively itself.
         guard availableWidth.isFinite, availableWidth > 0 else { return full }
         let usable = availableWidth - (2 * margin)
         guard usable > 0 else { return full }

--- a/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
@@ -19,6 +19,29 @@ struct PopoverGeometryTests {
         #expect(delta == PopoverGeometry.dividerWidth + PopoverGeometry.railWidth)
     }
 
+    @Test("Fitted width passes the full width through on a wide / headless screen")
+    func fittedWidthWideScreen() {
+        // Comfortably wider than 1122 → unchanged.
+        #expect(PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 1680) == 1122)
+        // Headless (no screen) passes a very large width → full geometry.
+        #expect(
+            PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: .greatestFiniteMagnitude) == 1122
+        )
+        // Zero / negative available width falls back to the full width.
+        #expect(PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 0) == 1122)
+    }
+
+    @Test("Fitted width caps the popover to the available screen, leaving room for the center to flex")
+    func fittedWidthNarrowScreen() {
+        // A scaled 1024-wide display can't fit 1122; cap to 1024 - 2*12 = 1000.
+        let capped = PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 1024, margin: 12)
+        #expect(capped == 1000)
+        // The rail + inspector + dividers still fit with the center at/above its
+        // floor: 1000 - (320*2 + 1*2) = 358 ≥ 340.
+        let sideColumns = PopoverGeometry.railWidth * 2 + PopoverGeometry.dividerWidth * 2
+        #expect(capped - sideColumns >= PopoverGeometry.minDashboardWidth)
+    }
+
     @Test("A popover that already fits is not moved")
     func clampLeavesFittingPopover() {
         // 1122 popover at x=200 on a 1680-wide display fits with room to spare.

--- a/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
@@ -31,6 +31,14 @@ struct PopoverGeometryTests {
         #expect(PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 0) == 1122)
     }
 
+    @Test("Fitted width boundary: exactly fits vs one point too narrow")
+    func fittedWidthBoundary() {
+        // 1122 + 2*12 exactly fits → unchanged.
+        #expect(PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 1122 + 24, margin: 12) == 1122)
+        // One point narrower → the cap engages by one point.
+        #expect(PopoverGeometry.fittedWidth(for: .threeColumn, availableWidth: 1122 + 23, margin: 12) == 1121)
+    }
+
     @Test("Fitted width caps the popover to the available screen, leaving room for the center to flex")
     func fittedWidthNarrowScreen() {
         // A scaled 1024-wide display can't fit 1122; cap to 1024 - 2*12 = 1000.

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -130,6 +130,8 @@ tech):
 | Check | Expected Result |
 |-------|-----------------|
 | No-jump on open/close | Selecting an account grows the popover rightward; the Wealth Summary rail does not shift horizontally. Deselecting returns to two columns without a jump |
+| First open with a persisted selection (AND-405) | With `dashboard.selectedAccountId` set from a prior session, the popover opens directly at the three-column width and the inspector fills in (brief loading placeholder) — it does NOT open two-column and jump to three-column once accounts load |
+| Narrow / scaled display (AND-405) | On a display/zoom where 1122 doesn't fit (e.g. scaled ~1024pt), the popover caps to the screen and the center dashboard flexes/scrolls while the rail + inspector keep 320pt; the inspector ✕ and recovery controls stay on-screen. Extreme zoom (≲ ~1002pt usable) is the documented Tier-2 overlay residual |
 | Near a display edge | Opening the inspector with the menu-bar item near the right edge clamps the popover on-screen (shifts left), keeping the rail visible; nothing renders off-screen |
 | Multi-monitor | Opening on a secondary display clamps within that display's visible frame |
 | Keyboard | Esc closes the inspector before the popover; focus returns to the selected row; filter change clears selection without trapping focus |

--- a/docs/three-column-popover-contract.md
+++ b/docs/three-column-popover-contract.md
@@ -114,9 +114,9 @@ optional, and is layered from least to most disruptive:
 
 | Tier | Trigger | Behavior |
 |------|---------|----------|
-| **0 — Ideal** | `1122 + margin ≤ visibleFrame.width` | Full three columns side by side. |
-| **1 — Clamp + internal scroll** | three-column ideal does not fit, but `summaryRail + dashboard` (the two-column block) plus a usable inspector does | Clamp popover width to `visibleFrame.width − margin`; columns keep their identity and scroll internally. **The left Wealth Summary stays visible.** |
-| **2 — Overlay inspector (last resort)** | even the clamped three-column block cannot show a usable inspector | The inspector overlays the trailing region of the center column as a layer above it; the left Wealth Summary remains visible. This last-resort path **must** be documented in code and be fully keyboard- and VoiceOver-reachable. |
+| **0 — Ideal** | `1122 + 2·margin ≤ visibleFrame.width` | Full three columns side by side. |
+| **1 — Cap + flexible center** *(implemented, AND-405)* | 1122 does not fit, but the rail + a `minDashboardWidth` center + the inspector do (≈ ≥ 1002pt usable, covering scaled displays down to ~1024pt) | `PopoverGeometry.fittedWidth` caps the popover to `visibleFrame.width − 2·margin`; the rail and inspector keep their fixed 320pt and the **center dashboard flexes** (down to `minDashboardWidth` = 340pt) and scrolls internally, so the trailing inspector and its ✕/recovery controls stay on-screen. **The left Wealth Summary stays visible.** |
+| **2 — Overlay inspector (last resort)** | even a `minDashboardWidth` center cannot fit alongside the rail + inspector (extreme accessibility zoom, ≲ 1002pt usable) | The inspector overlays the trailing region of the center column as a layer above it; the left Wealth Summary remains visible. This last-resort path **must** be documented in code and be fully keyboard- and VoiceOver-reachable. *(Not yet implemented; the residual case is documented here and in `docs/qa-matrix.md`.)* |
 
 Constraints that hold in every tier:
 


### PR DESCRIPTION
## Summary

Addresses the two Codex review follow-ups on PR #315's three-column popover. Closes **AND-405**.

## Fixes

**(1) Narrow / scaled displays — inspector no longer goes off-screen**
The popover always reported the full 1122pt width and relied on the window anchor to shift it on-screen, so on a display too narrow for 1122 the trailing inspector + its close/recovery controls ended up off-screen. Now `PopoverGeometry.fittedWidth` caps the popover to `visibleFrame.width − 2·margin`, and the **center dashboard flexes** (rail + inspector keep fixed 320pt; center floors at `minDashboardWidth` = 340pt and scrolls), so the inspector + ✕ stay on-screen down to ~1024pt scaled displays. The contract's **Tier-1 fallback is now implemented**; the sub-~1002pt overlay remains the documented Tier-2 residual.

**(2) First open with a persisted selection — no 801→1122 jump**
`selectedAccount` is nil until `loadInitialData()` populates accounts, so a popover opened with a persisted `dashboard.selectedAccountId` opened two-column and jumped to three-column once accounts arrived. `isAccountInspectorOpen` now derives from the persisted `selectedAccountId` (@AppStorage), reserving the three-column width + anchor immediately; the inspector column shows a brief loading placeholder until `selectedAccount` resolves, then fills in **with no resize jump**.

## Acceptance criteria
- [x] 1122 popover adapts on narrow/scaled displays so the inspector + close/recovery controls stay on-screen (rail always visible)
- [x] Persisted selection opens directly into three-column geometry (no resize jump)
- [x] Strict-concurrency build clean; no real data

## Tests
`PopoverGeometryTests` — `fittedWidth` passes full width through on wide/headless screens (and on 0/negative available), and caps on a scaled 1024pt display (→ 1000, center 358 ≥ 340 floor). **575 → 577 passing.**

## Validation
```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test                                                                        # 577 passing
./Scripts/qa-appearance-matrix.sh                                                 # wide-screen 801/1122 unchanged (no regression)
```
The narrow-display + persisted-open paths are runtime/AppKit behaviors (no real screen in headless renders), covered by the unit-tested geometry + documented manual passes in `docs/qa-matrix.md`.

## Docs
`docs/three-column-popover-contract.md` §5 (Tier-1 now implemented) + `docs/qa-matrix.md` (narrow-display + persisted-open manual checks).

## Risk / rollback
Low. On wide screens (≥1122+margin) behavior is identical (renders confirm). The flex/cap only engages below that. Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)