### PR TITLE
feat: AND-384 GUI pass — native translucent detached window, 3-columns-always, settled demo open

### DIFF
--- a/Sources/PlaidBar/App/AppActivationPolicyCoordinator.swift
+++ b/Sources/PlaidBar/App/AppActivationPolicyCoordinator.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+/// Single owner of `NSApplication.activationPolicy` elevation, shared by every
+/// surface that needs the menu-bar (`.accessory`) app to temporarily become a
+/// regular, front-and-Dock app: the detached dashboard window and the Settings
+/// window.
+///
+/// It is **refcounted**. The pre-elevation baseline policy is captured only on
+/// the *first* request and restored only when the *last* request is released, so
+/// two surfaces open at once cannot strand the app in `.regular`. Without this,
+/// each surface saved its own "previous" policy — and whichever opened second
+/// captured the already-elevated `.regular` as its baseline, leaving a spurious
+/// Dock / ⌘-Tab presence after both closed.
+///
+/// `@MainActor`-isolated; all `NSApplication` mutation happens on the main actor.
+@MainActor
+final class AppActivationPolicyCoordinator {
+    static let shared = AppActivationPolicyCoordinator()
+
+    private init() {}
+
+    private var requestCount = 0
+    private var baselinePolicy: NSApplication.ActivationPolicy?
+
+    /// Elevate to `.regular` for a surface that needs front/Dock presence. Balance
+    /// every call with exactly one `releaseRegular()`.
+    func requestRegular() {
+        if requestCount == 0 {
+            baselinePolicy = NSApp.activationPolicy()
+        }
+        requestCount += 1
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+    }
+
+    /// Release a previous `requestRegular()`. When the last outstanding request is
+    /// released, restore the policy captured before the first elevation (the
+    /// menu-bar app's `.accessory`, unless a launch flag had already set `.regular`).
+    func releaseRegular() {
+        guard requestCount > 0 else { return }
+        requestCount -= 1
+        guard requestCount == 0 else { return }
+        let restore = baselinePolicy ?? .accessory
+        baselinePolicy = nil
+        if NSApp.activationPolicy() != restore {
+            NSApp.setActivationPolicy(restore)
+        }
+    }
+}

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -200,6 +200,16 @@ final class AppState {
         if isSetupComplete {
             persistSetupCompletion(true)
         }
+        // Demo loads its fixtures synchronously HERE — before `MainPopover`'s
+        // first paint — so the popover opens directly in the populated dashboard
+        // at its settled width. Demo never persists setup completion
+        // (`persistSetupCompletion` no-ops in demo), so deferring this to
+        // `loadInitialData()` (a post-paint `.task`) made frame 1 render the
+        // 480pt setup screen and then resize to the 801pt dashboard, which read
+        // as a flicker/redraw on open. Production stays deferred to `.task`.
+        if CommandLine.arguments.contains("--demo") {
+            loadDemoData()
+        }
     }
 
     private func loadSettings() {
@@ -1204,7 +1214,12 @@ final class AppState {
 
         if CommandLine.arguments.contains("--demo") {
             isDemoMode = true
-            loadDemoData()
+            // `init` already loaded the demo fixtures synchronously so the
+            // popover opens settled (no setup→dashboard width jump). Reload only
+            // if something bypassed init — e.g. a test constructing this state
+            // and calling `loadInitialData()` directly — so we never re-assign
+            // identical fixtures (which would churn derived caches) on open.
+            if accounts.isEmpty { loadDemoData() }
             return
         }
         // Returning users see cached last-known data immediately: the cache

--- a/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
@@ -64,6 +64,13 @@ final class DetachedDashboardCoordinator {
         return true
     }
 
+    /// Open the floating window WITHOUT persisting the detached intent — for the
+    /// `--detach` QA/screenshot launch flag, which must not leave a durable
+    /// `dashboard.detached` preference behind (parity with `--show-popover`).
+    func presentForLaunchOverride(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
+    }
+
     // MARK: - Private
 
     private func present(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -41,8 +41,9 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// while a hide animation is in flight cannot order out the freshly-shown
     /// panel (which would leave `isDashboardDetached == true` with no window).
     private var presentationGeneration = 0
-    /// Observes `dashboard.selectedAccountId` so the panel's real resize floor
-    /// (`contentMinSize`) tracks whether the trailing inspector is showing.
+    /// Observes `UserDefaults.didChangeNotification` so the window picks up live
+    /// changes to the "keep on top" preference (and re-asserts its resize floor)
+    /// without a re-dock.
     ///
     /// No `deinit` removal: this controller is owned by the app scene's
     /// process-lifetime `DetachedDashboardCoordinator`, so it is never
@@ -51,12 +52,10 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// captures `self` weakly, so even an orphaned observation is a harmless
     /// no-op.
     private var selectionObserver: NSObjectProtocol?
-    /// The app's activation policy before the detached window was first shown. A
-    /// menu-bar app runs `.accessory`; while the floating dashboard is open we flip
-    /// to `.regular` so the window comes to the front and gains a Dock / ⌘-Tab
-    /// presence (a normal window from an `.accessory` app otherwise opens *behind*
-    /// the active app). Restored on re-dock so the app returns to menu-bar-only.
-    private var activationPolicyBeforeDetach: NSApplication.ActivationPolicy?
+    /// True while this window holds a `.regular` activation request with the shared
+    /// `AppActivationPolicyCoordinator` (managed mode only). Tracked so show/raise
+    /// request exactly once and re-dock releases exactly once.
+    private var holdsRegularRequest = false
 
     init(
         appState: AppState,
@@ -198,28 +197,22 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         }
     }
 
-    /// Flip the app to `.regular` while the detached window is on screen, saving
-    /// the prior policy once so re-dock can restore it. A normal window from an
-    /// `.accessory` (menu-bar) app otherwise opens behind the active app and never
-    /// takes focus. Idempotent.
+    /// Request `.regular` (front + Dock presence) for the window via the shared,
+    /// refcounted coordinator. Idempotent: holds at most one request so it does
+    /// not double-count or fight the Settings window's own elevation.
     private func elevateActivationPolicyForWindow() {
-        if activationPolicyBeforeDetach == nil {
-            activationPolicyBeforeDetach = NSApp.activationPolicy()
-        }
-        if NSApp.activationPolicy() != .regular {
-            NSApp.setActivationPolicy(.regular)
-        }
+        guard !holdsRegularRequest else { return }
+        holdsRegularRequest = true
+        AppActivationPolicyCoordinator.shared.requestRegular()
     }
 
-    /// Restore the activation policy captured before the window was shown
-    /// (menu-bar `.accessory`), so closing the window returns the app to
-    /// menu-bar-only. No-op when nothing was captured.
+    /// Release this window's `.regular` request. The coordinator returns the app
+    /// to menu-bar-only `.accessory` only when no other surface (e.g. Settings)
+    /// still needs `.regular`. No-op when this window held no request (glance mode).
     private func restoreActivationPolicy() {
-        guard let prior = activationPolicyBeforeDetach else { return }
-        activationPolicyBeforeDetach = nil
-        if NSApp.activationPolicy() != prior {
-            NSApp.setActivationPolicy(prior)
-        }
+        guard holdsRegularRequest else { return }
+        holdsRegularRequest = false
+        AppActivationPolicyCoordinator.shared.releaseRegular()
     }
 
     // MARK: - Resize floor
@@ -231,24 +224,22 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// (982pt) layout and clip the inspector when an account is selected.
     private func updateContentMinSize() {
         guard let panel else { return }
-        let inspectorOpen = !Self.selectedAccountId().isEmpty
-        let minWidth = DetachedDashboardPreferences.minContentWidth(isInspectorOpen: inspectorOpen)
+        // The inspector column is always present (three-column-always), so the
+        // resize floor always reserves it — the window can never be sized narrower
+        // than the full three-column layout and clip the empty inspector.
+        let minWidth = DetachedDashboardPreferences.minContentWidth(isInspectorOpen: true)
         panel.contentMinSize = CGSize(
             width: minWidth,
             height: DetachedDashboardPreferences.minContentHeight
         )
-        // If the user had already shrunk the window below the new floor, grow it
-        // so the inspector is not clipped the instant it opens.
+        // If a restored or pre-existing frame is below the new floor, grow it so
+        // the inspector is not clipped.
         if panel.frame.width < minWidth {
             var frame = panel.frame
             // Grow rightward from the existing origin (keeps the left edge put).
             frame.size.width = minWidth
             panel.setFrame(frame, display: true, animate: false)
         }
-    }
-
-    private static func selectedAccountId() -> String {
-        UserDefaults.standard.string(forKey: "dashboard.selectedAccountId") ?? ""
     }
 
     // MARK: - Panel construction

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -105,21 +105,16 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // layout move, so it never shifts the dashboard.
         if reduceMotion {
             panel.alphaValue = 1
-            panel.makeKeyAndOrderFront(nil)
+            bringWindowForward(panel)
         } else {
             panel.alphaValue = 0
-            panel.makeKeyAndOrderFront(nil)
+            bringWindowForward(panel)
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.18
                 context.allowsImplicitAnimation = true
                 panel.animator().alphaValue = 1
             }
         }
-        // Force the window to the front. `ignoringOtherApps: true` matches the
-        // proven `SettingsWindowActivationRestorer` path; the cooperative
-        // `activate()` does not steal focus, so the window would otherwise open
-        // behind the active app.
-        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     /// Hides the floating dashboard without tearing it down, so the next `show`
@@ -164,12 +159,44 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // A raise also supersedes an in-flight hide.
         presentationGeneration += 1
         panel.alphaValue = 1
-        elevateActivationPolicyForWindow()
-        NSApplication.shared.activate(ignoringOtherApps: true)
-        panel.makeKeyAndOrderFront(nil)
+        bringWindowForward(panel)
     }
 
