### PR TITLE
AND-393: Implement billing lifecycle handling

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -85,6 +85,7 @@ final class AppState {
     var serverStoragePath: String?
     var serverSyncReady: Bool?
     var serverSyncedItemCount: Int?
+    var billingSubscription: BillingSubscription?
     var itemStatuses: [ItemStatus] = []
     var isDemoMode = false
     var isDemoStatusRecoveryScenario = false
@@ -768,6 +769,7 @@ final class AppState {
             serverStoragePath = status.storagePath
             serverSyncReady = status.syncReady
             serverSyncedItemCount = status.syncedItemCount
+            billingSubscription = status.billingSubscription
             lastSyncDate = status.lastSync
             persistTransactionCacheContext()
             refreshSetupCompletionForActiveContext()
@@ -786,6 +788,7 @@ final class AppState {
             serverStoragePath = nil
             serverSyncReady = nil
             serverSyncedItemCount = nil
+            billingSubscription = nil
             itemStatuses = []
             switch error {
             case ServerClientError.serverNotRunning:

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -8,6 +8,7 @@ actor ServerClient {
     private let baseURL: String
     private let session: URLSession
     private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
     private let authTokenURL: URL
 
     init(
@@ -24,6 +25,9 @@ actor ServerClient {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         self.decoder = decoder
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
     }
 
     func getStatus() async throws -> ServerStatus {
@@ -38,6 +42,20 @@ actor ServerClient {
             throw ServerClientError.requestFailed
         }
         return try await get(url)
+    }
+
+    func getBillingSubscription() async throws -> BillingSubscription? {
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/billing/subscription") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
+    }
+
+    func saveBillingSubscription(_ request: SaveBillingSubscriptionRequest) async throws -> BillingSubscription {
+        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/billing/subscription") else {
+            throw ServerClientError.requestFailed
+        }
+        return try await put(url, body: request)
     }
 
     func getAccounts() async throws -> [AccountDTO] {
@@ -111,11 +129,24 @@ actor ServerClient {
         return try decoder.decode(T.self, from: data)
     }
 
+    private func put<T: Decodable & Sendable>(
+        _ url: URL,
+        body: some Encodable & Sendable
+    ) async throws -> T {
+        var request = try authorizedRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(body)
+        let (data, response) = try await data(for: request)
+        try Self.validateHTTPResponse(response, data: data)
+        return try decoder.decode(T.self, from: data)
+    }
+
     private func post(_ url: URL, body: some Encodable & Sendable) async throws {
         var request = try authorizedRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(body)
+        request.httpBody = try encoder.encode(body)
         let (data, response) = try await data(for: request)
         try Self.validateHTTPResponse(response, data: data)
     }

--- a/Sources/PlaidBar/Views/ManagedPlanShell.swift
+++ b/Sources/PlaidBar/Views/ManagedPlanShell.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// the copy never implies billing exists today.
 struct PlanSelectionShell: View {
     @Binding var selectedPlan: SubscriptionPlan
+    var billingSubscription: BillingSubscription?
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -41,6 +42,10 @@ struct PlanSelectionShell: View {
             }
             .accessibilityElement(children: .combine)
 
+            if let billingSubscription {
+                BillingStatusRow(subscription: billingSubscription)
+            }
+
             Text(
                 "Managed plans are a preview — billing and managed bank linking aren't "
                     + "available yet. Demo and bring-your-own-keys connections stay free."
@@ -51,6 +56,41 @@ struct PlanSelectionShell: View {
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .glassSurface(.inset)
+    }
+}
+
+private struct BillingStatusRow: View {
+    let subscription: BillingSubscription
+
+    private var gate: BillingFeatureGateResult {
+        BillingFeatureGate.evaluate(featureName: "managed plan features", subscription: subscription)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: iconName)
+                    .foregroundStyle(subscription.status.allowsPaidFeatures ? .secondary : SemanticColors.warning)
+                    .frame(width: 16)
+                Text("Billing: \(subscription.status.displayName)")
+                    .font(.caption.weight(.medium))
+            }
+            .accessibilityElement(children: .combine)
+
+            if case .locked(let lock) = gate {
+                Text("\(lock.message) \(lock.recoveryAction)")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if subscription.status == .trialing {
+                Text(subscription.status.recoveryAction)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var iconName: String {
+        subscription.status.allowsPaidFeatures ? "checkmark.circle" : "lock.circle"
     }
 }
 

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -175,7 +175,10 @@ struct SetupView: View {
             // The count reflects all linked institutions (`statusItemCount`), not
             // only currently-healthy ones, so an item needing reauth still counts.
             if environment == .production {
-                PlanSelectionShell(selectedPlan: selectedPlan)
+                PlanSelectionShell(
+                    selectedPlan: selectedPlan,
+                    billingSubscription: appState.billingSubscription
+                )
             }
             InstitutionUsageWidget(
                 usage: InstitutionUsage(connectedCount: appState.statusItemCount, limit: nil),

--- a/Sources/PlaidBarCore/Models/BillingSubscription.swift
+++ b/Sources/PlaidBarCore/Models/BillingSubscription.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Stripe subscription lifecycle as persisted by the local companion server.
+///
+/// This is display and gating metadata only. Do not add Stripe secrets, Plaid
+/// tokens, account IDs, balances, transactions, or raw webhook/provider payloads
+/// to this model.
+public enum BillingSubscriptionStatus: String, Codable, Sendable, CaseIterable {
+    case active
+    case trialing
+    case pastDue = "past_due"
+    case canceled
+    case expired
+
+    public var allowsPaidFeatures: Bool {
+        switch self {
+        case .active, .trialing:
+            true
+        case .pastDue, .canceled, .expired:
+            false
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case .active:
+            "Active"
+        case .trialing:
+            "Trial"
+        case .pastDue:
+            "Payment failed"
+        case .canceled:
+            "Canceled"
+        case .expired:
+            "Expired"
+        }
+    }
+
+    public var recoveryAction: String {
+        switch self {
+        case .active:
+            "Continue using VaultPeek."
+        case .trialing:
+            "Add billing before the trial ends to keep this feature."
+        case .pastDue:
+            "Update your payment method to restore access."
+        case .canceled:
+            "Restart your subscription to unlock this feature."
+        case .expired:
+            "Choose a plan to unlock this feature again."
+        }
+    }
+}
+
+public struct BillingSubscription: Codable, Sendable, Equatable {
+    public let status: BillingSubscriptionStatus
+    public let plan: SubscriptionPlan
+    public let updatedAt: Date
+    public let currentPeriodEnd: Date?
+    public let trialEndsAt: Date?
+
+    public init(
+        status: BillingSubscriptionStatus,
+        plan: SubscriptionPlan,
+        updatedAt: Date,
+        currentPeriodEnd: Date? = nil,
+        trialEndsAt: Date? = nil
+    ) {
+        self.status = status
+        self.plan = plan
+        self.updatedAt = updatedAt
+        self.currentPeriodEnd = currentPeriodEnd
+        self.trialEndsAt = trialEndsAt
+    }
+}
+
+public struct SaveBillingSubscriptionRequest: Codable, Sendable, Equatable {
+    public let status: BillingSubscriptionStatus
+    public let plan: SubscriptionPlan
+    public let currentPeriodEnd: Date?
+    public let trialEndsAt: Date?
+
+    public init(
+        status: BillingSubscriptionStatus,
+        plan: SubscriptionPlan,
+        currentPeriodEnd: Date? = nil,
+        trialEndsAt: Date? = nil
+    ) {
+        self.status = status
+        self.plan = plan
+        self.currentPeriodEnd = currentPeriodEnd
+        self.trialEndsAt = trialEndsAt
+    }
+}
+
+public struct BillingFeatureLock: Sendable, Equatable {
+    public let title: String
+    public let message: String
+    public let recoveryAction: String
+}
+
+public enum BillingFeatureGateResult: Sendable, Equatable {
+    case available
+    case locked(BillingFeatureLock)
+
+    public var isLocked: Bool {
+        switch self {
+        case .available:
+            false
+        case .locked:
+            true
+        }
+    }
+}
+
+public enum BillingFeatureGate {
+    public static func evaluate(
+        featureName: String,
+        subscription: BillingSubscription?
+    ) -> BillingFeatureGateResult {
+        guard let subscription else {
+            return .available
+        }
+        guard !subscription.status.allowsPaidFeatures else {
+            return .available
+        }
+        return .locked(
+            BillingFeatureLock(
+                title: "\(featureName) is locked",
+                message: "Your \(subscription.status.displayName.lowercased()) subscription cannot use \(featureName). Local financial data stays on this Mac and is not deleted.",
+                recoveryAction: subscription.status.recoveryAction
+            )
+        )
+    }
+}
+
+public struct BillingPlanTransition: Sendable, Equatable {
+    public let from: SubscriptionPlan
+    public let to: SubscriptionPlan
+
+    public init(from: SubscriptionPlan, to: SubscriptionPlan) {
+        self.from = from
+        self.to = to
+    }
+
+    public var isDowngrade: Bool {
+        to.institutionLimit < from.institutionLimit
+    }
+
+    public var preservesLocalFinancialData: Bool {
+        true
+    }
+
+    public var explanation: String {
+        if isDowngrade {
+            return "Downgrading changes future plan limits only. VaultPeek does not delete local accounts, transactions, balances, or budgets."
+        }
+        return "Changing plans updates feature access only. VaultPeek keeps local financial data intact."
+    }
+}

--- a/Sources/PlaidBarCore/Models/ServerStatus.swift
+++ b/Sources/PlaidBarCore/Models/ServerStatus.swift
@@ -14,6 +14,7 @@ public struct ServerStatus: Codable, Sendable {
         case storagePath
         case syncReady
         case syncedItemCount
+        case billingSubscription
     }
 
     public let version: String
@@ -24,6 +25,7 @@ public struct ServerStatus: Codable, Sendable {
     public let storagePath: String
     public let syncReady: Bool
     public let syncedItemCount: Int
+    public let billingSubscription: BillingSubscription?
 
     public init(
         version: String,
@@ -33,7 +35,8 @@ public struct ServerStatus: Codable, Sendable {
         credentialsConfigured: Bool = true,
         storagePath: String = LocalDataStore.displayPath,
         syncReady: Bool? = nil,
-        syncedItemCount: Int? = nil
+        syncedItemCount: Int? = nil,
+        billingSubscription: BillingSubscription? = nil
     ) {
         self.version = version
         self.environment = environment
@@ -43,6 +46,7 @@ public struct ServerStatus: Codable, Sendable {
         self.storagePath = storagePath
         self.syncReady = syncReady ?? (itemCount > 0)
         self.syncedItemCount = syncedItemCount ?? (lastSync == nil ? 0 : itemCount)
+        self.billingSubscription = billingSubscription
     }
 
     public init(from decoder: Decoder) throws {
@@ -55,6 +59,10 @@ public struct ServerStatus: Codable, Sendable {
         let storagePath = try container.decodeIfPresent(String.self, forKey: .storagePath)
         let syncReady = try container.decodeIfPresent(Bool.self, forKey: .syncReady)
         let syncedItemCount = try container.decodeIfPresent(Int.self, forKey: .syncedItemCount)
+        let billingSubscription = try container.decodeIfPresent(
+            BillingSubscription.self,
+            forKey: .billingSubscription
+        )
 
         self.init(
             version: version,
@@ -64,7 +72,8 @@ public struct ServerStatus: Codable, Sendable {
             credentialsConfigured: credentialsConfigured ?? true,
             storagePath: storagePath ?? LocalDataStore.displayPath,
             syncReady: syncReady,
-            syncedItemCount: syncedItemCount
+            syncedItemCount: syncedItemCount,
+            billingSubscription: billingSubscription
         )
     }
 }

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -49,12 +49,14 @@ struct PlaidBarServer: AsyncParsableCommand {
         await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateCategoryBudgets())
+        await fluent.migrations.add(CreateBillingSubscriptions())
         try await fluent.migrate()
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)
 
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent, logger: logger)
         let budgetStore = BudgetStore(fluent: fluent)
+        let billingStore = BillingSubscriptionStore(fluent: fluent)
         do {
             try await tokenStore.pruneOrphanedKeychainTokens()
         } catch {
@@ -97,9 +99,11 @@ struct PlaidBarServer: AsyncParsableCommand {
             .register(with: api)
         TransactionRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
             .register(with: api)
-        StatusRoutes(tokenStore: tokenStore, config: serverConfig)
+        StatusRoutes(tokenStore: tokenStore, billingStore: billingStore, config: serverConfig)
             .register(with: api)
         BudgetRoutes(budgetStore: budgetStore)
+            .register(with: api)
+        BillingRoutes(billingStore: billingStore)
             .register(with: api)
 
         // OAuth callback (top-level, not under /api)

--- a/Sources/PlaidBarServer/Routes/BillingRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/BillingRoutes.swift
@@ -24,10 +24,26 @@ struct BillingRoutes: Sendable {
 
     @Sendable
     func saveSubscription(request: Request, context: some RequestContext) async throws -> Response {
-        let body = try await request.decode(as: SaveBillingSubscriptionRequest.self, context: context)
+        // The app client encodes billing dates with `.iso8601`
+        // (ServerClient.encoder), but Hummingbird's default request decoder
+        // expects numeric `Date`s, so a non-nil trial/period-end date would fail
+        // to decode. Decode the raw body with a matching ISO-8601 decoder.
+        let buffer = try await request.body.collect(upTo: Self.maxBodyBytes)
+        let data = Data(buffer: buffer)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let body: SaveBillingSubscriptionRequest
+        do {
+            body = try decoder.decode(SaveBillingSubscriptionRequest.self, from: data)
+        } catch {
+            throw HTTPError(.badRequest, message: "Invalid billing subscription payload")
+        }
         let subscription = try await billingStore.save(body)
         return try Self.jsonResponse(subscription)
     }
+
+    /// Upper bound for the small JSON billing payload.
+    private static let maxBodyBytes = 64 * 1024
 
     private static func jsonResponse(_ value: (some Encodable)?) throws -> Response {
         let encoder = JSONEncoder()

--- a/Sources/PlaidBarServer/Routes/BillingRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/BillingRoutes.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import PlaidBarCore
+
+/// `/api/billing/subscription` — local subscription lifecycle metadata.
+///
+/// This endpoint receives already-normalized lifecycle state. It does not talk
+/// to Stripe, verify webhooks, or store provider secrets/payloads.
+struct BillingRoutes: Sendable {
+    let billingStore: BillingSubscriptionStore
+
+    func register(with group: RouterGroup<some RequestContext>) {
+        group.group("billing")
+            .get("subscription", use: getSubscription)
+            .put("subscription", use: saveSubscription)
+    }
+
+    @Sendable
+    func getSubscription(request: Request, context: some RequestContext) async throws -> Response {
+        let subscription = try await billingStore.currentSubscription()
+        return try Self.jsonResponse(subscription)
+    }
+
+    @Sendable
+    func saveSubscription(request: Request, context: some RequestContext) async throws -> Response {
+        let body = try await request.decode(as: SaveBillingSubscriptionRequest.self, context: context)
+        let subscription = try await billingStore.save(body)
+        return try Self.jsonResponse(subscription)
+    }
+
+    private static func jsonResponse(_ value: (some Encodable)?) throws -> Response {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -5,6 +5,7 @@ import PlaidBarCore
 
 struct StatusRoutes: Sendable {
     let tokenStore: TokenStore
+    let billingStore: BillingSubscriptionStore
     let config: ServerConfig
 
     func register(with group: RouterGroup<some RequestContext>) {
@@ -20,6 +21,7 @@ struct StatusRoutes: Sendable {
         let itemCount = try await tokenStore.itemCount()
         let lastSync = try await tokenStore.lastSyncDate()
         let syncedItemCount = try await tokenStore.syncedItemCount()
+        let billingSubscription = try await billingStore.currentSubscription()
 
         let status = ServerStatus(
             version: PlaidBarConstants.appVersion,
@@ -29,7 +31,8 @@ struct StatusRoutes: Sendable {
             credentialsConfigured: config.credentialsConfigured,
             storagePath: config.dataDirectoryPath,
             syncReady: itemCount > 0,
-            syncedItemCount: syncedItemCount
+            syncedItemCount: syncedItemCount,
+            billingSubscription: billingSubscription
         )
 
         let encoder = JSONEncoder()

--- a/Sources/PlaidBarServer/Storage/BillingSubscriptionModel.swift
+++ b/Sources/PlaidBarServer/Storage/BillingSubscriptionModel.swift
@@ -1,0 +1,57 @@
+import FluentKit
+import Foundation
+
+final class BillingSubscriptionModel: Model, @unchecked Sendable {
+    static let schema = "billing_subscriptions"
+
+    @ID(custom: "id", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "status")
+    var status: String
+
+    @Field(key: "plan")
+    var plan: String
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    @OptionalField(key: "current_period_end")
+    var currentPeriodEnd: Date?
+
+    @OptionalField(key: "trial_ends_at")
+    var trialEndsAt: Date?
+
+    init() {}
+
+    init(
+        id: String,
+        status: String,
+        plan: String,
+        currentPeriodEnd: Date? = nil,
+        trialEndsAt: Date? = nil
+    ) {
+        self.id = id
+        self.status = status
+        self.plan = plan
+        self.currentPeriodEnd = currentPeriodEnd
+        self.trialEndsAt = trialEndsAt
+    }
+}
+
+struct CreateBillingSubscriptions: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(BillingSubscriptionModel.schema)
+            .field("id", .string, .identifier(auto: false))
+            .field("status", .string, .required)
+            .field("plan", .string, .required)
+            .field("updated_at", .datetime)
+            .field("current_period_end", .datetime)
+            .field("trial_ends_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(BillingSubscriptionModel.schema).delete()
+    }
+}

--- a/Sources/PlaidBarServer/Storage/BillingSubscriptionStore.swift
+++ b/Sources/PlaidBarServer/Storage/BillingSubscriptionStore.swift
@@ -1,0 +1,63 @@
+import FluentKit
+import Foundation
+import HummingbirdFluent
+import PlaidBarCore
+
+/// Local persistence for subscription lifecycle metadata.
+///
+/// The row contains status/plan/dates only. Stripe customer IDs, payment method
+/// details, webhook payloads, and Plaid data must stay out of this store.
+actor BillingSubscriptionStore {
+    private static let singletonID = "current"
+
+    private let fluent: Fluent
+
+    init(fluent: Fluent) {
+        self.fluent = fluent
+    }
+
+    func currentSubscription() async throws -> BillingSubscription? {
+        guard let row = try await BillingSubscriptionModel.find(Self.singletonID, on: fluent.db()),
+              let status = BillingSubscriptionStatus(rawValue: row.status),
+              let plan = SubscriptionPlan(rawValue: row.plan)
+        else {
+            return nil
+        }
+
+        return BillingSubscription(
+            status: status,
+            plan: plan,
+            updatedAt: row.updatedAt ?? Date(timeIntervalSince1970: 0),
+            currentPeriodEnd: row.currentPeriodEnd,
+            trialEndsAt: row.trialEndsAt
+        )
+    }
+
+    func save(_ request: SaveBillingSubscriptionRequest) async throws -> BillingSubscription {
+        let row: BillingSubscriptionModel
+        if let existing = try await BillingSubscriptionModel.find(Self.singletonID, on: fluent.db()) {
+            row = existing
+            row.status = request.status.rawValue
+            row.plan = request.plan.rawValue
+            row.currentPeriodEnd = request.currentPeriodEnd
+            row.trialEndsAt = request.trialEndsAt
+        } else {
+            row = BillingSubscriptionModel(
+                id: Self.singletonID,
+                status: request.status.rawValue,
+                plan: request.plan.rawValue,
+                currentPeriodEnd: request.currentPeriodEnd,
+                trialEndsAt: request.trialEndsAt
+            )
+        }
+
+        try await row.save(on: fluent.db())
+        return BillingSubscription(
+            status: request.status,
+            plan: request.plan,
+            updatedAt: row.updatedAt ?? Date(),
+            currentPeriodEnd: request.currentPeriodEnd,
+            trialEndsAt: request.trialEndsAt
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
@@ -35,6 +35,78 @@ struct SubscriptionPlanTests {
     }
 }
 
+@Suite("Billing lifecycle Tests")
+struct BillingLifecycleTests {
+    @Test(
+        "Feature gates respond predictably to subscription statuses",
+        arguments: [
+            (BillingSubscriptionStatus.active, false),
+            (.trialing, false),
+            (.pastDue, true),
+            (.canceled, true),
+            (.expired, true),
+        ]
+    )
+    func featureGateStatusMatrix(status: BillingSubscriptionStatus, isLocked: Bool) {
+        let subscription = BillingSubscription(
+            status: status,
+            plan: .personal,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        let result = BillingFeatureGate.evaluate(
+            featureName: "managed insights",
+            subscription: subscription
+        )
+
+        #expect(result.isLocked == isLocked)
+    }
+
+    @Test("Locked copy explains the failed-payment recovery path")
+    func failedPaymentCopyExplainsRecovery() throws {
+        let subscription = BillingSubscription(
+            status: .pastDue,
+            plan: .plus,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_001)
+        )
+
+        let result = BillingFeatureGate.evaluate(
+            featureName: "managed insights",
+            subscription: subscription
+        )
+
+        guard case .locked(let lock) = result else {
+            Issue.record("Expected past_due to lock the feature")
+            return
+        }
+        #expect(lock.title == "managed insights is locked")
+        #expect(lock.message.contains("payment failed subscription"))
+        #expect(lock.message.contains("Local financial data stays on this Mac"))
+        #expect(lock.recoveryAction == "Update your payment method to restore access.")
+    }
+
+    @Test("Missing local subscription state leaves local-first installs ungated")
+    func nilSubscriptionAllowsLocalFirstInstalls() {
+        let result = BillingFeatureGate.evaluate(
+            featureName: "managed insights",
+            subscription: nil
+        )
+        #expect(result == .available)
+    }
+
+    @Test("Upgrade and downgrade transitions preserve local financial data")
+    func planTransitionsPreserveLocalData() {
+        let upgrade = BillingPlanTransition(from: .personal, to: .plus)
+        let downgrade = BillingPlanTransition(from: .plus, to: .personal)
+
+        #expect(upgrade.isDowngrade == false)
+        #expect(upgrade.preservesLocalFinancialData)
+        #expect(downgrade.isDowngrade)
+        #expect(downgrade.preservesLocalFinancialData)
+        #expect(downgrade.explanation.contains("does not delete local accounts"))
+    }
+}
+
 @Suite("InstitutionUsage Tests")
 struct InstitutionUsageTests {
     @Test("Summary text reports count of limit when a limit exists")

--- a/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionPlanTests.swift
@@ -55,7 +55,7 @@ struct BillingLifecycleTests {
     func featureGateStatusMatrix(status: BillingSubscriptionStatus, isLocked: Bool) {
         let subscription = BillingSubscription(
             status: status,
-            plan: .personal,
+            plan: .free,
             updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
@@ -101,8 +101,8 @@ struct BillingLifecycleTests {
 
     @Test("Upgrade and downgrade transitions preserve local financial data")
     func planTransitionsPreserveLocalData() {
-        let upgrade = BillingPlanTransition(from: .personal, to: .plus)
-        let downgrade = BillingPlanTransition(from: .plus, to: .personal)
+        let upgrade = BillingPlanTransition(from: .free, to: .plus)
+        let downgrade = BillingPlanTransition(from: .plus, to: .free)
 
         #expect(upgrade.isDowngrade == false)
         #expect(upgrade.preservesLocalFinancialData)

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -194,10 +194,10 @@ struct ConsumerFoundationTests {
             #expect(try await store.currentSubscription() == nil)
 
             let trial = try await store.save(
-                SaveBillingSubscriptionRequest(status: .trialing, plan: .personal)
+                SaveBillingSubscriptionRequest(status: .trialing, plan: .free)
             )
             #expect(trial.status == .trialing)
-            #expect(trial.plan == .personal)
+            #expect(trial.plan == .free)
 
             let upgraded = try await store.save(
                 SaveBillingSubscriptionRequest(status: .active, plan: .plus)
@@ -211,28 +211,28 @@ struct ConsumerFoundationTests {
             #expect(failedPayment.status == .pastDue)
 
             let downgraded = try await store.save(
-                SaveBillingSubscriptionRequest(status: .active, plan: .personal)
+                SaveBillingSubscriptionRequest(status: .active, plan: .free)
             )
-            #expect(downgraded.plan == .personal)
+            #expect(downgraded.plan == .free)
 
             let canceled = try await store.save(
-                SaveBillingSubscriptionRequest(status: .canceled, plan: .personal)
+                SaveBillingSubscriptionRequest(status: .canceled, plan: .free)
             )
             #expect(canceled.status == .canceled)
 
             let expired = try await store.save(
-                SaveBillingSubscriptionRequest(status: .expired, plan: .personal)
+                SaveBillingSubscriptionRequest(status: .expired, plan: .free)
             )
             #expect(expired.status == .expired)
 
             let reactivated = try await store.save(
-                SaveBillingSubscriptionRequest(status: .active, plan: .personal)
+                SaveBillingSubscriptionRequest(status: .active, plan: .free)
             )
             #expect(reactivated.status == .active)
 
             let loaded = try await store.currentSubscription()
             #expect(loaded?.status == .active)
-            #expect(loaded?.plan == .personal)
+            #expect(loaded?.plan == .free)
         }
     }
 
@@ -258,6 +258,37 @@ struct ConsumerFoundationTests {
         }
     }
 
+    @Test("Billing route accepts ISO-8601 trial and period-end dates from the app client")
+    func billingRouteDecodesISO8601Dates() async throws {
+        try await withFluent { fluent in
+            let store = BillingSubscriptionStore(fluent: fluent)
+            let routes = BillingRoutes(billingStore: store)
+            let context = TestRequestContext(source: TestRequestContextSource())
+            let trialEnd = Date(timeIntervalSince1970: 1_800_000_000)
+            let periodEnd = Date(timeIntervalSince1970: 1_802_000_000)
+
+            let response = try await routes.saveSubscription(
+                request: Self.makeJSONRequest(
+                    method: .put,
+                    path: "/api/billing/subscription",
+                    body: SaveBillingSubscriptionRequest(
+                        status: .trialing,
+                        plan: .plus,
+                        currentPeriodEnd: periodEnd,
+                        trialEndsAt: trialEnd
+                    )
+                ),
+                context: context
+            )
+
+            #expect(response.status == .ok)
+            let loaded = try await store.currentSubscription()
+            #expect(loaded?.status == .trialing)
+            #expect(loaded?.trialEndsAt == trialEnd)
+            #expect(loaded?.currentPeriodEnd == periodEnd)
+        }
+    }
+
     // MARK: - Helpers
 
     private static func makeRequest(path: String) -> Request {
@@ -272,7 +303,11 @@ struct ConsumerFoundationTests {
         path: String,
         body: some Encodable
     ) throws -> Request {
-        let data = try JSONEncoder().encode(body)
+        // Mirror the real app client (ServerClient encodes with .iso8601), so
+        // route tests exercise the same date wire format the server must accept.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(body)
         var headers = HTTPFields()
         headers[.contentType] = "application/json"
         return Request(

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -184,12 +184,100 @@ struct ConsumerFoundationTests {
         #expect(decoded == original)
     }
 
+    // MARK: - Billing lifecycle persistence
+
+    @Test("Billing subscription status persists and can move through lifecycle states")
+    func billingSubscriptionLifecyclePersists() async throws {
+        try await withFluent { fluent in
+            let store = BillingSubscriptionStore(fluent: fluent)
+
+            #expect(try await store.currentSubscription() == nil)
+
+            let trial = try await store.save(
+                SaveBillingSubscriptionRequest(status: .trialing, plan: .personal)
+            )
+            #expect(trial.status == .trialing)
+            #expect(trial.plan == .personal)
+
+            let upgraded = try await store.save(
+                SaveBillingSubscriptionRequest(status: .active, plan: .plus)
+            )
+            #expect(upgraded.status == .active)
+            #expect(upgraded.plan == .plus)
+
+            let failedPayment = try await store.save(
+                SaveBillingSubscriptionRequest(status: .pastDue, plan: .plus)
+            )
+            #expect(failedPayment.status == .pastDue)
+
+            let downgraded = try await store.save(
+                SaveBillingSubscriptionRequest(status: .active, plan: .personal)
+            )
+            #expect(downgraded.plan == .personal)
+
+            let canceled = try await store.save(
+                SaveBillingSubscriptionRequest(status: .canceled, plan: .personal)
+            )
+            #expect(canceled.status == .canceled)
+
+            let expired = try await store.save(
+                SaveBillingSubscriptionRequest(status: .expired, plan: .personal)
+            )
+            #expect(expired.status == .expired)
+
+            let reactivated = try await store.save(
+                SaveBillingSubscriptionRequest(status: .active, plan: .personal)
+            )
+            #expect(reactivated.status == .active)
+
+            let loaded = try await store.currentSubscription()
+            #expect(loaded?.status == .active)
+            #expect(loaded?.plan == .personal)
+        }
+    }
+
+    @Test("Billing route receives normalized subscription status")
+    func billingRouteReceivesSubscriptionStatus() async throws {
+        try await withFluent { fluent in
+            let store = BillingSubscriptionStore(fluent: fluent)
+            let routes = BillingRoutes(billingStore: store)
+            let context = TestRequestContext(source: TestRequestContextSource())
+            let response = try await routes.saveSubscription(
+                request: Self.makeJSONRequest(
+                    method: .put,
+                    path: "/api/billing/subscription",
+                    body: SaveBillingSubscriptionRequest(status: .pastDue, plan: .plus)
+                ),
+                context: context
+            )
+
+            #expect(response.status == .ok)
+            let loaded = try await store.currentSubscription()
+            #expect(loaded?.status == .pastDue)
+            #expect(loaded?.plan == .plus)
+        }
+    }
+
     // MARK: - Helpers
 
     private static func makeRequest(path: String) -> Request {
         Request(
             head: HTTPRequest(method: .get, scheme: nil, authority: nil, path: path),
             body: RequestBody(buffer: ByteBuffer())
+        )
+    }
+
+    private static func makeJSONRequest(
+        method: HTTPRequest.Method,
+        path: String,
+        body: some Encodable
+    ) throws -> Request {
+        let data = try JSONEncoder().encode(body)
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json"
+        return Request(
+            head: HTTPRequest(method: method, scheme: nil, authority: nil, path: path, headerFields: headers),
+            body: RequestBody(buffer: ByteBuffer(data: data))
         )
     }
 
@@ -202,6 +290,7 @@ struct ConsumerFoundationTests {
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
         await fluent.migrations.add(CreateSyncCursors())
+        await fluent.migrations.add(CreateBillingSubscriptions())
 
         var bodyError: Error?
         do {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -206,7 +206,7 @@ struct PlaidBarServerTests {
             syncedItemCount: 2,
             billingSubscription: BillingSubscription(
                 status: .active,
-                plan: .personal,
+                plan: .free,
                 updatedAt: Date(timeIntervalSince1970: 1_800_000_002)
             )
         )
@@ -274,7 +274,7 @@ struct PlaidBarServerTests {
             syncedItemCount: 1,
             billingSubscription: BillingSubscription(
                 status: .trialing,
-                plan: .personal,
+                plan: .free,
                 updatedAt: Date(timeIntervalSince1970: 1_800_000_002)
             )
         )

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -203,7 +203,12 @@ struct PlaidBarServerTests {
             credentialsConfigured: true,
             storagePath: "/Users/example/.plaidbar",
             syncReady: true,
-            syncedItemCount: 2
+            syncedItemCount: 2,
+            billingSubscription: BillingSubscription(
+                status: .active,
+                plan: .personal,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_002)
+            )
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -221,6 +226,7 @@ struct PlaidBarServerTests {
             "storagePath",
             "syncReady",
             "syncedItemCount",
+            "billingSubscription",
         ]
         let forbiddenFragments = [
             "account",
@@ -265,7 +271,12 @@ struct PlaidBarServerTests {
             credentialsConfigured: true,
             storagePath: "/Users/example/.plaidbar",
             syncReady: true,
-            syncedItemCount: 1
+            syncedItemCount: 1,
+            billingSubscription: BillingSubscription(
+                status: .trialing,
+                plan: .personal,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_002)
+            )
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-393/implement-billing-lifecycle-handling-for-trial-upgrade-downgrade

## Summary
- Add display-safe billing subscription lifecycle models for active, trialing, past_due, canceled, and expired states, including feature-gate recovery copy and downgrade data-preservation semantics.
- Persist normalized subscription status/plan/dates in the local companion server SQLite store and expose authenticated local `/api/billing/subscription` read/write routes.
- Include billing status in `/api/status` and surface locked/recovery copy in the managed plan shell without adding Plaid or Stripe secrets to app payloads.

## Tests
- `git diff --check`
- `swift test --skip-update --filter SubscriptionPlanTests`
- `swift test --skip-update --filter ConsumerFoundationTests`
- `swift test --skip-update --filter serverStatus`

## Risks
- This intentionally stores normalized billing lifecycle metadata only; it does not implement live Stripe Checkout/webhook verification or entitlement signature verification. A future owner-controlled Stripe integration must feed this local status surface without persisting raw webhook payloads or provider secrets.
- Feature-gate behavior is currently model/UI-copy level for managed-plan features. BYO/local Plaid data remains ungated and downgrade transitions do not delete local financial records.