### PR TITLE
AND-412: Stabilize Plaid Link token identity and config

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -78,6 +78,10 @@ public enum LocalDataStore {
     public static let accountCacheFilename = "accounts.json"
     public static let transactionCacheFilename = "transactions.json"
     public static let pendingLinkSessionsFilename = "pending-link-sessions.json"
+    /// Stable, non-PII install-scoped Plaid `client_user_id`. Cleared on local
+    /// reset so a fresh bank-link after reset does not reuse the pre-reset Plaid
+    /// dashboard/log identity (the reset boundary clears local Plaid state).
+    public static let linkClientUserIdFilename = "link-client-user-id"
     public static let legacyMigrationResetMarkerFilename = ".legacy-migration-reset"
     /// Preserve the existing Keychain service while moving local files so
     /// SQLite `keychain:<item_id>` references continue to resolve.
@@ -221,7 +225,8 @@ public enum LocalDataStore {
 
         if isAccountCacheFilename(filename) ||
             isTransactionCacheFilename(filename) ||
-            isPendingLinkSessionsFilename(filename) {
+            isPendingLinkSessionsFilename(filename) ||
+            filename == linkClientUserIdFilename {
             return true
         }
 

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -11,6 +11,7 @@ struct ServerConfig: Sendable {
     static let legacyDatabaseFilename = "plaidbar.sqlite"
     static let legacyMigrationEnvironmentVariable = "PLAIDBAR_MIGRATE_LEGACY_DATABASE"
     static let pendingLinkSessionsFilename = "pending-link-sessions.json"
+    static let linkClientUserIdFilename = "link-client-user-id"
     private static let sqliteSidecarSuffixes = ["-wal", "-shm", "-journal"]
 
     let port: Int
@@ -21,6 +22,8 @@ struct ServerConfig: Sendable {
     let pendingLinkSessionsPath: String
     let redirectUri: String
     let authToken: String
+    let linkClientUserId: String
+    let link: PlaidLinkConfiguration
 
     /// Deployment posture. `load` resolves it from config/env, defaulting to
     /// `.local` (today's BYO-keys behavior). `.hostedBridge` is inert
@@ -75,6 +78,7 @@ struct ServerConfig: Sendable {
         }
 
         let environmentValues = try resolvedEnvironment(from: configPath)
+        let link = try PlaidLinkConfiguration.resolved(from: environmentValues)
 
         // The standalone `--config` path consumes a server.conf that may hold
         // PLAID_CLIENT_ID/PLAID_SECRET; tighten it to owner-only the same way
@@ -110,6 +114,7 @@ struct ServerConfig: Sendable {
             in: URL(fileURLWithPath: dataDir, isDirectory: true)
         )
         let authToken = try loadOrCreateAuthToken(at: authTokenURL)
+        let linkClientUserId = try loadOrCreateLinkClientUserId(in: dataDir)
 
         let resolvedPort = portOverride ?? PlaidBarConstants.serverPort(environment: environmentValues)
 
@@ -135,6 +140,8 @@ struct ServerConfig: Sendable {
                 .path,
             redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
             authToken: authToken,
+            linkClientUserId: linkClientUserId,
+            link: link,
             deployment: deployment,
             remoteBridge: remoteBridge
         )
@@ -149,15 +156,20 @@ struct ServerConfig: Sendable {
     }
 
     private static func generateAuthToken() -> String {
-        var bytes = [UInt8](repeating: 0, count: 32)
+        authTokenString(randomBytes: secureRandomBytes(count: 32))
+    }
+
+    private static func secureRandomBytes(count: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: count)
         #if canImport(Security)
         if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess {
-            return authTokenString(randomBytes: bytes)
+            return bytes
         }
         #endif
 
-        return "\(UUID().uuidString)\(UUID().uuidString)"
+        let fallback = "\(UUID().uuidString)\(UUID().uuidString)"
             .replacingOccurrences(of: "-", with: "")
+        return Array(fallback.utf8.prefix(count))
     }
 
     private static func loadOrCreateAuthToken(at url: URL) throws -> String {
@@ -175,6 +187,33 @@ struct ServerConfig: Sendable {
         let generated = generateAuthToken()
         try writePrivateTextFile(generated, to: url)
         return generated
+    }
+
+    private static func loadOrCreateLinkClientUserId(in dataDir: String) throws -> String {
+        let url = URL(fileURLWithPath: dataDir, isDirectory: true)
+            .appendingPathComponent(linkClientUserIdFilename)
+        if let existing = try? String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            isValidStoredLinkClientUserId(existing)
+        {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+            return existing
+        }
+
+        let generated = "vaultpeek-install-\(authTokenString(randomBytes: secureRandomBytes(count: 32)))"
+        try writePrivateTextFile(generated, to: url)
+        return generated
+    }
+
+    static func isValidStoredLinkClientUserId(_ value: String) -> Bool {
+        value.hasPrefix("vaultpeek-install-")
+            && value.count == "vaultpeek-install-".count + 43
+            && value.allSatisfy { character in
+                character.isLetter || character.isNumber || character == "-" || character == "_"
+            }
     }
 
     private static func writePrivateTextFile(_ value: String, to url: URL) throws {

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -11,7 +11,8 @@ struct ServerConfig: Sendable {
     static let legacyDatabaseFilename = "plaidbar.sqlite"
     static let legacyMigrationEnvironmentVariable = "PLAIDBAR_MIGRATE_LEGACY_DATABASE"
     static let pendingLinkSessionsFilename = "pending-link-sessions.json"
-    static let linkClientUserIdFilename = "link-client-user-id"
+    // Shared with LocalDataStore so the reset boundary clears this exact file.
+    static let linkClientUserIdFilename = LocalDataStore.linkClientUserIdFilename
     private static let sqliteSidecarSuffixes = ["-wal", "-shm", "-journal"]
 
     let port: Int
@@ -78,12 +79,16 @@ struct ServerConfig: Sendable {
         }
 
         let environmentValues = try resolvedEnvironment(from: configPath)
-        let link = try PlaidLinkConfiguration.resolved(from: environmentValues)
 
         // The standalone `--config` path consumes a server.conf that may hold
         // PLAID_CLIENT_ID/PLAID_SECRET; tighten it to owner-only the same way
         // app-managed launches do (ServerProcessService.enforcePrivatePermissions).
+        // This must run before any further validation that can throw (e.g. Link
+        // config resolution), otherwise an invalid setting could abort startup
+        // and leave a secret-bearing server.conf at its original loose mode.
         tightenConfigFilePermissions(at: configPath)
+
+        let link = try PlaidLinkConfiguration.resolved(from: environmentValues)
 
         if environmentValues[LocalDataStore.dataDirectoryEnvironmentVariable]?.trimmedNonEmpty == nil {
             try LocalDataStore.migrateLegacyDefaultStorageIfNeeded()

--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -6,12 +6,12 @@ import PlaidBarCore
 
 protocol PlaidClientProtocol: Sendable {
     func createLinkToken(
-        userId: String,
+        clientUserId: String,
         completionRedirectUri: String
     ) async throws -> PlaidLinkTokenResponse
 
     func createUpdateLinkToken(
-        userId: String,
+        clientUserId: String,
         accessToken: String,
         completionRedirectUri: String
     ) async throws -> PlaidLinkTokenResponse
@@ -54,56 +54,29 @@ actor PlaidClient: PlaidClientProtocol {
     // MARK: - Link Token
 
     func createLinkToken(
-        userId: String,
+        clientUserId: String,
         completionRedirectUri: String
     ) async throws -> PlaidLinkTokenResponse {
-        let body = PlaidLinkTokenRequest(
+        let body = try config.link.createRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
-            clientName: PlaidBarConstants.appName,
-            user: .init(clientUserId: userId),
-            products: ["transactions"],
-            countryCodes: ["US"],
-            language: "en",
-            // Top-level redirect_uri is intentionally omitted for the default
-            // Hosted Link flow, which routes the post-completion return through
-            // hosted_link.completion_redirect_uri. Sending an *unregistered*
-            // redirect_uri is what produced the INVALID_FIELD 500 this fix
-            // resolves. NOTE: OAuth / app-to-app institutions still use the
-            // top-level redirect_uri for the bank-auth handoff, so full OAuth
-            // support requires a *dashboard-registered* redirect_uri threaded
-            // through here from config — tracked as a follow-up (the value and
-            // its config surface are a Plaid-dashboard decision, see PR #351
-            // review). Omitting it keeps non-OAuth Hosted Link sessions working
-            // and avoids re-introducing the 500 for unconfigured setups.
-            hostedLink: .init(
-                completionRedirectUri: completionRedirectUri,
-                urlLifetimeSeconds: 30 * 60
-            )
+            clientUserId: clientUserId,
+            completionRedirectURI: completionRedirectUri
         )
         return try await post("/link/token/create", body: body)
     }
 
     func createUpdateLinkToken(
-        userId: String,
+        clientUserId: String,
         accessToken: String,
         completionRedirectUri: String
     ) async throws -> PlaidLinkTokenResponse {
-        let body = PlaidLinkTokenRequest(
+        let body = try config.link.updateRequest(
             clientId: config.plaidClientId,
             secret: config.plaidSecret,
-            clientName: PlaidBarConstants.appName,
-            user: .init(clientUserId: userId),
-            countryCodes: ["US"],
-            language: "en",
-            // No top-level redirect_uri: Hosted Link update mode also returns
-            // through hosted_link.completion_redirect_uri. Sending redirect_uri
-            // too makes Plaid reject with INVALID_FIELD.
-            hostedLink: .init(
-                completionRedirectUri: completionRedirectUri,
-                urlLifetimeSeconds: 30 * 60
-            ),
-            accessToken: accessToken
+            clientUserId: clientUserId,
+            accessToken: accessToken,
+            completionRedirectURI: completionRedirectUri
         )
         return try await post("/link/token/create", body: body)
     }

--- a/Sources/PlaidBarServer/Plaid/PlaidLinkConfiguration.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidLinkConfiguration.swift
@@ -1,0 +1,204 @@
+import Foundation
+import PlaidBarCore
+
+struct PlaidLinkConfiguration: Equatable, Sendable {
+    static let defaultHostedLinkLifetimeSeconds = 30 * 60
+
+    let clientName: String
+    let products: [String]
+    let countryCodes: [String]
+    let language: String
+    let webhookURL: String?
+    let redirectURI: String?
+    let hostedLinkLifetimeSeconds: Int
+    let hostedLinkIsMobileApp: Bool
+
+    static func resolved(from environment: [String: String]) throws -> PlaidLinkConfiguration {
+        let config = PlaidLinkConfiguration(
+            clientName: PlaidBarConstants.appName,
+            products: listValue(environment["PLAID_LINK_PRODUCTS"]) ?? ["transactions"],
+            countryCodes: listValue(environment["PLAID_LINK_COUNTRY_CODES"]) ?? ["US"],
+            language: environment["PLAID_LINK_LANGUAGE"]?.trimmedLinkConfigValue ?? "en",
+            webhookURL: environment["PLAID_LINK_WEBHOOK_URL"]?.trimmedLinkConfigValue,
+            redirectURI: environment["PLAID_LINK_REDIRECT_URI"]?.trimmedLinkConfigValue,
+            hostedLinkLifetimeSeconds: try intValue(
+                environment["PLAID_HOSTED_LINK_LIFETIME_SECONDS"],
+                name: "PLAID_HOSTED_LINK_LIFETIME_SECONDS"
+            ) ?? defaultHostedLinkLifetimeSeconds,
+            hostedLinkIsMobileApp: try boolValue(
+                environment["PLAID_HOSTED_LINK_IS_MOBILE_APP"],
+                name: "PLAID_HOSTED_LINK_IS_MOBILE_APP"
+            ) ?? false
+        )
+        try config.validate()
+        return config
+    }
+
+    func createRequest(
+        clientId: String,
+        secret: String,
+        clientUserId: String,
+        completionRedirectURI: String
+    ) throws -> PlaidLinkTokenRequest {
+        try validate()
+        return PlaidLinkTokenRequest(
+            clientId: clientId,
+            secret: secret,
+            clientName: clientName,
+            user: .init(clientUserId: clientUserId),
+            products: products,
+            countryCodes: countryCodes,
+            language: language,
+            webhook: webhookURL,
+            redirectUri: redirectURI,
+            hostedLink: hostedLink(completionRedirectURI: completionRedirectURI)
+        )
+    }
+
+    func updateRequest(
+        clientId: String,
+        secret: String,
+        clientUserId: String,
+        accessToken: String,
+        completionRedirectURI: String
+    ) throws -> PlaidLinkTokenRequest {
+        try validate()
+        return PlaidLinkTokenRequest(
+            clientId: clientId,
+            secret: secret,
+            clientName: clientName,
+            user: .init(clientUserId: clientUserId),
+            countryCodes: countryCodes,
+            language: language,
+            webhook: webhookURL,
+            redirectUri: redirectURI,
+            hostedLink: hostedLink(completionRedirectURI: completionRedirectURI),
+            accessToken: accessToken
+        )
+    }
+
+    func validate() throws {
+        let trimmedClientName = clientName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedClientName.isEmpty else {
+            throw PlaidLinkConfigurationError.invalidClientName("client_name must not be empty")
+        }
+        guard trimmedClientName.count <= 30 else {
+            throw PlaidLinkConfigurationError.invalidClientName("client_name must be 30 characters or fewer")
+        }
+        guard !products.isEmpty else {
+            throw PlaidLinkConfigurationError.invalidProducts("products must contain at least one Plaid product")
+        }
+        guard !countryCodes.isEmpty else {
+            throw PlaidLinkConfigurationError.invalidCountryCodes("country_codes must contain at least one country")
+        }
+        guard supportedLanguages.contains(language) else {
+            throw PlaidLinkConfigurationError.invalidLanguage(language)
+        }
+        guard hostedLinkLifetimeSeconds > 0 else {
+            throw PlaidLinkConfigurationError.invalidHostedLinkLifetime(hostedLinkLifetimeSeconds)
+        }
+        try validateProducts()
+        try validateCountryCodes()
+    }
+
+    private func hostedLink(completionRedirectURI: String) -> PlaidHostedLink {
+        PlaidHostedLink(
+            completionRedirectUri: completionRedirectURI,
+            isMobileApp: hostedLinkIsMobileApp ? true : nil,
+            urlLifetimeSeconds: hostedLinkLifetimeSeconds
+        )
+    }
+
+    private func validateProducts() throws {
+        let unsupported = products.filter { !supportedProducts.contains($0) }
+        guard unsupported.isEmpty else {
+            throw PlaidLinkConfigurationError.invalidProducts(
+                "Unsupported Plaid products: \(unsupported.joined(separator: ", "))"
+            )
+        }
+    }
+
+    private func validateCountryCodes() throws {
+        let unsupportedCountries = countryCodes.filter { !supportedCountryCodes.contains($0) }
+        guard unsupportedCountries.isEmpty else {
+            throw PlaidLinkConfigurationError.invalidCountryCodes(
+                "Unsupported Plaid country_codes: \(unsupportedCountries.joined(separator: ", "))"
+            )
+        }
+    }
+
+    private static func listValue(_ rawValue: String?) -> [String]? {
+        guard let rawValue = rawValue?.trimmedLinkConfigValue else { return nil }
+        let values = rawValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return values.isEmpty ? nil : values
+    }
+
+    private static func intValue(_ rawValue: String?, name: String) throws -> Int? {
+        guard let rawValue = rawValue?.trimmedLinkConfigValue else { return nil }
+        guard let value = Int(rawValue) else {
+            throw PlaidLinkConfigurationError.invalidEnvironmentValue(name, rawValue)
+        }
+        return value
+    }
+
+    private static func boolValue(_ rawValue: String?, name: String) throws -> Bool? {
+        guard let rawValue = rawValue?.trimmedLinkConfigValue else { return nil }
+        switch rawValue.lowercased() {
+        case "1", "true", "yes": return true
+        case "0", "false", "no": return false
+        default:
+            throw PlaidLinkConfigurationError.invalidEnvironmentValue(name, rawValue)
+        }
+    }
+}
+
+enum PlaidLinkConfigurationError: LocalizedError, Equatable, Sendable {
+    case invalidClientName(String)
+    case invalidProducts(String)
+    case invalidCountryCodes(String)
+    case invalidLanguage(String)
+    case invalidHostedLinkLifetime(Int)
+    case invalidEnvironmentValue(String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidClientName(message),
+             let .invalidProducts(message),
+             let .invalidCountryCodes(message):
+            message
+        case let .invalidLanguage(language):
+            "Unsupported Plaid Link language: \(language)"
+        case let .invalidHostedLinkLifetime(seconds):
+            "Invalid Hosted Link lifetime \(seconds): must be greater than zero"
+        case let .invalidEnvironmentValue(name, value):
+            "Invalid value for \(name): \(value)"
+        }
+    }
+}
+
+private let supportedLanguages: Set<String> = [
+    "da", "nl", "en", "et", "fr", "de", "hi", "it", "lv", "lt", "no", "pl", "pt", "ro", "es", "sv", "vi",
+]
+
+private let supportedCountryCodes: Set<String> = [
+    "US", "GB", "ES", "NL", "FR", "IE", "CA", "DE", "IT", "PL", "DK", "NO", "SE", "EE", "LT", "LV", "PT",
+    "BE", "AT", "FI",
+]
+
+private let supportedProducts: Set<String> = [
+    "assets", "auth", "beacon", "employment", "identity", "income_verification", "identity_verification",
+    "investments", "investments_auth", "liabilities", "payment_initiation", "protect_transactions",
+    "standing_orders", "signal", "statements", "transactions", "transfer", "cra_base_report",
+    "cra_income_insights", "cra_cashflow_insights", "cra_lend_score", "cra_partner_insights",
+    "cra_network_insights", "cra_monitoring", "layer", "protect_linked_bank",
+]
+
+private extension String {
+    var trimmedLinkConfigValue: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/PlaidBarServer/Plaid/PlaidLinkConfiguration.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidLinkConfiguration.swift
@@ -116,6 +116,15 @@ struct PlaidLinkConfiguration: Equatable, Sendable {
                 "Unsupported Plaid products: \(unsupported.joined(separator: ", "))"
             )
         }
+        // The refresh path unconditionally calls /transactions/sync, so an Item
+        // linked without the transactions product would error on every sync and
+        // surface as a broken dashboard. Require it rather than silently linking
+        // Items the app cannot use.
+        guard products.contains("transactions") else {
+            throw PlaidLinkConfigurationError.invalidProducts(
+                "products must include \"transactions\"; VaultPeek syncs transactions for every linked Item"
+            )
+        }
     }
 
     private func validateCountryCodes() throws {

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -10,6 +10,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
     let products: [String]?
     let countryCodes: [String]
     let language: String
+    let webhook: String?
     /// Top-level OAuth `redirect_uri`. Deliberately omitted (left `nil`) for the
     /// Hosted Link flow: Hosted Link uses `hosted_link.completion_redirect_uri`
     /// instead, and sending both makes Plaid reject the request with
@@ -27,6 +28,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
         products: [String]? = nil,
         countryCodes: [String],
         language: String,
+        webhook: String? = nil,
         redirectUri: String? = nil,
         hostedLink: PlaidHostedLink? = nil,
         accessToken: String? = nil
@@ -38,6 +40,7 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
         self.products = products
         self.countryCodes = countryCodes
         self.language = language
+        self.webhook = webhook
         self.redirectUri = redirectUri
         self.hostedLink = hostedLink
         self.accessToken = accessToken
@@ -50,7 +53,18 @@ struct PlaidLinkTokenRequest: Encodable, Sendable {
 
 struct PlaidHostedLink: Encodable, Sendable {
     let completionRedirectUri: String
+    let isMobileApp: Bool?
     let urlLifetimeSeconds: Int
+
+    init(
+        completionRedirectUri: String,
+        isMobileApp: Bool? = nil,
+        urlLifetimeSeconds: Int
+    ) {
+        self.completionRedirectUri = completionRedirectUri
+        self.isMobileApp = isMobileApp
+        self.urlLifetimeSeconds = urlLifetimeSeconds
+    }
 }
 
 struct PlaidLinkTokenGetRequest: Encodable, Sendable {

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -22,11 +22,10 @@ struct LinkRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let state = await pendingLinkSessions.issueState()
         let plaidResponse = try await Self.mappingPlaidError {
             try await plaidClient.createLinkToken(
-                userId: userId,
+                clientUserId: config.linkClientUserId,
                 completionRedirectUri: callbackURL(state: state)
             )
         }
@@ -58,11 +57,10 @@ struct LinkRoutes: Sendable {
         }
         let accessToken = try tokenStore.accessToken(for: item)
 
-        let userId = "plaidbar-user-\(UUID().uuidString.prefix(8))"
         let state = await pendingLinkSessions.issueState()
         let plaidResponse = try await Self.mappingPlaidError {
             try await plaidClient.createUpdateLinkToken(
-                userId: userId,
+                clientUserId: config.linkClientUserId,
                 accessToken: accessToken,
                 completionRedirectUri: callbackURL(state: state)
             )

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3809,6 +3809,7 @@ struct PlaidBarCoreTests {
         let transactionCache = directory.appendingPathComponent("transactions-sandbox-0123456789abcdef.json")
         let pendingLinkSessions = directory.appendingPathComponent("pending-link-sessions.json")
         let pendingLinkSessionsBackup = directory.appendingPathComponent("pending-link-sessions.json.backup-20260604")
+        let linkClientUserId = directory.appendingPathComponent("link-client-user-id")
         let authToken = directory.appendingPathComponent("auth-token")
         let serverConfig = directory.appendingPathComponent("server.conf")
         let unrelatedFile = directory.appendingPathComponent("notes.txt")
@@ -3821,6 +3822,7 @@ struct PlaidBarCoreTests {
         try "cache".write(to: transactionCache, atomically: true, encoding: .utf8)
         try "sessions".write(to: pendingLinkSessions, atomically: true, encoding: .utf8)
         try "old sessions".write(to: pendingLinkSessionsBackup, atomically: true, encoding: .utf8)
+        try "vaultpeek-install-abc".write(to: linkClientUserId, atomically: true, encoding: .utf8)
         try "token".write(to: authToken, atomically: true, encoding: .utf8)
         try "PLAID_ENV=sandbox".write(to: serverConfig, atomically: true, encoding: .utf8)
         try "keep me".write(to: unrelatedFile, atomically: true, encoding: .utf8)
@@ -3836,6 +3838,7 @@ struct PlaidBarCoreTests {
 
         #expect(result.directoryPath == directory.path)
         #expect(result.removedEntries == [
+            "link-client-user-id",
             "pending-link-sessions.json",
             "pending-link-sessions.json.backup-20260604",
             "plaidbar-sandbox.sqlite",

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -26,23 +26,21 @@ struct LinkTokenRequestTests {
 
     @Test("Create link-token body omits redirect_uri but keeps hosted_link")
     func createLinkTokenBodyOmitsRedirectURI() throws {
-        // Mirrors PlaidClient.createLinkToken: nil redirectUri, hosted_link set.
-        let request = PlaidLinkTokenRequest(
+        let config = try PlaidLinkConfiguration.resolved(from: [:])
+        let request = try config.createRequest(
             clientId: "test-client",
             secret: "test-secret",
-            clientName: "VaultPeek",
-            user: .init(clientUserId: "plaidbar-user-test"),
-            products: ["transactions"],
-            countryCodes: ["US"],
-            language: "en",
-            hostedLink: .init(
-                completionRedirectUri: "http://localhost:8484/oauth/callback?state=abc",
-                urlLifetimeSeconds: 1800
-            )
+            clientUserId: "vaultpeek-install-test",
+            completionRedirectURI: "http://localhost:8484/oauth/callback?state=abc"
         )
 
         let json = try encodedRequest(request)
 
+        #expect(json["client_name"] as? String == "VaultPeek")
+        #expect(json["products"] as? [String] == ["transactions"])
+        #expect(json["country_codes"] as? [String] == ["US"])
+        #expect(json["language"] as? String == "en")
+        #expect(json["webhook"] == nil)
         // The OAuth redirect_uri must be omitted from the JSON entirely.
         #expect(json["redirect_uri"] == nil)
         #expect(!json.keys.contains("redirect_uri"))
@@ -54,31 +52,127 @@ struct LinkTokenRequestTests {
                 == "http://localhost:8484/oauth/callback?state=abc"
         )
         #expect(hostedLink["url_lifetime_seconds"] as? Int == 1800)
+        #expect(hostedLink["is_mobile_app"] == nil)
     }
 
     @Test("Update link-token body omits redirect_uri and includes access_token")
     func updateLinkTokenBodyOmitsRedirectURI() throws {
-        // Mirrors PlaidClient.createUpdateLinkToken: nil redirectUri, access_token set.
-        let request = PlaidLinkTokenRequest(
+        let config = try PlaidLinkConfiguration.resolved(from: [:])
+        let request = try config.updateRequest(
             clientId: "test-client",
             secret: "test-secret",
-            clientName: "VaultPeek",
-            user: .init(clientUserId: "plaidbar-user-test"),
-            countryCodes: ["US"],
-            language: "en",
-            hostedLink: .init(
-                completionRedirectUri: "http://localhost:8484/oauth/callback?state=def",
-                urlLifetimeSeconds: 1800
-            ),
-            accessToken: "access-sandbox-token"
+            clientUserId: "vaultpeek-install-test",
+            accessToken: "access-sandbox-token",
+            completionRedirectURI: "http://localhost:8484/oauth/callback?state=def"
         )
 
         let json = try encodedRequest(request)
 
         #expect(json["redirect_uri"] == nil)
         #expect(!json.keys.contains("redirect_uri"))
+        #expect(json["products"] == nil)
         #expect(json["access_token"] as? String == "access-sandbox-token")
         #expect(json["hosted_link"] != nil)
+    }
+
+    @Test("Managed/native config sets webhook redirect and mobile Hosted Link flags")
+    func managedNativeConfigBuildsHostedLinkOptions() throws {
+        let config = try PlaidLinkConfiguration.resolved(from: [
+            "PLAID_LINK_PRODUCTS": "transactions, liabilities",
+            "PLAID_LINK_COUNTRY_CODES": "US,CA",
+            "PLAID_LINK_LANGUAGE": "fr",
+            "PLAID_LINK_WEBHOOK_URL": "https://vaultpeek.example/webhooks/plaid-link",
+            "PLAID_LINK_REDIRECT_URI": "https://vaultpeek.example/oauth/plaid",
+            "PLAID_HOSTED_LINK_LIFETIME_SECONDS": "900",
+            "PLAID_HOSTED_LINK_IS_MOBILE_APP": "true",
+        ])
+        let request = try config.createRequest(
+            clientId: "test-client",
+            secret: "test-secret",
+            clientUserId: "vaultpeek-install-test",
+            completionRedirectURI: "vaultpeek://hosted-link-complete"
+        )
+
+        let json = try encodedRequest(request)
+        #expect(json["products"] as? [String] == ["transactions", "liabilities"])
+        #expect(json["country_codes"] as? [String] == ["US", "CA"])
+        #expect(json["language"] as? String == "fr")
+        #expect(json["webhook"] as? String == "https://vaultpeek.example/webhooks/plaid-link")
+        #expect(json["redirect_uri"] as? String == "https://vaultpeek.example/oauth/plaid")
+
+        let hostedLink = try #require(json["hosted_link"] as? [String: Any])
+        #expect(hostedLink["completion_redirect_uri"] as? String == "vaultpeek://hosted-link-complete")
+        #expect(hostedLink["url_lifetime_seconds"] as? Int == 900)
+        #expect(hostedLink["is_mobile_app"] as? Bool == true)
+    }
+
+    @Test("Link configuration rejects unsupported values before calling Plaid")
+    func linkConfigurationValidation() {
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration(
+                clientName: "This Name Is Far Too Long For Plaid Link",
+                products: ["transactions"],
+                countryCodes: ["US"],
+                language: "en",
+                webhookURL: nil,
+                redirectURI: nil,
+                hostedLinkLifetimeSeconds: 1800,
+                hostedLinkIsMobileApp: false
+            ).createRequest(
+                clientId: "test-client",
+                secret: "test-secret",
+                clientUserId: "vaultpeek-install-test",
+                completionRedirectURI: "http://localhost:8484/oauth/callback"
+            )
+        }
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration.resolved(
+                from: ["PLAID_LINK_PRODUCTS": "transactions,not_a_product"]
+            )
+        }
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration.resolved(from: ["PLAID_LINK_COUNTRY_CODES": "US,ZZ"])
+        }
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration.resolved(from: ["PLAID_LINK_LANGUAGE": "xx"])
+        }
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration.resolved(from: ["PLAID_HOSTED_LINK_LIFETIME_SECONDS": "0"])
+        }
+    }
+
+    @Test("Stable install client_user_id is non-PII and does not embed secrets")
+    func stableInstallClientUserIdIsSafe() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-link-id-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let configURL = directory.appendingPathComponent("server.conf")
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        try """
+        PLAID_CLIENT_ID=client-secret-shaped-value
+        PLAID_SECRET=secret-shaped-value
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let first = try ServerConfig.load(from: configURL.path)
+        let second = try ServerConfig.load(from: configURL.path)
+
+        #expect(first.linkClientUserId == second.linkClientUserId)
+        #expect(ServerConfig.isValidStoredLinkClientUserId(first.linkClientUserId))
+        #expect(!first.linkClientUserId.contains("client-secret-shaped-value"))
+        #expect(!first.linkClientUserId.contains("secret-shaped-value"))
+        #expect(!first.linkClientUserId.contains("access-"))
+        #expect(!first.linkClientUserId.contains("public-"))
+        #expect(!first.linkClientUserId.contains("account"))
+        #expect(!first.linkClientUserId.contains("@"))
+        #expect(!first.linkClientUserId.contains("+1"))
+
+        let storedURL = dataDirectory.appendingPathComponent(ServerConfig.linkClientUserIdFilename)
+        #expect(try String(contentsOf: storedURL, encoding: .utf8) == first.linkClientUserId)
+        #expect(try posixPermissions(at: storedURL) == 0o600)
     }
 
     @Test("Explicit redirectUri still encodes (non-Hosted-Link callers)")
@@ -98,6 +192,11 @@ struct LinkTokenRequestTests {
 
         let json = try encodedRequest(request)
         #expect(json["redirect_uri"] as? String == "http://localhost:8484/oauth/callback")
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
     }
 }
 

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -139,6 +139,12 @@ struct LinkTokenRequestTests {
         #expect(throws: PlaidLinkConfigurationError.self) {
             _ = try PlaidLinkConfiguration.resolved(from: ["PLAID_HOSTED_LINK_LIFETIME_SECONDS": "0"])
         }
+        // The refresh path always calls /transactions/sync, so a product list
+        // that omits transactions must be rejected up front rather than linking
+        // Items that error on every sync.
+        #expect(throws: PlaidLinkConfigurationError.self) {
+            _ = try PlaidLinkConfiguration.resolved(from: ["PLAID_LINK_PRODUCTS": "auth"])
+        }
     }
 
     @Test("Stable install client_user_id is non-PII and does not embed secrets")

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -91,14 +91,14 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
     }
 
     func createLinkToken(
-        userId _: String,
+        clientUserId _: String,
         completionRedirectUri _: String
     ) async throws -> PlaidLinkTokenResponse {
         throw PlaidError.invalidResponse
     }
 
     func createUpdateLinkToken(
-        userId _: String,
+        clientUserId _: String,
         accessToken _: String,
         completionRedirectUri _: String
     ) async throws -> PlaidLinkTokenResponse {
@@ -524,7 +524,7 @@ struct PlaidBarServerTests {
         // deterministically with the setup-state error.
         await #expect(throws: PlaidError.credentialsNotConfigured) {
             _ = try await client.createLinkToken(
-                userId: "test-user",
+                clientUserId: "test-user",
                 completionRedirectUri: "http://localhost:8484/oauth/callback"
             )
         }


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-412/stabilize-link-token-identity-countryproduct-config-and-hosted-link

## Summary
- Centralizes Plaid Link token configuration for product/country/language/webhook/redirect/Hosted Link/mobile settings.
- Adds a stable, non-PII install-scoped `client_user_id` stored under the private server data directory.
- Extends Link request tests for defaults, managed/native config, validation, update-mode access tokens, and no-secret identity behavior.

## Tests
- `git diff --check`
- `swift test --skip-update --filter PlaidBarServerTests.LinkTokenRequestTests` (6 tests passed)

## Risks
- Managed webhook/redirect values are now modelable and validated, but production managed broker endpoints remain separate follow-on work.
