### PR TITLE
feat: lightweight category-budget core + suggestions (AND-402)

### DIFF
--- a/Sources/PlaidBarCore/Models/CategoryBudgetPresentation.swift
+++ b/Sources/PlaidBarCore/Models/CategoryBudgetPresentation.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Discrete budget-pressure band for a single category — text + symbol, never
+/// color alone (ACCESSIBILITY.md). Derived purely from the fraction of the
+/// monthly limit consumed so the UI and any alert logic agree on the verdict.
+public enum CategoryBudgetStatus: String, Sendable, Hashable, CaseIterable {
+    /// Comfortably below the limit.
+    case under
+    /// Within reach of the limit — the early-warning band the feature exists for.
+    case nearing
+    /// Spend has passed the limit.
+    case over
+
+    /// `under`/`nearing` boundary, as a fraction of the limit. 0.8 = 80%.
+    public static let nearingThreshold = 0.8
+
+    /// Band a category falls into for a given consumed fraction. `> 1.0` is over;
+    /// `>= nearingThreshold` (and `<= 1.0`) is nearing; everything else is under.
+    public init(fractionUsed: Double) {
+        if fractionUsed > 1.0 {
+            self = .over
+        } else if fractionUsed >= Self.nearingThreshold {
+            self = .nearing
+        } else {
+            self = .under
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .under: "On track"
+        case .nearing: "Close to limit"
+        case .over: "Over budget"
+        }
+    }
+
+    /// SF Symbol carrying the verdict without relying on color.
+    public var iconName: String {
+        switch self {
+        case .under: "checkmark.circle"
+        case .nearing: "exclamationmark.circle"
+        case .over: "exclamationmark.triangle.fill"
+        }
+    }
+}
+
+/// Display-ready view of lightweight category budgets (AND-402).
+///
+/// Pure presentation logic: given a set of monthly limits and the transaction
+/// history, it computes each category's current-month spend, remaining amount,
+/// and pressure band, plus the aggregates a glance surface needs. All formatting
+/// stays in the view; this type owns ordering, netting, and the derived numbers
+/// so they are testable and identical across surfaces.
+///
+/// This is the *read-only* / suggestion half of AND-402. The limits here are
+/// either user-set or the planner's suggestions (`areSuggested`); persisting a
+/// user's edits (create / edit / delete a saved budget) is deliberately out of
+/// scope and shares the budgeting-suite persistence decision tracked across
+/// AND-399 / 400 / 402 / 403.
+public struct CategoryBudgetPresentation: Sendable, Hashable {
+    public struct Item: Sendable, Hashable, Identifiable {
+        /// Stable per-category identity (`category.rawValue`).
+        public let id: String
+        public let category: SpendingCategory
+        /// The monthly limit being tracked (suggested or user-set).
+        public let monthlyLimit: Double
+        /// Net current-month spend for the category, floored at 0. "Net" means
+        /// refunds (negative-amount transactions sharing the category) reduce the
+        /// figure; transfers and income are excluded entirely.
+        public let spent: Double
+        /// `monthlyLimit - spent`. Negative once the category is over budget.
+        public let remaining: Double
+        /// `spent / monthlyLimit`, floored at 0; 0 when the limit is non-positive.
+        public let fractionUsed: Double
+        public let status: CategoryBudgetStatus
+        /// True when this limit is a planner suggestion the user has not saved.
+        public let isSuggested: Bool
+
+        public init(
+            category: SpendingCategory,
+            monthlyLimit: Double,
+            spent: Double,
+            isSuggested: Bool
+        ) {
+            self.id = category.rawValue
+            self.category = category
+            self.monthlyLimit = monthlyLimit
+            let netSpent = max(0, spent)
+            self.spent = netSpent
+            self.remaining = monthlyLimit - netSpent
+            let fraction = monthlyLimit > 0 ? max(0, netSpent / monthlyLimit) : 0
+            self.fractionUsed = fraction
+            self.status = CategoryBudgetStatus(fractionUsed: fraction)
+            self.isSuggested = isSuggested
+        }
+
+        public var isOverBudget: Bool { status == .over }
+        public var needsAttention: Bool { status != .under }
+    }
+
+    /// Budgets, attention-first (over, then nearing) then by spend pressure — see
+    /// `CategoryBudgetPlanner.presentation`.
+    public let items: [Item]
+    /// Sum of every tracked limit.
+    public let totalLimit: Double
+    /// Sum of every category's net current-month spend.
+    public let totalSpent: Double
+    /// Count of categories over their limit.
+    public let overBudgetCount: Int
+    /// Count of categories in the nearing band (not yet over).
+    public let nearingCount: Int
+
+    public init(
+        items: [Item],
+        totalLimit: Double,
+        totalSpent: Double,
+        overBudgetCount: Int,
+        nearingCount: Int
+    ) {
+        self.items = items
+        self.totalLimit = totalLimit
+        self.totalSpent = totalSpent
+        self.overBudgetCount = overBudgetCount
+        self.nearingCount = nearingCount
+    }
+
+    public var isEmpty: Bool { items.isEmpty }
+    public var count: Int { items.count }
+
+    public static let empty = CategoryBudgetPresentation(
+        items: [],
+        totalLimit: 0,
+        totalSpent: 0,
+        overBudgetCount: 0,
+        nearingCount: 0
+    )
+}

