### PR TITLE
fix: return 404 for transaction sync with unknown explicit item_id (#353)

### DIFF
--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -22,12 +22,15 @@ struct TransactionRoutes: Sendable {
         let items: [ItemModel]
 
         if let itemIdParam {
+            // An explicit item filter for an id we don't have is a caller error
+            // (typo or stale id), not an empty no-op sync. Surface it as a 404 so
+            // the app/CLI can distinguish a bad filter from a clean sync with no
+            // updates. The unfiltered path below stays a successful empty sync.
             let itemId = String(itemIdParam)
-            if let item = try await tokenStore.getItem(id: itemId) {
-                items = [item]
-            } else {
-                items = []
+            guard let item = try await tokenStore.getItem(id: itemId) else {
+                throw HTTPError(.notFound, message: "Plaid item not found")
             }
+            items = [item]
         } else {
             items = try await tokenStore.getAllItems()
         }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -957,6 +957,48 @@ struct PlaidBarServerTests {
         #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 3))
     }
 
+    @Test func transactionSyncRejectsUnknownExplicitItemFilter() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-sync-item-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=test-client
+        PLAID_SECRET=test-secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(directory.appendingPathComponent("data").path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        let config = try ServerConfig.load(from: configURL.path)
+        let plaidClient = PlaidClient(config: config)
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.sync-item")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = TransactionRoutes(plaidClient: plaidClient, tokenStore: store)
+
+            // An explicit filter for an unknown item id is a 404, not a silent
+            // 200 empty sync that looks like a clean no-op. The Plaid client is
+            // never reached because the guard throws first.
+            let unknownError = await #expect(throws: HTTPError.self) {
+                _ = try await route.syncTransactions(
+                    request: Self.makeRequest(path: "/api/transactions/sync?item_id=does-not-exist"),
+                    context: TestRequestContext(source: TestRequestContextSource())
+                )
+            }
+            #expect(unknownError?.status == .notFound)
+
+            // The unfiltered path against an empty store stays a successful empty sync.
+            let response = try await route.syncTransactions(
+                request: Self.makeRequest(path: "/api/transactions/sync"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            #expect(response.status == .ok)
+        }
+    }
+
     @Test func linkResponseCodable() throws {
         let response = LinkResponse(linkToken: "token_123", linkUrl: "https://example.com/link")
         let data = try JSONEncoder().encode(response)


### PR DESCRIPTION
## Summary

Fixes #353. The transaction sync endpoint treated an explicit but unknown `item_id` filter as an empty item set and returned a successful empty `SyncResponse` (HTTP 200). A typo or stale id (e.g. `plaidbar-cli transactions sync --item <bad-id>`) therefore looked identical to a clean sync with no updates, hiding item-not-found errors from the app and CLI and making stale local item references hard to diagnose.

## Change

- `Sources/PlaidBarServer/Routes/TransactionRoutes.swift`: when an explicit `item_id` has no matching local item, throw `HTTPError(.notFound, message: "Plaid item not found")` before building the sync response. The unfiltered no-items path is unchanged and still returns a successful empty sync.

## Tests

- `Tests/PlaidBarServerTests/PlaidBarServerTests.swift`: adds `transactionSyncRejectsUnknownExplicitItemFilter`, covering both the unknown-item 404 and the unfiltered empty-store 200 paths.

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → clean
- `swift test` → 665 tests passed

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)