### PR TITLE
AND-417: Complete retention alert triggers

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -21,6 +21,10 @@ final class AppState {
         static let notifyLargeTransaction = "notifyLargeTransaction"
         static let notifyLowBalance = "notifyLowBalance"
         static let notifyHighUtilization = "notifyHighUtilization"
+        static let notifyRecurringChargeDetected = "notifyRecurringChargeDetected"
+        static let notifyRecurringChargeChanged = "notifyRecurringChargeChanged"
+        static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
+        static let notifyBrokenConnection = "notifyBrokenConnection"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
@@ -166,6 +170,30 @@ final class AppState {
             UserDefaults.standard.set(notifyHighUtilization, forKey: Keys.notifyHighUtilization)
         }
     }
+    var notifyRecurringChargeDetected: Bool = true {
+        didSet {
+            guard notifyRecurringChargeDetected != oldValue else { return }
+            UserDefaults.standard.set(notifyRecurringChargeDetected, forKey: Keys.notifyRecurringChargeDetected)
+        }
+    }
+    var notifyRecurringChargeChanged: Bool = true {
+        didSet {
+            guard notifyRecurringChargeChanged != oldValue else { return }
+            UserDefaults.standard.set(notifyRecurringChargeChanged, forKey: Keys.notifyRecurringChargeChanged)
+        }
+    }
+    var notifyRecurringChargeDueSoon: Bool = true {
+        didSet {
+            guard notifyRecurringChargeDueSoon != oldValue else { return }
+            UserDefaults.standard.set(notifyRecurringChargeDueSoon, forKey: Keys.notifyRecurringChargeDueSoon)
+        }
+    }
+    var notifyBrokenConnection: Bool = true {
+        didSet {
+            guard notifyBrokenConnection != oldValue else { return }
+            UserDefaults.standard.set(notifyBrokenConnection, forKey: Keys.notifyBrokenConnection)
+        }
+    }
 
     var launchAtLogin: Bool = false {
         didSet {
@@ -255,6 +283,18 @@ final class AppState {
         }
         if defaults.object(forKey: Keys.notifyHighUtilization) != nil {
             notifyHighUtilization = defaults.bool(forKey: Keys.notifyHighUtilization)
+        }
+        if defaults.object(forKey: Keys.notifyRecurringChargeDetected) != nil {
+            notifyRecurringChargeDetected = defaults.bool(forKey: Keys.notifyRecurringChargeDetected)
+        }
+        if defaults.object(forKey: Keys.notifyRecurringChargeChanged) != nil {
+            notifyRecurringChargeChanged = defaults.bool(forKey: Keys.notifyRecurringChargeChanged)
+        }
+        if defaults.object(forKey: Keys.notifyRecurringChargeDueSoon) != nil {
+            notifyRecurringChargeDueSoon = defaults.bool(forKey: Keys.notifyRecurringChargeDueSoon)
+        }
+        if defaults.object(forKey: Keys.notifyBrokenConnection) != nil {
+            notifyBrokenConnection = defaults.bool(forKey: Keys.notifyBrokenConnection)
         }
         // Balance history
         loadPersistedBalanceHistory()
@@ -1175,6 +1215,12 @@ final class AppState {
             largeTransaction: notifyLargeTransaction,
             lowBalance: notifyLowBalance,
             highUtilization: notifyHighUtilization,
+            recurringChargeDetected: notifyRecurringChargeDetected,
+            recurringChargeChanged: notifyRecurringChargeChanged,
+            recurringChargeDueSoon: notifyRecurringChargeDueSoon,
+            staleSync: notifyBrokenConnection,
+            loginRequired: notifyBrokenConnection,
+            itemError: notifyBrokenConnection,
             largeTransactionThreshold: largeTransactionThreshold,
             lowBalanceThreshold: lowBalanceThreshold,
             creditUtilizationThreshold: creditUtilizationThreshold
@@ -1182,6 +1228,9 @@ final class AppState {
         await notificationService.evaluateTriggers(
             transactions: transactions,
             accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
             config: config
         )
     }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1340,6 +1340,12 @@ final class AppState {
                 await syncTransactions()
             }
             startBackgroundRefresh()
+        } else {
+            // Offline cold start: the background refresh loop (the usual caller
+            // of evaluateNotifications) never starts, so evaluate once here so a
+            // stale-sync / broken-connection alert can still fire for cached or
+            // never-synced state booted without a reachable local server.
+            await evaluateNotifications()
         }
     }
 

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -10,6 +10,9 @@ protocol NotificationServiceProtocol {
     func evaluateTriggers(
         transactions: [TransactionDTO],
         accounts: [AccountDTO],
+        recurringTransactions: [RecurringTransaction],
+        itemStatuses: [ItemStatus],
+        isSyncStale: Bool,
         config: NotificationTriggers
     ) async
 }
@@ -51,8 +54,9 @@ enum NotificationPermissionState {
 final class NotificationService: NotificationServiceProtocol {
     static let shared = NotificationService()
 
-    private static let notifiedTxKey = "notifiedTransactionIds"
-    private static let notifiedAccountKey = "notifiedAccountIds"
+    private static let deliveredDedupKeysKey = "deliveredNotificationDedupKeys"
+    private static let legacyNotifiedTxKey = "notifiedTransactionIds"
+    private static let legacyNotifiedAccountKey = "notifiedAccountIds"
     private static var hasNotificationIdentity: Bool {
         guard let identifier = Bundle.main.bundleIdentifier ??
             (Bundle.main.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String)
@@ -63,43 +67,31 @@ final class NotificationService: NotificationServiceProtocol {
         return !identifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    /// Ordered array for LRU cap (most recent at end)
-    private var notifiedTransactionIds: [String]
-    private var notifiedTransactionIdSet: Set<String>
-    private var notifiedAccountIds: Set<String>
+    /// Ordered array for LRU cap (most recent at end).
+    private var deliveredDedupKeys: [String]
+    private var deliveredDedupKeySet: Set<String>
 
     private init() {
         let defaults = UserDefaults.standard
-        let txIds = defaults.stringArray(forKey: Self.notifiedTxKey) ?? []
-        notifiedTransactionIds = txIds
-        notifiedTransactionIdSet = Set(txIds)
-        notifiedAccountIds = Set(defaults.stringArray(forKey: Self.notifiedAccountKey) ?? [])
+        let keys = defaults.stringArray(forKey: Self.deliveredDedupKeysKey)
+            ?? Self.migratedLegacyDedupKeys(from: defaults)
+        deliveredDedupKeys = keys
+        deliveredDedupKeySet = Set(keys)
     }
 
     private func persistNotifiedIds() {
         let defaults = UserDefaults.standard
-        defaults.set(notifiedTransactionIds, forKey: Self.notifiedTxKey)
-        defaults.set(Array(notifiedAccountIds), forKey: Self.notifiedAccountKey)
+        defaults.set(deliveredDedupKeys, forKey: Self.deliveredDedupKeysKey)
     }
 
     func resetDeduplicationState() {
-        notifiedTransactionIds = []
-        notifiedTransactionIdSet = []
-        notifiedAccountIds = []
+        deliveredDedupKeys = []
+        deliveredDedupKeySet = []
 
         let defaults = UserDefaults.standard
-        defaults.removeObject(forKey: Self.notifiedTxKey)
-        defaults.removeObject(forKey: Self.notifiedAccountKey)
-    }
-
-    // MARK: - Notification Key Helpers
-
-    private enum NotifKey {
-        static func largeTx(_ id: String) -> String { "large-tx-\(id)" }
-        static func lowBalance(_ id: String) -> String { "low-balance-\(id)" }
-        static func highUtil(_ id: String) -> String { "high-util-\(id)" }
-        static func dedupLow(_ id: String) -> String { "low-\(id)" }
-        static func dedupUtil(_ id: String) -> String { "util-\(id)" }
+        defaults.removeObject(forKey: Self.deliveredDedupKeysKey)
+        defaults.removeObject(forKey: Self.legacyNotifiedTxKey)
+        defaults.removeObject(forKey: Self.legacyNotifiedAccountKey)
     }
 
     // MARK: - Permissions
@@ -127,105 +119,45 @@ final class NotificationService: NotificationServiceProtocol {
     func evaluateTriggers(
         transactions: [TransactionDTO],
         accounts: [AccountDTO],
+        recurringTransactions: [RecurringTransaction],
+        itemStatuses: [ItemStatus],
+        isSyncStale: Bool,
         config: NotificationTriggers
     ) async {
-        if config.largeTransaction {
-            await checkLargeTransactions(transactions: transactions, threshold: config.largeTransactionThreshold)
-        }
-        if config.lowBalance {
-            await checkLowBalance(accounts: accounts, threshold: config.lowBalanceThreshold)
-        }
-        if config.highUtilization {
-            await checkHighUtilization(accounts: accounts, threshold: config.creditUtilizationThreshold)
-        }
-        persistNotifiedIds()
-    }
-
-    private func checkLargeTransactions(transactions: [TransactionDTO], threshold: Double) async {
-        let large = NotificationTriggerSelection.largeTransactions(
-            from: transactions,
-            threshold: threshold,
-            excluding: notifiedTransactionIdSet
+        let evaluation = NotificationTriggerSelection.evaluate(
+            transactions: transactions,
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            config: config,
+            deliveredDedupKeys: deliveredDedupKeySet
         )
 
-        for tx in large {
+        for resolvedKey in evaluation.resolvedDedupKeys {
+            deliveredDedupKeySet.remove(resolvedKey)
+            deliveredDedupKeys.removeAll { $0 == resolvedKey }
+        }
+
+        for decision in evaluation.decisions {
             let didSchedule = await sendNotification(
-                title: "Large Transaction",
-                body: "\(tx.displayName): \(Formatters.currency(tx.displayAmount, format: .full))",
-                identifier: NotifKey.largeTx(tx.id)
+                title: decision.title,
+                body: decision.body,
+                identifier: decision.dedupKey
             )
             guard didSchedule else { continue }
-            notifiedTransactionIds.append(tx.id)
-            notifiedTransactionIdSet.insert(tx.id)
+            deliveredDedupKeys.append(decision.dedupKey)
+            deliveredDedupKeySet.insert(decision.dedupKey)
         }
 
-        // LRU cap: drop oldest entries first
-        if notifiedTransactionIds.count > 500 {
-            let excess = notifiedTransactionIds.count - 500
-            let removed = notifiedTransactionIds.prefix(excess)
-            notifiedTransactionIds.removeFirst(excess)
-            for id in removed { notifiedTransactionIdSet.remove(id) }
+        if deliveredDedupKeys.count > 1_000 {
+            let excess = deliveredDedupKeys.count - 1_000
+            let removed = deliveredDedupKeys.prefix(excess)
+            deliveredDedupKeys.removeFirst(excess)
+            for key in removed { deliveredDedupKeySet.remove(key) }
         }
-    }
 
-    private func checkLowBalance(accounts: [AccountDTO], threshold: Double) async {
-        let lowAccounts = NotificationTriggerSelection.lowBalanceAccounts(
-            from: accounts,
-            threshold: threshold
-        )
-
-        clearResolvedDedup(
-            activeIds: Set(lowAccounts.map(\.id)),
-            allIds: Set(accounts.filter { $0.type == .depository }.map(\.id)),
-            keyPrefix: NotifKey.dedupLow
-        )
-
-        for account in lowAccounts {
-            let key = NotifKey.dedupLow(account.id)
-            guard !notifiedAccountIds.contains(key) else { continue }
-            let didSchedule = await sendNotification(
-                title: "Low Balance",
-                body: "\(account.name): \(Formatters.currency(account.balances.effectiveBalance, format: .full))",
-                identifier: NotifKey.lowBalance(account.id)
-            )
-            if didSchedule {
-                notifiedAccountIds.insert(key)
-            }
-        }
-    }
-
-    private func checkHighUtilization(accounts: [AccountDTO], threshold: Double) async {
-        let highUtil = NotificationTriggerSelection.highUtilizationAccounts(
-            from: accounts,
-            threshold: threshold
-        )
-
-        clearResolvedDedup(
-            activeIds: Set(highUtil.map(\.id)),
-            allIds: Set(accounts.filter { $0.type == .credit }.map(\.id)),
-            keyPrefix: NotifKey.dedupUtil
-        )
-
-        for account in highUtil {
-            let key = NotifKey.dedupUtil(account.id)
-            guard !notifiedAccountIds.contains(key) else { continue }
-            let util = account.balances.utilizationPercent ?? 0
-            let didSchedule = await sendNotification(
-                title: "High Credit Utilization",
-                body: "\(account.name): \(Formatters.percent(util)) used",
-                identifier: NotifKey.highUtil(account.id)
-            )
-            if didSchedule {
-                notifiedAccountIds.insert(key)
-            }
-        }
-    }
-
-    /// Remove dedup entries for accounts whose condition resolved
-    private func clearResolvedDedup(activeIds: Set<String>, allIds: Set<String>, keyPrefix: (String) -> String) {
-        for id in allIds where !activeIds.contains(id) {
-            notifiedAccountIds.remove(keyPrefix(id))
-        }
+        persistNotifiedIds()
     }
 
     private func sendNotification(title: String, body: String, identifier: String) async -> Bool {
@@ -243,5 +175,36 @@ final class NotificationService: NotificationServiceProtocol {
         } catch {
             return false
         }
+    }
+
+    private static func migratedLegacyDedupKeys(from defaults: UserDefaults) -> [String] {
+        var keys: [String] = []
+        var keySet = Set<String>()
+
+        func append(_ key: String) {
+            guard keySet.insert(key).inserted else { return }
+            keys.append(key)
+        }
+
+        for transactionID in defaults.stringArray(forKey: legacyNotifiedTxKey) ?? [] {
+            append(NotificationTriggerSelection.dedupKey(kind: .largeTransaction, sourceID: transactionID))
+        }
+
+        for legacyAccountKey in defaults.stringArray(forKey: legacyNotifiedAccountKey) ?? [] {
+            if legacyAccountKey.hasPrefix("low-") {
+                let accountID = String(legacyAccountKey.dropFirst("low-".count))
+                append(NotificationTriggerSelection.dedupKey(kind: .lowBalance, sourceID: accountID))
+            } else if legacyAccountKey.hasPrefix("util-") {
+                let accountID = String(legacyAccountKey.dropFirst("util-".count))
+                append(NotificationTriggerSelection.dedupKey(kind: .highUtilization, sourceID: accountID))
+            }
+        }
+
+        if !keys.isEmpty {
+            defaults.set(keys, forKey: deliveredDedupKeysKey)
+        }
+        defaults.removeObject(forKey: legacyNotifiedTxKey)
+        defaults.removeObject(forKey: legacyNotifiedAccountKey)
+        return keys
     }
 }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -912,6 +912,10 @@ struct NotificationSettingsView: View {
                         }
                     }
                     .disabled(permissionPresentation.isNotificationToggleDisabled)
+
+                Text("Alerts are evaluated from local cached VaultPeek data. Lock-screen copy avoids account names, merchants, exact balances, and transaction amounts.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Transaction alerts") {
@@ -978,6 +982,30 @@ struct NotificationSettingsView: View {
                 )
                 .detailText()
                 .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Recurring alerts") {
+                Toggle("New recurring charge detected", isOn: $state.notifyRecurringChargeDetected)
+                    .disabled(areNotificationControlsDisabled)
+
+                Toggle("Recurring charge changed", isOn: $state.notifyRecurringChargeChanged)
+                    .disabled(areNotificationControlsDisabled)
+
+                Toggle("Recurring charge due soon", isOn: $state.notifyRecurringChargeDueSoon)
+                    .disabled(areNotificationControlsDisabled)
+
+                Text("Due-soon alerts use inferred recurring patterns from synced transaction history and the default 3-day window.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Connection alerts") {
+                Toggle("Broken connection or stale sync", isOn: $state.notifyBrokenConnection)
+                    .disabled(areNotificationControlsDisabled)
+
+                Text("Alerts point you back to VaultPeek when a linked institution needs login, reports a sync error, or local data has gone stale.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .formStyle(.grouped)

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -362,9 +362,16 @@ public enum NotificationTriggerSelection {
     private static func recurringChargeChangedDecision(
         for recurring: RecurringTransaction
     ) -> NotificationTriggerDecision {
-        NotificationTriggerDecision(
+        // Key on the changed amount, not just the stream id, so a second price
+        // increase on the same stream (e.g. $10→$15 then $15→$20) produces a
+        // new dedupe key and is not suppressed by the first change alert.
+        let latestAmountCents = Int((recurring.latestAmount * 100).rounded())
+        return NotificationTriggerDecision(
             kind: .recurringChargeChanged,
-            dedupKey: dedupKey(kind: .recurringChargeChanged, sourceID: recurring.id),
+            dedupKey: dedupKey(
+                kind: .recurringChargeChanged,
+                sourceID: "\(recurring.id)#\(latestAmountCents)"
+            ),
             title: "Recurring charge changed",
             body: "A recurring charge appears higher than its recent pattern.",
             severity: .warning
@@ -374,9 +381,16 @@ public enum NotificationTriggerSelection {
     private static func recurringChargeDueSoonDecision(
         for recurring: RecurringTransaction
     ) -> NotificationTriggerDecision {
-        NotificationTriggerDecision(
+        // Key on the specific due date so each due occurrence can notify
+        // independently. Using only the stream id would let one cycle's
+        // delivered key suppress the next cycle's due-soon alert when the app
+        // was asleep across the gap and sync advanced nextExpectedDate.
+        return NotificationTriggerDecision(
             kind: .recurringChargeDueSoon,
-            dedupKey: dedupKey(kind: .recurringChargeDueSoon, sourceID: recurring.id),
+            dedupKey: dedupKey(
+                kind: .recurringChargeDueSoon,
+                sourceID: "\(recurring.id)#\(recurring.nextExpectedDate)"
+            ),
             title: "Recurring charge due soon",
             body: "An inferred recurring charge is expected soon.",
             severity: .informational

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -5,33 +5,45 @@ public struct NotificationTriggers: Sendable {
     public var largeTransaction: Bool
     public var lowBalance: Bool
     public var highUtilization: Bool
+    public var recurringChargeDetected: Bool
+    public var recurringChargeChanged: Bool
+    public var recurringChargeDueSoon: Bool
     public var staleSync: Bool
     public var loginRequired: Bool
     public var itemError: Bool
     public var largeTransactionThreshold: Double
     public var lowBalanceThreshold: Double
     public var creditUtilizationThreshold: Double
+    public var recurringDueSoonDays: Int
 
     public init(
         largeTransaction: Bool = true,
         lowBalance: Bool = true,
         highUtilization: Bool = true,
+        recurringChargeDetected: Bool = true,
+        recurringChargeChanged: Bool = true,
+        recurringChargeDueSoon: Bool = true,
         staleSync: Bool = true,
         loginRequired: Bool = true,
         itemError: Bool = true,
         largeTransactionThreshold: Double = 500,
         lowBalanceThreshold: Double = 100,
-        creditUtilizationThreshold: Double = 30
+        creditUtilizationThreshold: Double = 30,
+        recurringDueSoonDays: Int = 3
     ) {
         self.largeTransaction = largeTransaction
         self.lowBalance = lowBalance
         self.highUtilization = highUtilization
+        self.recurringChargeDetected = recurringChargeDetected
+        self.recurringChargeChanged = recurringChargeChanged
+        self.recurringChargeDueSoon = recurringChargeDueSoon
         self.staleSync = staleSync
         self.loginRequired = loginRequired
         self.itemError = itemError
         self.largeTransactionThreshold = largeTransactionThreshold
         self.lowBalanceThreshold = lowBalanceThreshold
         self.creditUtilizationThreshold = creditUtilizationThreshold
+        self.recurringDueSoonDays = recurringDueSoonDays
     }
 }
 
@@ -42,12 +54,16 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
     case highUtilization = "high-utilization"
     case lowBalance = "low-balance"
     case largeTransaction = "large-transaction"
+    case recurringChargeDetected = "recurring-charge-detected"
+    case recurringChargeChanged = "recurring-charge-changed"
+    case recurringChargeDueSoon = "recurring-charge-due-soon"
 
     public var clearsWhenResolved: Bool {
         switch self {
-        case .itemError, .loginRequired, .syncStale, .highUtilization, .lowBalance:
+        case .itemError, .loginRequired, .syncStale, .highUtilization, .lowBalance,
+             .recurringChargeChanged, .recurringChargeDueSoon:
             true
-        case .largeTransaction:
+        case .largeTransaction, .recurringChargeDetected:
             false
         }
     }
@@ -103,8 +119,11 @@ public enum NotificationTriggerSelection {
     public static func evaluate(
         transactions: [TransactionDTO] = [],
         accounts: [AccountDTO] = [],
+        recurringTransactions: [RecurringTransaction] = [],
         itemStatuses: [ItemStatus] = [],
         isSyncStale: Bool = false,
+        now: Date = Date(),
+        calendar: Calendar = .current,
         config: NotificationTriggers = NotificationTriggers(),
         deliveredDedupKeys: Set<String> = []
     ) -> NotificationTriggerEvaluation {
@@ -144,6 +163,29 @@ public enum NotificationTriggerSelection {
         if config.lowBalance {
             for account in lowBalanceAccounts(from: accounts, threshold: config.lowBalanceThreshold) {
                 append(lowBalanceDecision(for: account))
+            }
+        }
+
+        if config.recurringChargeChanged {
+            for recurring in changedRecurringCharges(from: recurringTransactions) {
+                append(recurringChargeChangedDecision(for: recurring))
+            }
+        }
+
+        if config.recurringChargeDueSoon {
+            for recurring in dueSoonRecurringCharges(
+                from: recurringTransactions,
+                withinDays: config.recurringDueSoonDays,
+                now: now,
+                calendar: calendar
+            ) {
+                append(recurringChargeDueSoonDecision(for: recurring))
+            }
+        }
+
+        if config.recurringChargeDetected {
+            for recurring in detectedRecurringCharges(from: recurringTransactions) {
+                append(recurringChargeDetectedDecision(for: recurring))
             }
         }
 
@@ -210,6 +252,41 @@ public enum NotificationTriggerSelection {
         }
     }
 
+    public static func detectedRecurringCharges(
+        from recurringTransactions: [RecurringTransaction],
+        minimumConfidence: Double = RecurringTransaction.priceIncreaseConfidenceThreshold
+    ) -> [RecurringTransaction] {
+        recurringTransactions.filter { $0.confidence >= minimumConfidence }
+    }
+
+    public static func changedRecurringCharges(
+        from recurringTransactions: [RecurringTransaction]
+    ) -> [RecurringTransaction] {
+        recurringTransactions.filter(\.hasPriceIncrease)
+    }
+
+    public static func dueSoonRecurringCharges(
+        from recurringTransactions: [RecurringTransaction],
+        withinDays: Int,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [RecurringTransaction] {
+        guard withinDays >= 0 else { return [] }
+        let today = calendar.startOfDay(for: now)
+        guard let windowEnd = calendar.date(byAdding: .day, value: withinDays, to: today) else {
+            return []
+        }
+
+        return recurringTransactions.filter { recurring in
+            guard recurring.confidence >= RecurringTransaction.priceIncreaseConfidenceThreshold,
+                  let dueDate = Formatters.parseTransactionDate(recurring.nextExpectedDate)
+            else { return false }
+
+            let dueStart = calendar.startOfDay(for: dueDate)
+            return dueStart >= today && dueStart <= windowEnd
+        }
+    }
+
     private static func itemErrorDecision(for item: ItemStatus) -> NotificationTriggerDecision {
         NotificationTriggerDecision(
             kind: .itemError,
@@ -266,6 +343,42 @@ public enum NotificationTriggerSelection {
             dedupKey: dedupKey(kind: .largeTransaction, sourceID: transaction.id),
             title: "Large transaction alert",
             body: "A local transaction crossed your configured threshold.",
+            severity: .informational
+        )
+    }
+
+    private static func recurringChargeDetectedDecision(
+        for recurring: RecurringTransaction
+    ) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .recurringChargeDetected,
+            dedupKey: dedupKey(kind: .recurringChargeDetected, sourceID: recurring.id),
+            title: "Recurring charge detected",
+            body: "VaultPeek found a repeated local charge pattern.",
+            severity: .informational
+        )
+    }
+
+    private static func recurringChargeChangedDecision(
+        for recurring: RecurringTransaction
+    ) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .recurringChargeChanged,
+            dedupKey: dedupKey(kind: .recurringChargeChanged, sourceID: recurring.id),
+            title: "Recurring charge changed",
+            body: "A recurring charge appears higher than its recent pattern.",
+            severity: .warning
+        )
+    }
+
+    private static func recurringChargeDueSoonDecision(
+        for recurring: RecurringTransaction
+    ) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .recurringChargeDueSoon,
+            dedupKey: dedupKey(kind: .recurringChargeDueSoon, sourceID: recurring.id),
+            title: "Recurring charge due soon",
+            body: "An inferred recurring charge is expected soon.",
             severity: .informational
         )
     }

--- a/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
@@ -156,6 +156,56 @@ struct NotificationTriggerEvaluationTests {
         #expect(resolved.resolvedDedupKeys.contains(stickyChangedStreamDetectedKey) == false)
     }
 
+    @Test("A second price increase on the same stream notifies after the first was delivered")
+    func secondPriceIncreaseNotifiesAfterFirstDelivered() {
+        let firstChange = NotificationTriggerSelection.evaluate(
+            recurringTransactions: [
+                recurring(id: "Stream", latestAmount: 15, trailingAverageAmount: 10, nextExpectedDate: "2026-07-16"),
+            ],
+            now: fixedNow,
+            config: testConfig
+        )
+        let delivered = firstChange.activeDedupKeys
+        #expect(firstChange.decisions.contains { $0.kind == .recurringChargeChanged })
+
+        // Same stream id, higher latest amount: the second increase must not be
+        // suppressed by the first change alert's delivered key.
+        let secondChange = NotificationTriggerSelection.evaluate(
+            recurringTransactions: [
+                recurring(id: "Stream", latestAmount: 20, trailingAverageAmount: 10, nextExpectedDate: "2026-07-16"),
+            ],
+            now: fixedNow,
+            config: testConfig,
+            deliveredDedupKeys: delivered
+        )
+        #expect(secondChange.decisions.contains { $0.kind == .recurringChargeChanged })
+    }
+
+    @Test("A new due-soon cycle notifies even after the prior cycle was delivered")
+    func dueSoonNotifiesPerCycle() {
+        let june = NotificationTriggerSelection.evaluate(
+            recurringTransactions: [
+                recurring(id: "Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-06-16"),
+            ],
+            now: fixedNow,
+            config: testConfig
+        )
+        let delivered = june.activeDedupKeys
+        #expect(june.decisions.contains { $0.kind == .recurringChargeDueSoon })
+
+        // Next cycle's due date, evaluated when it enters the window, must not be
+        // suppressed by the previous cycle's delivered due-soon key.
+        let july = NotificationTriggerSelection.evaluate(
+            recurringTransactions: [
+                recurring(id: "Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-07-16"),
+            ],
+            now: Formatters.parseTransactionDate("2026-07-14")!,
+            config: testConfig,
+            deliveredDedupKeys: delivered
+        )
+        #expect(july.decisions.contains { $0.kind == .recurringChargeDueSoon })
+    }
+
     @Test("Dedup keys are stable and do not expose source identifiers")
     func dedupKeysAreStableAndOpaque() {
         let key = NotificationTriggerSelection.dedupKey(

--- a/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
@@ -18,12 +18,17 @@ struct NotificationTriggerEvaluationTests {
                 credit(id: "acct-high-util", current: -4_500, limit: 5_000),
                 credit(id: "acct-at-util-threshold", current: -300, limit: 1_000),
             ],
+            recurringTransactions: [
+                recurring(id: "Changed Stream", latestAmount: 16, trailingAverageAmount: 10, nextExpectedDate: "2026-06-16"),
+                recurring(id: "Detected Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-07-16"),
+            ],
             itemStatuses: [
                 ItemStatus(id: "item-login", institutionName: "Example Bank", status: .loginRequired),
                 ItemStatus(id: "item-error", institutionName: "City Credit", status: .error),
                 ItemStatus(id: "item-ok", institutionName: "Healthy Bank", status: .connected),
             ],
             isSyncStale: true,
+            now: fixedNow,
             config: testConfig
         )
 
@@ -34,6 +39,10 @@ struct NotificationTriggerEvaluationTests {
             NotificationTriggerKind.syncStale,
             NotificationTriggerKind.highUtilization,
             NotificationTriggerKind.lowBalance,
+            NotificationTriggerKind.recurringChargeChanged,
+            NotificationTriggerKind.recurringChargeDueSoon,
+            NotificationTriggerKind.recurringChargeDetected,
+            NotificationTriggerKind.recurringChargeDetected,
             NotificationTriggerKind.largeTransaction,
             NotificationTriggerKind.largeTransaction,
         ])
@@ -44,6 +53,10 @@ struct NotificationTriggerEvaluationTests {
             NotificationTriggerSeverity.warning,
             NotificationTriggerSeverity.warning,
             NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.warning,
+            NotificationTriggerSeverity.informational,
+            NotificationTriggerSeverity.informational,
+            NotificationTriggerSeverity.informational,
             NotificationTriggerSeverity.informational,
             NotificationTriggerSeverity.informational,
         ])
@@ -59,11 +72,16 @@ struct NotificationTriggerEvaluationTests {
                 depository(id: "acct-low", balance: 50),
                 credit(id: "acct-high-util", current: -4_500, limit: 5_000),
             ],
+            recurringTransactions: [
+                recurring(id: "Changed Stream", latestAmount: 16, trailingAverageAmount: 10, nextExpectedDate: "2026-06-16"),
+                recurring(id: "Detected Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-07-16"),
+            ],
             itemStatuses: [
                 ItemStatus(id: "item-login", status: .loginRequired),
                 ItemStatus(id: "item-error", status: .error),
             ],
             isSyncStale: true,
+            now: fixedNow,
             config: testConfig
         )
         let deliveredKeys = active.activeDedupKeys
@@ -74,11 +92,16 @@ struct NotificationTriggerEvaluationTests {
                 depository(id: "acct-low", balance: 50),
                 credit(id: "acct-high-util", current: -4_500, limit: 5_000),
             ],
+            recurringTransactions: [
+                recurring(id: "Changed Stream", latestAmount: 16, trailingAverageAmount: 10, nextExpectedDate: "2026-06-16"),
+                recurring(id: "Detected Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-07-16"),
+            ],
             itemStatuses: [
                 ItemStatus(id: "item-login", status: .loginRequired),
                 ItemStatus(id: "item-error", status: .error),
             ],
             isSyncStale: true,
+            now: fixedNow,
             config: testConfig,
             deliveredDedupKeys: deliveredKeys
         )
@@ -93,11 +116,15 @@ struct NotificationTriggerEvaluationTests {
                 depository(id: "acct-low", balance: 500),
                 credit(id: "acct-high-util", current: -200, limit: 5_000),
             ],
+            recurringTransactions: [
+                recurring(id: "Detected Stream", latestAmount: 20, trailingAverageAmount: 20, nextExpectedDate: "2026-07-16"),
+            ],
             itemStatuses: [
                 ItemStatus(id: "item-login", status: .connected),
                 ItemStatus(id: "item-error", status: .connected),
             ],
             isSyncStale: false,
+            now: fixedNow,
             config: testConfig,
             deliveredDedupKeys: deliveredKeys
         )
@@ -106,11 +133,27 @@ struct NotificationTriggerEvaluationTests {
             kind: .largeTransaction,
             sourceID: "tx-large"
         )
+        let stickyDetectedKey = NotificationTriggerSelection.dedupKey(
+            kind: .recurringChargeDetected,
+            sourceID: recurring(id: "Detected Stream").id
+        )
+        let stickyChangedStreamDetectedKey = NotificationTriggerSelection.dedupKey(
+            kind: .recurringChargeDetected,
+            sourceID: recurring(id: "Changed Stream").id
+        )
 
         #expect(resolved.decisions.isEmpty)
-        #expect(resolved.activeDedupKeys.isEmpty)
-        #expect(resolved.resolvedDedupKeys == deliveredKeys.subtracting([stickyLargeTransactionKey]))
+        #expect(resolved.activeDedupKeys == [stickyDetectedKey])
+        #expect(
+            resolved.resolvedDedupKeys == deliveredKeys.subtracting([
+                stickyLargeTransactionKey,
+                stickyDetectedKey,
+                stickyChangedStreamDetectedKey,
+            ])
+        )
         #expect(resolved.resolvedDedupKeys.contains(stickyLargeTransactionKey) == false)
+        #expect(resolved.resolvedDedupKeys.contains(stickyDetectedKey) == false)
+        #expect(resolved.resolvedDedupKeys.contains(stickyChangedStreamDetectedKey) == false)
     }
 
     @Test("Dedup keys are stable and do not expose source identifiers")
@@ -160,10 +203,19 @@ struct NotificationTriggerEvaluationTests {
                     institutionName: institutionName
                 ),
             ],
+            recurringTransactions: [
+                recurring(
+                    id: "Sensitive Subscription",
+                    latestAmount: 22.22,
+                    trailingAverageAmount: 10,
+                    nextExpectedDate: "2026-06-16"
+                ),
+            ],
             itemStatuses: [
                 ItemStatus(id: rawItemID, institutionName: institutionName, status: .error),
             ],
             isSyncStale: true,
+            now: fixedNow,
             config: testConfig
         )
 
@@ -179,13 +231,53 @@ struct NotificationTriggerEvaluationTests {
             merchantName,
             institutionName,
             "Raw Sensitive Merchant",
+            "Sensitive Subscription",
             "9876.54",
             "12.34",
+            "22.22",
         ] {
             #expect(renderedCopy.contains(privateText) == false)
         }
 
         #expect(evaluation.decisions.allSatisfy { !$0.body.contains("$") })
+    }
+
+    @Test("Disabled trigger families suppress their decisions")
+    func disabledTriggerFamiliesSuppressDecisions() {
+        let evaluation = NotificationTriggerSelection.evaluate(
+            transactions: [transaction(id: "tx-large", amount: 650)],
+            accounts: [
+                depository(id: "acct-low", balance: 50),
+                credit(id: "acct-high-util", current: -4_500, limit: 5_000),
+            ],
+            recurringTransactions: [
+                recurring(id: "Changed Stream", latestAmount: 16, trailingAverageAmount: 10, nextExpectedDate: "2026-06-16"),
+            ],
+            itemStatuses: [
+                ItemStatus(id: "item-login", status: .loginRequired),
+                ItemStatus(id: "item-error", status: .error),
+            ],
+            isSyncStale: true,
+            now: fixedNow,
+            config: NotificationTriggers(
+                largeTransaction: false,
+                lowBalance: false,
+                highUtilization: false,
+                recurringChargeDetected: false,
+                recurringChargeChanged: false,
+                recurringChargeDueSoon: false,
+                staleSync: false,
+                loginRequired: false,
+                itemError: false,
+                largeTransactionThreshold: 500,
+                lowBalanceThreshold: 100,
+                creditUtilizationThreshold: 30
+            )
+        )
+
+        #expect(evaluation.decisions.isEmpty)
+        #expect(evaluation.activeDedupKeys.isEmpty)
+        #expect(evaluation.resolvedDedupKeys.isEmpty)
     }
 
     private var testConfig: NotificationTriggers {
@@ -223,6 +315,30 @@ struct NotificationTriggerEvaluationTests {
             name: "Synthetic Credit",
             type: .credit,
             balances: BalanceDTO(current: current, limit: limit)
+        )
+    }
+
+    private var fixedNow: Date {
+        Formatters.parseTransactionDate("2026-06-14")!
+    }
+
+    private func recurring(
+        id merchantName: String,
+        latestAmount: Double = 20,
+        trailingAverageAmount: Double? = 20,
+        nextExpectedDate: String = "2026-07-16"
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchantName,
+            frequency: .monthly,
+            averageAmount: trailingAverageAmount ?? latestAmount,
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            lastDate: "2026-05-16",
+            nextExpectedDate: nextExpectedDate,
+            category: nil,
+            transactionCount: 3,
+            confidence: 0.9
         )
     }
 }


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-417/complete-retention-alert-triggers-and-notification-settings\n\n## Summary\n- Add core alert decisions for recurring charge detected, recurring charge changed, due-soon recurring charges, and broken connection/stale sync paths alongside existing large transaction, low balance, and high utilization alerts.\n- Route app notifications through the shared core evaluator using cached local data, privacy-safe copy, opaque dedupe keys, and a migration from legacy local dedupe defaults.\n- Expose per-trigger notification controls plus recovery/privacy guidance in Settings.\n\n## Tests\n- PASS: git diff --check\n- PASS: swift test --skip-update --filter NotificationTriggerEvaluationTests\n\n## Risks\n- Recurring due-soon uses the existing inferred recurring detector and a default 3-day window; unusual merchant cadence can still produce false positives/negatives.\n- Notification scheduling itself remains macOS/permission dependent and was validated through unit-covered trigger selection plus app build during the focused test run, not by delivering live notifications.\n- SwiftPM printed one transient internal corrupted JSON message during the first cold test build, but the rerun completed cleanly.