--- a/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+/// Pure, deterministic category-budget planning (AND-402).
+///
+/// Mirrors the shape of `SpendingSummary` / `SafeToSpendCalculator`: a stateless
+/// `enum` whose functions take an explicit `asOf:` reference date and `Calendar`,
+/// so there is no hidden `Date()` and every result is fully testable.
+///
+/// Two responsibilities:
+/// 1. `suggestedBudgets` — propose monthly limits for the top spending categories
+///    from trailing *complete*-month history (the read-only wedge: the app can
+///    show guardrails before the user has saved any).
+/// 2. `presentation` — score a set of limits against the *current* month's spend.
+///
+/// Spend is computed from **signed** transaction amounts (Plaid convention:
+/// positive = money out, negative = money in). Summing the raw amount per
+/// category therefore nets refunds against spend automatically — unlike
+/// `SpendingSummary`, which uses `displayAmount` (`abs`) and drops every
+/// negative-amount transaction as income. Budgets need the netting, so this type
+/// aggregates the signed amounts itself. Transfers and the income category are
+/// excluded so a paycheck or an own-account move never counts as category spend.
+public enum CategoryBudgetPlanner {
+    /// How many categories `suggestedBudgets` proposes by default. Kept small so
+    /// the surface stays glanceable (HIG / the issue's "avoid every category").
+    public static let defaultSuggestionCount = 5
+    /// Trailing complete months averaged into a suggestion.
+    public static let defaultTrailingMonths = 3
+
+    /// Categories that are never spend: income and transfers (both directions).
+    /// A refund keeps its spend category (e.g. a returned purchase stays
+    /// `GENERAL_MERCHANDISE`), so it is *not* excluded here — it nets via its
+    /// negative amount.
+    public static let excludedCategories: Set<SpendingCategory> = [
+        .income, .transfer, .transferOut,
+    ]
+
+    // MARK: - Suggestions
+
+    /// Suggested monthly limits for the highest-spend categories, derived from the
+    /// trailing complete months before the current one (the current, partial month
+    /// is excluded so a mid-month snapshot never understates the baseline).
+    ///
+    /// Each category's trailing net spend is averaged over the window and rounded
+    /// up to a sensible limit. Only positive-spend categories qualify, ranked
+    /// high-to-low, capped at `topCategories`.
+    public static func suggestedBudgets(
+        from transactions: [TransactionDTO],
+        asOf date: Date,
+        calendar: Calendar = .current,
+        topCategories: Int = defaultSuggestionCount,
+        trailingMonths: Int = defaultTrailingMonths
+    ) -> [SpendingCategory: Double] {
+        guard topCategories > 0, trailingMonths > 0,
+              let currentMonthStart = monthStartDate(asOf: date, calendar: calendar)
+        else { return [:] }
+
+        var totals: [SpendingCategory: Double] = [:]
+        for monthsBack in 1...trailingMonths {
+            guard
+                let monthStart = calendar.date(
+                    byAdding: .month, value: -monthsBack, to: currentMonthStart
+                ),
+                let monthEnd = calendar.date(byAdding: .month, value: 1, to: monthStart)
+            else { continue }
+
+            let monthly = netSpendByCategory(
+                from: transactions,
+                startKey: Formatters.transactionDateString(monthStart),
+                endKey: Formatters.transactionDateString(monthEnd)
+            )
+            // Only positive months feed the baseline — a refund-heavy month should
+            // not deflate a category's suggested guardrail below its typical spend.
+            for (category, amount) in monthly where amount > 0 {
+                totals[category, default: 0] += amount
+            }
+        }
+
+        var averages: [CategoryAverage] = []
+        for (category, total) in totals {
+            let average = total / Double(trailingMonths)
+            if average > 0 {
+                averages.append(CategoryAverage(category: category, average: average))
+            }
+        }
+        averages.sort { lhs, rhs in
+            lhs.average != rhs.average
+                ? lhs.average > rhs.average
+                : lhs.category.displayName < rhs.category.displayName
+        }
+
+        var suggestions: [SpendingCategory: Double] = [:]
+        for entry in averages.prefix(topCategories) {
+            suggestions[entry.category] = roundedSuggestedLimit(entry.average)
+        }
+        return suggestions
+    }
+
+    // MARK: - Progress
+
+    /// Score `budgets` against the current month's spend. Non-positive limits are
+    /// dropped. Items are ordered attention-first (over, then nearing), then by
+    /// spend pressure, then category name.
+    public static func presentation(
+        budgets: [SpendingCategory: Double],
+        transactions: [TransactionDTO],
+        asOf date: Date,
+        calendar: Calendar = .current,
+        areSuggested: Bool = false
+    ) -> CategoryBudgetPresentation {
+        let positiveBudgets = budgets.filter { $0.value > 0 }
+        guard
+            !positiveBudgets.isEmpty,
+            let monthStart = monthStartDate(asOf: date, calendar: calendar),
+            let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: monthStart)
+        else { return .empty }
+
+        let spendByCategory = netSpendByCategory(
+            from: transactions,
+            startKey: Formatters.transactionDateString(monthStart),
+            endKey: Formatters.transactionDateString(nextMonthStart)
+        )
+
+        let items = positiveBudgets
+            .map { category, limit in
+                CategoryBudgetPresentation.Item(
+                    category: category,
+                    monthlyLimit: limit,
+                    spent: spendByCategory[category] ?? 0,
+                    isSuggested: areSuggested
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.status != rhs.status {
+                    return statusRank(lhs.status) < statusRank(rhs.status)
+                }
+                if lhs.fractionUsed != rhs.fractionUsed {
+                    return lhs.fractionUsed > rhs.fractionUsed
+                }
+                return lhs.category.displayName < rhs.category.displayName
+            }
+
+        return CategoryBudgetPresentation(
+            items: items,
+            totalLimit: items.reduce(0) { $0 + $1.monthlyLimit },
+            totalSpent: items.reduce(0) { $0 + $1.spent },
+            overBudgetCount: items.reduce(0) { $0 + ($1.status == .over ? 1 : 0) },
+            nearingCount: items.reduce(0) { $0 + ($1.status == .nearing ? 1 : 0) }
+        )
+    }
+
+    /// Convenience for the read-only slice: suggest limits from history and score
+    /// them against the current month in one call. Items are flagged `isSuggested`.
+    public static func suggestedPresentation(
+        from transactions: [TransactionDTO],
+        asOf date: Date,
+        calendar: Calendar = .current,
+        topCategories: Int = defaultSuggestionCount,
+        trailingMonths: Int = defaultTrailingMonths
+    ) -> CategoryBudgetPresentation {
+        let budgets = suggestedBudgets(
+            from: transactions,
+            asOf: date,
+            calendar: calendar,
+            topCategories: topCategories,
+            trailingMonths: trailingMonths
+        )
+        return presentation(
+            budgets: budgets,
+            transactions: transactions,
+            asOf: date,
+            calendar: calendar,
+            areSuggested: true
+        )
+    }
+
+    // MARK: - Internals
+
+    /// Net signed spend per category within `[startKey, endKey)`, excluding income
+    /// and transfers. Pending transactions are included — they represent committed
+    /// spend, and the sync layer (`TransactionSyncReducer`) reconciles a pending
+    /// row into its posted form, so there is no double-count here.
+    static func netSpendByCategory(
+        from transactions: [TransactionDTO],
+        startKey: String,
+        endKey: String
+    ) -> [SpendingCategory: Double] {
+        var totals: [SpendingCategory: Double] = [:]
+        for transaction in transactions {
+            if transaction.date < startKey || transaction.date >= endKey { continue }
+            let category = transaction.category ?? .other
+            if excludedCategories.contains(category) { continue }
+            totals[category, default: 0] += transaction.amount
+        }
+        return totals
+    }
+
+    /// First instant of the month containing `date`, in `calendar`.
+    static func monthStartDate(asOf date: Date, calendar: Calendar) -> Date? {
+        calendar.date(from: calendar.dateComponents([.year, .month], from: date))
+    }
+
+    /// Round a trailing-average spend up to a tidy monthly limit. Larger spends
+    /// round to coarser steps so suggestions read as round numbers, never to the
+    /// cent.
+    static func roundedSuggestedLimit(_ value: Double) -> Double {
+        guard value > 0 else { return 0 }
+        let step: Double = value < 100 ? 10 : (value < 500 ? 25 : 50)
+        return (value / step).rounded(.up) * step
+    }
+
+    /// A category's trailing average spend, used to rank suggestions. A named
+    /// type (rather than an inline labeled tuple) keeps the ranking pipeline
+    /// fast to type-check.
+    private struct CategoryAverage {
+        let category: SpendingCategory
+        let average: Double
+    }
+
+    /// Attention-first ordering: over (0) before nearing (1) before under (2).
+    private static func statusRank(_ status: CategoryBudgetStatus) -> Int {
+        switch status {
+        case .over: 0
+        case .nearing: 1
+        case .under: 2
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryBudgetPlannerTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetPlannerTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Category budgets (AND-402)")
+struct CategoryBudgetPlannerTests {
+    // June 13, 2026 — current month is June; trailing complete months are
+    // May / April / March.
+    private let now = Formatters.parseTransactionDate("2026-06-13")!
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func tx(
+        _ amount: Double,
+        _ date: String,
+        _ category: SpendingCategory,
+        pending: Bool = false,
+        name: String = "Merchant"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: "\(name)-\(date)-\(amount)",
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: name,
+            category: category,
+            pending: pending
+        )
+    }
+
+    // MARK: - Progress
+
+    @Test("Only the current month's spend counts — prior-month spend rolls off")
+    func monthlyRollover() {
+        let transactions = [
+            tx(400, "2026-05-20", .foodAndDrink), // previous month — excluded
+            tx(100, "2026-06-05", .foodAndDrink), // current month — counts
+            tx(75, "2026-07-01", .foodAndDrink),  // next month — excluded
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.foodAndDrink: 500],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.count == 1)
+        #expect(result.items[0].spent == 100)
+        #expect(result.items[0].remaining == 400)
+        #expect(result.items[0].status == .under)
+    }
+
+    @Test("Spend is bucketed by each transaction's category, not its merchant")
+    func categoryReassignment() {
+        // Same merchant, two categories — each lands in its own bucket.
+        let transactions = [
+            tx(150, "2026-06-04", .shopping, name: "Target"),
+            tx(50, "2026-06-09", .foodAndDrink, name: "Target"),
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.shopping: 200, .foodAndDrink: 200],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        let byCategory = Dictionary(uniqueKeysWithValues: result.items.map { ($0.category, $0.spent) })
+        #expect(byCategory[.shopping] == 150)
+        #expect(byCategory[.foodAndDrink] == 50)
+    }
+
+    @Test("Refunds net against spend in the same category")
+    func refundsNet() {
+        let transactions = [
+            tx(120, "2026-06-03", .shopping),  // purchase
+            tx(-20, "2026-06-08", .shopping),  // refund (money in, same category)
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.shopping: 200],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.items[0].spent == 100)
+    }
+
+    @Test("A net-negative category floors spend at zero")
+    func netNegativeFloorsAtZero() {
+        let transactions = [
+            tx(40, "2026-06-03", .shopping),
+            tx(-100, "2026-06-08", .shopping), // large refund > spend
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.shopping: 200],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.items[0].spent == 0)
+        #expect(result.items[0].fractionUsed == 0)
+        #expect(result.items[0].status == .under)
+    }
+
+    @Test("Transfers and income are excluded from category spend")
+    func transfersAndIncomeExcluded() {
+        let spend = CategoryBudgetPlanner.netSpendByCategory(
+            from: [
+                tx(100, "2026-06-05", .foodAndDrink),
+                tx(-2000, "2026-06-01", .income),      // paycheck
+                tx(500, "2026-06-02", .transferOut),
+                tx(-500, "2026-06-02", .transfer),
+            ],
+            startKey: "2026-06-01",
+            endKey: "2026-07-01"
+        )
+        #expect(spend[.foodAndDrink] == 100)
+        #expect(spend[.income] == nil)
+        #expect(spend[.transfer] == nil)
+        #expect(spend[.transferOut] == nil)
+    }
+
+    @Test("Pending transactions count toward spend")
+    func pendingCounts() {
+        let transactions = [
+            tx(50, "2026-06-05", .foodAndDrink, pending: false),
+            tx(30, "2026-06-11", .foodAndDrink, pending: true),
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.foodAndDrink: 200],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.items[0].spent == 80)
+    }
+
+    // MARK: - Status bands + ordering
+
+    @Test("Status bands and attention-first ordering")
+    func statusBandsAndOrdering() {
+        let transactions = [
+            tx(150, "2026-06-05", .foodAndDrink),    // over: 150/100
+            tx(85, "2026-06-05", .shopping),         // nearing: 85/100
+            tx(40, "2026-06-05", .transportation),   // under: 40/100
+        ]
+        let result = CategoryBudgetPlanner.presentation(
+            budgets: [.foodAndDrink: 100, .shopping: 100, .transportation: 100],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.items.map(\.status) == [.over, .nearing, .under])
+        #expect(result.items.map(\.category) == [.foodAndDrink, .shopping, .transportation])
+        #expect(result.overBudgetCount == 1)
+        #expect(result.nearingCount == 1)
+        #expect(result.totalLimit == 300)
+        #expect(result.totalSpent == 275)
+    }
+
+    @Test("Nearing threshold is exactly 80% of the limit")
+    func nearingThresholdBoundary() {
+        #expect(CategoryBudgetStatus(fractionUsed: 0.79) == .under)
+        #expect(CategoryBudgetStatus(fractionUsed: 0.80) == .nearing)
+        #expect(CategoryBudgetStatus(fractionUsed: 1.0) == .nearing)
+        #expect(CategoryBudgetStatus(fractionUsed: 1.01) == .over)
+    }
+
+    @Test("Non-positive limits are dropped; no budgets yields empty")
+    func dropsNonPositiveAndEmpty() {
+        let transactions = [tx(50, "2026-06-05", .foodAndDrink)]
+        let zeroed = CategoryBudgetPlanner.presentation(
+            budgets: [.foodAndDrink: 0, .shopping: -10],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(zeroed.isEmpty)
+
+        let none = CategoryBudgetPlanner.presentation(
+            budgets: [:],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(none.isEmpty)
+    }
+
+    // MARK: - Suggestions
+
+    @Test("Suggestions come from trailing complete months, excluding the current month")
+    func suggestionsFromTrailingMonths() {
+        let transactions = [
+            // Trailing months: food $300/mo, shopping $200/mo across Mar/Apr/May.
+            tx(300, "2026-03-15", .foodAndDrink),
+            tx(300, "2026-04-15", .foodAndDrink),
+            tx(300, "2026-05-15", .foodAndDrink),
+            tx(200, "2026-03-10", .shopping),
+            tx(200, "2026-04-10", .shopping),
+            tx(200, "2026-05-10", .shopping),
+            // Current (partial) month must NOT seed a suggestion.
+            tx(9999, "2026-06-02", .travel),
+        ]
+        let suggestions = CategoryBudgetPlanner.suggestedBudgets(
+            from: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(suggestions[.foodAndDrink] == 300)
+        #expect(suggestions[.shopping] == 200)
+        #expect(suggestions[.travel] == nil) // current month excluded
+    }
+
+    @Test("Suggestions are capped at the requested top-N highest spenders")
+    func suggestionsCappedAtTopN() {
+        let transactions = [
+            tx(500, "2026-05-01", .foodAndDrink),
+            tx(400, "2026-05-01", .shopping),
+            tx(300, "2026-05-01", .transportation),
+            tx(200, "2026-05-01", .entertainment),
+        ]
+        let suggestions = CategoryBudgetPlanner.suggestedBudgets(
+            from: transactions,
+            asOf: now,
+            calendar: calendar,
+            topCategories: 2,
+            trailingMonths: 1
+        )
+        #expect(suggestions.count == 2)
+        #expect(suggestions[.foodAndDrink] != nil)
+        #expect(suggestions[.shopping] != nil)
+        #expect(suggestions[.transportation] == nil)
+    }
+
+    @Test("suggestedPresentation flags items and scores them against the current month")
+    func suggestedPresentationFlags() {
+        let transactions = [
+            tx(300, "2026-05-15", .foodAndDrink), // seeds a ~300 suggestion
+            tx(120, "2026-06-05", .foodAndDrink), // current-month spend
+        ]
+        let result = CategoryBudgetPlanner.suggestedPresentation(
+            from: transactions,
+            asOf: now,
+            calendar: calendar,
+            trailingMonths: 1
+        )
+        #expect(!result.isEmpty)
+        let food = result.items.first { $0.category == .foodAndDrink }
+        #expect(food?.isSuggested == true)
+        #expect(food?.spent == 120)
+        #expect(food?.monthlyLimit == 300) // 300 / 1 month → roundedSuggestedLimit(300) = 300
+    }
+
+    @Test("No history yields no suggestions")
+    func noHistoryNoSuggestions() {
+        #expect(CategoryBudgetPlanner.suggestedBudgets(from: [], asOf: now, calendar: calendar).isEmpty)
+    }
+
+    // MARK: - Rounding
+
+    @Test("Suggested limits round up to tidy steps")
+    func roundingSteps() {
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(0) == 0)
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(45) == 50)   // <100 → step 10
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(95) == 100)  // <100 → step 10
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(120) == 125) // <500 → step 25
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(300) == 300) // <500 → step 25
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(480) == 500) // <500 → step 25
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(600) == 600) // >=500 → step 50
+        #expect(CategoryBudgetPlanner.roundedSuggestedLimit(610) == 650) // >=500 → step 50
+    }
+}


