### PR TITLE
feat: surface detected recurring obligations in the Wealth Summary (AND-400)

### DIFF
--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -1,0 +1,175 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Read-only "Recurring" glance card for the Wealth Summary flyout (AND-400).
+///
+/// Surfaces the obligations `RecurringDetector` already finds — merchant,
+/// cadence, expected amount, next date — with attention badges (price up /
+/// missing) for the series that need a look. Self-hides when nothing is
+/// detected so it never adds an empty card to a dense popover.
+///
+/// Purely presentational: ordering, flagging, and the monthly total come from
+/// `RecurringObligationsPresentation` (PlaidBarCore). Mutating a series
+/// (confirm / rename / ignore) is the persistence-backed half of AND-400 and is
+/// intentionally not here.
+struct RecurringObligationsSection: View {
+    let presentation: RecurringObligationsPresentation
+
+    /// Keep the narrow column dense: show the most relevant few, summarize the
+    /// rest. Attention-first ordering means flagged items are never hidden
+    /// behind the "+N more" line as long as there are fewer than this many.
+    private let visibleLimit = 5
+
+    var body: some View {
+        if !presentation.isEmpty {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                header
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    ForEach(Array(presentation.items.prefix(visibleLimit))) { item in
+                        RecurringObligationRow(item: item)
+                    }
+                }
+
+                if presentation.count > visibleLimit {
+                    Text("+\(presentation.count - visibleLimit) more")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.raised)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(accessibilitySummary)
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Text("Recurring")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            Text("~\(Formatters.currency(presentation.estimatedMonthlyTotal, format: .compact))/mo")
+                .microText()
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var accessibilitySummary: String {
+        let countText = "\(presentation.count) recurring \(presentation.count == 1 ? "charge" : "charges")"
+        let total = Formatters.currency(presentation.estimatedMonthlyTotal, format: .full)
+        let attention = presentation.attentionCount > 0
+            ? " \(presentation.attentionCount) need attention."
+            : ""
+        return "\(countText), about \(total) per month.\(attention)"
+    }
+}
+
+private struct RecurringObligationRow: View {
+    let item: RecurringObligationsPresentation.Item
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Label {
+                    Text(item.merchantName)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                } icon: {
+                    Image(systemName: item.frequency.iconName)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                Text(Formatters.currency(item.expectedAmount, format: .compact))
+                    .font(.subheadline.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(AppearanceTextColors.primary)
+                    .lineLimit(1)
+            }
+
+            HStack(spacing: Spacing.xs) {
+                Text("\(item.frequency.displayName) · next \(Formatters.displayTransactionDate(item.nextExpectedDate))")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                ForEach(orderedFlags, id: \.self) { flag in
+                    FlagBadge(flag: flag)
+                }
+
+                if item.confidenceLevel == .low {
+                    LowConfidenceBadge()
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// Deterministic flag order so badges don't reshuffle between renders.
+    private var orderedFlags: [RecurringStreamFlag] {
+        RecurringStreamFlag.allCases.filter { item.flags.contains($0) }
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [
+            item.merchantName,
+            item.frequency.displayName,
+            "expected \(Formatters.currency(item.expectedAmount, format: .full))",
+            "next \(Formatters.displayTransactionDate(item.nextExpectedDate))",
+        ]
+        parts.append(contentsOf: orderedFlags.map(\.accessibilityDescription))
+        if item.confidenceLevel == .low { parts.append("low confidence") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+/// Attention badge — text + SF Symbol, never color alone (ACCESSIBILITY.md).
+private struct FlagBadge: View {
+    let flag: RecurringStreamFlag
+
+    var body: some View {
+        Label {
+            Text(flag.label)
+        } icon: {
+            Image(systemName: flag.iconName)
+        }
+        .font(.caption2.weight(.semibold))
+        // Both flags are attention states; the warm tint is a redundant cue that
+        // draws the eye (text + symbol already distinguish which flag it is, so
+        // the badge never reads through color alone — ACCESSIBILITY.md). Tinting
+        // one flag and not the other would make color the type discriminator.
+        .foregroundStyle(SemanticColors.warning)
+        .padding(.horizontal, Spacing.xs)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
+        .lineLimit(1)
+    }
+}
+
+private struct LowConfidenceBadge: View {
+    var body: some View {
+        Label {
+            Text(RecurringConfidenceLevel.low.label)
+        } icon: {
+            Image(systemName: RecurringConfidenceLevel.low.iconName)
+        }
+        .font(.caption2.weight(.medium))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, Spacing.xs)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
+        .lineLimit(1)
+    }
+}

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -61,6 +61,19 @@ struct WealthSummaryFlyout: View {
                     .loadingRedaction(appState.loadState(for: .summaryCards))
                     .scrollEdgeDepth(reduceMotion: reduceMotion)
 
+                    // Read-only recurring obligations (AND-400). Built inline
+                    // from the already-cached detector output, mirroring how the
+                    // safe-to-spend card is composed above; self-hides when no
+                    // recurring series are detected.
+                    RecurringObligationsSection(
+                        presentation: RecurringObligationsPresentation.make(
+                            from: appState.recurringTransactions,
+                            asOf: Date()
+                        )
+                    )
+                    .loadingRedaction(appState.loadState(for: .transactions))
+                    .scrollEdgeDepth(reduceMotion: reduceMotion)
+
                     WealthCreditSection(
                         summary: presentation.creditUtilization,
                         threshold: appState.creditUtilizationThreshold

--- a/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Display-ready view of detected recurring obligations (AND-400).
+///
+/// Pure presentation logic: takes the `[RecurringTransaction]` already produced
+/// by `RecurringDetector` and turns it into a sorted, annotated list plus the
+/// aggregates a glance surface needs (estimated monthly total, attention count).
+/// All formatting stays in the view; this type owns ordering, flagging, and
+/// derived numbers so they are testable and identical across surfaces.
+///
+/// This is the *read-only* half of AND-400. User mutation (confirm / rename /
+/// ignore / correct a detected series) and the local persistence it requires
+/// are deliberately out of scope here — that half shares the budgeting-suite
+/// persistence decision tracked across AND-399/400/402/403.
+public struct RecurringObligationsPresentation: Sendable, Hashable {
+    public struct Item: Sendable, Hashable, Identifiable {
+        public let id: String
+        public let merchantName: String
+        public let frequency: RecurringFrequency
+        /// Typical charge amount for one occurrence (the detector's average).
+        public let expectedAmount: Double
+        /// `expectedAmount` normalized to a monthly-equivalent cost.
+        public let monthlyEquivalent: Double
+        public let nextExpectedDate: String
+        public let lastDate: String
+        public let confidence: Double
+        public let confidenceLevel: RecurringConfidenceLevel
+        public let flags: Set<RecurringStreamFlag>
+        public let category: SpendingCategory?
+
+        public init(
+            id: String,
+            merchantName: String,
+            frequency: RecurringFrequency,
+            expectedAmount: Double,
+            monthlyEquivalent: Double,
+            nextExpectedDate: String,
+            lastDate: String,
+            confidence: Double,
+            confidenceLevel: RecurringConfidenceLevel,
+            flags: Set<RecurringStreamFlag>,
+            category: SpendingCategory?
+        ) {
+            self.id = id
+            self.merchantName = merchantName
+            self.frequency = frequency
+            self.expectedAmount = expectedAmount
+            self.monthlyEquivalent = monthlyEquivalent
+            self.nextExpectedDate = nextExpectedDate
+            self.lastDate = lastDate
+            self.confidence = confidence
+            self.confidenceLevel = confidenceLevel
+            self.flags = flags
+            self.category = category
+        }
+
+        /// True when the series carries any flag the user should look at.
+        public var needsAttention: Bool { !flags.isEmpty }
+        public var hasPriceIncrease: Bool { flags.contains(.priceIncrease) }
+        public var isStale: Bool { flags.contains(.stale) }
+    }
+
+    /// Detected obligations, attention-first then soonest-due (see `make`).
+    public let items: [Item]
+    /// Monthly-equivalent cost of the *active* (non-stale) obligations — matches
+    /// `RecurringSummary.estimatedMonthlyTotal(asOf:)` so the section header and
+    /// any safe-to-spend math agree.
+    public let estimatedMonthlyTotal: Double
+    /// Count of obligations carrying at least one flag.
+    public let attentionCount: Int
+
+    public init(items: [Item], estimatedMonthlyTotal: Double, attentionCount: Int) {
+        self.items = items
+        self.estimatedMonthlyTotal = estimatedMonthlyTotal
+        self.attentionCount = attentionCount
+    }
+
+    public var isEmpty: Bool { items.isEmpty }
+    public var count: Int { items.count }
+
+    /// Build the presentation from detected recurring series.
+    ///
+    /// Ordering: items needing attention first (so price increases / missing
+    /// charges surface at the top), then soonest `nextExpectedDate`, then
+    /// merchant name for a stable tiebreak. ISO `yyyy-MM-dd` strings sort
+    /// lexicographically, so a plain string compare is the date order.
+    public static func make(
+        from recurring: [RecurringTransaction],
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> RecurringObligationsPresentation {
+        let items = recurring.map { stream -> Item in
+            Item(
+                id: stream.id,
+                merchantName: stream.merchantName,
+                frequency: stream.frequency,
+                expectedAmount: stream.averageAmount,
+                monthlyEquivalent: stream.averageAmount * stream.frequency.monthlyMultiplier,
+                nextExpectedDate: stream.nextExpectedDate,
+                lastDate: stream.lastDate,
+                confidence: stream.confidence,
+                confidenceLevel: RecurringConfidenceLevel(confidence: stream.confidence),
+                flags: stream.flags(asOf: date, calendar: calendar),
+                category: stream.category
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.needsAttention != rhs.needsAttention {
+                return lhs.needsAttention && !rhs.needsAttention
+            }
+            if lhs.nextExpectedDate != rhs.nextExpectedDate {
+                return lhs.nextExpectedDate < rhs.nextExpectedDate
+            }
+            return lhs.merchantName < rhs.merchantName
+        }
+
+        return RecurringObligationsPresentation(
+            items: items,
+            estimatedMonthlyTotal: RecurringSummary.estimatedMonthlyTotal(
+                from: recurring,
+                asOf: date,
+                calendar: calendar
+            ),
+            attentionCount: items.reduce(0) { $0 + ($1.needsAttention ? 1 : 0) }
+        )
+    }
+}
+
+/// Discrete confidence band for display — text + symbol, never color alone
+/// (ACCESSIBILITY.md).
+public enum RecurringConfidenceLevel: String, Sendable, Hashable, CaseIterable {
+    case high
+    case medium
+    case low
+
+    /// `medium`/`low` boundary. A standalone constant (not reusing
+    /// `RecurringTransaction.priceIncreaseConfidenceThreshold`, which governs an
+    /// unrelated decision) so display banding can move without dragging the
+    /// price-increase gate with it.
+    static let mediumConfidenceThreshold = 0.6
+    static let highConfidenceThreshold = 0.8
+
+    public init(confidence: Double) {
+        if confidence >= Self.highConfidenceThreshold {
+            self = .high
+        } else if confidence >= Self.mediumConfidenceThreshold {
+            self = .medium
+        } else {
+            self = .low
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .high: "Confident"
+        case .medium: "Likely"
+        case .low: "Low confidence"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .high: "checkmark.seal"
+        case .medium: "questionmark.circle"
+        case .low: "exclamationmark.circle"
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/RecurringTransaction.swift
+++ b/Sources/PlaidBarCore/Models/RecurringTransaction.swift
@@ -113,6 +113,30 @@ public struct RecurringPriceIncrease: Sendable, Hashable {
 public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
     case priceIncrease
     case stale
+
+    /// Short badge text. Paired with `iconName` so the flag never reads through
+    /// color alone (ACCESSIBILITY.md).
+    public var label: String {
+        switch self {
+        case .priceIncrease: "Price up"
+        case .stale: "Missing"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .priceIncrease: "arrow.up.right"
+        case .stale: "calendar.badge.exclamationmark"
+        }
+    }
+
+    /// Longer phrasing for VoiceOver / accessibility labels.
+    public var accessibilityDescription: String {
+        switch self {
+        case .priceIncrease: "price increased"
+        case .stale: "expected charge missing"
+        }
+    }
 }
 
 public enum RecurringFrequency: String, Codable, Sendable, CaseIterable, Hashable {

--- a/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Recurring Obligations Presentation")
+struct RecurringObligationsPresentationTests {
+    private static let asOf = Formatters.parseTransactionDate("2026-05-01")!
+
+    private func recurring(
+        merchantName: String,
+        frequency: RecurringFrequency = .monthly,
+        averageAmount: Double = 10,
+        latestAmount: Double? = nil,
+        trailingAverageAmount: Double? = nil,
+        lastDate: String = "2026-04-15",
+        nextExpectedDate: String = "2026-05-15",
+        confidence: Double = 0.9
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchantName,
+            frequency: frequency,
+            averageAmount: averageAmount,
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            lastDate: lastDate,
+            nextExpectedDate: nextExpectedDate,
+            category: .subscriptions,
+            transactionCount: 3,
+            confidence: confidence
+        )
+    }
+
+    @Test("Empty input yields an empty, zeroed presentation")
+    func emptyInput() {
+        let presentation = RecurringObligationsPresentation.make(from: [], asOf: Self.asOf)
+
+        #expect(presentation.isEmpty)
+        #expect(presentation.count == 0)
+        #expect(presentation.estimatedMonthlyTotal == 0)
+        #expect(presentation.attentionCount == 0)
+    }
+
+    @Test("Flagged obligations sort ahead of clean ones, then by soonest due")
+    func attentionFirstThenSoonestDue() {
+        let clean = recurring(merchantName: "Spotify", nextExpectedDate: "2026-05-10")
+        let cleanLater = recurring(merchantName: "iCloud", nextExpectedDate: "2026-05-20")
+        // Price increase → flagged, but due last; must still sort first.
+        let flagged = recurring(
+            merchantName: "Gym",
+            latestAmount: 22,
+            trailingAverageAmount: 20,
+            nextExpectedDate: "2026-05-28",
+            confidence: 0.95
+        )
+
+        let presentation = RecurringObligationsPresentation.make(
+            from: [clean, cleanLater, flagged],
+            asOf: Self.asOf
+        )
+
+        #expect(presentation.items.map(\.merchantName) == ["Gym", "Spotify", "iCloud"])
+        #expect(presentation.items.first?.hasPriceIncrease == true)
+    }
+
+    @Test("Attention count includes price-increase and missing (stale) streams")
+    func attentionCountCountsFlaggedStreams() {
+        let priceUp = recurring(
+            merchantName: "Gym",
+            latestAmount: 22,
+            trailingAverageAmount: 20,
+            confidence: 0.95
+        )
+        // lastDate far in the past → stale/missing relative to asOf 2026-05-01.
+        let missing = recurring(merchantName: "Dormant", lastDate: "2026-01-01")
+        let healthy = recurring(merchantName: "Spotify")
+
+        let presentation = RecurringObligationsPresentation.make(
+            from: [priceUp, missing, healthy],
+            asOf: Self.asOf
+        )
+
+        #expect(presentation.attentionCount == 2)
+        #expect(presentation.items.first { $0.merchantName == "Dormant" }?.isStale == true)
+        #expect(presentation.items.first { $0.merchantName == "Spotify" }?.needsAttention == false)
+    }
+
+    @Test("Estimated monthly total excludes stale streams and matches RecurringSummary")
+    func estimatedMonthlyTotalExcludesStale() {
+        let active = recurring(merchantName: "Active", averageAmount: 30, lastDate: "2026-04-20")
+        let stale = recurring(merchantName: "Dormant", averageAmount: 50, lastDate: "2026-01-01")
+
+        let presentation = RecurringObligationsPresentation.make(from: [active, stale], asOf: Self.asOf)
+
+        // Only the active monthly stream counts toward the total.
+        #expect(presentation.estimatedMonthlyTotal == 30)
+        #expect(
+            presentation.estimatedMonthlyTotal
+                == RecurringSummary.estimatedMonthlyTotal(from: [active, stale], asOf: Self.asOf)
+        )
+    }
+
+    @Test("Monthly-equivalent normalizes weekly and annual cadences")
+    func monthlyEquivalentNormalizesCadence() {
+        let weekly = recurring(merchantName: "Coffee", frequency: .weekly, averageAmount: 5)
+        let annual = recurring(merchantName: "Domain", frequency: .annual, averageAmount: 120)
+
+        let presentation = RecurringObligationsPresentation.make(from: [weekly, annual], asOf: Self.asOf)
+
+        let coffee = try! #require(presentation.items.first { $0.merchantName == "Coffee" })
+        let domain = try! #require(presentation.items.first { $0.merchantName == "Domain" })
+
+        #expect(abs(coffee.monthlyEquivalent - 5 * (52.0 / 12.0)) < 0.001)
+        #expect(abs(domain.monthlyEquivalent - 10) < 0.001) // 120 / 12
+    }
+
+    @Test("Confidence bands map to high/medium/low at the documented thresholds")
+    func confidenceLevelThresholds() {
+        #expect(RecurringConfidenceLevel(confidence: 0.85) == .high)
+        #expect(RecurringConfidenceLevel(confidence: 0.80) == .high)
+        #expect(RecurringConfidenceLevel(confidence: 0.70) == .medium)
+        #expect(RecurringConfidenceLevel(confidence: 0.60) == .medium)
+        #expect(RecurringConfidenceLevel(confidence: 0.59) == .low)
+    }
+
+    @Test("Stream flags expose label + icon so they never read through color alone")
+    func flagDisplayMetadata() {
+        #expect(RecurringStreamFlag.priceIncrease.label == "Price up")
+        #expect(!RecurringStreamFlag.priceIncrease.iconName.isEmpty)
+        #expect(RecurringStreamFlag.stale.label == "Missing")
+        #expect(!RecurringStreamFlag.stale.iconName.isEmpty)
+        #expect(RecurringStreamFlag.priceIncrease.accessibilityDescription == "price increased")
+    }
+}


### PR DESCRIPTION
Implements the **read-only presentation half** of [AND-400](https://linear.app/andeslab/issue/AND-400). The detection engine (`RecurringDetector` / `RecurringTransaction` / `RecurringSummary`) already existed and feeds safe-to-spend — the only recurring surfacing was the aggregate monthly total. This adds the per-obligation glance card the issue asks for.

### Core (tested — `PlaidBarCore`)
- `RecurringObligationsPresentation.make(from:asOf:)` — turns the already-cached detector output into a display-ready list: **attention-first then soonest-due** ordering, `estimatedMonthlyTotal` (delegated to `RecurringSummary` so the header agrees with safe-to-spend), `attentionCount`, and a `RecurringConfidenceLevel` band.
- `RecurringStreamFlag` gains `label`/`iconName`/`accessibilityDescription` so *price-up* / *missing* read as **text + symbol, never color alone**.
- **7 unit tests**: empty input, flagged-first sort, attention count, stale exclusion from total, cadence normalization, confidence thresholds, flag metadata.

### View
- `RecurringObligationsSection` — a read-only glass card in the left Wealth Summary rail (after Safe to Spend), built inline from `appState.recurringTransactions` **exactly like `SafeToSpendCard`**. Rows: merchant · cadence · next date · expected amount + text+symbol attention/confidence badges. **Self-hides** when nothing is detected; caps visible rows with a `+N more` line. Per-row + section VoiceOver labels.

### Deferred (persistence-backed half)
User mutation of a series (confirm / rename / ignore / correct) needs local review-state storage — the **same budgeting-suite persistence decision shared across AND-399/402/403**. Display is derived each sync, so it needs none.

### Review (no must-fix) — applied
- Unified attention-badge tint (was color-distinguishing the two flag types) → both warm-tinted; text+symbol differentiate.
- Decoupled the confidence band threshold from the unrelated `priceIncreaseConfidenceThreshold` → standalone documented constants.
- `Array(prefix(...))` for explicitness.
- `asOf: Date()` inline is intentionally identical to the sibling `SafeToSpendCard` (consistency; cross-midnight staleness is a pre-existing shared concern, not introduced here).

### Validation
Strict-concurrency build clean (`-warnings-as-errors`); `swift test` **610 pass** (+7); **light + dark** headless render confirms the section renders legibly (merchant/cadence/amount/badges) with **no layout regression**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)