### PR TITLE
AND-416: Implement financial attention states in the menu bar cockpit

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -372,9 +372,16 @@ final class AppState {
             needsLoginItemCount: needsLoginItemCount,
             isSyncStale: isSyncStale,
             hasEverSynced: lastSyncDate != nil,
-            financialAttentionText: attentionQueue.rows.first?.menuBarAttentionText,
+            financialAttentionText: firstMenuBarAttentionText,
             iconStyle: menuBarIconStyle
         )
+    }
+
+    /// First attention row that actually carries menu-bar text. A higher-priority
+    /// row without menu-bar text (e.g. an advisory recent-error) must not
+    /// suppress a lower Cash/Credit/Spend badge.
+    private var firstMenuBarAttentionText: String? {
+        attentionQueue.rows.compactMap(\.menuBarAttentionText).first
     }
 
     var menuBarAttentionText: String? {
@@ -400,7 +407,11 @@ final class AppState {
     }
 
     var menuBarAccessibilityLabel: String {
-        let status = "Status \(diagnosticsSummary)"
+        // diagnosticsSummary stays "healthy" for finance warnings, so fold the
+        // visible finance badge (Cash/Credit/Spend) into the spoken status to
+        // keep VoiceOver in sync with the badge sighted users see.
+        let attention = menuBarAttentionText.map { ". Attention \($0)" } ?? ""
+        let status = "Status \(diagnosticsSummary)\(attention)"
         switch menuBarSummaryMode {
         case .netWorth:
             return "VaultPeek net worth \(menuBarText). \(status)"

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -364,6 +364,7 @@ final class AppState {
             needsLoginItemCount: needsLoginItemCount,
             isSyncStale: isSyncStale,
             hasEverSynced: lastSyncDate != nil,
+            financialAttentionText: attentionQueue.rows.first?.menuBarAttentionText,
             iconStyle: menuBarIconStyle
         )
     }
@@ -600,7 +601,12 @@ final class AppState {
             itemStatuses: itemStatuses,
             isSyncStale: isSyncStale,
             lastSyncRelative: lastSyncRelative,
-            errorMessage: error
+            errorMessage: error,
+            accounts: accounts,
+            transactions: transactions,
+            lowCashThreshold: lowBalanceThreshold,
+            largeTransactionThreshold: largeTransactionThreshold,
+            creditUtilizationThreshold: creditUtilizationThreshold
         )
     }
 

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -21,6 +21,8 @@ struct WealthSummaryFlyout: View {
             statusSyncText: appState.statusSyncText,
             errorMessage: appState.error,
             creditUtilizationThreshold: appState.creditUtilizationThreshold,
+            lowCashThreshold: appState.lowBalanceThreshold,
+            largeTransactionThreshold: appState.largeTransactionThreshold,
             balanceHistory: appState.balanceHistory
         )
     }

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -40,6 +40,7 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
     public let severity: AttentionQueueSeverity
     public let title: String
     public let detail: String
+    public let menuBarAttentionText: String?
     public let action: DashboardStatusReadinessAction?
     public let actionTitle: String?
     public let actionIconName: String?
@@ -57,6 +58,7 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
         severity: AttentionQueueSeverity,
         title: String,
         detail: String,
+        menuBarAttentionText: String? = nil,
         action: DashboardStatusReadinessAction? = nil,
         actionTitle: String? = nil,
         actionIconName: String? = nil,
@@ -68,6 +70,7 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
         self.severity = severity
         self.title = title
         self.detail = detail
+        self.menuBarAttentionText = menuBarAttentionText
         self.action = action
         self.actionTitle = actionTitle ?? action?.defaultTitle
         self.actionIconName = actionIconName ?? action?.defaultIconName