-    // MARK: - Activation policy
+    // MARK: - Activation policy & window level
+
+    /// Whether the user wants the floating dashboard to stay above other windows
+    /// (a non-activating glance HUD) instead of behaving as a normal managed
+    /// window. Read from UserDefaults so the SettingsView `@AppStorage` toggle and
+    /// the window stay in sync via the defaults-change observer.
+    private var keepDashboardOnTop: Bool {
+        UserDefaults.standard.bool(forKey: DetachedDashboardPreferences.keepOnTopStorageKey)
+    }
+
+    /// Apply the window level + Spaces behavior for the current "keep on top"
+    /// preference: a floating, all-Spaces glance HUD when on; a managed normal
+    /// window (one Space, default collection behavior) when off.
+    private func applyWindowLevelBehavior(to panel: NSWindow) {
+        if keepDashboardOnTop {
+            panel.level = .floating
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .moveToActiveSpace]
+        } else {
+            panel.level = .normal
+            panel.collectionBehavior = []
+        }
+    }
+
+    /// Order the window in. In "keep on top" mode it floats above without stealing
+    /// focus from the active app (a glance HUD); otherwise it becomes a regular,
+    /// frontmost app window with Dock / ⌘-Tab presence.
+    private func bringWindowForward(_ panel: NSWindow) {
+        if keepDashboardOnTop {
+            panel.orderFrontRegardless()
+        } else {
+            elevateActivationPolicyForWindow()
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+        }
+    }
 
     /// Flip the app to `.regular` while the detached window is on screen, saving
     /// the prior policy once so re-dock can restore it. A normal window from an
@@ -255,10 +282,10 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // `.windowStyle(.hiddenTitleBar)`).
         panel.titlebarAppearsTransparent = true
         panel.titleVisibility = .hidden
-        // Leave `level` at `.normal` and `collectionBehavior` at its default
-        // (Managed): the window lives on one Space in normal z-order and
-        // Mission-Controls / Stage-Manages / tiles normally. A non-normal level or
-        // `.canJoinAllSpaces` is what made the old panel behave like a HUD.
+        // Window level + Spaces behavior follow the "keep on top" preference:
+        // a managed normal window by default, or a floating glance HUD when the
+        // user opts in. Applied here and re-applied live when the toggle changes.
+        applyWindowLevelBehavior(to: panel)
 
         // True translucency: an opaque window fully paints its rect, so the
         // material/glass had only the window's own solid backing to sample and
@@ -284,7 +311,13 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                 queue: .main
             ) { [weak self] _ in
                 MainActor.assumeIsolated {
-                    self?.updateContentMinSize()
+                    guard let self else { return }
+                    self.updateContentMinSize()
+                    // Pick up live changes to the "keep on top" toggle so the
+                    // window's level / Spaces behavior updates without a re-dock.
+                    if let panel = self.panel {
+                        self.applyWindowLevelBehavior(to: panel)
+                    }
                 }
             }
         }

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -2,19 +2,25 @@ import AppKit
 import PlaidBarCore
 import SwiftUI
 
-/// Hosts the dashboard (`MainPopover`) in a floating, draggable desktop window
-/// so the user can pull it off the menu bar and move it anywhere (AND-384).
+/// Hosts the dashboard (`MainPopover`) in a real, draggable, resizable desktop
+/// window so the user can pull it off the menu bar and move it anywhere (AND-384).
 ///
-/// The window is a non-activating `NSPanel` at `.floating` level: it survives
-/// app-switches (it does not vanish on focus loss the way the menu-bar popover
-/// does), shows across Spaces, and is movable by dragging anywhere on its
-/// surface (`isMovableByWindowBackground`). It hosts the *same* `MainPopover`
-/// view bound to the *same* `AppState`, so there is no duplicate data, sync
-/// timer, or server client — only a second presentation surface.
+/// The window is a managed `NSWindow` (titled, closable, miniaturizable,
+/// resizable) at the normal window level with the default (Managed) collection
+/// behavior, so it drags, resizes, minimizes, tiles, and participates in Mission
+/// Control / Spaces / Stage Manager like any first-class app window — *not* a
+/// floating utility palette. It is movable by dragging anywhere on its surface
+/// (`isMovableByWindowBackground`) and translucent (a behind-window
+/// `NSVisualEffectView` backdrop over a non-opaque, clear window) so the desktop
+/// shows through. It hosts the *same* `MainPopover` view bound to the *same*
+/// `AppState`, so there is no duplicate data, sync timer, or server client — only
+/// a second presentation surface.
 ///
 /// Frame (origin + size) is persisted by AppKit via `frameAutosaveName`, so the
 /// window reopens where the user left it. Open/closed intent is persisted
-/// separately by `AppState.isDashboardDetached`.
+/// separately by `AppState.isDashboardDetached`. Window appearance is left to
+/// inherit the single `NSApp.appearance` owner (pinned only for the `--appearance`
+/// QA override) so flipping Light/Dark updates the window live.
 ///
 /// `@MainActor`-isolated; all AppKit window mutation happens on the main actor,
 /// which keeps it correct under `-strict-concurrency=complete`.
@@ -27,7 +33,7 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// the owner so the controller does not reach back into app state policy.
     private let onRedock: @MainActor () -> Void
 
