### PR TITLE
fix: use active screen for popover width

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -13,6 +13,7 @@ struct MainPopover: View {
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
     @State private var dashboardContentHeight: CGFloat = 0
+    @State private var activeScreenVisibleWidth: CGFloat?
     /// True after the first render. Gates the inspector's trailing slide-in so a
     /// popover opened with a persisted selection appears directly in three-column
     /// geometry (no slide on restore); in-session selections still slide (AND-405).
@@ -83,7 +84,10 @@ struct MainPopover: View {
     /// unbounded when there is no screen (headless renders) so the full geometry
     /// is used.
     private var availableScreenWidth: CGFloat {
-        NSScreen.main?.visibleFrame.width ?? .greatestFiniteMagnitude
+        PopoverGeometry.availableWidth(
+            activeScreenWidth: activeScreenVisibleWidth,
+            fallbackScreenWidth: NSScreen.main?.visibleFrame.width
+        )
     }
 
     /// Two-column base width: Wealth Summary rail + divider + dashboard. This is
@@ -161,6 +165,9 @@ struct MainPopover: View {
                     collapsedWidth: twoColumnWidth,
                     screenEdgeMargin: Layout.screenEdgeMargin
                 )
+            }
+            .background {
+                PopoverScreenWidthReader(visibleWidth: $activeScreenVisibleWidth)
             }
             .animation(
                 MotionTokens.animation(MotionTokens.content, reduceMotion: reduceMotion),

--- a/Sources/PlaidBar/Views/PopoverWindowAnchor.swift
+++ b/Sources/PlaidBar/Views/PopoverWindowAnchor.swift
@@ -179,3 +179,107 @@ struct PopoverLeadingEdgeAnchor: NSViewRepresentable {
         }
     }
 }