@@ -104,7 +107,12 @@ public struct AttentionQueue: Equatable, Sendable {
         itemStatuses: [ItemStatus],
         isSyncStale: Bool,
         lastSyncRelative: String?,
-        errorMessage: String?
+        errorMessage: String?,
+        accounts: [AccountDTO] = [],
+        transactions: [TransactionDTO] = [],
+        lowCashThreshold: Double = 100,
+        largeTransactionThreshold: Double = 500,
+        creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
     ) -> AttentionQueue {
         if isDemoMode {
             return AttentionQueue(rows: [healthyDemoRow])
@@ -203,8 +211,19 @@ public struct AttentionQueue: Equatable, Sendable {
                 severity: .warning,
                 title: "Sync is stale",
                 detail: "Last sync: \(lastSyncRelative ?? "never"). Refresh for current data.",
+                menuBarAttentionText: lastSyncRelative == nil ? "Never" : "Stale",
                 action: .refresh,
                 actionTitle: "Refresh Now"
+            ))
+        }
+
+        if credentialsReady, serverConnected, linkedItemCount > 0, accountCount > 0, syncedItemCount > 0 {
+            rows.append(contentsOf: financialAttentionRows(
+                accounts: accounts,
+                transactions: transactions,
+                lowCashThreshold: lowCashThreshold,
+                largeTransactionThreshold: largeTransactionThreshold,
+                creditUtilizationThreshold: creditUtilizationThreshold
             ))
         }
 
@@ -268,6 +287,66 @@ public struct AttentionQueue: Equatable, Sendable {
                 )
             }
         }