-    private var panel: NSPanel?
+    private var panel: NSWindow?
     private var hostingController: NSHostingController<AnyView>?
     /// Monotonic counter bumped on every `show`/`raise`. A pending hide
     /// fade-out captures the value at the time it started and only orders the
@@ -45,6 +51,12 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
     /// captures `self` weakly, so even an orphaned observation is a harmless
     /// no-op.
     private var selectionObserver: NSObjectProtocol?
+    /// The app's activation policy before the detached window was first shown. A
+    /// menu-bar app runs `.accessory`; while the floating dashboard is open we flip
+    /// to `.regular` so the window comes to the front and gains a Dock / ⌘-Tab
+    /// presence (a normal window from an `.accessory` app otherwise opens *behind*
+    /// the active app). Restored on re-dock so the app returns to menu-bar-only.
+    private var activationPolicyBeforeDetach: NSApplication.ActivationPolicy?
 
     init(
         appState: AppState,
@@ -78,6 +90,10 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // Make sure the resize floor reflects the current inspector state before
         // the window appears (a launch-restore could already have a selection).
         updateContentMinSize()
+        // Become a regular app while the window is up so it comes to the front
+        // and is reachable from the Dock / ⌘-Tab; restored to the prior policy
+        // (menu-bar-only `.accessory`) on re-dock.
+        elevateActivationPolicyForWindow()
 
         if panel.isVisible {
             raise()
@@ -89,16 +105,21 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // layout move, so it never shifts the dashboard.
         if reduceMotion {
             panel.alphaValue = 1
-            panel.orderFrontRegardless()
+            panel.makeKeyAndOrderFront(nil)
         } else {
             panel.alphaValue = 0
-            panel.orderFrontRegardless()
+            panel.makeKeyAndOrderFront(nil)
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.18
                 context.allowsImplicitAnimation = true
                 panel.animator().alphaValue = 1
             }
         }
+        // Force the window to the front. `ignoringOtherApps: true` matches the
+        // proven `SettingsWindowActivationRestorer` path; the cooperative
+        // `activate()` does not steal focus, so the window would otherwise open
+        // behind the active app.
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     /// Hides the floating dashboard without tearing it down, so the next `show`
@@ -108,6 +129,7 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
 
         if reduceMotion {
             panel.orderOut(nil)
+            restoreActivationPolicy()
         } else {
             // Capture the generation this hide belongs to; if a `show`/`raise`
             // bumps it before the fade completes, the panel was re-presented and
@@ -126,6 +148,9 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                     }
                     panel?.orderOut(nil)
                     panel?.alphaValue = 1
+                    // The window is actually gone now — return the app to its
+                    // prior (menu-bar-only) activation policy.
+                    self.restoreActivationPolicy()
                 }
             }
         }
@@ -139,8 +164,35 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // A raise also supersedes an in-flight hide.
         presentationGeneration += 1
         panel.alphaValue = 1
-        panel.orderFrontRegardless()
-        panel.makeKey()
+        elevateActivationPolicyForWindow()
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    // MARK: - Activation policy
+
+    /// Flip the app to `.regular` while the detached window is on screen, saving
+    /// the prior policy once so re-dock can restore it. A normal window from an
+    /// `.accessory` (menu-bar) app otherwise opens behind the active app and never
+    /// takes focus. Idempotent.
+    private func elevateActivationPolicyForWindow() {
+        if activationPolicyBeforeDetach == nil {
+            activationPolicyBeforeDetach = NSApp.activationPolicy()
+        }
+        if NSApp.activationPolicy() != .regular {
+            NSApp.setActivationPolicy(.regular)
+        }
+    }
+
+    /// Restore the activation policy captured before the window was shown
+    /// (menu-bar `.accessory`), so closing the window returns the app to
+    /// menu-bar-only. No-op when nothing was captured.
+    private func restoreActivationPolicy() {
+        guard let prior = activationPolicyBeforeDetach else { return }
+        activationPolicyBeforeDetach = nil
+        if NSApp.activationPolicy() != prior {
+            NSApp.setActivationPolicy(prior)
+        }
     }
 
     // MARK: - Resize floor
@@ -174,39 +226,49 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
 
     // MARK: - Panel construction
 
