### PR TITLE
AND-415: Mount first-run money snapshot

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -23,6 +23,7 @@ final class AppState {
         static let notifyHighUtilization = "notifyHighUtilization"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
+        static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
         static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
     }
@@ -75,6 +76,12 @@ final class AppState {
         didSet {
             guard oldValue != isSetupComplete else { return }
             persistSetupCompletion(isSetupComplete)
+        }
+    }
+    var isFirstRunSnapshotDismissed = false {
+        didSet {
+            guard oldValue != isFirstRunSnapshotDismissed else { return }
+            persistFirstRunSnapshotDismissal(isFirstRunSnapshotDismissed)
         }
     }
     var serverConnected = false
@@ -197,6 +204,7 @@ final class AppState {
         self.notificationService = notificationService ?? NotificationService.shared
         loadSettings()
         isSetupComplete = storedSetupCompletion()
+        isFirstRunSnapshotDismissed = storedFirstRunSnapshotDismissal()
         if isSetupComplete {
             persistSetupCompletion(true)
         }
@@ -570,6 +578,18 @@ final class AppState {
         )
     }
 
+    var firstRunSnapshotPresentation: FirstRunSnapshotPresentation? {
+        FirstRunSnapshotPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            completionState: firstRunCompletionState,
+            isDismissed: isFirstRunSnapshotDismissed,
+            isInitialLoad: isBootLoadInFlight,
+            isDemoMode: isDemoMode,
+            largeTransactionThreshold: largeTransactionThreshold
+        )
+    }
+
     var dashboardStatusReadiness: DashboardStatusReadiness {
         DashboardStatusReadiness.evaluate(
             isDemoMode: isDemoMode && !isDemoStatusRecoveryScenario,
@@ -771,6 +791,7 @@ final class AppState {
             lastSyncDate = status.lastSync
             persistTransactionCacheContext()
             refreshSetupCompletionForActiveContext()
+            refreshFirstRunSnapshotDismissalForActiveContext()
             updateSetupCompletion()
             if !(await refreshItemStatuses()) {
                 itemStatuses = []
@@ -1144,7 +1165,9 @@ final class AppState {
         serverSyncedItemCount = nil
         lastSyncDate = nil
         UserDefaults.standard.set(false, forKey: resetSetupCompletionDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: firstRunSnapshotDismissalDefaultsKey)
         isSetupComplete = false
+        isFirstRunSnapshotDismissed = false
         serverStoragePath = nil
         isDemoMode = false
         isDemoStatusRecoveryScenario = false
@@ -1190,6 +1213,10 @@ final class AppState {
         let granted = await notificationService.requestPermission()
         notificationPermissionState = await notificationService.checkPermissionStatus()
         return granted
+    }
+
+    func dismissFirstRunSnapshot() {
+        isFirstRunSnapshotDismissed = true
     }
 
     func notificationPermissionStatus() async -> NotificationPermissionState {
@@ -1575,6 +1602,13 @@ final class AppState {
         }
     }
 
+    private func refreshFirstRunSnapshotDismissalForActiveContext() {
+        let storedValue = storedFirstRunSnapshotDismissal()
+        if isFirstRunSnapshotDismissed != storedValue {
+            isFirstRunSnapshotDismissed = storedValue
+        }
+    }
+
     private func storedSetupCompletion() -> Bool {
         let defaults = UserDefaults.standard
         if let scopedValue = defaults.object(forKey: setupCompletionDefaultsKey) as? Bool {
@@ -1593,11 +1627,30 @@ final class AppState {
         UserDefaults.standard.set(isComplete, forKey: setupCompletionDefaultsKey)
     }
 
+    private func storedFirstRunSnapshotDismissal() -> Bool {
+        UserDefaults.standard.bool(forKey: firstRunSnapshotDismissalDefaultsKey)
+    }
+
+    private func persistFirstRunSnapshotDismissal(_ isDismissed: Bool) {
+        if isDismissed {
+            UserDefaults.standard.set(true, forKey: firstRunSnapshotDismissalDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: firstRunSnapshotDismissalDefaultsKey)
+        }
+    }
+
     private var setupCompletionDefaultsKey: String {
         let environment = setupCompletionEnvironment.rawValue
         let path = activeStorageDirectoryURL.standardizedFileURL.path
         let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? path
         return "\(Keys.setupCompletedContextPrefix).\(environment).\(encodedPath)"
+    }
+
+    private var firstRunSnapshotDismissalDefaultsKey: String {
+        let environment = setupCompletionEnvironment.rawValue
+        let path = activeStorageDirectoryURL.standardizedFileURL.path
+        let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? path
+        return "\(Keys.firstRunSnapshotDismissedContextPrefix).\(environment).\(encodedPath)"
     }
 
     private var setupCompletionEnvironment: PlaidEnvironment {

--- a/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
+++ b/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
@@ -17,9 +17,9 @@ struct FirstRunSnapshotView: View {
                 SnapshotMetricTile(
                     title: "Cash Available",
                     value: Formatters.currency(snapshot.cashAvailable, format: .compact),
-                    detail: "\(snapshot.accountCount) account\(snapshot.accountCount == 1 ? "" : "s") connected",
+                    detail: "\(snapshot.cashAccountCount) cash account\(snapshot.cashAccountCount == 1 ? "" : "s")",
                     icon: "banknote",
-                    accessibilityLabel: "Cash available \(Formatters.currency(snapshot.cashAvailable, format: .full)) across \(snapshot.accountCount) account\(snapshot.accountCount == 1 ? "" : "s")."
+                    accessibilityLabel: "Cash available \(Formatters.currency(snapshot.cashAvailable, format: .full)) across \(snapshot.cashAccountCount) cash account\(snapshot.cashAccountCount == 1 ? "" : "s")."
                 )
 
                 SnapshotMetricTile(

--- a/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
+++ b/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
@@ -1,0 +1,312 @@
+import PlaidBarCore
+import SwiftUI
+
+struct FirstRunSnapshotView: View {
+    let presentation: FirstRunSnapshotPresentation
+    let onDismiss: () -> Void
+
+    private var snapshot: FirstRunSnapshot {
+        presentation.snapshot
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            header
+
+            LazyVGrid(columns: metricColumns, alignment: .leading, spacing: Spacing.sm) {
+                SnapshotMetricTile(
+                    title: "Cash Available",
+                    value: Formatters.currency(snapshot.cashAvailable, format: .compact),
+                    detail: "\(snapshot.accountCount) account\(snapshot.accountCount == 1 ? "" : "s") connected",
+                    icon: "banknote",
+                    accessibilityLabel: "Cash available \(Formatters.currency(snapshot.cashAvailable, format: .full)) across \(snapshot.accountCount) account\(snapshot.accountCount == 1 ? "" : "s")."
+                )
+
+                SnapshotMetricTile(
+                    title: "Net Worth",
+                    value: Formatters.currency(snapshot.netWorth, format: .compact),
+                    detail: "Local estimate",
+                    icon: "sum",
+                    accessibilityLabel: "Net worth estimate \(Formatters.currency(snapshot.netWorth, format: .full))."
+                )
+
+                SnapshotMetricTile(
+                    title: "Month To Date",
+                    value: monthToDateValue,
+                    detail: monthToDateDetail,
+                    icon: "calendar",
+                    accessibilityLabel: monthToDateAccessibilityLabel
+                )
+
+                SnapshotMetricTile(
+                    title: "Credit",
+                    value: creditValue,
+                    detail: creditDetail,
+                    icon: creditIcon,
+                    accessibilityLabel: creditAccessibilityLabel
+                )
+            }
+
+            largeTransactionsSection
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.hero(SemanticColors.brand))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(presentation.primaryAccessibilityLabel)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: "sparkles.rectangle.stack")
+                .font(.title3.weight(.medium))
+                .foregroundStyle(SemanticColors.brand)
+                .frame(width: Sizing.iconChip)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(presentation.title)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+
+                Text(presentation.subtitle)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .frame(width: Sizing.hitTargetMin, height: Sizing.hitTargetMin)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss first snapshot")
+            .accessibilityHint(presentation.dismissalAccessibilityHint)
+            .help("Dismiss")
+        }
+    }
+
+    private var largeTransactionsSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(alignment: .firstTextBaseline) {
+                Label("Large Recent Transactions", systemImage: "list.bullet.rectangle")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text(largeTransactionSummary)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if snapshot.largeTransactions.isEmpty {
+                SnapshotEmptyRow(
+                    icon: "checkmark.circle",
+                    text: largeTransactionEmptyText,
+                    accessibilityLabel: largeTransactionEmptyText
+                )
+            } else {
+                VStack(spacing: Spacing.xs) {
+                    ForEach(snapshot.largeTransactions) { transaction in
+                        SnapshotTransactionRow(transaction: transaction)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var metricColumns: [GridItem] {
+        [
+            GridItem(.flexible(minimum: 118), spacing: Spacing.sm),
+            GridItem(.flexible(minimum: 118), spacing: Spacing.sm),
+        ]
+    }
+
+    private var monthToDateValue: String {
+        guard let spend = snapshot.monthToDateSpend else { return "Not Available" }
+        return Formatters.currency(spend, format: .compact)
+    }
+
+    private var monthToDateDetail: String {
+        switch snapshot.transactionState {
+        case .ready:
+            "Synced spend"
+        case .syncing:
+            "Transactions syncing"
+        case .empty:
+            "No transaction rows"
+        }
+    }
+
+    private var monthToDateAccessibilityLabel: String {
+        guard let spend = snapshot.monthToDateSpend else {
+            return "\(monthToDateDetail). Month-to-date spend is not available."
+        }
+        return "Month-to-date spend \(Formatters.currency(spend, format: .full))."
+    }
+
+    private var creditValue: String {
+        guard snapshot.hasCreditAccounts else { return "No Credit" }
+        guard let utilization = snapshot.creditUtilization else { return "No Limit" }
+        return Formatters.percent(utilization, decimals: 0)
+    }
+
+    private var creditDetail: String {
+        if snapshot.hasCreditAccounts, let utilization = snapshot.creditUtilization {
+            return "Utilization, \(creditUtilizationStatus(for: utilization))"
+        }
+        if snapshot.hasDebtAccounts {
+            return "\(Formatters.currency(snapshot.debtTotal, format: .compact)) balance"
+        }
+        return "No credit balance"
+    }
+
+    private var creditIcon: String {
+        guard let utilization = snapshot.creditUtilization else { return "creditcard" }
+        return SemanticColors.utilizationIcon(for: utilization)
+    }
+
+    private var creditAccessibilityLabel: String {
+        if snapshot.hasCreditAccounts, let utilization = snapshot.creditUtilization {
+            return "Credit utilization \(Formatters.percent(utilization, decimals: 0)), \(creditUtilizationStatus(for: utilization)). Debt balance \(Formatters.currency(snapshot.debtTotal, format: .full))."
+        }
+        if snapshot.hasDebtAccounts {
+            return "Credit utilization unavailable. Debt balance \(Formatters.currency(snapshot.debtTotal, format: .full))."
+        }
+        return "No credit utilization or debt balance available."
+    }
+
+    private var largeTransactionSummary: String {
+        if snapshot.largeTransactions.isEmpty { return "None found" }
+        return "\(snapshot.largeTransactions.count) found"
+    }
+
+    private var largeTransactionEmptyText: String {
+        switch snapshot.transactionState {
+        case .ready:
+            "No recent transactions above your alert threshold."
+        case .syncing:
+            "Transaction history is still syncing."
+        case .empty:
+            "No transaction rows are available yet."
+        }
+    }
+
+    private func creditUtilizationStatus(for utilization: Double) -> String {
+        if utilization < 30 { return "low" }
+        if utilization < 75 { return "elevated" }
+        return "high"
+    }
+}
+
+private struct SnapshotMetricTile: View {
+    let title: String
+    let value: String
+    let detail: String
+    let icon: String
+    let accessibilityLabel: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(alignment: .center, spacing: Spacing.xs) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: Sizing.iconInline)
+                    .accessibilityHidden(true)
+
+                Text(title)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+            }
+
+            Text(value)
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+        }
+        .padding(Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.inset)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+private struct SnapshotTransactionRow: View {
+    let transaction: FirstRunSnapshot.LargeTransaction
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Image(systemName: "arrow.up.right.circle")
+                .foregroundStyle(.secondary)
+                .frame(width: Sizing.iconInline)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(transaction.displayName)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+
+                Text(Formatters.displayTransactionDate(transaction.date))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Text(Formatters.currency(transaction.amount, format: .compact))
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(transaction.displayName), \(Formatters.currency(transaction.amount, format: .full)), \(Formatters.displayTransactionDate(transaction.date)).")
+    }
+}
+
+private struct SnapshotEmptyRow: View {
+    let icon: String
+    let text: String
+    let accessibilityLabel: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+                .frame(width: Sizing.iconInline)
+                .accessibilityHidden(true)
+
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -391,6 +391,13 @@ struct MainPopover: View {
                         DashboardChangeReceiptStrip()
                             .environment(appState)
 
+                        if let presentation = appState.firstRunSnapshotPresentation {
+                            FirstRunSnapshotView(
+                                presentation: presentation,
+                                onDismiss: appState.dismissFirstRunSnapshot
+                            )
+                        }
+
                         if shouldElevateStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                                 AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)

--- a/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
@@ -27,6 +27,10 @@ public struct FirstRunSnapshot: Equatable, Sendable {
     }
 
     public let accountCount: Int
+    /// Number of depository accounts that contribute to `cashAvailable`. The
+    /// cash figure sums only depository balances, so reporting the total
+    /// `accountCount` next to it would overstate how many accounts hold cash.
+    public let cashAccountCount: Int
     public let transactionCount: Int
     public let netWorth: Double
     public let cashAvailable: Double
@@ -41,6 +45,7 @@ public struct FirstRunSnapshot: Equatable, Sendable {
 
     public init(
         accountCount: Int,
+        cashAccountCount: Int = 0,
         transactionCount: Int,
         netWorth: Double,
         cashAvailable: Double,
@@ -54,6 +59,7 @@ public struct FirstRunSnapshot: Equatable, Sendable {
         accessibilitySummary: String
     ) {
         self.accountCount = accountCount
+        self.cashAccountCount = cashAccountCount
         self.transactionCount = transactionCount
         self.netWorth = netWorth
         self.cashAvailable = cashAvailable
@@ -95,6 +101,7 @@ public struct FirstRunSnapshot: Equatable, Sendable {
 
         return FirstRunSnapshot(
             accountCount: accounts.count,
+            cashAccountCount: accounts.filter { $0.type == .depository }.count,
             transactionCount: transactions.count,
             netWorth: netWorth,
             cashAvailable: cashAvailable,
@@ -151,9 +158,14 @@ public struct FirstRunSnapshot: Equatable, Sendable {
             return $0.displayName < $1.displayName
         }
         .prefix(3)
-        .map { transaction in
+        .enumerated()
+        .map { offset, transaction in
             LargeTransaction(
-                id: displaySafeLargeTransactionID(for: transaction),
+                // Two large transactions can share date + name + amount, which
+                // would collide on identity and make SwiftUI ForEach diffing
+                // undefined. The sorted-occurrence index disambiguates while
+                // keeping the id display-safe (no account/transaction ids).
+                id: displaySafeLargeTransactionID(for: transaction, occurrence: offset),
                 displayName: transaction.displayName,
                 amount: transaction.displayAmount,
                 date: transaction.date
@@ -161,9 +173,12 @@ public struct FirstRunSnapshot: Equatable, Sendable {
         })
     }
 
-    private static func displaySafeLargeTransactionID(for transaction: TransactionDTO) -> String {
+    private static func displaySafeLargeTransactionID(
+        for transaction: TransactionDTO,
+        occurrence: Int
+    ) -> String {
         let amountCents = Int((transaction.displayAmount * 100).rounded())
-        return "\(transaction.date)-\(transaction.displayName)-\(amountCents)"
+        return "\(transaction.date)-\(transaction.displayName)-\(amountCents)-\(occurrence)"
     }
 
     private static func accessibilitySummary(

--- a/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FirstRunSnapshot.swift
@@ -206,3 +206,74 @@ public struct FirstRunSnapshot: Equatable, Sendable {
         return parts.joined(separator: " ")
     }
 }
+
+public struct FirstRunSnapshotPresentation: Equatable, Sendable {
+    public let snapshot: FirstRunSnapshot
+    public let title: String
+    public let subtitle: String
+    public let primaryAccessibilityLabel: String
+    public let dismissalAccessibilityHint: String
+
+    public init(
+        snapshot: FirstRunSnapshot,
+        title: String,
+        subtitle: String,
+        primaryAccessibilityLabel: String,
+        dismissalAccessibilityHint: String
+    ) {
+        self.snapshot = snapshot
+        self.title = title
+        self.subtitle = subtitle
+        self.primaryAccessibilityLabel = primaryAccessibilityLabel
+        self.dismissalAccessibilityHint = dismissalAccessibilityHint
+    }
+
+    public static func evaluate(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        completionState: FirstRunCompletionState,
+        isDismissed: Bool,
+        isInitialLoad: Bool,
+        isDemoMode: Bool,
+        largeTransactionThreshold: Double = 500,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> FirstRunSnapshotPresentation? {
+        guard !isDismissed,
+              !isInitialLoad,
+              !isDemoMode,
+              completionState.isReady,
+              completionState.step == .ready,
+              !accounts.isEmpty
+        else {
+            return nil
+        }
+
+        let snapshot = FirstRunSnapshot.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            completionState: completionState,
+            largeTransactionThreshold: largeTransactionThreshold,
+            now: now,
+            calendar: calendar
+        )
+        return FirstRunSnapshotPresentation(
+            snapshot: snapshot,
+            title: "First Snapshot",
+            subtitle: subtitle(for: snapshot),
+            primaryAccessibilityLabel: snapshot.accessibilitySummary,
+            dismissalAccessibilityHint: "Dismisses this first-run snapshot and keeps it hidden on future launches."
+        )
+    }
+
+    private static func subtitle(for snapshot: FirstRunSnapshot) -> String {
+        switch snapshot.transactionState {
+        case .ready:
+            return "Your local account and transaction sync is ready."
+        case .syncing:
+            return "Accounts are ready; transaction history is still syncing."
+        case .empty:
+            return "Accounts are ready; no transaction rows are available yet."
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
@@ -30,6 +30,9 @@ struct FirstRunSnapshotTests {
         )
 
         #expect(snapshot.accountCount == 4)
+        // Only the depository account contributes to cashAvailable; the cash
+        // tile must not imply all four accounts hold cash.
+        #expect(snapshot.cashAccountCount == 1)
         #expect(snapshot.transactionCount == 8)
         #expect(snapshot.netWorth == 49_450)
         #expect(snapshot.cashAvailable == 8_200)
@@ -44,6 +47,26 @@ struct FirstRunSnapshotTests {
         #expect(snapshot.largeTransactions.allSatisfy { !$0.id.contains("internal") })
         #expect(snapshot.accessibilitySummary.contains("Net worth $49,450.00"))
         #expect(snapshot.accessibilitySummary.contains("3 recent large transactions"))
+    }
+
+    @Test("Large transactions get unique ids even when date, name, and amount collide")
+    func largeTransactionsHaveUniqueIdentities() {
+        let snapshot = FirstRunSnapshot.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 10_000)),
+            ],
+            transactions: [
+                expense("a-internal", amount: 800, date: "2026-06-10", name: "Furniture"),
+                expense("b-internal", amount: 800, date: "2026-06-10", name: "Furniture"),
+            ],
+            completionState: readyCompletion(transactionCount: 2),
+            now: now
+        )
+
+        let ids = snapshot.largeTransactions.map(\.id)
+        #expect(ids.count == 2)
+        #expect(Set(ids).count == ids.count)
+        #expect(snapshot.largeTransactions.allSatisfy { !$0.id.contains("internal") })
     }
 
     @Test("Handles no credit and no liabilities")

--- a/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/FirstRunSnapshotTests.swift
@@ -111,6 +111,125 @@ struct FirstRunSnapshotTests {
         #expect(MenuBarSummary.monthToDateSpend(from: transactions, now: localNow, calendar: calendar) == 40)
     }
 
+    @Test("Presentation appears after first successful account and transaction sync")
+    func presentationAppearsAfterFirstSuccessfulSync() {
+        let presentation = FirstRunSnapshotPresentation.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 2_000)),
+                AccountDTO(id: "card", itemId: "item-a", name: "Card", type: .credit, balances: BalanceDTO(current: -250, limit: 1_000)),
+            ],
+            transactions: [
+                expense("large", amount: 650, date: "2026-06-12", name: "Appliance"),
+            ],
+            completionState: readyCompletion(transactionCount: 1),
+            isDismissed: false,
+            isInitialLoad: false,
+            isDemoMode: false,
+            now: now
+        )
+
+        #expect(presentation?.snapshot.cashAvailable == 2_000)
+        #expect(presentation?.snapshot.creditUtilization == 25)
+        #expect(presentation?.snapshot.largeTransactions.map(\.displayName) == ["Appliance"])
+        #expect(presentation?.subtitle == "Your local account and transaction sync is ready.")
+    }
+
+    @Test("Presentation stays hidden while loading, dismissed, demo, or not ready")
+    func presentationGatingHidesWhenIneligible() {
+        let accounts = [
+            AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 2_000)),
+        ]
+        let transactions = [
+            expense("coffee", amount: 8, date: "2026-06-12", name: "Coffee"),
+        ]
+        let completion = readyCompletion(transactionCount: 1)
+
+        #expect(FirstRunSnapshotPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            completionState: completion,
+            isDismissed: true,
+            isInitialLoad: false,
+            isDemoMode: false,
+            now: now
+        ) == nil)
+        #expect(FirstRunSnapshotPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            completionState: completion,
+            isDismissed: false,
+            isInitialLoad: true,
+            isDemoMode: false,
+            now: now
+        ) == nil)
+        #expect(FirstRunSnapshotPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            completionState: completion,
+            isDismissed: false,
+            isInitialLoad: false,
+            isDemoMode: true,
+            now: now
+        ) == nil)
+        #expect(FirstRunSnapshotPresentation.evaluate(
+            accounts: accounts,
+            transactions: [],
+            completionState: FirstRunCompletionState(
+                step: .syncTransactions,
+                title: "Accounts loaded",
+                detail: "Run the first transaction sync check to finish setup.",
+                isReady: false,
+                canRetry: true
+            ),
+            isDismissed: false,
+            isInitialLoad: false,
+            isDemoMode: false,
+            now: now
+        ) == nil)
+    }
+
+    @Test("Presentation handles no transaction rows after completed sync")
+    func presentationHandlesNoTransactionRows() {
+        let presentation = FirstRunSnapshotPresentation.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 2_000)),
+            ],
+            transactions: [],
+            completionState: readyCompletion(transactionCount: 0),
+            isDismissed: false,
+            isInitialLoad: false,
+            isDemoMode: false,
+            now: now
+        )
+
+        #expect(presentation?.snapshot.transactionState == .empty)
+        #expect(presentation?.snapshot.monthToDateSpend == nil)
+        #expect(presentation?.snapshot.largeTransactions.isEmpty == true)
+        #expect(presentation?.subtitle == "Accounts are ready; no transaction rows are available yet.")
+        #expect(presentation?.primaryAccessibilityLabel.contains("No transactions synced yet") == true)
+    }
+
+    @Test("Presentation keeps partial credit data explicit")
+    func presentationHandlesPartialCreditData() {
+        let presentation = FirstRunSnapshotPresentation.evaluate(
+            accounts: [
+                AccountDTO(id: "checking", itemId: "item-a", name: "Checking", type: .depository, balances: BalanceDTO(available: 1_200)),
+            ],
+            transactions: [
+                expense("grocery", amount: 120, date: "2026-06-10", name: "Groceries"),
+            ],
+            completionState: readyCompletion(transactionCount: 1),
+            isDismissed: false,
+            isInitialLoad: false,
+            isDemoMode: false,
+            now: now
+        )
+
+        #expect(presentation?.snapshot.hasCreditAccounts == false)
+        #expect(presentation?.snapshot.creditUtilization == nil)
+        #expect(presentation?.primaryAccessibilityLabel.contains("No credit utilization available") == true)
+    }
+
     private func readyCompletion(transactionCount: Int) -> FirstRunCompletionState {
         FirstRunCompletionState(
             step: .ready,


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-415/mount-first-run-money-snapshot-ui-after-account-connection

## Summary
- Added a core first-run snapshot presentation gate around the existing display-safe FirstRunSnapshot model.
- Mounted a dismissible native macOS snapshot card in the dashboard after the first successful account and transaction sync.
- Persisted dismissal per local storage/environment context so the card does not reappear every launch.
- Covered ready, dismissed, partial-credit, and no-transaction states in focused core tests.

## Tests
- PASS: git diff --check
- PASS: git diff --cached --check
- PASS: swift test --skip-update --filter FirstRunSnapshotTests

## Risks
- UI validation is compile/test based; no screenshot snapshot was generated in this pass.
- The card uses existing local DTOs only and does not add menu bar or notification exposure, but real-world density may need follow-up tuning after visual review on smaller displays.