### PR TITLE
AND-420: Fix detached dashboard review comments

### DIFF
--- a/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
@@ -52,6 +52,12 @@ final class DetachedDashboardCoordinator {
         if appState.isDashboardDetached {
             present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
         } else {
+            // Docking (e.g. the user turning off "Keep dashboard in a floating
+            // window" in Settings, which flips isDashboardDetached and calls
+            // sync) must also retire a `--detach` launch override. Otherwise the
+            // window hides but a later menu-bar click would reopen it via the
+            // still-active override, diverging from the Settings state.
+            nonPersistedLaunchOverrideActive = false
             controller?.hide(reduceMotion: reduceMotion)
         }
     }

--- a/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
@@ -17,6 +17,7 @@ import SwiftUI
 @Observable
 final class DetachedDashboardCoordinator {
     private var controller: DetachedDashboardWindowController?
+    private var nonPersistedLaunchOverrideActive = false
 
     /// True while the floating dashboard window is on screen. Used to decide
     /// whether a menu-bar click should raise the window vs. open the popover.
@@ -29,6 +30,7 @@ final class DetachedDashboardCoordinator {
     /// User asked to detach: persist the intent, open the floating window, and
     /// dismiss the menu-bar popover so only one surface is up.
     func detach(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        nonPersistedLaunchOverrideActive = false
         appState.isDashboardDetached = true
         appState.isPopoverPresented = false
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
@@ -38,6 +40,7 @@ final class DetachedDashboardCoordinator {
     /// clear the intent and hide the floating window. The popover resumes opening
     /// from the menu-bar item on the next click.
     func redock(appState: AppState, reduceMotion: Bool) {
+        nonPersistedLaunchOverrideActive = false
         appState.isDashboardDetached = false
         controller?.hide(reduceMotion: reduceMotion)
     }
@@ -58,7 +61,7 @@ final class DetachedDashboardCoordinator {
     /// raising the window; the caller then keeps `isPopoverPresented` false.
     @discardableResult
     func handleMenuBarActivation(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) -> Bool {
-        guard appState.isDashboardDetached else { return false }
+        guard appState.isDashboardDetached || nonPersistedLaunchOverrideActive else { return false }
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
         controller?.raise()
         return true
@@ -68,6 +71,8 @@ final class DetachedDashboardCoordinator {
     /// `--detach` QA/screenshot launch flag, which must not leave a durable
     /// `dashboard.detached` preference behind (parity with `--show-popover`).
     func presentForLaunchOverride(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
+        nonPersistedLaunchOverrideActive = true
+        appState.isPopoverPresented = false
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
     }
 

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -119,8 +119,11 @@ struct PlaidBarApp: App {
                 // While detached, a status-item click sets isPopoverPresented
                 // true; intercept it on the always-mounted label, snap it back to
                 // false, and raise the floating window instead of the popover.
+                // A `--detach` launch override also has a visible detached window
+                // but intentionally leaves the persisted detached preference off,
+                // so include window visibility in the intercept.
                 .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isDashboardDetached else { return }
+                    guard isPresented, appState.isDashboardDetached || detachedDashboard.isWindowVisible else { return }
                     appState.isPopoverPresented = false
                     detachedDashboard.handleMenuBarActivation(
                         appState: appState,


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-420/fix-pr-357-detached-dashboard-review-comments

## Summary
- Keeps the detached dashboard minimum width aligned with the always-present three-column content.
- Makes `--detach` a non-persisted QA/screenshot launch override instead of writing `dashboard.detached`.
- Coordinates the redock path through the existing activation policy coordinator to avoid Settings/window activation drift.

## Tests
- `git diff --check`
- `swift test --skip-update --filter PlaidBarTests.DetachedDashboardPreferencesTests` (build succeeded; no matching tests were selected by that filter)

## Risks
- UI behavior should still get manual smoke coverage before merge because this touches macOS window/persistence behavior.
