### PR TITLE
feat: subtle scroll-edge depth on dashboard + flyout lists (AND-383)

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -147,6 +147,9 @@ enum MotionTokens {
 
     static let staticLoadingOpacity = 0.62
     static let loadingPulseOpacity = 0.55
+    /// Scroll-edge depth floor (AND-383): rows/sections fade to this as they reach
+    /// the scroll viewport edge; identity (1.0) when fully visible.
+    static let scrollEdgeFadeOpacity = 0.6
 
     static func animation(_ animation: Animation, reduceMotion: Bool) -> Animation? {
         reduceMotion ? nil : animation

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -68,19 +68,26 @@ struct AccountDetailFlyout: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: Spacing.lg) {
                     statusSection(connection: connection, summary: summary)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                     balancesSection(summary: summary)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                     changesSection(insights: insights)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                     if !insights.reviewItems.isEmpty {
                         reviewSection(insights: insights)
+                            .scrollEdgeDepth(reduceMotion: reduceMotion)
                     }
                     if !insights.topCategories.isEmpty {
                         categoriesSection(insights: insights)
+                            .scrollEdgeDepth(reduceMotion: reduceMotion)
                     }
                     activitySection(
                         recent: recent,
                         emptyState: emptyState(snapshot: snapshot, connection: connection)
                     )
+                    .scrollEdgeDepth(reduceMotion: reduceMotion)
                     actionsSection(summary: summary)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                 }
                 .padding(Spacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1280,6 +1280,7 @@ private struct DashboardOverviewFallbackBanner: View {
 
 private struct AccountsSection: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let accounts: [AccountDTO]
     let filter: DashboardAccountFilter
     let selectedAccountId: String?
@@ -1335,6 +1336,7 @@ private struct AccountsSection: View {
                             }
                         )
                         .environment(appState)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                     }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: Radius.panel))

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -146,6 +146,19 @@ extension View {
     func heroAccentSurface(tint: Color = SemanticColors.brand) -> some View {
         glassSurface(.hero(tint), cornerRadius: Radius.panel)
     }
+
+    /// Subtle scroll-edge depth (AND-383): a scrolling row fades as it approaches the
+    /// top/bottom of the scroll viewport and returns to identity when fully visible.
+    /// Render-only (opacity) — zero layout impact, so row heights and the density
+    /// rhythm are unchanged, and there is no horizontal drift on left-aligned content.
+    /// Under Reduce Motion it renders at full opacity throughout (effect disabled).
+    /// Apply to each scrolling row or section — never to pinned headers/footers.
+    func scrollEdgeDepth(reduceMotion: Bool) -> some View {
+        scrollTransition { content, phase in
+            content
+                .opacity(reduceMotion || phase.isIdentity ? 1 : MotionTokens.scrollEdgeFadeOpacity)
+        }
+    }
 }
 
 private extension View {

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -39,12 +39,15 @@ struct WealthSummaryFlyout: View {
                 VStack(alignment: .leading, spacing: Spacing.lg) {
                     WealthMetricGrid(presentation: presentation)
                         .loadingRedaction(appState.loadState(for: .summaryCards))
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     WealthBalanceMixSection(presentation: presentation)
                         .loadingRedaction(appState.loadState(for: .summaryCards))
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     WealthCashflowSection(cashflow: presentation.cashflow)
                         .loadingRedaction(appState.loadState(for: .transactions))
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     SafeToSpendCard(
                         result: SafeToSpendCalculator.compute(
@@ -56,14 +59,17 @@ struct WealthSummaryFlyout: View {
                         lastUpdatedRelative: appState.lastSyncRelative
                     )
                     .loadingRedaction(appState.loadState(for: .summaryCards))
+                    .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     WealthCreditSection(
                         summary: presentation.creditUtilization,
                         threshold: appState.creditUtilizationThreshold
                     )
                         .loadingRedaction(appState.loadState(for: .credit))
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     WealthAttentionSection(summary: presentation.attention)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     if presentation.accountCount == 0 {
                         Button(action: onAddAccount) {
@@ -71,6 +77,7 @@ struct WealthSummaryFlyout: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .scrollEdgeDepth(reduceMotion: reduceMotion)
                     }
                 }
                 .padding(Spacing.md)


### PR DESCRIPTION
Implements [AND-383](https://linear.app/andeslab/issue/AND-383).

Centralized `View.scrollEdgeDepth(reduceMotion:)` in SharedModifiers — a `scrollTransition` opacity falloff (to `MotionTokens.scrollEdgeFadeOpacity` = 0.6) at the top/bottom of the scroll viewport, identity when fully visible. Render-only (opacity), **zero layout impact**. Applied per-row to the dashboard account list and per-section to the Wealth Summary + Account Detail flyout scroll bodies; pinned headers/footers excluded. Reduce Motion → full opacity throughout (disabled).

**Review (APPROVE-WITH-NITS) — applied:** dropped the optional micro-scale (it center-anchored a subtle horizontal wobble on left-aligned flyout sections) → **opacity-only**, eliminating the wobble while keeping the depth cue; tokenized the opacity floor into `MotionTokens`. Dashboard scope is account-rows-only per the issue (the heatmap/insight cards aren't list rows) — deliberate.

**Validation:** strict build clean (`-warnings-as-errors`); `swift test` **597 passed**; headless light+dark render verified (no at-rest regression, rows at identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)