### PR TITLE
feat: group coexisting Liquid Glass surfaces in GlassEffectContainer (AND-381)

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -187,6 +187,11 @@ enum SurfaceTokens {
     static let popoverCornerRadius: CGFloat = 12
     static let panelCornerRadius: CGFloat = 7
     static let compactCornerRadius: CGFloat = 6
+    /// Glass merge radius for `GlassEffectContainer` (AND-381): the proximity
+    /// under which adjacent Liquid Glass shapes fuse into one sampling blob.
+    /// Deliberately small so only genuinely-adjacent glass merges — this is a
+    /// merge radius, not layout spacing.
+    static let glassMergeRadius: CGFloat = 8
 
     static let panelFillOpacity = 0.022
     static let insetFillOpacity = 0.045

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -91,6 +91,11 @@ struct AccountDetailFlyout: View {
                 }
                 .padding(Spacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                // Group the inspector's coexisting glass surfaces (inset/
+                // emphasized action chips) into one GlassEffectContainer sampling
+                // region on macOS 26; passthrough on macOS 15 (AND-381).
+                // Merge radius = SurfaceTokens.glassMergeRadius.
+                .glassGroup()
             }
             .scrollContentBackground(.hidden)
         }

--- a/Sources/PlaidBar/Views/GlassGroup.swift
+++ b/Sources/PlaidBar/Views/GlassGroup.swift
@@ -1,0 +1,55 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Glass Effect Container Grouping (AND-381)
+
+/// Groups coexisting Liquid Glass surfaces so the system samples and blends them
+/// as one glass field instead of each `glassSurface` resolving its own isolated
+/// sampling region.
+///
+/// `GlassEffectContainer(spacing:)`'s `spacing` is the glass **merge radius** —
+/// the proximity under which two glass shapes fuse into one blob — NOT layout
+/// spacing. It is intentionally small (`SurfaceTokens.glassMergeRadius`) so only
+/// genuinely-adjacent glass merges; distant glass islands in a tall scroll column
+/// stay visually distinct, which is why wrapping a whole scroll body is safe.
+///
+/// macOS-26 / SwiftUI-7 only; on macOS 15 (and the Swift <6.3 CI toolchain where
+/// the glass APIs aren't compiled at all) this is a transparent passthrough — the
+/// wrapped content renders byte-for-byte as it does today, so the fallback look
+/// never regresses. Glass is chrome only: wrap regions that *contain* glass
+/// surfaces; `GlassEffectContainer` only samples/merges its `glassEffect`
+/// descendants, so non-glass content/text inside is unaffected.
+struct GlassGroup<Content: View>: View {
+    var spacing: CGFloat
+    @ViewBuilder var content: () -> Content
+
+    init(spacing: CGFloat = SurfaceTokens.glassMergeRadius, @ViewBuilder content: @escaping () -> Content) {
+        self.spacing = spacing
+        self.content = content
+    }
+
+    var body: some View {
+        #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
+            if #available(macOS 26.0, *) {
+                GlassEffectContainer(spacing: spacing) {
+                    content()
+                }
+            } else {
+                content()
+            }
+        #else
+            content()
+        #endif
+    }
+}
+
+extension View {
+    /// Group this region's descendant `glassSurface(...)` shapes into one
+    /// `GlassEffectContainer` sampling region on macOS 26 (passthrough on macOS 15
+    /// / pre-6.3 CI). `spacing` is the glass merge radius, default
+    /// `SurfaceTokens.glassMergeRadius` — apply at the smallest ancestor that
+    /// contains the coexisting glass shapes.
+    func glassGroup(spacing: CGFloat = SurfaceTokens.glassMergeRadius) -> some View {
+        GlassGroup(spacing: spacing) { self }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -377,6 +377,13 @@ struct MainPopover: View {
                     .padding(.horizontal, Layout.contentHorizontalPadding)
                     .padding(.top, Layout.contentTopPadding)
                     .padding(.bottom, Layout.contentBottomPadding)
+                    // The dashboard's coexisting glass surfaces (heatmap, status
+                    // readiness panel, insights card + chips, overview cards)
+                    // share one GlassEffectContainer sampling region on macOS 26;
+                    // passthrough on macOS 15 (AND-381). Merge radius =
+                    // SurfaceTokens.glassMergeRadius (small), so only adjacent
+                    // glass fuses — distant cards in this tall column stay distinct.
+                    .glassGroup()
                     .onGeometryChange(for: CGFloat.self) { proxy in
                         proxy.size.height
                     } action: { height in

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -82,6 +82,10 @@ struct WealthSummaryFlyout: View {
                 }
                 .padding(Spacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                // Group the flyout's coexisting glass panels (metric tiles) into
+                // one GlassEffectContainer sampling region on macOS 26; passthrough
+                // on macOS 15 (AND-381). Merge radius = SurfaceTokens.glassMergeRadius.
+                .glassGroup()
             }
             .scrollContentBackground(.hidden)
         }


### PR DESCRIPTION
Partially implements [AND-381](https://linear.app/andeslab/issue/AND-381) — the **GlassEffectContainer grouping** (acceptance #1), the Apple-required correctness piece for coexisting glass.

Adds a gated `GlassGroup` / `.glassGroup()` (SharedModifiers-style `#if compiler(>=6.3) && canImport(SwiftUI,_version:7.0)` + `#available(macOS 26)`; passthrough on the fallback) wrapping the dashboard + both flyout scroll bodies. Merge radius = dedicated `SurfaceTokens.glassMergeRadius` (8pt) — small so only adjacent glass fuses (distant cards stay distinct). macOS-15 fallback byte-for-byte unchanged.

**Deferred to interactive validation (NOT in this PR):** popover-container glass (part 2), opacity-slider coexistence (part 3), and `appearsActive` dimming (part 4). A headless render showed the popover-glass washing out dark-mode identity, and glass-over-a-real-desktop can't be faithfully validated headlessly — so the primary-surface change needs your eyes over real light/dark desktops. Reverted to the proven `.ultraThinMaterial` stack here.

**Review (APPROVE-WITH-NITS) — applied:** fixed merge-radius-vs-layout-spacing semantics (dedicated token); the legibility should-fix is exactly why part 2 is deferred.

**Validation:** strict build clean (`-warnings-as-errors`, glass path compiled on Swift 6.3.2/macOS 26); `swift test` **597 passed**; light+dark render verified (dark-mode identity intact, grouping clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)