+    }
+
+    private static func financialAttentionRows(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        lowCashThreshold: Double,
+        largeTransactionThreshold: Double,
+        creditUtilizationThreshold: Double
+    ) -> [AttentionQueueRow] {
+        var rows: [AttentionQueueRow] = []
+
+        let cashAccounts = accounts.filter { $0.type == .depository }
+        let totalCash = MenuBarSummary.totalCash(from: accounts)
+        if !cashAccounts.isEmpty, totalCash < lowCashThreshold {
+            rows.append(AttentionQueueRow(
+                id: "financial-low-cash",
+                severity: .warning,
+                title: "Cash buffer is low",
+                detail: "Depository cash is below your local attention threshold. Review cash accounts before upcoming payments.",
+                menuBarAttentionText: "Cash",
+                action: .refresh,
+                actionTitle: "Refresh Data",
+                accessibilityHint: "Refreshes local balances before you review cash accounts."
+            ))
+        }
+
+        if let utilization = MenuBarSummary.creditUtilization(from: accounts),
+           utilization >= creditUtilizationThreshold {
+            rows.append(AttentionQueueRow(
+                id: "financial-high-utilization",
+                severity: .warning,
+                title: "Credit utilization is high",
+                detail: "Credit usage is at or above your local attention threshold. Review credit accounts for the next payment step.",
+                menuBarAttentionText: "Credit",
+                action: .refresh,
+                actionTitle: "Refresh Data",
+                accessibilityHint: "Refreshes local credit balances before you review utilization."
+            ))
+        }
+
+        let unusualSpendCount = NotificationTriggerSelection.largeTransactions(
+            from: transactions,
+            threshold: largeTransactionThreshold
+        ).count
+        if unusualSpendCount > 0 {
+            rows.append(AttentionQueueRow(
+                id: "financial-unusual-spending",
+                severity: .warning,
+                title: "Recent spending changed",
+                detail: unusualSpendCount == 1
+                    ? "One local transaction crossed your spending attention threshold. Review recent activity."
+                    : "\(unusualSpendCount) local transactions crossed your spending attention threshold. Review recent activity.",
+                menuBarAttentionText: "Spend",
+                action: .refresh,
+                actionTitle: "Refresh Data",
+                accessibilityHint: "Refreshes local transactions before you review recent activity."
+            ))
+        }
+
+        return rows
     }
 
     private static func itemTitle(_ item: ItemStatus, fallback: String) -> String {
@@ -386,6 +465,9 @@ public struct AttentionQueue: Equatable, Sendable {
             case "first-sync-needed": return 9
             case "first-sync-incomplete": return 10
             case "sync-stale": return 11
+            case "financial-low-cash": return 12
+            case "financial-high-utilization": return 13
+            case "financial-unusual-spending": return 14
             default:
                 // Unknown rows fall back to severity-tier ordering: blocking
                 // failures first, advisories next, healthy rows last.

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -48,9 +48,19 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
     public let accessibilityLabel: String
     public let accessibilityHint: String?
 
+    /// Id prefix for financial cockpit rows (low cash, high utilization,
+    /// unusual spend). Used to keep these out of sync-health treatment.
+    public static let financialAttentionIDPrefix = "financial-"
+
     /// Severity tier derived from the row's existing severity state.
     public var errorSeverity: ErrorSeverity? {
         severity.errorSeverity
+    }
+
+    /// `true` when this row is a financial cockpit warning rather than a
+    /// sync/connection state. Sync-health UI should ignore these rows.
+    public var isFinancialAttention: Bool {
+        id.hasPrefix(Self.financialAttentionIDPrefix)
     }
 
     public init(
@@ -112,7 +122,9 @@ public struct AttentionQueue: Equatable, Sendable {
         transactions: [TransactionDTO] = [],
         lowCashThreshold: Double = 100,
         largeTransactionThreshold: Double = 500,
-        creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
+        creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        now: Date = Date(),
+        calendar: Calendar = .current
     ) -> AttentionQueue {
         if isDemoMode {
             return AttentionQueue(rows: [healthyDemoRow])
@@ -217,13 +229,20 @@ public struct AttentionQueue: Equatable, Sendable {
             ))
         }
 
-        if credentialsReady, serverConnected, linkedItemCount > 0, accountCount > 0, syncedItemCount > 0 {
+        // Only evaluate aggregate finance warnings once every linked item has
+        // completed its first sync. With a partially-synced set, balances and
+        // transactions from the unsynced item are absent, so aggregate
+        // cash/utilization/spend could fire on incomplete data.
+        if credentialsReady, serverConnected, linkedItemCount > 0, accountCount > 0,
+           syncedItemCount >= linkedItemCount {
             rows.append(contentsOf: financialAttentionRows(
                 accounts: accounts,
                 transactions: transactions,
                 lowCashThreshold: lowCashThreshold,
                 largeTransactionThreshold: largeTransactionThreshold,
-                creditUtilizationThreshold: creditUtilizationThreshold
+                creditUtilizationThreshold: creditUtilizationThreshold,
+                now: now,
+                calendar: calendar
             ))
         }
 
@@ -289,23 +308,34 @@ public struct AttentionQueue: Equatable, Sendable {
         }
     }
 
+    /// Sliding window for "recent spending changed". A large transaction older
+    /// than this no longer keeps the Spend attention state active.
+    static let unusualSpendingWindowDays = 7
+
     private static func financialAttentionRows(
         accounts: [AccountDTO],
         transactions: [TransactionDTO],
         lowCashThreshold: Double,
         largeTransactionThreshold: Double,
-        creditUtilizationThreshold: Double
+        creditUtilizationThreshold: Double,
+        now: Date,
+        calendar: Calendar
     ) -> [AttentionQueueRow] {
         var rows: [AttentionQueueRow] = []
 
-        let cashAccounts = accounts.filter { $0.type == .depository }
-        let totalCash = MenuBarSummary.totalCash(from: accounts)
-        if !cashAccounts.isEmpty, totalCash < lowCashThreshold {
+        // Low cash is per-account: a single checking account below the threshold
+        // is a low-cash signal even if a savings account holds enough, matching
+        // NotificationTriggerSelection.lowBalanceAccounts.
+        let lowCashAccounts = NotificationTriggerSelection.lowBalanceAccounts(
+            from: accounts,
+            threshold: lowCashThreshold
+        )
+        if !lowCashAccounts.isEmpty {
             rows.append(AttentionQueueRow(
                 id: "financial-low-cash",
                 severity: .warning,
                 title: "Cash buffer is low",
-                detail: "Depository cash is below your local attention threshold. Review cash accounts before upcoming payments.",
+                detail: "A cash account is below your local attention threshold. Review cash accounts before upcoming payments.",
                 menuBarAttentionText: "Cash",
                 action: .refresh,
                 actionTitle: "Refresh Data",
@@ -327,10 +357,25 @@ public struct AttentionQueue: Equatable, Sendable {
             ))
         }
 
+        // Only count large transactions inside the recent window so a one-time
+        // months-old purchase does not keep the Spend badge active indefinitely.
+        let windowStart = calendar.date(
+            byAdding: .day,
+            value: -unusualSpendingWindowDays,
+            to: calendar.startOfDay(for: now)
+        )
         let unusualSpendCount = NotificationTriggerSelection.largeTransactions(
             from: transactions,
             threshold: largeTransactionThreshold
-        ).count
+        )
+        .filter { transaction in
+            guard let windowStart,
+                  let date = Formatters.parseTransactionDate(transaction.date)
+            else { return false }
+            let day = calendar.startOfDay(for: date)
+            return day >= windowStart && day <= calendar.startOfDay(for: now)
+        }
+        .count
         if unusualSpendCount > 0 {
             rows.append(AttentionQueueRow(
                 id: "financial-unusual-spending",

--- a/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarStatusPresentation.swift
@@ -65,6 +65,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         needsLoginItemCount: Int,
         isSyncStale: Bool,
         hasEverSynced: Bool,
+        financialAttentionText: String? = nil,
         iconStyle: MenuBarIconStyle = .classic
     ) -> MenuBarStatusPresentation {
         let connection = ServerConnectionPresentation.evaluate(
@@ -82,7 +83,8 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
                 erroredItemCount: erroredItemCount,
                 needsLoginItemCount: needsLoginItemCount,
                 isSyncStale: isSyncStale,
-                hasEverSynced: hasEverSynced
+                hasEverSynced: hasEverSynced,
+                financialAttentionText: financialAttentionText
             ),
             symbolName: symbolName(
                 isDemoMode: isDemoMode,
@@ -91,6 +93,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
                 erroredItemCount: erroredItemCount,
                 needsLoginItemCount: needsLoginItemCount,
                 isSyncStale: isSyncStale,
+                hasFinancialAttention: financialAttentionText != nil,
                 iconStyle: iconStyle
             ),
             severity: severity(
@@ -98,7 +101,8 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
                 connection: connection,
                 erroredItemCount: erroredItemCount,
                 needsLoginItemCount: needsLoginItemCount,
-                isSyncStale: isSyncStale
+                isSyncStale: isSyncStale,
+                hasFinancialAttention: financialAttentionText != nil
             )
         )
     }
@@ -109,7 +113,8 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         erroredItemCount: Int,
         needsLoginItemCount: Int,
         isSyncStale: Bool,
-        hasEverSynced: Bool
+        hasEverSynced: Bool,
+        financialAttentionText: String?
     ) -> String? {
         if isDemoMode { return nil }
         if connection.issue == .localAuthMissing || connection.issue == .localAuthRejected {
@@ -124,6 +129,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         }
         if needsLoginItemCount > 0 { return "Login" }
         if isSyncStale { return hasEverSynced ? "Stale" : "Never" }
+        if let financialAttentionText { return financialAttentionText }
         return nil
     }
 
@@ -134,6 +140,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         erroredItemCount: Int,
         needsLoginItemCount: Int,
         isSyncStale: Bool,
+        hasFinancialAttention: Bool,
         iconStyle: MenuBarIconStyle
     ) -> String {
         // State is carried by the symbol shape, not color: the menu bar
@@ -163,6 +170,7 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         if needsLoginItemCount > 0 || isSyncStale {
             return "exclamationmark.triangle"
         }
+        if hasFinancialAttention { return "exclamationmark.triangle" }
         return iconStyle.healthySymbolName
     }
 
@@ -171,12 +179,13 @@ public struct MenuBarStatusPresentation: Equatable, Sendable {
         connection: ServerConnectionPresentation,
         erroredItemCount: Int,
         needsLoginItemCount: Int,
-        isSyncStale: Bool
+        isSyncStale: Bool,
+        hasFinancialAttention: Bool
     ) -> ErrorSeverity? {
         if isDemoMode { return erroredItemCount > 0 ? .blocking : nil }
         if erroredItemCount > 0 { return .blocking }
         if let connectionSeverity = connection.errorSeverity { return connectionSeverity }
-        if needsLoginItemCount > 0 || isSyncStale { return .advisory }
+        if needsLoginItemCount > 0 || isSyncStale || hasFinancialAttention { return .advisory }
         return nil
     }
 }

--- a/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
@@ -141,6 +141,8 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         statusSyncText: String,
         errorMessage: String?,
         creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        lowCashThreshold: Double = 100,
+        largeTransactionThreshold: Double = 500,
         balanceHistory: [BalanceSnapshot] = [],
         windowDays: Int = 30,
         now: Date = Date(),
@@ -156,7 +158,12 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
             itemStatuses: itemStatuses,
             isSyncStale: isSyncStale,
             lastSyncRelative: lastSyncRelative,
-            errorMessage: errorMessage
+            errorMessage: errorMessage,
+            accounts: accounts,
+            transactions: transactions,
+            lowCashThreshold: lowCashThreshold,
+            largeTransactionThreshold: largeTransactionThreshold,
+            creditUtilizationThreshold: creditUtilizationThreshold
         )
         let attention = attentionSummary(from: attentionQueue)
 

--- a/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
@@ -191,7 +191,7 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
             ),
             attention: attention,
             syncHealth: syncHealthSummary(
-                from: attention,
+                from: attentionQueue,
                 isDemoMode: isDemoMode,
                 statusSyncText: statusSyncText
             )
@@ -285,11 +285,17 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
     }
 
     private static func syncHealthSummary(
-        from attention: AttentionSummary,
+        from queue: AttentionQueue,
         isDemoMode: Bool,
         statusSyncText: String
     ) -> SyncHealthSummary {
-        guard attention.severity != .healthy else {
+        // Sync health reflects sync/connection state only. Finance warnings
+        // (low cash, high utilization, unusual spend) are surfaced through the
+        // attention queue, not the sync-health pill, so an otherwise-fresh sync
+        // with a finance warning still reports as healthy here.
+        let syncRow = queue.rows.first { !$0.isFinancialAttention && $0.severity != .healthy }
+
+        guard let syncRow else {
             return SyncHealthSummary(
                 severity: .healthy,
                 title: isDemoMode ? "Demo data ready" : "Sync healthy",
@@ -300,11 +306,11 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         }
 
         return SyncHealthSummary(
-            severity: attention.severity,
-            title: attention.title,
-            detail: attention.detail,
+            severity: syncRow.severity,
+            title: syncRow.title,
+            detail: syncRow.detail,
             statusText: statusSyncText,
-            iconName: attention.severity == .blocked ? "xmark.octagon.fill" : "exclamationmark.triangle.fill"
+            iconName: syncRow.severity == .blocked ? "xmark.octagon.fill" : "exclamationmark.triangle.fill"
         )
     }
 }

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -346,6 +346,96 @@ struct AttentionQueueTests {
         #expect(belowWarnings.rows.map(\.id) == ["healthy"])
     }
 
+    @Test("Stale large transactions outside the recent window do not raise spend attention")
+    func staleLargeTransactionsDoNotRaiseSpendAttention() {
+        let now = Formatters.parseTransactionDate("2026-06-14")!
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [depository(id: "checking", balance: 5_000)],
+            transactions: [
+                // A large purchase from over a month ago must not keep the Spend
+                // badge active once it is outside the recent window.
+                TransactionDTO(id: "old-large", accountId: "acct", amount: 900, date: "2026-05-01", name: "Old Purchase"),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30,
+            now: now
+        )
+
+        #expect(!queue.rows.map(\.id).contains("financial-unusual-spending"))
+        #expect(queue.rows.map(\.id) == ["healthy"])
+    }
+
+    @Test("Finance attention is suppressed until all linked items finish first sync")
+    func financeAttentionWaitsForAllItemsSynced() {
+        let now = Formatters.parseTransactionDate("2026-06-14")!
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 2,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [depository(id: "checking", balance: 10)],
+            transactions: [
+                TransactionDTO(id: "recent-large", accountId: "acct", amount: 900, date: "2026-06-13", name: "Recent"),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30,
+            now: now
+        )
+
+        // With one of two items still unsynced, partial data must not drive
+        // aggregate finance warnings; only the first-sync-incomplete row shows.
+        #expect(!queue.rows.contains { $0.isFinancialAttention })
+        #expect(queue.rows.map(\.id) == ["first-sync-incomplete"])
+    }
+
+    @Test("Low cash is detected per account, not by summed depository cash")
+    func lowCashIsDetectedPerAccount() {
+        let now = Formatters.parseTransactionDate("2026-06-14")!
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [
+                // Checking is below threshold even though total depository cash
+                // (checking + savings) is well above it.
+                depository(id: "checking", balance: 20),
+                depository(id: "savings", balance: 5_000),
+            ],
+            transactions: [],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30,
+            now: now
+        )
+
+        #expect(queue.rows.map(\.id).contains("financial-low-cash"))
+    }
+
     @Test("Financial attention copy stays private and amount-free")
     func financialAttentionCopyStaysPrivateAndAmountFree() {
         let accountID = "acct_sensitive_private"

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -221,4 +221,230 @@ struct AttentionQueueTests {
         #expect(queue.rows[0].title == "Plaid sync healthy")
         #expect(queue.rows[0].detail.contains("2 linked items connected"))
     }
+
+    @Test("Queue represents financial attention states in deterministic priority order")
+    func representsFinancialAttentionStatesInPriorityOrder() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 3,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [
+                depository(id: "checking-sensitive-id", balance: 99),
+                credit(id: "card-sensitive-id", current: -300, limit: 1_000),
+            ],
+            transactions: [
+                transaction(id: "tx-sensitive-id", amount: 500),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30
+        )
+
+        #expect(queue.rows.map(\.id) == [
+            "financial-low-cash",
+            "financial-high-utilization",
+            "financial-unusual-spending",
+        ])
+        #expect(queue.rows.map(\.menuBarAttentionText) == ["Cash", "Credit", "Spend"])
+        #expect(queue.rows.allSatisfy { $0.severity == .warning })
+        #expect(queue.highestErrorSeverity == .advisory)
+    }
+
+    @Test("Queue keeps sync and recovery warnings ahead of financial attention")
+    func keepsRecoveryWarningsAheadOfFinancialAttention() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-login-sensitive", institutionName: "Example Bank", status: .loginRequired),
+            ],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            errorMessage: nil,
+            accounts: [
+                depository(id: "checking-sensitive-id", balance: 10),
+                credit(id: "card-sensitive-id", current: -900, limit: 1_000),
+            ],
+            transactions: [
+                transaction(id: "tx-sensitive-id", amount: 900),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30
+        )
+
+        #expect(queue.rows.map(\.id) == [
+            "item-login-0",
+            "sync-stale",
+            "financial-low-cash",
+        ])
+        #expect(queue.rows.first?.action == .reconnect)
+    }
+
+    @Test("Financial attention threshold edges are inclusive where configured")
+    func financialThresholdEdgesAreInclusiveWhereConfigured() {
+        let atThreshold = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 3,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [
+                depository(id: "checking", balance: 100),
+                credit(id: "card", current: -300, limit: 1_000),
+            ],
+            transactions: [
+                transaction(id: "tx-at-threshold", amount: 500),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30
+        )
+        let belowWarnings = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 3,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [
+                depository(id: "checking", balance: 100),
+                credit(id: "card", current: -299, limit: 1_000),
+            ],
+            transactions: [
+                transaction(id: "tx-below-threshold", amount: 499.99),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30
+        )
+
+        #expect(atThreshold.rows.map(\.id) == [
+            "financial-high-utilization",
+            "financial-unusual-spending",
+        ])
+        #expect(belowWarnings.rows.map(\.id) == ["healthy"])
+    }
+
+    @Test("Financial attention copy stays private and amount-free")
+    func financialAttentionCopyStaysPrivateAndAmountFree() {
+        let accountID = "acct_sensitive_private"
+        let transactionID = "tx_sensitive_private"
+        let accountName = "Sensitive Checking 4321"
+        let merchant = "Sensitive Merchant"
+        let institution = "Sensitive Bank"
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            accounts: [
+                AccountDTO(
+                    id: accountID,
+                    itemId: "item_sensitive_private",
+                    name: accountName,
+                    type: .depository,
+                    balances: BalanceDTO(available: 12.34),
+                    institutionName: institution
+                ),
+                credit(id: "credit_sensitive_private", current: -900, limit: 1_000),
+            ],
+            transactions: [
+                TransactionDTO(
+                    id: transactionID,
+                    accountId: accountID,
+                    amount: 9_876.54,
+                    date: "2026-06-12",
+                    name: "Raw Sensitive Merchant",
+                    merchantName: merchant
+                ),
+            ],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30
+        )
+
+        let renderedCopy = queue.rows
+            .flatMap {
+                [
+                    $0.title,
+                    $0.detail,
+                    $0.menuBarAttentionText ?? "",
+                    $0.actionTitle ?? "",
+                    $0.accessibilityLabel,
+                    $0.accessibilityHint ?? "",
+                ]
+            }
+            .joined(separator: " ")
+
+        for privateText in [
+            accountID,
+            transactionID,
+            accountName,
+            merchant,
+            institution,
+            "Raw Sensitive Merchant",
+            "9876.54",
+            "12.34",
+            "$",
+        ] {
+            #expect(renderedCopy.contains(privateText) == false)
+        }
+    }
+
+    private func transaction(id: String, amount: Double) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acct-\(id)",
+            amount: amount,
+            date: "2026-06-12",
+            name: "Synthetic Transaction"
+        )
+    }
+
+    private func depository(id: String, balance: Double) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item-\(id)",
+            name: "Synthetic Checking",
+            type: .depository,
+            balances: BalanceDTO(available: balance)
+        )
+    }
+
+    private func credit(id: String, current: Double, limit: Double) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item-\(id)",
+            name: "Synthetic Credit",
+            type: .credit,
+            balances: BalanceDTO(current: current, limit: limit)
+        )
+    }
 }

