### PR TITLE
feat: persist user category budgets via /api/budgets (AND-402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,9 @@ when the local app created the Hosted Link session.
 | `GET` | `/api/accounts/balances` | Real-time balances |
 | `DELETE` | `/api/accounts/:itemId` | Remove a bank connection |
 | `GET` | `/api/transactions/sync` | Incremental transaction sync |
+| `GET` | `/api/budgets` | List saved category budgets (display-safe monthly limits only) |
+| `PUT` | `/api/budgets/:category` | Upsert a category's monthly limit (body `{ "monthlyLimit": Double }`); income/transfer categories are rejected |
+| `DELETE` | `/api/budgets/:category` | Remove a category's budget |
 
 ## Roadmap
 

--- a/Sources/PlaidBarCore/Models/CategoryBudgetDTO.swift
+++ b/Sources/PlaidBarCore/Models/CategoryBudgetDTO.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A single saved category budget — the persisted, user-set monthly limit for a
+/// spending category. Shared across the server (storage + `/api/budgets`) and the
+/// app (which scores it against transactions via `CategoryBudgetPlanner`).
+public struct CategoryBudgetDTO: Codable, Sendable, Hashable, Identifiable {
+    /// Stable identity is the category itself — at most one budget per category.
+    public var id: String { category.rawValue }
+    public let category: SpendingCategory
+    public let monthlyLimit: Double
+
+    public init(category: SpendingCategory, monthlyLimit: Double) {
+        self.category = category
+        self.monthlyLimit = monthlyLimit
+    }
+}
+
+/// `GET /api/budgets` payload.
+public struct CategoryBudgetsResponse: Codable, Sendable, Hashable {
+    public let budgets: [CategoryBudgetDTO]
+
+    public init(budgets: [CategoryBudgetDTO]) {
+        self.budgets = budgets
+    }
+
+    /// Convenience map for scoring with `CategoryBudgetPlanner.presentation`.
+    public var byCategory: [SpendingCategory: Double] {
+        Dictionary(budgets.map { ($0.category, $0.monthlyLimit) }) { first, _ in first }
+    }
+}
+
+/// `PUT /api/budgets/{category}` body — the category is taken from the path.
+public struct SaveCategoryBudgetRequest: Codable, Sendable, Hashable {
+    public let monthlyLimit: Double
+
+    public init(monthlyLimit: Double) {
+        self.monthlyLimit = monthlyLimit
+    }
+}

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -48,11 +48,13 @@ struct PlaidBarServer: AsyncParsableCommand {
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
+        await fluent.migrations.add(CreateCategoryBudgets())
         try await fluent.migrate()
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)
 
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent, logger: logger)
+        let budgetStore = BudgetStore(fluent: fluent)
         do {
             try await tokenStore.pruneOrphanedKeychainTokens()
         } catch {
@@ -91,6 +93,8 @@ struct PlaidBarServer: AsyncParsableCommand {
         TransactionRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
             .register(with: api)
         StatusRoutes(tokenStore: tokenStore, config: serverConfig)
+            .register(with: api)
+        BudgetRoutes(budgetStore: budgetStore)
             .register(with: api)
 
         // OAuth callback (top-level, not under /api)

--- a/Sources/PlaidBarServer/Routes/BudgetRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/BudgetRoutes.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import PlaidBarCore
+
+/// `/api/budgets` — CRUD for user-set category budgets (AND-402). Registered
+/// under the same `APITokenMiddleware`-guarded group as the other API routes, so
+/// every call requires the bearer token. Budgets are display-safe values only.
+struct BudgetRoutes: Sendable {
+    let budgetStore: BudgetStore
+
+    func register(with group: RouterGroup<some RequestContext>) {
+        group.group("budgets")
+            .get(use: listBudgets)
+            .put(":category", use: saveBudget)
+            .delete(":category", use: deleteBudget)
+    }
+
+    @Sendable
+    func listBudgets(request: Request, context: some RequestContext) async throws -> Response {
+        let budgets = try await budgetStore.allBudgets()
+        return try Self.jsonResponse(CategoryBudgetsResponse(budgets: budgets))
+    }
+
+    @Sendable
+    func saveBudget(request: Request, context: some RequestContext) async throws -> Response {
+        let category = try Self.budgetableCategory(context.parameters.get("category"))
+        let body = try await request.decode(as: SaveCategoryBudgetRequest.self, context: context)
+        try Self.validateLimit(body.monthlyLimit)
+        try await budgetStore.saveBudget(category: category, monthlyLimit: body.monthlyLimit)
+        return try Self.jsonResponse(CategoryBudgetDTO(category: category, monthlyLimit: body.monthlyLimit))
+    }
+
+    @Sendable
+    func deleteBudget(request: Request, context: some RequestContext) async throws -> HTTPResponse.Status {
+        let category = try Self.budgetableCategory(context.parameters.get("category"))
+        try await budgetStore.deleteBudget(category: category)
+        return .noContent
+    }
+
+    // MARK: - Validation (pure, testable without a request context)
+
+    /// Resolve the `{category}` path parameter to a budgetable `SpendingCategory`.
+    /// Income and transfer categories are not spend, so they are rejected.
+    static func budgetableCategory(_ raw: String?) throws -> SpendingCategory {
+        guard let raw, !raw.isEmpty else {
+            throw HTTPError(.badRequest, message: "Missing category path parameter")
+        }
+        guard let category = SpendingCategory(rawValue: raw) else {
+            throw HTTPError(.badRequest, message: "Unknown spending category '\(raw)'")
+        }
+        guard !CategoryBudgetPlanner.excludedCategories.contains(category) else {
+            throw HTTPError(.badRequest, message: "Income and transfer categories cannot be budgeted")
+        }
+        return category
+    }
+
+    static func validateLimit(_ limit: Double) throws {
+        guard limit.isFinite, limit > 0 else {
+            throw HTTPError(.badRequest, message: "monthlyLimit must be a positive amount")
+        }
+    }
+
+    static func jsonResponse(_ value: some Encodable) throws -> Response {
+        let data = try JSONEncoder().encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Storage/BudgetStore.swift
+++ b/Sources/PlaidBarServer/Storage/BudgetStore.swift
@@ -1,0 +1,52 @@
+import FluentKit
+import Foundation
+import HummingbirdFluent
+import PlaidBarCore
+
+/// Local persistence for user-set category budgets (AND-402).
+///
+/// Mirrors `TokenStore`: an `actor` over the same Fluent/SQLite store, so writes
+/// are serialized and the database stays single-writer. Budgets are display-safe
+/// numbers (no Plaid tokens or account data), so unlike `TokenStore` there is no
+/// Keychain indirection — the value lives directly in SQLite.
+actor BudgetStore {
+    private let fluent: Fluent
+
+    init(fluent: Fluent) {
+        self.fluent = fluent
+    }
+
+    /// All saved budgets, ordered by category display name for a stable list.
+    /// Rows whose stored category no longer maps to a known `SpendingCategory`
+    /// (e.g. a taxonomy change) are skipped rather than surfaced as garbage.
+    func allBudgets() async throws -> [CategoryBudgetDTO] {
+        let rows = try await CategoryBudgetModel.query(on: fluent.db()).all()
+        return rows
+            .compactMap { row -> CategoryBudgetDTO? in
+                guard let key = row.id, let category = SpendingCategory(rawValue: key) else {
+                    return nil
+                }
+                return CategoryBudgetDTO(category: category, monthlyLimit: row.monthlyLimit)
+            }
+            .sorted { $0.category.displayName < $1.category.displayName }
+    }
+
+    /// Upsert the monthly limit for a category (one budget per category).
+    func saveBudget(category: SpendingCategory, monthlyLimit: Double) async throws {
+        let key = category.rawValue
+        if let existing = try await CategoryBudgetModel.find(key, on: fluent.db()) {
+            existing.monthlyLimit = monthlyLimit
+            try await existing.save(on: fluent.db())
+        } else {
+            try await CategoryBudgetModel(category: key, monthlyLimit: monthlyLimit)
+                .save(on: fluent.db())
+        }
+    }
+
+    /// Remove a category's budget. A no-op if none is saved.
+    func deleteBudget(category: SpendingCategory) async throws {
+        guard let existing = try await CategoryBudgetModel.find(category.rawValue, on: fluent.db())
+        else { return }
+        try await existing.delete(on: fluent.db())
+    }
+}

--- a/Sources/PlaidBarServer/Storage/CategoryBudgetModel.swift
+++ b/Sources/PlaidBarServer/Storage/CategoryBudgetModel.swift
@@ -1,0 +1,47 @@
+import FluentKit
+import Foundation
+
+// MARK: - Category Budget Model (Fluent)
+
+/// One saved monthly limit per spending category (AND-402). The row id is the
+/// `SpendingCategory.rawValue`, so a category has at most one budget and upserts
+/// are a primary-key lookup. Holds only a display-safe number — no Plaid data.
+final class CategoryBudgetModel: Model, @unchecked Sendable {
+    static let schema = "category_budgets"
+
+    @ID(custom: "category", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "monthly_limit")
+    var monthlyLimit: Double
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    init() {}
+
+    init(category: String, monthlyLimit: Double) {
+        self.id = category
+        self.monthlyLimit = monthlyLimit
+    }
+}
+
+// MARK: - Migration
+
+struct CreateCategoryBudgets: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("category_budgets")
+            .field("category", .string, .identifier(auto: false))
+            .field("monthly_limit", .double, .required)
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("category_budgets").delete()
+    }
+}

--- a/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
+++ b/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import FluentKit
+import FluentSQLiteDriver
+import Hummingbird
+import HummingbirdFluent
+import Logging
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+@Suite("Category budget persistence (AND-402)")
+struct CategoryBudgetStoreTests {
+    /// Runs `body` against a BudgetStore backed by a temporary SQLite file, then
+    /// always shuts Fluent down so the test does not hold database files.
+    private func withBudgetStore(_ body: (BudgetStore) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-budget-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("budgets.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.budgets")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateCategoryBudgets())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(BudgetStore(fluent: fluent))
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    // MARK: - Storage round-trip
+
+    @Test("Saved budgets round-trip and list sorted by category name")
+    func roundTripSorted() async throws {
+        try await withBudgetStore { store in
+            try await store.saveBudget(category: .transportation, monthlyLimit: 200)
+            try await store.saveBudget(category: .foodAndDrink, monthlyLimit: 500)
+
+            let budgets = try await store.allBudgets()
+            // "Food & Drink" sorts before "Transportation".
+            #expect(budgets.map(\.category) == [.foodAndDrink, .transportation])
+            #expect(budgets.map(\.monthlyLimit) == [500, 200])
+        }
+    }
+
+    @Test("Saving the same category twice updates rather than duplicates")
+    func upsertReplaces() async throws {
+        try await withBudgetStore { store in
+            try await store.saveBudget(category: .shopping, monthlyLimit: 150)
+            try await store.saveBudget(category: .shopping, monthlyLimit: 250)
+
+            let budgets = try await store.allBudgets()
+            #expect(budgets.count == 1)
+            #expect(budgets.first?.monthlyLimit == 250)
+        }
+    }
+
+    @Test("Deleting a budget removes it; deleting a missing one is a no-op")
+    func deleteRemovesAndTolerates() async throws {
+        try await withBudgetStore { store in
+            try await store.saveBudget(category: .entertainment, monthlyLimit: 100)
+            try await store.deleteBudget(category: .entertainment)
+            let afterDelete = try await store.allBudgets()
+            #expect(afterDelete.isEmpty)
+
+            // No throw when nothing is stored.
+            try await store.deleteBudget(category: .entertainment)
+        }
+    }
+
+    @Test("An empty store returns no budgets")
+    func emptyStore() async throws {
+        try await withBudgetStore { store in
+            let budgets = try await store.allBudgets()
+            #expect(budgets.isEmpty)
+        }
+    }
+
+    // MARK: - Route validation
+
+    @Test("Path category parameter parses, with bad/missing/excluded values rejected")
+    func categoryValidation() throws {
+        #expect(try BudgetRoutes.budgetableCategory("FOOD_AND_DRINK") == .foodAndDrink)
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory(nil) }
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory("") }
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory("NOT_A_CATEGORY") }
+        // Income and transfers are not budgetable spend.
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory("INCOME") }
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory("TRANSFER_IN") }
+        #expect(throws: (any Error).self) { try BudgetRoutes.budgetableCategory("TRANSFER_OUT") }
+    }
+
+    @Test("Monthly limit must be positive and finite")
+    func limitValidation() throws {
+        #expect(throws: Never.self) { try BudgetRoutes.validateLimit(100) }
+        #expect(throws: (any Error).self) { try BudgetRoutes.validateLimit(0) }
+        #expect(throws: (any Error).self) { try BudgetRoutes.validateLimit(-50) }
+        #expect(throws: (any Error).self) { try BudgetRoutes.validateLimit(.nan) }
+        #expect(throws: (any Error).self) { try BudgetRoutes.validateLimit(.infinity) }
+    }
+
+    @Test("CategoryBudgetsResponse.byCategory maps for the planner")
+    func responseMapsToPlannerInput() {
+        let response = CategoryBudgetsResponse(budgets: [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500),
+            CategoryBudgetDTO(category: .shopping, monthlyLimit: 200),
+        ])
+        #expect(response.byCategory == [.foodAndDrink: 500, .shopping: 200])
+    }
+}


