### PR TITLE
AND-418: Add recurring payments surface

### DIFF
--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -18,6 +18,7 @@ struct MainPopover: View {
     @State private var shouldShowSetupRecoveryDashboard = false
     @State private var dashboardContentHeight: CGFloat = 0
     @State private var activeScreenVisibleWidth: CGFloat?
+    @State private var isRecurringInspectorOpen = false
     /// True after the first render. Gates the inspector's trailing slide-in so a
     /// popover opened with a persisted selection appears directly in three-column
     /// geometry (no slide on restore); in-session selections still slide (AND-405).
@@ -68,6 +69,7 @@ struct MainPopover: View {
     }
 
     private var selectedAccount: AccountDTO? {
+        guard !isRecurringInspectorOpen else { return nil }
         let accounts = filteredAccounts
         // A selection survives only while the account is still visible; a filter
         // change or a removed/synced-away account deselects it (AND-373/375).
@@ -116,6 +118,15 @@ struct MainPopover: View {
 
     private func deselectAccount() {
         selectedAccountId = ""
+    }
+
+    private func openRecurringInspector() {
+        selectedAccountId = ""
+        isRecurringInspectorOpen = true
+    }
+
+    private func closeRecurringInspector() {
+        isRecurringInspectorOpen = false
     }
 
     private var filteredAccounts: [AccountDTO] {
@@ -231,6 +242,7 @@ struct MainPopover: View {
     /// event falls through and closes the popover (AND-373). Hoisted out of the
     /// view chain as an explicitly-typed value to keep the type-checker fast.
     private var exitCommandHandler: (() -> Void)? {
+        guard !isRecurringInspectorOpen else { return { closeRecurringInspector() } }
         guard isAccountInspectorOpen else { return nil }
         return { deselectAccount() }
     }
@@ -263,7 +275,10 @@ struct MainPopover: View {
     // contract, AND-367/369). A stable id keeps SwiftUI from remounting/flashing
     // it when the trailing inspector opens or closes.
     private var wealthSummaryRail: some View {
-        WealthSummaryFlyout(onAddAccount: openAccountSetup)
+        WealthSummaryFlyout(
+            onAddAccount: openAccountSetup,
+            onOpenSubscriptions: openRecurringInspector
+        )
             .environment(appState)
             .id("wealth-summary-rail")
             .frame(width: Layout.flyoutWidth)
@@ -295,6 +310,14 @@ struct MainPopover: View {
                         onClose: deselectAccount
                     )
                     .environment(appState)
+                } else if isRecurringInspectorOpen {
+                    RecurringPaymentsView(
+                        presentation: RecurringPaymentsSurfacePresentation.make(
+                            from: appState.recurringTransactions,
+                            asOf: Date()
+                        ),
+                        onClose: closeRecurringInspector
+                    )
                 } else if !selectedAccountId.isEmpty {
                     // A persisted selection is still resolving (accounts not loaded
                     // yet); a brief placeholder holds the column until it fills in.
@@ -410,7 +433,10 @@ struct MainPopover: View {
                             filter: selectedFilter,
                             filterSelection: filterBinding,
                             selectedAccountId: selectedAccount?.id,
-                            onSelectAccount: { selectedAccountId = $0.id },
+                            onSelectAccount: {
+                                isRecurringInspectorOpen = false
+                                selectedAccountId = $0.id
+                            },
                             onDeselectAccount: { selectedAccountId = "" },
                             onAddAccount: openAccountSetup
                         )
@@ -471,7 +497,8 @@ struct MainPopover: View {
                 DashboardFooter(
                     settingsActivation: .shared,
                     openSettings: openSettings,
-                    onAddAccount: openAccountSetup
+                    onAddAccount: openAccountSetup,
+                    onOpenSubscriptions: openRecurringInspector
                 )
                 .environment(appState)
             }
@@ -1981,6 +2008,7 @@ private struct DashboardFooter: View {
     let settingsActivation: SettingsWindowActivationRestorer
     let openSettings: OpenSettingsAction
     let onAddAccount: () -> Void
+    let onOpenSubscriptions: () -> Void
 
     var body: some View {
         HStack(spacing: Spacing.md) {
@@ -2003,6 +2031,15 @@ private struct DashboardFooter: View {
                 .accessibilityLabel("Status: \(statusLineText)")
 
             Spacer()
+
+            Button(action: onOpenSubscriptions) {
+                Image(systemName: "calendar.badge.clock")
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+            }
+            .buttonStyle(.borderless)
+            .help("Recurring payments")
+            .accessibilityLabel("Open recurring payments")
 
             detachControl
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -316,6 +316,7 @@ struct MainPopover: View {
                             from: appState.recurringTransactions,
                             asOf: Date()
                         ),
+                        loadState: appState.loadState(for: .recurring),
                         onClose: closeRecurringInspector
                     )
                 } else if !selectedAccountId.isEmpty {

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -14,6 +14,7 @@ import SwiftUI
 /// intentionally not here.
 struct RecurringObligationsSection: View {
     let presentation: RecurringObligationsPresentation
+    var onOpenSubscriptions: (() -> Void)?
 
     /// Keep the narrow column dense: show the most relevant few, summarize the
     /// rest. Attention-first ordering means flagged items are never hidden
@@ -58,6 +59,18 @@ struct RecurringObligationsSection: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .accessibilityHidden(true)
+
+            if let onOpenSubscriptions {
+                Button(action: onOpenSubscriptions) {
+                    Image(systemName: "list.bullet.rectangle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+                }
+                .buttonStyle(.borderless)
+                .help("Open recurring payments")
+                .accessibilityLabel("Open recurring payments")
+            }
         }
     }
 

--- a/Sources/PlaidBar/Views/RecurringPaymentsView.swift
+++ b/Sources/PlaidBar/Views/RecurringPaymentsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct RecurringPaymentsView: View {
     let presentation: RecurringPaymentsSurfacePresentation
+    var loadState: DashboardLoadState?
     let onClose: () -> Void
 
     var body: some View {
@@ -13,7 +14,19 @@ struct RecurringPaymentsView: View {
                 .opacity(0.4)
 
             if presentation.isEmpty {
-                emptyState
+                // Honor load phase before declaring "nothing recurring": an
+                // empty rows list during loading/offline/error should not read
+                // as a confident "no recurring payments detected".
+                switch loadState?.phase {
+                case .loading:
+                    loadingState
+                case .offline:
+                    offlineState
+                case .error:
+                    errorState
+                default:
+                    emptyState
+                }
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Spacing.md) {
@@ -89,6 +102,37 @@ struct RecurringPaymentsView: View {
             Label(presentation.emptyTitle, systemImage: "calendar.badge.clock")
         } description: {
             Text(presentation.emptyDetail)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+    }
+
+    private var loadingState: some View {
+        ContentUnavailableView {
+            Label(DashboardLoadSurface.recurring.loadingTitle, systemImage: "calendar.badge.clock")
+        } description: {
+            Text(DashboardLoadSurface.recurring.loadingDetail)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+        .accessibilityLabel(loadState?.loadingAccessibilityLabel ?? DashboardLoadSurface.recurring.loadingTitle)
+    }
+
+    private var offlineState: some View {
+        ContentUnavailableView {
+            Label("Recurring charges unavailable", systemImage: "wifi.slash")
+        } description: {
+            Text("VaultPeek can't reach the local server, so recurring charges aren't available yet. Reconnect to refresh.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+    }
+
+    private var errorState: some View {
+        ContentUnavailableView {
+            Label("Recurring charges unavailable", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text("The last refresh didn't finish, so recurring charges aren't available yet. Refresh to try again.")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(Spacing.md)

--- a/Sources/PlaidBar/Views/RecurringPaymentsView.swift
+++ b/Sources/PlaidBar/Views/RecurringPaymentsView.swift
@@ -1,0 +1,168 @@
+import PlaidBarCore
+import SwiftUI
+
+struct RecurringPaymentsView: View {
+    let presentation: RecurringPaymentsSurfacePresentation
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+                .opacity(0.4)
+
+            if presentation.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Spacing.md) {
+                        summary
+
+                        LazyVStack(alignment: .leading, spacing: Spacing.sm) {
+                            ForEach(presentation.rows) { row in
+                                RecurringPaymentRow(row: row)
+                            }
+                        }
+                    }
+                    .padding(Spacing.md)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Recurring payments. \(presentation.summaryText)")
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Subscriptions")
+                    .font(.headline.weight(.semibold))
+                    .lineLimit(1)
+
+                Text("Estimated \(presentation.estimatedMonthlyTotalText)/mo")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+            }
+            .buttonStyle(.borderless)
+            .help("Close recurring payments")
+            .accessibilityLabel("Close recurring payments")
+            .keyboardShortcut(.escape, modifiers: [])
+        }
+        .padding(Spacing.md)
+    }
+
+    private var summary: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(presentation.summaryText)
+                .detailText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if presentation.attentionCount > 0 {
+                Label("\(presentation.attentionCount) changed or stale", systemImage: "exclamationmark.triangle")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(SemanticColors.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.raised)
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(presentation.emptyTitle, systemImage: "calendar.badge.clock")
+        } description: {
+            Text(presentation.emptyDetail)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+    }
+}
+
+private struct RecurringPaymentRow: View {
+    let row: RecurringPaymentsSurfacePresentation.Row
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Text(row.merchantName)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+
+                Spacer(minLength: Spacing.sm)
+
+                Text(row.amountText)
+                    .font(.subheadline.weight(.semibold))
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
+
+            Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: Spacing.md, verticalSpacing: Spacing.xs) {
+                GridRow {
+                    RecurringPaymentMetric(title: "Frequency", value: row.frequencyText)
+                    RecurringPaymentMetric(title: "Last", value: row.lastChargeText)
+                }
+                GridRow {
+                    RecurringPaymentMetric(title: "Next", value: row.nextExpectedText)
+                    RecurringPaymentMetric(title: "Monthly", value: row.monthlyEquivalentText)
+                }
+                GridRow {
+                    RecurringPaymentMetric(title: "Confidence", value: row.confidenceText)
+                    Spacer(minLength: 0)
+                }
+            }
+
+            if !row.flagExplanations.isEmpty {
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    ForEach(row.flagExplanations, id: \.self) { explanation in
+                        Label(explanation, systemImage: row.needsAttention ? "exclamationmark.triangle" : "questionmark.circle")
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(row.needsAttention ? SemanticColors.warning : .secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .padding(Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(row.needsAttention ? .emphasized(SemanticColors.warning) : .raised)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(row.accessibilityLabel)
+    }
+}
+
+private struct RecurringPaymentMetric: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text(title)
+                .microText()
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(value)
+                .font(.caption.weight(.medium))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -5,6 +5,7 @@ struct WealthSummaryFlyout: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let onAddAccount: () -> Void
+    var onOpenSubscriptions: (() -> Void)?
 
     private var presentation: WealthSummaryPresentation {
         WealthSummaryPresentation.evaluate(
@@ -69,7 +70,8 @@ struct WealthSummaryFlyout: View {
                         presentation: RecurringObligationsPresentation.make(
                             from: appState.recurringTransactions,
                             asOf: Date()
-                        )
+                        ),
+                        onOpenSubscriptions: onOpenSubscriptions
                     )
                     .loadingRedaction(appState.loadState(for: .transactions))
                     .scrollEdgeDepth(reduceMotion: reduceMotion)

--- a/Sources/PlaidBarCore/Models/RecurringPaymentsSurfacePresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringPaymentsSurfacePresentation.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Full recurring payments/subscriptions surface model.
+///
+/// This wraps `RecurringObligationsPresentation` with display-ready row text so
+/// the macOS view can stay thin and tests can cover the user-facing wording
+/// without rendering SwiftUI.
+public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
+    public struct Row: Sendable, Hashable, Identifiable {
+        public let id: String
+        public let merchantName: String
+        public let amountText: String
+        public let frequencyText: String
+        public let lastChargeText: String
+        public let nextExpectedText: String
+        public let confidenceText: String
+        public let monthlyEquivalentText: String
+        public let flagExplanations: [String]
+        public let accessibilityLabel: String
+        public let needsAttention: Bool
+        public let isLowConfidence: Bool
+
+        public init(item: RecurringObligationsPresentation.Item) {
+            id = item.id
+            merchantName = item.merchantName
+            amountText = Formatters.currency(item.expectedAmount, format: .compact)
+            frequencyText = item.frequency.displayName
+            lastChargeText = Formatters.displayTransactionDate(item.lastDate)
+            nextExpectedText = item.nextExpectedDate.isEmpty
+                ? "Not enough history"
+                : Formatters.displayTransactionDate(item.nextExpectedDate)
+            confidenceText = item.confidenceLevel.label
+            monthlyEquivalentText = "\(Formatters.currency(item.monthlyEquivalent, format: .compact))/mo"
+            flagExplanations = Self.flagExplanations(for: item)
+            needsAttention = item.needsAttention
+            isLowConfidence = item.confidenceLevel == .low
+
+            var parts = [
+                merchantName,
+                amountText,
+                frequencyText,
+                "last charged \(lastChargeText)",
+                "next expected \(nextExpectedText)",
+                confidenceText,
+                "\(monthlyEquivalentText) monthly equivalent",
+            ]
+            parts.append(contentsOf: flagExplanations)
+            accessibilityLabel = parts.joined(separator: ", ")
+        }
+
+        private static func flagExplanations(for item: RecurringObligationsPresentation.Item) -> [String] {
+            var explanations: [String] = []
+            if item.hasPriceIncrease {
+                explanations.append("Latest charge is higher than the prior pattern.")
+            }
+            if item.isStale {
+                explanations.append("Expected charge has not appeared recently.")
+            }
+            if item.confidenceLevel == .low {
+                explanations.append("Pattern is still low confidence.")
+            }
+            return explanations
+        }
+    }
+
+    public let rows: [Row]
+    public let estimatedMonthlyTotalText: String
+    public let summaryText: String
+    public let emptyTitle: String
+    public let emptyDetail: String
+    public let attentionCount: Int
+    public let lowConfidenceCount: Int
+
+    public init(
+        rows: [Row],
+        estimatedMonthlyTotalText: String,
+        summaryText: String,
+        emptyTitle: String,
+        emptyDetail: String,
+        attentionCount: Int,
+        lowConfidenceCount: Int
+    ) {
+        self.rows = rows
+        self.estimatedMonthlyTotalText = estimatedMonthlyTotalText
+        self.summaryText = summaryText
+        self.emptyTitle = emptyTitle
+        self.emptyDetail = emptyDetail
+        self.attentionCount = attentionCount
+        self.lowConfidenceCount = lowConfidenceCount
+    }
+
+    public var isEmpty: Bool { rows.isEmpty }
+
+    public static func make(
+        from recurring: [RecurringTransaction],
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> RecurringPaymentsSurfacePresentation {
+        let obligations = RecurringObligationsPresentation.make(
+            from: recurring,
+            asOf: date,
+            calendar: calendar
+        )
+        let rows = obligations.items.map(Row.init(item:))
+        let lowConfidenceCount = rows.count(where: \.isLowConfidence)
+
+        return RecurringPaymentsSurfacePresentation(
+            rows: rows,
+            estimatedMonthlyTotalText: Formatters.currency(obligations.estimatedMonthlyTotal, format: .compact),
+            summaryText: Self.summaryText(
+                rowCount: rows.count,
+                attentionCount: obligations.attentionCount,
+                lowConfidenceCount: lowConfidenceCount
+            ),
+            emptyTitle: "No recurring payments detected",
+            emptyDetail: "VaultPeek will list subscriptions here after it sees a repeated merchant pattern in synced local transactions.",
+            attentionCount: obligations.attentionCount,
+            lowConfidenceCount: lowConfidenceCount
+        )
+    }
+
+    private static func summaryText(
+        rowCount: Int,
+        attentionCount: Int,
+        lowConfidenceCount: Int
+    ) -> String {
+        guard rowCount > 0 else {
+            return "No recurring payments detected yet."
+        }
+
+        var parts = [
+            "\(rowCount) detected \(rowCount == 1 ? "stream" : "streams")",
+        ]
+        if attentionCount > 0 {
+            parts.append("\(attentionCount) flagged")
+        }
+        if lowConfidenceCount > 0 {
+            parts.append("\(lowConfidenceCount) low confidence")
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/Tests/PlaidBarCoreTests/RecurringPaymentsSurfacePresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringPaymentsSurfacePresentationTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Recurring Payments Surface Presentation")
+struct RecurringPaymentsSurfacePresentationTests {
+    private static let asOf = Formatters.parseTransactionDate("2026-05-01")!
+
+    @Test("Rows expose merchant, amount, cadence, dates, confidence, and monthly equivalent")
+    func rowPresentationIncludesRequiredFields() throws {
+        let presentation = RecurringPaymentsSurfacePresentation.make(
+            from: [
+                Self.recurring(
+                    merchantName: "StreamCo",
+                    frequency: .annual,
+                    averageAmount: 120,
+                    lastDate: "2026-04-01",
+                    nextExpectedDate: "2027-04-01",
+                    confidence: 0.85
+                ),
+            ],
+            asOf: Self.asOf
+        )
+
+        let row = try! #require(presentation.rows.first)
+
+        #expect(row.merchantName == "StreamCo")
+        #expect(row.amountText == "$120")
+        #expect(row.frequencyText == "Annual")
+        #expect(row.lastChargeText.contains("Apr"))
+        #expect(row.nextExpectedText.contains("2027"))
+        #expect(row.confidenceText == "Confident")
+        #expect(row.monthlyEquivalentText == "$10/mo")
+        #expect(row.accessibilityLabel.contains("monthly equivalent"))
+    }
+
+    @Test("Estimated monthly total excludes stale streams")
+    func monthlyTotalTextExcludesStaleStreams() {
+        let presentation = RecurringPaymentsSurfacePresentation.make(
+            from: [
+                Self.recurring(merchantName: "Active", averageAmount: 30, lastDate: "2026-04-15"),
+                Self.recurring(merchantName: "Dormant", averageAmount: 50, lastDate: "2026-01-01"),
+            ],
+            asOf: Self.asOf
+        )
+
+        #expect(presentation.estimatedMonthlyTotalText == "$30")
+        #expect(presentation.summaryText.contains("2 detected streams"))
+        #expect(presentation.attentionCount == 1)
+    }
+
+    @Test("Changed and stale streams include explanatory text")
+    func flagExplanationsDescribeChangedAndStaleStreams() throws {
+        let presentation = RecurringPaymentsSurfacePresentation.make(
+            from: [
+                Self.recurring(
+                    merchantName: "Gym",
+                    latestAmount: 22,
+                    trailingAverageAmount: 20,
+                    confidence: 0.95
+                ),
+                Self.recurring(merchantName: "Old Plan", lastDate: "2026-01-01"),
+            ],
+            asOf: Self.asOf
+        )
+
+        let gym = try! #require(presentation.rows.first { $0.merchantName == "Gym" })
+        let oldPlan = try! #require(presentation.rows.first { $0.merchantName == "Old Plan" })
+
+        #expect(gym.flagExplanations.contains("Latest charge is higher than the prior pattern."))
+        #expect(oldPlan.flagExplanations.contains("Expected charge has not appeared recently."))
+        #expect(gym.needsAttention)
+        #expect(oldPlan.needsAttention)
+    }
+
+    @Test("Empty and low-confidence states use honest, non-alarming copy")
+    func emptyAndLowConfidenceCopy() throws {
+        let empty = RecurringPaymentsSurfacePresentation.make(from: [], asOf: Self.asOf)
+
+        #expect(empty.isEmpty)
+        #expect(empty.emptyTitle == "No recurring payments detected")
+        #expect(empty.emptyDetail.contains("after it sees a repeated merchant pattern"))
+        #expect(empty.summaryText == "No recurring payments detected yet.")
+
+        let lowConfidence = RecurringPaymentsSurfacePresentation.make(
+            from: [
+                Self.recurring(merchantName: "Maybe Cloud", confidence: 0.45),
+            ],
+            asOf: Self.asOf
+        )
+        let row = try! #require(lowConfidence.rows.first)
+
+        #expect(lowConfidence.lowConfidenceCount == 1)
+        #expect(lowConfidence.summaryText.contains("1 low confidence"))
+        #expect(row.confidenceText == "Low confidence")
+        #expect(row.flagExplanations.contains("Pattern is still low confidence."))
+        #expect(!row.needsAttention)
+    }
+
+    private static func recurring(
+        merchantName: String,
+        frequency: RecurringFrequency = .monthly,
+        averageAmount: Double = 10,
+        latestAmount: Double? = nil,
+        trailingAverageAmount: Double? = nil,
+        lastDate: String = "2026-04-15",
+        nextExpectedDate: String = "2026-05-15",
+        confidence: Double = 0.9
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchantName,
+            frequency: frequency,
+            averageAmount: averageAmount,
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            lastDate: lastDate,
+            nextExpectedDate: nextExpectedDate,
+            category: .subscriptions,
+            transactionCount: 3,
+            confidence: confidence
+        )
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-418/build-recurring-payments-and-subscriptions-view-surface

## Summary
- Adds a dedicated Subscriptions inspector opened from the dashboard footer and the existing recurring rail card.
- Shows merchant, amount, frequency, last charge, next expected charge, confidence, monthly equivalent, estimated monthly total, and explanatory changed/stale/low-confidence text.
- Adds a core presenter for testable row/empty-state copy without exposing provider payloads, account IDs, transaction IDs, tokens, or secrets.

## Tests
- PASS: `swift test --skip-update --filter RecurringPaymentsSurfacePresentationTests`
- PASS: `swift test --skip-update --filter Recurring`
- PASS: `swift build --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- PASS: `git diff --cached --check`
- PASS: `git diff --check HEAD`

## Risks
- The surface is read-only and relies on existing local recurring detection from synced transactions; no cancellation or manual correction flow is included.
- Next expected charge remains based on the current detector inference and may be absent or low confidence until enough transaction history exists.
- No Linear state was updated; root orchestration owns Linear updates.