### PR TITLE
fix: scope transaction-cache deletion to app-generated files on reset (#341)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -296,22 +296,33 @@ public enum LocalDataStore {
     }
 
     private static func isTransactionCacheFilename(_ filename: String) -> Bool {
-        filename == transactionCacheFilename ||
-            (
-                filename.hasPrefix("transactions-") &&
-                    (filename.hasSuffix(".json") || filename.contains(".json.backup-"))
-            )
+        isScopedCacheFilename(filename, legacyFilename: transactionCacheFilename, prefix: "transactions")
     }
 
     private static func isAccountCacheFilename(_ filename: String) -> Bool {
+        isScopedCacheFilename(filename, legacyFilename: accountCacheFilename, prefix: "accounts")
+    }
+
+    /// Matches only VaultPeek-generated cache files: the legacy unscoped name
+    /// (e.g. `transactions.json`), an optional `.json.backup-...` variant of
+    /// either shape, or the scoped `{prefix}-{sandbox|production}-{16hex}.json`
+    /// form the cache writers emit. Unrelated user/export files such as
+    /// `transactions-2026.json` are intentionally not matched, so local data
+    /// reset preserves them.
+    private static func isScopedCacheFilename(
+        _ filename: String,
+        legacyFilename: String,
+        prefix: String
+    ) -> Bool {
         let cacheFilename = normalizedCacheFilename(filename)
-        if cacheFilename == accountCacheFilename { return true }
+        if cacheFilename == legacyFilename { return true }
 
         return [PlaidEnvironment.sandbox.rawValue, PlaidEnvironment.production.rawValue].contains { environment in
-            guard cacheFilename.hasPrefix("accounts-\(environment)-"),
+            let scopedPrefix = "\(prefix)-\(environment)-"
+            guard cacheFilename.hasPrefix(scopedPrefix),
                   cacheFilename.hasSuffix(".json") else { return false }
 
-            let hashStart = cacheFilename.index(cacheFilename.startIndex, offsetBy: "accounts-\(environment)-".count)
+            let hashStart = cacheFilename.index(cacheFilename.startIndex, offsetBy: scopedPrefix.count)
             let hashEnd = cacheFilename.index(cacheFilename.endIndex, offsetBy: -".json".count)
             let hash = cacheFilename[hashStart..<hashEnd]
             return hash.count == 16 && hash.allSatisfy(\.isHexDigit)

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3796,7 +3796,7 @@ struct PlaidBarCoreTests {
         let database = directory.appendingPathComponent("plaidbar.sqlite")
         let sandboxDatabase = directory.appendingPathComponent("plaidbar-sandbox.sqlite")
         let databaseWAL = directory.appendingPathComponent("plaidbar.sqlite-wal")
-        let transactionCache = directory.appendingPathComponent("transactions-sandbox-abc123.json")
+        let transactionCache = directory.appendingPathComponent("transactions-sandbox-0123456789abcdef.json")
         let pendingLinkSessions = directory.appendingPathComponent("pending-link-sessions.json")
         let pendingLinkSessionsBackup = directory.appendingPathComponent("pending-link-sessions.json.backup-20260604")
         let authToken = directory.appendingPathComponent("auth-token")
@@ -3831,7 +3831,7 @@ struct PlaidBarCoreTests {
             "plaidbar-sandbox.sqlite",
             "plaidbar.sqlite",
             "plaidbar.sqlite-wal",
-            "transactions-sandbox-abc123.json",
+            "transactions-sandbox-0123456789abcdef.json",
         ])
         #expect(result.preservedEntries == ["auth-token", "exports", "notes.txt", "server.conf"])
         #expect(result.keychainTokensCleared)

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -823,6 +823,36 @@ struct PlaidBarServerTests {
         #expect(result.preservedEntries.contains("accounts-2026.json"))
     }
 
+    @Test func transactionCacheIsRemovedButUnrelatedExportPreservedDuringLocalDataReset() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-transaction-cache-reset-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let context = TransactionCacheContext(
+            environment: .sandbox,
+            storagePath: directory.appendingPathComponent("plaidbar-sandbox.sqlite").path
+        )
+        // A user/export file that merely looks transaction-shaped must survive
+        // reset, just like the unrelated accounts-2026.json export above.
+        let unrelatedExport = directory.appendingPathComponent("transactions-2026.json")
+        try Data("user export".utf8).write(to: unrelatedExport)
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(id: "tx-old", accountId: "checking", amount: 12, date: "2026-01-01", name: "Coffee")],
+            to: directory,
+            context: context
+        )
+
+        let result = try LocalDataStore.resetLocalData(
+            at: directory,
+            resetKeychainTokens: false
+        )
+
+        #expect(try LocalDataStore.loadTransactions(from: directory, context: context).isEmpty)
+        #expect(FileManager.default.fileExists(atPath: unrelatedExport.path))
+        #expect(result.preservedEntries.contains("transactions-2026.json"))
+    }
+
     @Test func serverCanCopyLegacyDatabaseAfterWrongEnvironmentCreatedEmptyDatabase() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Problem
`LocalDataStore.resetLocalData` deleted **any** `transactions-*.json` file, so an unrelated user/export file (e.g. `transactions-2026.json`) was removed by Settings → General → Reset Local Data — despite reset otherwise preserving unknown files. Account-cache matching already enforced the exact `accounts-{env}-{16hex}.json` shape, so the two surfaces were inconsistent and the transaction path was data-lossy.

## Root Cause
`isTransactionCacheFilename` matched on a loose `transactions-` prefix + `.json` suffix, while the cache writer only ever emits `transactions-{sandbox|production}-{16hex}.json`.

## Solution
Factor the scoped-shape check shared by account and transaction caches into a single `isScopedCacheFilename(_:legacyFilename:prefix:)` helper. Transaction matching now requires the same strict scoped shape (or the legacy unscoped name / `.json.backup-` variant), mirroring account-cache behavior. Unrelated transaction-looking files are preserved.

## Validation
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- `swift test` — 606 tests pass
- New regression `transactionCacheIsRemovedButUnrelatedExportPreservedDuringLocalDataReset`: a real scoped cache is removed while `transactions-2026.json` is preserved (mirrors the existing `accounts-2026.json` test).
- Tightened the existing reset test fixture, which used a 6-char hash (`transactions-sandbox-abc123.json`) that never matched the real 16-hex writer output → now `transactions-sandbox-0123456789abcdef.json`.

## Risk
Low. Narrows deletion to genuinely app-generated files; the only behavior change is that non-conforming `transactions-*.json` names are now preserved (the intended fix). Refactor keeps account-cache matching byte-identical.

## Rollback
Revert the merge commit; no migrations or persisted-state changes.

Fixes #341