+
+/// Reports the screen that actually owns the popover window back into SwiftUI
+/// layout. This keeps the content width cap aligned with the AppKit clamp in
+/// `PopoverLeadingEdgeAnchor`; `NSScreen.main` can be a wider primary display
+/// while the menu-bar popover is opening on a narrower secondary display.
+struct PopoverScreenWidthReader: NSViewRepresentable {
+    @Binding var visibleWidth: CGFloat?
+
+    func makeNSView(context: Context) -> ScreenWidthHostView {
+        let view = ScreenWidthHostView()
+        view.onMoveToWindow = { [coordinator = context.coordinator] window in
+            coordinator.attach(to: window)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: ScreenWidthHostView, context: Context) {
+        context.coordinator.configure(visibleWidth: $visibleWidth)
+        context.coordinator.attach(to: nsView.window)
+    }
+
+    static func dismantleNSView(_ nsView: ScreenWidthHostView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(visibleWidth: $visibleWidth)
+    }
+
+    final class ScreenWidthHostView: NSView {
+        var onMoveToWindow: ((NSWindow?) -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            onMoveToWindow?(window)
+        }
+    }
+
+    @MainActor
+    final class Coordinator {
+        private var visibleWidth: Binding<CGFloat?>
+        private weak var window: NSWindow?
+        private var screenObserver: NSObjectProtocol?
+        private var screenParametersObserver: NSObjectProtocol?
+
+        init(visibleWidth: Binding<CGFloat?>) {
+            self.visibleWidth = visibleWidth
+        }
+
+        func configure(visibleWidth: Binding<CGFloat?>) {
+            self.visibleWidth = visibleWidth
+        }
+
+        func attach(to window: NSWindow?) {
+            guard let window else {
+                detach()
+                publish(nil)
+                return
+            }
+
+            if window !== self.window {
+                detach()
+                self.window = window
+                screenObserver = NotificationCenter.default.addObserver(
+                    forName: NSWindow.didChangeScreenNotification,
+                    object: window,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.publishCurrentWidth() }
+                }
+                screenParametersObserver = NotificationCenter.default.addObserver(
+                    forName: NSApplication.didChangeScreenParametersNotification,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.publishCurrentWidth() }
+                }
+            }
+
+            publishCurrentWidth()
+        }
+
+        func detach() {
+            if let screenObserver {
+                NotificationCenter.default.removeObserver(screenObserver)
+                self.screenObserver = nil
+            }
+            if let screenParametersObserver {
+                NotificationCenter.default.removeObserver(screenParametersObserver)
+                self.screenParametersObserver = nil
+            }
+            window = nil
+        }
+
+        private func publishCurrentWidth() {
+            publish(window?.screen?.visibleFrame.width)
+        }
+
+        private func publish(_ width: CGFloat?) {
+            guard visibleWidth.wrappedValue != width else { return }
+            visibleWidth.wrappedValue = width
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
+++ b/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
@@ -71,6 +71,24 @@ public enum PopoverGeometry {
         return min(full, usable)
     }
 
+    /// Prefer the popover window's actual screen width over a global fallback.
+    ///
+    /// `NSScreen.main` can point at a different display than the menu-bar
+    /// popover window, so callers should pass the active window screen when
+    /// available and use the fallback only before the window attaches.
+    public static func availableWidth(
+        activeScreenWidth: CGFloat?,
+        fallbackScreenWidth: CGFloat?
+    ) -> CGFloat {
+        if let activeScreenWidth, activeScreenWidth.isFinite, activeScreenWidth > 0 {
+            return activeScreenWidth
+        }
+        if let fallbackScreenWidth, fallbackScreenWidth.isFinite, fallbackScreenWidth > 0 {
+            return fallbackScreenWidth
+        }
+        return .greatestFiniteMagnitude
+    }
+
     /// Clamp a desired leading-edge X so a popover of `width` stays within a
     /// screen's visible horizontal span `[visibleMinX, visibleMaxX]`, keeping
     /// `margin` from each edge.

--- a/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
@@ -50,6 +50,17 @@ struct PopoverGeometryTests {
         #expect(capped - sideColumns >= PopoverGeometry.minDashboardWidth)
     }
 
+    @Test("Available width prefers the active popover screen over the primary-screen fallback")
+    func availableWidthPrefersActiveScreen() {
+        #expect(PopoverGeometry.availableWidth(activeScreenWidth: 1024, fallbackScreenWidth: 1680) == 1024)
+        #expect(PopoverGeometry.availableWidth(activeScreenWidth: nil, fallbackScreenWidth: 1680) == 1680)
+        #expect(PopoverGeometry.availableWidth(activeScreenWidth: 0, fallbackScreenWidth: 1680) == 1680)
+        #expect(
+            PopoverGeometry.availableWidth(activeScreenWidth: nil, fallbackScreenWidth: nil)
+                == .greatestFiniteMagnitude
+        )
+    }
+
     @Test("A popover that already fits is not moved")
     func clampLeavesFittingPopover() {
         // 1122 popover at x=200 on a 1680-wide display fits with room to spare.


### PR DESCRIPTION
## Summary
- Fix the post-#326 popover width regression where SwiftUI content width still used the primary screen while AppKit clamped against the popover window screen.
- Feed the actual popover window screen visible width into the existing `PopoverGeometry` cap so narrow/scaled secondary displays engage the same width math as the window clamp.
- Add a focused geometry test proving active screen width wins over a wider primary-screen fallback.

## Changes
- `Sources/PlaidBar/Views/MainPopover.swift`: tracks active popover screen width and uses it for `availableScreenWidth` before falling back to `NSScreen.main`.
- `Sources/PlaidBar/Views/PopoverWindowAnchor.swift`: adds `PopoverScreenWidthReader`, an AppKit bridge that publishes `window.screen?.visibleFrame.width` on attach, screen changes, and display parameter changes.
- `Sources/PlaidBarCore/Utilities/PopoverGeometry.swift`: adds pure `availableWidth(activeScreenWidth:fallbackScreenWidth:)` selection helper.
- `Tests/PlaidBarCoreTests/PopoverGeometryTests.swift`: covers active-screen-over-primary fallback behavior.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter PopoverGeometryTests --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (11 tests passed)
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (579 tests passed)
- [x] Targeted diff scan for Plaid secrets, public/access tokens, raw Plaid payloads, real finance IDs/balances, local SQLite data, logs/screenshots/generated artifacts, direct Plaid app-target access, and local-first/privacy boundary changes. Matches were limited to project/file names containing `PlaidBar` and existing `MotionTokens`; no sensitive values or boundary changes found.

## Notes
- Regression source: https://github.com/ftchvs/PlaidBar/pull/326
- CI limitation: primary CI/review workflows are reported disabled in https://github.com/ftchvs/PlaidBar/issues/309. This PR does not re-enable workflows, repair GitHub settings, or rerun CI.
- Residual risk: runtime multi-display behavior is code/test verified only; I did not perform a live UI spot-check on a narrow secondary/scaled display.