### PR TITLE
feat: interactive activity heatmap — day selection + keyboard + focused-day detail (AND-380)

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -528,11 +528,21 @@ private struct BalanceActivityHeatmap: View {
     var loadState: DashboardLoadState?
 
     @AppStorage("dashboard.heatmapMode") private var modeRawValue = SpendingHeatmapMode.spending.rawValue
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Day key (yyyy-MM-dd) of the selected cell, or nil when none is selected.
+    /// Persists until another cell is chosen or focus moves (AND-380).
+    @State private var selectedDay: String?
+    /// Mirrors keyboard focus so arrow keys can move it across the grid.
+    @FocusState private var focusedDay: String?
 
     private let calendar = Calendar.current
     private let spacing: CGFloat = 2
     private let monthLabelHeight: CGFloat = 10
     private let monthLabelWidth: CGFloat = 22
+    /// Caption row reserves this height so showing/hiding the focused-day
+    /// summary never shifts the layout below the grid.
+    private let captionRowHeight: CGFloat = 14
 
     private var mode: SpendingHeatmapMode {
         SpendingHeatmapMode(rawValue: modeRawValue) ?? .spending
@@ -594,15 +604,22 @@ private struct BalanceActivityHeatmap: View {
                     }
 
                     HStack(alignment: .top, spacing: spacing) {
-                        ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { _, week in
+                        ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { columnIndex, week in
                             VStack(spacing: spacing) {
-                                ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                                ForEach(Array(week.enumerated()), id: \.offset) { rowIndex, day in
                                     if let day {
                                         BalanceHeatmapCell(
                                             day: day,
                                             peakValue: layout.peakValue,
                                             mode: layout.mode,
-                                            size: cell
+                                            size: cell,
+                                            isSelected: selectedDay == day.date,
+                                            focusBinding: $focusedDay,
+                                            reduceMotion: reduceMotion,
+                                            onSelect: { toggleSelection(day.date) },
+                                            onMove: { direction in
+                                                moveFocus(direction, from: (columnIndex, rowIndex), in: layout)
+                                            }
                                         )
                                     } else {
                                         RoundedRectangle(cornerRadius: Radius.cell)
@@ -621,6 +638,12 @@ private struct BalanceActivityHeatmap: View {
             // First sync in flight: the empty grid dims so it reads as a
             // placeholder, not as a year of zero activity.
             .opacity(isInitialLoad ? 0.45 : 1)
+
+            // Fixed-height caption: the focused day when a cell is selected,
+            // otherwise a hint — so selecting never shifts the layout (AND-380).
+            focusedDayCaption(for: layout)
+                .frame(height: captionRowHeight, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 5) {
                 if layout.mode == .spending {
@@ -655,12 +678,95 @@ private struct BalanceActivityHeatmap: View {
         }
         .padding(Spacing.sm)
         .glassSurface(.raised)
+        // Drop a selection that no longer maps to a day in the current range
+        // (e.g. after a sync rolls the window forward), so the caption never
+        // shows a stale date and the ring never points at a vanished cell.
+        // Keyed on the last day — correct for the fixed end-at-today 365-day
+        // window (the end always advances); broaden the key (e.g. days.count)
+        // if the window ever becomes configurable from the front.
+        .onChange(of: layout.days.last?.date) {
+            if let selectedDay, !layout.days.contains(where: { $0.date == selectedDay }) {
+                self.selectedDay = nil
+            }
+        }
+        // Keep selection following keyboard focus so VoiceOver/arrow users hear
+        // the same day the caption shows. Intentional consequence: tabbing back
+        // into the grid re-selects the last-focused cell (focus implies
+        // selection here).
+        .onChange(of: focusedDay) { _, current in
+            if let current { selectedDay = current }
+        }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(
             isInitialLoad
                 ? (loadState?.loadingAccessibilityLabel ?? "Loading activity heatmap.")
-                : "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
+                : "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription). Select a day to see its detail."
         )
+    }
+
+    @ViewBuilder
+    private func focusedDayCaption(for layout: SpendingHeatmapLayout) -> some View {
+        if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout), !isInitialLoad {
+            HStack(spacing: 4) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(summary.captionText)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(AppearanceTextColors.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(summary.accessibilityLabel)
+        } else {
+            Text("Select a day for its detail")
+                .microText()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func toggleSelection(_ day: String) {
+        withAnimation(MotionTokens.animation(MotionTokens.micro, reduceMotion: reduceMotion)) {
+            selectedDay = (selectedDay == day) ? nil : day
+        }
+        // Deselect correctness depends on the activated cell already holding
+        // focus: re-tapping a selected cell clears `selectedDay`, and this
+        // assignment is then a no-op (focus was already on `day`), so
+        // `.onChange(of: focusedDay)` does not fire and the selection stays
+        // cleared. Keep this LAST — focusing a different cell before clearing
+        // would resurrect the selection via the focus→selection sync below.
+        focusedDay = day
+    }
+
+    /// Arrow-key navigation across the padded week grid. Columns are weeks,
+    /// rows are weekdays; movement skips nil padding cells and stays in bounds
+    /// (no wraparound — predictable for keyboard users).
+    private func moveFocus(
+        _ direction: MoveCommandDirection,
+        from origin: (column: Int, row: Int),
+        in layout: SpendingHeatmapLayout
+    ) {
+        let columns = layout.weekColumns
+        guard !columns.isEmpty else { return }
+
+        var column = origin.column
+        var row = origin.row
+        for _ in 0 ..< (columns.count * 7) {
+            switch direction {
+            case .up: row -= 1
+            case .down: row += 1
+            case .left: column -= 1
+            case .right: column += 1
+            @unknown default: return
+            }
+            guard column >= 0, column < columns.count, row >= 0, row < 7 else { return }
+            if let day = columns[column][row] {
+                focusedDay = day.date
+                return
+            }
+        }
     }
 
     private var isInitialLoad: Bool {
@@ -717,13 +823,35 @@ private struct BalanceHeatmapCell: View {
     let peakValue: Double
     let mode: SpendingHeatmapMode
     let size: CGFloat
+    var isSelected: Bool = false
+    var focusBinding: FocusState<String?>.Binding
+    var reduceMotion: Bool = false
+    var onSelect: () -> Void = {}
+    var onMove: (MoveCommandDirection) -> Void = { _ in }
 
     var body: some View {
-        RoundedRectangle(cornerRadius: Radius.cell)
-            .fill(Self.fillColor(intensity: intensity, value: day.value, mode: mode))
-            .frame(width: size, height: size)
-            .help(helpText)
-            .accessibilityLabel(helpText)
+        Button(action: onSelect) {
+            RoundedRectangle(cornerRadius: Radius.cell)
+                .fill(Self.fillColor(intensity: intensity, value: day.value, mode: mode))
+                .frame(width: size, height: size)
+        }
+        .buttonStyle(.plain)
+        .focused(focusBinding, equals: day.date)
+        // Non-color highlight: a ring/stroke that reads in both appearances and
+        // does not depend on the fill hue (AND-380).
+        .overlay {
+            if isSelected {
+                RoundedRectangle(cornerRadius: Radius.cell)
+                    .strokeBorder(AppearanceTextColors.primary, lineWidth: 1.5)
+                    .frame(width: size + 2, height: size + 2)
+            }
+        }
+        // Space/Return select via the Button; arrows move focus across the grid.
+        .onMoveCommand(perform: onMove)
+        .animation(MotionTokens.animation(MotionTokens.micro, reduceMotion: reduceMotion), value: isSelected)
+        .help(helpText)
+        .accessibilityLabel(helpText)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 
     private var intensity: Double {
@@ -731,15 +859,7 @@ private struct BalanceHeatmapCell: View {
     }
 
     private var helpText: String {
-        let amount: String
-        if mode == .netCashflow {
-            let displayAmount = SpendingHeatmap.displayCashflowAmount(day.value)
-            let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
-            amount = "\(prefix)\(Formatters.currency(abs(displayAmount), format: .full))"
-        } else {
-            amount = Formatters.currency(day.value, format: .full)
-        }
-        return "\(Formatters.displayTransactionDate(day.date)): \(amount) across \(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
+        SpendingHeatmap.cellLabel(for: day, mode: mode)
     }
 
     static func fillColor(intensity: Double, value: Double, mode: SpendingHeatmapMode) -> Color {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -76,6 +76,36 @@ public struct SpendingHeatmapEmptyPresentation: Sendable, Hashable {
     }
 }
 
+/// Presentation for the heatmap's focused-day caption (AND-380). The same
+/// composition backs the per-cell `.help()` / VoiceOver label and the inline
+/// caption shown when a cell is selected, so both stay in lockstep.
+public struct SpendingHeatmapFocusSummary: Sendable, Hashable {
+    /// Localized day, e.g. "Jan 1, 2026".
+    public let dateText: String
+    /// Signed amount in the active mode, e.g. "$120.00" or "+$300.00".
+    public let amountText: String
+    /// Transaction count phrase, e.g. "3 transactions" / "1 transaction".
+    public let transactionText: String
+    /// Compact caption shown inline next to the date.
+    public let captionText: String
+    /// Full sentence for the cell's accessibility label / pointer help.
+    public let accessibilityLabel: String
+
+    public init(
+        dateText: String,
+        amountText: String,
+        transactionText: String,
+        captionText: String,
+        accessibilityLabel: String
+    ) {
+        self.dateText = dateText
+        self.amountText = amountText
+        self.transactionText = transactionText
+        self.captionText = captionText
+        self.accessibilityLabel = accessibilityLabel
+    }
+}
+
 public struct SpendingHeatmapMonthMarker: Identifiable, Sendable, Hashable {
     public let id: String
     public let weekIndex: Int
@@ -222,6 +252,56 @@ public enum SpendingHeatmap {
     public static func cellIntensity(for day: SpendingHeatmapDay, peakValue: Double) -> Double {
         guard day.transactionCount > 0, peakValue > 0 else { return 0 }
         return min(max(abs(day.value) / peakValue, 0), 1)
+    }
+
+    /// Signed, mode-aware amount string for a single day (e.g. "$120.00" for
+    /// spend, "+$300.00" / "-$75.00" for net cashflow). Single source of truth
+    /// for both the cell label and the focused-day caption.
+    public static func amountText(for day: SpendingHeatmapDay, mode: SpendingHeatmapMode) -> String {
+        switch mode {
+        case .spending:
+            return Formatters.currency(day.value, format: .full)
+        case .netCashflow:
+            let displayAmount = displayCashflowAmount(day.value)
+            let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
+            return "\(prefix)\(Formatters.currency(abs(displayAmount), format: .full))"
+        }
+    }
+
+    /// Transaction-count phrase with correct pluralization.
+    public static func transactionText(for day: SpendingHeatmapDay) -> String {
+        "\(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
+    }
+
+    /// Full cell label / pointer-help sentence for a single day.
+    public static func cellLabel(for day: SpendingHeatmapDay, mode: SpendingHeatmapMode) -> String {
+        "\(Formatters.displayTransactionDate(day.date)): \(amountText(for: day, mode: mode)) across \(transactionText(for: day))"
+    }
+
+    /// Summary for the focused-day caption. Returns `nil` when nothing is
+    /// selected (the caller shows the range total instead) or when the selected
+    /// day key is not present in the layout (stale selection after a data or
+    /// range change). Reuses the layout's already-derived `days`.
+    public static func focusedDaySummary(
+        for selectedDay: String?,
+        in layout: SpendingHeatmapLayout
+    ) -> SpendingHeatmapFocusSummary? {
+        guard let selectedDay,
+              let day = layout.days.first(where: { $0.date == selectedDay })
+        else {
+            return nil
+        }
+
+        let dateText = Formatters.displayTransactionDate(day.date)
+        let amount = amountText(for: day, mode: layout.mode)
+        let count = transactionText(for: day)
+        return SpendingHeatmapFocusSummary(
+            dateText: dateText,
+            amountText: amount,
+            transactionText: count,
+            captionText: "\(dateText) · \(amount) · \(count)",
+            accessibilityLabel: cellLabel(for: day, mode: layout.mode)
+        )
     }
 
     public static func days(

--- a/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Heatmap Focused Day Summary")
+struct HeatmapFocusSummaryTests {
+    private func layout(mode: SpendingHeatmapMode) -> SpendingHeatmapLayout {
+        let days = [
+            SpendingHeatmapDay(date: "2026-01-01", value: 120, transactionCount: 3),
+            SpendingHeatmapDay(date: "2026-01-02", value: -300, transactionCount: 1),
+            SpendingHeatmapDay(date: "2026-01-03", value: 0, transactionCount: 0),
+        ]
+        var peak = 0.0
+        var total = 0.0
+        var active = 0
+        for day in days {
+            peak = max(peak, abs(day.value))
+            total += day.value
+            if day.transactionCount > 0 { active += 1 }
+        }
+        return SpendingHeatmapLayout(
+            mode: mode,
+            days: days,
+            peakValue: max(peak, 1),
+            totalValue: total,
+            activeDayCount: active,
+            weekColumns: [days.map(Optional.some)],
+            monthMarkers: []
+        )
+    }
+
+    @Test("Selected spend day summarizes that day's amount and count")
+    func selectedSpendDaySummary() {
+        let summary = SpendingHeatmap.focusedDaySummary(for: "2026-01-01", in: layout(mode: .spending))
+
+        #expect(summary != nil)
+        #expect(summary?.transactionText == "3 transactions")
+        #expect(summary?.captionText.contains("transaction") == true)
+        #expect(summary?.accessibilityLabel.contains("3 transactions") == true)
+    }
+
+    @Test("Selected net-cashflow day reports outflow direction")
+    func selectedNetCashflowDaySummary() {
+        // Stored value -300 is income (negative outflow). Stored value 120 is an
+        // outflow under net mode (displayCashflowAmount flips the sign).
+        let summary = SpendingHeatmap.focusedDaySummary(for: "2026-01-02", in: layout(mode: .netCashflow))
+
+        #expect(summary?.transactionText == "1 transaction")
+        // displayCashflowAmount(-300) == 300 → positive → "+" prefix.
+        #expect(summary?.amountText.hasPrefix("+") == true)
+    }
+
+    @Test("No selection yields no focused summary (caller shows the total)")
+    func noSelectionYieldsNil() {
+        #expect(SpendingHeatmap.focusedDaySummary(for: nil, in: layout(mode: .spending)) == nil)
+    }
+
+    @Test("Out-of-range selected date yields no focused summary")
+    func outOfRangeSelectionYieldsNil() {
+        #expect(SpendingHeatmap.focusedDaySummary(for: "1999-12-31", in: layout(mode: .spending)) == nil)
+    }
+
+    @Test("Zero-activity selected day still summarizes with a zero count")
+    func zeroActivityDaySummary() {
+        let summary = SpendingHeatmap.focusedDaySummary(for: "2026-01-03", in: layout(mode: .spending))
+
+        #expect(summary != nil)
+        #expect(summary?.transactionText == "0 transactions")
+    }
+
+    @Test("Caption composes 'date · amount · count'; spend amount carries no sign prefix")
+    func captionFormatAndUnsignedSpend() {
+        let summary = SpendingHeatmap.focusedDaySummary(for: "2026-01-01", in: layout(mode: .spending))
+
+        // Spend-mode amounts are unsigned (sign prefixes are net-cashflow only).
+        #expect(summary?.amountText.hasPrefix("+") == false)
+        #expect(summary?.amountText.hasPrefix("-") == false)
+
+        // Caption is exactly "{date} · {amount} · {count}" — assert the structure
+        // (not the locale-dependent date string) so it stays robust.
+        let parts = summary?.captionText.components(separatedBy: " · ")
+        #expect(parts?.count == 3)
+        #expect(parts?[1] == summary?.amountText)
+        #expect(parts?[2] == summary?.transactionText)
+    }
+}


### PR DESCRIPTION
Implements the **heatmap half** of [AND-380](https://linear.app/andeslab/issue/AND-380) (the trend-scrub half is descoped — see below).

- **Core (tested):** `SpendingHeatmap.focusedDaySummary(for:in:)` + `amountText`/`transactionText`/`cellLabel` — one source of truth for the cell label, `.help()`, and the focused-day caption. 6 unit tests (spend/net day, no-selection→total, out-of-range, zero-activity, caption format).
- **View:** `BalanceHeatmapCell` → focusable `Button` with a **non-color selection ring**; cells are **pointer + keyboard** selectable (`.focused` + `.onMoveCommand` arrow-grid navigation, Space/Return select); a **fixed-height focused-day caption** (date · amount · count) with **no layout shift**; stale-selection reconcile + focus→selection sync; **Reduce-Motion** gated; per-cell **VoiceOver** label + `.help()` fallback retained.
- **Descoped:** trend-scrub — the only trend chart is the shared 38pt `BalanceTrendChart` sparkline (reused in per-account row sparklines); adding `chartXSelection` there would leak/degrade. Recommend a dedicated expanded net-worth chart if scrub is wanted.

**Review (APPROVE-WITH-NITS) — applied:** documented the toggle-off no-op invariant + the window-coupling of the stale reconcile + the focus-implies-selection intent; added a caption-format test. Reviewer confirmed no must-fix: toggle-off works, `moveFocus` grid logic correct, `.onMoveCommand` fires only for the focused cell, 365-`.focused()` cost acceptable for a one-shot popover.

**Validation:** strict build clean (`-warnings-as-errors`); `swift test` **603 passed**; light/dark render verified (heatmap + caption render at-rest, no regression). Keyboard-nav/selection *behavior* validated by build + review; an interactive pass is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)