### PR TITLE
fix: rank server mode mismatch above item reconnect in readiness panel (#343)

### DIFF
--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -129,6 +129,20 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
             )
         }
 
+        // A sandbox/production mismatch outranks item reconnect guidance:
+        // reconnecting an institution cannot succeed against the wrong Plaid
+        // environment, so this must be checked before degraded item counts.
+        // Mirrors AttentionQueue, which ranks the mode-mismatch row above item
+        // reconnect rows for the same dashboard status domain.
+        if let modeMismatch = serverModeMismatchError(from: errorMessage) {
+            return DashboardStatusReadiness(
+                level: .blocked,
+                title: modeMismatch.title,
+                detail: modeMismatch.detail,
+                primaryAction: .checkServer
+            )
+        }
+
         if erroredItemCount > 0 {
             return DashboardStatusReadiness(
                 level: .blocked,
@@ -152,15 +166,6 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 ),
                 detail: "One or more institutions need an updated login before sync can stay healthy.",
                 primaryAction: .reconnect
-            )
-        }
-
-        if let modeMismatch = serverModeMismatchError(from: errorMessage) {
-            return DashboardStatusReadiness(
-                level: .blocked,
-                title: modeMismatch.title,
-                detail: modeMismatch.detail,
-                primaryAction: .checkServer
             )
         }
 

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -2373,6 +2373,30 @@ struct PlaidBarCoreTests {
         #expect(readiness.secondaryActions.isEmpty)
     }
 
+    @Test("Dashboard status readiness ranks server mode mismatch above item reconnect")
+    func dashboardStatusReadinessRanksModeMismatchAboveItemReconnect() {
+        // A mode mismatch with a concurrent degraded item must surface the
+        // server fix, not an item reconnect CTA — reconnecting cannot succeed
+        // against the wrong Plaid environment. Mirrors AttentionQueue ordering.
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 0,
+            needsLoginItemCount: 1,
+            erroredItemCount: 1,
+            isSyncStale: true,
+            lastSyncRelative: nil,
+            errorMessage: "Server is running in production, not sandbox. Restart with ./Scripts/run.sh --sandbox."
+        )
+
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Server mode mismatch")
+        #expect(readiness.primaryAction == .checkServer)
+    }
+
     @Test("Notification permission presentation gives denied state one settings action")
     func notificationPermissionPresentationDeniedAction() {
         let presentation = NotificationPermissionPresentation.evaluate(kind: .denied)


### PR DESCRIPTION
## Problem
`DashboardStatusReadiness.evaluate` checked degraded item counts (`erroredItemCount`/`needsLoginItemCount`) before parsing a server mode-mismatch error. With any stale/degraded item present, a sandbox↔production mismatch surfaced a **Reconnect** CTA on the primary readiness card while the compact `AttentionQueue` correctly surfaced **Server mode mismatch / Check Server** — the two status surfaces disagreed.

## Root Cause
The `serverModeMismatchError(from:)` branch sat below the two item-recovery branches in the evaluation order. `AttentionQueue.evaluate` already appends the mode-mismatch row before degraded item rows (with an explicit regression test), so only the readiness panel had the wrong priority.

## Solution
Move the `serverModeMismatchError` branch above the errored/needs-login item branches, mirroring `AttentionQueue` ordering. Reconnecting an institution cannot succeed against the wrong Plaid environment, so the server fix must outrank item recovery.

## Validation
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- `swift test` — 605 tests pass
- New regression: `dashboardStatusReadinessRanksModeMismatchAboveItemReconnect` asserts that with `erroredItemCount=1`, `needsLoginItemCount=1`, and a mode-mismatch `errorMessage`, the readiness title is `Server mode mismatch` and `primaryAction == .checkServer`.

## Risk
Low. Pure reordering of mutually-exclusive branches in a single pure function; only changes which verdict wins when a mode mismatch and a degraded item co-occur. Existing mode-mismatch and item-recovery tests still pass.

## Rollback
Revert the merge commit; no migrations, schema, or persisted-state changes.

Fixes #343