### PR DESCRIPTION
## Problem
AND-402's editable-budget half (create / edit / delete monthly category limits) needs durable, local-first storage. The deterministic scoring core already merged in #349; this adds the persistence layer.

## Root Cause
No store or endpoints existed for user-set budgets.

## Solution
Server-side SQLite persistence (the architecture chosen for the budgeting suite — the app is a stateless HTTP client; the server owns all storage):
- **`CategoryBudgetModel` + `CreateCategoryBudgets`** — `category_budgets` table keyed by `SpendingCategory.rawValue` (one budget/category). Display-safe limit only — no Plaid tokens/account data, so no Keychain indirection.
- **`BudgetStore`** actor — mirrors `TokenStore` over the same Fluent store: list / upsert / delete.
- **`BudgetRoutes`** under the `APITokenMiddleware`-guarded `/api` group: `GET /api/budgets`, `PUT /api/budgets/:category`, `DELETE /api/budgets/:category`. Rejects unknown + income/transfer categories; limit must be positive & finite.
- Shared DTOs in `PlaidBarCore` (`CategoryBudgetDTO` / `CategoryBudgetsResponse` / `SaveCategoryBudgetRequest`); `byCategory` feeds `CategoryBudgetPlanner.presentation` directly.
- README API table updated.

## Validation
CI intentionally off (#309) → local:
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!**
- `swift test` → **634 tests passed** (7 new)

Tests: storage round-trip + sort, upsert-replaces-not-duplicates, delete (+ no-op on missing), empty store, route category validation (unknown/missing/income/transfer rejected), limit validation (zero/negative/NaN/Inf rejected), response→planner mapping.

## Risk
Low. Additive table (no migration of existing data); all endpoints token-gated; budgets never widen the `/api/status` privacy posture. `BudgetStore` is an `actor`; strict-concurrency clean.

## Rollback
Revert this commit. The `category_budgets` table is independent — a revert simply stops touching it.

## Scope / follow-up
**Slice 2** of AND-402. Remaining **slice 3**: app-side `ServerClient` methods + the Wealth Summary budgets UI (suggested-budget progress + create/edit/delete), which makes this user-reachable. AND-402 stays In Progress until then.

Part of AND-402