### PR DESCRIPTION
## Problem
Users need category-level guardrails for the spending areas that change month to month (AND-402), without the weight of a full zero-based budget suite.

## Root Cause
No budgeting primitives existed. This PR lands the deterministic foundation only.

## Solution
The read-only / suggestion half of AND-402, in `PlaidBarCore`:
- **`CategoryBudgetPlanner`** — pure `enum` (mirrors `SpendingSummary`/`SafeToSpendCalculator`, explicit `asOf:`/`Calendar`).
  - `suggestedBudgets` proposes monthly limits for the top spenders from trailing **complete**-month history (current partial month excluded), rounded up to tidy steps.
  - `presentation` scores limits against the current month. Spend = sum of **signed** amounts per category, so **refunds net against spend** — unlike `SpendingSummary`, which uses `abs()` and drops negative-amount rows as income. Transfers + income excluded; pending counts (the sync layer reconciles pending→posted, so no double-count).
- **`CategoryBudgetPresentation` + `CategoryBudgetStatus`** — display-ready items (spend / remaining / fraction / band), attention-first ordering, aggregates. Status is label **+ SF Symbol, never color alone** (ACCESSIBILITY.md).

## Validation
CI is intentionally off (#309) → validated locally:
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!**
- `swift test` → **627 tests passed** (14 new)

New tests cover every acceptance criterion: monthly rollover, category reassignment, refund netting, net-negative floor, transfer/income exclusion, pending inclusion, status bands + the 80% boundary, suggestion derivation + top-N cap + current-month exclusion, and rounding steps.

## Risk
Minimal — additive `PlaidBarCore` types with no consumers yet (no behavior change on any surface). Pure functions, no I/O, `Sendable`.

## Rollback
Revert this commit; the new files are self-contained.

## Scope / follow-ups
This is **slice 1** of AND-402. Deferred (per the AND-399/400/402/403 budgeting-suite persistence decision):
1. The Wealth Summary section that renders this presentation (read-only).
2. User-editable / saved budgets (server-side SQLite persistence).

Part of AND-402