### PR TITLE
feat: fix Hosted Link 500 + detachable desktop window + consumer-prod foundation

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -24,6 +24,7 @@ final class AppState {
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
+        static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
     }
 
     // MARK: - State
@@ -51,6 +52,20 @@ final class AppState {
         }
     }
     var isPopoverPresented = false
+
+    /// When true, the dashboard lives in a floating desktop window instead of
+    /// the menu-bar popover (AND-384). Persisted so the window reopens on the
+    /// next launch. While detached, a click on the menu-bar item raises the
+    /// floating window rather than opening the popover; re-docking flips this
+    /// back to false and the popover resumes. Mirrors the `dashboard.detached`
+    /// `@AppStorage` key the Settings toggle writes, so the toggle and the
+    /// in-dashboard pin/re-dock controls stay in sync.
+    var isDashboardDetached = false {
+        didSet {
+            guard isDashboardDetached != oldValue else { return }
+            UserDefaults.standard.set(isDashboardDetached, forKey: Keys.dashboardDetached)
+        }
+    }
 
     /// Persisted across launches so configured installs boot straight into
     /// the dashboard instead of flashing first-run onboarding until the
@@ -235,6 +250,10 @@ final class AppState {
         loadPersistedBalanceHistory()
         // Launch at login
         launchAtLogin = LaunchService.isEnabled
+        // Detached-dashboard intent (AND-384)
+        if defaults.object(forKey: Keys.dashboardDetached) != nil {
+            isDashboardDetached = defaults.bool(forKey: Keys.dashboardDetached)
+        }
     }
 
     // MARK: - Computed

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -250,10 +250,19 @@ final class AppState {
         loadPersistedBalanceHistory()
         // Launch at login
         launchAtLogin = LaunchService.isEnabled
-        // Detached-dashboard intent (AND-384)
-        if defaults.object(forKey: Keys.dashboardDetached) != nil {
-            isDashboardDetached = defaults.bool(forKey: Keys.dashboardDetached)
-        }
+        // Detached-dashboard intent (AND-384). A headless snapshot render
+        // ignores the persisted intent so the popover-capture path stays
+        // deterministic regardless of host/CI defaults — otherwise a stale
+        // `dashboard.detached = true` would spawn the floating window and
+        // intercept the renderer's popover open. The stored value is left
+        // untouched (no write-back) so the real user preference survives.
+        let storedDetached = defaults.object(forKey: Keys.dashboardDetached) != nil
+            ? defaults.bool(forKey: Keys.dashboardDetached)
+            : nil
+        isDashboardDetached = DetachedDashboardPreferences.resolvedDetachedIntent(
+            storedValue: storedDetached,
+            isRenderingSnapshot: CommandLineOptions.isRenderingSnapshot()
+        )
     }
 
     // MARK: - Computed

--- a/Sources/PlaidBar/App/DashboardPresentation.swift
+++ b/Sources/PlaidBar/App/DashboardPresentation.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// How the dashboard (`MainPopover`) is currently being presented, plus the
+/// affordance to switch surfaces (AND-384).
+///
+/// The same `MainPopover` view renders in two hosts: the menu-bar popover and a
+/// floating desktop window. This environment value tells the view which host it
+/// is in so it can show the right control — a "Detach" pin in popover mode, a
+/// "Re-dock" control in detached mode — without the view ever touching AppKit
+/// window lifecycle. The closures are supplied by the host (the app scene for
+/// detach, the window controller for re-dock).
+enum DashboardPresentation: Sendable {
+    /// Rendered inside the menu-bar popover. `detach` opens the floating window.
+    case popover(detach: @MainActor @Sendable () -> Void)
+    /// Rendered inside the floating desktop window. `redock` returns to the
+    /// popover.
+    case detached(redock: @MainActor @Sendable () -> Void)
+
+    var isDetached: Bool {
+        if case .detached = self { return true }
+        return false
+    }
+}
+
+private struct DashboardPresentationKey: EnvironmentKey {
+    /// Default: a popover with a no-op detach, used by previews, the snapshot
+    /// renderer, and any host that does not wire detaching. The control still
+    /// renders but does nothing, so headless renders are unaffected.
+    static let defaultValue: DashboardPresentation = .popover(detach: {})
+}
+
+extension EnvironmentValues {
+    var dashboardPresentation: DashboardPresentation {
+        get { self[DashboardPresentationKey.self] }
+        set { self[DashboardPresentationKey.self] = newValue }
+    }
+}

