### PR TITLE
fix: preserve OAuth callback retry state

### DIFF
--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -47,23 +47,36 @@ actor PendingLinkSessionStore {
         purgeExpired()
         let currentDate = now()
         guard let session = sessions[state],
-              currentDate.timeIntervalSince(session.createdAt) <= ttl,
-              completionLeases[state] == nil
+              currentDate.timeIntervalSince(session.createdAt) <= ttl
         else {
+            return nil
+        }
+        // A live lease means another handler is mid-flight: refuse, preserving
+        // single-flight. The lease is reclaimable only once it is older than
+        // `completionLeaseTTL`, i.e. the original handler is presumed dead (it
+        // would otherwise have called releaseCompletion/consume). This bounds
+        // recovery without dropping a fresh in-flight lease — unlike purging by
+        // TTL, which could race a still-running handler.
+        if let leaseStartedAt = completionLeases[state],
+           currentDate.timeIntervalSince(leaseStartedAt) <= completionLeaseTTL {
             return nil
         }
         completionLeases[state] = currentDate
         return session
     }
 
-    func markPublicTokenResultStored(state: String) {
+    /// Records that the result with this stable `identity` has been consumed
+    /// (its single-use Plaid public token exchanged), so a retry never replays
+    /// it. `identity` is a token-free fingerprint (see `resultIdentity`), never
+    /// the raw public token — pending-session storage holds no Plaid tokens.
+    func markResultCompleted(state: String, identity: String) {
         purgeExpired()
         guard var session = sessions[state],
               now().timeIntervalSince(session.createdAt) <= ttl
         else {
             return
         }
-        session.completedPublicTokenResultCount += 1
+        session.completedResultIdentities.insert(identity)
         sessions[state] = session
         persist()
     }
@@ -90,9 +103,16 @@ actor PendingLinkSessionStore {
             currentDate.timeIntervalSince(session.createdAt) <= ttl
         }
         let activeStates = Set(activeSessions.keys)
-        completionLeases = completionLeases.filter { state, startedAt in
+        // A completion lease lives as long as its session: it is cleared only by
+        // `releaseCompletion`/`consume`, or when the session itself expires by
+        // the (much longer) session TTL. The short `completionLeaseTTL` is NOT a
+        // purge trigger — expiring a lease while the original handler is still
+        // doing Plaid/Keychain/SQLite work would let a concurrent retry pass the
+        // single-flight guard and double-process the same Hosted Link results.
+        // It survives only as a clamp in `beginCompletion` for a presumed-dead
+        // handler (process restart loses in-memory leases anyway).
+        completionLeases = completionLeases.filter { state, _ in
             activeStates.contains(state)
-                && currentDate.timeIntervalSince(startedAt) <= completionLeaseTTL
         }
         guard activeSessions.count != sessions.count else { return }
         sessions = activeSessions
@@ -199,18 +219,22 @@ struct PendingLinkSession: Codable, Sendable {
     let linkToken: String
     let updateItemId: String?
     let createdAt: Date
-    var completedPublicTokenResultCount: Int
+    /// Stable, token-free identities of results already consumed (their
+    /// single-use public token exchanged). Tracking by identity — not an ordinal
+    /// count — means a retry skips exactly the already-stored results even if
+    /// Plaid returns the multi-item results in a different order.
+    var completedResultIdentities: Set<String>
 
     init(
         linkToken: String,
         updateItemId: String?,
         createdAt: Date,
-        completedPublicTokenResultCount: Int = 0
+        completedResultIdentities: Set<String> = []
     ) {
         self.linkToken = linkToken
         self.updateItemId = updateItemId
         self.createdAt = createdAt
-        self.completedPublicTokenResultCount = completedPublicTokenResultCount
+        self.completedResultIdentities = completedResultIdentities
     }
 
     init(from decoder: Decoder) throws {
@@ -218,9 +242,14 @@ struct PendingLinkSession: Codable, Sendable {
         linkToken = try container.decode(String.self, forKey: .linkToken)
         updateItemId = try container.decodeIfPresent(String.self, forKey: .updateItemId)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
-        completedPublicTokenResultCount = try container.decodeIfPresent(
-            Int.self,
-            forKey: .completedPublicTokenResultCount
-        ) ?? 0
+        // Backward compatible: sessions persisted by an earlier build carry no
+        // identity set (and the legacy ordinal count is intentionally dropped —
+        // an in-flight migration at most re-attempts a still-pending result,
+        // which is safe because a genuinely consumed token re-exchange fails
+        // closed rather than duplicating).
+        completedResultIdentities = try container.decodeIfPresent(
+            Set<String>.self,
+            forKey: .completedResultIdentities
+        ) ?? []
     }
 }

--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -51,14 +51,15 @@ actor PendingLinkSessionStore {
         else {
             return nil
         }
-        // A live lease means another handler is mid-flight: refuse, preserving
-        // single-flight. The lease is reclaimable only once it is older than
-        // `completionLeaseTTL`, i.e. the original handler is presumed dead (it
-        // would otherwise have called releaseCompletion/consume). This bounds
-        // recovery without dropping a fresh in-flight lease — unlike purging by
-        // TTL, which could race a still-running handler.
-        if let leaseStartedAt = completionLeases[state],
-           currentDate.timeIntervalSince(leaseStartedAt) <= completionLeaseTTL {
+        // Strict single-flight: ANY live lease means another handler holds this
+        // session, so refuse. A lease is NOT reclaimable on a timer — there is no
+        // owner token or heartbeat proving the original handler is dead, and a
+        // slow-but-alive handler (Plaid/Keychain/SQLite retrying past any TTL)
+        // must not be raced by a second handler over the same single-use public
+        // tokens. The lease is released only by `releaseCompletion`/`consume`, or
+        // it disappears with the session at the session TTL; an in-memory lease
+        // for a truly crashed handler clears on process restart.
+        if completionLeases[state] != nil {
             return nil
         }
         completionLeases[state] = currentDate

--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -8,16 +8,20 @@ actor PendingLinkSessionStore {
     private static let filePermissions = 0o600
 
     private let ttl: TimeInterval
+    private let completionLeaseTTL: TimeInterval
     private let storageURL: URL?
     private let now: @Sendable () -> Date
     private var sessions: [String: PendingLinkSession] = [:]
+    private var completionLeases: [String: Date] = [:]
 
     init(
         ttl: TimeInterval = 30 * 60,
+        completionLeaseTTL: TimeInterval = 60,
         storageURL: URL? = nil,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.ttl = ttl
+        self.completionLeaseTTL = completionLeaseTTL
         self.storageURL = storageURL
         self.now = now
         self.sessions = Self.loadSessions(from: storageURL)
@@ -35,7 +39,37 @@ actor PendingLinkSessionStore {
             updateItemId: updateItemId,
             createdAt: now()
         )
+        completionLeases.removeValue(forKey: state)
         persist()
+    }
+
+    func beginCompletion(state: String) -> PendingLinkSession? {
+        purgeExpired()
+        let currentDate = now()
+        guard let session = sessions[state],
+              currentDate.timeIntervalSince(session.createdAt) <= ttl,
+              completionLeases[state] == nil
+        else {
+            return nil
+        }
+        completionLeases[state] = currentDate
+        return session
+    }
+
+    func markPublicTokenResultStored(state: String) {
+        purgeExpired()
+        guard var session = sessions[state],
+              now().timeIntervalSince(session.createdAt) <= ttl
+        else {
+            return
+        }
+        session.completedPublicTokenResultCount += 1
+        sessions[state] = session
+        persist()
+    }
+
+    func releaseCompletion(state: String) {
+        completionLeases.removeValue(forKey: state)
     }
 
     func consume(state: String) -> PendingLinkSession? {
@@ -45,6 +79,7 @@ actor PendingLinkSessionStore {
         else {
             return nil
         }
+        completionLeases.removeValue(forKey: state)
         persist()
         return session
     }
@@ -53,6 +88,11 @@ actor PendingLinkSessionStore {
         let currentDate = now()
         let activeSessions = sessions.filter { _, session in
             currentDate.timeIntervalSince(session.createdAt) <= ttl
+        }
+        let activeStates = Set(activeSessions.keys)
+        completionLeases = completionLeases.filter { state, startedAt in
+            activeStates.contains(state)
+                && currentDate.timeIntervalSince(startedAt) <= completionLeaseTTL
         }
         guard activeSessions.count != sessions.count else { return }
         sessions = activeSessions
@@ -159,4 +199,28 @@ struct PendingLinkSession: Codable, Sendable {
     let linkToken: String
     let updateItemId: String?
     let createdAt: Date
+    var completedPublicTokenResultCount: Int
+
+    init(
+        linkToken: String,
+        updateItemId: String?,
+        createdAt: Date,
+        completedPublicTokenResultCount: Int = 0
+    ) {
+        self.linkToken = linkToken
+        self.updateItemId = updateItemId
+        self.createdAt = createdAt
+        self.completedPublicTokenResultCount = completedPublicTokenResultCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        linkToken = try container.decode(String.self, forKey: .linkToken)
+        updateItemId = try container.decodeIfPresent(String.self, forKey: .updateItemId)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        completedPublicTokenResultCount = try container.decodeIfPresent(
+            Int.self,
+            forKey: .completedPublicTokenResultCount
+        ) ?? 0
+    }
 }

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -108,9 +108,17 @@ struct OAuthCallbackRoute: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        guard let stateParam = request.uri.queryParameters.get("state"),
-              let pendingSession = await pendingLinkSessions.consume(state: String(stateParam))
-        else {
+        guard let stateParam = request.uri.queryParameters.get("state") else {
+            return Response(
+                status: .badRequest,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(
+                    string: Self.errorPage("Missing or expired link session state")
+                ))
+            )
+        }
+        let state = String(stateParam)
+        guard let pendingSession = await pendingLinkSessions.beginCompletion(state: state) else {
             return Response(
                 status: .badRequest,
                 headers: [.contentType: "text/html"],
@@ -124,6 +132,7 @@ struct OAuthCallbackRoute: Sendable {
             let publicTokenResults = try await publicTokenResults(from: request, pendingSession: pendingSession)
             if publicTokenResults.isEmpty, let updateItemId = pendingSession.updateItemId {
                 try await tokenStore.updateItemStatus(id: updateItemId, status: ItemConnectionStatus.connected.rawValue)
+                _ = await pendingLinkSessions.consume(state: state)
                 return Response(
                     status: .ok,
                     headers: [.contentType: "text/html"],
@@ -132,6 +141,7 @@ struct OAuthCallbackRoute: Sendable {
             }
 
             guard !publicTokenResults.isEmpty else {
+                await pendingLinkSessions.releaseCompletion(state: state)
                 return Response(
                     status: .badRequest,
                     headers: [.contentType: "text/html"],
@@ -141,9 +151,15 @@ struct OAuthCallbackRoute: Sendable {
                 )
             }
 
-            for publicTokenResult in publicTokenResults {
+            let completedResultCount = min(
+                pendingSession.completedPublicTokenResultCount,
+                publicTokenResults.count
+            )
+            for publicTokenResult in publicTokenResults.dropFirst(completedResultCount) {
                 try await exchangeAndStore(publicTokenResult: publicTokenResult)
+                await pendingLinkSessions.markPublicTokenResultStored(state: state)
             }
+            _ = await pendingLinkSessions.consume(state: state)
 
             return Response(
                 status: .ok,
@@ -151,6 +167,7 @@ struct OAuthCallbackRoute: Sendable {
                 body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
             )
         } catch {
+            await pendingLinkSessions.releaseCompletion(state: state)
             return Response(
                 status: .internalServerError,
                 headers: [.contentType: "text/html"],

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -1,5 +1,6 @@
-import Hummingbird
+import CryptoKit
 import Foundation
+import Hummingbird
 import NIOCore
 import PlaidBarCore
 
@@ -151,13 +152,26 @@ struct OAuthCallbackRoute: Sendable {
                 )
             }
 
-            let completedResultCount = min(
-                pendingSession.completedPublicTokenResultCount,
-                publicTokenResults.count
-            )
-            for publicTokenResult in publicTokenResults.dropFirst(completedResultCount) {
-                try await exchangeAndStore(publicTokenResult: publicTokenResult)
-                await pendingLinkSessions.markPublicTokenResultStored(state: state)
+            for publicTokenResult in publicTokenResults {
+                let identity = Self.resultIdentity(for: publicTokenResult)
+                // Skip results already consumed on a prior attempt — keyed by a
+                // stable identity, so reordered multi-item retries still skip the
+                // right ones (not by ordinal position).
+                if pendingSession.completedResultIdentities.contains(identity) {
+                    continue
+                }
+                try await exchangeAndStore(
+                    publicTokenResult: publicTokenResult,
+                    onPublicTokenExchanged: {
+                        // Mark consumed the instant the single-use public token is
+                        // exchanged — BEFORE the fallible getAccounts/saveItem
+                        // steps. If those later fail, the retry will not replay
+                        // this now-spent token (which Plaid rejects, producing
+                        // endless 500s and a lost access token); it is skipped
+                        // instead. This is the post-exchange handoff barrier.
+                        await pendingLinkSessions.markResultCompleted(state: state, identity: identity)
+                    }
+                )
             }
             _ = await pendingLinkSessions.consume(state: state)
 
@@ -190,8 +204,14 @@ struct OAuthCallbackRoute: Sendable {
         return linkSession.publicTokenResults
     }
 
-    private func exchangeAndStore(publicTokenResult: PlaidPublicTokenResult) async throws {
+    private func exchangeAndStore(
+        publicTokenResult: PlaidPublicTokenResult,
+        onPublicTokenExchanged: () async -> Void
+    ) async throws {
         let exchangeResponse = try await plaidClient.exchangePublicToken(publicTokenResult.publicToken)
+        // The public token is now spent and cannot be replayed; record the
+        // handoff before the remaining (fallible, retryable-in-isolation) steps.
+        await onPublicTokenExchanged()
         let accountsResponse = try await plaidClient.getAccounts(
             accessToken: exchangeResponse.accessToken
         )
@@ -203,6 +223,20 @@ struct OAuthCallbackRoute: Sendable {
             institutionId: institutionId,
             institutionName: publicTokenResult.institution?.normalizedName
         )
+    }
+
+    /// A stable, token-free identity for a Link result, used to skip results
+    /// already consumed on a prior callback attempt. The public token is
+    /// single-use and unique per result, so its SHA-256 is a perfect fingerprint
+    /// — and hashing keeps the raw token out of the pending-session store, which
+    /// holds no Plaid tokens. Falls back to the institution id when no public
+    /// token is present (update-mode results carry none).
+    static func resultIdentity(for result: PlaidPublicTokenResult) -> String {
+        let seed = result.publicToken.isEmpty
+            ? "institution:\(result.institution?.institutionId ?? "unknown")"
+            : "public-token:\(result.publicToken)"
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     // MARK: - HTML Pages

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -152,35 +152,55 @@ struct OAuthCallbackRoute: Sendable {
                 )
             }
 
+            var unrecoverableItemCount = 0
             for publicTokenResult in publicTokenResults {
                 let identity = Self.resultIdentity(for: publicTokenResult)
-                // Skip results already consumed on a prior attempt — keyed by a
-                // stable identity, so reordered multi-item retries still skip the
-                // right ones (not by ordinal position).
+                // Skip results already finalized on a prior attempt — keyed by a
+                // stable identity, so reordered multi-item retries skip the right
+                // ones (not by ordinal position). "Finalized" means either stored
+                // OR irrecoverably spent (see below); both must never be replayed.
                 if pendingSession.completedResultIdentities.contains(identity) {
                     continue
                 }
-                try await exchangeAndStore(
-                    publicTokenResult: publicTokenResult,
-                    onPublicTokenExchanged: {
-                        // Mark consumed the instant the single-use public token is
-                        // exchanged — BEFORE the fallible getAccounts/saveItem
-                        // steps. If those later fail, the retry will not replay
-                        // this now-spent token (which Plaid rejects, producing
-                        // endless 500s and a lost access token); it is skipped
-                        // instead. This is the post-exchange handoff barrier.
-                        await pendingLinkSessions.markResultCompleted(state: state, identity: identity)
-                    }
-                )
+
+                let outcome = await storeResult(publicTokenResult: publicTokenResult)
+                switch outcome {
+                case .stored:
+                    // Fully persisted — mark finalized so a retry skips it.
+                    await pendingLinkSessions.markResultCompleted(state: state, identity: identity)
+                case .notExchanged:
+                    // The public token was NOT consumed (exchange itself failed),
+                    // so it is still replayable. Release the session and surface
+                    // an error; the user (or an auto-retry) can try again.
+                    await pendingLinkSessions.releaseCompletion(state: state)
+                    return Self.errorResponse("Connecting your account failed. Please try again.")
+                case .spentButNotStored:
+                    // Exchange SUCCEEDED but the item could not be stored: the
+                    // single-use token is spent and the access token is lost.
+                    // Mark finalized so the dead token is never replayed (no
+                    // endless 500s), but count it so we do NOT report success —
+                    // the user must re-link this institution.
+                    await pendingLinkSessions.markResultCompleted(state: state, identity: identity)
+                    unrecoverableItemCount += 1
+                }
             }
             _ = await pendingLinkSessions.consume(state: state)
 
+            if unrecoverableItemCount > 0 {
+                // Honest outcome: do not show "Connected" when an item was lost.
+                return Self.errorResponse(
+                    "Some accounts could not be finished connecting. Please re-link "
+                        + "them from VaultPeek."
+                )
+            }
             return Response(
                 status: .ok,
                 headers: [.contentType: "text/html"],
                 body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
             )
         } catch {
+            // A failure outside the per-result loop (e.g. /link/token/get) leaves
+            // nothing consumed, so the session stays retryable.
             await pendingLinkSessions.releaseCompletion(state: state)
             return Response(
                 status: .internalServerError,
@@ -190,6 +210,27 @@ struct OAuthCallbackRoute: Sendable {
                 ))
             )
         }
+    }
+
+    /// The outcome of attempting to exchange + store a single Link result, which
+    /// determines both whether the result may be retried and what the user sees.
+    private enum StoreResultOutcome {
+        /// Exchanged and persisted locally; safe to mark finalized.
+        case stored
+        /// The public-token exchange itself failed; the token is unspent and the
+        /// result is still replayable.
+        case notExchanged
+        /// Exchange succeeded but the item could not be persisted; the token is
+        /// spent and lost. Never replay, but report failure to the user.
+        case spentButNotStored
+    }
+
+    private static func errorResponse(_ message: String) -> Response {
+        Response(
+            status: .internalServerError,
+            headers: [.contentType: "text/html"],
+            body: .init(byteBuffer: ByteBuffer(string: errorPage(message)))
+        )
     }
 
     private func publicTokenResults(
@@ -204,25 +245,43 @@ struct OAuthCallbackRoute: Sendable {
         return linkSession.publicTokenResults
     }
 
-    private func exchangeAndStore(
-        publicTokenResult: PlaidPublicTokenResult,
-        onPublicTokenExchanged: () async -> Void
-    ) async throws {
-        let exchangeResponse = try await plaidClient.exchangePublicToken(publicTokenResult.publicToken)
-        // The public token is now spent and cannot be replayed; record the
-        // handoff before the remaining (fallible, retryable-in-isolation) steps.
-        await onPublicTokenExchanged()
-        let accountsResponse = try await plaidClient.getAccounts(
-            accessToken: exchangeResponse.accessToken
-        )
-        let institutionId = publicTokenResult.institution?.institutionId ?? accountsResponse.item?.institutionId
+    /// Exchanges the result's public token and persists the item, returning an
+    /// outcome that captures exactly how far it got. Crucially it distinguishes a
+    /// pre-exchange failure (token unspent → retryable) from a post-exchange
+    /// failure (token spent → not retryable, must report failure), so the caller
+    /// never both consumes a token AND tells the user the account connected.
+    private func storeResult(publicTokenResult: PlaidPublicTokenResult) async -> StoreResultOutcome {
+        let exchangeResponse: PlaidTokenExchangeResponse
+        do {
+            exchangeResponse = try await plaidClient.exchangePublicToken(publicTokenResult.publicToken)
+        } catch {
+            // The single-use public token was not consumed — still replayable.
+            return .notExchanged
+        }
 
-        try await tokenStore.saveItem(
-            id: exchangeResponse.itemId,
-            accessToken: exchangeResponse.accessToken,
-            institutionId: institutionId,
-            institutionName: publicTokenResult.institution?.normalizedName
-        )
+        // From here the token is SPENT. Any failure means the item is
+        // unrecoverable, so we always return `.spentButNotStored` rather than
+        // throwing back into a path that could replay the token.
+
+        // getAccounts only enriches institution metadata; a failure here must NOT
+        // lose the item, since we already hold the access token. Fall back to the
+        // result's own institution id (best-effort) and still persist.
+        let accountsItemInstitutionId = try? await plaidClient.getAccounts(
+            accessToken: exchangeResponse.accessToken
+        ).item?.institutionId
+        let institutionId = publicTokenResult.institution?.institutionId ?? accountsItemInstitutionId
+
+        do {
+            try await tokenStore.saveItem(
+                id: exchangeResponse.itemId,
+                accessToken: exchangeResponse.accessToken,
+                institutionId: institutionId,
+                institutionName: publicTokenResult.institution?.normalizedName
+            )
+        } catch {
+            return .spentButNotStored
+        }
+        return .stored
     }
 
     /// A stable, token-free identity for a Link result, used to skip results

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1061,8 +1061,8 @@ struct PlaidBarServerTests {
         #expect(afterRelease != nil)
     }
 
-    @Test("A presumed-dead lease is reclaimable once it is older than the lease TTL")
-    func completionLeaseReclaimableWhenStale() async {
+    @Test("A held lease is never reclaimed on a timer; only release/consume frees it")
+    func completionLeaseIsNotReclaimedByTimer() async {
         let clock = ManualDateClock(Date(timeIntervalSince1970: 1000))
         let store = PendingLinkSessionStore(
             ttl: 30 * 60,
@@ -1075,12 +1075,19 @@ struct PlaidBarServerTests {
         let first = await store.beginCompletion(state: state)
         #expect(first != nil)
 
-        // No release (handler presumed dead). Past the lease TTL, a fresh handler
-        // may reclaim the lease so the user is not blocked forever — bounded
-        // recovery without dropping a still-fresh in-flight lease.
+        // Past the lease TTL with no release, a second handler must STILL be
+        // refused: there is no proof the original handler is dead, and a
+        // slow-but-alive handler must not be raced over the same single-use
+        // tokens. (An in-memory lease for a truly crashed handler clears on
+        // process restart, and the session itself expires at the session TTL.)
         clock.advance(by: 61)
-        let reclaimed = await store.beginCompletion(state: state)
-        #expect(reclaimed != nil)
+        let blocked = await store.beginCompletion(state: state)
+        #expect(blocked == nil)
+
+        // Only an explicit release returns the session to a retryable state.
+        await store.releaseCompletion(state: state)
+        let afterRelease = await store.beginCompletion(state: state)
+        #expect(afterRelease != nil)
     }
 
     @Test func pendingLinkSessionSurvivesStoreRecreation() async throws {
@@ -1497,10 +1504,10 @@ struct PlaidBarServerTests {
     }
 
     @Test(
-        "OAuth callback never replays a public token consumed before a post-exchange failure",
+        "A transient getAccounts failure does not lose the item; it is salvaged and stored once",
         .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
     )
-    func oauthCallbackDoesNotReplayConsumedPublicTokenAfterPostExchangeFailure() async throws {
+    func oauthCallbackSalvagesItemWhenGetAccountsFails() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-oauth-postexchange-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -1538,8 +1545,10 @@ struct PlaidBarServerTests {
             onSuccess: nil,
             results: nil
         )
-        // Exchange SUCCEEDS on the first attempt; the failure is in the
-        // post-exchange getAccounts step, so the public token is already spent.
+        // Exchange SUCCEEDS; getAccounts fails. getAccounts only enriches
+        // institution metadata, so a failure there must NOT lose the item — it is
+        // salvaged using the result's own institution and stored on the first
+        // attempt, with the public token exchanged exactly once.
         let plaidClient = HostedLinkStubPlaidClient(
             linkTokenGetResponse: linkTokenGetResponse,
             exchangeResponse: PlaidTokenExchangeResponse(
@@ -1575,21 +1584,18 @@ struct PlaidBarServerTests {
             )
             let request = Self.makeRequest(path: "/oauth/callback?state=\(state)")
 
-            let failedResponse = try await route.handleCallback(
+            let response = try await route.handleCallback(
                 request: request,
                 context: TestRequestContext(source: TestRequestContextSource())
             )
-            let retryResponse = try await route.handleCallback(
-                request: request,
-                context: TestRequestContext(source: TestRequestContextSource())
-            )
+            let savedItem = try await store.getItem(id: itemId)
             let calls = await plaidClient.recordedCalls()
 
-            // First attempt fails in getAccounts (post-exchange).
-            #expect(failedResponse.status == .internalServerError)
-            // Retry must NOT replay the now-spent public token — it is skipped by
-            // identity, so the callback completes without a second exchange call.
-            #expect(retryResponse.status == .ok)
+            // The getAccounts failure was non-fatal: the item is stored and the
+            // callback succeeds on the FIRST attempt, with no replay needed.
+            #expect(response.status == .ok)
+            #expect(savedItem != nil)
+            #expect(savedItem?.institutionName == "Example Credit Union")
             #expect(calls.publicTokens == [publicToken]) // exchanged exactly once
         }
     }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -45,6 +45,10 @@ private final class ManualDateClock: @unchecked Sendable {
     }
 }
 
+private enum HostedLinkStubError: Error {
+    case transientExchangeFailure
+}
+
 private let plaidTokenVaultKeychainAvailable: Bool = {
     let itemId = "test_keychain_probe_\(UUID().uuidString)"
     do {
@@ -59,7 +63,10 @@ private let plaidTokenVaultKeychainAvailable: Bool = {
 private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
     private let linkTokenGetResponse: PlaidLinkTokenGetResponse
     private let exchangeResponse: PlaidTokenExchangeResponse
+    private let exchangeResponsesByPublicToken: [String: PlaidTokenExchangeResponse]
     private let accountsResponse: PlaidAccountsResponse
+    private var exchangeFailuresRemaining: Int
+    private var exchangeFailuresByPublicToken: [String: Int]
     private var requestedLinkTokens: [String] = []
     private var exchangedPublicTokens: [String] = []
     private var requestedAccountAccessTokens: [String] = []
@@ -67,11 +74,17 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
     init(
         linkTokenGetResponse: PlaidLinkTokenGetResponse,
         exchangeResponse: PlaidTokenExchangeResponse,
-        accountsResponse: PlaidAccountsResponse
+        accountsResponse: PlaidAccountsResponse,
+        exchangeFailuresBeforeSuccess: Int = 0,
+        exchangeFailuresByPublicToken: [String: Int] = [:],
+        exchangeResponsesByPublicToken: [String: PlaidTokenExchangeResponse] = [:]
     ) {
         self.linkTokenGetResponse = linkTokenGetResponse
         self.exchangeResponse = exchangeResponse
+        self.exchangeResponsesByPublicToken = exchangeResponsesByPublicToken
         self.accountsResponse = accountsResponse
+        self.exchangeFailuresRemaining = exchangeFailuresBeforeSuccess
+        self.exchangeFailuresByPublicToken = exchangeFailuresByPublicToken
     }
 
     func createLinkToken(
@@ -96,7 +109,16 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
 
     func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse {
         exchangedPublicTokens.append(publicToken)
-        return exchangeResponse
+        if let failuresRemaining = exchangeFailuresByPublicToken[publicToken],
+           failuresRemaining > 0 {
+            exchangeFailuresByPublicToken[publicToken] = failuresRemaining - 1
+            throw HostedLinkStubError.transientExchangeFailure
+        }
+        if exchangeFailuresRemaining > 0 {
+            exchangeFailuresRemaining -= 1
+            throw HostedLinkStubError.transientExchangeFailure
+        }
+        return exchangeResponsesByPublicToken[publicToken] ?? exchangeResponse
     }
 
     func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse {
@@ -1167,6 +1189,242 @@ struct PlaidBarServerTests {
             #expect(calls.linkTokens == ["test-link-token"])
             #expect(calls.publicTokens == ["test-public-token"])
             #expect(calls.accountAccessTokens == [accessToken])
+        }
+    }
+
+    @Test(
+        "OAuth callback can retry after transient completion failure",
+        .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func oauthCallbackCanRetryAfterTransientCompletionFailure() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-retry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let itemId = "synthetic_item_\(UUID().uuidString)"
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+
+        let linkToken = "synthetic-link-token"
+        let publicToken = "synthetic-public-token"
+        let accessToken = "synthetic-access-token-\(UUID().uuidString)"
+        let linkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: linkToken,
+            linkSessions: [
+                PlaidLinkSession(
+                    linkSessionId: "synthetic-link-session",
+                    results: PlaidLinkResults(
+                        itemAddResults: [
+                            PlaidLinkItemAddResult(
+                                publicToken: publicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Example Credit Union",
+                                    institutionId: "ins_example_credit_union"
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            onSuccess: nil,
+            results: nil
+        )
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: accessToken,
+                itemId: itemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: itemId,
+                    institutionId: "ins_accounts_fallback",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            ),
+            exchangeFailuresBeforeSuccess: 1
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-retry")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions
+            )
+            let request = Self.makeRequest(path: "/oauth/callback?state=\(state)")
+
+            let failedResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let retryResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let replayResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let savedItem = try #require(try await store.getItem(id: itemId))
+            let calls = await plaidClient.recordedCalls()
+
+            #expect(failedResponse.status == .internalServerError)
+            #expect(retryResponse.status == .ok)
+            #expect(replayResponse.status == .badRequest)
+            #expect(savedItem.institutionName == "Example Credit Union")
+            #expect(calls.linkTokens == [linkToken, linkToken])
+            #expect(calls.publicTokens == [publicToken, publicToken])
+            #expect(calls.accountAccessTokens == [accessToken])
+        }
+    }
+
+    @Test(
+        "OAuth callback retry skips completed Hosted Link results",
+        .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func oauthCallbackRetrySkipsCompletedHostedLinkResults() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-retry-progress-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstItemId = "synthetic_item_one_\(UUID().uuidString)"
+        let secondItemId = "synthetic_item_two_\(UUID().uuidString)"
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: firstItemId),
+                fallbackItemId: firstItemId
+            )
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: secondItemId),
+                fallbackItemId: secondItemId
+            )
+        }
+
+        let linkToken = "synthetic-link-token"
+        let firstPublicToken = "synthetic-public-token-one"
+        let secondPublicToken = "synthetic-public-token-two"
+        let firstAccessToken = "synthetic-access-token-one-\(UUID().uuidString)"
+        let secondAccessToken = "synthetic-access-token-two-\(UUID().uuidString)"
+        let linkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: linkToken,
+            linkSessions: [
+                PlaidLinkSession(
+                    linkSessionId: "synthetic-link-session",
+                    results: PlaidLinkResults(
+                        itemAddResults: [
+                            PlaidLinkItemAddResult(
+                                publicToken: firstPublicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Example Credit Union",
+                                    institutionId: "ins_example_credit_union"
+                                )
+                            ),
+                            PlaidLinkItemAddResult(
+                                publicToken: secondPublicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Example Bank",
+                                    institutionId: "ins_example_bank"
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            onSuccess: nil,
+            results: nil
+        )
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: firstAccessToken,
+                itemId: firstItemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: firstItemId,
+                    institutionId: "ins_accounts_fallback",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            ),
+            exchangeFailuresByPublicToken: [secondPublicToken: 1],
+            exchangeResponsesByPublicToken: [
+                firstPublicToken: PlaidTokenExchangeResponse(
+                    accessToken: firstAccessToken,
+                    itemId: firstItemId,
+                    requestId: nil
+                ),
+                secondPublicToken: PlaidTokenExchangeResponse(
+                    accessToken: secondAccessToken,
+                    itemId: secondItemId,
+                    requestId: nil
+                ),
+            ]
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-retry-progress")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions
+            )
+            let request = Self.makeRequest(path: "/oauth/callback?state=\(state)")
+
+            let failedResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let retryResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let replayResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let firstSavedItem = try #require(try await store.getItem(id: firstItemId))
+            let secondSavedItem = try #require(try await store.getItem(id: secondItemId))
+            let calls = await plaidClient.recordedCalls()
+
+            #expect(failedResponse.status == .internalServerError)
+            #expect(retryResponse.status == .ok)
+            #expect(replayResponse.status == .badRequest)
+            #expect(firstSavedItem.institutionName == "Example Credit Union")
+            #expect(secondSavedItem.institutionName == "Example Bank")
+            #expect(calls.linkTokens == [linkToken, linkToken])
+            #expect(calls.publicTokens == [
+                firstPublicToken,
+                secondPublicToken,
+                secondPublicToken,
+            ])
+            #expect(calls.accountAccessTokens == [firstAccessToken, secondAccessToken])
         }
     }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -67,6 +67,7 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
     private let accountsResponse: PlaidAccountsResponse
     private var exchangeFailuresRemaining: Int
     private var exchangeFailuresByPublicToken: [String: Int]
+    private var accountsFailuresRemaining: Int
     private var requestedLinkTokens: [String] = []
     private var exchangedPublicTokens: [String] = []
     private var requestedAccountAccessTokens: [String] = []
@@ -77,7 +78,8 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
         accountsResponse: PlaidAccountsResponse,
         exchangeFailuresBeforeSuccess: Int = 0,
         exchangeFailuresByPublicToken: [String: Int] = [:],
-        exchangeResponsesByPublicToken: [String: PlaidTokenExchangeResponse] = [:]
+        exchangeResponsesByPublicToken: [String: PlaidTokenExchangeResponse] = [:],
+        accountsFailuresBeforeSuccess: Int = 0
     ) {
         self.linkTokenGetResponse = linkTokenGetResponse
         self.exchangeResponse = exchangeResponse
@@ -85,6 +87,7 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
         self.accountsResponse = accountsResponse
         self.exchangeFailuresRemaining = exchangeFailuresBeforeSuccess
         self.exchangeFailuresByPublicToken = exchangeFailuresByPublicToken
+        self.accountsFailuresRemaining = accountsFailuresBeforeSuccess
     }
 
     func createLinkToken(
@@ -123,6 +126,13 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
 
     func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse {
         requestedAccountAccessTokens.append(accessToken)
+        // Simulates a failure AFTER the public token was already exchanged, to
+        // exercise the post-exchange handoff barrier: the spent token must not
+        // be replayed on retry.
+        if accountsFailuresRemaining > 0 {
+            accountsFailuresRemaining -= 1
+            throw HostedLinkStubError.transientExchangeFailure
+        }
         return accountsResponse
     }
 
@@ -1015,6 +1025,64 @@ struct PlaidBarServerTests {
         #expect(expired == nil)
     }
 
+    @Test("A completion lease holds single-flight even past the lease TTL until released")
+    func completionLeaseHoldsUntilReleased() async {
+        let clock = ManualDateClock(Date(timeIntervalSince1970: 1000))
+        let store = PendingLinkSessionStore(
+            ttl: 30 * 60,
+            completionLeaseTTL: 60,
+            now: { @Sendable in clock.now() }
+        )
+        let state = await store.issueState()
+        await store.save(state: state, linkToken: "link-token")
+
+        // First handler takes the lease.
+        let first = await store.beginCompletion(state: state)
+        #expect(first != nil)
+
+        // A concurrent retry within the lease window is refused (single-flight).
+        let concurrent = await store.beginCompletion(state: state)
+        #expect(concurrent == nil)
+
+        // The bug fix: advancing time past completionLeaseTTL while the original
+        // handler is STILL running must not let purgeExpired drop the lease and
+        // admit a second handler. Any intervening store call triggers a purge;
+        // markResultCompleted is one such call.
+        clock.advance(by: 30)
+        await store.markResultCompleted(state: state, identity: "result-a")
+        // Still within the 60s lease window → retry still refused even though a
+        // purge just ran.
+        let stillHeld = await store.beginCompletion(state: state)
+        #expect(stillHeld == nil)
+
+        // Only an explicit release returns the session to a retryable state.
+        await store.releaseCompletion(state: state)
+        let afterRelease = await store.beginCompletion(state: state)
+        #expect(afterRelease != nil)
+    }
+
+    @Test("A presumed-dead lease is reclaimable once it is older than the lease TTL")
+    func completionLeaseReclaimableWhenStale() async {
+        let clock = ManualDateClock(Date(timeIntervalSince1970: 1000))
+        let store = PendingLinkSessionStore(
+            ttl: 30 * 60,
+            completionLeaseTTL: 60,
+            now: { @Sendable in clock.now() }
+        )
+        let state = await store.issueState()
+        await store.save(state: state, linkToken: "link-token")
+
+        let first = await store.beginCompletion(state: state)
+        #expect(first != nil)
+
+        // No release (handler presumed dead). Past the lease TTL, a fresh handler
+        // may reclaim the lease so the user is not blocked forever — bounded
+        // recovery without dropping a still-fresh in-flight lease.
+        clock.advance(by: 61)
+        let reclaimed = await store.beginCompletion(state: state)
+        #expect(reclaimed != nil)
+    }
+
     @Test func pendingLinkSessionSurvivesStoreRecreation() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-link-session-\(UUID().uuidString)", isDirectory: true)
@@ -1425,6 +1493,104 @@ struct PlaidBarServerTests {
                 secondPublicToken,
             ])
             #expect(calls.accountAccessTokens == [firstAccessToken, secondAccessToken])
+        }
+    }
+
+    @Test(
+        "OAuth callback never replays a public token consumed before a post-exchange failure",
+        .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func oauthCallbackDoesNotReplayConsumedPublicTokenAfterPostExchangeFailure() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-postexchange-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let itemId = "synthetic_item_\(UUID().uuidString)"
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+
+        let linkToken = "synthetic-link-token"
+        let publicToken = "synthetic-public-token"
+        let accessToken = "synthetic-access-token-\(UUID().uuidString)"
+        let linkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: linkToken,
+            linkSessions: [
+                PlaidLinkSession(
+                    linkSessionId: "synthetic-link-session",
+                    results: PlaidLinkResults(
+                        itemAddResults: [
+                            PlaidLinkItemAddResult(
+                                publicToken: publicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Example Credit Union",
+                                    institutionId: "ins_example_credit_union"
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            onSuccess: nil,
+            results: nil
+        )
+        // Exchange SUCCEEDS on the first attempt; the failure is in the
+        // post-exchange getAccounts step, so the public token is already spent.
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: accessToken,
+                itemId: itemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: itemId,
+                    institutionId: "ins_accounts_fallback",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            ),
+            accountsFailuresBeforeSuccess: 1
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-postexchange")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions
+            )
+            let request = Self.makeRequest(path: "/oauth/callback?state=\(state)")
+
+            let failedResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let retryResponse = try await route.handleCallback(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let calls = await plaidClient.recordedCalls()
+
+            // First attempt fails in getAccounts (post-exchange).
+            #expect(failedResponse.status == .internalServerError)
+            // Retry must NOT replay the now-spent public token — it is skipped by
+            // identity, so the callback completes without a second exchange call.
+            #expect(retryResponse.status == .ok)
+            #expect(calls.publicTokens == [publicToken]) // exchanged exactly once
         }
     }
 


### PR DESCRIPTION
## Summary
- Keeps pending Hosted Link state retryable until callback completion succeeds, instead of consuming it before fallible completion work.
- Adds a short in-flight completion lease plus completed-result progress so concurrent/retried callbacks do not replay already stored Hosted Link results.
- Covers the retry behavior with synthetic server tests only.

## Changes
- `Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift`: adds completion lookup/release, success consume, and a backward-compatible persisted completed-result count.
- `Sources/PlaidBarServer/Routes/LinkRoutes.swift`: consumes pending state only after update/add completion succeeds; releases retry state on failure; skips completed result indexes on retry.
- `Tests/PlaidBarServerTests/PlaidBarServerTests.swift`: adds fail-then-retry coverage plus multi-result partial-progress replay coverage using synthetic IDs/tokens.

## Test plan
- [x] `git diff --check`
- [x] `swift test --filter 'PlaidBarServerTests/oauthCallback' --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (4 tests passed)
- [x] `swift test --filter 'PlaidBarServerTests' --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (68 tests passed)
- [x] `swift build --target PlaidBar --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] Diff-only privacy/security scan for Plaid secrets, public/access tokens, raw Plaid payloads, real account/transaction IDs, balances, local SQLite data, logs, screenshots/generated artifacts, app-target Plaid access, and local-first boundary drift. Findings were expected server/test symbols and synthetic fixtures only.
- [x] `codex review --uncommitted`; first pass found partial-result replay risk, fixed here; rerun reported no actionable findings and its own server test run passed.

## Privacy/security notes
- No SwiftUI app-target changes and no direct Plaid app access.
- No real Plaid credentials, provider tokens, raw Plaid payloads, real account IDs, transaction IDs, balances, local data, logs, screenshots, or generated artifacts added.
- Persisted retry progress is only an integer completed-result count; public/access tokens are not added to pending-session storage.

## CI/check state
- Draft PR because primary CI/review-gate workflows are disabled under #309 and checks may be missing.

## Risks
- This preserves retryability for failures before completed result storage and prevents completed multi-result replay. A failure after Plaid public-token exchange succeeds but before local item storage/progress marking remains a harder edge; fully recovering that would require a larger token-handoff design.

Refs #338