### PR TITLE
AND-392: Define Free / Plus / Managed entitlement matrix

### DIFF
--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -15,7 +15,7 @@ struct SetupView: View {
 
     private var selectedPlan: Binding<SubscriptionPlan> {
         Binding(
-            get: { SubscriptionPlan(rawValue: selectedPlanRawValue) ?? .personal },
+            get: { SubscriptionPlan(rawValue: selectedPlanRawValue) ?? .free },
             set: { selectedPlanRawValue = $0.rawValue }
         )
     }

--- a/Sources/PlaidBarCore/Models/Entitlement.swift
+++ b/Sources/PlaidBarCore/Models/Entitlement.swift
@@ -8,8 +8,9 @@ import Foundation
 /// coupling to the UI preview enum. Nothing issues or verifies real
 /// entitlements yet — see `docs/strategy/subscription-entitlements.md`.
 public enum EntitlementTier: String, Sendable, Codable, CaseIterable {
-    case personal
+    case free
     case plus
+    case managed
 }
 
 /// A signed consumer entitlement, as it will eventually arrive from the hosted

--- a/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
+++ b/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
@@ -50,12 +50,17 @@ public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifia
 
     /// Short forward-looking tagline. Deliberately framed as a preview so copy
     /// never implies billing or a managed backend exists today.
+    ///
+    /// Final public pricing is gated behind `docs/strategy/approval-gates.md`
+    /// (AND-349, "Pricing bundles and launch copy") and must not appear in any
+    /// shipping app surface before that gate passes, so this preview copy states
+    /// the managed institution cap only — never a dollar amount.
     public var priceDescription: String {
         switch self {
         case .free:
             "Preview · demo and BYO keys"
         case .plus:
-            "Preview · $15/mo or $129/yr · up to 8 institutions"
+            "Preview · up to 8 institutions"
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
+++ b/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-/// Client-side shape for the proposed managed consumer plans.
+/// Client-side shape for the locked consumer plan matrix.
 ///
 /// FOUNDATION ONLY. These types describe plan limits and connection origin so
 /// the UI can render restrained, honest plan-selection and usage shells. They
 /// do **not** enforce anything: there is no Stripe billing, no entitlement
 /// token, no managed broker, and no server-side limit check behind them yet.
 /// The managed cloud backend remains gated by `docs/strategy/approval-gates.md`
-/// (decisions D1-D10 in `docs/strategy/subscription-entitlements.md` are
-/// unresolved as of 2026-06-12). Until those gates pass, every plan is a
-/// preview and demo / bring-your-own-keys mode stays fully free and ungated.
+/// (remaining architecture decisions in `docs/strategy/subscription-entitlements.md`
+/// are unresolved). Until those gates pass, every plan is a preview and demo /
+/// bring-your-own-keys mode stays fully free and ungated.
 public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifiable {
-    case personal
+    case free
     case plus
 
     /// `@AppStorage` key for the locally-remembered plan preference. This is a
@@ -19,29 +19,30 @@ public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifia
     public static let storageKey = "subscription.selectedPlan"
 
     /// Default plan when nothing has been chosen yet.
-    public static let defaultPlan = SubscriptionPlan.personal
+    public static let defaultPlan = SubscriptionPlan.free
 
     public var id: String { rawValue }
 
     /// Human-facing plan name for pickers and labels.
     public var displayName: String {
         switch self {
-        case .personal:
-            "Personal"
+        case .free:
+            "Free"
         case .plus:
             "Plus"
         }
     }
 
-    /// Managed-institution cap proposed for each tier.
+    /// Managed-institution cap locked for each self-serve tier.
     ///
-    /// Values come from `docs/strategy/subscription-entitlements.md` §D2
-    /// (Personal = 3, Plus = 8). These are design proposals, not commitments,
-    /// and are surfaced here for the usage shell only — nothing enforces them.
+    /// Values come from `docs/strategy/entitlement-matrix.md` (Free = 0 managed
+    /// institutions, Plus = 8). These are surfaced for the usage shell only —
+    /// nothing enforces them yet. BYO-keys connections are outside this managed
+    /// cap and remain ungated.
     public var institutionLimit: Int {
         switch self {
-        case .personal:
-            3
+        case .free:
+            0
         case .plus:
             8
         }
@@ -51,10 +52,10 @@ public enum SubscriptionPlan: String, CaseIterable, Sendable, Codable, Identifia
     /// never implies billing or a managed backend exists today.
     public var priceDescription: String {
         switch self {
-        case .personal:
-            "Preview · up to 3 institutions"
+        case .free:
+            "Preview · demo and BYO keys"
         case .plus:
-            "Preview · up to 8 institutions"
+            "Preview · $15/mo or $129/yr · up to 8 institutions"
         }
     }
 }

--- a/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
@@ -4,10 +4,15 @@ import Testing
 
 @Suite("SubscriptionPlan Tests")
 struct SubscriptionPlanTests {
-    @Test("Plan institution limits match the proposed entitlement design")
+    @Test("Plan institution limits match the accepted entitlement matrix")
     func planInstitutionLimits() {
-        #expect(SubscriptionPlan.personal.institutionLimit == 3)
+        #expect(SubscriptionPlan.free.institutionLimit == 0)
         #expect(SubscriptionPlan.plus.institutionLimit == 8)
+    }
+
+    @Test("Default plan is Free")
+    func defaultPlan() {
+        #expect(SubscriptionPlan.defaultPlan == .free)
     }
 
     @Test("Every plan exposes a display name and preview tagline")
@@ -39,8 +44,8 @@ struct SubscriptionPlanTests {
 struct InstitutionUsageTests {
     @Test("Summary text reports count of limit when a limit exists")
     func summaryTextWithLimit() {
-        let usage = InstitutionUsage(connectedCount: 2, plan: .personal)
-        #expect(usage.summaryText == "2 of 3 institutions connected")
+        let usage = InstitutionUsage(connectedCount: 2, plan: .plus)
+        #expect(usage.summaryText == "2 of 8 institutions connected")
     }
 
     @Test("Summary text drops the cap when there is no limit")
@@ -51,23 +56,24 @@ struct InstitutionUsageTests {
 
     @Test("Under the limit is not at limit")
     func underLimit() {
-        let usage = InstitutionUsage(connectedCount: 2, plan: .personal)
+        let usage = InstitutionUsage(connectedCount: 2, plan: .plus)
         #expect(usage.isAtLimit == false)
-        #expect(usage.summaryText == "2 of 3 institutions connected")
+        #expect(usage.summaryText == "2 of 8 institutions connected")
     }
 
-    @Test("At the limit is at limit")
-    func atLimit() {
-        let usage = InstitutionUsage(connectedCount: 3, plan: .personal)
+    @Test("Free managed limit is zero")
+    func freeLimitIsZero() {
+        let usage = InstitutionUsage(connectedCount: 0, plan: .free)
+        #expect(usage.limit == 0)
         #expect(usage.isAtLimit == true)
-        #expect(usage.summaryText == "3 of 3 institutions connected")
+        #expect(usage.summaryText == "0 of 0 institutions connected")
     }
 
     @Test("Over the limit is at limit")
     func overLimit() {
-        let usage = InstitutionUsage(connectedCount: 4, plan: .personal)
+        let usage = InstitutionUsage(connectedCount: 9, plan: .plus)
         #expect(usage.isAtLimit == true)
-        #expect(usage.summaryText == "4 of 3 institutions connected")
+        #expect(usage.summaryText == "9 of 8 institutions connected")
     }
 
     @Test("A nil limit is never at limit, even with many connections")

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -161,9 +161,9 @@ struct ConsumerFoundationTests {
         #expect(belowLimit.hasSpareCapacity == true)
 
         let atLimit = Entitlement(
-            tier: .personal,
-            institutionLimit: 3,
-            itemsUsed: 3,
+            tier: .free,
+            institutionLimit: 0,
+            itemsUsed: 0,
             subscriptionStatus: "active",
             expiresAt: nil
         )

--- a/docs/strategy/approval-gates.md
+++ b/docs/strategy/approval-gates.md
@@ -1,7 +1,7 @@
 ---
 title: Strategy Approval Gates for Managed Consumer Work
 status: proposed
-linear: [AND-344, AND-345, AND-346, AND-347, AND-348, AND-349]
+linear: [AND-344, AND-345, AND-346, AND-347, AND-348, AND-349, AND-392]
 date: 2026-06-12
 ---
 
@@ -24,8 +24,9 @@ records what reviewers must approve.
 | Teller evaluation | AND-345 | `docs/strategy/teller-evaluation.md` | Decide whether Teller is experimental-only, fallback/secondary, or declined. Approval requires the PoC exit criteria, coverage review for target institutions, legal/native Connect answer, production cost confirmation, balance-call avoidance plan, and trust/SOC 2 answer. |
 | Provider abstraction | AND-346 | `docs/strategy/provider-abstraction.md` | Approve the smallest server-side abstraction scope before adding interfaces or migrations. The approved scope must preserve local BYO behavior, keep raw provider payloads out of UI/logs, count provider Items/enrollments for plan limits, and define strict-concurrency expectations. |
 | Managed broker architecture | AND-347 | `docs/strategy/managed-link-architecture.md` | Explicit go/no-go on the hosted footprint: link-token broker, public-token exchange, stateless blind proxy, item registry, disconnect/removal, webhook stance, and no-body-log proxy rules. Approval must accept the privacy-promise change that managed financial data transits VaultPeek infrastructure but is never stored there. |
-| Stripe entitlements and institution limits | AND-348 | `docs/strategy/subscription-entitlements.md` | Resolve decisions D1-D10 before any Stripe, entitlement, device activation, or institution-limit code. In particular: signer architecture, BYO ungated behavior, offline grace, cancellation retention, trial/refund policy, tax/distribution posture, and rename timing before Stripe products exist. |
-| Pricing bundles and launch copy | AND-349 | `docs/strategy/pricing-and-launch.md` | Approve public packaging and copy only after Plaid pricing and Teller comparison are real enough to support margins. Confirm Personal/Plus caps and prices, no unlimited or lifetime plans, BYO-free promise, trial/refund policy, distribution channel, price-lock stance, and amended privacy copy. |
+| Entitlement matrix | AND-392 | `docs/strategy/entitlement-matrix.md` | Canonical Free / Plus / Managed limits, prices, grace states, downgrade behavior, and support-copy boundaries are locked here. This approval does not authorize Stripe, broker, provider-token custody, or hosted enforcement implementation by itself. |
+| Stripe entitlements and institution limits | AND-348 | `docs/strategy/subscription-entitlements.md` + `docs/strategy/entitlement-matrix.md` | Resolve signer architecture, BYO ungated behavior, tax/distribution posture, and rename timing before any Stripe, entitlement, device activation, or institution-limit code. Use AND-392 for the locked plan matrix and lifecycle semantics. |
+| Pricing bundles and launch copy | AND-349 | `docs/strategy/pricing-and-launch.md` + `docs/strategy/entitlement-matrix.md` | Approve public packaging and copy only after Plaid pricing and Teller comparison are real enough to support margins. Use AND-392 for Free/Plus/Managed caps and prices; keep no unlimited or lifetime plans, BYO-free promise, trial/refund policy, distribution channel, price-lock stance, and amended privacy copy aligned. |
 | Privacy promise change | Cross-doc | `README.md`, `SECURITY.md`, `docs/privacy.md`, and the strategy docs above | Before any managed public or product surface ships, approve exact wording that distinguishes BYO local-only mode from managed mode. Managed copy must say what the broker stores, what transits it, what is never stored, and what happens on cancellation. |
 
 ## Implementation entry rule
@@ -66,7 +67,8 @@ Gate approval:
   answered.
 - Managed broker work remains deferred until the go/no-go gates in
   `managed-link-architecture.md` pass.
-- Stripe entitlement implementation remains deferred until decisions D1-D10 in
-  `subscription-entitlements.md` are resolved.
+- Stripe entitlement implementation remains deferred until the remaining
+  architecture gates in `subscription-entitlements.md` are resolved; the plan
+  matrix itself is locked in `entitlement-matrix.md`.
 - Public paid pricing and launch copy remain provisional until Plaid/Teller
-  economics, distribution, trial/refund, and privacy wording are approved.
+  economics, distribution, and privacy wording are approved.

--- a/docs/strategy/approval-gates.md
+++ b/docs/strategy/approval-gates.md
@@ -1,8 +1,8 @@
 ---
 title: Strategy Approval Gates for Managed Consumer Work
 status: proposed
-linear: [AND-344, AND-345, AND-346, AND-347, AND-348, AND-349, AND-392]
-date: 2026-06-12
+linear: [AND-344, AND-345, AND-346, AND-347, AND-348, AND-349, AND-392, AND-394]
+date: 2026-06-14
 ---
 
 # Strategy Approval Gates for Managed Consumer Work
@@ -24,6 +24,7 @@ records what reviewers must approve.
 | Teller evaluation | AND-345 | `docs/strategy/teller-evaluation.md` | Decide whether Teller is experimental-only, fallback/secondary, or declined. Approval requires the PoC exit criteria, coverage review for target institutions, legal/native Connect answer, production cost confirmation, balance-call avoidance plan, and trust/SOC 2 answer. |
 | Provider abstraction | AND-346 | `docs/strategy/provider-abstraction.md` | Approve the smallest server-side abstraction scope before adding interfaces or migrations. The approved scope must preserve local BYO behavior, keep raw provider payloads out of UI/logs, count provider Items/enrollments for plan limits, and define strict-concurrency expectations. |
 | Managed broker architecture | AND-347 | `docs/strategy/managed-link-architecture.md` | Explicit go/no-go on the hosted footprint: link-token broker, public-token exchange, stateless blind proxy, item registry, disconnect/removal, webhook stance, and no-body-log proxy rules. Approval must accept the privacy-promise change that managed financial data transits VaultPeek infrastructure but is never stored there. |
+| Managed consent operations | AND-394 | `docs/strategy/managed-link-consent-operations.md` | Approve exact consent copy, support-helper boundaries, audit event schema, forbidden audit fields, escalation rules for credentials/MFA/failed links/account removal, and the rule that support channels never collect raw credentials or financial secrets. |
 | Entitlement matrix | AND-392 | `docs/strategy/entitlement-matrix.md` | Canonical Free / Plus / Managed limits, prices, grace states, downgrade behavior, and support-copy boundaries are locked here. This approval does not authorize Stripe, broker, provider-token custody, or hosted enforcement implementation by itself. |
 | Stripe entitlements and institution limits | AND-348 | `docs/strategy/subscription-entitlements.md` + `docs/strategy/entitlement-matrix.md` | Resolve signer architecture, BYO ungated behavior, tax/distribution posture, and rename timing before any Stripe, entitlement, device activation, or institution-limit code. Use AND-392 for the locked plan matrix and lifecycle semantics. |
 | Pricing bundles and launch copy | AND-349 | `docs/strategy/pricing-and-launch.md` + `docs/strategy/entitlement-matrix.md` | Approve public packaging and copy only after Plaid pricing and Teller comparison are real enough to support margins. Use AND-392 for Free/Plus/Managed caps and prices; keep no unlimited or lifetime plans, BYO-free promise, trial/refund policy, distribution channel, price-lock stance, and amended privacy copy aligned. |
@@ -67,6 +68,8 @@ Gate approval:
   answered.
 - Managed broker work remains deferred until the go/no-go gates in
   `managed-link-architecture.md` pass.
+- Managed support-assisted setup remains deferred until the consent, audit, and
+  escalation gates in `managed-link-consent-operations.md` pass.
 - Stripe entitlement implementation remains deferred until the remaining
   architecture gates in `subscription-entitlements.md` are resolved; the plan
   matrix itself is locked in `entitlement-matrix.md`.

--- a/docs/strategy/consumer-experience-roadmap.md
+++ b/docs/strategy/consumer-experience-roadmap.md
@@ -1,7 +1,7 @@
 ---
 title: VaultPeek Consumer Experience Roadmap — Feature Design Specs
 status: proposed
-linear: [AND-351, AND-352, AND-353, AND-354, AND-355]
+linear: [AND-351, AND-352, AND-353, AND-354, AND-355, AND-392]
 date: 2026-06-12
 ---
 
@@ -28,17 +28,21 @@ Two things in this roadmap cannot be fully local:
 
 Every feature section below has a **Local-first compliance** subsection stating whether it touches either hosted component.
 
-### 0.3 Tier mapping (proposal, not final pricing)
+### 0.3 Tier mapping
 
-Competitive band (all retrieved 2026-06-12): Lunch Money floor $60/yr, Copilot $95/yr, Monarch Core $99.99/yr, Monarch Plus ceiling $199/yr. VaultPeek working tiers (proposed in the pricing doc, which owns these numbers — not final): **Personal** $79/yr or $9/mo (managed linking, up to 3 institutions) and **Plus** $129/yr early-access or $15/mo (up to 8 institutions; → $149/yr once premium features mature). BYO-keys mode stays free outside the tier table; whether Plus features are gated for BYO users is an open decision (entitlements doc D3, default: BYO ungated).
+AND-392 owns the canonical Free / Plus / Managed matrix:
+`entitlement-matrix.md`. Feature specs below use that matrix for limits and
+pricing. Free includes demo fixtures and BYO-keys mode; Plus is $15/month or
+$129/year early-access with up to 8 managed institutions; Managed is a custom
+written quote starting from Plus. BYO-keys mode stays free and ungated.
 
-| Feature | Personal | Plus |
+| Feature | Free | Plus / Managed |
 |---|---|---|
-| AND-351 first-run snapshot | Yes | Yes |
-| AND-352 menu bar cockpit | Yes | Yes |
-| AND-353 alerts | Core triggers | Advanced rules |
-| AND-354 recurring view | Basic view | Review controls (later) |
-| AND-355 monthly review | — | Yes |
+| AND-351 first-run snapshot | Demo/BYO | Managed live data |
+| AND-352 menu bar cockpit | Demo/BYO | Managed live data |
+| AND-353 alerts | Core local triggers | Advanced rules when built |
+| AND-354 recurring view | Basic local view | Review controls when built |
+| AND-355 monthly review | Not promised | Plus/Managed when built |
 
 ---
 

--- a/docs/strategy/consumer-production-checklist.md
+++ b/docs/strategy/consumer-production-checklist.md
@@ -1,7 +1,7 @@
 ---
 title: Consumer Plaid Integration — Production Readiness Checklist
 status: owner-gated
-linear: [AND-347, AND-348, AND-349, AND-350]
+linear: [AND-347, AND-348, AND-349, AND-350, AND-392]
 date: 2026-06-13
 ---
 
@@ -20,7 +20,8 @@ infrastructure, and live billing. **Do not let an agent perform any step here.**
 
 Design source of truth, do not duplicate it here:
 `docs/strategy/managed-link-architecture.md` (broker + blind proxy),
-`docs/strategy/subscription-entitlements.md` (Stripe + Ed25519 entitlements, D1–D10),
+`docs/strategy/entitlement-matrix.md` (Free / Plus / Managed matrix),
+`docs/strategy/subscription-entitlements.md` (Stripe + Ed25519 signer shape),
 `docs/strategy/approval-gates.md` (what must be approved before code).
 
 ---
@@ -59,11 +60,14 @@ approval record:
    managed financial data *transits* VaultPeek's stateless proxy but is *never
    stored* there; access tokens stay on the device (Variant 1, architecture doc
    §5.3).
-3. **Stripe entitlements decisions D1–D10 (AND-348)** — in particular D1 (Stripe
-   + DIY Ed25519 signer), D3 (BYO stays ungated), D4 (30-day TTL / 14-day grace),
-   D8 (cancellation retention + 7-day reconnect), D10 (rename timing).
-4. **Pricing + privacy copy (AND-349 + cross-doc)** — Personal/Plus caps and
-   prices, BYO-free promise, amended `SECURITY.md` / `docs/privacy.md` wording.
+3. **Entitlement matrix (AND-392)** — Free = 0 managed institutions, Plus =
+   $15/month or $129/year with 8 managed institutions, Managed = custom written
+   quote with Plus as the default cap unless the order says otherwise.
+4. **Stripe entitlements decisions (AND-348)** — in particular D1 (Stripe + DIY
+   Ed25519 signer), D3 (BYO stays ungated), and D10 (rename timing). Use
+   AND-392 for grace, cancellation, downgrade, and limit semantics.
+5. **Pricing + privacy copy (AND-349 + cross-doc)** — align with the AND-392
+   matrix, BYO-free promise, amended `SECURITY.md` / `docs/privacy.md` wording.
 
 ---
 
@@ -115,8 +119,9 @@ approval record:
 
 ## Phase 3 — Stripe billing + entitlement signer (owner-only; live money)
 
-14. **Create Stripe products/prices** for Personal and Plus (no unlimited, no
-    lifetime — AND-349). Decide tax posture (Stripe Tax vs MoR — D9).
+14. **Create Stripe products/prices** for Free / Plus / Managed as specified in
+    `entitlement-matrix.md` (no unlimited, no lifetime). Decide tax posture
+    (Stripe Tax vs MoR — D9).
 15. **Wire Stripe Checkout** (browser-based sign-in + purchase; the app polls for
     the entitlement to land — architecture doc §7, "plan-before-link").
 16. **Wire the Stripe webhook receiver** in the control plane with **signature

--- a/docs/strategy/entitlement-matrix.md
+++ b/docs/strategy/entitlement-matrix.md
@@ -1,0 +1,102 @@
+---
+title: VaultPeek Free / Plus / Managed Entitlement Matrix
+status: accepted
+linear: [AND-392]
+date: 2026-06-14
+---
+
+# VaultPeek Free / Plus / Managed Entitlement Matrix
+
+This is the canonical entitlement matrix for implementation and support copy.
+It supersedes the earlier Personal/Plus draft naming in
+`pricing-and-launch.md` and `subscription-entitlements.md`.
+
+This document does **not** approve Stripe, hosted broker, entitlement-token, or
+provider-token-custody implementation. Those remain gated by
+`approval-gates.md`. Until that infrastructure exists, these are product rules
+and model constants only.
+
+## Plan Matrix
+
+| Plan | Price | Managed live institutions | What is included | What is not included |
+|---|---:|---:|---|---|
+| Free | $0 | 0 | Demo fixtures, all local-first app surfaces on sample data, and bring-your-own Plaid keys for users who run their own local Plaid setup. BYO connections are free, local, ungated, and do not count against a managed plan. | No VaultPeek-managed bank linking, no hosted entitlement check, no Stripe subscription, no provider-cost subsidy. |
+| Plus | $15/month or $129/year early-access | 8 | VaultPeek-managed bank linking for up to 8 institutions once the broker is approved and built. Existing core surfaces are included: balances, transactions, spending, credit utilization, recurring obligations, budgets/safe-to-spend, local insights, reconnect, and unlink. | No unlimited institutions, no lifetime deal, no free live-bank trial, no unreleased premium feature promise. |
+| Managed | Custom written quote; starts from Plus | Written quote; default 8 until an order explicitly says otherwise | Plus entitlements plus hands-on setup and operational support from Felipe/Otto for onboarding, connection-health triage, billing coordination, and managed-item cleanup. | Not accountancy, financial advice, tax advice, bank support, guaranteed institution uptime, or a promise that VaultPeek can bypass Plaid/provider/bank outages. |
+
+## Managed Tier Responsibility Boundary
+
+Felipe/Otto manage:
+
+- VaultPeek's provider production relationship, broker operations, and Stripe
+  product/portal configuration once approved.
+- Onboarding help, connection-health triage, and clear next steps when an
+  institution needs reauth or provider support.
+- Subscription lifecycle handling, including disabling future managed sync/link
+  at lapse and driving managed-item cleanup.
+- Support copy that explains what VaultPeek stores, what transits managed
+  infrastructure, and what remains only on the user's Mac.
+
+The user still owns:
+
+- Bank credentials, MFA, consent screens, and any bank-side permission changes.
+- Their Mac, app install, local database, Keychain, backups, and local deletion.
+- Choosing which institutions stay live after a downgrade or cap reduction.
+- Keeping the app online often enough for entitlement refresh and item cleanup.
+- Deciding whether to use Free BYO mode instead of the managed service.
+
+## Grace And Billing States
+
+Entitlement state and Stripe subscription status are separate. Offline grace is
+for connectivity failures only; it is not a hidden extension after cancellation.
+
+| State | Sync existing managed institutions | Add managed institution | Cached local data | Support copy |
+|---|---|---|---|---|
+| Demo trial | Not applicable; no live managed institutions | No | Demo data only | "Try the full interface with sample data. No card, signup, or bank login." |
+| Active Plus/Managed | Yes, for live institutions within the cap | Yes, until the cap is reached | Fully readable | "Your plan is active." |
+| Payment failed / past due | Yes during Stripe dunning, up to 14 days | No new managed institutions | Fully readable | "Update billing to keep live sync from pausing." |
+| Canceled, before period end | Yes until the paid-through date | No new managed institutions | Fully readable | "Your plan remains active until DATE." |
+| Expired / canceled after period end | No managed sync; update-link for cleanup/recovery may still be offered | No | Fully readable forever unless the user deletes it locally | "Live sync has paused. Your downloaded data stays on your Mac." |
+| Offline token expired | Yes during the 14-day connectivity grace after the 30-day token TTL | No new managed institutions during grace | Fully readable | "Subscription check is overdue; get online before live sync pauses." |
+| Offline grace elapsed | No managed sync until refresh succeeds | No | Fully readable | "Live sync is paused until VaultPeek can verify the subscription." |
+
+Payment-failed dunning may be shortened by Stripe or owner policy, but support
+copy must never promise more than 14 days. A successful payment or entitlement
+refresh restores normal Plus/Managed behavior without deleting local data.
+
+## Downgrades And Institution Caps
+
+- Free has a managed institution limit of 0. Downgrading to Free pauses all
+  managed institutions and blocks new managed links. BYO connections remain
+  outside the entitlement system.
+- Plus has a managed institution limit of 8.
+- Managed uses the written order's institution limit; if no limit is written,
+  it inherits Plus's 8-institution limit.
+- Downgrades never delete local accounts, transactions, balances, screenshots,
+  or logs. Cached data remains readable.
+- If active managed institutions exceed the new limit, VaultPeek enters an
+  `over_limit` state. The user chooses which institutions stay live. Until they
+  choose, the most recently synced institutions up to the limit stay live and
+  the rest are paused.
+- Paused institutions keep their local history visible, but scheduled managed
+  sync and new data refresh stop for those institutions.
+- Reconnect/update-link flows for an existing selected-live institution are not
+  blocked by the add-institution cap because repair does not add a new
+  institution.
+- Add-account actions stay visible but disabled with text and an icon explaining
+  the limit; color must not be the only signal.
+
+## Implementation Guardrails
+
+- The app target may call only the local `PlaidBarServer` API for Plaid-backed
+  data.
+- Plaid `client_secret`, access tokens, public tokens, raw Plaid payloads, real
+  account IDs, transaction IDs, balances, local SQLite data, logs, and
+  screenshots must not be copied into app code, docs, tests, or generated
+  artifacts.
+- Provider secrets and provider-token custody remain server-side. Free BYO mode
+  remains local and ungated.
+- Plan claims must map to built app surfaces or explicitly say "once the broker
+  is approved and built." Do not promise advanced alerts, monthly financial
+  review, realtime balance refresh, multi-Mac sync, tax/accounting service, or
+  financial advice until those features exist.

--- a/docs/strategy/managed-link-architecture.md
+++ b/docs/strategy/managed-link-architecture.md
@@ -232,18 +232,21 @@ sequenceDiagram
 
 ## 6. Institution limits per tier (AND-350)
 
+AND-392 locks the plan matrix in `entitlement-matrix.md`; the table below keeps
+the managed-link enforcement mechanics and COGS rationale aligned to that
+matrix.
+
 Enforcement is **server-side at link-session creation** (step 3 in 5.5) — the only place it cannot be bypassed by a patched client. The client-side meter is UX, not security.
 
-| Tier | Live institutions (Items) | Price (proposed — companion pricing doc owns these numbers) | Plaid COGS at estimate rates¹ | Notes |
+| Tier | Live institutions (Items) | Price | Plaid COGS at estimate rates¹ | Notes |
 |---|---|---|---|---|
-| Demo / Free | 0 live (demo fixtures only) | $0 | $0 | Existing demo mode, zero provider cost (AND-350 AC) |
-| BYO-keys | Unlimited (user's own Plaid account; Trial plan = 10 free Items, retrieved 2026-06-12) | $0 — free forever (pricing doc D6 default) | $0 to VaultPeek | The verbatim-local-first mode; stays available indefinitely |
-| Personal (managed) | 3 | $79/yr or $9/mo — **proposed, not final** | ~$0.90–$4.50/mo | Worst case (3 Items × $1.50 PAYG estimate = $4.50) consumes ~50–70% of net revenue — committed Plaid rates are a launch prerequisite |
-| Plus (managed) | 8 | $129/yr early-access or $15/mo (→ $149/yr later) — **proposed, not final** | ~$2.40–$12.00/mo | Underwater at the 8-cap on PAYG estimates (pricing doc §5.3); the extra-institution add-on (est. $24/yr each, pricing doc D8) is the pressure valve, not bigger caps |
+| Free | 0 managed live institutions | $0 | $0 | Demo fixtures and BYO-keys mode only. BYO uses the user's own Plaid account and remains outside VaultPeek managed entitlements. |
+| Plus | 8 managed live institutions | $15/month or $129/year early-access | ~$2.40–$12.00/mo | Underwater at the 8-cap on PAYG estimates; committed provider rates or lower actual item mix remain launch prerequisites. |
+| Managed | Written quote; defaults to 8 unless the order says otherwise | Custom; starts from Plus | Scales with written cap | White-glove support tier, not unlimited provider usage. |
 
 ¹ Plaid publishes no prices. Transactions is a **per-Item monthly subscription that bills even with zero API calls** (official, retrieved 2026-06-12). Third-party estimates put it at **~$0.30–$0.60/Item/mo (committed, Vendr) to ~$1.50/Item/mo (PAYG, Monetizely)** — all **estimates, retrieved 2026-06-12**; a sales quote is go/no-go gate G2.
 
-Mechanics: `items_limit` comes from the Stripe-subscription→entitlement mapping; `items_used` counts registry items in non-removed status. Removing an institution frees a slot immediately (and stops its meter). Limit reached → `402 limit_reached` → upgrade sheet (Section 7).
+Mechanics: `items_limit` comes from the Stripe-subscription→entitlement mapping; `items_used` counts registry items in non-removed status. Removing an institution frees a slot immediately (and stops its meter). Limit reached → `402 limit_reached` → upgrade sheet (Section 7). Downgrades and grace states follow `entitlement-matrix.md`.
 
 ---
 
@@ -257,7 +260,7 @@ flowchart TD
     B -->|"Try the demo"| DEMO["Demo mode<br/>fixtures, zero Plaid calls<br/>(unchanged)"]
     B -->|"Connect my banks"| C["Sign in<br/>passkey / magic link"]
     B -->|"Advanced: my own Plaid keys"| BYO["Existing sandbox/production<br/>BYO flow (unchanged)"]
-    C --> D["Choose plan<br/>Personal (3 institutions) / Plus (8)<br/>Stripe Checkout in browser"]
+    C --> D["Choose plan<br/>Free (0 managed) / Plus (8) / Managed (quote)<br/>Stripe Checkout or owner quote in browser"]
     D --> E["Privacy explainer<br/>(Section 11 copy, must scroll/ack)"]
     E --> F["Connect first institution<br/>Hosted Link (flow 5.5)"]
     F --> G["Dashboard<br/>meter: '1 of 3 institutions connected'"]

--- a/docs/strategy/pricing-and-launch.md
+++ b/docs/strategy/pricing-and-launch.md
@@ -1,11 +1,18 @@
 ---
 title: VaultPeek Pricing Bundles, Launch Copy, and Consumer Strategy Summary
-status: proposed
-linear: [AND-349, AND-343]
+status: superseded
+linear: [AND-349, AND-343, AND-392]
 date: 2026-06-12
 ---
 
 # VaultPeek Pricing & Launch Strategy
+
+> **Superseded for plan packaging by AND-392.** Use
+> [`entitlement-matrix.md`](entitlement-matrix.md) as the canonical Free / Plus
+> / Managed matrix for prices, limits, grace states, downgrade behavior, and
+> support copy. This earlier document remains useful background for unit
+> economics and launch positioning, but its Personal/Plus tier table is no
+> longer the plan source of truth.
 
 > **Design/research document only. Nothing in this doc is implemented, and nothing should be implemented from it until the open decisions in §9 are resolved.** All pricing figures retrieved 2026-06-12 unless noted; third-party Plaid cost figures are **estimates** (Plaid publishes no price list).
 

--- a/docs/strategy/subscription-entitlements.md
+++ b/docs/strategy/subscription-entitlements.md
@@ -1,11 +1,18 @@
 ---
 title: Stripe Subscription Entitlements & Institution Limits
-status: proposed
-linear: [AND-348]
+status: superseded
+linear: [AND-348, AND-392]
 date: 2026-06-12
 ---
 
 # Stripe Subscription Entitlements & Institution Limits — Design
+
+> **Superseded for plan packaging by AND-392.** Use
+> [`entitlement-matrix.md`](entitlement-matrix.md) as the canonical Free / Plus
+> / Managed matrix for prices, limits, grace states, downgrade behavior, and
+> support copy. This earlier document remains useful for the proposed Stripe
+> signer architecture and local entitlement API shape, but its Personal/Plus
+> packaging and open decision list are no longer the plan source of truth.
 
 **Design doc only. No implementation.** Linear AND-348 is titled "Implement Stripe subscription entitlements and institution limits"; this document is the design that must be approved *before* any implementation starts. Its acceptance criteria are treated as the spec this design must satisfy (traceability table in §10). All code references below are to the current tree (`Sources/`), read 2026-06-12. All third-party pricing figures were retrieved 2026-06-12; figures marked **(est.)** come from third-party comparisons, not vendor invoices. Proposed numbers (limits, windows, prices) are **proposals**, not commitments.
 


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-392/define-free-plus-managed-entitlement-matrix-and-institution-limits

## Summary
- Adds the canonical Free / Plus / Managed entitlement matrix covering pricing, limits, grace states, downgrade behavior, and support copy boundaries.
- Updates subscription plan/core entitlement models and tests to match the accepted matrix.
- Cross-links and supersedes older strategy docs so implementation/support has one source of truth.

## Tests
- `git diff --check`
- `swift test --skip-update --filter SubscriptionPlanTests` (12 tests passed)

## Risks
- Managed tier behavior remains a product/broker implementation plan until the backend approval gates land.
