### PR TITLE
feat: explainable safe-to-spend calculation + card (AND-401)

### DIFF
--- a/Sources/PlaidBar/Views/SafeToSpendCard.swift
+++ b/Sources/PlaidBar/Views/SafeToSpendCard.swift
@@ -1,0 +1,194 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Compact, explainable "safe to spend" card.
+///
+/// Shows the headline number, a last-updated timestamp, a confidence cue (text
+/// + SF Symbol, never color alone — ACCESSIBILITY.md), and an expandable,
+/// signed breakdown that reconciles to the number. The card is purely
+/// presentational: all math lives in `SafeToSpendCalculator` (PlaidBarCore).
+struct SafeToSpendCard: View {
+    let result: SafeToSpendResult
+    /// Relative "last updated" text (e.g. "2 minutes ago"). Nil hides the line.
+    var lastUpdatedRelative: String?
+
+    @State private var isBreakdownExpanded = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            header
+
+            amountRow
+
+            confidenceCue
+
+            breakdownDisclosure
+        }
+        .padding(Spacing.sm)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Text("Safe to spend")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            // The amount is never shown without a freshness cue (AND-401 AC):
+            // fall back to "Not yet updated" when no sync has happened.
+            Label(lastUpdatedText, systemImage: "clock")
+                .microText()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityLabel(lastUpdatedAccessibilityText)
+        }
+    }
+
+    private var amountRow: some View {
+        Text(Formatters.currency(result.amount, format: .full))
+            .dataText()
+            .foregroundStyle(amountTint)
+            .contentTransition(.numericText())
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .accessibilityLabel("\(Formatters.currency(result.amount, format: .full)) safe to spend through \(horizonText)")
+    }
+
+    private var confidenceCue: some View {
+        // Text + symbol carry the confidence; the tint is a redundant cue, not
+        // the only one.
+        Label {
+            Text(result.confidence.label)
+                .microText()
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: result.confidence.iconName)
+                .font(.caption2.weight(.semibold))
+        }
+        .foregroundStyle(confidenceTint)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
+        .accessibilityLabel("Confidence: \(result.confidence.label)")
+    }
+
+    private var breakdownDisclosure: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Button {
+                withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+                    isBreakdownExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: isBreakdownExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                    Text(isBreakdownExpanded ? "Hide breakdown" : "Show breakdown")
+                        .microText()
+                }
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isBreakdownExpanded ? "Hide breakdown" : "Show breakdown")
+
+            if isBreakdownExpanded {
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    ForEach(result.visibleComponents) { component in
+                        SafeToSpendBreakdownRow(component: component)
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private var amountTint: Color {
+        // Negative spendable balance is a genuine warning; otherwise neutral.
+        result.amount < 0 ? SemanticColors.negative : AppearanceTextColors.primary
+    }
+
+    private var confidenceTint: Color {
+        switch result.confidence {
+        case .ok:
+            .secondary
+        case .lowConfidence:
+            SemanticColors.warning
+        case .insufficientData:
+            .secondary
+        }
+    }
+
+    private var lastUpdatedText: String {
+        lastUpdatedRelative ?? "Not yet updated"
+    }
+
+    private var lastUpdatedAccessibilityText: String {
+        lastUpdatedRelative.map { "Updated \($0)" } ?? "Not yet updated"
+    }
+
+    private var horizonText: String {
+        Formatters.displayDate(result.horizonEnd)
+    }
+
+    private var accessibilitySummary: String {
+        let amount = Formatters.currency(result.amount, format: .full)
+        let updated = lastUpdatedRelative.map { " Updated \($0)." } ?? " Not yet updated."
+        return "Safe to spend \(amount) through \(horizonText). Confidence: \(result.confidence.label).\(updated)"
+    }
+}
+
+private struct SafeToSpendBreakdownRow: View {
+    let component: SafeToSpendComponent
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label {
+                Text(component.label)
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            } icon: {
+                Image(systemName: component.kind.iconName)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Text(amountText)
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(amountTint)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(component.label): \(accessibilityAmountText)")
+    }
+
+    private var amountText: String {
+        signPrefix + Formatters.currency(abs(component.amount), format: .compact)
+    }
+
+    private var accessibilityAmountText: String {
+        let magnitude = Formatters.currency(abs(component.amount), format: .full)
+        if component.amount > 0 { return "plus \(magnitude)" }
+        if component.amount < 0 { return "minus \(magnitude)" }
+        return magnitude
+    }
+
+    private var signPrefix: String {
+        if component.amount > 0 { return "+" }
+        if component.amount < 0 { return "-" }
+        return ""
+    }
+
+    private var amountTint: Color {
+        if component.amount > 0 { return SemanticColors.positive }
+        if component.amount < 0 { return AppearanceTextColors.primary }
+        return AppearanceTextColors.secondary
+    }
+}

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -45,6 +45,17 @@ struct WealthSummaryFlyout: View {
                     WealthCashflowSection(cashflow: presentation.cashflow)
                         .loadingRedaction(appState.loadState(for: .transactions))
 
+                    SafeToSpendCard(
+                        result: SafeToSpendCalculator.compute(
+                            accounts: appState.accounts,
+                            recurringTransactions: appState.recurringTransactions,
+                            cashflow: presentation.cashflow,
+                            asOf: Date()
+                        ),
+                        lastUpdatedRelative: appState.lastSyncRelative
+                    )
+                    .loadingRedaction(appState.loadState(for: .summaryCards))
+
                     WealthCreditSection(
                         summary: presentation.creditUtilization,
                         threshold: appState.creditUtilizationThreshold

--- a/Sources/PlaidBarCore/Models/SafeToSpend.swift
+++ b/Sources/PlaidBarCore/Models/SafeToSpend.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// Explainable "safe to spend" result.
+///
+/// The headline `amount` is the conservative discretionary balance the user can
+/// spend through `SafeToSpendInputs.horizon` without touching money already
+/// committed to known obligations or the user's safety buffer. It is the signed
+/// sum of `components` (see the sign convention below), so the breakdown always
+/// reconciles to the number — there is no hidden math.
+///
+/// Sign convention (documented and enforced by `SafeToSpendCalculator`):
+/// every component's `amount` is signed relative to the final balance. Inflows
+/// (starting cash, expected income) are positive; outflows (upcoming
+/// obligations, credit-card payments, budget reservations, safety buffer) are
+/// negative. `amount == components.reduce(0) { $0 + $1.amount }`. The number is
+/// allowed to go negative — a negative result is reported honestly rather than
+/// clamped to zero, because hiding a shortfall would be the opposite of safe.
+public struct SafeToSpendResult: Sendable, Equatable {
+    /// The conservative discretionary balance. May be negative when committed
+    /// outflows and the buffer exceed available cash plus expected income.
+    public let amount: Double
+
+    /// Ordered, signed breakdown. Always reconciles: the components sum to
+    /// `amount`. Order follows the calculation: cash, income, then the
+    /// subtractions in `SafeToSpendComponentKind` declaration order.
+    public let components: [SafeToSpendComponent]
+
+    /// How much trust the UI should place in `amount`. Drives the confidence
+    /// cue so the number is never presented as more certain than the inputs
+    /// justify.
+    public let confidence: SafeToSpendConfidence
+
+    /// End of the look-ahead window the result covers (inclusive). Surfaced so
+    /// the UI can say "through <date>" without re-deriving the horizon.
+    public let horizonEnd: Date
+
+    public init(
+        amount: Double,
+        components: [SafeToSpendComponent],
+        confidence: SafeToSpendConfidence,
+        horizonEnd: Date
+    ) {
+        self.amount = amount
+        self.components = components
+        self.confidence = confidence
+        self.horizonEnd = horizonEnd
+    }
+
+    /// Components that carry a non-zero amount, in display order. The starting
+    /// cash and (when present) income lines are always kept even at zero so the
+    /// breakdown reads as a complete statement; pure-zero subtractions are
+    /// dropped to avoid noise.
+    public var visibleComponents: [SafeToSpendComponent] {
+        components.filter { component in
+            switch component.kind {
+            case .startingCash, .expectedIncome:
+                return true
+            default:
+                return component.amount != 0
+            }
+        }
+    }
+}
+
+/// One signed line in the safe-to-spend breakdown.
+public struct SafeToSpendComponent: Sendable, Equatable, Identifiable {
+    public let kind: SafeToSpendComponentKind
+    /// Human-readable label, e.g. "Starting cash" or "Upcoming bills".
+    public let label: String
+    /// Signed contribution to `SafeToSpendResult.amount` (positive = inflow,
+    /// negative = outflow). See the type-level sign convention.
+    public let amount: Double
+
+    public init(kind: SafeToSpendComponentKind, label: String, amount: Double) {
+        self.kind = kind
+        self.label = label
+        self.amount = amount
+    }
+
+    public var id: SafeToSpendComponentKind { kind }
+}
+
+/// The fixed set of breakdown line kinds, in calculation/display order.
+public enum SafeToSpendComponentKind: String, Sendable, CaseIterable, Hashable {
+    case startingCash
+    case expectedIncome
+    case upcomingObligations
+    case loanPayments
+    case budgetReservations
+    case safetyBuffer
+
+    /// SF Symbol used by the UI for this line. Paired with text everywhere so
+    /// meaning never rides on color alone (ACCESSIBILITY.md).
+    public var iconName: String {
+        switch self {
+        case .startingCash: "banknote"
+        case .expectedIncome: "arrow.down.circle"
+        case .upcomingObligations: "calendar.badge.clock"
+        case .loanPayments: "creditcard"
+        case .budgetReservations: "tray.full"
+        case .safetyBuffer: "shield.lefthalf.filled"
+        }
+    }
+}
+
+/// Confidence in the headline number. Ordered from least to most trustworthy so
+/// callers can compare and the UI can pick a matching cue.
+public enum SafeToSpendConfidence: String, Sendable, CaseIterable, Comparable {
+    /// Inputs too thin to stand behind a number (no obligation history AND no
+    /// income signal). The UI should treat `amount` as indicative only.
+    case insufficientData
+    /// Income was estimated from recurring inflows or cashflow rather than a
+    /// manual override, so the upside is softer than the cash floor.
+    case lowConfidence
+    /// Inputs are defensible: real cash plus either a manual income override or
+    /// no reliance on estimated income.
+    case ok
+
+    private var rank: Int {
+        switch self {
+        case .insufficientData: 0
+        case .lowConfidence: 1
+        case .ok: 2
+        }
+    }
+
+    public static func < (lhs: SafeToSpendConfidence, rhs: SafeToSpendConfidence) -> Bool {
+        lhs.rank < rhs.rank
+    }
+
+    /// Short label for the confidence cue.
+    public var label: String {
+        switch self {
+        case .insufficientData: "Estimate only"
+        case .lowConfidence: "Lower confidence"
+        case .ok: "On track"
+        }
+    }
+
+    /// SF Symbol paired with `label` so the cue is never color-only.
+    public var iconName: String {
+        switch self {
+        case .insufficientData: "questionmark.circle"
+        case .lowConfidence: "exclamationmark.circle"
+        case .ok: "checkmark.circle"
+        }
+    }
+}
+
+/// How far ahead the safe-to-spend window looks.
+public enum SafeToSpendHorizon: Sendable, Equatable {
+    /// To the end of the current calendar month (inclusive of the last day).
+    case endOfMonth
+    /// A fixed number of days from `asOf` (clamped to at least 1 day).
+    case days(Int)
+
+    /// Resolves the inclusive end-of-window date for a reference date.
+    public func endDate(asOf date: Date, calendar: Calendar) -> Date {
+        let startOfDay = calendar.startOfDay(for: date)
+        switch self {
+        case .endOfMonth:
+            guard
+                let monthInterval = calendar.dateInterval(of: .month, for: startOfDay),
+                let lastDay = calendar.date(byAdding: .day, value: -1, to: monthInterval.end)
+            else {
+                return startOfDay
+            }
+            return calendar.startOfDay(for: lastDay)
+        case let .days(count):
+            let clamped = max(count, 1)
+            return calendar.date(byAdding: .day, value: clamped, to: startOfDay) ?? startOfDay
+        }
+    }
+}
+
+/// Configuration for a safe-to-spend computation: which accounts count as
+/// spendable cash, the user's safety buffer, the look-ahead horizon, any budget
+/// reservations, and an optional manual income override.
+public struct SafeToSpendInputs: Sendable, Equatable {
+    /// Account types treated as spendable cash for "starting cash". Defaults to
+    /// depository only — credit, loan, and investment are excluded so the floor
+    /// reflects money actually available to spend.
+    public let includedCashAccountTypes: Set<AccountType>
+    /// Amount the user always wants to keep untouched. Subtracted from the
+    /// result. Clamped to non-negative.
+    public let safetyBuffer: Double
+    /// Money the user has earmarked (e.g. a sinking fund) that should not count
+    /// as spendable. Subtracted. Clamped to non-negative.
+    public let budgetReservations: Double
+    /// Look-ahead window for obligations and income.
+    public let horizon: SafeToSpendHorizon
+    /// Manual expected-income override for the horizon. When set (>= 0) it is
+    /// used verbatim and yields full confidence on the income side; when nil
+    /// the calculator falls back to estimated income at lower confidence.
+    public let manualExpectedIncome: Double?
+
+    public init(
+        includedCashAccountTypes: Set<AccountType> = [.depository],
+        safetyBuffer: Double = 0,
+        budgetReservations: Double = 0,
+        horizon: SafeToSpendHorizon = .endOfMonth,
+        manualExpectedIncome: Double? = nil
+    ) {
+        self.includedCashAccountTypes = includedCashAccountTypes
+        self.safetyBuffer = max(safetyBuffer, 0)
+        self.budgetReservations = max(budgetReservations, 0)
+        self.horizon = horizon
+        self.manualExpectedIncome = manualExpectedIncome.map { max($0, 0) }
+    }
+
+    /// Sensible default: depository cash only, no buffer, end-of-month horizon.
+    public static let `default` = SafeToSpendInputs()
+}

--- a/Sources/PlaidBarCore/Utilities/SafeToSpendCalculator.swift
+++ b/Sources/PlaidBarCore/Utilities/SafeToSpendCalculator.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+/// Pure, deterministic safe-to-spend calculation.
+///
+/// Mirrors the shape of `RecurringSummary` / `SpendingSummary`: a stateless
+/// `enum` with a single `static func compute(...)` that takes an explicit
+/// `asOf:` reference date and `Calendar`, so there is no hidden `Date()` and the
+/// result is fully testable.
+///
+/// Conservatism is the design rule. The number leans toward *under*-promising:
+/// it prefers the available balance over the current balance (via
+/// `BalanceDTO.effectiveBalance`), counts only outflow obligations with a
+/// defensible signal, never invents optimistic income, and reports a shortfall
+/// honestly instead of clamping to zero. See `SafeToSpend.swift` for the sign
+/// convention every component obeys.
+public enum SafeToSpendCalculator {
+    /// Recurring streams below this confidence are ignored as obligations — a
+    /// weakly-detected stream should not silently shrink the spendable number.
+    public static let minimumObligationConfidence = 0.5
+
+    public static func compute(
+        accounts: [AccountDTO],
+        recurringTransactions: [RecurringTransaction],
+        cashflow: WealthSummaryPresentation.CashflowSummary? = nil,
+        inputs: SafeToSpendInputs = .default,
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> SafeToSpendResult {
+        let referenceDay = calendar.startOfDay(for: date)
+        let horizonEnd = inputs.horizon.endDate(asOf: date, calendar: calendar)
+
+        let startingCash = startingCash(from: accounts, inputs: inputs)
+
+        let obligations = obligations(
+            from: recurringTransactions,
+            asOf: referenceDay,
+            horizonEnd: horizonEnd,
+            calendar: calendar
+        )
+
+        let income = expectedIncome(
+            inputs: inputs,
+            recurringTransactions: recurringTransactions,
+            cashflow: cashflow,
+            asOf: referenceDay,
+            horizonEnd: horizonEnd,
+            calendar: calendar
+        )
+
+        var components: [SafeToSpendComponent] = [
+            SafeToSpendComponent(kind: .startingCash, label: "Starting cash", amount: startingCash),
+            SafeToSpendComponent(kind: .expectedIncome, label: "Expected income", amount: income.amount),
+            SafeToSpendComponent(
+                kind: .upcomingObligations,
+                label: "Upcoming bills",
+                amount: -obligations.recurringTotal
+            ),
+            SafeToSpendComponent(
+                kind: .loanPayments,
+                label: "Loans & cards",
+                amount: -obligations.loanPaymentTotal
+            ),
+            SafeToSpendComponent(
+                kind: .budgetReservations,
+                label: "Reserved",
+                amount: -inputs.budgetReservations
+            ),
+            SafeToSpendComponent(
+                kind: .safetyBuffer,
+                label: "Safety buffer",
+                amount: -inputs.safetyBuffer
+            ),
+        ]
+
+        // Keep components in the fixed declaration order so the breakdown always
+        // reads the same way and reconciles to the sum.
+        components.sort { lhs, rhs in
+            order(of: lhs.kind) < order(of: rhs.kind)
+        }
+
+        let amount = components.reduce(0) { $0 + $1.amount }
+
+        let confidence = confidence(
+            hasObligationSignal: obligations.hasSignal,
+            income: income
+        )
+
+        return SafeToSpendResult(
+            amount: amount,
+            components: components,
+            confidence: confidence,
+            horizonEnd: horizonEnd
+        )
+    }
+
+    // MARK: - Starting cash
+
+    private static func startingCash(
+        from accounts: [AccountDTO],
+        inputs: SafeToSpendInputs
+    ) -> Double {
+        accounts
+            .filter { inputs.includedCashAccountTypes.contains($0.type) }
+            // effectiveBalance already prefers `available` over `current`, the
+            // conservative choice for spendable cash.
+            .reduce(0) { $0 + $1.balances.effectiveBalance }
+    }
+
+    // MARK: - Obligations
+
+    private struct Obligations {
+        let recurringTotal: Double
+        let loanPaymentTotal: Double
+        /// Whether any recurring history was usable at all — feeds confidence.
+        let hasSignal: Bool
+    }
+
+    private static func obligations(
+        from recurringTransactions: [RecurringTransaction],
+        asOf referenceDay: Date,
+        horizonEnd: Date,
+        calendar: Calendar
+    ) -> Obligations {
+        var recurringTotal = 0.0
+        var loanPaymentTotal = 0.0
+        var hasSignal = false
+
+        for recurring in recurringTransactions {
+            guard recurring.confidence >= minimumObligationConfidence else { continue }
+            // Recurring detection stores absolute amounts, so inflow vs outflow
+            // is read from the category. Skip inflows and own-account transfers
+            // so income is never double-counted as a bill and a transfer between
+            // the user's own accounts nets to zero here.
+            guard isOutflowObligation(recurring.category) else { continue }
+
+            hasSignal = true
+
+            guard let nextDate = Formatters.parseTransactionDate(recurring.nextExpectedDate) else {
+                continue
+            }
+            let nextDay = calendar.startOfDay(for: nextDate)
+            // Inclusive of both ends: an obligation due exactly on the horizon
+            // edge still falls inside the window.
+            guard nextDay >= referenceDay, nextDay <= horizonEnd else { continue }
+
+            let amount = max(recurring.averageAmount, 0)
+            if isLoanPayment(recurring.category) {
+                loanPaymentTotal += amount
+            } else {
+                recurringTotal += amount
+            }
+        }
+
+        return Obligations(
+            recurringTotal: recurringTotal,
+            loanPaymentTotal: loanPaymentTotal,
+            hasSignal: hasSignal
+        )
+    }
+
+    private static func isOutflowObligation(_ category: SpendingCategory?) -> Bool {
+        switch category {
+        case .income, .transfer, .transferOut:
+            // Inflows and own-account transfers are not spendable-cash outflows.
+            return false
+        case .none:
+            // Uncategorized recurring outflows are still real bills.
+            return true
+        default:
+            return true
+        }
+    }
+
+    private static func isLoanPayment(_ category: SpendingCategory?) -> Bool {
+        // Plaid's LOAN_PAYMENTS bucket (this enum's `.subscriptions` case) covers
+        // credit-card payments, loan payments, AND recurring subscriptions — the
+        // taxonomy can't separate them at this granularity, so they share one
+        // "Loans & cards" line. The total is unaffected (each amount is subtracted
+        // exactly once); only the line-item attribution is coarse.
+        category == .subscriptions
+    }
+
+    // MARK: - Expected income
+
+    private struct ExpectedIncome {
+        let amount: Double
+        let isManual: Bool
+        let hasSignal: Bool
+    }
+
+    private static func expectedIncome(
+        inputs: SafeToSpendInputs,
+        recurringTransactions: [RecurringTransaction],
+        cashflow: WealthSummaryPresentation.CashflowSummary?,
+        asOf referenceDay: Date,
+        horizonEnd: Date,
+        calendar: Calendar
+    ) -> ExpectedIncome {
+        // A manual override is authoritative and carries full confidence.
+        if let manual = inputs.manualExpectedIncome {
+            return ExpectedIncome(amount: manual, isManual: true, hasSignal: true)
+        }
+
+        // Otherwise prefer recurring inflows due within the horizon — a
+        // defensible, dated signal.
+        let recurringIncome = recurringInflow(
+            from: recurringTransactions,
+            asOf: referenceDay,
+            horizonEnd: horizonEnd,
+            calendar: calendar
+        )
+        if recurringIncome > 0 {
+            return ExpectedIncome(amount: recurringIncome, isManual: false, hasSignal: true)
+        }
+
+        // Fall back to a horizon-scaled slice of observed cashflow income. This
+        // is the softest signal, so it lowers confidence rather than inflating
+        // the number.
+        if let cashflow, cashflow.income > 0, cashflow.windowDays > 0 {
+            // Day count is exclusive of the inclusive `horizonEnd` by one day.
+            // Scaling income by the smaller count deliberately under-counts income
+            // (the conservative direction), so the asymmetry with the inclusive
+            // obligation bound never lets safe-to-spend overstate.
+            let horizonDays = max(
+                calendar.dateComponents([.day], from: referenceDay, to: horizonEnd).day ?? 0,
+                0
+            )
+            guard horizonDays > 0 else {
+                return ExpectedIncome(amount: 0, isManual: false, hasSignal: false)
+            }
+            let dailyIncome = cashflow.income / Double(cashflow.windowDays)
+            let scaled = dailyIncome * Double(horizonDays)
+            return ExpectedIncome(amount: max(scaled, 0), isManual: false, hasSignal: true)
+        }
+
+        // No defensible income signal: treat as zero and let confidence drop,
+        // rather than guessing optimistically.
+        return ExpectedIncome(amount: 0, isManual: false, hasSignal: false)
+    }
+
+    /// Dated recurring inflow within the horizon.
+    ///
+    /// NOTE: `RecurringDetector.detect` currently filters income transactions out
+    /// before grouping, so no `.income` `RecurringTransaction` is produced by the
+    /// running app today — this path is forward-looking (it activates if/when
+    /// recurring-income detection lands). In production, income therefore comes
+    /// from a manual override or the cashflow estimate, so `.ok` confidence
+    /// requires a manual override until then. The unit tests exercise this branch
+    /// directly by constructing `.income` streams to lock the calculator contract.
+    private static func recurringInflow(
+        from recurringTransactions: [RecurringTransaction],
+        asOf referenceDay: Date,
+        horizonEnd: Date,
+        calendar: Calendar
+    ) -> Double {
+        recurringTransactions.reduce(0) { total, recurring in
+            guard recurring.confidence >= minimumObligationConfidence,
+                  recurring.category == .income,
+                  let nextDate = Formatters.parseTransactionDate(recurring.nextExpectedDate)
+            else {
+                return total
+            }
+            let nextDay = calendar.startOfDay(for: nextDate)
+            guard nextDay >= referenceDay, nextDay <= horizonEnd else { return total }
+            return total + max(recurring.averageAmount, 0)
+        }
+    }
+
+    // MARK: - Confidence
+
+    private static func confidence(
+        hasObligationSignal: Bool,
+        income: ExpectedIncome
+    ) -> SafeToSpendConfidence {
+        // Nothing to stand on: no obligation history and no income signal.
+        if !hasObligationSignal, !income.hasSignal {
+            return .insufficientData
+        }
+        // Estimated (non-manual) income softens the upside.
+        if income.hasSignal, !income.isManual {
+            return .lowConfidence
+        }
+        return .ok
+    }
+
+    // MARK: - Ordering
+
+    private static func order(of kind: SafeToSpendComponentKind) -> Int {
+        SafeToSpendComponentKind.allCases.firstIndex(of: kind) ?? 0
+    }
+}

--- a/Tests/PlaidBarCoreTests/SafeToSpendCalculatorTests.swift
+++ b/Tests/PlaidBarCoreTests/SafeToSpendCalculatorTests.swift
@@ -1,0 +1,284 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Safe to spend calculator")
+struct SafeToSpendCalculatorTests {
+    private let now = Formatters.parseTransactionDate("2026-06-13")!
+    private let calendar = Calendar(identifier: .gregorian)
+
+    @Test("Cash minus obligations plus income minus buffer reconciles to the breakdown")
+    func basicReconciliation() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [
+                checking(900),
+                savings(600),
+            ],
+            recurringTransactions: [
+                recurring("Rent", amount: 500, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+                recurring("Paycheck", amount: 1_000, nextExpectedDate: "2026-06-25", category: .income),
+            ],
+            inputs: SafeToSpendInputs(safetyBuffer: 200, horizon: .endOfMonth),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(component(result, .startingCash) == 1_500)
+        #expect(component(result, .expectedIncome) == 1_000)
+        #expect(component(result, .upcomingObligations) == -500)
+        #expect(component(result, .safetyBuffer) == -200)
+        // 1500 + 1000 - 500 - 200 = 1800
+        #expect(result.amount == 1_800)
+        // The signed components must always sum to the headline.
+        #expect(result.components.reduce(0) { $0 + $1.amount } == result.amount)
+        // Recurring income is a dated signal but not a manual override.
+        #expect(result.confidence == .lowConfidence)
+    }
+
+    @Test("Credit card and loan accounts are excluded from starting cash by default")
+    func excludesCreditAccountsByDefault() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [
+                checking(800),
+                AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -300, limit: 2_000)),
+                AccountDTO(id: "loan", itemId: "item", name: "Loan", type: .loan, balances: BalanceDTO(current: -5_000)),
+                AccountDTO(id: "brokerage", itemId: "item", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 10_000)),
+            ],
+            recurringTransactions: [],
+            inputs: SafeToSpendInputs(manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(component(result, .startingCash) == 800)
+        #expect(result.amount == 800)
+    }
+
+    @Test("Loan and card payments share their own line, separate from bills, and transfers are ignored")
+    func cardPaymentsTrackedSeparatelyAndTransfersIgnored() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(2_000)],
+            recurringTransactions: [
+                recurring("Card payment", amount: 250, nextExpectedDate: "2026-06-18", category: .subscriptions),
+                recurring("Rent", amount: 400, nextExpectedDate: "2026-06-19", category: .billsAndUtilities),
+                // A transfer between the user's own accounts must net to zero:
+                // it is neither a bill nor income.
+                recurring("Move to savings", amount: 700, nextExpectedDate: "2026-06-20", category: .transferOut),
+            ],
+            inputs: SafeToSpendInputs(manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(component(result, .loanPayments) == -250)
+        #expect(component(result, .upcomingObligations) == -400)
+        // Transfer excluded entirely — 2000 - 250 - 400 = 1350, not 650.
+        #expect(result.amount == 1_350)
+    }
+
+    @Test("Low-confidence recurring streams are ignored as obligations")
+    func lowConfidenceStreamsAreConservative() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Maybe-bill", amount: 300, nextExpectedDate: "2026-06-20", category: .billsAndUtilities, confidence: 0.3),
+            ],
+            // No manual income override either, so there is genuinely no signal
+            // (a manual override — even 0 — would count as an authoritative one).
+            inputs: .default,
+            asOf: now,
+            calendar: calendar
+        )
+
+        // The weakly-detected stream neither reduces cash nor counts as signal.
+        #expect(component(result, .upcomingObligations) == 0)
+        #expect(result.amount == 1_000)
+        // No usable obligation history and no income signal → insufficient.
+        #expect(result.confidence == .insufficientData)
+    }
+
+    @Test("No recurring data and no income signal yields insufficient data")
+    func insufficientDataState() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(500)],
+            recurringTransactions: [],
+            inputs: .default,
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(result.amount == 500)
+        #expect(result.confidence == .insufficientData)
+    }
+
+    @Test("Estimated cashflow income lowers confidence but is never fabricated optimistically")
+    func estimatedCashflowIncomeLowersConfidence() {
+        let cashflow = WealthSummaryPresentation.CashflowSummary(
+            windowDays: 30,
+            income: 3_000,
+            spending: 1_000,
+            net: 2_000,
+            transactionCount: 10
+        )
+
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Rent", amount: 400, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+            ],
+            cashflow: cashflow,
+            inputs: SafeToSpendInputs(horizon: .endOfMonth),
+            asOf: now,
+            calendar: calendar
+        )
+
+        // Horizon = 2026-06-13 .. 2026-06-30 inclusive end = 17 days ahead.
+        // Daily income 3000/30 = 100, scaled by 17 days = 1700.
+        #expect(component(result, .expectedIncome) == 1_700)
+        #expect(result.confidence == .lowConfidence)
+    }
+
+    @Test("Manual income override is authoritative and keeps full confidence")
+    func manualIncomeOverrideIsAuthoritative() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Rent", amount: 400, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(horizon: .endOfMonth, manualExpectedIncome: 2_500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(component(result, .expectedIncome) == 2_500)
+        // 1000 + 2500 - 400 = 3100
+        #expect(result.amount == 3_100)
+        #expect(result.confidence == .ok)
+    }
+
+    @Test("Buffer larger than available cash produces an honest negative result")
+    func bufferLargerThanCashGoesNegative() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(300)],
+            recurringTransactions: [
+                recurring("Rent", amount: 100, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(safetyBuffer: 1_000, manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+
+        // 300 + 0 - 100 - 1000 = -800. Reported honestly, not clamped.
+        #expect(result.amount == -800)
+        #expect(component(result, .safetyBuffer) == -1_000)
+    }
+
+    @Test("An obligation due exactly on the horizon edge is included; one past it is excluded")
+    func horizonBoundaryIsInclusive() {
+        let onEdge = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                // 2026-06-30 is the inclusive end-of-month edge.
+                recurring("Edge bill", amount: 200, nextExpectedDate: "2026-06-30", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(horizon: .endOfMonth, manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(component(onEdge, .upcomingObligations) == -200)
+        #expect(onEdge.amount == 800)
+
+        let pastEdge = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Next month bill", amount: 200, nextExpectedDate: "2026-07-01", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(horizon: .endOfMonth, manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+        // Outside the window: not subtracted, but the stream is still a signal.
+        #expect(component(pastEdge, .upcomingObligations) == 0)
+        #expect(pastEdge.amount == 1_000)
+    }
+
+    @Test("Visible components keep cash and income lines but drop zero subtractions")
+    func visibleComponentsDropZeroSubtractions() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(500)],
+            recurringTransactions: [],
+            inputs: SafeToSpendInputs(manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+
+        let kinds = result.visibleComponents.map(\.kind)
+        #expect(kinds.contains(.startingCash))
+        #expect(kinds.contains(.expectedIncome))
+        #expect(!kinds.contains(.safetyBuffer))
+        #expect(!kinds.contains(.upcomingObligations))
+    }
+
+    @Test("Fixed-day horizon clamps to at least one day")
+    func fixedDayHorizon() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Soon bill", amount: 100, nextExpectedDate: "2026-06-15", category: .billsAndUtilities),
+                recurring("Later bill", amount: 100, nextExpectedDate: "2026-06-25", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(horizon: .days(5), manualExpectedIncome: 0),
+            asOf: now,
+            calendar: calendar
+        )
+
+        // Horizon end = 2026-06-18; only the 06-15 bill is inside the window.
+        #expect(component(result, .upcomingObligations) == -100)
+        #expect(result.horizonEnd == Formatters.parseTransactionDate("2026-06-18")!)
+    }
+
+    // MARK: - Fixtures
+
+    private func component(_ result: SafeToSpendResult, _ kind: SafeToSpendComponentKind) -> Double {
+        result.components.first { $0.kind == kind }?.amount ?? 0
+    }
+
+    private func checking(_ available: Double) -> AccountDTO {
+        AccountDTO(
+            id: "checking",
+            itemId: "item",
+            name: "Checking",
+            type: .depository,
+            balances: BalanceDTO(available: available, current: available + 50)
+        )
+    }
+
+    private func savings(_ available: Double) -> AccountDTO {
+        AccountDTO(
+            id: "savings",
+            itemId: "item",
+            name: "Savings",
+            type: .depository,
+            balances: BalanceDTO(available: available, current: available)
+        )
+    }
+
+    private func recurring(
+        _ merchant: String,
+        amount: Double,
+        nextExpectedDate: String,
+        category: SpendingCategory?,
+        confidence: Double = 0.9
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchant,
+            frequency: .monthly,
+            averageAmount: amount,
+            lastDate: "2026-05-20",
+            nextExpectedDate: nextExpectedDate,
+            category: category,
+            transactionCount: 4,
+            confidence: confidence
+        )
+    }
+}


### PR DESCRIPTION
Implements [AND-401](https://linear.app/andeslab/issue/AND-401) — an explainable safe-to-spend number.

**What**
- `SafeToSpendCalculator` (PlaidBarCore, pure/deterministic): starting cash − upcoming obligations − loans/cards − reservations + expected income − safety buffer.
- Signed breakdown that always reconciles to the headline; confidence states (`insufficientData`/`lowConfidence`/`ok`) so the number is never overstated.
- `SafeToSpendCard` wired into `WealthSummaryFlyout` — last-updated timestamp + confidence cue (text+symbol, not color alone) + expandable breakdown.

**Validation**
- Strict-concurrency build (`-strict-concurrency=complete -warnings-as-errors`): clean.
- `swift test`: **589 passed** (11 new fixture tests).
- Adversarial code review (APPROVE-WITH-NITS): all findings addressed — relabelled loans/cards line, documented the forward-looking recurring-income path, AC-compliant timestamp fallback.

Local-only deterministic calc + UI; no billing/credentials/brokerage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)