--- a/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
@@ -1,0 +1,84 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Bridges the declarative `AppState.isDashboardDetached` flag and the menu-bar
+/// popover to the imperative `DetachedDashboardWindowController` (AND-384).
+///
+/// Owned by the app scene as `@State` so it lives for the process lifetime and
+/// survives `body` recomputes. It lazily builds the window controller on first
+/// detach (so a user who never detaches never allocates an `NSPanel`), and
+/// exposes the small set of intents the scene needs: `detach`, `redock`, sync
+/// after a state change, the click-intercept decision, and restore-on-launch.
+///
+/// `@MainActor`/`@Observable`; all window work is main-actor isolated, which
+/// keeps it correct under `-strict-concurrency=complete`.
+@MainActor
+@Observable
+final class DetachedDashboardCoordinator {
+    private var controller: DetachedDashboardWindowController?
+
+    /// True while the floating dashboard window is on screen. Used to decide
+    /// whether a menu-bar click should raise the window vs. open the popover.
+    var isWindowVisible: Bool {
+        controller?.isPresented ?? false
+    }
+
+    // MARK: - Intents
+
+    /// User asked to detach: persist the intent, open the floating window, and
+    /// dismiss the menu-bar popover so only one surface is up.
+    func detach(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        appState.isDashboardDetached = true
+        appState.isPopoverPresented = false
+        present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
+    }
+
+    /// User asked to re-dock (close button, in-dashboard control, or toggle off):
+    /// clear the intent and hide the floating window. The popover resumes opening
+    /// from the menu-bar item on the next click.
+    func redock(appState: AppState, reduceMotion: Bool) {
+        appState.isDashboardDetached = false
+        controller?.hide(reduceMotion: reduceMotion)
+    }
+
+    /// Reconciles the window with the persisted/observed `isDashboardDetached`
+    /// flag. Call from `.onChange(of: appState.isDashboardDetached)` and once at
+    /// launch to restore a window that was open when the app last quit.
+    func sync(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        if appState.isDashboardDetached {
+            present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
+        } else {
+            controller?.hide(reduceMotion: reduceMotion)
+        }
+    }
+
+    /// A click on the menu-bar item while detached should raise the floating
+    /// window, not open the popover. Returns true when the click was consumed by
+    /// raising the window; the caller then keeps `isPopoverPresented` false.
+    @discardableResult
+    func handleMenuBarActivation(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) -> Bool {
+        guard appState.isDashboardDetached else { return false }
+        present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
+        controller?.raise()
+        return true
+    }
+
+    // MARK: - Private
+
+    private func present(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        let controller = controller ?? DetachedDashboardWindowController(
+            appState: appState,
+            forcedColorScheme: forcedColorScheme,
+            onRedock: { [weak self] in
+                // The close button / in-window control routes here. Use the
+                // resolved Reduce Motion setting at call time so the hide matches
+                // the user's current accessibility preference.
+                let reduceMotionNow = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                self?.redock(appState: appState, reduceMotion: reduceMotionNow)
+            }
+        )
+        self.controller = controller
+        controller.show(reduceMotion: reduceMotion)
+    }
+}

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -1,0 +1,222 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Hosts the dashboard (`MainPopover`) in a floating, draggable desktop window
+/// so the user can pull it off the menu bar and move it anywhere (AND-384).
+///
+/// The window is a non-activating `NSPanel` at `.floating` level: it survives
+/// app-switches (it does not vanish on focus loss the way the menu-bar popover
+/// does), shows across Spaces, and is movable by dragging anywhere on its
+/// surface (`isMovableByWindowBackground`). It hosts the *same* `MainPopover`
+/// view bound to the *same* `AppState`, so there is no duplicate data, sync
+/// timer, or server client — only a second presentation surface.
+///
+/// Frame (origin + size) is persisted by AppKit via `frameAutosaveName`, so the
+/// window reopens where the user left it. Open/closed intent is persisted
+/// separately by `AppState.isDashboardDetached`.
+///
+/// `@MainActor`-isolated; all AppKit window mutation happens on the main actor,
+/// which keeps it correct under `-strict-concurrency=complete`.
+@MainActor
+final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
+    private let appState: AppState
+    private let forcedColorScheme: ColorScheme?
+    /// Re-docks the dashboard back into the menu-bar popover when the panel is
+    /// closed (via the close button or the in-dashboard re-dock control). Set by
+    /// the owner so the controller does not reach back into app state policy.
+    private let onRedock: @MainActor () -> Void
+
+    private var panel: NSPanel?
+    private var hostingController: NSHostingController<AnyView>?
+
+    init(
+        appState: AppState,
+        forcedColorScheme: ColorScheme?,
+        onRedock: @escaping @MainActor () -> Void
+    ) {
+        self.appState = appState
+        self.forcedColorScheme = forcedColorScheme
+        self.onRedock = onRedock
+        super.init()
+    }
+
+    /// True while the floating panel exists and is on screen.
+    var isPresented: Bool {
+        panel?.isVisible ?? false
+    }
+
+    // MARK: - Lifecycle
+
+    /// Shows the floating dashboard, creating the panel on first use. Idempotent:
+    /// when the panel already exists it is raised and re-focused instead of
+    /// recreated, so a second "detach" or a status-item click while detached
+    /// just brings the existing window forward (no duplicate windows).
+    func show(reduceMotion: Bool) {
+        let panel = panel ?? makePanel()
+        self.panel = panel
+
+        if panel.isVisible {
+            raise()
+            return
+        }
+
+        // Reduce Motion: appear instantly. Otherwise a brief cross-fade in so the
+        // window does not pop. The window's content alpha is animated, not a
+        // layout move, so it never shifts the dashboard.
+        if reduceMotion {
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+        } else {
+            panel.alphaValue = 0
+            panel.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.18
+                context.allowsImplicitAnimation = true
+                panel.animator().alphaValue = 1
+            }
+        }
+    }
+
+    /// Hides the floating dashboard without tearing it down, so the next `show`
+    /// is instant and the hosted SwiftUI state survives. Respects Reduce Motion.
+    func hide(reduceMotion: Bool) {
+        guard let panel, panel.isVisible else { return }
+
+        if reduceMotion {
+            panel.orderOut(nil)
+        } else {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.14
+                context.allowsImplicitAnimation = true
+                panel.animator().alphaValue = 0
+            } completionHandler: { [weak panel] in
+                MainActor.assumeIsolated {
+                    panel?.orderOut(nil)
+                    panel?.alphaValue = 1
+                }
+            }
+        }
+    }
+
+    /// Brings an already-visible panel to the front and gives it key focus, so a
+    /// click on the menu-bar item while detached surfaces the window instead of
+    /// opening the popover.
+    func raise() {
+        guard let panel else { return }
+        panel.alphaValue = 1
+        panel.orderFrontRegardless()
+        panel.makeKey()
+    }
+
+    // MARK: - Panel construction
+
+    private func makePanel() -> NSPanel {
+        let size = DetachedDashboardPreferences.defaultContentSize
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            // .nonactivatingPanel keeps the rest of the app from losing focus
+            // when the window comes forward; titled/closable/resizable give it
+            // standard window chrome (drag, close, resize handles).
+            styleMask: [.titled, .closable, .resizable, .nonactivatingPanel, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.title = DetachedDashboardPreferences.windowTitle
+        // Float above ordinary windows but below modal panels, so the dashboard
+        // stays glanceable over other apps the way the popover does.
+        panel.level = .floating
+        // Drag the whole surface — the dashboard has no title-bar-only grab area,
+        // so the user can move it by grabbing anywhere not interactive (AND-384).
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isFloatingPanel = true
+        // Show on every Space and stay up in full-screen apps, so the dashboard
+        // is reachable from wherever the user is working.
+        panel.collectionBehavior = [
+            .canJoinAllSpaces,
+            .fullScreenAuxiliary,
+            .moveToActiveSpace,
+        ]
+        panel.contentMinSize = DetachedDashboardPreferences.minContentSize
+        panel.delegate = self
+
+        if let forcedColorScheme {
+            panel.appearance = NSAppearance(named: forcedColorScheme == .dark ? .darkAqua : .aqua)
+        }
+
+        // No `.preferredContentSize`: the dashboard fills the resizable panel
+        // (maxWidth/maxHeight: .infinity) and the panel's frame drives the
+        // hosting view, so dragging the resize handle resizes the content rather
+        // than SwiftUI's intrinsic size fighting the user's chosen frame.
+        let hosting = NSHostingController(rootView: makeRootView())
+        panel.contentViewController = hosting
+        self.hostingController = hosting
+
+        // Restore the persisted frame (origin + size) if one exists; otherwise
+        // center the default-sized window. setFrameUsingName returns false the
+        // first time, before any frame has been autosaved.
+        panel.setFrameAutosaveName(DetachedDashboardPreferences.frameAutosaveName)
+        if !panel.setFrameUsingName(DetachedDashboardPreferences.frameAutosaveName) {
+            panel.setContentSize(size)
+            panel.center()
+        }
+
+        return panel
+    }
+
+    /// The hosted dashboard: the SAME `MainPopover` the menu-bar popover shows,
+    /// bound to the SAME `AppState`. A re-dock affordance is injected via the
+    /// environment so the dashboard's pin control can return to popover mode
+    /// without the view knowing about AppKit windows.
+    private func makeRootView() -> AnyView {
+        AnyView(
+            MainPopover()
+                .environment(appState)
+                .environment(\.dashboardPresentation, .detached(redock: { [weak self] in
+                    self?.onRedock()
+                }))
+                .forcedDetachedColorScheme(forcedColorScheme)
+                // The panel owns its own width via resize; let the dashboard fill
+                // it rather than imposing the popover's screen-anchored width math.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        )
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// Closing the window (red close button) re-docks to the popover, so the
+    /// menu-bar item resumes opening the popover and the toggle reflects reality.
+    /// `windowShouldClose` lets the owner drive teardown through the same
+    /// `onRedock` path the in-dashboard control uses, keeping one source of truth
+    /// for the detached → docked transition.
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onRedock()
+        // Return false: the owner hides the panel through `hide(reduceMotion:)`
+        // as part of re-docking, so we never let AppKit destroy the panel and its
+        // hosted SwiftUI state out from under us.
+        return false
+    }
+}
+
+// MARK: - Forced appearance helper
+
+private extension View {
+    /// Mirrors `PlaidBarApp`'s `--appearance` CLI override into the hosted
+    /// dashboard so the floating window honors the same forced light/dark pin as
+    /// the popover and Settings (QA aid / AND-365 parity).
+    @ViewBuilder
+    func forcedDetachedColorScheme(_ scheme: ColorScheme?) -> some View {
+        if let scheme {
+            environment(\.colorScheme, scheme)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -227,8 +227,15 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
             }
         }
 
-        if let forcedColorScheme {
-            panel.appearance = NSAppearance(named: forcedColorScheme == .dark ? .darkAqua : .aqua)
+        // Appearance for the window chrome. The CLI `--appearance` override
+        // wins; otherwise honor the stored app appearance preference so a
+        // detached window restored at launch (created from the menu-bar label,
+        // before any `.appliesAppAppearance()` scene mounts) follows the user's
+        // Light/Dark setting instead of defaulting to the system appearance.
+        // `.followSystem` leaves `panel.appearance` nil so AppKit follows the
+        // system, matching the rest of the app.
+        if let scheme = Self.effectiveColorScheme(forcedColorScheme: forcedColorScheme) {
+            panel.appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua)
         }
 
         // No `.preferredContentSize`: the dashboard fills the resizable panel
@@ -262,11 +269,28 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                 .environment(\.dashboardPresentation, .detached(redock: { [weak self] in
                     self?.onRedock()
                 }))
-                .forcedDetachedColorScheme(forcedColorScheme)
+                // Same precedence as the panel chrome: CLI override, else the
+                // stored Light/Dark preference, else follow the system.
+                .forcedDetachedColorScheme(Self.effectiveColorScheme(forcedColorScheme: forcedColorScheme))
                 // The panel owns its own width via resize; let the dashboard fill
                 // it rather than imposing the popover's screen-anchored width math.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
+    }
+
+    /// The color scheme to pin the detached window to: the CLI `--appearance`
+    /// override if present, otherwise the stored app appearance preference
+    /// (`AppAppearanceMode`), otherwise `nil` to follow the system. Resolving the
+    /// stored preference here is what lets a launch-restored detached window
+    /// honor Light/Dark before any `.appliesAppAppearance()` scene has mounted.
+    static func effectiveColorScheme(forcedColorScheme: ColorScheme?) -> ColorScheme? {
+        if let forcedColorScheme { return forcedColorScheme }
+        let raw = UserDefaults.standard.string(forKey: AppAppearanceMode.storageKey)
+        switch AppAppearanceMode(rawValue: raw ?? "") ?? .followSystem {
+        case .followSystem: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
     }
 
     // MARK: - NSWindowDelegate

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -29,6 +29,22 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
 
     private var panel: NSPanel?
     private var hostingController: NSHostingController<AnyView>?
+    /// Monotonic counter bumped on every `show`/`raise`. A pending hide
+    /// fade-out captures the value at the time it started and only orders the
+    /// panel out if it is still the latest — so quickly re-showing the window
+    /// while a hide animation is in flight cannot order out the freshly-shown
+    /// panel (which would leave `isDashboardDetached == true` with no window).
+    private var presentationGeneration = 0
+    /// Observes `dashboard.selectedAccountId` so the panel's real resize floor
+    /// (`contentMinSize`) tracks whether the trailing inspector is showing.
+    ///
+    /// No `deinit` removal: this controller is owned by the app scene's
+    /// process-lifetime `DetachedDashboardCoordinator`, so it is never
+    /// deallocated during a run, and a nonisolated `deinit` cannot legally touch
+    /// this main-actor, non-`Sendable` token under Swift 6 anyway. The closure
+    /// captures `self` weakly, so even an orphaned observation is a harmless
+    /// no-op.
+    private var selectionObserver: NSObjectProtocol?
 
     init(
         appState: AppState,
@@ -55,6 +71,13 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     func show(reduceMotion: Bool) {
         let panel = panel ?? makePanel()
         self.panel = panel
+
+        // A show supersedes any in-flight hide: bump the generation so a pending
+        // fade-out completion does not order this panel back out.
+        presentationGeneration += 1
+        // Make sure the resize floor reflects the current inspector state before
+        // the window appears (a launch-restore could already have a selection).
+        updateContentMinSize()
 
         if panel.isVisible {
             raise()
@@ -86,12 +109,21 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         if reduceMotion {
             panel.orderOut(nil)
         } else {
+            // Capture the generation this hide belongs to; if a `show`/`raise`
+            // bumps it before the fade completes, the panel was re-presented and
+            // must NOT be ordered out by this stale completion.
+            let hideGeneration = presentationGeneration
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.14
                 context.allowsImplicitAnimation = true
                 panel.animator().alphaValue = 0
-            } completionHandler: { [weak panel] in
+            } completionHandler: { [weak self, weak panel] in
                 MainActor.assumeIsolated {
+                    guard let self, self.presentationGeneration == hideGeneration else {
+                        // Superseded by a newer show/raise — leave it visible.
+                        panel?.alphaValue = 1
+                        return
+                    }
                     panel?.orderOut(nil)
                     panel?.alphaValue = 1
                 }
@@ -104,9 +136,40 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// opening the popover.
     func raise() {
         guard let panel else { return }
+        // A raise also supersedes an in-flight hide.
+        presentationGeneration += 1
         panel.alphaValue = 1
         panel.orderFrontRegardless()
         panel.makeKey()
+    }
+
+    // MARK: - Resize floor
+
+    /// Keeps the panel's real resize floor (`contentMinSize`) in step with the
+    /// trailing inspector: the SwiftUI `frame(minWidth:)` only constrains layout
+    /// *inside* the hosting view, so without this a window already resized down
+    /// to the two-column minimum could stay narrower than the three-column
+    /// (982pt) layout and clip the inspector when an account is selected.
+    private func updateContentMinSize() {
+        guard let panel else { return }
+        let inspectorOpen = !Self.selectedAccountId().isEmpty
+        let minWidth = DetachedDashboardPreferences.minContentWidth(isInspectorOpen: inspectorOpen)
+        panel.contentMinSize = CGSize(
+            width: minWidth,
+            height: DetachedDashboardPreferences.minContentHeight
+        )
+        // If the user had already shrunk the window below the new floor, grow it
+        // so the inspector is not clipped the instant it opens.
+        if panel.frame.width < minWidth {
+            var frame = panel.frame
+            // Grow rightward from the existing origin (keeps the left edge put).
+            frame.size.width = minWidth
+            panel.setFrame(frame, display: true, animate: false)
+        }
+    }
+
+    private static func selectedAccountId() -> String {
+        UserDefaults.standard.string(forKey: "dashboard.selectedAccountId") ?? ""
     }
 
     // MARK: - Panel construction
@@ -146,6 +209,23 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         ]
         panel.contentMinSize = DetachedDashboardPreferences.minContentSize
         panel.delegate = self
+
+        // Keep the resize floor in step with account selection while the window
+        // is open: selecting an account opens the inspector, which needs the
+        // wider three-column floor. `dashboard.selectedAccountId` is the same
+        // `@AppStorage` key `MainPopover` drives, so observing UserDefaults
+        // reflects both in-window selection and persisted restores.
+        if selectionObserver == nil {
+            selectionObserver = NotificationCenter.default.addObserver(
+                forName: UserDefaults.didChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.updateContentMinSize()
+                }
+            }
+        }
 
         if let forcedColorScheme {
             panel.appearance = NSAppearance(named: forcedColorScheme == .dark ? .darkAqua : .aqua)

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -72,8 +72,32 @@ struct PlaidBarApp: App {
                 }))
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
-                // Restore a window that was open at last quit, and keep the
-                // floating window in lockstep with the persisted/toggled flag.
+                // While detached, a status-item click sets isPopoverPresented
+                // true; intercept it, snap it back to false, and raise the
+                // floating window instead of opening the popover (AND-384). This
+                // observer belongs on the popover content because it reacts to
+                // the popover being presented.
+                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                    guard isPresented, appState.isDashboardDetached else { return }
+                    appState.isPopoverPresented = false
+                    detachedDashboard.handleMenuBarActivation(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }
+        } label: {
+            MenuBarLabel()
+                .environment(appState)
+                .forcedAppColorScheme(Self.forcedColorScheme)
+                // The menu-bar label is the only scene content that is mounted
+                // for the whole app lifetime — `MainPopover` is mounted lazily,
+                // only while the popover/menu-extra window is presented, and
+                // `Settings` likewise. So the floating-window restore-at-launch
+                // and the persisted/toggled-intent sync live here: otherwise a
+                // saved `dashboard.detached = true` would not reopen the window
+                // until the user first opened the popover, and a Settings-only
+                // toggle would not take effect until then either (AND-384).
                 .task {
                     detachedDashboard.sync(
                         appState: appState,
@@ -88,22 +112,6 @@ struct PlaidBarApp: App {
                         reduceMotion: reduceMotion
                     )
                 }
-                // While detached, a status-item click sets isPopoverPresented
-                // true; intercept it, snap it back to false, and raise the
-                // floating window instead of opening the popover (AND-384).
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isDashboardDetached else { return }
-                    appState.isPopoverPresented = false
-                    detachedDashboard.handleMenuBarActivation(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                }
-        } label: {
-            MenuBarLabel()
-                .environment(appState)
-                .forcedAppColorScheme(Self.forcedColorScheme)
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
             statusItemContextMenuController.configure(

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -72,20 +72,6 @@ struct PlaidBarApp: App {
                 }))
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
-                // While detached, a status-item click sets isPopoverPresented
-                // true; intercept it, snap it back to false, and raise the
-                // floating window instead of opening the popover (AND-384). This
-                // observer belongs on the popover content because it reacts to
-                // the popover being presented.
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isDashboardDetached else { return }
-                    appState.isPopoverPresented = false
-                    detachedDashboard.handleMenuBarActivation(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                }
         } label: {
             MenuBarLabel()
                 .environment(appState)
@@ -93,13 +79,30 @@ struct PlaidBarApp: App {
                 // The menu-bar label is the only scene content that is mounted
                 // for the whole app lifetime — `MainPopover` is mounted lazily,
                 // only while the popover/menu-extra window is presented, and
-                // `Settings` likewise. So the floating-window restore-at-launch
-                // and the persisted/toggled-intent sync live here: otherwise a
-                // saved `dashboard.detached = true` would not reopen the window
-                // until the user first opened the popover, and a Settings-only
-                // toggle would not take effect until then either (AND-384).
+                // `Settings` likewise. So the floating-window restore-at-launch,
+                // the persisted/toggled-intent sync, AND the click interceptor
+                // all live here: otherwise a saved `dashboard.detached = true`
+                // would not reopen the window until the user first opened the
+                // popover, a Settings-only toggle would not take effect until
+                // then, and — critically — a status-item click while detached
+                // (before the popover ever mounted) would set
+                // `isPopoverPresented = true` with no observer installed yet, so
+                // SwiftUI would open the popover instead of raising the floating
+                // window (AND-384).
                 .task {
                     detachedDashboard.sync(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }
+                // While detached, a status-item click sets isPopoverPresented
+                // true; intercept it on the always-mounted label, snap it back to
+                // false, and raise the floating window instead of the popover.
+                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                    guard isPresented, appState.isDashboardDetached else { return }
+                    appState.isPopoverPresented = false
+                    detachedDashboard.handleMenuBarActivation(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -7,7 +7,11 @@ import SwiftUI
 @main
 struct PlaidBarApp: App {
     @State private var appState: AppState
+    /// Owns the floating desktop-window dashboard (AND-384). `@State` so it
+    /// persists across `body` recomputes for the process lifetime.
+    @State private var detachedDashboard = DetachedDashboardCoordinator()
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let updaterController: SPUStandardUpdaterController
     private let statusItemContextMenuController = StatusItemContextMenuController()
 
@@ -59,8 +63,43 @@ struct PlaidBarApp: App {
         MenuBarExtra {
             MainPopover()
                 .environment(appState)
+                .environment(\.dashboardPresentation, .popover(detach: {
+                    detachedDashboard.detach(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }))
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
+                // Restore a window that was open at last quit, and keep the
+                // floating window in lockstep with the persisted/toggled flag.
+                .task {
+                    detachedDashboard.sync(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }
+                .onChange(of: appState.isDashboardDetached) { _, _ in
+                    detachedDashboard.sync(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }
+                // While detached, a status-item click sets isPopoverPresented
+                // true; intercept it, snap it back to false, and raise the
+                // floating window instead of opening the popover (AND-384).
+                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                    guard isPresented, appState.isDashboardDetached else { return }
+                    appState.isPopoverPresented = false
+                    detachedDashboard.handleMenuBarActivation(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    )
+                }
         } label: {
             MenuBarLabel()
                 .environment(appState)
@@ -71,6 +110,15 @@ struct PlaidBarApp: App {
                 statusItem: statusItem,
                 actions: StatusItemContextMenuActions(
                     showDashboard: {
+                        // "Open VaultPeek" raises the floating window when
+                        // detached; otherwise it opens the popover (AND-384).
+                        if detachedDashboard.handleMenuBarActivation(
+                            appState: appState,
+                            forcedColorScheme: Self.forcedColorScheme,
+                            reduceMotion: reduceMotion
+                        ) {
+                            return
+                        }
                         appState.isPopoverPresented = true
                     },
                     refreshDashboard: {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -364,6 +364,17 @@ struct GeneralSettingsView: View {
                 .help("Credit cards above this utilization threshold show warning colors")
 
                 Toggle("Launch at login", isOn: $state.launchAtLogin)
+
+                // AND-384: pop the dashboard out of the menu bar into a
+                // floating desktop window the user can drag anywhere and that
+                // survives app-switches. Bound to AppState (single source of
+                // truth, persisted to the dashboard.detached key), so toggling
+                // here opens/closes the floating window and stays in sync with
+                // the in-dashboard pin/dock control.
+                Toggle("Keep dashboard in a floating window", isOn: $state.isDashboardDetached)
+                Text("Detaches the dashboard from the menu bar into a movable desktop window that stays open when you switch apps. Click the menu bar item to bring it back to the front; dock it again from the window or this toggle.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Local AI") {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -199,7 +199,10 @@ struct MainPopover: View {
                 .frame(
                     minWidth: shouldShowSetupScreen
                         ? PopoverGeometry.width(for: .setup)
-                        : PopoverGeometry.minDashboardWidth + Layout.flyoutWidth + PopoverGeometry.dividerWidth,
+                        // Include the inspector column in the floor so selecting
+                        // an account near the minimum width does not clip the
+                        // inspector off the resizable window (AND-384/405).
+                        : PopoverGeometry.detachedMinContentWidth(isInspectorOpen: isAccountInspectorOpen),
                     maxWidth: .infinity,
                     alignment: .topLeading
                 )

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -7,6 +7,10 @@ struct MainPopover: View {
     @Environment(\.openSettings) private var openSettings
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    /// Whether this dashboard is hosted in the menu-bar popover or a floating
+    /// desktop window (AND-384). Detached, the host window owns width/height, so
+    /// the popover's fixed-width frame and screen-edge anchor are skipped.
+    @Environment(\.dashboardPresentation) private var dashboardPresentation
     @AppStorage("dashboard.accountFilter") private var selectedFilterRawValue = DashboardAccountFilter.all.rawValue
     @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
     @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
@@ -50,6 +54,13 @@ struct MainPopover: View {
         let screenCap = NSScreen.main.map { $0.visibleFrame.height - Layout.screenHeightInset } ?? fallback
         let contentCap = dashboardContentHeight > 0 ? dashboardContentHeight : screenCap
         return max(Layout.dashboardMinHeight, min(screenCap, contentCap))
+    }
+
+    /// Max height for the side columns (rail / inspector). In the popover this is
+    /// the screen-bounded scroll height so tall content scrolls inside a column;
+    /// in the detached window (AND-384) the columns fill the resizable panel.
+    private var columnMaxHeight: CGFloat {
+        dashboardPresentation.isDetached ? .infinity : dashboardScrollHeight
     }
 
     private var selectedFilter: DashboardAccountFilter {
@@ -146,29 +157,24 @@ struct MainPopover: View {
     // The visual chrome is kept on its own opaque property so neither it nor the
     // lifecycle chain in `body` overflows the single-expression type-checker.
     private var chromedPopover: some View {
-        popoverColumns
-            .frame(width: popoverWidth)
+        sizedColumns
             .foregroundStyle(AppearanceTextColors.primary)
             .environment(\.colorScheme, effectiveColorScheme)
             .background {
                 PopoverMaterialBackground(transparencySetting: transparencySetting)
             }
-            // Hold the two-column block's leading edge stable so opening the
-            // trailing inspector grows the popover rightward instead of letting
-            // AppKit re-center the widened window and slide the Wealth Summary
-            // sideways (AND-370). The same anchor clamps the widened popover
-            // inside the visible screen so it never renders off-screen near a
-            // display edge (AND-374 primary fallback).
-            .background {
-                PopoverLeadingEdgeAnchor(
-                    isInspectorOpen: isAccountInspectorOpen,
-                    collapsedWidth: twoColumnWidth,
-                    screenEdgeMargin: Layout.screenEdgeMargin
-                )
-            }
-            .background {
-                PopoverScreenWidthReader(visibleWidth: $activeScreenVisibleWidth)
-            }
+            // The screen-edge anchor and width reader only apply to the menu-bar
+            // popover window (which AppKit re-centers under the status item). The
+            // detached desktop window owns its own resizable geometry, so they
+            // are skipped there (AND-384) and the popover behavior (AND-370/374)
+            // is unchanged.
+            .modifier(PopoverWindowGeometryModifier(
+                isDetached: dashboardPresentation.isDetached,
+                isInspectorOpen: isAccountInspectorOpen,
+                collapsedWidth: twoColumnWidth,
+                screenEdgeMargin: Layout.screenEdgeMargin,
+                activeScreenVisibleWidth: $activeScreenVisibleWidth
+            ))
             .animation(
                 MotionTokens.animation(MotionTokens.content, reduceMotion: reduceMotion),
                 value: selectedAccount?.id
@@ -181,6 +187,26 @@ struct MainPopover: View {
                 MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion),
                 value: appState.error != nil
             )
+    }
+
+    /// Width handling differs by host (AND-384): the menu-bar popover pins to the
+    /// computed `popoverWidth` (screen-anchored, fixed); the floating window fills
+    /// its resizable frame down to a usable minimum so the user can size it.
+    @ViewBuilder
+    private var sizedColumns: some View {
+        if dashboardPresentation.isDetached {
+            popoverColumns
+                .frame(
+                    minWidth: shouldShowSetupScreen
+                        ? PopoverGeometry.width(for: .setup)
+                        : PopoverGeometry.minDashboardWidth + Layout.flyoutWidth + PopoverGeometry.dividerWidth,
+                    maxWidth: .infinity,
+                    alignment: .topLeading
+                )
+        } else {
+            popoverColumns
+                .frame(width: popoverWidth)
+        }
     }
 
     /// Esc handler: dismiss the inspector when open, otherwise `nil` so the key
@@ -225,8 +251,9 @@ struct MainPopover: View {
             .frame(width: Layout.flyoutWidth)
             // Cap the rail to the same screen-bounded height as the dashboard
             // scroll column so tall content scrolls inside the rail instead of
-            // growing the whole popover past the screen-bounded height.
-            .frame(maxHeight: dashboardScrollHeight)
+            // growing the whole popover past the screen-bounded height. In the
+            // detached window the panel owns the height, so the rail fills it.
+            .frame(maxHeight: columnMaxHeight)
             .leftPanelSurface()
             .transition(.move(edge: .leading).combined(with: .opacity))
     }
@@ -257,7 +284,7 @@ struct MainPopover: View {
                 }
             }
             .frame(width: Layout.flyoutWidth)
-            .frame(maxHeight: dashboardScrollHeight)
+            .frame(maxHeight: columnMaxHeight)
             .leftPanelSurface()
             // Slide in only for an in-session selection; a popover opened with a
             // persisted selection appears directly in three-column (AND-405).
@@ -399,7 +426,10 @@ struct MainPopover: View {
                 }
                 .scrollContentBackground(.hidden)
                 .frame(maxWidth: .infinity)
-                .frame(height: dashboardScrollHeight)
+                .modifier(DashboardScrollHeightModifier(
+                    isDetached: dashboardPresentation.isDetached,
+                    fixedHeight: dashboardScrollHeight
+                ))
 
                 Divider()
 
@@ -1912,6 +1942,7 @@ private func accountTrendAccessibility(_ trend: BalanceTrend) -> String {
 
 private struct DashboardFooter: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.dashboardPresentation) private var dashboardPresentation
     let settingsActivation: SettingsWindowActivationRestorer
     let openSettings: OpenSettingsAction
     let onAddAccount: () -> Void
@@ -1938,6 +1969,8 @@ private struct DashboardFooter: View {
 
             Spacer()
 
+            detachControl
+
             Button {
                 Task { await appState.refreshDashboard() }
             } label: {
@@ -1963,6 +1996,34 @@ private struct DashboardFooter: View {
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.xs)
+    }
+
+    /// Detach / re-dock affordance (AND-384). In popover mode it pops the
+    /// dashboard out into a floating desktop window the user can drag anywhere;
+    /// in the floating window it docks back to the menu-bar popover. The glyph
+    /// (macwindow vs. pin.slash) and label carry the meaning, never color.
+    @ViewBuilder
+    private var detachControl: some View {
+        switch dashboardPresentation {
+        case let .popover(detach):
+            Button(action: detach) {
+                Image(systemName: "macwindow")
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+            }
+            .buttonStyle(.borderless)
+            .help("Open dashboard in a floating window")
+            .accessibilityLabel("Detach dashboard into a floating window")
+        case let .detached(redock):
+            Button(action: redock) {
+                Image(systemName: "pin.slash")
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+            }
+            .buttonStyle(.borderless)
+            .help("Dock dashboard back to the menu bar")
+            .accessibilityLabel("Dock dashboard back to the menu bar")
+        }
     }
 
     private var statusLineText: String {
@@ -2086,6 +2147,54 @@ final class SettingsWindowActivationRestorer {
         guard let discoveryObserver else { return }
         NotificationCenter.default.removeObserver(discoveryObserver)
         self.discoveryObserver = nil
+    }
+}
+
+/// Applies the menu-bar popover's AppKit window geometry — the leading-edge
+/// anchor (AND-370/374) and the active-screen width reader (AND-405) — only when
+/// the dashboard is hosted in the popover. In the detached desktop window
+/// (AND-384) the host `NSPanel` owns its resizable geometry, so these are no-ops
+/// there and the popover behavior is untouched.
+private struct PopoverWindowGeometryModifier: ViewModifier {
+    let isDetached: Bool
+    let isInspectorOpen: Bool
+    let collapsedWidth: CGFloat
+    let screenEdgeMargin: CGFloat
+    @Binding var activeScreenVisibleWidth: CGFloat?
+
+    func body(content: Content) -> some View {
+        if isDetached {
+            content
+        } else {
+            content
+                .background {
+                    PopoverLeadingEdgeAnchor(
+                        isInspectorOpen: isInspectorOpen,
+                        collapsedWidth: collapsedWidth,
+                        screenEdgeMargin: screenEdgeMargin
+                    )
+                }
+                .background {
+                    PopoverScreenWidthReader(visibleWidth: $activeScreenVisibleWidth)
+                }
+        }
+    }
+}
+
+/// Heights for the center scroll column differ by host (AND-384). The menu-bar
+/// popover pins the scroll view to a fixed, screen-bounded height so the popover
+/// window sizes to it; the detached desktop window fills its resizable frame
+/// (with a sensible floor) so dragging the window taller shows more content.
+private struct DashboardScrollHeightModifier: ViewModifier {
+    let isDetached: Bool
+    let fixedHeight: CGFloat
+
+    func body(content: Content) -> some View {
+        if isDetached {
+            content.frame(maxHeight: .infinity)
+        } else {
+            content.frame(height: fixedHeight)
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -57,7 +57,17 @@ public enum DetachedDashboardPreferences {
     /// two-column minimum (fixed rail + the flexible center's floor), so the
     /// Wealth Summary rail and a usable dashboard always stay legible.
     public static var minContentWidth: CGFloat {
-        PopoverGeometry.railWidth + PopoverGeometry.dividerWidth + PopoverGeometry.minDashboardWidth
+        minContentWidth(isInspectorOpen: false)
+    }
+
+    /// Minimum content width the floating panel may be resized to for the current
+    /// inspector state. When the trailing account inspector is open the floor
+    /// must include its fixed-width column, or a window resized to the two-column
+    /// minimum would clip the inspector the moment an account is selected
+    /// (AND-384/405). Shares `PopoverGeometry` so the panel's `contentMinSize`
+    /// and `MainPopover`'s SwiftUI `frame(minWidth:)` agree on the floor.
+    public static func minContentWidth(isInspectorOpen: Bool) -> CGFloat {
+        PopoverGeometry.detachedMinContentWidth(isInspectorOpen: isInspectorOpen)
     }
 
     /// Minimum content height the floating panel may be resized to: enough for

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -1,0 +1,63 @@
+import CoreGraphics
+
+/// Pure, `Sendable` configuration for the detached (floating-window) dashboard
+/// mode (AND-384): UserDefaults keys, the default content size, and the
+/// clamp that keeps a restored frame size sane.
+///
+/// Kept in `PlaidBarCore` so the storage keys and sizing math are a single
+/// source of truth shared by the SwiftUI views (`MainPopover`, `SettingsView`),
+/// the app scene (`PlaidBarApp`), and the AppKit window controller
+/// (`DetachedDashboardWindowController`), and so the size derivation stays
+/// unit-testable without importing AppKit.
+public enum DetachedDashboardPreferences {
+    /// `@AppStorage` key for the user preference that the dashboard should live
+    /// in a floating desktop window instead of the menu-bar popover. This is the
+    /// durable intent; `AppState.isDashboardDetached` mirrors it at runtime.
+    public static let detachedStorageKey = "dashboard.detached"
+
+    /// `frameAutosaveName` for the floating panel. AppKit persists the panel's
+    /// origin and size under this name in the standard user defaults, so the
+    /// window reopens where the user last left it across launches.
+    public static let frameAutosaveName = "VaultPeekDetachedDashboard"
+
+    /// Accessibility / window title for the floating panel. Read by VoiceOver and
+    /// shown in the window menu and Mission Control.
+    public static let windowTitle = "VaultPeek Dashboard"
+
+    /// Default content width of the floating panel before any persisted frame is
+    /// restored: the popover's two-column base (rail + divider + dashboard), so
+    /// the detached window opens at the same width the popover uses with no
+    /// account selected.
+    public static var defaultContentWidth: CGFloat {
+        PopoverGeometry.width(for: .twoColumn)
+    }
+
+    /// Default content height of the floating panel before any persisted frame is
+    /// restored: the realistic popover height budget, so a freshly detached
+    /// window matches the popover's vertical footprint.
+    public static var defaultContentHeight: CGFloat {
+        CGFloat(DashboardOverviewHeightBudget.realisticPopoverHeight)
+    }
+
+    /// Minimum content width the floating panel may be resized to: the
+    /// two-column minimum (fixed rail + the flexible center's floor), so the
+    /// Wealth Summary rail and a usable dashboard always stay legible.
+    public static var minContentWidth: CGFloat {
+        PopoverGeometry.railWidth + PopoverGeometry.dividerWidth + PopoverGeometry.minDashboardWidth
+    }
+
+    /// Minimum content height the floating panel may be resized to: enough for
+    /// the header, status strip, and a couple of account rows before the body
+    /// scrolls.
+    public static let minContentHeight: CGFloat = 360
+
+    /// The default content size used when the panel has no persisted frame yet.
+    public static var defaultContentSize: CGSize {
+        CGSize(width: defaultContentWidth, height: defaultContentHeight)
+    }
+
+    /// The minimum content size enforced as the panel's `contentMinSize`.
+    public static var minContentSize: CGSize {
+        CGSize(width: minContentWidth, height: minContentHeight)
+    }
+}

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -15,6 +15,20 @@ public enum DetachedDashboardPreferences {
     /// durable intent; `AppState.isDashboardDetached` mirrors it at runtime.
     public static let detachedStorageKey = "dashboard.detached"
 
+    /// Resolves the detached intent to apply at launch from the persisted value.
+    ///
+    /// A headless snapshot render must ignore any persisted intent: on a host/CI
+    /// machine where `dashboard.detached = true`, honoring it would spawn the
+    /// floating window *and* make the scene intercept the renderer's
+    /// `isPopoverPresented = true` (snapping it back to false), so the popover
+    /// never opens and the wrong window — or none — is captured. Returns `false`
+    /// during a snapshot render regardless of the stored value; otherwise returns
+    /// the stored value, defaulting to `false` when unset.
+    public static func resolvedDetachedIntent(storedValue: Bool?, isRenderingSnapshot: Bool) -> Bool {
+        guard !isRenderingSnapshot else { return false }
+        return storedValue ?? false
+    }
+
     /// `frameAutosaveName` for the floating panel. AppKit persists the panel's
     /// origin and size under this name in the standard user defaults, so the
     /// window reopens where the user last left it across launches.

--- a/Sources/PlaidBarCore/Models/Entitlement.swift
+++ b/Sources/PlaidBarCore/Models/Entitlement.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Plan tier for a consumer entitlement.
+///
+/// FOUNDATION ONLY. Mirrors `SubscriptionPlan` (the client-side preview type)
+/// but lives on the entitlement wire/verification side. Kept as a distinct type
+/// so the entitlement layer can evolve (e.g. add-ons, custom caps) without
+/// coupling to the UI preview enum. Nothing issues or verifies real
+/// entitlements yet — see `docs/strategy/subscription-entitlements.md`.
+public enum EntitlementTier: String, Sendable, Codable, CaseIterable {
+    case personal
+    case plus
+}
+
+/// A signed consumer entitlement, as it will eventually arrive from the hosted
+/// bridge's Stripe-backed signer.
+///
+/// FOUNDATION ONLY. This is the in-memory shape of the entitlement token
+/// described in `subscription-entitlements.md` §4.2 (an Ed25519/PASETO-signed
+/// document verified locally with an embedded public key). **Nothing produces,
+/// signs, verifies, or enforces this today.** It exists so the entitlement
+/// middleware shell and future verification have a stable `Sendable` model, and
+/// so the wire contract is documented in one place. `.local` (BYO-keys) mode is
+/// ungated and never constructs an `Entitlement` (entitlements doc D3: BYO stays
+/// fully ungated).
+public struct Entitlement: Sendable, Codable, Equatable {
+    /// Plan tier this entitlement grants.
+    public let tier: EntitlementTier
+
+    /// Managed institutions this plan allows (the documented `institution_limit`
+    /// claim). Display/enforcement uses this; nothing enforces it yet.
+    public let institutionLimit: Int
+
+    /// Managed institutions currently counted against the plan (`items_used`).
+    public let itemsUsed: Int
+
+    /// Subscription lifecycle as reported by the signer (`active`, `canceled`,
+    /// …). Free-form here because the canonical set lives with the signer; the
+    /// foundation only needs to carry it through.
+    public let subscriptionStatus: String
+
+    /// Token expiry (the 30-day TTL of the signed artifact, NOT the subscription
+    /// end date — see entitlements doc §4.2 / §5).
+    public let expiresAt: Date?
+
+    public init(
+        tier: EntitlementTier,
+        institutionLimit: Int,
+        itemsUsed: Int,
+        subscriptionStatus: String,
+        expiresAt: Date?
+    ) {
+        self.tier = tier
+        self.institutionLimit = institutionLimit
+        self.itemsUsed = itemsUsed
+        self.subscriptionStatus = subscriptionStatus
+        self.expiresAt = expiresAt
+    }
+
+    /// Whether the plan has spare managed-institution capacity. Pure display
+    /// logic; not an enforcement point.
+    public var hasSpareCapacity: Bool {
+        itemsUsed < institutionLimit
+    }
+}
+
+/// The outcome of evaluating entitlement for a request.
+///
+/// FOUNDATION ONLY. The middleware shell always returns `.allow` today (local /
+/// BYO mode is ungated and the hosted path is not built). The non-`allow` cases
+/// document the future shape so enforcement can be added behind a gate without
+/// changing the decision type. The `retryAfter`/`reason` payloads map to the
+/// `402 limit_reached` / entitlement-required responses described in
+/// `managed-link-architecture.md` §6–§7.
+public enum EntitlementDecision: Sendable, Equatable {
+    /// Request proceeds. The only outcome today.
+    case allow
+
+    /// A valid entitlement is required but absent (future: missing/expired
+    /// signed token on a managed-only route).
+    case entitlementRequired(reason: String)
+
+    /// The plan's managed-institution limit is reached (future: `402`).
+    case limitReached(reason: String)
+}

--- a/Sources/PlaidBarCore/Utilities/CommandLineOptions.swift
+++ b/Sources/PlaidBarCore/Utilities/CommandLineOptions.swift
@@ -1,4 +1,8 @@
 public enum CommandLineOptions {
+    /// Flag that drives the headless snapshot renderer
+    /// (`--demo --render-snapshot <dir>`); see `SnapshotRenderer`.
+    public static let renderSnapshotFlag = "--render-snapshot"
+
     public static func value(for flag: String, in arguments: [String] = CommandLine.arguments) -> String? {
         guard let index = arguments.firstIndex(of: flag),
               index + 1 < arguments.count else {
@@ -8,5 +12,14 @@ public enum CommandLineOptions {
         let value = arguments[index + 1]
         guard !value.hasPrefix("--") else { return nil }
         return value
+    }
+
+    /// True when the process was launched to render headless snapshots. Such
+    /// runs must behave deterministically regardless of host/CI defaults, so
+    /// callers use this to neutralize persisted intents (e.g. a stale
+    /// `dashboard.detached = true`) that would otherwise change which window is
+    /// captured. Keyed on the flag's presence — no real app launch passes it.
+    public static func isRenderingSnapshot(_ arguments: [String] = CommandLine.arguments) -> Bool {
+        arguments.contains(renderSnapshotFlag)
     }
 }

--- a/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
+++ b/Sources/PlaidBarCore/Utilities/PopoverGeometry.swift
@@ -47,6 +47,22 @@ public enum PopoverGeometry {
         }
     }
 
+    /// The minimum content width for the detached floating dashboard window
+    /// (AND-384). Unlike the menu-bar popover — which AppKit pins to a computed
+    /// width — the floating window is user-resizable, so this is the floor below
+    /// which the columns would clip.
+    ///
+    /// The center dashboard may shrink to `minDashboardWidth`, but the rail and,
+    /// when present, the trailing account inspector keep their fixed `railWidth`.
+    /// When the inspector is open it must be included: otherwise the floor stays
+    /// at the two-column size and selecting an account near the minimum width
+    /// overflows the inspector off the resizable window (it cannot grow itself).
+    public static func detachedMinContentWidth(isInspectorOpen: Bool) -> CGFloat {
+        let twoColumn = railWidth + dividerWidth + minDashboardWidth
+        guard isInspectorOpen else { return twoColumn }
+        return twoColumn + dividerWidth + railWidth
+    }
+
     /// The popover's content width capped to fit the available screen width.
     ///
     /// When the full layout width exceeds the available width (minus a margin on

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -77,6 +77,11 @@ struct PlaidBarServer: AsyncParsableCommand {
         // API routes
         let api = router.group("api")
         api.add(middleware: APITokenMiddleware(authToken: serverConfig.authToken))
+        // Entitlement seam (foundation only): enforces nothing today — always
+        // allows — and is a no-op in `.local` mode. Placed between auth and
+        // setup-state so the gated consumer (Hosted Link) track has a fixed
+        // place to add Stripe-backed checks without re-threading the router.
+        api.add(middleware: EntitlementMiddleware(deployment: serverConfig.deployment))
         api.add(middleware: SetupStateMiddleware(
             credentialDiagnosis: serverConfig.credentialDiagnosis,
             plaidEnvironment: serverConfig.plaidEnvironment

--- a/Sources/PlaidBarServer/Auth/AccessTokenResolver.swift
+++ b/Sources/PlaidBarServer/Auth/AccessTokenResolver.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Hummingbird
+import PlaidBarCore
+
+/// Resolves the Plaid access token a read route needs for a given linked item.
+///
+/// FOUNDATION ONLY — a seam, not a behavior change. Today every route resolves
+/// the token the same way: `TokenStore.accessToken(for:)` reads it from the
+/// macOS Keychain (local custody). The consumer Hosted Link track needs a
+/// second posture — the *device* holds the token and supplies it on the request,
+/// while a stateless hosted proxy injects the org secret and never stores the
+/// token (`docs/strategy/managed-link-architecture.md` §5.4, Variant 1 device
+/// custody). This protocol is the single point both postures share so routes can
+/// adopt it without caring which one is active.
+///
+/// `.local` mode uses `TokenStoreAccessTokenResolver`, which delegates verbatim
+/// to today's code path — so wiring this in is behavior-preserving. The
+/// request-supplied resolver is an inert stub: it is never constructed in
+/// `.local` mode and throws `unsupportedInLocalMode` if reached, so it cannot
+/// accidentally weaken local custody.
+protocol AccessTokenResolver: Sendable {
+    /// Resolve the access token for a stored item, given the inbound request
+    /// (which a hosted-stateless resolver reads a device-supplied token from).
+    /// Local custody ignores the request entirely.
+    func accessToken(
+        for item: ItemModel,
+        request: Request
+    ) throws -> String
+}
+
+/// Local-custody resolver: the only resolver wired today. Delegates straight to
+/// `TokenStore.accessToken(for:)` (Keychain-backed), so routes that adopt the
+/// seam behave exactly as they do now in `.local` mode.
+struct TokenStoreAccessTokenResolver: AccessTokenResolver {
+    let tokenStore: TokenStore
+
+    func accessToken(for item: ItemModel, request: Request) throws -> String {
+        // `request` is intentionally unused: local custody never trusts a
+        // client-supplied token. The token lives in the Keychain.
+        try tokenStore.accessToken(for: item)
+    }
+}
+
+/// Hosted-stateless resolver STUB for the future `.hostedBridge` posture, where
+/// the device holds the access token and supplies it per request and the hosted
+/// blind proxy injects the org secret without ever persisting the token.
+///
+/// FOUNDATION ONLY. This is not wired anywhere and is never constructed in
+/// `.local` mode. It documents the intended contract (read a verified,
+/// item-bound device token off the request) and fails closed until the gated
+/// bridge work lands — it must never silently fall back to an empty or
+/// unverified token. The eventual implementation must verify the token is bound
+/// to the named managed item before returning it (architecture doc §5.4
+/// "Managed Item binding"); this stub does no such verification and therefore
+/// refuses to run.
+struct RequestSuppliedAccessTokenResolver: AccessTokenResolver {
+    /// Header the device uses to supply its custodied access token in the future
+    /// hosted-stateless posture. Defined now so the contract is documented in
+    /// one place; nothing reads it yet.
+    static let deviceTokenHeader = "X-VaultPeek-Device-Token"
+
+    func accessToken(for item: ItemModel, request: Request) throws -> String {
+        throw AccessTokenResolverError.unsupportedInLocalMode
+    }
+}
+
+/// Selects the resolver for a deployment posture. Today this always returns the
+/// local-custody resolver; `.hostedBridge` returns the inert stub. Centralizing
+/// the choice here keeps route construction posture-agnostic and gives the gated
+/// work one place to swap in the real device-token resolver.
+enum AccessTokenResolverFactory {
+    static func make(
+        deployment: DeploymentMode,
+        tokenStore: TokenStore
+    ) -> any AccessTokenResolver {
+        switch deployment {
+        case .local:
+            TokenStoreAccessTokenResolver(tokenStore: tokenStore)
+        case .hostedBridge:
+            // Inert today: `.hostedBridge` is foundation-only and the stub
+            // fails closed. When the gated bridge lands, this returns the real
+            // device-token resolver bound to `RemoteBridgeConfig`.
+            RequestSuppliedAccessTokenResolver()
+        }
+    }
+}
+
+enum AccessTokenResolverError: Error, LocalizedError, Sendable {
+    /// The request-supplied (hosted-stateless) resolver was reached, but that
+    /// posture is not implemented. Foundation guard: never weaken local custody.
+    case unsupportedInLocalMode
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedInLocalMode:
+            "Request-supplied access token resolution is not available yet; "
+                + "this build only supports local (Keychain) token custody."
+        }
+    }
+}

--- a/Sources/PlaidBarServer/Config/DeploymentMode.swift
+++ b/Sources/PlaidBarServer/Config/DeploymentMode.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Where this `PlaidBarServer` process runs and which Plaid-credential posture
+/// it uses.
+///
+/// FOUNDATION ONLY. This seam exists so the consumer (Hosted Link) track can be
+/// built incrementally without forking the server. **`.local` is the default and
+/// is byte-for-byte today's behavior**: the server holds the user's own Plaid
+/// `client_id`/`secret` (BYO-keys) and proxies Plaid directly. `.hostedBridge`
+/// is a placeholder for the future stateless bridge described in
+/// `docs/strategy/managed-link-architecture.md`; nothing reads a live bridge
+/// endpoint yet, and selecting it changes no runtime path until the gated work
+/// in `docs/strategy/approval-gates.md` lands.
+///
+/// Parsed from `PLAIDBAR_DEPLOYMENT` (env or `server.conf`). Unknown/blank
+/// values fall back to `.local` so a malformed config can never silently flip a
+/// user into a non-existent hosted path.
+enum DeploymentMode: String, Sendable, Equatable, CaseIterable {
+    /// Today's only real path: local-first, server holds the user's own Plaid
+    /// credentials and talks to Plaid directly. The default.
+    case local
+
+    /// Future consumer path: end users supply no Plaid credentials; a hosted
+    /// VaultPeek bridge mints link tokens and a stateless blind proxy injects the
+    /// org secret. Access tokens + financial data stay on the device. Inert
+    /// today — see `RemoteBridgeConfig` and the gated checklist.
+    case hostedBridge = "hosted-bridge"
+
+    static let environmentVariable = "PLAIDBAR_DEPLOYMENT"
+
+    /// Resolve from a config/env dictionary. Defaults to `.local`; an
+    /// unrecognized value also resolves to `.local` (fail-safe, never throws) so
+    /// the existing BYO path can never be broken by a typo.
+    static func resolved(from environment: [String: String]) -> DeploymentMode {
+        guard let raw = environment[environmentVariable]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty,
+            let mode = DeploymentMode(rawValue: raw)
+        else {
+            return .local
+        }
+        return mode
+    }
+}
+
+/// Placeholder configuration for the future hosted VaultPeek bridge.
+///
+/// FOUNDATION ONLY. Holds **no** live endpoints, secrets, or keys. It records
+/// the *shape* of what `.hostedBridge` mode will eventually need — a control-plane
+/// base URL (link/exchange/remove + entitlement), a blind-proxy base URL
+/// (data-plane relay), and the base64 Ed25519 public key the server verifies
+/// signed entitlements against (per `subscription-entitlements.md` §4.2). Every
+/// field is optional and defaults to `nil`; `.local` mode never constructs a
+/// non-nil value, and no code dials these URLs yet. Registering real endpoints,
+/// the org secret, and the entitlement public key is owner-gated
+/// (`docs/strategy/consumer-production-checklist.md`).
+struct RemoteBridgeConfig: Sendable, Equatable {
+    /// Control-plane base URL (link-token mint, public-token exchange, item
+    /// removal, entitlement ping). `nil` until the bridge is provisioned.
+    let controlPlaneBaseURL: String?
+
+    /// Blind-proxy (data-plane) base URL — the stateless relay that injects the
+    /// org secret for `/transactions/sync`, `/accounts/get`, etc. `nil` until
+    /// provisioned.
+    let dataPlaneProxyBaseURL: String?
+
+    /// Base64-encoded Ed25519 public key used to verify signed entitlement
+    /// tokens locally. `nil` until the signer exists. Never a private key.
+    let entitlementPublicKeyBase64: String?
+
+    /// The inert placeholder used in `.local` mode and as the default in
+    /// `.hostedBridge` mode until real values are registered.
+    static let unconfigured = RemoteBridgeConfig(
+        controlPlaneBaseURL: nil,
+        dataPlaneProxyBaseURL: nil,
+        entitlementPublicKeyBase64: nil
+    )
+
+    /// `true` only when both control-plane and data-plane URLs are present.
+    /// Today this is always `false`; it is the future guard that gates any code
+    /// path from attempting a remote call.
+    var isProvisioned: Bool {
+        controlPlaneBaseURL?.isEmpty == false
+            && dataPlaneProxyBaseURL?.isEmpty == false
+    }
+
+    /// Resolve placeholder values from a config/env dictionary. Returns
+    /// `.unconfigured` unless explicit non-empty values are present; this lets
+    /// the checklist's "provision the bridge" step populate config without any
+    /// code change, while keeping today's behavior untouched (nothing reads the
+    /// result in `.local` mode).
+    static func resolved(from environment: [String: String]) -> RemoteBridgeConfig {
+        func value(_ key: String) -> String? {
+            guard let raw = environment[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !raw.isEmpty
+            else {
+                return nil
+            }
+            return raw
+        }
+        return RemoteBridgeConfig(
+            controlPlaneBaseURL: value("PLAIDBAR_BRIDGE_CONTROL_PLANE_URL"),
+            dataPlaneProxyBaseURL: value("PLAIDBAR_BRIDGE_DATA_PLANE_URL"),
+            entitlementPublicKeyBase64: value("PLAIDBAR_ENTITLEMENT_PUBLIC_KEY")
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -22,6 +22,17 @@ struct ServerConfig: Sendable {
     let redirectUri: String
     let authToken: String
 
+    /// Deployment posture. `load` resolves it from config/env, defaulting to
+    /// `.local` (today's BYO-keys behavior). `.hostedBridge` is inert
+    /// foundation — see `DeploymentMode`. Declared without a stored default so
+    /// it stays part of the implicit memberwise initializer; `load` is the only
+    /// construction site and always supplies it.
+    let deployment: DeploymentMode
+
+    /// Placeholder hosted-bridge config. `.unconfigured` in `.local` mode and
+    /// until the bridge is provisioned. Nothing dials these endpoints yet.
+    let remoteBridge: RemoteBridgeConfig
+
     var dataDirectoryPath: String {
         URL(fileURLWithPath: databasePath)
             .deletingLastPathComponent()
@@ -102,6 +113,13 @@ struct ServerConfig: Sendable {
 
         let resolvedPort = portOverride ?? PlaidBarConstants.serverPort(environment: environmentValues)
 
+        // Deployment seam: read from config/env, defaulting to `.local` so
+        // today's BYO-keys behavior is byte-for-byte unchanged. `.hostedBridge`
+        // is inert foundation; the bridge placeholder holds no live endpoints
+        // until the owner provisions them (see consumer-production-checklist.md).
+        let deployment = DeploymentMode.resolved(from: environmentValues)
+        let remoteBridge = RemoteBridgeConfig.resolved(from: environmentValues)
+
         return ServerConfig(
             port: resolvedPort,
             plaidEnvironment: environment,
@@ -116,7 +134,9 @@ struct ServerConfig: Sendable {
                 .appendingPathComponent(pendingLinkSessionsFilename)
                 .path,
             redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
-            authToken: authToken
+            authToken: authToken,
+            deployment: deployment,
+            remoteBridge: remoteBridge
         )
     }
 

--- a/Sources/PlaidBarServer/Middleware/EntitlementMiddleware.swift
+++ b/Sources/PlaidBarServer/Middleware/EntitlementMiddleware.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import PlaidBarCore
+
+/// Entitlement enforcement seam for the consumer (Hosted Link) track.
+///
+/// FOUNDATION ONLY — **this middleware enforces nothing.** It is inserted into
+/// the `/api` chain between `APITokenMiddleware` (authentication) and
+/// `SetupStateMiddleware` (credential-readiness) so the gated managed-consumer
+/// work has a fixed, reviewed place to add Stripe-backed entitlement checks
+/// later, without re-threading the router.
+///
+/// Today it evaluates to `.allow` for every request and calls `next` unchanged,
+/// so the request path is byte-for-byte identical to before it existed. In
+/// `.local` (BYO-keys) mode it is wired but always allows; entitlements doc D3
+/// keeps BYO fully ungated, so even when enforcement is built it must stay a
+/// no-op in `.local` mode. There are **no Stripe calls, no token verification,
+/// and no network access** here.
+///
+/// When the gated work lands, `evaluate` gains: parse the device-signed
+/// entitlement, verify the embedded Ed25519 signature
+/// (`RemoteBridgeConfig.entitlementPublicKeyBase64`), check TTL/grace, and map
+/// managed-only routes to `.entitlementRequired` / `.limitReached`. The decision
+/// type (`EntitlementDecision`) already models those outcomes.
+struct EntitlementMiddleware<Context: RequestContext>: RouterMiddleware {
+    let deployment: DeploymentMode
+
+    func handle(
+        _ request: Request,
+        context: Context,
+        next: (Request, Context) async throws -> Response
+    ) async throws -> Response {
+        switch Self.evaluate(deployment: deployment, request: request) {
+        case .allow:
+            return try await next(request, context)
+        case .entitlementRequired(let reason):
+            // Unreachable today (`evaluate` only returns `.allow`). Wired so the
+            // gated implementation has the correct response shape ready.
+            return try Self.errorResponse(status: Self.paymentRequired, message: reason)
+        case .limitReached(let reason):
+            return try Self.errorResponse(status: Self.paymentRequired, message: reason)
+        }
+    }
+
+    /// HTTP 402 — `swift-http-types` does not ship a named member for it, so the
+    /// future `.entitlementRequired` / `.limitReached` paths construct it here.
+    /// Matches the `402 limit_reached` response in `managed-link-architecture.md`.
+    private static var paymentRequired: HTTPResponse.Status {
+        HTTPResponse.Status(code: 402, reasonPhrase: "Payment Required")
+    }
+
+    /// Pure decision function — no I/O, fully testable. Always `.allow` today.
+    /// `.local` mode short-circuits to `.allow` so BYO can never be gated even
+    /// after enforcement is added (entitlements doc D3).
+    static func evaluate(
+        deployment: DeploymentMode,
+        request: Request
+    ) -> EntitlementDecision {
+        switch deployment {
+        case .local:
+            return .allow
+        case .hostedBridge:
+            // FOUNDATION: the hosted path is not built. Allow unconditionally so
+            // selecting `.hostedBridge` today changes no behavior. Real checks
+            // are gated (consumer-production-checklist.md).
+            return .allow
+        }
+    }
+
+    /// Flat `{"error": ...}` body — the shape `ServerClient` extracts a
+    /// user-facing message from (matches `SetupStateMiddleware`).
+    private static func errorResponse(
+        status: HTTPResponse.Status,
+        message: String
+    ) throws -> Response {
+        let body = try JSONEncoder().encode(["error": message])
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: body))
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -65,9 +65,17 @@ actor PlaidClient: PlaidClientProtocol {
             products: ["transactions"],
             countryCodes: ["US"],
             language: "en",
-            // No top-level redirect_uri: this is a Hosted Link flow, which
-            // routes the OAuth return through hosted_link.completion_redirect_uri.
-            // Sending redirect_uri too makes Plaid reject with INVALID_FIELD.
+            // Top-level redirect_uri is intentionally omitted for the default
+            // Hosted Link flow, which routes the post-completion return through
+            // hosted_link.completion_redirect_uri. Sending an *unregistered*
+            // redirect_uri is what produced the INVALID_FIELD 500 this fix
+            // resolves. NOTE: OAuth / app-to-app institutions still use the
+            // top-level redirect_uri for the bank-auth handoff, so full OAuth
+            // support requires a *dashboard-registered* redirect_uri threaded
+            // through here from config — tracked as a follow-up (the value and
+            // its config surface are a Plaid-dashboard decision, see PR #351
+            // review). Omitting it keeps non-OAuth Hosted Link sessions working
+            // and avoids re-introducing the 500 for unconfigured setups.
             hostedLink: .init(
                 completionRedirectUri: completionRedirectUri,
                 urlLifetimeSeconds: 30 * 60

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -65,7 +65,9 @@ actor PlaidClient: PlaidClientProtocol {
             products: ["transactions"],
             countryCodes: ["US"],
             language: "en",
-            redirectUri: config.redirectUri,
+            // No top-level redirect_uri: this is a Hosted Link flow, which
+            // routes the OAuth return through hosted_link.completion_redirect_uri.
+            // Sending redirect_uri too makes Plaid reject with INVALID_FIELD.
             hostedLink: .init(
                 completionRedirectUri: completionRedirectUri,
                 urlLifetimeSeconds: 30 * 60
@@ -86,7 +88,9 @@ actor PlaidClient: PlaidClientProtocol {
             user: .init(clientUserId: userId),
             countryCodes: ["US"],
             language: "en",
-            redirectUri: config.redirectUri,
+            // No top-level redirect_uri: Hosted Link update mode also returns
+            // through hosted_link.completion_redirect_uri. Sending redirect_uri
+            // too makes Plaid reject with INVALID_FIELD.
             hostedLink: .init(
                 completionRedirectUri: completionRedirectUri,
                 urlLifetimeSeconds: 30 * 60

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -10,7 +10,12 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
     let products: [String]?
     let countryCodes: [String]
     let language: String
-    let redirectUri: String
+    /// Top-level OAuth `redirect_uri`. Deliberately omitted (left `nil`) for the
+    /// Hosted Link flow: Hosted Link uses `hosted_link.completion_redirect_uri`
+    /// instead, and sending both makes Plaid reject the request with
+    /// `INVALID_FIELD` ("OAuth redirect URI must be configured in the developer
+    /// dashboard"). The synthesized encoder omits this key entirely when `nil`.
+    let redirectUri: String?
     let hostedLink: PlaidHostedLink?
     let accessToken: String?
 
@@ -22,7 +27,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
         products: [String]? = nil,
         countryCodes: [String],
         language: String,
-        redirectUri: String,
+        redirectUri: String? = nil,
         hostedLink: PlaidHostedLink? = nil,
         accessToken: String? = nil
     ) {

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -124,28 +124,26 @@ struct LinkRoutes: Sendable {
         errorType: String?,
         errorCode: String?
     ) -> String {
-        // Sanitize the identifier before it can reach the app: a known code maps
-        // to curated guidance; an *unknown but enum-shaped* code is carried as-is
-        // (it is a bounded `A–Z 0–9 _` token, safe to show); anything else —
-        // prose, request data, an over-long or oddly-charactered string a
-        // misbehaving sandbox/proxy might return — is collapsed to `PLAID_ERROR`
-        // so no raw provider payload can leak through this path (AGENTS.md).
-        let code = sanitizedErrorIdentifier(errorCode) ?? sanitizedErrorIdentifier(errorType) ?? "PLAID_ERROR"
-        if let description = knownLinkErrorDescriptions[code] {
-            return "Plaid Link error (\(code)): \(description)"
+        // ONLY allowlisted codes are ever surfaced. The identifier reaches the
+        // app (AppState.error via ServerClient), so even an enum-shaped but
+        // unknown code is NOT echoed — a misbehaving sandbox/proxy could put a
+        // numeric/uppercase account or request token into error_code/error_type
+        // that happens to pass a shape check, which would still move a raw
+        // provider identifier into the SwiftUI app (AGENTS.md). Anything not in
+        // `knownLinkErrorDescriptions` collapses to the generic PLAID_ERROR.
+        if let code = allowlistedErrorCode(errorCode) ?? allowlistedErrorCode(errorType) {
+            return "Plaid Link error (\(code)): \(knownLinkErrorDescriptions[code]!)"
         }
-        return "Plaid Link error (\(code)). Please try connecting again, or check the "
-            + "VaultPeek companion server logs for details."
+        return "Plaid Link error (PLAID_ERROR). Please try connecting again, or check "
+            + "the VaultPeek companion server logs for details."
     }
 
-    /// Returns the identifier only when it matches Plaid's stable enum shape
-    /// (uppercase letters, digits, underscores; bounded length). Returns `nil`
-    /// for anything that does not look like an error-code identifier, so the
-    /// caller falls back to a generic label rather than echoing provider text.
-    private static func sanitizedErrorIdentifier(_ value: String?) -> String? {
-        guard let value, !value.isEmpty, value.count <= 64 else { return nil }
-        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
-        guard value.allSatisfy({ allowed.contains($0) }) else { return nil }
+    /// Returns the identifier only when it is a curated, allowlisted Plaid Link
+    /// error code. Returns `nil` for anything else — unknown codes, prose, or
+    /// provider tokens — so the caller surfaces the generic label instead of
+    /// echoing a raw provider identifier into the app.
+    private static func allowlistedErrorCode(_ value: String?) -> String? {
+        guard let value, knownLinkErrorDescriptions[value] != nil else { return nil }
         return value
     }
 

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -124,12 +124,29 @@ struct LinkRoutes: Sendable {
         errorType: String?,
         errorCode: String?
     ) -> String {
-        let code = errorCode ?? errorType ?? "PLAID_ERROR"
+        // Sanitize the identifier before it can reach the app: a known code maps
+        // to curated guidance; an *unknown but enum-shaped* code is carried as-is
+        // (it is a bounded `A–Z 0–9 _` token, safe to show); anything else —
+        // prose, request data, an over-long or oddly-charactered string a
+        // misbehaving sandbox/proxy might return — is collapsed to `PLAID_ERROR`
+        // so no raw provider payload can leak through this path (AGENTS.md).
+        let code = sanitizedErrorIdentifier(errorCode) ?? sanitizedErrorIdentifier(errorType) ?? "PLAID_ERROR"
         if let description = knownLinkErrorDescriptions[code] {
             return "Plaid Link error (\(code)): \(description)"
         }
         return "Plaid Link error (\(code)). Please try connecting again, or check the "
             + "VaultPeek companion server logs for details."
+    }
+
+    /// Returns the identifier only when it matches Plaid's stable enum shape
+    /// (uppercase letters, digits, underscores; bounded length). Returns `nil`
+    /// for anything that does not look like an error-code identifier, so the
+    /// caller falls back to a generic label rather than echoing provider text.
+    private static func sanitizedErrorIdentifier(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.count <= 64 else { return nil }
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+        guard value.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return value
     }
 
     /// Allowlist of Plaid Link `error_code`/`error_type` identifiers mapped to

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -99,11 +99,10 @@ struct LinkRoutes: Sendable {
             switch error {
             case .credentialsNotConfigured:
                 throw error
-            case let .apiError(_, errorType, errorCode, errorMessage):
+            case let .apiError(_, errorType, errorCode, _):
                 throw HTTPError(.badGateway, message: linkErrorMessage(
                     errorType: errorType,
-                    errorCode: errorCode,
-                    errorMessage: errorMessage
+                    errorCode: errorCode
                 ))
             case .invalidResponse:
                 throw HTTPError(.badGateway, message: "Plaid returned an invalid response")
@@ -111,17 +110,51 @@ struct LinkRoutes: Sendable {
         }
     }
 
-    /// Builds an operator-readable Plaid error string. Only carries Plaid's own
-    /// `error_code`/`error_message`/`error_type` — never the request body, which
-    /// contains the Plaid `client_secret` and any access token.
+    /// Builds an actionable, app-safe Link error string from Plaid's *stable*
+    /// `error_code`/`error_type` enum identifiers only.
+    ///
+    /// Plaid's free-form `error_message` is deliberately NOT echoed: `AGENTS.md`
+    /// treats moving raw provider payloads into the SwiftUI app as high priority,
+    /// and that field is provider-controlled text that can carry request/provider
+    /// detail beyond the local diagnosis (this string reaches `AppState.error`
+    /// via `ServerClient`). Instead, known codes map to a curated local
+    /// description, and anything unrecognized degrades to a generic message that
+    /// still carries only the bounded code identifier — never provider prose.
     static func linkErrorMessage(
         errorType: String?,
-        errorCode: String?,
-        errorMessage: String
+        errorCode: String?
     ) -> String {
         let code = errorCode ?? errorType ?? "PLAID_ERROR"
-        return "Plaid: \(code) \(errorMessage)"
+        if let description = knownLinkErrorDescriptions[code] {
+            return "Plaid Link error (\(code)): \(description)"
+        }
+        return "Plaid Link error (\(code)). Please try connecting again, or check the "
+            + "VaultPeek companion server logs for details."
     }
+
+    /// Allowlist of Plaid Link `error_code`/`error_type` identifiers mapped to
+    /// locally-authored, secret-free guidance. Keys are Plaid's documented enum
+    /// values; values never contain provider-supplied free text.
+    private static let knownLinkErrorDescriptions: [String: String] = [
+        "INVALID_FIELD":
+            "A Link request field was rejected by Plaid. If this is an OAuth flow, "
+            + "confirm the redirect URI is registered in the Plaid dashboard.",
+        "INVALID_API_KEYS":
+            "Plaid rejected the configured credentials. Verify PLAID_CLIENT_ID and "
+            + "PLAID_SECRET in the VaultPeek companion server config.",
+        "INVALID_REQUEST":
+            "Plaid rejected the Link request. Please try connecting again.",
+        "RATE_LIMIT_EXCEEDED":
+            "Plaid is rate-limiting requests. Please wait a moment and try again.",
+        "INSTITUTION_DOWN":
+            "The selected institution is temporarily unavailable. Please try again later.",
+        "INSTITUTION_NOT_RESPONDING":
+            "The selected institution is not responding. Please try again later.",
+        "INTERNAL_SERVER_ERROR":
+            "Plaid reported a temporary internal error. Please try again shortly.",
+        "PLANNED_MAINTENANCE":
+            "Plaid is undergoing planned maintenance. Please try again later.",
+    ]
 
     private func callbackURL(state: String) -> String {
         guard var components = URLComponents(string: config.redirectUri) else {

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -23,10 +23,12 @@ struct LinkRoutes: Sendable {
     ) async throws -> Response {
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let state = await pendingLinkSessions.issueState()
-        let plaidResponse = try await plaidClient.createLinkToken(
-            userId: userId,
-            completionRedirectUri: callbackURL(state: state)
-        )
+        let plaidResponse = try await Self.mappingPlaidError {
+            try await plaidClient.createLinkToken(
+                userId: userId,
+                completionRedirectUri: callbackURL(state: state)
+            )
+        }
 
         guard let linkUrl = plaidResponse.hostedLinkUrl else {
             throw HTTPError(.internalServerError, message: "Plaid did not return a hosted Link URL")
@@ -57,11 +59,13 @@ struct LinkRoutes: Sendable {
 
         let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let state = await pendingLinkSessions.issueState()
-        let plaidResponse = try await plaidClient.createUpdateLinkToken(
-            userId: userId,
-            accessToken: accessToken,
-            completionRedirectUri: callbackURL(state: state)
-        )
+        let plaidResponse = try await Self.mappingPlaidError {
+            try await plaidClient.createUpdateLinkToken(
+                userId: userId,
+                accessToken: accessToken,
+                completionRedirectUri: callbackURL(state: state)
+            )
+        }
 
         guard let linkUrl = plaidResponse.hostedLinkUrl else {
             throw HTTPError(.internalServerError, message: "Plaid did not return a hosted Link URL")
@@ -79,6 +83,44 @@ struct LinkRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+
+    /// Runs a Plaid Link call and translates `PlaidError.apiError` into an
+    /// actionable `HTTPError` so the client sees the Plaid error code/message
+    /// instead of an opaque, empty-bodied 500. `credentialsNotConfigured` is
+    /// rethrown unchanged so the setup-state middleware can map it to a 503
+    /// with credential guidance.
+    private static func mappingPlaidError<T: Sendable>(
+        _ body: () async throws -> T
+    ) async throws -> T {
+        do {
+            return try await body()
+        } catch let error as PlaidError {
+            switch error {
+            case .credentialsNotConfigured:
+                throw error
+            case let .apiError(_, errorType, errorCode, errorMessage):
+                throw HTTPError(.badGateway, message: linkErrorMessage(
+                    errorType: errorType,
+                    errorCode: errorCode,
+                    errorMessage: errorMessage
+                ))
+            case .invalidResponse:
+                throw HTTPError(.badGateway, message: "Plaid returned an invalid response")
+            }
+        }
+    }
+
+    /// Builds an operator-readable Plaid error string. Only carries Plaid's own
+    /// `error_code`/`error_message`/`error_type` — never the request body, which
+    /// contains the Plaid `client_secret` and any access token.
+    static func linkErrorMessage(
+        errorType: String?,
+        errorCode: String?,
+        errorMessage: String
+    ) -> String {
+        let code = errorCode ?? errorType ?? "PLAID_ERROR"
+        return "Plaid: \(code) \(errorMessage)"
     }
 
     private func callbackURL(state: String) -> String {

--- a/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
+++ b/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import PlaidBarCore
+import Testing
+
+@Suite("Detached dashboard preferences (AND-384)")
+struct DetachedDashboardPreferencesTests {
+    @Test("Storage keys, autosave name, and window title are stable identifiers")
+    func stableIdentifiers() {
+        // These strings are persisted to UserDefaults / read by VoiceOver, so
+        // changing them silently is a breaking change. Pin them.
+        #expect(DetachedDashboardPreferences.detachedStorageKey == "dashboard.detached")
+        #expect(DetachedDashboardPreferences.frameAutosaveName == "VaultPeekDetachedDashboard")
+        #expect(DetachedDashboardPreferences.windowTitle == "VaultPeek Dashboard")
+    }
+
+    @Test("Default content size matches the popover's two-column footprint")
+    func defaultContentSize() {
+        // A freshly detached window opens at the same width the popover uses with
+        // no account selected (two-column) and the realistic popover height.
+        #expect(DetachedDashboardPreferences.defaultContentWidth == PopoverGeometry.width(for: .twoColumn))
+        #expect(
+            DetachedDashboardPreferences.defaultContentHeight
+                == CGFloat(DashboardOverviewHeightBudget.realisticPopoverHeight)
+        )
+        #expect(DetachedDashboardPreferences.defaultContentSize.width == DetachedDashboardPreferences.defaultContentWidth)
+        #expect(DetachedDashboardPreferences.defaultContentSize.height == DetachedDashboardPreferences.defaultContentHeight)
+    }
+
+    @Test("Minimum content width keeps the rail plus a usable dashboard")
+    func minContentWidth() {
+        // The fixed rail + divider + the flexible center's floor — so the Wealth
+        // Summary rail and a legible dashboard always fit when resized small.
+        let expected = PopoverGeometry.railWidth
+            + PopoverGeometry.dividerWidth
+            + PopoverGeometry.minDashboardWidth
+        #expect(DetachedDashboardPreferences.minContentWidth == expected)
+        #expect(DetachedDashboardPreferences.minContentSize.width == expected)
+        #expect(DetachedDashboardPreferences.minContentSize.height == DetachedDashboardPreferences.minContentHeight)
+    }
+
+    @Test("Minimum size never exceeds the default size")
+    func minNeverExceedsDefault() {
+        // A window can always open at its default and still be shrinkable, so the
+        // floor must be ≤ the default in both dimensions.
+        #expect(DetachedDashboardPreferences.minContentWidth <= DetachedDashboardPreferences.defaultContentWidth)
+        #expect(DetachedDashboardPreferences.minContentHeight <= DetachedDashboardPreferences.defaultContentHeight)
+    }
+}

--- a/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
+++ b/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
@@ -45,4 +45,23 @@ struct DetachedDashboardPreferencesTests {
         #expect(DetachedDashboardPreferences.minContentWidth <= DetachedDashboardPreferences.defaultContentWidth)
         #expect(DetachedDashboardPreferences.minContentHeight <= DetachedDashboardPreferences.defaultContentHeight)
     }
+
+    @Test("Outside a snapshot render, the persisted detach intent is honored")
+    func resolvedDetachedIntentHonorsStoredValue() {
+        // Normal launches mirror exactly what the Settings toggle persisted,
+        // defaulting to docked when the key has never been written.
+        #expect(DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: true, isRenderingSnapshot: false))
+        #expect(!DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: false, isRenderingSnapshot: false))
+        #expect(!DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: nil, isRenderingSnapshot: false))
+    }
+
+    @Test("A snapshot render always resolves to docked, ignoring host defaults")
+    func resolvedDetachedIntentForcesDockedDuringSnapshot() {
+        // The renderer captures the popover; a host/CI machine with
+        // `dashboard.detached = true` must not spawn the floating window or
+        // intercept the popover-open path. False wins regardless of stored value.
+        #expect(!DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: true, isRenderingSnapshot: true))
+        #expect(!DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: false, isRenderingSnapshot: true))
+        #expect(!DetachedDashboardPreferences.resolvedDetachedIntent(storedValue: nil, isRenderingSnapshot: true))
+    }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3308,6 +3308,16 @@ struct PlaidBarCoreTests {
         #expect(CommandLineOptions.value(for: "--settings-tab", in: ["PlaidBar", "--settings-tab"]) == nil)
     }
 
+    @Test("Snapshot render is detected by the --render-snapshot flag")
+    func commandLineOptionsDetectSnapshotRender() {
+        #expect(CommandLineOptions.isRenderingSnapshot(["PlaidBar", "--demo", "--render-snapshot", "/tmp/out"]))
+        // Presence alone is enough — the directory value follows the flag.
+        #expect(CommandLineOptions.isRenderingSnapshot(["PlaidBar", "--render-snapshot"]))
+        // A normal app launch never opts in.
+        #expect(!CommandLineOptions.isRenderingSnapshot(["PlaidBar", "--demo"]))
+        #expect(!CommandLineOptions.isRenderingSnapshot(["PlaidBar"]))
+    }
+
     // MARK: - RecurringTransaction Model Tests
 
     @Test("RecurringTransaction identity by merchantName")

--- a/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverGeometryTests.swift
@@ -19,6 +19,22 @@ struct PopoverGeometryTests {
         #expect(delta == PopoverGeometry.dividerWidth + PopoverGeometry.railWidth)
     }
 
+    @Test("Detached minimum width grows by an inspector column when one is open")
+    func detachedMinContentWidthIncludesInspector() {
+        // Two-column floor: rail + divider + the flexible dashboard's floor.
+        let docked = PopoverGeometry.detachedMinContentWidth(isInspectorOpen: false)
+        #expect(docked == PopoverGeometry.railWidth
+            + PopoverGeometry.dividerWidth
+            + PopoverGeometry.minDashboardWidth)
+
+        // Opening the inspector adds exactly a divider + a fixed-width rail, so
+        // the resizable window's floor reserves room for the inspector instead
+        // of clipping it (AND-384/405).
+        let withInspector = PopoverGeometry.detachedMinContentWidth(isInspectorOpen: true)
+        #expect(withInspector - docked == PopoverGeometry.dividerWidth + PopoverGeometry.railWidth)
+        #expect(withInspector == 982)
+    }
+
     @Test("Fitted width passes the full width through on a wide / headless screen")
     func fittedWidthWideScreen() {
         // Comfortably wider than 1122 → unchanged.

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import FluentKit
+import FluentSQLiteDriver
+import Hummingbird
+import HummingbirdFluent
+import HTTPTypes
+import Logging
+import NIOCore
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+/// Foundation tests for the consumer (Hosted Link) deployment seam. These prove
+/// the seam is inert: `.local` is the default, the bridge holds no live
+/// endpoints, and the entitlement middleware enforces nothing. They guard
+/// against a future change accidentally flipping a user out of local mode or
+/// gating BYO requests.
+@Suite("Consumer foundation seam")
+struct ConsumerFoundationTests {
+    // MARK: - DeploymentMode
+
+    @Test("Empty environment defaults to .local")
+    func deploymentDefaultsToLocal() {
+        #expect(DeploymentMode.resolved(from: [:]) == .local)
+    }
+
+    @Test("Unknown deployment value falls back to .local (fail-safe)")
+    func deploymentUnknownFallsBackToLocal() {
+        let env = [DeploymentMode.environmentVariable: "totally-bogus"]
+        #expect(DeploymentMode.resolved(from: env) == .local)
+    }
+
+    @Test("Blank/whitespace deployment value falls back to .local")
+    func deploymentBlankFallsBackToLocal() {
+        let env = [DeploymentMode.environmentVariable: "   "]
+        #expect(DeploymentMode.resolved(from: env) == .local)
+    }
+
+    @Test("Explicit values resolve to the named mode")
+    func deploymentExplicitValues() {
+        #expect(
+            DeploymentMode.resolved(from: [DeploymentMode.environmentVariable: "local"]) == .local
+        )
+        #expect(
+            DeploymentMode.resolved(
+                from: [DeploymentMode.environmentVariable: "hosted-bridge"]
+            ) == .hostedBridge
+        )
+    }
+
+    // MARK: - RemoteBridgeConfig
+
+    @Test("Bridge config is unconfigured and not provisioned by default")
+    func bridgeDefaultsUnconfigured() {
+        let bridge = RemoteBridgeConfig.resolved(from: [:])
+        #expect(bridge == .unconfigured)
+        #expect(bridge.isProvisioned == false)
+        #expect(bridge.controlPlaneBaseURL == nil)
+        #expect(bridge.dataPlaneProxyBaseURL == nil)
+        #expect(bridge.entitlementPublicKeyBase64 == nil)
+    }
+
+    @Test("Bridge is provisioned only when both planes have URLs")
+    func bridgeProvisionedRequiresBothPlanes() {
+        let controlOnly = RemoteBridgeConfig.resolved(
+            from: ["PLAIDBAR_BRIDGE_CONTROL_PLANE_URL": "https://example.test"]
+        )
+        #expect(controlOnly.isProvisioned == false)
+
+        let both = RemoteBridgeConfig.resolved(from: [
+            "PLAIDBAR_BRIDGE_CONTROL_PLANE_URL": "https://cp.example.test",
+            "PLAIDBAR_BRIDGE_DATA_PLANE_URL": "https://dp.example.test"
+        ])
+        #expect(both.isProvisioned == true)
+    }
+
+    // MARK: - EntitlementMiddleware (enforces nothing)
+
+    @Test("Entitlement evaluation always allows in .local mode")
+    func entitlementAllowsLocal() {
+        let decision = EntitlementMiddleware<TestRequestContext>.evaluate(
+            deployment: .local,
+            request: Self.makeRequest(path: "/api/accounts")
+        )
+        #expect(decision == .allow)
+    }
+
+    @Test("Entitlement evaluation allows even in .hostedBridge mode (inert)")
+    func entitlementAllowsHostedBridge() {
+        let decision = EntitlementMiddleware<TestRequestContext>.evaluate(
+            deployment: .hostedBridge,
+            request: Self.makeRequest(path: "/api/transactions/sync")
+        )
+        #expect(decision == .allow)
+    }
+
+    @Test("Entitlement middleware passes the request through unchanged")
+    func entitlementMiddlewarePassesThrough() async throws {
+        let middleware = EntitlementMiddleware<TestRequestContext>(deployment: .local)
+        let request = Self.makeRequest(path: "/api/accounts")
+        let context = TestRequestContext(source: TestRequestContextSource())
+
+        let response = try await middleware.handle(request, context: context) { _, _ in
+            Response(status: .ok)
+        }
+        #expect(response.status == .ok)
+    }
+
+    // MARK: - AccessTokenResolver seam
+
+    @Test("Local deployment selects the Keychain-backed resolver")
+    func resolverFactoryLocalIsTokenStoreBacked() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let resolver = AccessTokenResolverFactory.make(
+                deployment: .local,
+                tokenStore: tokenStore
+            )
+            #expect(resolver is TokenStoreAccessTokenResolver)
+        }
+    }
+
+    @Test("Hosted-bridge deployment selects the inert request-supplied stub")
+    func resolverFactoryHostedBridgeIsStub() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let resolver = AccessTokenResolverFactory.make(
+                deployment: .hostedBridge,
+                tokenStore: tokenStore
+            )
+            #expect(resolver is RequestSuppliedAccessTokenResolver)
+        }
+    }
+
+    @Test("Request-supplied resolver stub fails closed (never weakens custody)")
+    func requestSuppliedResolverFailsClosed() throws {
+        let item = ItemModel(
+            id: "item-foundation",
+            accessToken: "keychain:item-foundation"
+        )
+        let resolver = RequestSuppliedAccessTokenResolver()
+        #expect(throws: AccessTokenResolverError.self) {
+            _ = try resolver.accessToken(
+                for: item,
+                request: Self.makeRequest(path: "/api/accounts")
+            )
+        }
+    }
+
+    // MARK: - Entitlement model
+
+    @Test("Entitlement spare-capacity is pure arithmetic")
+    func entitlementSpareCapacity() {
+        let belowLimit = Entitlement(
+            tier: .plus,
+            institutionLimit: 8,
+            itemsUsed: 3,
+            subscriptionStatus: "active",
+            expiresAt: nil
+        )
+        #expect(belowLimit.hasSpareCapacity == true)
+
+        let atLimit = Entitlement(
+            tier: .personal,
+            institutionLimit: 3,
+            itemsUsed: 3,
+            subscriptionStatus: "active",
+            expiresAt: nil
+        )
+        #expect(atLimit.hasSpareCapacity == false)
+    }
+
+    @Test("Entitlement round-trips through Codable")
+    func entitlementCodableRoundTrip() throws {
+        let original = Entitlement(
+            tier: .plus,
+            institutionLimit: 8,
+            itemsUsed: 2,
+            subscriptionStatus: "active",
+            expiresAt: Date(timeIntervalSince1970: 1_752_278_400)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Entitlement.self, from: data)
+        #expect(decoded == original)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeRequest(path: String) -> Request {
+        Request(
+            head: HTTPRequest(method: .get, scheme: nil, authority: nil, path: path),
+            body: RequestBody(buffer: ByteBuffer())
+        )
+    }
+
+    /// In-memory SQLite Fluent for the resolver-factory type assertions. Always
+    /// shuts Fluent down so the test holds no database handle.
+    private func withFluent(_ body: (Fluent) async throws -> Void) async throws {
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.consumer-foundation")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.memory), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(CreateSyncCursors())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(fluent)
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+}
+
+// MARK: - Local request-context scaffolding
+
+private struct TestRequestContextSource: RequestContextSource {
+    let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.consumer-foundation")
+}
+
+private struct TestRequestContext: RequestContext {
+    typealias Source = TestRequestContextSource
+
+    var coreContext: CoreRequestContextStorage
+
+    init(source: TestRequestContextSource) {
+        coreContext = CoreRequestContextStorage(source: source)
+    }
+}

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -102,50 +102,69 @@ struct LinkTokenRequestTests {
 }
 
 /// Plaid API errors from the Link flow must surface an actionable, secret-free
-/// message instead of a bare HTTP 500.
+/// message instead of a bare HTTP 500 — and without echoing Plaid's raw,
+/// provider-controlled `error_message` into the SwiftUI app (see `AGENTS.md`).
 @Suite("Link error surfacing")
 struct LinkErrorSurfacingTests {
-    @Test("Error message carries Plaid error_code and error_message")
-    func errorMessageCarriesCodeAndMessage() {
+    @Test("Known error code maps to a curated local description, not Plaid's prose")
+    func knownCodeMapsToLocalDescription() {
         let message = LinkRoutes.linkErrorMessage(
             errorType: "INVALID_REQUEST",
-            errorCode: "INVALID_FIELD",
-            errorMessage: "OAuth redirect URI must be configured in the developer dashboard."
+            errorCode: "INVALID_FIELD"
         )
 
-        #expect(message == "Plaid: INVALID_FIELD OAuth redirect URI must be configured in the developer dashboard.")
+        // Carries the stable code identifier and locally-authored guidance.
+        #expect(message.contains("INVALID_FIELD"))
+        #expect(message.contains("redirect URI is registered in the Plaid dashboard"))
+        #expect(message.hasPrefix("Plaid Link error (INVALID_FIELD):"))
     }
 
-    @Test("Error message falls back to error_type then a stable label")
-    func errorMessageFallsBack() {
-        #expect(
-            LinkRoutes.linkErrorMessage(
-                errorType: "RATE_LIMIT_EXCEEDED",
-                errorCode: nil,
-                errorMessage: "Too many requests."
-            ) == "Plaid: RATE_LIMIT_EXCEEDED Too many requests."
+    @Test("Error code falls back to error_type, then a stable label")
+    func errorCodeFallsBack() {
+        // error_code nil → uses error_type, which is itself an allowlisted key.
+        let rateLimited = LinkRoutes.linkErrorMessage(
+            errorType: "RATE_LIMIT_EXCEEDED",
+            errorCode: nil
         )
+        #expect(rateLimited.hasPrefix("Plaid Link error (RATE_LIMIT_EXCEEDED):"))
+        #expect(rateLimited.contains("rate-limiting"))
 
-        #expect(
-            LinkRoutes.linkErrorMessage(
-                errorType: nil,
-                errorCode: nil,
-                errorMessage: "Unknown error"
-            ) == "Plaid: PLAID_ERROR Unknown error"
-        )
+        // Both nil → stable PLAID_ERROR label, generic guidance, no provider text.
+        let unknown = LinkRoutes.linkErrorMessage(errorType: nil, errorCode: nil)
+        #expect(unknown.contains("PLAID_ERROR"))
+        #expect(unknown.contains("try connecting again"))
     }
 
-    @Test("Error message never leaks credential values")
-    func errorMessageNeverLeaksCredentials() {
-        let secret = "super-secret-\(UUID().uuidString)"
+    @Test("Unrecognized code degrades to a generic message carrying only the code")
+    func unrecognizedCodeIsGeneric() {
         let message = LinkRoutes.linkErrorMessage(
-            errorType: "INVALID_REQUEST",
-            errorCode: "INVALID_API_KEYS",
-            errorMessage: "Invalid client_id or secret provided."
+            errorType: "SOME_NEW_TYPE",
+            errorCode: "SOME_UNMAPPED_CODE"
         )
 
-        // The helper only ever echoes Plaid's own code/message, never the
-        // request body, so a configured secret can never appear here.
-        #expect(!message.contains(secret))
+        // The bounded code identifier is preserved; no provider prose is invented.
+        #expect(message.contains("SOME_UNMAPPED_CODE"))
+        #expect(message.contains("try connecting again"))
+    }
+
+    @Test("Raw Plaid error_message is never echoed into the surfaced text")
+    func rawProviderMessageIsNeverEchoed() {
+        // Even when Plaid would supply detailed prose for a known code, the
+        // helper no longer accepts or forwards that field — the signature only
+        // takes the stable code/type. Construct messages for several codes and
+        // assert none contain hallmark provider-prose fragments or credential
+        // hints that historically appeared in Plaid's free-form error_message.
+        let leakedFragments = [
+            "client_id",
+            "secret",
+            "Invalid client_id or secret provided",
+            "request_id",
+        ]
+        for code in ["INVALID_API_KEYS", "INVALID_FIELD", "RATE_LIMIT_EXCEEDED"] {
+            let message = LinkRoutes.linkErrorMessage(errorType: "INVALID_REQUEST", errorCode: code)
+            for fragment in leakedFragments {
+                #expect(!message.contains(fragment), "Leaked provider fragment '\(fragment)' for code \(code)")
+            }
+        }
     }
 }

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -135,7 +135,7 @@ struct LinkErrorSurfacingTests {
         #expect(unknown.contains("try connecting again"))
     }
 
-    @Test("Unrecognized code degrades to a generic message carrying only the code")
+    @Test("Unrecognized but enum-shaped code degrades to a generic message carrying only the code")
     func unrecognizedCodeIsGeneric() {
         let message = LinkRoutes.linkErrorMessage(
             errorType: "SOME_NEW_TYPE",
@@ -145,6 +145,30 @@ struct LinkErrorSurfacingTests {
         // The bounded code identifier is preserved; no provider prose is invented.
         #expect(message.contains("SOME_UNMAPPED_CODE"))
         #expect(message.contains("try connecting again"))
+    }
+
+    @Test("A non-identifier-shaped code is collapsed to PLAID_ERROR, never echoed")
+    func nonIdentifierCodeIsSanitized() {
+        // A misbehaving sandbox/proxy could return prose, request data, or an
+        // over-long string in error_code/error_type. None of it may reach the app.
+        let prose = LinkRoutes.linkErrorMessage(
+            errorType: "the redirect uri http://evil/?token=abc was rejected",
+            errorCode: "OAuth redirect URI must be configured; request_id=req_123"
+        )
+        #expect(prose.contains("PLAID_ERROR"))
+        #expect(!prose.contains("request_id"))
+        #expect(!prose.contains("http://"))
+
+        // Lowercase / mixed-case is not Plaid's enum shape → collapsed too.
+        let mixed = LinkRoutes.linkErrorMessage(errorType: "SomethingWeird", errorCode: nil)
+        #expect(mixed.contains("PLAID_ERROR"))
+
+        // An absurdly long all-caps token is rejected by the length bound.
+        let tooLong = LinkRoutes.linkErrorMessage(
+            errorType: nil,
+            errorCode: String(repeating: "A", count: 200)
+        )
+        #expect(tooLong.contains("PLAID_ERROR"))
     }
 
     @Test("Raw Plaid error_message is never echoed into the surfaced text")

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -135,19 +135,22 @@ struct LinkErrorSurfacingTests {
         #expect(unknown.contains("try connecting again"))
     }
 
-    @Test("Unrecognized but enum-shaped code degrades to a generic message carrying only the code")
-    func unrecognizedCodeIsGeneric() {
+    @Test("An unknown code — even enum-shaped — collapses to PLAID_ERROR, never echoed")
+    func unknownCodeCollapsesToPlaidError() {
+        // Only allowlisted codes are surfaced. An enum-shaped but unmapped code
+        // (which a sandbox/proxy could fabricate from an account/request token)
+        // must NOT reach the app as a raw identifier.
         let message = LinkRoutes.linkErrorMessage(
             errorType: "SOME_NEW_TYPE",
             errorCode: "SOME_UNMAPPED_CODE"
         )
-
-        // The bounded code identifier is preserved; no provider prose is invented.
-        #expect(message.contains("SOME_UNMAPPED_CODE"))
+        #expect(message.contains("PLAID_ERROR"))
+        #expect(!message.contains("SOME_UNMAPPED_CODE"))
+        #expect(!message.contains("SOME_NEW_TYPE"))
         #expect(message.contains("try connecting again"))
     }
 
-    @Test("A non-identifier-shaped code is collapsed to PLAID_ERROR, never echoed")
+    @Test("Non-identifier-shaped codes are collapsed to PLAID_ERROR, never echoed")
     func nonIdentifierCodeIsSanitized() {
         // A misbehaving sandbox/proxy could return prose, request data, or an
         // over-long string in error_code/error_type. None of it may reach the app.
@@ -159,16 +162,11 @@ struct LinkErrorSurfacingTests {
         #expect(!prose.contains("request_id"))
         #expect(!prose.contains("http://"))
 
-        // Lowercase / mixed-case is not Plaid's enum shape → collapsed too.
-        let mixed = LinkRoutes.linkErrorMessage(errorType: "SomethingWeird", errorCode: nil)
-        #expect(mixed.contains("PLAID_ERROR"))
-
-        // An absurdly long all-caps token is rejected by the length bound.
-        let tooLong = LinkRoutes.linkErrorMessage(
-            errorType: nil,
-            errorCode: String(repeating: "A", count: 200)
-        )
-        #expect(tooLong.contains("PLAID_ERROR"))
+        // A numeric/uppercase token that happens to be enum-shaped is still not
+        // allowlisted → collapsed, so no raw provider identifier leaks.
+        let tokenLike = LinkRoutes.linkErrorMessage(errorType: nil, errorCode: "REQ_9F3A1B2C")
+        #expect(tokenLike.contains("PLAID_ERROR"))
+        #expect(!tokenLike.contains("REQ_9F3A1B2C"))
     }
 
     @Test("Raw Plaid error_message is never echoed into the surfaced text")

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+@testable import PlaidBarServer
+import Testing
+
+/// Hosted Link request-shape and error-surfacing guarantees for the
+/// `/api/link/create` flow.
+///
+/// Regression coverage for the sandbox/consumer link 500: `PlaidClient` used to
+/// send BOTH a top-level `redirect_uri` AND `hosted_link.completion_redirect_uri`.
+/// Plaid rejects that combination with `INVALID_FIELD` ("OAuth redirect URI must
+/// be configured in the developer dashboard"), which `LinkRoutes` turned into an
+/// opaque, empty-bodied HTTP 500. Hosted Link must omit the top-level
+/// `redirect_uri` entirely.
+///
+/// All values here are synthetic; nothing contacts Plaid, the network, or the
+/// Keychain.
+@Suite("Hosted Link token request shape")
+struct LinkTokenRequestTests {
+    private func encodedRequest(_ request: PlaidLinkTokenRequest) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(request)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("Create link-token body omits redirect_uri but keeps hosted_link")
+    func createLinkTokenBodyOmitsRedirectURI() throws {
+        // Mirrors PlaidClient.createLinkToken: nil redirectUri, hosted_link set.
+        let request = PlaidLinkTokenRequest(
+            clientId: "test-client",
+            secret: "test-secret",
+            clientName: "VaultPeek",
+            user: .init(clientUserId: "plaidbar-user-test"),
+            products: ["transactions"],
+            countryCodes: ["US"],
+            language: "en",
+            hostedLink: .init(
+                completionRedirectUri: "http://localhost:8484/oauth/callback?state=abc",
+                urlLifetimeSeconds: 1800
+            )
+        )
+
+        let json = try encodedRequest(request)
+
+        // The OAuth redirect_uri must be omitted from the JSON entirely.
+        #expect(json["redirect_uri"] == nil)
+        #expect(!json.keys.contains("redirect_uri"))
+
+        // Hosted Link routing must remain present and carry the completion URI.
+        let hostedLink = try #require(json["hosted_link"] as? [String: Any])
+        #expect(
+            hostedLink["completion_redirect_uri"] as? String
+                == "http://localhost:8484/oauth/callback?state=abc"
+        )
+        #expect(hostedLink["url_lifetime_seconds"] as? Int == 1800)
+    }
+
+    @Test("Update link-token body omits redirect_uri and includes access_token")
+    func updateLinkTokenBodyOmitsRedirectURI() throws {
+        // Mirrors PlaidClient.createUpdateLinkToken: nil redirectUri, access_token set.
+        let request = PlaidLinkTokenRequest(
+            clientId: "test-client",
+            secret: "test-secret",
+            clientName: "VaultPeek",
+            user: .init(clientUserId: "plaidbar-user-test"),
+            countryCodes: ["US"],
+            language: "en",
+            hostedLink: .init(
+                completionRedirectUri: "http://localhost:8484/oauth/callback?state=def",
+                urlLifetimeSeconds: 1800
+            ),
+            accessToken: "access-sandbox-token"
+        )
+
+        let json = try encodedRequest(request)
+
+        #expect(json["redirect_uri"] == nil)
+        #expect(!json.keys.contains("redirect_uri"))
+        #expect(json["access_token"] as? String == "access-sandbox-token")
+        #expect(json["hosted_link"] != nil)
+    }
+
+    @Test("Explicit redirectUri still encodes (non-Hosted-Link callers)")
+    func explicitRedirectURIStillEncodes() throws {
+        // The field is optional, not removed: a caller that does pass a value
+        // must still serialize it, so we never silently drop a real redirect_uri.
+        let request = PlaidLinkTokenRequest(
+            clientId: "test-client",
+            secret: "test-secret",
+            clientName: "VaultPeek",
+            user: .init(clientUserId: "plaidbar-user-test"),
+            products: ["transactions"],
+            countryCodes: ["US"],
+            language: "en",
+            redirectUri: "http://localhost:8484/oauth/callback"
+        )
+
+        let json = try encodedRequest(request)
+        #expect(json["redirect_uri"] as? String == "http://localhost:8484/oauth/callback")
+    }
+}
+
+/// Plaid API errors from the Link flow must surface an actionable, secret-free
+/// message instead of a bare HTTP 500.
+@Suite("Link error surfacing")
+struct LinkErrorSurfacingTests {
+    @Test("Error message carries Plaid error_code and error_message")
+    func errorMessageCarriesCodeAndMessage() {
+        let message = LinkRoutes.linkErrorMessage(
+            errorType: "INVALID_REQUEST",
+            errorCode: "INVALID_FIELD",
+            errorMessage: "OAuth redirect URI must be configured in the developer dashboard."
+        )
+
+        #expect(message == "Plaid: INVALID_FIELD OAuth redirect URI must be configured in the developer dashboard.")
+    }
+
+    @Test("Error message falls back to error_type then a stable label")
+    func errorMessageFallsBack() {
+        #expect(
+            LinkRoutes.linkErrorMessage(
+                errorType: "RATE_LIMIT_EXCEEDED",
+                errorCode: nil,
+                errorMessage: "Too many requests."
+            ) == "Plaid: RATE_LIMIT_EXCEEDED Too many requests."
+        )
+
+        #expect(
+            LinkRoutes.linkErrorMessage(
+                errorType: nil,
+                errorCode: nil,
+                errorMessage: "Unknown error"
+            ) == "Plaid: PLAID_ERROR Unknown error"
+        )
+    }
+
+    @Test("Error message never leaks credential values")
+    func errorMessageNeverLeaksCredentials() {
+        let secret = "super-secret-\(UUID().uuidString)"
+        let message = LinkRoutes.linkErrorMessage(
+            errorType: "INVALID_REQUEST",
+            errorCode: "INVALID_API_KEYS",
+            errorMessage: "Invalid client_id or secret provided."
+        )
+
+        // The helper only ever echoes Plaid's own code/message, never the
+        // request body, so a configured secret can never appear here.
+        #expect(!message.contains(secret))
+    }
+}

--- a/docs/strategy/consumer-production-checklist.md
+++ b/docs/strategy/consumer-production-checklist.md
@@ -1,0 +1,178 @@
+---
+title: Consumer Plaid Integration — Production Readiness Checklist
+status: owner-gated
+linear: [AND-347, AND-348, AND-349, AND-350]
+date: 2026-06-13
+---
+
+# Consumer Plaid Integration — Production Readiness Checklist
+
+**Owner-only runbook.** This is the concrete, sequenced list of what Felipe (the
+owner) must do to take the consumer (Hosted Link) integration live — real
+end-users link banks **without supplying their own Plaid credentials**, funded by
+a Stripe subscription, through a stateless hosted bridge that stores **no** user
+financial data. The non-gated software foundation for this track already exists
+in the tree (deployment seam, credential-resolver seam, entitlement middleware
+shell, entitlement model — see "What is already built" below). Everything in this
+checklist is gated behind `docs/strategy/approval-gates.md` and requires owner
+action: production credentials, dashboard configuration, Plaid approval, hosted
+infrastructure, and live billing. **Do not let an agent perform any step here.**
+
+Design source of truth, do not duplicate it here:
+`docs/strategy/managed-link-architecture.md` (broker + blind proxy),
+`docs/strategy/subscription-entitlements.md` (Stripe + Ed25519 entitlements, D1–D10),
+`docs/strategy/approval-gates.md` (what must be approved before code).
+
+---
+
+## What is already built (non-gated foundation, no action needed)
+
+These shipped as inert seams; selecting them changes no runtime behavior until
+the steps below are done. They exist so the gated work drops in without
+re-architecting:
+
+- **Deployment seam** — `DeploymentMode { .local | .hostedBridge }` +
+  `RemoteBridgeConfig` placeholder (`Sources/PlaidBarServer/Config/DeploymentMode.swift`).
+  Read from `PLAIDBAR_DEPLOYMENT`; defaults to `.local` (today's BYO-keys path),
+  byte-for-byte unchanged. `RemoteBridgeConfig` holds no live endpoints.
+- **Credential-resolver seam** — `AccessTokenResolver` protocol with the
+  Keychain-backed local impl (the only one wired) and an inert request-supplied
+  stub that fails closed (`Sources/PlaidBarServer/Auth/AccessTokenResolver.swift`).
+- **Entitlement middleware shell** — `EntitlementMiddleware` between
+  `APITokenMiddleware` and `SetupStateMiddleware`; always `.allow`, enforces
+  nothing (`Sources/PlaidBarServer/Middleware/EntitlementMiddleware.swift`).
+- **Entitlement model** — `Entitlement` / `EntitlementTier` / `EntitlementDecision`
+  (`Sources/PlaidBarCore/Models/Entitlement.swift`), the verified-token shape from
+  the entitlements doc §4.2.
+
+---
+
+## Phase 0 — Strategy gates (no money, no infra yet)
+
+Nothing below may begin until these `approval-gates.md` gates are signed with an
+approval record:
+
+1. **Plaid pricing/COGS gate (AND-344)** — replace estimate-only rates with a
+   dated dashboard or sales quote (Transactions, Balance, Hosted Link delivery,
+   `/item/remove` billing shutoff, PAYG vs committed, Growth minimums).
+2. **Managed broker go/no-go (AND-347)** — accept the privacy-promise change:
+   managed financial data *transits* VaultPeek's stateless proxy but is *never
+   stored* there; access tokens stay on the device (Variant 1, architecture doc
+   §5.3).
+3. **Stripe entitlements decisions D1–D10 (AND-348)** — in particular D1 (Stripe
+   + DIY Ed25519 signer), D3 (BYO stays ungated), D4 (30-day TTL / 14-day grace),
+   D8 (cancellation retention + 7-day reconnect), D10 (rename timing).
+4. **Pricing + privacy copy (AND-349 + cross-doc)** — Personal/Plus caps and
+   prices, BYO-free promise, amended `SECURITY.md` / `docs/privacy.md` wording.
+
+---
+
+## Phase 1 — Plaid production access (owner-only; weeks of lead time)
+
+5. **Open a Plaid production account** under the **VaultPeek** name (resolve the
+   rename first — D10 / open question O5 — so you do not undergo Plaid review
+   twice). Capture `PLAID_CLIENT_ID` and the **production** `PLAID_SECRET`; these
+   are the *organization* credentials that live **only** on the hosted bridge,
+   never in any user's app or local server.
+6. **Request Plaid production approval.** Complete the Plaid application review:
+   product questionnaire, company/use-case description, security questionnaire
+   (point to `SECURITY.md` and the no-storage blind-proxy posture), and the data
+   handling / data minimization answers (registry-only storage; no financial
+   payloads persisted). Expect back-and-forth; this is the long pole.
+7. **Enable Hosted Link** for the production application in the Plaid dashboard
+   (the consumer flow opens Plaid's hosted page; no embedded Link SDK).
+8. **Register production redirect / allowed URIs** in the Plaid dashboard:
+   - The bridge HTTPS completion redirect (replaces today's
+     `http://localhost:8484/oauth/callback`; localhost is a sandbox-only
+     affordance — architecture doc §5.5).
+   - Any OAuth-institution redirect URIs Plaid requires for prod.
+   - Confirm the `vaultpeek://link/complete` deep-link bounce / associated-domains
+     fallback (open question O2).
+9. **Resolve open question O1 with Plaid:** can an Item be administratively
+   removed (to stop per-Item billing) **without** the access token, given device
+   custody? The answer decides the orphan runbook vs forcing the token-vault
+   variant. Document the answer in `managed-link-architecture.md` §5.3.
+
+## Phase 2 — Provision the hosted bridge (owner-only infra + secrets)
+
+10. **Stand up the control plane** (the ~6-endpoint broker: link-token mint,
+    public-token exchange, item registry, removal, entitlement issuance, Stripe
+    webhook). It stores **only** identity, entitlement, device public keys, and an
+    item registry (`user_id, item_id, institution_id, status, timestamps`). Never
+    transactions, balances, account numbers, or tokens (architecture doc §5.2).
+11. **Stand up the blind proxy** (data plane: stateless, no DB, no body logs;
+    injects the org secret; enforces the endpoint allowlist `/transactions/sync`,
+    `/accounts/get`, `/item/remove`; validates managed-item binding). Open-source
+    it — openness is the trust mechanism (architecture doc §5.4, §13).
+12. **Store the Plaid org secret in KMS**, reachable only by the two bridge
+    services; rotation on schedule and on incident. No human reads it in
+    plaintext in normal operation (architecture doc §9).
+13. **Point the app/server at the bridge** via config/env (these are the
+    placeholders the foundation already reads): set `PLAIDBAR_DEPLOYMENT=hosted-bridge`,
+    `PLAIDBAR_BRIDGE_CONTROL_PLANE_URL`, `PLAIDBAR_BRIDGE_DATA_PLANE_URL`, and
+    `PLAIDBAR_ENTITLEMENT_PUBLIC_KEY` (the Ed25519 *public* key only). Until the
+    gated client code lands these are inert; they activate nothing on their own.
+
+## Phase 3 — Stripe billing + entitlement signer (owner-only; live money)
+
+14. **Create Stripe products/prices** for Personal and Plus (no unlimited, no
+    lifetime — AND-349). Decide tax posture (Stripe Tax vs MoR — D9).
+15. **Wire Stripe Checkout** (browser-based sign-in + purchase; the app polls for
+    the entitlement to land — architecture doc §7, "plan-before-link").
+16. **Wire the Stripe webhook receiver** in the control plane with **signature
+    verification + idempotent processing** (threat T9). On
+    `checkout.session.completed` / subscription lifecycle events, issue/refresh
+    the entitlement.
+17. **Stand up the Ed25519 entitlement signer** co-located in the broker (D1
+    pattern C): Stripe webhook → Ed25519/PASETO-signed entitlement token
+    (`tier`, `institution_limit`, `items_used`, `subscription_status`,
+    `expires_at`; 30-day TTL — entitlements doc §4.2). Keep the **private** key
+    in KMS; embed only the **public** key in the client (step 13).
+18. **Implement cancellation cleanup (D8):** at period end + 7-day reconnect
+    window, drive `/item/remove` (device-driven under Variant 1) and run the
+    orphan runbook for devices that never return — every lingering Item is live
+    Plaid COGS.
+
+## Phase 4 — Activate enforcement + privacy copy (owner-only)
+
+19. **Turn on entitlement enforcement** in the (now-gated) client code:
+    `EntitlementMiddleware.evaluate` verifies the signed token, TTL/grace, and
+    managed-item count for `.hostedBridge` mode, returning `402` on
+    limit/entitlement failures. BYO/`.local` stays ungated (D3) — the shell
+    already short-circuits `.local` to `.allow`.
+20. **Swap the read-route token source** to the request-supplied resolver for
+    `.hostedBridge` (device supplies its custodied token; proxy injects the org
+    secret). The local Keychain path is unchanged for `.local`.
+21. **Publish the amended privacy promise** (`SECURITY.md`, `docs/privacy.md`,
+    marketing): distinguish BYO local-only mode from managed mode — what the
+    broker stores, what transits it, what is never stored, what happens on
+    cancellation (cross-doc gate).
+
+## Phase 5 — Pre-launch verification (owner-only)
+
+22. **End-to-end sandbox dry-run** of the full bridge path (link → exchange →
+    sync → remove) before pointing at production.
+23. **Verify the no-storage / no-body-log claim** on the live blind proxy
+    (inspect logs; confirm metadata-only access logs, 30-day retention).
+24. **Confirm billing shutoff:** removing an institution stops its Plaid meter;
+    cancellation removes managed Items within the documented window.
+25. **Security review of the bridge** against the threat model (architecture doc
+    §10): org-secret blast radius, link-session CSRF (one-time state + TTL +
+    single-use device-signed claim), entitlement bypass, webhook forgery.
+
+---
+
+## Owner-gated items (never auto-implemented)
+
+- Deploying the hosted bridge (control plane + blind proxy + KMS).
+- Entering / storing production Plaid credentials (`PLAID_CLIENT_ID`, prod
+  `PLAID_SECRET`).
+- Obtaining Plaid production approval.
+- Registering production redirect / allowed URIs and enabling Hosted Link in the
+  Plaid dashboard.
+- All live Stripe billing: products/prices, Checkout, webhook, the Ed25519
+  entitlement signer and its private key.
+- Publishing the amended privacy promise.
+
+These are listed in `gatedItems` of the implementing PR and must carry an
+`approval-gates.md` approval record before any related code merges.


### PR DESCRIPTION
Three lanes (dynamic workflow: author → adversarial review; all **APPROVE-WITH-NITS, no must-fix**). **Not merged — your review/merge call.**

## 1. Fix sandbox/consumer Plaid link **500** ✅ verified live
`PlaidClient` sent a top-level OAuth `redirect_uri` **and** Hosted Link → Plaid `INVALID_FIELD` ("OAuth redirect URI must be configured in the developer dashboard") → opaque empty **500** (the Connect-screen error). Fix: `redirectUri` optional + omitted; dropped from both Hosted Link bodies; `LinkRoutes` surfaces Plaid's real `error_code`/`error_message` (secret-free). **Verified:** `POST /api/link/create` → **200** + `https://secure.plaid.com/hl/…`. Same fix applies to production.

## 2. Detachable desktop dashboard (AND-384) — opt-in
`MainPopover` hosted in a floating, draggable `NSPanel` — "not linked to the nav menu, drag across desktop." Opt-in Detach control + Settings toggle; re-dock; menu-bar item raises the panel; one shared `AppState`; Reduce-Motion aware. **Default popover unchanged** (render-verified).
⚠️ Detach *interaction* needs a hands-on pass (drag / app-switch survival / re-dock / ⌘-shortcuts + Esc / VoiceOver) — headless can't exercise NSPanel lifecycle.

## 3. Consumer production-readiness **foundation** (inert)
`deployment` seam (`.local` default), `AccessTokenResolver` (local + fail-closed stub), `EntitlementMiddleware` shell, `Entitlement` model, **`consumer-production-checklist.md`**. Local mode byte-for-byte unchanged.
🔒 Gated (NOT here): hosted-bridge deploy, prod Plaid creds, prod redirect/Hosted-Link registration, Plaid production approval, live Stripe billing.

## Validation
Strict build clean; `swift test` **658**; `/api/link/create` **200 + Hosted Link URL** (live sandbox); dashboard unchanged light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)