### PR TITLE
fix: demo Connect Bank continues into Plaid Link on first click (#340)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -902,7 +902,11 @@ final class AppState {
             // synthetic 60-day series. Restore persisted real history when it
             // exists so the first real snapshot cannot persist a demo trend.
             loadPersistedBalanceHistory()
-            return
+            // Fall through into the real add-account flow: the demo readiness
+            // card advertises "Connect Bank", so the first click must continue
+            // into the server check + Plaid Link handoff (or surface the precise
+            // server/credential blocker) instead of stranding the user in setup
+            // and requiring a second click.
         }
 
         isLoading = true


### PR DESCRIPTION
## Problem
Clicking the demo dashboard's "Connect Bank" CTA exited demo mode but returned before checking the server or creating a Plaid Link token. The user landed in a real-mode empty/offline setup state and had to click connect a second time to actually open Plaid Link — the app looked stalled and the demo→real conversion path was broken.

## Root Cause
`AppState.addAccount()` entered the `if isDemoMode` branch, cleared demo state, and `return`ed. The server-connectivity check and `serverClient.createLinkToken()` call sit after that early return, so they could never run on the first click from demo mode.

## Solution
Drop the early `return` so demo teardown falls through into the existing real add-account flow. The first click now leaves demo mode and continues to the server check + Plaid Link handoff, or surfaces the precise server/credential blocker (`Start the VaultPeek companion server…` / `Plaid credentials are not configured…`) when the real setup is not ready.

## Validation
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- `swift test` — 613 tests pass
- No dedicated regression test: `AppState` constructs `serverClient` as a hardcoded private `ServerClient()` with no injection seam, and `addAccount()` drives `NSWorkspace.open`, so a behavioral test of the first-click path would require a DI refactor beyond this fix's scope. The change is the removal of a premature `return`; the subsequent real-flow guards are already covered.

## Risk
Low. After demo teardown `serverConnected` is reset to `false`, so the fall-through re-runs `checkServerConnection()` and the existing readiness guards exactly as a cold real-mode `addAccount()` would. No behavior change for the non-demo path.

## Rollback
Revert the merge commit; no migrations or persisted-state changes.

Fixes #340