### PR TITLE
AND-403: Add weekly money review loop

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -21,6 +21,8 @@ final class AppState {
         static let notifyLargeTransaction = "notifyLargeTransaction"
         static let notifyLowBalance = "notifyLowBalance"
         static let notifyHighUtilization = "notifyHighUtilization"
+        static let weeklyReviewState = "weeklyReview.state"
+        static let weeklyReviewPreviousSafeToSpend = "weeklyReview.previousSafeToSpend"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
@@ -91,6 +93,12 @@ final class AppState {
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
     var notificationPermissionState: NotificationPermissionState = .notDetermined
+    var weeklyReviewState: WeeklyReviewState = .empty {
+        didSet {
+            guard weeklyReviewState != oldValue else { return }
+            persistWeeklyReviewState()
+        }
+    }
 
     // MARK: - Settings (persisted to UserDefaults)
     var menuBarSummaryMode: MenuBarSummaryMode = .netWorth {
@@ -258,6 +266,7 @@ final class AppState {
         }
         // Balance history
         loadPersistedBalanceHistory()
+        loadPersistedWeeklyReviewState()
         // Launch at login
         launchAtLogin = LaunchService.isEnabled
         // Detached-dashboard intent (AND-384). A headless snapshot render
@@ -369,42 +378,44 @@ final class AppState {
     }
 
     var menuBarAttentionText: String? {
-        menuBarStatusPresentation.attentionText
+        menuBarStatusPresentation.attentionText ?? weeklyReviewPresentation.menuBarPrompt
     }
 
     var menuBarHelpText: String {
         let status = "Status: \(diagnosticsSummary)"
+        let review = weeklyReviewPresentation.menuBarPrompt.map { " Weekly review: \($0)." } ?? ""
         switch menuBarSummaryMode {
         case .netWorth:
-            return "VaultPeek - Net worth: \(menuBarText). \(status)"
+            return "VaultPeek - Net worth: \(menuBarText). \(status)\(review)"
         case .netCash:
-            return "VaultPeek - Net cash: \(menuBarText). \(status)"
+            return "VaultPeek - Net cash: \(menuBarText). \(status)\(review)"
         case .totalCash:
-            return "VaultPeek - Total cash: \(menuBarText). \(status)"
+            return "VaultPeek - Total cash: \(menuBarText). \(status)\(review)"
         case .creditUtilization:
-            return "VaultPeek - Credit utilization: \(menuBarText). \(status)"
+            return "VaultPeek - Credit utilization: \(menuBarText). \(status)\(review)"
         case .recentSpend:
-            return "VaultPeek - Recent spend: \(menuBarText). \(status)"
+            return "VaultPeek - Recent spend: \(menuBarText). \(status)\(review)"
         case .iconOnly:
-            return "VaultPeek. \(status)"
+            return "VaultPeek. \(status)\(review)"
         }
     }
 
     var menuBarAccessibilityLabel: String {
         let status = "Status \(diagnosticsSummary)"
+        let review = weeklyReviewPresentation.menuBarPrompt.map { " Weekly review \($0)." } ?? ""
         switch menuBarSummaryMode {
         case .netWorth:
-            return "VaultPeek net worth \(menuBarText). \(status)"
+            return "VaultPeek net worth \(menuBarText). \(status)\(review)"
         case .netCash:
-            return "VaultPeek net cash \(menuBarText). \(status)"
+            return "VaultPeek net cash \(menuBarText). \(status)\(review)"
         case .totalCash:
-            return "VaultPeek total cash \(menuBarText). \(status)"
+            return "VaultPeek total cash \(menuBarText). \(status)\(review)"
         case .creditUtilization:
-            return "VaultPeek credit utilization \(menuBarText). \(status)"
+            return "VaultPeek credit utilization \(menuBarText). \(status)\(review)"
         case .recentSpend:
-            return "VaultPeek recent spend \(menuBarText). \(status)"
+            return "VaultPeek recent spend \(menuBarText). \(status)\(review)"
         case .iconOnly:
-            return "VaultPeek. \(status)"
+            return "VaultPeek. \(status)\(review)"
         }
     }
 
@@ -602,6 +613,65 @@ final class AppState {
             lastSyncRelative: lastSyncRelative,
             errorMessage: error
         )
+    }
+
+    var weeklyReviewPresentation: WeeklyReviewPresentation {
+        let safeToSpend = SafeToSpendCalculator.compute(
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            cashflow: WealthSummaryPresentation.evaluate(
+                accounts: accounts,
+                transactions: transactions,
+                isDemoMode: usesDemoConnectionPresentation,
+                serverConnected: serverConnected,
+                credentialsConfigured: serverCredentialsConfigured,
+                linkedItemCount: statusItemCount,
+                syncedItemCount: serverSyncedItemCount ?? 0,
+                itemStatuses: itemStatuses,
+                isSyncStale: isSyncStale,
+                lastSyncRelative: lastSyncRelative,
+                statusSyncText: statusSyncText,
+                errorMessage: error,
+                creditUtilizationThreshold: creditUtilizationThreshold,
+                balanceHistory: balanceHistory
+            ).cashflow,
+            asOf: Date()
+        )
+
+        return WeeklyReviewBuilder.evaluate(
+            state: weeklyReviewState,
+            transactionState: weeklyReviewTransactionState,
+            transactions: transactions,
+            recurringTransactions: recurringTransactions,
+            safeToSpend: safeToSpend,
+            previousSafeToSpendAmount: persistedPreviousSafeToSpendAmount,
+            categoryBudgets: CategoryBudgetPlanner.suggestedPresentation(
+                from: transactions,
+                asOf: Date()
+            ),
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale
+        )
+    }
+
+    private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {
+        // AND-403 is intentionally gated on AND-399. Production must provide
+        // trusted/unreviewed transaction state before this returns a value; raw
+        // Plaid transactions alone are not treated as reviewed. Demo mode uses
+        // synthetic ids so the checklist surface remains locally exercisable.
+        guard isDemoMode else { return nil }
+        let unreviewed = Set(transactions.filter(\.pending).map(\.id))
+        let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
+        return WeeklyReviewTransactionState(
+            trustedTransactionIds: trusted,
+            unreviewedTransactionIds: unreviewed
+        )
+    }
+
+    private var persistedPreviousSafeToSpendAmount: Double? {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: Keys.weeklyReviewPreviousSafeToSpend) != nil else { return nil }
+        return defaults.double(forKey: Keys.weeklyReviewPreviousSafeToSpend)
     }
 
     var notificationPermissionPresentation: NotificationPermissionPresentation {
@@ -1153,6 +1223,9 @@ final class AppState {
         balanceHistory = []
         UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
         UserDefaults.standard.removeObject(forKey: Keys.lastTransactionCacheContext)
+        UserDefaults.standard.removeObject(forKey: Keys.weeklyReviewState)
+        UserDefaults.standard.removeObject(forKey: Keys.weeklyReviewPreviousSafeToSpend)
+        weeklyReviewState = .empty
         notificationService.resetDeduplicationState()
 
         return result
@@ -1190,6 +1263,41 @@ final class AppState {
         let granted = await notificationService.requestPermission()
         notificationPermissionState = await notificationService.checkPermissionStatus()
         return granted
+    }
+
+    func toggleWeeklyReviewItem(_ item: WeeklyReviewItem) {
+        if weeklyReviewState.completedItemIds.contains(item.id) {
+            weeklyReviewState.completedItemIds.remove(item.id)
+        } else {
+            weeklyReviewState.completedItemIds.insert(item.id)
+        }
+    }
+
+    func completeWeeklyReview() {
+        let presentation = weeklyReviewPresentation
+        weeklyReviewState.completedItemIds.formUnion(presentation.items.map(\.id))
+        weeklyReviewState.dismissedItemIds = []
+        weeklyReviewState.lastCompletedAt = Date()
+        UserDefaults.standard.set(currentSafeToSpendAmount(), forKey: Keys.weeklyReviewPreviousSafeToSpend)
+    }
+
+    func performWeeklyReviewAction(_ item: WeeklyReviewItem) {
+        switch item.action {
+        case .openReviewInbox:
+            error = "Transaction review inbox is required before weekly review can approve transactions."
+        case .inspectCategory:
+            error = "Category budget drill-in is not available in this slice yet."
+        case .reviewRecurring, .inspectSafeToSpend:
+            break
+        case .reconnectAccount:
+            guard let itemId = ItemRecoveryTarget.itemId(from: itemStatuses) else {
+                Task { await refreshDashboard() }
+                return
+            }
+            Task { await reconnectItem(itemId: itemId) }
+        case .refreshData:
+            Task { await refreshDashboard() }
+        }
     }
 
     func notificationPermissionStatus() async -> NotificationPermissionState {
@@ -1678,6 +1786,46 @@ final class AppState {
         if let data = try? JSONEncoder().encode(balanceHistory) {
             UserDefaults.standard.set(data, forKey: Keys.balanceHistory)
         }
+    }
+
+    private func loadPersistedWeeklyReviewState() {
+        guard let data = UserDefaults.standard.data(forKey: Keys.weeklyReviewState),
+              let state = try? JSONDecoder().decode(WeeklyReviewState.self, from: data)
+        else {
+            weeklyReviewState = .empty
+            return
+        }
+        weeklyReviewState = state
+    }
+
+    private func persistWeeklyReviewState() {
+        guard let data = try? JSONEncoder().encode(weeklyReviewState) else { return }
+        UserDefaults.standard.set(data, forKey: Keys.weeklyReviewState)
+    }
+
+    private func currentSafeToSpendAmount() -> Double {
+        let presentation = WealthSummaryPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            isDemoMode: usesDemoConnectionPresentation,
+            serverConnected: serverConnected,
+            credentialsConfigured: serverCredentialsConfigured,
+            linkedItemCount: statusItemCount,
+            syncedItemCount: serverSyncedItemCount ?? 0,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            statusSyncText: statusSyncText,
+            errorMessage: error,
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            balanceHistory: balanceHistory
+        )
+        return SafeToSpendCalculator.compute(
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            cashflow: presentation.cashflow,
+            asOf: Date()
+        ).amount
     }
 
     // MARK: - Demo Data

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -151,7 +151,7 @@ final class NotificationService: NotificationServiceProtocol {
         for tx in large {
             let didSchedule = await sendNotification(
                 title: "Large Transaction",
-                body: "\(tx.displayName): \(Formatters.currency(tx.displayAmount, format: .full))",
+                body: "A transaction crossed your configured review threshold. Open VaultPeek to review it privately.",
                 identifier: NotifKey.largeTx(tx.id)
             )
             guard didSchedule else { continue }
@@ -185,7 +185,7 @@ final class NotificationService: NotificationServiceProtocol {
             guard !notifiedAccountIds.contains(key) else { continue }
             let didSchedule = await sendNotification(
                 title: "Low Balance",
-                body: "\(account.name): \(Formatters.currency(account.balances.effectiveBalance, format: .full))",
+                body: "A depository account is below your configured threshold. Open VaultPeek to review it privately.",
                 identifier: NotifKey.lowBalance(account.id)
             )
             if didSchedule {
@@ -209,10 +209,9 @@ final class NotificationService: NotificationServiceProtocol {
         for account in highUtil {
             let key = NotifKey.dedupUtil(account.id)
             guard !notifiedAccountIds.contains(key) else { continue }
-            let util = account.balances.utilizationPercent ?? 0
             let didSchedule = await sendNotification(
                 title: "High Credit Utilization",
-                body: "\(account.name): \(Formatters.percent(util)) used",
+                body: "A credit account is above your configured utilization threshold. Open VaultPeek to review it privately.",
                 identifier: NotifKey.highUtil(account.id)
             )
             if didSchedule {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -391,6 +391,9 @@ struct MainPopover: View {
                         DashboardChangeReceiptStrip()
                             .environment(appState)
 
+                        WeeklyReviewCard()
+                            .environment(appState)
+
                         if shouldElevateStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                                 AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)

--- a/Sources/PlaidBar/Views/WeeklyReviewCard.swift
+++ b/Sources/PlaidBar/Views/WeeklyReviewCard.swift
@@ -1,0 +1,236 @@
+import PlaidBarCore
+import SwiftUI
+
+struct WeeklyReviewCard: View {
+    @Environment(AppState.self) private var appState
+
+    private var presentation: WeeklyReviewPresentation {
+        appState.weeklyReviewPresentation
+    }
+
+    var body: some View {
+        let presentation = presentation
+
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            header(presentation)
+
+            if presentation.isBlockedByTransactionReviewDependency {
+                dependencyState
+            } else if presentation.items.isEmpty || presentation.remainingCount == 0 {
+                positiveState(presentation)
+            } else {
+                checklist(presentation)
+            }
+        }
+        .padding(Spacing.sm)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilitySummary(presentation))
+    }
+
+    private func header(_ presentation: WeeklyReviewPresentation) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label("Weekly Review", systemImage: "calendar.badge.checkmark")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            Label(presentation.outcome.title, systemImage: outcomeIcon(presentation.outcome))
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(outcomeTint(presentation.outcome))
+                .lineLimit(1)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(outcomeTint(presentation.outcome).opacity(0.11), in: Capsule())
+                .accessibilityLabel("Weekly review status: \(presentation.outcome.title)")
+        }
+    }
+
+    private var dependencyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("Weekly review unlocks after the transaction review inbox can say which transactions are trusted.")
+                .microText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Label("Waiting for AND-399 review state", systemImage: "checklist")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(SemanticColors.warning)
+                .accessibilityLabel("Waiting for transaction review state")
+        }
+        .padding(Spacing.sm)
+        .nativeInsetSurface()
+    }
+
+    private func positiveState(_ presentation: WeeklyReviewPresentation) -> some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(SemanticColors.positive)
+                .frame(width: 22, height: 22)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Nothing needs review")
+                    .font(.caption.weight(.semibold))
+                Text(nextReviewText(presentation))
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Button {
+                appState.completeWeeklyReview()
+            } label: {
+                Label("Complete", systemImage: "checkmark")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            .help("Complete weekly review")
+            .accessibilityLabel("Complete weekly review")
+        }
+        .padding(Spacing.sm)
+        .nativeInsetSurface(stroke: SemanticColors.positive.opacity(0.18))
+    }
+
+    private func checklist(_ presentation: WeeklyReviewPresentation) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: Spacing.xs) {
+                Text("\(presentation.completedCount)/\(presentation.totalCount) complete")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+
+                if presentation.reviewedTransactionCount > 0 {
+                    Text("\(presentation.reviewedTransactionCount) reviewed this week")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            ForEach(presentation.items) { item in
+                WeeklyReviewItemRow(
+                    item: item,
+                    isCompleted: appState.weeklyReviewState.completedItemIds.contains(item.id),
+                    isDisabled: appState.isLoading,
+                    onToggle: { appState.toggleWeeklyReviewItem(item) },
+                    onAction: { appState.performWeeklyReviewAction(item) }
+                )
+            }
+
+            Button {
+                appState.completeWeeklyReview()
+            } label: {
+                Label("Complete Review", systemImage: "checkmark.circle")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(presentation.totalCount == 0)
+            .accessibilityHint("Records this weekly review locally on this Mac.")
+        }
+    }
+
+    private func nextReviewText(_ presentation: WeeklyReviewPresentation) -> String {
+        guard let nextReviewDueAt = presentation.nextReviewDueAt else {
+            return "Complete this review to start the weekly cadence."
+        }
+        return "Next review \(Formatters.relativeDate(nextReviewDueAt))."
+    }
+
+    private func accessibilitySummary(_ presentation: WeeklyReviewPresentation) -> String {
+        if presentation.isBlockedByTransactionReviewDependency {
+            return "Weekly review. Transaction review inbox required before this checklist can run."
+        }
+        return "Weekly review. \(presentation.outcome.title). \(presentation.completedCount) of \(presentation.totalCount) items complete."
+    }
+
+    private func outcomeIcon(_ outcome: WeeklyReviewOutcome) -> String {
+        switch outcome {
+        case .looksGood: "checkmark.circle.fill"
+        case .reviewItems: "exclamationmark.circle.fill"
+        case .payAttention: "exclamationmark.triangle.fill"
+        case .waitingForTransactionReview: "checklist"
+        }
+    }
+
+    private func outcomeTint(_ outcome: WeeklyReviewOutcome) -> Color {
+        switch outcome {
+        case .looksGood: SemanticColors.positive
+        case .reviewItems, .waitingForTransactionReview: SemanticColors.warning
+        case .payAttention: SemanticColors.negative
+        }
+    }
+}
+
+private struct WeeklyReviewItemRow: View {
+    let item: WeeklyReviewItem
+    let isCompleted: Bool
+    let isDisabled: Bool
+    let onToggle: () -> Void
+    let onAction: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Button(action: onToggle) {
+                Image(systemName: isCompleted ? "checkmark.square.fill" : "square")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(isCompleted ? SemanticColors.positive : tint)
+            .help(isCompleted ? "Mark incomplete" : "Mark complete")
+            .accessibilityLabel(isCompleted ? "Completed" : "Not completed")
+            .accessibilityValue(item.title)
+
+            Image(systemName: item.severity.statusSymbolName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 18, height: 18)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(item.title)
+                    .font(.caption.weight(.semibold))
+                    .strikethrough(isCompleted)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+
+                Text(item.detail)
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: Spacing.xs)
+
+            Button(action: onAction) {
+                Label(item.action.title, systemImage: item.action.iconName)
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            .help(item.action.title)
+            .accessibilityLabel(item.action.title)
+            .accessibilityHint(item.accessibilityHint)
+            .disabled(isDisabled)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.rowVertical)
+        .nativeInsetSurface(stroke: isCompleted ? SemanticColors.positive.opacity(0.16) : tint.opacity(0.14))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(item.accessibilityLabel)
+        .accessibilityValue(isCompleted ? "Completed" : "Not completed")
+    }
+
+    private var tint: Color {
+        switch item.severity {
+        case .healthy: .secondary
+        case .warning: SemanticColors.warning
+        case .blocked: SemanticColors.negative
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -1,0 +1,451 @@
+import Foundation
+
+public enum WeeklyReviewCadence: String, Codable, Sendable, CaseIterable, Hashable {
+    case weekly
+
+    public var days: Int {
+        switch self {
+        case .weekly: 7
+        }
+    }
+}
+
+public struct WeeklyReviewState: Codable, Sendable, Equatable {
+    public var lastCompletedAt: Date?
+    public var cadence: WeeklyReviewCadence
+    public var completedItemIds: Set<String>
+    public var dismissedItemIds: Set<String>
+
+    public init(
+        lastCompletedAt: Date? = nil,
+        cadence: WeeklyReviewCadence = .weekly,
+        completedItemIds: Set<String> = [],
+        dismissedItemIds: Set<String> = []
+    ) {
+        self.lastCompletedAt = lastCompletedAt
+        self.cadence = cadence
+        self.completedItemIds = completedItemIds
+        self.dismissedItemIds = dismissedItemIds
+    }
+
+    public func nextReviewDueAt(calendar: Calendar = .current) -> Date? {
+        guard let lastCompletedAt else { return nil }
+        return calendar.date(byAdding: .day, value: cadence.days, to: lastCompletedAt)
+    }
+
+    public func isDue(asOf date: Date, calendar: Calendar = .current) -> Bool {
+        guard let dueAt = nextReviewDueAt(calendar: calendar) else { return true }
+        return date >= dueAt
+    }
+
+    public static let empty = WeeklyReviewState()
+}
+
+public struct WeeklyReviewTransactionState: Sendable, Equatable {
+    public let trustedTransactionIds: Set<String>
+    public let unreviewedTransactionIds: Set<String>
+
+    public init(
+        trustedTransactionIds: Set<String>,
+        unreviewedTransactionIds: Set<String>
+    ) {
+        self.trustedTransactionIds = trustedTransactionIds
+        self.unreviewedTransactionIds = unreviewedTransactionIds
+    }
+}
+
+public enum WeeklyReviewOutcome: String, Sendable, Equatable {
+    case looksGood
+    case reviewItems
+    case payAttention
+    case waitingForTransactionReview
+
+    public var title: String {
+        switch self {
+        case .looksGood: "Looks good"
+        case .reviewItems: "Review these few items"
+        case .payAttention: "Pay attention"
+        case .waitingForTransactionReview: "Transaction review required"
+        }
+    }
+}
+
+public enum WeeklyReviewItemKind: String, Sendable, Hashable, CaseIterable {
+    case transactionReview
+    case categoryDrift
+    case upcomingBills
+    case safeToSpendChange
+    case subscriptionChange
+    case connectionHealth
+}
+
+public enum WeeklyReviewAction: String, Sendable, Hashable {
+    case openReviewInbox
+    case inspectCategory
+    case reviewRecurring
+    case inspectSafeToSpend
+    case reconnectAccount
+    case refreshData
+
+    public var title: String {
+        switch self {
+        case .openReviewInbox: "Open Review Inbox"
+        case .inspectCategory: "Inspect Category"
+        case .reviewRecurring: "Review Recurring"
+        case .inspectSafeToSpend: "Inspect Breakdown"
+        case .reconnectAccount: "Reconnect"
+        case .refreshData: "Refresh"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .openReviewInbox: "checklist"
+        case .inspectCategory: "tag"
+        case .reviewRecurring: "calendar.badge.clock"
+        case .inspectSafeToSpend: "banknote"
+        case .reconnectAccount: "link.badge.plus"
+        case .refreshData: "arrow.clockwise"
+        }
+    }
+}
+
+public struct WeeklyReviewItem: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let kind: WeeklyReviewItemKind
+    public let severity: AttentionQueueSeverity
+    public let title: String
+    public let detail: String
+    public let action: WeeklyReviewAction
+    public let accessibilityLabel: String
+    public let accessibilityHint: String
+
+    public init(
+        id: String,
+        kind: WeeklyReviewItemKind,
+        severity: AttentionQueueSeverity,
+        title: String,
+        detail: String,
+        action: WeeklyReviewAction,
+        accessibilityLabel: String? = nil,
+        accessibilityHint: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.severity = severity
+        self.title = title
+        self.detail = detail
+        self.action = action
+        self.accessibilityLabel = accessibilityLabel ?? "\(severity.statusLabel). \(title). \(detail)"
+        self.accessibilityHint = accessibilityHint ?? action.title
+    }
+}
+
+public struct WeeklyReviewPresentation: Sendable, Equatable {
+    public let outcome: WeeklyReviewOutcome
+    public let isDue: Bool
+    public let nextReviewDueAt: Date?
+    public let completedCount: Int
+    public let totalCount: Int
+    public let reviewedTransactionCount: Int
+    public let items: [WeeklyReviewItem]
+    public let isBlockedByTransactionReviewDependency: Bool
+
+    public init(
+        outcome: WeeklyReviewOutcome,
+        isDue: Bool,
+        nextReviewDueAt: Date?,
+        completedCount: Int,
+        totalCount: Int,
+        reviewedTransactionCount: Int,
+        items: [WeeklyReviewItem],
+        isBlockedByTransactionReviewDependency: Bool
+    ) {
+        self.outcome = outcome
+        self.isDue = isDue
+        self.nextReviewDueAt = nextReviewDueAt
+        self.completedCount = completedCount
+        self.totalCount = totalCount
+        self.reviewedTransactionCount = reviewedTransactionCount
+        self.items = items
+        self.isBlockedByTransactionReviewDependency = isBlockedByTransactionReviewDependency
+    }
+
+    public var remainingCount: Int {
+        max(totalCount - completedCount, 0)
+    }
+
+    public var menuBarPrompt: String? {
+        if isBlockedByTransactionReviewDependency { return nil }
+        guard isDue else { return nil }
+        return remainingCount > 0 ? "\(remainingCount) items to review" : "Weekly review due"
+    }
+
+    public var notificationTitle: String {
+        "Weekly review due"
+    }
+
+    public var notificationBody: String {
+        if remainingCount > 0 {
+            return "VaultPeek found \(remainingCount) private item\(remainingCount == 1 ? "" : "s") to review."
+        }
+        return "Open VaultPeek to complete your private weekly review."
+    }
+
+    public static let waitingForTransactionReview = WeeklyReviewPresentation(
+        outcome: .waitingForTransactionReview,
+        isDue: false,
+        nextReviewDueAt: nil,
+        completedCount: 0,
+        totalCount: 0,
+        reviewedTransactionCount: 0,
+        items: [],
+        isBlockedByTransactionReviewDependency: true
+    )
+}
+
+public enum WeeklyReviewBuilder {
+    public static let safeToSpendWarningAmount: Double = 0
+    public static let safeToSpendDropThreshold: Double = 100
+
+    public static func evaluate(
+        state: WeeklyReviewState,
+        transactionState: WeeklyReviewTransactionState?,
+        transactions: [TransactionDTO],
+        recurringTransactions: [RecurringTransaction],
+        safeToSpend: SafeToSpendResult,
+        previousSafeToSpendAmount: Double? = nil,
+        categoryBudgets: CategoryBudgetPresentation = .empty,
+        itemStatuses: [ItemStatus] = [],
+        isSyncStale: Bool = false,
+        asOf date: Date = Date(),
+        calendar: Calendar = .current
+    ) -> WeeklyReviewPresentation {
+        guard let transactionState else {
+            return .waitingForTransactionReview
+        }
+
+        let isDue = state.isDue(asOf: date, calendar: calendar)
+        let nextDue = state.nextReviewDueAt(calendar: calendar)
+        let reviewedCount = reviewedTransactionCount(
+            transactions: transactions,
+            trustedIds: transactionState.trustedTransactionIds,
+            since: state.lastCompletedAt,
+            calendar: calendar
+        )
+        let items = reviewItems(
+            transactionState: transactionState,
+            recurringTransactions: recurringTransactions,
+            safeToSpend: safeToSpend,
+            previousSafeToSpendAmount: previousSafeToSpendAmount,
+            categoryBudgets: categoryBudgets,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            asOf: date,
+            calendar: calendar
+        )
+        let activeItems = items.filter { !state.dismissedItemIds.contains($0.id) }
+        let completedCount = activeItems.reduce(0) { total, item in
+            total + (state.completedItemIds.contains(item.id) ? 1 : 0)
+        }
+        let unresolvedItems = activeItems.filter { !state.completedItemIds.contains($0.id) }
+        let outcome = outcome(for: unresolvedItems)
+
+        return WeeklyReviewPresentation(
+            outcome: outcome,
+            isDue: isDue,
+            nextReviewDueAt: nextDue,
+            completedCount: completedCount,
+            totalCount: activeItems.count,
+            reviewedTransactionCount: reviewedCount,
+            items: activeItems,
+            isBlockedByTransactionReviewDependency: false
+        )
+    }
+
+    private static func reviewItems(
+        transactionState: WeeklyReviewTransactionState,
+        recurringTransactions: [RecurringTransaction],
+        safeToSpend: SafeToSpendResult,
+        previousSafeToSpendAmount: Double?,
+        categoryBudgets: CategoryBudgetPresentation,
+        itemStatuses: [ItemStatus],
+        isSyncStale: Bool,
+        asOf date: Date,
+        calendar: Calendar
+    ) -> [WeeklyReviewItem] {
+        var items: [WeeklyReviewItem] = []
+
+        if !transactionState.unreviewedTransactionIds.isEmpty {
+            let count = transactionState.unreviewedTransactionIds.count
+            items.append(WeeklyReviewItem(
+                id: "weekly-review.transactions",
+                kind: .transactionReview,
+                severity: .warning,
+                title: "\(count) transaction\(count == 1 ? "" : "s") need review",
+                detail: "Approve or categorize the latest inbox items before closing the week.",
+                action: .openReviewInbox,
+                accessibilityHint: "Opens the transaction review inbox."
+            ))
+        }
+
+        let budgetItems = categoryBudgets.items.filter(\.needsAttention)
+        if !budgetItems.isEmpty {
+            let overCount = categoryBudgets.overBudgetCount
+            let title = overCount > 0
+                ? "\(overCount) budget\(overCount == 1 ? "" : "s") over"
+                : "\(categoryBudgets.nearingCount) budget\(categoryBudgets.nearingCount == 1 ? "" : "s") close"
+            items.append(WeeklyReviewItem(
+                id: "weekly-review.category-drift",
+                kind: .categoryDrift,
+                severity: overCount > 0 ? .blocked : .warning,
+                title: title,
+                detail: "Category pressure changed this month.",
+                action: .inspectCategory,
+                accessibilityHint: "Opens the category budget details."
+            ))
+        }
+
+        let upcomingCount = upcomingRecurringCount(
+            recurringTransactions,
+            asOf: date,
+            calendar: calendar
+        )
+        if upcomingCount > 0 {
+            items.append(WeeklyReviewItem(
+                id: "weekly-review.upcoming-bills",
+                kind: .upcomingBills,
+                severity: .warning,
+                title: "\(upcomingCount) upcoming bill\(upcomingCount == 1 ? "" : "s")",
+                detail: "Confirm known obligations before they hit.",
+                action: .reviewRecurring,
+                accessibilityHint: "Opens recurring obligations."
+            ))
+        }
+
+        if let safeToSpendItem = safeToSpendReviewItem(
+            safeToSpend: safeToSpend,
+            previousAmount: previousSafeToSpendAmount
+        ) {
+            items.append(safeToSpendItem)
+        }
+
+        let changedRecurringCount = recurringTransactions.filter {
+            !$0.flags(asOf: date, calendar: calendar).isEmpty
+        }.count
+        if changedRecurringCount > 0 {
+            items.append(WeeklyReviewItem(
+                id: "weekly-review.subscription-changes",
+                kind: .subscriptionChange,
+                severity: .warning,
+                title: "\(changedRecurringCount) recurring charge\(changedRecurringCount == 1 ? "" : "s") changed",
+                detail: "Review price increases or missing expected charges.",
+                action: .reviewRecurring,
+                accessibilityHint: "Opens recurring obligations."
+            ))
+        }
+
+        let unhealthyItems = itemStatuses.filter { $0.status != .connected }.count
+        if unhealthyItems > 0 || isSyncStale {
+            let blocked = itemStatuses.contains { $0.status == .error }
+            items.append(WeeklyReviewItem(
+                id: "weekly-review.connection-health",
+                kind: .connectionHealth,
+                severity: blocked ? .blocked : .warning,
+                title: blocked ? "Connection needs attention" : "Connection freshness changed",
+                detail: unhealthyItems > 0
+                    ? "\(unhealthyItems) linked item\(unhealthyItems == 1 ? "" : "s") need a check."
+                    : "Refresh local data before trusting this review.",
+                action: blocked ? .reconnectAccount : .refreshData,
+                accessibilityHint: blocked ? "Reconnects the affected institution." : "Refreshes local data."
+            ))
+        }
+
+        return items
+    }
+
+    private static func reviewedTransactionCount(
+        transactions: [TransactionDTO],
+        trustedIds: Set<String>,
+        since lastCompletedAt: Date?,
+        calendar: Calendar
+    ) -> Int {
+        guard let lastCompletedAt else { return trustedIds.count }
+        let lastCompletedDay = Formatters.transactionDateString(calendar.startOfDay(for: lastCompletedAt))
+        return transactions.reduce(0) { count, transaction in
+            guard trustedIds.contains(transaction.id), transaction.date >= lastCompletedDay else {
+                return count
+            }
+            return count + 1
+        }
+    }
+
+    private static func upcomingRecurringCount(
+        _ recurringTransactions: [RecurringTransaction],
+        asOf date: Date,
+        calendar: Calendar
+    ) -> Int {
+        let start = calendar.startOfDay(for: date)
+        guard let end = calendar.date(byAdding: .day, value: 7, to: start) else { return 0 }
+        return recurringTransactions.reduce(0) { count, recurring in
+            guard let nextDate = Formatters.parseTransactionDate(recurring.nextExpectedDate) else {
+                return count
+            }
+            return (nextDate >= start && nextDate <= end) ? count + 1 : count
+        }
+    }
+
+    private static func safeToSpendReviewItem(
+        safeToSpend: SafeToSpendResult,
+        previousAmount: Double?
+    ) -> WeeklyReviewItem? {
+        if safeToSpend.amount < safeToSpendWarningAmount {
+            return WeeklyReviewItem(
+                id: "weekly-review.safe-to-spend",
+                kind: .safeToSpendChange,
+                severity: .blocked,
+                title: "Safe-to-spend is below zero",
+                detail: "Committed obligations exceed available money for this period.",
+                action: .inspectSafeToSpend,
+                accessibilityHint: "Opens the safe-to-spend breakdown."
+            )
+        }
+
+        if let previousAmount {
+            let drop = previousAmount - safeToSpend.amount
+            if drop >= safeToSpendDropThreshold {
+                return WeeklyReviewItem(
+                    id: "weekly-review.safe-to-spend",
+                    kind: .safeToSpendChange,
+                    severity: .warning,
+                    title: "Safe-to-spend dropped",
+                    detail: "Available money moved materially since the last review.",
+                    action: .inspectSafeToSpend,
+                    accessibilityHint: "Opens the safe-to-spend breakdown."
+                )
+            }
+        }
+
+        if safeToSpend.confidence < .ok {
+            return WeeklyReviewItem(
+                id: "weekly-review.safe-to-spend",
+                kind: .safeToSpendChange,
+                severity: .warning,
+                title: "Safe-to-spend confidence is low",
+                detail: "A review will be more useful after recurring income and obligations settle.",
+                action: .inspectSafeToSpend,
+                accessibilityHint: "Opens the safe-to-spend breakdown."
+            )
+        }
+
+        return nil
+    }
+
+    private static func outcome(for unresolvedItems: [WeeklyReviewItem]) -> WeeklyReviewOutcome {
+        guard !unresolvedItems.isEmpty else { return .looksGood }
+        if unresolvedItems.contains(where: { $0.severity == .blocked }) {
+            return .payAttention
+        }
+        return .reviewItems
+    }
+}

--- a/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
+++ b/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
@@ -1,0 +1,175 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Weekly review")
+struct WeeklyReviewTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_781_510_400) // 2026-06-14
+
+    @Test("Review waits for transaction review state instead of raw transactions")
+    func waitsForTransactionReviewState() {
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: nil,
+            transactions: [transaction(id: "realistic-raw-id", date: "2026-06-14")],
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(presentation.outcome == .waitingForTransactionReview)
+        #expect(presentation.isBlockedByTransactionReviewDependency)
+        #expect(presentation.items.isEmpty)
+        #expect(presentation.menuBarPrompt == nil)
+    }
+
+    @Test("Derived items summarize review inbox, budgets, recurring, safe-to-spend, and connection health")
+    func derivesWeeklyChecklistItems() {
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: WeeklyReviewState(lastCompletedAt: daysAgo(8)),
+            transactionState: WeeklyReviewTransactionState(
+                trustedTransactionIds: ["tx-trusted"],
+                unreviewedTransactionIds: ["tx-unreviewed"]
+            ),
+            transactions: [transaction(id: "tx-trusted", date: "2026-06-13")],
+            recurringTransactions: [
+                RecurringTransaction(
+                    merchantName: "Synthetic Streaming",
+                    frequency: .monthly,
+                    averageAmount: 20,
+                    latestAmount: 24,
+                    trailingAverageAmount: 20,
+                    lastDate: "2026-06-10",
+                    nextExpectedDate: "2026-06-17",
+                    category: .entertainment,
+                    transactionCount: 4,
+                    confidence: 0.9
+                ),
+            ],
+            safeToSpend: safeToSpend(amount: -25),
+            categoryBudgets: CategoryBudgetPresentation(
+                items: [
+                    CategoryBudgetPresentation.Item(
+                        category: .foodAndDrink,
+                        monthlyLimit: 100,
+                        spent: 125,
+                        isSuggested: false
+                    ),
+                ],
+                totalLimit: 100,
+                totalSpent: 125,
+                overBudgetCount: 1,
+                nearingCount: 0
+            ),
+            itemStatuses: [ItemStatus(id: "item-synthetic", status: .error)],
+            isSyncStale: true,
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(presentation.outcome == .payAttention)
+        #expect(presentation.isDue)
+        #expect(presentation.reviewedTransactionCount == 1)
+        #expect(presentation.items.map(\.kind) == [
+            .transactionReview,
+            .categoryDrift,
+            .upcomingBills,
+            .safeToSpendChange,
+            .subscriptionChange,
+            .connectionHealth,
+        ])
+        #expect(presentation.menuBarPrompt == "6 items to review")
+    }
+
+    @Test("Completing all derived items yields positive empty state")
+    func completedItemsYieldLooksGood() {
+        let state = WeeklyReviewState(
+            lastCompletedAt: daysAgo(8),
+            completedItemIds: ["weekly-review.transactions"]
+        )
+
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: state,
+            transactionState: WeeklyReviewTransactionState(
+                trustedTransactionIds: [],
+                unreviewedTransactionIds: ["tx-unreviewed"]
+            ),
+            transactions: [],
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(presentation.outcome == .looksGood)
+        #expect(presentation.completedCount == 1)
+        #expect(presentation.totalCount == 1)
+        #expect(presentation.remainingCount == 0)
+        #expect(presentation.menuBarPrompt == "Weekly review due")
+    }
+
+    @Test("Notification copy is privacy preserving by default")
+    func notificationCopyIsPrivate() {
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: WeeklyReviewTransactionState(
+                trustedTransactionIds: [],
+                unreviewedTransactionIds: ["tx_private_123"]
+            ),
+            transactions: [
+                TransactionDTO(
+                    id: "tx_private_123",
+                    accountId: "acct_private_456",
+                    amount: 9_999.99,
+                    date: "2026-06-14",
+                    name: "Raw Private Merchant",
+                    merchantName: "Private Merchant"
+                ),
+            ],
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        let copy = [presentation.notificationTitle, presentation.notificationBody, presentation.menuBarPrompt ?? ""]
+            .joined(separator: " ")
+
+        for privateText in [
+            "tx_private_123",
+            "acct_private_456",
+            "9999.99",
+            "Raw Private Merchant",
+            "Private Merchant",
+        ] {
+            #expect(copy.contains(privateText) == false)
+        }
+        #expect(copy.contains("$") == false)
+    }
+
+    private func transaction(id: String, date: String) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acct-\(id)",
+            amount: 10,
+            date: date,
+            name: "Synthetic"
+        )
+    }
+
+    private func safeToSpend(amount: Double) -> SafeToSpendResult {
+        SafeToSpendResult(
+            amount: amount,
+            components: [
+                SafeToSpendComponent(kind: .startingCash, label: "Starting cash", amount: amount),
+            ],
+            confidence: .ok,
+            horizonEnd: now
+        )
+    }
+
+    private func daysAgo(_ days: Int) -> Date {
+        calendar.date(byAdding: .day, value: -days, to: now) ?? now
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-403/design-weekly-money-review-workflow-as-vault

## Summary
- Adds `WeeklyReviewState` plus a derived weekly review presentation model that explicitly requires transaction review state before raw transactions can feed the checklist.
- Adds a compact popover weekly review card with local checklist completion, due-state persistence, VoiceOver labels, and a privacy-safe menu-bar prompt.
- Tightens default notification bodies so existing alerts do not expose merchant names, account names, amounts, or balances.

## Tests
- PASS: `git diff --check`
- PASS: `swift test --skip-update --filter WeeklyReview`
  - Note: SwiftPM emitted two `Internal Error: DecodingError.dataCorrupted: Corrupted JSON` diagnostics while compiling unrelated server tests, but the command exited 0 and all 4 filtered weekly review tests passed.
- PASS: `swift build --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`

## Risks
- AND-399 is still the hard dependency. Production sessions intentionally keep weekly review blocked until a real transaction review inbox supplies trusted/unreviewed transaction state; demo mode uses synthetic pending transactions only so the UI can be exercised.
- Corrective actions for category drill-in, recurring review, safe-to-spend drill-in, and transaction review inbox are limited by the currently available app navigation. The model/actions are present, but full deep links should be completed when those workflows are available.
- Weekly review notifications are modeled with privacy-safe copy but are not scheduled as a new notification trigger in this slice; existing notification bodies were made privacy-safe by default.

## Product impact
- Establishes the retention-loop shell without weakening VaultPeek's local-first privacy boundary or treating raw Plaid data as trusted review data.
- Gives demo/local builds a visible weekly cockpit while preserving the AND-399 sequencing for production data.