--- a/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
+++ b/Tests/PlaidBarCoreTests/ErrorSeverityTests.swift
@@ -335,6 +335,39 @@ struct ErrorSeverityTests {
         #expect(neverSynced.severity == .advisory)
     }
 
+    @Test("Financial attention uses privacy-safe menu bar text")
+    func financialAttentionUsesPrivacySafeMenuBarText() {
+        let presentation = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: true,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true,
+            financialAttentionText: "Cash"
+        )
+        let offline = MenuBarStatusPresentation.evaluate(
+            isDemoMode: false,
+            isLoading: false,
+            serverConnected: false,
+            errorMessage: nil,
+            erroredItemCount: 0,
+            needsLoginItemCount: 0,
+            isSyncStale: false,
+            hasEverSynced: true,
+            financialAttentionText: "Cash"
+        )
+
+        #expect(presentation.attentionText == "Cash")
+        #expect(presentation.symbolName == "exclamationmark.triangle")
+        #expect(presentation.severity == .advisory)
+        #expect(offline.attentionText == "Offline")
+        #expect(offline.symbolName == "network.slash")
+        #expect(offline.severity == .blocking)
+    }
+
     @Test("Healthy and demo states show no menu bar attention chrome")
     func healthyAndDemoShowNoAttentionChrome() {
         let healthy = MenuBarStatusPresentation.evaluate(


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-416/implement-financial-attention-states-in-the-menu-bar-cockpit

## Summary
- Extend the shared attention queue with privacy-safe financial cockpit rows for low cash, high credit utilization, and unusual spending.
- Preserve recovery/readiness priority ahead of financial warnings, with stale sync and broken connection states still represented in the same deterministic ladder.
- Feed the highest financial attention state into menu-bar warning chrome using short labels like `Cash`, `Credit`, and `Spend`, without amounts, merchants, account names, or identifiers.
- Reuse the existing popover attention queue row treatment so warnings include shaped icons, severity text, explanatory copy, and refresh/reconnect actions instead of relying on color alone.

## Tests
- `git diff --check` passed.
- `swift test --skip-update --filter AttentionQueueTests` passed: 13 tests.
- `swift test --skip-update --filter ErrorSeverityTests` passed: 19 tests.

## Risks
- Financial attention thresholds reuse the existing local notification/settings thresholds; there is no new preference UI in this slice.
- Unusual spending is modeled as local transactions crossing the existing large-transaction threshold, not a statistical anomaly detector.
- `swift test --skip-update --filter 'AttentionQueue Tests'` was attempted first and ran 0 tests because the filter did not match Swift Testing's generated names; the corrected `AttentionQueueTests` command passed.
