### PR TITLE
feat: per-account inline sparklines on dashboard rows (AND-379)

### DIFF
--- a/Sources/PlaidBar/Views/Charts/AccountRowSparkline.swift
+++ b/Sources/PlaidBar/Views/Charts/AccountRowSparkline.swift
@@ -1,0 +1,57 @@
+import Charts
+import PlaidBarCore
+import SwiftUI
+
+/// Inline glance sparkline for a dashboard account row (AND-379). Renders a
+/// normalized `AccountSparkline.Series` as a hidden-axis line tinted by trend
+/// direction, sized to fit the row's trailing cluster ahead of the chevron
+/// without changing row height.
+///
+/// It renders **complete**, with no reveal animation. Unlike the always-present
+/// net-worth header chart (`BalanceTrendChart`), this view is one-per-row inside
+/// a scrollable, filterable account list, so a per-appearance mask reveal would
+/// replay every time a row is re-realized on scroll or a filter toggle — visual
+/// noise that works against the "calm glance" intent. Rendering complete also
+/// makes it trivially correct under Reduce Motion (there is simply no motion).
+///
+/// The sparkline is decorative: the row already announces the balance and the
+/// trailing delta carries direction in text, so it is hidden from VoiceOver by
+/// its caller; the color is a supplementary cue, never the sole one.
+struct AccountRowSparkline: View {
+    let series: AccountSparkline.Series
+
+    /// Tuned to the account-row density: wide enough to read a shape, short
+    /// enough to keep the row at its existing height.
+    static let width: CGFloat = 54
+    static let height: CGFloat = 16
+
+    var body: some View {
+        Chart(series.indexedPoints, id: \.x) { point in
+            LineMark(
+                x: .value("Point", point.x),
+                y: .value("Balance", point.y)
+            )
+            .interpolationMethod(.monotone)
+            .foregroundStyle(tint)
+            .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        // Normalized data lives in 0...1; pad the domain slightly so a flat
+        // mid-line and the rounded line caps are not clipped at the edges.
+        .chartYScale(domain: -0.15 ... 1.15)
+        .frame(width: Self.width, height: Self.height)
+    }
+
+    private var tint: Color {
+        switch series.direction {
+        case .up:
+            SemanticColors.positive
+        case .down:
+            SemanticColors.negative
+        case .flat:
+            .secondary
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1600,9 +1600,13 @@ private struct DashboardAccountRow: View {
 
             Spacer(minLength: Spacing.compactRowContentSpacing)
 
-            if let demoTrend {
-                BalanceTrendChart(trend: demoTrend)
-                    .frame(width: 54, height: 16)
+            // Inline per-account sparkline (AND-379), ahead of the chevron.
+            // Decorative: the row announces the balance and the trailing delta
+            // carries direction in text, so this is hidden from VoiceOver and
+            // never the sole cue. Rows with insufficient history render nothing
+            // and keep identical height and rhythm.
+            if let accountSparkline {
+                AccountRowSparkline(series: accountSparkline)
                     .accessibilityHidden(true)
             }
 
@@ -1725,15 +1729,30 @@ private struct DashboardAccountRow: View {
         accountConnectionTint(for: connectionPresentation.level)
     }
 
-    private var demoTrend: BalanceTrend? {
-        demoAccountTrend(for: account, appState: appState)
+    private var accountSparkline: AccountSparkline.Series? {
+        accountSparklineSeries(for: account, appState: appState)
     }
 }
 
 @MainActor
+private func accountSparklineSeries(for account: AccountDTO, appState: AppState) -> AccountSparkline.Series? {
+    AccountSparkline.evaluate(history: accountBalanceHistory(for: account, appState: appState))
+}
+
+@MainActor
 private func demoAccountTrend(for account: AccountDTO, appState: AppState) -> BalanceTrend? {
-    guard appState.usesDemoConnectionPresentation else { return nil }
-    return BalanceTrend.evaluate(history: DemoFixtures.accountBalanceHistory(forAccountId: account.id))
+    BalanceTrend.evaluate(history: accountBalanceHistory(for: account, appState: appState))
+}
+
+/// Per-account balance history source. Real builds do not record per-account
+/// history yet (`AppState.balanceHistory` is aggregate net worth only), so the
+/// row sparkline is sourced from deterministic demo fixtures in demo mode and
+/// is intentionally absent otherwise — degrading to no line rather than a
+/// misleading one.
+@MainActor
+private func accountBalanceHistory(for account: AccountDTO, appState: AppState) -> [BalanceSnapshot] {
+    guard appState.usesDemoConnectionPresentation else { return [] }
+    return DemoFixtures.accountBalanceHistory(forAccountId: account.id)
 }
 
 private func accountTrendAccessibility(_ trend: BalanceTrend) -> String {

--- a/Sources/PlaidBarCore/Utilities/AccountSparkline.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountSparkline.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Pure, presentation-agnostic source for the per-account dashboard row
+/// sparkline (AND-379). Given an account's recorded balance history, it
+/// produces a normalized 0...1 series and a trend direction so the row view
+/// can render a tiny glance line without doing any math of its own.
+///
+/// Direction is delegated to `BalanceTrend.evaluate`, so the row sparkline,
+/// the net-worth header sparkline, and the wealth fly-out all classify
+/// up/down/flat identically — there is one source of truth for "which way did
+/// the balance move".
+///
+/// The series degrades gracefully: when history has fewer than the required
+/// points inside the window (the same gate `BalanceTrend` applies), it returns
+/// `nil` so the row renders no line at all rather than a misleading one.
+public enum AccountSparkline {
+    /// Minimum recorded points required before a row will draw a sparkline.
+    /// Matches `BalanceTrend.requiredPointCount` so "enough data for a trend"
+    /// and "enough data for a sparkline" stay the same judgement.
+    public static let defaultMinimumPointCount = BalanceTrend.requiredPointCount
+
+    /// A render-ready sparkline: the trend direction plus the balance series
+    /// normalized into 0...1 (lowest balance → 0, highest → 1). A flat series
+    /// (no spread between min and max) collapses to a mid-line so the row draws
+    /// a calm horizontal stroke instead of dividing by zero.
+    public struct Series: Sendable, Equatable {
+        public let direction: BalanceTrend.Direction
+        /// Balance points normalized to 0...1, oldest first. Always at least
+        /// `minimumPointCount` long when produced via `evaluate`.
+        public let normalizedValues: [Double]
+
+        public init(direction: BalanceTrend.Direction, normalizedValues: [Double]) {
+            self.direction = direction
+            self.normalizedValues = normalizedValues
+        }
+
+        /// Indexed points for charting: `(x: position, y: normalized value)`,
+        /// oldest at x = 0. Convenience for a hidden-axis `Chart`.
+        public var indexedPoints: [(x: Int, y: Double)] {
+            normalizedValues.enumerated().map { (x: $0.offset, y: $0.element) }
+        }
+    }
+
+    /// Builds a normalized sparkline series for an account's balance history,
+    /// or `nil` when there is too little history to draw an honest line.
+    ///
+    /// - Parameters:
+    ///   - history: Recorded balance snapshots for a single account.
+    ///   - minimumPointCount: Fewest in-window points that may render a line.
+    ///     Clamped to at least `BalanceTrend.requiredPointCount`, because a
+    ///     direction itself needs two points.
+    ///   - now: Upper bound of the window (defaults to the current date).
+    ///   - windowDays: Trailing window the series is drawn from.
+    ///   - calendar: Calendar used for the window math (testable).
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        minimumPointCount: Int = defaultMinimumPointCount,
+        now: Date = Date(),
+        windowDays: Int = 90,
+        calendar: Calendar = .current
+    ) -> Series? {
+        // Reuse the trend evaluator: it owns the windowing, sorting, and the
+        // up/down/flat classification, so the sparkline never drifts from the
+        // delta arrow shown next to it. A nil trend means insufficient data.
+        guard let trend = BalanceTrend.evaluate(
+            history: history,
+            now: now,
+            windowDays: windowDays,
+            calendar: calendar
+        ) else {
+            return nil
+        }
+
+        let effectiveMinimum = max(minimumPointCount, BalanceTrend.requiredPointCount)
+        let balances = trend.points.map(\.balance)
+        guard balances.count >= effectiveMinimum else { return nil }
+
+        return Series(
+            direction: trend.direction,
+            normalizedValues: normalize(balances)
+        )
+    }
+
+    /// Maps balances onto 0...1 by min/max. A zero-spread (flat) series maps to
+    /// a constant mid-line so the chart draws a level stroke, not a NaN.
+    static func normalize(_ balances: [Double]) -> [Double] {
+        guard let minimum = balances.min(), let maximum = balances.max() else {
+            return []
+        }
+        let spread = maximum - minimum
+        guard spread > 0 else {
+            return balances.map { _ in 0.5 }
+        }
+        return balances.map { ($0 - minimum) / spread }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AccountSparklineTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountSparklineTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("AccountSparkline")
+struct AccountSparklineTests {
+    private let calendar = Calendar.current
+
+    private func date(_ string: String) throws -> Date {
+        try #require(Formatters.parseTransactionDate(string))
+    }
+
+    private func history(_ balances: [Double], endingAt end: Date) -> [BalanceSnapshot] {
+        // Oldest first; one point per day ending at `end`.
+        balances.enumerated().map { offset, balance in
+            let daysAgo = balances.count - 1 - offset
+            let pointDate = calendar.date(byAdding: .day, value: -daysAgo, to: end) ?? end
+            return BalanceSnapshot(date: pointDate, balance: balance)
+        }
+    }
+
+    @Test("Insufficient history renders nothing")
+    func insufficientHistoryRendersNothing() throws {
+        let now = try date("2026-06-10")
+
+        // Empty history.
+        #expect(AccountSparkline.evaluate(history: [], now: now, calendar: calendar) == nil)
+
+        // Single point cannot establish a direction or a line.
+        #expect(
+            AccountSparkline.evaluate(
+                history: history([5_000], endingAt: now),
+                now: now,
+                calendar: calendar
+            ) == nil
+        )
+
+        // Two points, but a higher custom minimum is not met.
+        #expect(
+            AccountSparkline.evaluate(
+                history: history([5_000, 5_200], endingAt: now),
+                minimumPointCount: 3,
+                now: now,
+                calendar: calendar
+            ) == nil
+        )
+    }
+
+    @Test("Single in-window point renders nothing even with old history")
+    func singlePointInWindowRendersNothing() throws {
+        let now = try date("2026-06-10")
+        let ancient = try #require(calendar.date(byAdding: .day, value: -200, to: now))
+
+        // One recent point plus one outside the 90-day window: only one point
+        // counts, so there is no honest line.
+        let series = AccountSparkline.evaluate(
+            history: [
+                BalanceSnapshot(date: ancient, balance: 4_000),
+                BalanceSnapshot(date: now, balance: 5_000),
+            ],
+            now: now,
+            calendar: calendar
+        )
+        #expect(series == nil)
+    }
+
+    @Test("Upward history yields an up direction and a rising normalized series")
+    func upwardHistory() throws {
+        let now = try date("2026-06-10")
+        let series = try #require(
+            AccountSparkline.evaluate(
+                history: history([8_000, 8_300, 8_900, 9_400], endingAt: now),
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        #expect(series.direction == .up)
+        #expect(series.normalizedValues.count == 4)
+        // Min maps to 0, max maps to 1, oldest first.
+        #expect(series.normalizedValues.first == 0)
+        #expect(series.normalizedValues.last == 1)
+        #expect(series.normalizedValues == series.normalizedValues.sorted())
+    }
+
+    @Test("Downward history yields a down direction and a falling normalized series")
+    func downwardHistory() throws {
+        let now = try date("2026-06-10")
+        let series = try #require(
+            AccountSparkline.evaluate(
+                history: history([9_400, 8_900, 8_300, 8_000], endingAt: now),
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        #expect(series.direction == .down)
+        #expect(series.normalizedValues.count == 4)
+        // Oldest (highest) maps to 1, newest (lowest) maps to 0.
+        #expect(series.normalizedValues.first == 1)
+        #expect(series.normalizedValues.last == 0)
+        #expect(series.normalizedValues == series.normalizedValues.sorted(by: >))
+    }
+
+    @Test("Flat history yields a flat direction and a level mid-line")
+    func flatHistory() throws {
+        let now = try date("2026-06-10")
+        let series = try #require(
+            AccountSparkline.evaluate(
+                history: history([10_000, 10_000, 10_000], endingAt: now),
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        #expect(series.direction == .flat)
+        #expect(series.normalizedValues == [0.5, 0.5, 0.5])
+    }
+
+    @Test("Indexed points are ordered oldest-first by x")
+    func indexedPointsOrdered() throws {
+        let now = try date("2026-06-10")
+        let series = try #require(
+            AccountSparkline.evaluate(
+                history: history([1_000, 2_000, 3_000], endingAt: now),
+                now: now,
+                calendar: calendar
+            )
+        )
+
+        let points = series.indexedPoints
+        #expect(points.map(\.x) == [0, 1, 2])
+        #expect(points.map(\.y) == series.normalizedValues)
+    }
+
+    @Test("Normalize collapses a zero-spread series to a mid-line")
+    func normalizeZeroSpread() {
+        #expect(AccountSparkline.normalize([]) == [])
+        #expect(AccountSparkline.normalize([42, 42, 42]) == [0.5, 0.5, 0.5])
+        #expect(AccountSparkline.normalize([0, 5, 10]) == [0, 0.5, 1])
+    }
+
+    @Test("Credit-account debt paydown reads as an up direction")
+    func creditAccountPaydownReadsUp() throws {
+        let now = try date("2026-06-10")
+        // Paying a card down (-2000 → -1000) is a positive trend for the user;
+        // normalize is sign-agnostic, so the oldest (lowest) balance maps to 0.
+        let series = try #require(
+            AccountSparkline.evaluate(
+                history: history([-2_000, -1_600, -1_000], endingAt: now),
+                now: now,
+                calendar: calendar
+            )
+        )
+        #expect(series.direction == .up)
+        #expect(series.normalizedValues.first == 0)
+        #expect(series.normalizedValues.last == 1)
+    }
+}


### PR DESCRIPTION
Implements [AND-379](https://linear.app/andeslab/issue/AND-379).

**What**
- `AccountSparkline` (PlaidBarCore, pure/tested): normalized 0...1 series + direction via `BalanceTrend` (single source of truth); returns nil on insufficient history (graceful no-line, never a misleading flat stroke).
- `AccountRowSparkline` (54×16) in the account-row trailing cluster ahead of the chevron; replaces the prior heavy header-style `BalanceTrendChart` there. Renders **complete** — no per-row reveal animation (avoids replay on scroll/filter re-realization; trivially Reduce-Motion correct). Decorative + `.accessibilityHidden(true)`; direction also carried by the trailing delta text (color supplementary).
- 8 fixture tests (insufficient/single-point/up/down/flat/normalize/ordering/credit-account).

**Scope honesty:** real (sandbox/production) builds record only **aggregate** net-worth history, not per-account — so real-mode rows show **no sparkline** today; the feature is visible in demo mode + ships the tested infrastructure. Recording per-account balance history is a follow-up to make this a real-data end-user feature.

**Validation:** strict-concurrency build clean; `swift test` **597 passed** (+8). Adversarial code review APPROVE-WITH-NITS → reveal-replay fixed (render complete), credit-account test added, scope documented; no regression to the net-worth header or the accessibility path; row height unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)