### PR TITLE
feat: monospaced tabular numerics with numeric-roll on change (AND-378)

### DIFF
--- a/Sources/PlaidBar/Theme/Typography.swift
+++ b/Sources/PlaidBar/Theme/Typography.swift
@@ -1,5 +1,25 @@
 import SwiftUI
 
+// MARK: - Rolling Tabular Numerics
+
+/// Centralized numeric-display modifier (AND-378): monospaced (tabular) digits so
+/// decimals align into a column, plus a `.numericText()` content transition that
+/// rolls the figure only when it changes (the value-keyed `.animation` does not run
+/// on first render, so no "slot machine" on open) and is disabled under Reduce
+/// Motion via `MotionTokens.animation` (which returns nil). Pass the exact string
+/// the wrapped `Text` displays as `value`.
+struct RollingTabularNumber: ViewModifier {
+    let value: String
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .monospacedDigit()
+            .contentTransition(.numericText())
+            .animation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion), value: value)
+    }
+}
+
 // MARK: - Type Scale ViewModifiers
 
 /// Level 0 — Display: the one hero number per surface (net worth).
@@ -66,6 +86,12 @@ extension View {
 
     func dataText() -> some View {
         modifier(DataText())
+    }
+
+    /// Monospaced + rolls on value change (never on first appearance; instant under
+    /// Reduce Motion). Pass the rendered string. See `RollingTabularNumber`.
+    func rollingTabularNumber(_ value: String, reduceMotion: Bool) -> some View {
+        modifier(RollingTabularNumber(value: value, reduceMotion: reduceMotion))
     }
 
     func heroBalance() -> some View {

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -36,6 +36,7 @@ struct AccountInspector: View {
 struct AccountDetailFlyout: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let account: AccountDTO
     let isStatusFilter: Bool
     let onClose: () -> Void
@@ -188,12 +189,14 @@ struct AccountDetailFlyout: View {
             DetailValue(
                 title: summary.availableTitle,
                 value: Formatters.currency(summary.availableBalance, format: .compact),
-                tint: AppearanceTextColors.primary
+                tint: AppearanceTextColors.primary,
+                reduceMotion: reduceMotion
             )
             DetailValue(
                 title: summary.currentTitle,
                 value: Formatters.currency(summary.currentBalance, format: .compact),
-                tint: AppearanceTextColors.primary
+                tint: AppearanceTextColors.primary,
+                reduceMotion: reduceMotion
             )
 
             // Utilization stays neutral here — risk severity is carried by the
@@ -208,7 +211,8 @@ struct AccountDetailFlyout: View {
                 DetailValue(
                     title: "Utilization",
                     value: utilizationText,
-                    tint: AppearanceTextColors.primary
+                    tint: AppearanceTextColors.primary,
+                    reduceMotion: reduceMotion
                 )
             }
         }
@@ -423,6 +427,7 @@ private struct FlyoutSectionLabel: View {
 // MARK: - Change Row
 
 private struct FlyoutChangeRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let title: String
     let total: Double
     let delta: Double
@@ -437,6 +442,7 @@ private struct FlyoutChangeRow: View {
 
             Text(Formatters.currency(total, format: .compact))
                 .dataText()
+                .rollingTabularNumber(Formatters.currency(total, format: .compact), reduceMotion: reduceMotion)
 
             Spacer(minLength: Spacing.xs)
 
@@ -504,6 +510,7 @@ private struct ReviewReasonChip: View {
 // MARK: - Category Slice Row
 
 private struct CategorySliceRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let slice: AccountDetailInsights.CategorySlice
 
     var body: some View {
@@ -522,12 +529,12 @@ private struct CategorySliceRow: View {
 
                 Text(Formatters.currency(slice.total, format: .compact))
                     .font(.caption.weight(.semibold))
-                    .monospacedDigit()
+                    .rollingTabularNumber(Formatters.currency(slice.total, format: .compact), reduceMotion: reduceMotion)
 
                 Text(shareText)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .monospacedDigit()
+                    .rollingTabularNumber(shareText, reduceMotion: reduceMotion)
                     .frame(width: 34, alignment: .trailing)
             }
 
@@ -593,6 +600,7 @@ struct DetailValue: View {
     let title: String
     let value: String
     let tint: Color
+    var reduceMotion: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -601,6 +609,7 @@ struct DetailValue: View {
                 .foregroundStyle(.secondary)
             Text(value)
                 .dataText()
+                .rollingTabularNumber(value, reduceMotion: reduceMotion)
                 .foregroundStyle(tint)
         }
         .accessibilityElement(children: .ignore)
@@ -609,6 +618,7 @@ struct DetailValue: View {
 }
 
 struct TransactionMiniRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let transaction: TransactionDTO
 
     var body: some View {
@@ -630,6 +640,7 @@ struct TransactionMiniRow: View {
 
             Text(amountText)
                 .dataText()
+                .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
                 .foregroundStyle(
                     transaction.isIncome ? SemanticColors.positive : AppearanceTextColors.primary
                 )

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -432,6 +432,7 @@ struct MainPopover: View {
 
 private struct DashboardChangeReceiptStrip: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var receipt: DashboardChangeReceipt? {
         DashboardChangeReceipt.evaluate(
@@ -461,7 +462,7 @@ private struct DashboardChangeReceiptStrip: View {
                     ForEach(receipt.rows) { row in
                         Text(row.value)
                             .font(.caption2.weight(.semibold))
-                            .monospacedDigit()
+                            .rollingTabularNumber(row.value, reduceMotion: reduceMotion)
                             .lineLimit(1)
                             .help(row.accessibilityText)
                     }
@@ -481,6 +482,7 @@ private struct DashboardChangeReceiptStrip: View {
 
 private struct RecentSpendChip: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         // 7-day spend velocity — the one summary metric the left rail does not
@@ -499,7 +501,7 @@ private struct RecentSpendChip: View {
 
                 Text(Formatters.currency(appState.recentSpend, format: .compact))
                     .font(.caption.weight(.semibold))
-                    .monospacedDigit()
+                    .rollingTabularNumber(Formatters.currency(appState.recentSpend, format: .compact), reduceMotion: reduceMotion)
                     .lineLimit(1)
             }
             .padding(.horizontal, Spacing.sm)
@@ -1564,6 +1566,7 @@ private struct DashboardEmptyAccountState: View {
 
 private struct DashboardAccountRow: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let account: AccountDTO
     let isStatusFilter: Bool
     let isSelected: Bool
@@ -1616,6 +1619,7 @@ private struct DashboardAccountRow: View {
                 // and only once the user's own threshold is crossed.
                 Text(amountText)
                     .dataText()
+                    .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
                     .foregroundStyle(AppearanceTextColors.primary)
                     .lineLimit(1)
 

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct WealthSummaryFlyout: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let onAddAccount: () -> Void
 
     private var presentation: WealthSummaryPresentation {
@@ -101,7 +102,7 @@ struct WealthSummaryFlyout: View {
 
                 Text(Formatters.currency(presentation.netWorth, format: .full))
                     .displayBalance()
-                    .contentTransition(.numericText())
+                    .rollingTabularNumber(Formatters.currency(presentation.netWorth, format: .full), reduceMotion: reduceMotion)
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
 
@@ -196,6 +197,7 @@ private struct WealthSyncPill: View {
 }
 
 private struct WealthMetricGrid: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let presentation: WealthSummaryPresentation
 
     private var columns: [GridItem] {
@@ -211,7 +213,8 @@ private struct WealthMetricGrid: View {
                 title: "Assets",
                 value: Formatters.currency(presentation.totalAssets, format: .compact),
                 detail: "\(presentation.accountCount) accounts",
-                systemImage: "building.columns.fill"
+                systemImage: "building.columns.fill",
+                reduceMotion: reduceMotion
             )
 
             WealthMetricTile(
@@ -219,7 +222,8 @@ private struct WealthMetricGrid: View {
                 value: Formatters.currency(presentation.totalDebt, format: .compact),
                 detail: presentation.totalDebt > 0 ? "Credit and loans" : "No debt synced",
                 systemImage: "creditcard.fill",
-                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : AppearanceTextColors.secondary
+                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : AppearanceTextColors.secondary,
+                reduceMotion: reduceMotion
             )
         }
         .accessibilityElement(children: .contain)
@@ -232,6 +236,7 @@ private struct WealthMetricTile: View {
     let detail: String
     let systemImage: String
     var tint: Color = .secondary
+    var reduceMotion: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -247,6 +252,7 @@ private struct WealthMetricTile: View {
 
             Text(value)
                 .dataText()
+                .rollingTabularNumber(value, reduceMotion: reduceMotion)
                 .foregroundStyle(AppearanceTextColors.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.78)
@@ -318,6 +324,7 @@ private struct WealthBalanceMixSection: View {
 }
 
 private struct WealthMixLegendRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let segment: BalanceCompositionPresentation.Segment
     let tint: Color
 
@@ -337,13 +344,13 @@ private struct WealthMixLegendRow: View {
 
             Text(Formatters.currency(segment.value, format: .compact))
                 .font(.caption.weight(.semibold))
-                .monospacedDigit()
+                .rollingTabularNumber(Formatters.currency(segment.value, format: .compact), reduceMotion: reduceMotion)
                 .lineLimit(1)
 
             Text(percentText(segment.share))
                 .microText()
                 .foregroundStyle(.secondary)
-                .monospacedDigit()
+                .rollingTabularNumber(percentText(segment.share), reduceMotion: reduceMotion)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(
@@ -353,6 +360,7 @@ private struct WealthMixLegendRow: View {
 }
 
 private struct WealthCashflowSection: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let cashflow: WealthSummaryPresentation.CashflowSummary
 
     var body: some View {
@@ -366,9 +374,9 @@ private struct WealthCashflowSection: View {
             }
 
             VStack(spacing: Spacing.xs) {
-                WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income)
-                WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending)
-                WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net)
+                WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income, reduceMotion: reduceMotion)
+                WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending, reduceMotion: reduceMotion)
+                WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net, reduceMotion: reduceMotion)
             }
         }
         .accessibilityElement(children: .contain)
@@ -385,6 +393,7 @@ private struct WealthCashflowRow: View {
     let title: String
     let amount: Double
     let role: WealthCashflowRole
+    var reduceMotion: Bool = false
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
@@ -397,7 +406,7 @@ private struct WealthCashflowRow: View {
             Text(amountText)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
-                .monospacedDigit()
+                .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
                 .lineLimit(1)
         }
         .accessibilityElement(children: .ignore)


### PR DESCRIPTION
Implements [AND-378](https://linear.app/andeslab/issue/AND-378).

Centralized `RollingTabularNumber` Typography modifier — `.monospacedDigit()` + `.contentTransition(.numericText())` + a value-keyed `.animation(MotionTokens.animation(MotionTokens.standard, reduceMotion:))` — applied to the genuine numeric columns across dashboard account rows, Wealth Summary (net worth, Assets/Debt tiles, balance-mix legend, cashflow), and the account flyout (balances, 30-day change rows, category totals, transaction amounts).

- **Roll on change only:** value-keyed `.animation` doesn't run on first render (no slot-machine on open); load→loaded is a structural redaction branch-swap (no spurious roll); ForEach rows keyed on stable ids.
- **Reduce Motion:** `MotionTokens.animation` returns nil → instant, no roll.
- **No layout change:** existing trailing layouts already right-align; only monospaced-width + transition added.
- Reserved for numeric columns — reverted the modifier off prose strings (credit utilization sentence, 'N tx', change-receipt summary, 'vs prior') per review.

**Validation:** strict-concurrency build clean (`-warnings-as-errors`); `swift test` **597 passed**; headless light+dark appearance render verified (columns align by decimal, no clipping/regression). Adversarial code review APPROVE-WITH-NITS → prose sites reverted; `.standard` kept per the issue spec. Manual check recommended: 7-figure net worth on the narrow rail (guarded by `minimumScaleFactor(0.72)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)