-    private func makePanel() -> NSPanel {
+    private func makePanel() -> NSWindow {
         let size = DetachedDashboardPreferences.defaultContentSize
 
-        let panel = NSPanel(
+        // A real, managed desktop window — deliberately NOT an NSPanel. An
+        // NSPanel at `.floating` level with `.utilityWindow`/`.nonactivatingPanel`
+        // is a floating palette: it sits above every app, shows on all Spaces,
+        // can't minimize, and is invisible to Mission Control / Stage Manager /
+        // window tiling — exactly what made the dashboard "feel stuck to the menu
+        // bar." A titled, miniaturizable, resizable `NSWindow` at the normal level
+        // with the default (Managed) collection behavior drags, resizes,
+        // minimizes, tiles, and lives on one Space like a first-class window.
+        let panel = NSWindow(
             contentRect: NSRect(origin: .zero, size: size),
-            // .nonactivatingPanel keeps the rest of the app from losing focus
-            // when the window comes forward; titled/closable/resizable give it
-            // standard window chrome (drag, close, resize handles).
-            styleMask: [.titled, .closable, .resizable, .nonactivatingPanel, .utilityWindow],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
 
         panel.title = DetachedDashboardPreferences.windowTitle
-        // Float above ordinary windows but below modal panels, so the dashboard
-        // stays glanceable over other apps the way the popover does.
-        panel.level = .floating
         // Drag the whole surface — the dashboard has no title-bar-only grab area,
         // so the user can move it by grabbing anywhere not interactive (AND-384).
         panel.isMovableByWindowBackground = true
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
-        panel.becomesKeyOnlyIfNeeded = true
+        // Chrome-light look: keep the traffic lights but let the dashboard content
+        // run to the top edge (the AppKit equivalent of
+        // `.windowStyle(.hiddenTitleBar)`).
         panel.titlebarAppearsTransparent = true
         panel.titleVisibility = .hidden
-        panel.isFloatingPanel = true
-        // Show on every Space and stay up in full-screen apps, so the dashboard
-        // is reachable from wherever the user is working.
-        panel.collectionBehavior = [
-            .canJoinAllSpaces,
-            .fullScreenAuxiliary,
-            .moveToActiveSpace,
-        ]
+        // Leave `level` at `.normal` and `collectionBehavior` at its default
+        // (Managed): the window lives on one Space in normal z-order and
+        // Mission-Controls / Stage-Manages / tiles normally. A non-normal level or
+        // `.canJoinAllSpaces` is what made the old panel behave like a HUD.
+
+        // True translucency: an opaque window fully paints its rect, so the
+        // material/glass had only the window's own solid backing to sample and
+        // rendered flat/gray. A non-opaque, clear window plus the behind-window
+        // `NSVisualEffectView` backdrop (added below) lets the desktop show
+        // through with a real frosted blur (AND-384).
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+
         panel.contentMinSize = DetachedDashboardPreferences.minContentSize
         panel.delegate = self
 
@@ -227,23 +289,36 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
             }
         }
 
-        // Appearance for the window chrome. The CLI `--appearance` override
-        // wins; otherwise honor the stored app appearance preference so a
-        // detached window restored at launch (created from the menu-bar label,
-        // before any `.appliesAppAppearance()` scene mounts) follows the user's
-        // Light/Dark setting instead of defaulting to the system appearance.
-        // `.followSystem` leaves `panel.appearance` nil so AppKit follows the
-        // system, matching the rest of the app.
-        if let scheme = Self.effectiveColorScheme(forcedColorScheme: forcedColorScheme) {
-            panel.appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua)
+        // Leave `panel.appearance == nil` so the window inherits the single
+        // `NSApp.appearance` owner live — flipping Light/Dark in Settings updates
+        // the detached window while it is open. Pin explicitly ONLY for the
+        // `--appearance` CLI QA override, which `AppAppearance.applyToNSApp`
+        // deliberately leaves off `NSApp.appearance`.
+        if let forcedColorScheme {
+            panel.appearance = NSAppearance(named: forcedColorScheme == .dark ? .darkAqua : .aqua)
         }
 
-        // No `.preferredContentSize`: the dashboard fills the resizable panel
-        // (maxWidth/maxHeight: .infinity) and the panel's frame drives the
-        // hosting view, so dragging the resize handle resizes the content rather
-        // than SwiftUI's intrinsic size fighting the user's chosen frame.
+        // Behind-window vibrancy backdrop: `.behindWindow` samples the desktop
+        // (the only blending mode that yields real translucency) and `.active`
+        // keeps the blur even when this window is not key. The hosted SwiftUI
+        // fills it edge-to-edge; while detached, `MainPopover` renders a clear
+        // root background so this backdrop *is* the translucent surface rather
+        // than an opaque material painted over an opaque window.
+        let backdrop = NSVisualEffectView()
+        backdrop.material = .underWindowBackground
+        backdrop.blendingMode = .behindWindow
+        backdrop.state = .active
+
         let hosting = NSHostingController(rootView: makeRootView())
-        panel.contentViewController = hosting
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        backdrop.addSubview(hosting.view)
+        NSLayoutConstraint.activate([
+            hosting.view.leadingAnchor.constraint(equalTo: backdrop.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: backdrop.trailingAnchor),
+            hosting.view.topAnchor.constraint(equalTo: backdrop.topAnchor),
+            hosting.view.bottomAnchor.constraint(equalTo: backdrop.bottomAnchor),
+        ])
+        panel.contentView = backdrop
         self.hostingController = hosting
 
         // Restore the persisted frame (origin + size) if one exists; otherwise
@@ -269,28 +344,15 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                 .environment(\.dashboardPresentation, .detached(redock: { [weak self] in
                     self?.onRedock()
                 }))
-                // Same precedence as the panel chrome: CLI override, else the
-                // stored Light/Dark preference, else follow the system.
-                .forcedDetachedColorScheme(Self.effectiveColorScheme(forcedColorScheme: forcedColorScheme))
+                // Pin the SwiftUI color scheme ONLY for the `--appearance` CLI QA
+                // override; otherwise leave it unset so the content inherits the
+                // window's live (NSApp-driven) appearance and follows Light/Dark
+                // changes made while the window is open.
+                .forcedDetachedColorScheme(forcedColorScheme)
                 // The panel owns its own width via resize; let the dashboard fill
                 // it rather than imposing the popover's screen-anchored width math.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
-    }
-
-    /// The color scheme to pin the detached window to: the CLI `--appearance`
-    /// override if present, otherwise the stored app appearance preference
-    /// (`AppAppearanceMode`), otherwise `nil` to follow the system. Resolving the
-    /// stored preference here is what lets a launch-restored detached window
-    /// honor Light/Dark before any `.appliesAppAppearance()` scene has mounted.
-    static func effectiveColorScheme(forcedColorScheme: ColorScheme?) -> ColorScheme? {
-        if let forcedColorScheme { return forcedColorScheme }
-        let raw = UserDefaults.standard.string(forKey: AppAppearanceMode.storageKey)
-        switch AppAppearanceMode(rawValue: raw ?? "") ?? .followSystem {
-        case .followSystem: return nil
-        case .light: return .light
-        case .dark: return .dark
-        }
     }
 
     // MARK: - NSWindowDelegate

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -17,10 +17,17 @@ struct PlaidBarApp: App {
 
     init() {
         Self.applyForcedAppearance()
+        Self.applyStoredAppearance()
         Self.applyScreenshotDefaults()
 
         let state = AppState()
         _appState = State(initialValue: state)
+        // QA/screenshot aid: "--detach" opens the floating desktop window at
+        // launch (parallel to "--show-popover"), so the detached window can be
+        // exercised and captured without driving the menu-bar UI by hand.
+        if CommandLine.arguments.contains("--detach") {
+            state.isDashboardDetached = true
+        }
         updaterController = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: nil,
@@ -76,6 +83,14 @@ struct PlaidBarApp: App {
             MenuBarLabel()
                 .environment(appState)
                 .forcedAppColorScheme(Self.forcedColorScheme)
+                // The label is the only scene content mounted for the whole app
+                // lifetime, so it also carries the live appearance updater: with
+                // it here, flipping Light/Dark re-applies NSApp.appearance even
+                // when the popover and Settings are both closed (the popover and
+                // Settings keep their own copies for when they are the only
+                // mounted scene). Without this, a change made while only the label
+                // is up would not take effect until the popover next opened.
+                .appliesAppAppearance()
                 // The menu-bar label is the only scene content that is mounted
                 // for the whole app lifetime — `MainPopover` is mounted lazily,
                 // only while the popover/menu-extra window is presented, and
@@ -132,6 +147,15 @@ struct PlaidBarApp: App {
                         }
                         appState.isPopoverPresented = true
                     },
+                    openInWindow: {
+                        // Detach into the floating desktop window directly, so the
+                        // window is reachable without hunting for the footer glyph.
+                        detachedDashboard.detach(
+                            appState: appState,
+                            forcedColorScheme: Self.forcedColorScheme,
+                            reduceMotion: reduceMotion
+                        )
+                    },
                     refreshDashboard: {
                         Task { await appState.refreshDashboard() }
                     },
@@ -176,6 +200,20 @@ struct PlaidBarApp: App {
         default:
             break
         }
+    }
+
+    /// Applies the *stored* appearance-mode preference to `NSApplication.appearance`
+    /// **before first paint**, so the very first frame renders in the chosen
+    /// Light/Dark — window chrome and AppKit materials included — instead of
+    /// flashing the system appearance and correcting `onAppear`. `NSApp.appearance`
+    /// is the only API that cascades to chrome + materials; `environment(\.colorScheme)`
+    /// moves SwiftUI content only. The `--appearance` CLI override wins:
+    /// `applyForcedAppearance()` already pinned it and `applyToNSApp` no-ops when set.
+    private static func applyStoredAppearance() {
+        AppAppearance.applyToNSApp(
+            modeRaw: UserDefaults.standard.string(forKey: AppAppearanceMode.storageKey)
+                ?? AppAppearanceMode.defaultValue.rawValue
+        )
     }
 
     /// The color scheme forced by the `--appearance` CLI flag (QA aid), or `nil`
@@ -256,6 +294,20 @@ private struct AppAppearanceApplier: ViewModifier {
     }
 
     @MainActor private func apply() {
+        AppAppearance.applyToNSApp(modeRaw: modeRaw)
+    }
+}
+
+/// Single mapping from the stored appearance mode to `NSApplication.appearance`,
+/// shared by the launch-time application (`PlaidBarApp.applyStoredAppearance`,
+/// before first paint) and the live `AppAppearanceApplier` (`onChange`). Making
+/// this the one writer of `NSApp.appearance` for the stored preference gives every
+/// window — popover, Settings, and the detached dashboard (whose panel leaves
+/// `appearance == nil` so it inherits) — a single source of truth, so flipping
+/// Light/Dark updates all surfaces live. The `--appearance` CLI override wins and
+/// makes this a no-op.
+enum AppAppearance {
+    @MainActor static func applyToNSApp(modeRaw: String) {
         guard CommandLineOptions.value(for: "--appearance") == nil else { return }
         switch AppAppearanceMode(rawValue: modeRaw) ?? .followSystem {
         case .followSystem: NSApplication.shared.appearance = nil

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -22,12 +22,6 @@ struct PlaidBarApp: App {
 
         let state = AppState()
         _appState = State(initialValue: state)
-        // QA/screenshot aid: "--detach" opens the floating desktop window at
-        // launch (parallel to "--show-popover"), so the detached window can be
-        // exercised and captured without driving the menu-bar UI by hand.
-        if CommandLine.arguments.contains("--detach") {
-            state.isDashboardDetached = true
-        }
         updaterController = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: nil,
@@ -110,6 +104,17 @@ struct PlaidBarApp: App {
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
                     )
+                    // QA/screenshot aid: "--detach" opens the floating window at
+                    // launch (parallel to "--show-popover") WITHOUT persisting the
+                    // detached intent, so a QA run never leaves a durable
+                    // `dashboard.detached` preference behind.
+                    if CommandLine.arguments.contains("--detach") {
+                        detachedDashboard.presentForLaunchOverride(
+                            appState: appState,
+                            forcedColorScheme: Self.forcedColorScheme,
+                            reduceMotion: reduceMotion
+                        )
+                    }
                 }
                 // While detached, a status-item click sets isPopoverPresented
                 // true; intercept it on the always-mounted label, snap it back to

--- a/Sources/PlaidBar/App/StatusItemContextMenuController.swift
+++ b/Sources/PlaidBar/App/StatusItemContextMenuController.swift
@@ -2,6 +2,7 @@ import AppKit
 
 struct StatusItemContextMenuActions {
     let showDashboard: @MainActor () -> Void
+    let openInWindow: @MainActor () -> Void
     let refreshDashboard: @MainActor () -> Void
     let openSettings: @MainActor () -> Void
     let checkForUpdates: @MainActor () -> Void
@@ -50,6 +51,7 @@ final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
         menu.delegate = self
 
         menu.addActionItem("Open VaultPeek", action: #selector(showDashboard), target: self)
+        menu.addActionItem("Open in Window", action: #selector(openInWindow), target: self)
         menu.addActionItem("Refresh Dashboard", action: #selector(refreshDashboard), target: self)
         menu.addItem(.separator())
         menu.addActionItem("Settings...", action: #selector(openSettings), target: self)
@@ -70,6 +72,10 @@ final class StatusItemContextMenuController: NSObject, NSMenuDelegate {
 
     @objc private func showDashboard() {
         actions?.showDashboard()
+    }
+
+    @objc private func openInWindow() {
+        actions?.openInWindow()
     }
 
     @objc private func refreshDashboard() {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -307,6 +307,7 @@ private struct AppearancePreviewCard: View {
 
 struct GeneralSettingsView: View {
     @Environment(AppState.self) private var appState
+    @AppStorage(DetachedDashboardPreferences.keepOnTopStorageKey) private var keepDashboardOnTop = false
     @State private var isShowingResetConfirmation = false
     @State private var resetResultMessage: String?
     @State private var resetErrorMessage: String?
@@ -373,6 +374,16 @@ struct GeneralSettingsView: View {
                 // the in-dashboard pin/dock control.
                 Toggle("Keep dashboard in a floating window", isOn: $state.isDashboardDetached)
                 Text("Detaches the dashboard from the menu bar into a movable desktop window that stays open when you switch apps. Click the menu bar item to bring it back to the front; dock it again from the window or this toggle.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // AND-384 glance mode: when on, the floating window floats above
+                // other apps on every Space and does not steal focus — the
+                // original "monitor at a glance while you work" behavior — as an
+                // explicit opt-in rather than the default.
+                Toggle("Keep the floating window on top", isOn: $keepDashboardOnTop)
+                    .disabled(!state.isDashboardDetached)
+                Text("Floats the window above other windows on every Space without taking focus from the app you're working in. Off (default): it behaves like a normal window — one Space, normal order, and visible in Mission Control and the Dock.")
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -2081,17 +2081,18 @@ final class SettingsWindowActivationRestorer {
 
     private var closeObserver: NSObjectProtocol?
     private var discoveryObserver: NSObjectProtocol?
-    private var previousActivationPolicy: NSApplication.ActivationPolicy?
+    /// True while Settings holds a `.regular` request with the shared coordinator,
+    /// so opening Settings twice does not double-count and closing releases once.
+    private var holdsRegularRequest = false
 
     func open(openSettings: OpenSettingsAction) {
         let app = NSApplication.shared
-        if previousActivationPolicy == nil {
-            previousActivationPolicy = app.activationPolicy()
-        }
-
         removeDiscoveryObserver()
-        if app.activationPolicy() != .regular {
-            app.setActivationPolicy(.regular)
+        // Elevate via the shared, refcounted coordinator (not a private save) so
+        // Settings and the detached dashboard cannot strand the app in `.regular`.
+        if !holdsRegularRequest {
+            holdsRegularRequest = true
+            AppActivationPolicyCoordinator.shared.requestRegular()
         }
 
         openSettings()
@@ -2150,9 +2151,10 @@ final class SettingsWindowActivationRestorer {
     }
 
     private func restoreActivationPolicy() {
-        let app = NSApplication.shared
-        app.setActivationPolicy(previousActivationPolicy ?? .accessory)
-        previousActivationPolicy = nil
+        if holdsRegularRequest {
+            holdsRegularRequest = false
+            AppActivationPolicyCoordinator.shared.releaseRegular()
+        }
         removeCloseObserver()
         removeDiscoveryObserver()
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -78,15 +78,21 @@ struct MainPopover: View {
         return accounts.first { $0.id == id }
     }
 
-    /// The trailing account inspector is reserved: a selection is persisted and
-    /// we are past setup. Derived from the persisted `selectedAccountId`
-    /// (`@AppStorage`) rather than the resolved `selectedAccount`, so a popover
-    /// opened with a persisted selection reserves the three-column width and
-    /// anchor immediately — before `loadInitialData()` populates accounts —
-    /// instead of opening two-column and jumping to three-column once accounts
-    /// arrive (AND-405). The inspector column shows a brief loading placeholder
-    /// until `selectedAccount` resolves. Also drives the popover width, the
-    /// leading-edge anchor, and Esc precedence.
+    /// The trailing inspector COLUMN is present whenever setup is complete — the
+    /// three-column workspace is stable and never collapses to two columns on
+    /// deselect ("3 columns always open"). It drives the popover width, the
+    /// leading-edge anchor, and the detached resize floor, so the layout opens
+    /// directly in three-column geometry and stays there. Only the column's
+    /// CONTENT varies (selected-account inspector, a brief loading placeholder for
+    /// a still-resolving persisted selection, or an empty-selection prompt) —
+    /// never the column's existence.
+    private var isInspectorColumnVisible: Bool {
+        !shouldShowSetupScreen
+    }
+
+    /// Whether a specific account's inspector is showing (a row is selected).
+    /// Distinct from the column's existence: drives Esc-to-deselect precedence
+    /// (AND-373) and which content the always-present inspector column renders.
     private var isAccountInspectorOpen: Bool {
         !selectedAccountId.isEmpty && !shouldShowSetupScreen
     }
@@ -161,7 +167,16 @@ struct MainPopover: View {
             .foregroundStyle(AppearanceTextColors.primary)
             .environment(\.colorScheme, effectiveColorScheme)
             .background {
-                PopoverMaterialBackground(transparencySetting: transparencySetting)
+                // The detached desktop window supplies its own behind-window
+                // vibrancy backdrop (a translucent NSVisualEffectView), so the
+                // dashboard renders a clear root there and lets the desktop show
+                // through. The menu-bar popover keeps the in-content material
+                // backdrop (its host window is not vibrant on its own).
+                if dashboardPresentation.isDetached {
+                    Color.clear
+                } else {
+                    PopoverMaterialBackground(transparencySetting: transparencySetting)
+                }
             }
             // The screen-edge anchor and width reader only apply to the menu-bar
             // popover window (which AppKit re-centers under the status item). The
@@ -170,7 +185,7 @@ struct MainPopover: View {
             // is unchanged.
             .modifier(PopoverWindowGeometryModifier(
                 isDetached: dashboardPresentation.isDetached,
-                isInspectorOpen: isAccountInspectorOpen,
+                isInspectorOpen: isInspectorColumnVisible,
                 collapsedWidth: twoColumnWidth,
                 screenEdgeMargin: Layout.screenEdgeMargin,
                 activeScreenVisibleWidth: $activeScreenVisibleWidth
@@ -199,10 +214,10 @@ struct MainPopover: View {
                 .frame(
                     minWidth: shouldShowSetupScreen
                         ? PopoverGeometry.width(for: .setup)
-                        // Include the inspector column in the floor so selecting
-                        // an account near the minimum width does not clip the
-                        // inspector off the resizable window (AND-384/405).
-                        : PopoverGeometry.detachedMinContentWidth(isInspectorOpen: isAccountInspectorOpen),
+                        // The inspector column is always present, so the resize
+                        // floor always includes it — the window can never be sized
+                        // narrower than the full three-column layout (AND-384/405).
+                        : PopoverGeometry.detachedMinContentWidth(isInspectorOpen: isInspectorColumnVisible),
                     maxWidth: .infinity,
                     alignment: .topLeading
                 )
@@ -261,13 +276,14 @@ struct MainPopover: View {
             .transition(.move(edge: .leading).combined(with: .opacity))
     }
 
-    // RIGHT: the account inspector opens on the trailing side only when a row is
-    // selected, leaving the left rail and center dashboard in place
-    // (AND-369/371). It slides in from the trailing edge and is independently
-    // dismissible.
+    // RIGHT: the account inspector column is always present once setup is complete
+    // (three-column-always contract): the left rail and center dashboard stay put
+    // and the column's CONTENT — not its existence — changes with selection, so
+    // deselecting reverts to an empty-selection prompt instead of collapsing the
+    // workspace to two columns.
     @ViewBuilder
     private var accountInspectorColumn: some View {
-        if isAccountInspectorOpen {
+        if isInspectorColumnVisible {
             Divider()
                 .opacity(0.35)
 
@@ -279,18 +295,21 @@ struct MainPopover: View {
                         onClose: deselectAccount
                     )
                     .environment(appState)
-                } else {
-                    // A persisted selection reserves the column before accounts
-                    // load; show a brief placeholder so the width is correct
-                    // immediately and fills in without a resize jump (AND-405).
+                } else if !selectedAccountId.isEmpty {
+                    // A persisted selection is still resolving (accounts not loaded
+                    // yet); a brief placeholder holds the column until it fills in.
                     inspectorLoadingPlaceholder
+                } else {
+                    // Nothing selected: the column stays as a stable third column
+                    // with a prompt instead of collapsing to two columns.
+                    inspectorEmptySelectionState
                 }
             }
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: columnMaxHeight)
             .leftPanelSurface()
-            // Slide in only for an in-session selection; a popover opened with a
-            // persisted selection appears directly in three-column (AND-405).
+            // The column is stable now, so this transition only plays when it
+            // first appears as setup completes — not on every selection (AND-405).
             .transition(.asymmetric(
                 insertion: inspectorInsertionTransition,
                 removal: .move(edge: .trailing).combined(with: .opacity)
@@ -309,6 +328,19 @@ struct MainPopover: View {
             .accessibilityLabel("Loading account details")
     }
 
+    // Empty-selection content for the always-present inspector column: a quiet
+    // prompt (icon + label, never color alone) so the third column reads as
+    // intentional context space rather than a blank gap.
+    private var inspectorEmptySelectionState: some View {
+        ContentUnavailableView {
+            Label("No Account Selected", systemImage: "creditcard")
+        } description: {
+            Text("Select an account to see its balances, recent activity, and trend here.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel("No account selected. Select an account to see its details here.")
+    }
+
     private var popoverWidth: CGFloat {
         // Cap the content to the available screen width so the popover never
         // renders off-screen; the center dashboard flexes to absorb the cap so
@@ -316,7 +348,7 @@ struct MainPopover: View {
         // narrow/scaled displays (AND-405). Setup renders at the dashboard width.
         guard !shouldShowSetupScreen else { return PopoverGeometry.width(for: .setup) }
         return PopoverGeometry.fittedWidth(
-            for: isAccountInspectorOpen ? .threeColumn : .twoColumn,
+            for: isInspectorColumnVisible ? .threeColumn : .twoColumn,
             availableWidth: availableScreenWidth
         )
     }

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -47,11 +47,11 @@ public enum DetachedDashboardPreferences {
     public static let windowTitle = "VaultPeek Dashboard"
 
     /// Default content width of the floating panel before any persisted frame is
-    /// restored: the popover's two-column base (rail + divider + dashboard), so
-    /// the detached window opens at the same width the popover uses with no
-    /// account selected.
+    /// restored: the full three-column width (rail + dashboard + the
+    /// always-present inspector), so a freshly detached window opens wide enough
+    /// to show all three columns without clipping the inspector.
     public static var defaultContentWidth: CGFloat {
-        PopoverGeometry.width(for: .twoColumn)
+        PopoverGeometry.width(for: .threeColumn)
     }
 
     /// Default content height of the floating panel before any persisted frame is
@@ -62,10 +62,11 @@ public enum DetachedDashboardPreferences {
     }
 
     /// Minimum content width the floating panel may be resized to: the
-    /// two-column minimum (fixed rail + the flexible center's floor), so the
-    /// Wealth Summary rail and a usable dashboard always stay legible.
+    /// three-column minimum (fixed rail + the flexible center's floor + the
+    /// always-present inspector), so the rail, a usable dashboard, AND the
+    /// inspector always stay legible.
     public static var minContentWidth: CGFloat {
-        minContentWidth(isInspectorOpen: false)
+        minContentWidth(isInspectorOpen: true)
     }
 
     /// Minimum content width the floating panel may be resized to for the current

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -15,6 +15,14 @@ public enum DetachedDashboardPreferences {
     /// durable intent; `AppState.isDashboardDetached` mirrors it at runtime.
     public static let detachedStorageKey = "dashboard.detached"
 
+    /// `@AppStorage` key for "keep the floating dashboard window on top". When
+    /// true the detached window floats above other windows on every Space and is
+    /// non-activating (a glance HUD that does not steal focus — the original
+    /// AND-384 glance behavior). When false (default) it is a normal managed
+    /// window that lives on one Space and participates in Mission Control /
+    /// Stage Manager / tiling.
+    public static let keepOnTopStorageKey = "dashboard.keepOnTop"
+
     /// Resolves the detached intent to apply at launch from the persisted value.
     ///
     /// A headless snapshot render must ignore any persisted intent: on a host/CI

--- a/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
+++ b/Tests/PlaidBarCoreTests/DetachedDashboardPreferencesTests.swift
@@ -13,11 +13,12 @@ struct DetachedDashboardPreferencesTests {
         #expect(DetachedDashboardPreferences.windowTitle == "VaultPeek Dashboard")
     }
 
-    @Test("Default content size matches the popover's two-column footprint")
+    @Test("Default content size opens the full three-column workspace")
     func defaultContentSize() {
-        // A freshly detached window opens at the same width the popover uses with
-        // no account selected (two-column) and the realistic popover height.
-        #expect(DetachedDashboardPreferences.defaultContentWidth == PopoverGeometry.width(for: .twoColumn))
+        // The inspector column is always present, so a freshly detached window
+        // opens at the full three-column width (and the realistic popover height)
+        // — wide enough to show all three columns without clipping the inspector.
+        #expect(DetachedDashboardPreferences.defaultContentWidth == PopoverGeometry.width(for: .threeColumn))
         #expect(
             DetachedDashboardPreferences.defaultContentHeight
                 == CGFloat(DashboardOverviewHeightBudget.realisticPopoverHeight)
@@ -26,13 +27,16 @@ struct DetachedDashboardPreferencesTests {
         #expect(DetachedDashboardPreferences.defaultContentSize.height == DetachedDashboardPreferences.defaultContentHeight)
     }
 
-    @Test("Minimum content width keeps the rail plus a usable dashboard")
+    @Test("Minimum content width keeps the rail, a usable dashboard, and the inspector")
     func minContentWidth() {
-        // The fixed rail + divider + the flexible center's floor — so the Wealth
-        // Summary rail and a legible dashboard always fit when resized small.
+        // The inspector column is always present, so the floor reserves it too:
+        // rail + divider + center floor + divider + inspector — the full
+        // three-column minimum, so nothing clips when the window is resized small.
         let expected = PopoverGeometry.railWidth
             + PopoverGeometry.dividerWidth
             + PopoverGeometry.minDashboardWidth
+            + PopoverGeometry.dividerWidth
+            + PopoverGeometry.railWidth
         #expect(DetachedDashboardPreferences.minContentWidth == expected)
         #expect(DetachedDashboardPreferences.minContentSize.width == expected)
         #expect(DetachedDashboardPreferences.minContentSize.height == DetachedDashboardPreferences.minContentHeight)

--- a/docs/ux-audit-2026-06-13.md
+++ b/docs/ux-audit-2026-06-13.md
@@ -1,0 +1,124 @@
+# VaultPeek UX Audit & Remediation — 2026-06-13
+
+Principal/Staff review of the demo experience against current Apple platform
+guidance (Context7 + HIG + WWDC), with root causes, fixes, and a prioritized
+roadmap. Findings were adversarially verified against the source and validated
+against documentation by a multi-agent workflow.
+
+**User constraint (decided):** keep the **menu-bar popover as the primary,
+default surface** ("polish the popover only" + "quick popover, window on
+demand"). The free-drag/resize requirement is therefore delivered by **fixing
+the existing on-demand detached window into a real native window**, not by a
+desktop-first rewrite. No new SwiftUI `Window` scene; no architecture pivot.
+
+---
+
+## 1. Documentation research summary
+
+| Area | Recommended (current) | Anti-pattern found in code |
+|------|-----------------------|----------------------------|
+| Windowing | A primary desktop window is a managed `NSWindow` — `[.titled,.closable,.miniaturizable,.resizable]`, `level=.normal`, default (Managed) `collectionBehavior`. SwiftUI equivalents: `Window` scene, `.windowStyle(.hiddenTitleBar)`, `.windowResizability(.automatic)`, `.windowBackgroundDragBehavior(.enabled)`. | Detached window was an `NSPanel` `[.utilityWindow,.nonactivatingPanel]`, `level=.floating`, `.canJoinAllSpaces`, no `.miniaturizable` → a floating **utility HUD**: above all apps, on every Space, no minimize, invisible to Mission Control / Stage Manager / tiling. |
+| Materials / Liquid Glass | True translucency needs a non-opaque host: `NSWindow.isOpaque=false`, `backgroundColor=.clear`, and an `NSVisualEffectView(blendingMode: .behindWindow, state: .active)` backdrop (it samples the desktop). | Detached `NSPanel` left opaque (no `isOpaque=false`, no `NSVisualEffectView`) → `.ultraThinMaterial`/`.glassEffect` sampled the window's own solid backing → **flat/opaque**. A `windowBackgroundColor` color was also painted *over* the material. |
+| Three-column layout | Keep the column; vary its **content**, not its **existence**. Show a `ContentUnavailableView` placeholder in the detail/inspector column when nothing is selected. | Third column was existence-gated on `selectedAccountId` inside a hand-rolled `HStack` (no `NavigationSplitView`) → default was two columns; the third appeared/vanished on selection, filter change, and background sync. |
+| Appearance | `NSApp.appearance` is the single API that cascades to **all** windows + chrome + AppKit materials; apply it **before first paint** (`applicationWillFinishLaunching`/`init`). A separately-hosted window must leave `appearance == nil` to inherit, or observe to update. `environment(\.colorScheme)` moves SwiftUI content only. | Three overlapping scheme sources; `NSApp.appearance` applied `onAppear` (post-paint) on lazily-mounted views only; detached `panel.appearance` pinned once at creation with no observer → frozen while open. |
+| MenuBarExtra startup | `MenuBarExtra(.window)` recreates its window each open and mounts content lazily; **pin one width across all states** (vary height, not width) and make the first frame look settled. | Demo booted `isSetupComplete=false` → 480pt setup frame, then post-paint `.task` loaded data → window jumped **480→801pt** and replaced all content. |
+
+**Key citations:** Apple — *Choosing a Specific Appearance for Your macOS App*;
+`NSVisualEffectView.BlendingMode.behindWindow`; *Setting Window Collection
+Behavior* (non-normal levels default to Transient); SwiftUI `Window`,
+`windowStyle(.hiddenTitleBar)`, `windowResizability`; HIG *Materials*, *Dark
+Mode*, *Split views*; WWDC24 *Tailor macOS windows with SwiftUI*; WWDC25 *Meet
+Liquid Glass*.
+
+---
+
+## 2. Severity matrix (verified)
+
+| # | Symptom | Verdict | Severity | Root cause (file:line) |
+|---|---------|---------|----------|------------------------|
+| 1 | Buggy / not seamless on open | partially (real cause found) | Medium | Demo setup→dashboard width swap — `AppState.swift` init/`loadDemoData`, `MainPopover` `popoverWidth`, `PopoverGeometry` 480/801/1122 |
+| 2 | Attached to menu bar; can't drag/resize; non-native | confirmed | **High** | Floating utility `NSPanel` + lone footer detach glyph — `DetachedDashboardWindowController.makePanel`, `MainPopover` `detachControl` |
+| 3 | Three columns collapse | confirmed | Medium | Inspector column existence-gated on selection — `MainPopover.accountInspectorColumn` |
+| 4 | Liquid Glass opaque | confirmed | Medium | Opaque panel, no `NSVisualEffectView`; color over material — `DetachedDashboardWindowController.makePanel`, `PopoverMaterialBackground` |
+| 5 | Appearance inconsistent | confirmed | Medium | No single `NSApp.appearance` owner; detached window frozen at creation — `PlaidBarApp`, `DetachedDashboardWindowController` |
+
+---
+
+## 3. Remediation — implemented (this change)
+
+Delivered in three verified waves (strict-concurrency build + full test suite
+green after each).
+
+### Wave 1 — startup + appearance (P0)
+- **Demo opens settled.** `AppState.init` loads demo fixtures **synchronously**
+  (before first paint), eliminating the 480→801 width jump / content swap.
+- **Appearance authoritative before first paint.** `PlaidBarApp.init` applies the
+  stored Light/Dark to `NSApp.appearance` (new shared `AppAppearance.applyToNSApp`),
+  killing the launch flash.
+- **Live appearance everywhere.** The updater is attached to the always-mounted
+  menu-bar label, so changes propagate even when popover/Settings are closed.
+
+### Wave 2 — real window + true translucency (P0/P1)
+- **Real managed window.** `NSPanel`→`NSWindow`,
+  `[.titled,.closable,.miniaturizable,.resizable]`, `level=.normal`, default
+  (Managed) collection behavior → drag, resize, minimize, tile, Mission Control,
+  Stage Manager, lives on one Space.
+- **True translucency.** `isOpaque=false`, `backgroundColor=.clear`,
+  `hasShadow=true`, plus a behind-window `NSVisualEffectView(.underWindowBackground,
+  .behindWindow, .active)` backdrop; `MainPopover` renders a clear root while
+  detached so the desktop shows through.
+- **Detached window follows live appearance** (`appearance==nil` inherits
+  `NSApp.appearance`; pinned only for the `--appearance` QA override).
+- **Discoverable detach:** "Open in Window" added to the status-item right-click
+  menu (alongside the footer glyph).
+
+### Wave 3 — three columns always (P1)
+- Inspector column is **always present once setup completes**; content switches
+  between the account inspector, a loading placeholder (persisted selection still
+  resolving), and a `ContentUnavailableView` empty-selection prompt. Width/anchor
+  open directly in three-column and stay; Esc still deselects (revert to empty
+  state) rather than collapsing the column.
+
+---
+
+## 4. Technical debt / deferred (P2)
+
+- **Remove redundant `environment(\.colorScheme)` overrides** (`ForcedAppColorScheme`,
+  `MainPopover.chromedPopover`'s re-set, `forcedDetachedColorScheme`) now that
+  `NSApp.appearance` is authoritative — keep `@Environment(\.colorScheme)`
+  read-only. (Touches tests; do as a focused follow-up.)
+- **`windowBackgroundColor`-over-material veil** in `PopoverMaterialBackground`
+  (popover only, ~12% at default): bypasses Reduce Transparency / Increase
+  Contrast. Prefer dimming *under* the glass. Left as-is to avoid a popover
+  legibility regression; revisit with the transparency slider.
+- **SwiftUI `Window` scene migration** (would delete the controller + coordinator
+  panel plumbing + KVO observer + race counter) — out of scope given the
+  popover-primary decision; revisit if the product ever goes desktop-first.
+
+---
+
+## 5. Open decisions for the owner
+
+- **Popover width when always-3-columns:** the popover now opens at the
+  three-column width (~1122pt, capped to screen with the center flexing to a
+  340pt floor). On narrow/scaled displays it caps and the center compresses. If
+  this feels too wide for a menu-bar popover, the easy dial-back is to apply
+  always-3-columns only in the resizable detached window and keep the popover
+  adaptive.
+- **Always-on-top option:** the detached window is now a normal managed window
+  (one Space, normal z-order). If you want the old glanceable always-on-top
+  behavior, it should be an explicit "Keep on top" toggle (`.floating` level),
+  not the default.
+
+---
+
+## 6. Prioritized roadmap
+
+- **P0 (done):** demo startup jump; appearance before-paint + live propagation;
+  real native detached window; detached-window live appearance.
+- **P1 (done):** true translucency (behind-window vibrancy); three-columns-always.
+- **P1 (follow-up):** validate always-3-columns popover width on a scaled
+  1024-wide display; capture detached-window screenshots over a controlled
+  background.
+- **P2:** consolidate color-scheme sources; rework the material over-paint;
+  optional SwiftUI `Window` migration if desktop-first is ever chosen.


### PR DESCRIPTION
## Summary

The **AND-384 GUI pass** — a demo-UX remediation that makes VaultPeek feel like a polished native macOS app. Triggered by a report that the `--demo` experience looked buggy / non-native. Root causes were validated against current Apple HIG/WWDC + Context7 docs (multi-agent audit; full writeup in `docs/ux-audit-2026-06-13.md`).

**Scope decision (owner):** *polish the popover only* — the menu-bar popover stays the primary/default surface. Drag/resize is delivered by fixing the **existing** on-demand detached window into a real native window, **not** a desktop-first rewrite or a new SwiftUI `Window` scene.

## What changed

- **Startup flicker (`AppState.swift`)** — demo fixtures load synchronously in `init` (before first paint), so the popover opens settled instead of rendering the 480pt setup screen for one frame and then resizing to the 801pt dashboard.
- **Appearance (`PlaidBarApp.swift`)** — `NSApp.appearance` is applied from the stored Light/Dark **before first paint** (new shared `AppAppearance.applyToNSApp`), killing the launch flash; the live updater is attached to the always-mounted menu-bar label so changes propagate even with the popover and Settings closed.
- **Real native window (`DetachedDashboardWindowController.swift`)** — `NSPanel` → managed `NSWindow` (`[.titled,.closable,.miniaturizable,.resizable]`, `.normal` level, default Managed collection behavior): drags, resizes, minimizes, tiles, and joins Mission Control / Stage Manager / Spaces instead of floating as a utility HUD. Adds `.accessory → .regular` activation on show (restored on re-dock) so the window comes to the front with Dock / ⌘-Tab presence.
- **True translucency (same file + `MainPopover.swift`)** — non-opaque window + clear background + behind-window `NSVisualEffectView(.underWindowBackground, .behindWindow, .active)` backdrop; the dashboard renders a clear root while detached so the desktop shows through. Window appearance left `nil` to inherit `NSApp.appearance` live (pinned only for the `--appearance` QA override).
- **Three columns always (`MainPopover.swift`)** — the account inspector column is always present once setup completes, showing a `ContentUnavailableView` empty state when nothing is selected, instead of collapsing to two columns on deselect / filter change / background sync.
- **Discoverability (`StatusItemContextMenuController.swift`)** — "Open in Window" added to the status-item right-click menu. Plus a `--detach` launch flag for QA/screenshots (parallel to `--show-popover`).

## Why

The detached window was an `NSPanel` floating-utility HUD (above all apps, on every Space, no minimize, invisible to Mission Control) and opaque (no `NSVisualEffectView`), the three columns were existence-gated on selection, and demo/appearance were applied after first paint. See the severity matrix + citations in `docs/ux-audit-2026-06-13.md`.

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — **670 tests pass**.
- Live run (`PlaidBar --demo --detach`) confirmed on device: three columns, working Light/Dark, frosted translucent window, frontmost (screenshots shared in-session).

## Reviewer notes / open decisions

- **Popover width:** always-3-columns opens the *popover* at ~1122pt (capped to screen, center flexes to a 340pt floor). May want to limit always-3-columns to the resizable detached window and keep the popover adaptive — flagging for a product call. Worth validating on a scaled 1024-wide display.
- **Always-on-top:** the detached window is now a normal managed window (one Space, normal z-order), not the old always-on-top HUD. If that behavior is wanted, it should be an explicit "Keep on top" toggle (`.windowLevel(.floating)`), not the default.
- **Deferred P2:** consolidate the redundant `environment(\.colorScheme)` sources now that `NSApp.appearance` is authoritative; rework the `windowBackgroundColor`-over-material veil in `PopoverMaterialBackground` (popover only; bypasses Reduce Transparency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
