### PR TITLE
AND-399: Build transaction review inbox

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -37,6 +37,8 @@ final class AppState {
             invalidateLocalAIActivitySummaries()
         }
     }
+    var transactionReviewMetadata: [TransactionReviewMetadata] = []
+    var transactionRules: [TransactionRule] = []
     var isLoading = false
     /// True from launch until the first `loadInitialData()` pass completes.
     /// While booting, data surfaces render loading/skeleton states instead
@@ -186,6 +188,7 @@ final class AppState {
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
     private var localAISummaryRefreshTask: Task<Void, Never>?
+    private var reviewUndoStack: [(metadata: [TransactionReviewMetadata], rules: [TransactionRule])] = []
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
     private var lastAttemptedCredentialUpgradeConfig: String?
@@ -372,39 +375,50 @@ final class AppState {
         menuBarStatusPresentation.attentionText
     }
 
+    var menuBarReviewText: String? {
+        guard transactionReviewCount > 0 else { return nil }
+        return "\(transactionReviewCount) review"
+    }
+
     var menuBarHelpText: String {
+        let reviewText = transactionReviewCount > 0
+            ? " \(transactionReviewCount) transaction\(transactionReviewCount == 1 ? "" : "s") need review."
+            : ""
         let status = "Status: \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netWorth:
-            return "VaultPeek - Net worth: \(menuBarText). \(status)"
+            return "VaultPeek - Net worth: \(menuBarText).\(reviewText) \(status)"
         case .netCash:
-            return "VaultPeek - Net cash: \(menuBarText). \(status)"
+            return "VaultPeek - Net cash: \(menuBarText).\(reviewText) \(status)"
         case .totalCash:
-            return "VaultPeek - Total cash: \(menuBarText). \(status)"
+            return "VaultPeek - Total cash: \(menuBarText).\(reviewText) \(status)"
         case .creditUtilization:
-            return "VaultPeek - Credit utilization: \(menuBarText). \(status)"
+            return "VaultPeek - Credit utilization: \(menuBarText).\(reviewText) \(status)"
         case .recentSpend:
-            return "VaultPeek - Recent spend: \(menuBarText). \(status)"
+            return "VaultPeek - Recent spend: \(menuBarText).\(reviewText) \(status)"
         case .iconOnly:
-            return "VaultPeek. \(status)"
+            return "VaultPeek.\(reviewText) \(status)"
         }
     }
 
     var menuBarAccessibilityLabel: String {
+        let reviewText = transactionReviewCount > 0
+            ? "\(transactionReviewCount) transaction\(transactionReviewCount == 1 ? "" : "s") need review. "
+            : ""
         let status = "Status \(diagnosticsSummary)"
         switch menuBarSummaryMode {
         case .netWorth:
-            return "VaultPeek net worth \(menuBarText). \(status)"
+            return "VaultPeek net worth \(menuBarText). \(reviewText)\(status)"
         case .netCash:
-            return "VaultPeek net cash \(menuBarText). \(status)"
+            return "VaultPeek net cash \(menuBarText). \(reviewText)\(status)"
         case .totalCash:
-            return "VaultPeek total cash \(menuBarText). \(status)"
+            return "VaultPeek total cash \(menuBarText). \(reviewText)\(status)"
         case .creditUtilization:
-            return "VaultPeek credit utilization \(menuBarText). \(status)"
+            return "VaultPeek credit utilization \(menuBarText). \(reviewText)\(status)"
         case .recentSpend:
-            return "VaultPeek recent spend \(menuBarText). \(status)"
+            return "VaultPeek recent spend \(menuBarText). \(reviewText)\(status)"
         case .iconOnly:
-            return "VaultPeek. \(status)"
+            return "VaultPeek. \(reviewText)\(status)"
         }
     }
 
@@ -602,6 +616,20 @@ final class AppState {
             lastSyncRelative: lastSyncRelative,
             errorMessage: error
         )
+    }
+
+    var transactionReviewInboxSnapshot: TransactionReviewInboxSnapshot {
+        TransactionReviewInbox.evaluate(
+            transactions: transactions,
+            metadata: transactionReviewMetadata,
+            rules: transactionRules,
+            recurring: recurringTransactions,
+            now: Date()
+        )
+    }
+
+    var transactionReviewCount: Int {
+        transactionReviewInboxSnapshot.totalCount
     }
 
     var notificationPermissionPresentation: NotificationPermissionPresentation {
@@ -893,6 +921,7 @@ final class AppState {
                 // array. The cursor is still committed only after the cache
                 // write succeeds, preserving local-first durability.
                 transactions = updatedTransactions
+                seedReviewMetadataForNewTransactions(updatedTransactions)
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
                 try await localDataCache.saveTransactions(
@@ -935,6 +964,8 @@ final class AppState {
             // counts would otherwise linger on the real dashboard.
             accounts = []
             transactions = []
+            transactionReviewMetadata = []
+            transactionRules = []
             itemStatuses = []
             // loadDemoData() replaced the in-memory balance history with a
             // synthetic 60-day series. Restore persisted real history when it
@@ -1108,6 +1139,9 @@ final class AppState {
                 transaction.itemId == removedItemId ||
                     (transaction.itemId == nil && removedAccountIds.contains(transaction.accountId))
             }
+            transactionReviewMetadata.removeAll { metadata in
+                !transactions.contains { $0.id == metadata.id }
+            }
             do {
                 let cacheAccounts = accounts
                 let cacheTransactions = transactions
@@ -1119,6 +1153,7 @@ final class AppState {
                     to: cacheDirectory,
                     context: cacheContext
                 )
+                persistReviewStorage()
             } catch {
                 self.error = "Local cache failed to save: \(error.localizedDescription)"
             }
@@ -1137,6 +1172,8 @@ final class AppState {
 
         accounts = []
         transactions = []
+        transactionReviewMetadata = []
+        transactionRules = []
         itemStatuses = []
         serverItemCount = 0
         serverCredentialsConfigured = nil
@@ -1367,6 +1404,12 @@ final class AppState {
         ), !cachedTransactions.isEmpty {
             transactions = cachedTransactions
         }
+        if let cachedMetadata = try? await localDataCache.loadTransactionReviewMetadata(from: cacheDirectory) {
+            transactionReviewMetadata = cachedMetadata
+        }
+        if let cachedRules = try? await localDataCache.loadTransactionRules(from: cacheDirectory) {
+            transactionRules = cachedRules
+        }
     }
 
     private func preconnectCacheDirectory(for context: TransactionCacheContext) -> URL? {
@@ -1488,6 +1531,7 @@ final class AppState {
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
+            await loadTransactionReviewStorage()
         } catch {
             self.error = "Transaction cache failed to load: \(error.localizedDescription)"
         }
@@ -1501,8 +1545,26 @@ final class AppState {
                 to: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
+            transactionReviewMetadata = []
+            transactionRules = []
+            try await localDataCache.saveTransactionReviewMetadata([], to: activeStorageDirectoryURL)
+            try await localDataCache.saveTransactionRules([], to: activeStorageDirectoryURL)
         } catch {
             self.error = "Transaction cache failed to clear: \(error.localizedDescription)"
+        }
+    }
+
+    private func loadTransactionReviewStorage() async {
+        do {
+            transactionReviewMetadata = try await localDataCache.loadTransactionReviewMetadata(
+                from: activeStorageDirectoryURL
+            )
+            transactionRules = try await localDataCache.loadTransactionRules(
+                from: activeStorageDirectoryURL
+            )
+            seedReviewMetadataForNewTransactions(transactions)
+        } catch {
+            self.error = "Review inbox storage failed to load: \(error.localizedDescription)"
         }
     }
 
@@ -1693,6 +1755,8 @@ final class AppState {
         // stay testable. See DemoFixtures and DemoFixturesTests.
         accounts = DemoFixtures.accounts
         transactions = DemoFixtures.transactions()
+        transactionReviewMetadata = []
+        transactionRules = []
         balanceHistory = DemoFixtures.balanceHistory()
 
         isSetupComplete = true
@@ -1714,6 +1778,165 @@ final class AppState {
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),
         ]
         lastSyncDate = isDemoStatusRecoveryScenario ? recoveredSync : Date()
+    }
+
+    // MARK: - Transaction Review
+
+    func approveReviewItem(_ id: String) {
+        updateReviewMetadata(id: id) { metadata, transaction in
+            metadata.status = .reviewed
+            metadata.reviewedAt = Date()
+            metadata.reviewReasonCodes = []
+            metadata.lastSeenAmount = transaction.amount
+            metadata.lastSeenName = transaction.name
+            metadata.lastSeenPending = transaction.pending
+        }
+    }
+
+    func ignoreReviewItem(_ id: String) {
+        updateReviewMetadata(id: id) { metadata, transaction in
+            metadata.status = .ignored
+            metadata.reviewedAt = Date()
+            metadata.lastSeenAmount = transaction.amount
+            metadata.lastSeenName = transaction.name
+            metadata.lastSeenPending = transaction.pending
+        }
+    }
+
+    func updateReviewCategory(_ id: String, category: SpendingCategory) {
+        updateReviewMetadata(id: id) { metadata, transaction in
+            metadata.status = .reviewed
+            metadata.userCategory = category
+            metadata.reviewedAt = Date()
+            metadata.reviewReasonCodes = []
+            metadata.lastSeenAmount = transaction.amount
+            metadata.lastSeenName = transaction.name
+            metadata.lastSeenPending = transaction.pending
+        }
+    }
+
+    func renameReviewMerchant(_ id: String, merchantName: String) {
+        let trimmed = merchantName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        updateReviewMetadata(id: id) { metadata, transaction in
+            metadata.status = .reviewed
+            metadata.userMerchantName = trimmed
+            metadata.reviewedAt = Date()
+            metadata.reviewReasonCodes = []
+            metadata.lastSeenAmount = transaction.amount
+            metadata.lastSeenName = transaction.name
+            metadata.lastSeenPending = transaction.pending
+        }
+    }
+
+    func markReviewItemTransfer(_ id: String, isTransfer: Bool = true) {
+        updateReviewMetadata(id: id) { metadata, transaction in
+            metadata.status = .reviewed
+            metadata.isTransferOverride = isTransfer
+            metadata.excludedFromBudgets = isTransfer
+            metadata.reviewedAt = Date()
+            metadata.reviewReasonCodes = []
+            metadata.lastSeenAmount = transaction.amount
+            metadata.lastSeenName = transaction.name
+            metadata.lastSeenPending = transaction.pending
+        }
+    }
+
+    func createRule(
+        from item: TransactionReviewItem,
+        category: SpendingCategory? = nil,
+        markTransfer: Bool? = nil
+    ) {
+        let matcher = item.effectiveMerchantName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !matcher.isEmpty else { return }
+        let resolvedTransfer = markTransfer ?? (item.reasonCodes.contains(.possibleTransfer) ? true : item.isTransfer)
+        pushReviewUndoState()
+        transactionRules.append(TransactionRule(
+            matchMerchantContains: matcher,
+            matchOriginalNameContains: nil,
+            category: category ?? item.effectiveCategory,
+            merchantName: item.effectiveMerchantName,
+            isTransfer: resolvedTransfer ? true : nil,
+            excludedFromBudgets: (resolvedTransfer || item.excludedFromBudgets) ? true : nil
+        ))
+        approveReviewItemWithoutUndo(item.id)
+        persistReviewStorage()
+    }
+
+    func undoLastReviewAction() {
+        guard let previous = reviewUndoStack.popLast() else { return }
+        transactionReviewMetadata = previous.metadata
+        transactionRules = previous.rules
+        persistReviewStorage()
+    }
+
+    private func updateReviewMetadata(
+        id: String,
+        mutate: (inout TransactionReviewMetadata, TransactionDTO) -> Void
+    ) {
+        guard let transaction = transactions.first(where: { $0.id == id }) else { return }
+        pushReviewUndoState()
+        var byId = Dictionary(uniqueKeysWithValues: transactionReviewMetadata.map { ($0.id, $0) })
+        var metadata = byId[id] ?? TransactionReviewMetadata(id: id)
+        mutate(&metadata, transaction)
+        byId[id] = metadata
+        transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
+        persistReviewStorage()
+    }
+
+    private func approveReviewItemWithoutUndo(_ id: String) {
+        guard let transaction = transactions.first(where: { $0.id == id }) else { return }
+        var byId = Dictionary(uniqueKeysWithValues: transactionReviewMetadata.map { ($0.id, $0) })
+        var metadata = byId[id] ?? TransactionReviewMetadata(id: id)
+        metadata.status = .reviewed
+        metadata.reviewedAt = Date()
+        metadata.reviewReasonCodes = []
+        metadata.lastSeenAmount = transaction.amount
+        metadata.lastSeenName = transaction.name
+        metadata.lastSeenPending = transaction.pending
+        byId[id] = metadata
+        transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
+    }
+
+    private func seedReviewMetadataForNewTransactions(_ transactions: [TransactionDTO]) {
+        var byId = Dictionary(uniqueKeysWithValues: transactionReviewMetadata.map { ($0.id, $0) })
+        var changed = false
+        for transaction in transactions where byId[transaction.id] == nil {
+            byId[transaction.id] = TransactionReviewMetadata(
+                id: transaction.id,
+                lastSeenAmount: transaction.amount,
+                lastSeenName: transaction.name,
+                lastSeenPending: transaction.pending
+            )
+            changed = true
+        }
+        guard changed else { return }
+        transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
+        persistReviewStorage()
+    }
+
+    private func pushReviewUndoState() {
+        reviewUndoStack.append((transactionReviewMetadata, transactionRules))
+        if reviewUndoStack.count > 20 {
+            reviewUndoStack.removeFirst(reviewUndoStack.count - 20)
+        }
+    }
+
+    private func persistReviewStorage() {
+        let metadata = transactionReviewMetadata
+        let rules = transactionRules
+        let cacheDirectory = activeStorageDirectoryURL
+        let cache = localDataCache
+        Task {
+            do {
+                try await cache.saveTransactionReviewMetadata(metadata, to: cacheDirectory)
+                try await cache.saveTransactionRules(rules, to: cacheDirectory)
+            } catch {
+                await MainActor.run {
+                    self.error = "Review inbox storage failed to save: \(error.localizedDescription)"
+                }
+            }
+        }
     }
 
 }

--- a/Sources/PlaidBar/Services/LocalDataCacheService.swift
+++ b/Sources/PlaidBar/Services/LocalDataCacheService.swift
@@ -32,6 +32,28 @@ actor LocalDataCacheService {
         try LocalDataStore.saveTransactions(transactions, to: directory, context: context)
     }
 
+    func loadTransactionReviewMetadata(from directory: URL) throws -> [TransactionReviewMetadata] {
+        try LocalDataStore.loadTransactionReviewMetadata(from: directory)
+    }
+
+    func saveTransactionReviewMetadata(
+        _ metadata: [TransactionReviewMetadata],
+        to directory: URL
+    ) throws {
+        try LocalDataStore.saveTransactionReviewMetadata(metadata, to: directory)
+    }
+
+    func loadTransactionRules(from directory: URL) throws -> [TransactionRule] {
+        try LocalDataStore.loadTransactionRules(from: directory)
+    }
+
+    func saveTransactionRules(
+        _ rules: [TransactionRule],
+        to directory: URL
+    ) throws {
+        try LocalDataStore.saveTransactionRules(rules, to: directory)
+    }
+
     func resetLocalData(at directory: URL) throws -> LocalDataResetResult {
         try LocalDataStore.resetLocalData(at: directory)
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -391,6 +391,9 @@ struct MainPopover: View {
                         DashboardChangeReceiptStrip()
                             .environment(appState)
 
+                        ReviewInboxView()
+                            .environment(appState)
+
                         if shouldElevateStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                                 AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -24,6 +24,12 @@ struct MenuBarLabel: View {
                     .font(.caption.weight(.medium))
                     .lineLimit(1)
             }
+            if presentation.attentionText == nil,
+               let reviewText = appState.menuBarReviewText {
+                Text(reviewText)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+            }
             if !appState.menuBarText.isEmpty {
                 Text(appState.menuBarText)
                     .monospacedDigit()

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -1,0 +1,345 @@
+import PlaidBarCore
+import SwiftUI
+
+struct ReviewInboxView: View {
+    @Environment(AppState.self) private var appState
+    @FocusState private var isFocused: Bool
+    @State private var selectedIndex = 0
+    @State private var merchantDrafts: [String: String] = [:]
+
+    private var snapshot: TransactionReviewInboxSnapshot {
+        appState.transactionReviewInboxSnapshot
+    }
+
+    private var items: [TransactionReviewItem] {
+        Array(snapshot.items.prefix(6))
+    }
+
+    var body: some View {
+        if snapshot.totalCount > 0 {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                header
+
+                VStack(spacing: Spacing.xs) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        ReviewInboxRow(
+                            item: item,
+                            isSelected: index == selectedIndex,
+                            merchantDraft: merchantDraftBinding(for: item),
+                            onSelect: { selectedIndex = index },
+                            onApprove: { appState.approveReviewItem(item.id) },
+                            onCategory: { appState.updateReviewCategory(item.id, category: $0) },
+                            onRename: { appState.renameReviewMerchant(item.id, merchantName: merchantDraft(for: item)) },
+                            onTransfer: { appState.markReviewItemTransfer(item.id) },
+                            onNotTransfer: { appState.markReviewItemTransfer(item.id, isTransfer: false) },
+                            onCategoryRule: { appState.createRule(from: item, category: $0) },
+                            onTransferRule: { appState.createRule(from: item, markTransfer: true) },
+                            onIgnore: { appState.ignoreReviewItem(item.id) }
+                        )
+                    }
+                }
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.raised)
+            .focusable()
+            .focused($isFocused)
+            .onAppear {
+                isFocused = true
+                clampSelection()
+            }
+            .onChange(of: snapshot.totalCount) { _, _ in
+                clampSelection()
+            }
+            .onMoveCommand(perform: moveSelection)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Review inbox. \(snapshot.totalCount) transaction\(snapshot.totalCount == 1 ? "" : "s") need attention.")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Review Inbox")
+                    .sectionTitle()
+
+                Text("\(snapshot.totalCount) item\(snapshot.totalCount == 1 ? "" : "s") need attention")
+                    .microText()
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if snapshot.highPriorityCount > 0 {
+                Label("\(snapshot.highPriorityCount) high priority", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(SemanticColors.warning)
+                    .labelStyle(.titleAndIcon)
+                    .accessibilityLabel("\(snapshot.highPriorityCount) high priority review item\(snapshot.highPriorityCount == 1 ? "" : "s")")
+            }
+
+            Button {
+                appState.undoLastReviewAction()
+            } label: {
+                Label("Undo", systemImage: "arrow.uturn.backward")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            .keyboardShortcut("z", modifiers: .command)
+            .help("Undo last review action")
+            .accessibilityLabel("Undo last review action")
+        }
+    }
+
+    private func merchantDraftBinding(for item: TransactionReviewItem) -> Binding<String> {
+        Binding(
+            get: { merchantDraft(for: item) },
+            set: { merchantDrafts[item.id] = $0 }
+        )
+    }
+
+    private func merchantDraft(for item: TransactionReviewItem) -> String {
+        merchantDrafts[item.id] ?? item.effectiveMerchantName
+    }
+
+    private func moveSelection(_ direction: MoveCommandDirection) {
+        switch direction {
+        case .down, .right:
+            selectedIndex = min(selectedIndex + 1, max(items.count - 1, 0))
+        case .up, .left:
+            selectedIndex = max(selectedIndex - 1, 0)
+        @unknown default:
+            break
+        }
+    }
+
+    private func clampSelection() {
+        selectedIndex = min(max(selectedIndex, 0), max(items.count - 1, 0))
+    }
+}
+
+private struct ReviewInboxRow: View {
+    let item: TransactionReviewItem
+    let isSelected: Bool
+    @Binding var merchantDraft: String
+    let onSelect: () -> Void
+    let onApprove: () -> Void
+    let onCategory: (SpendingCategory) -> Void
+    let onRename: () -> Void
+    let onTransfer: () -> Void
+    let onNotTransfer: () -> Void
+    let onCategoryRule: (SpendingCategory) -> Void
+    let onTransferRule: () -> Void
+    let onIgnore: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Button(action: onSelect) {
+                rowSummary
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(accessibilitySummary)
+            .accessibilityHint("Selects this transaction review row.")
+
+            if isSelected {
+                selectedControls
+            }
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.rowVertical)
+        .nativePanelSurface(
+            fill: AnyShapeStyle(SurfaceTokens.panelFill(emphasisTint: isSelected ? SemanticColors.warning : nil)),
+            stroke: isSelected ? SemanticColors.warning.opacity(0.22) : Color.primary.opacity(0.07)
+        )
+    }
+
+    private var rowSummary: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: leadingSymbolName)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(leadingTint)
+                .frame(width: 24, height: 24)
+                .background(leadingTint.opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                HStack(spacing: Spacing.xs) {
+                    Text(item.effectiveMerchantName)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.82)
+
+                    Spacer(minLength: Spacing.xs)
+
+                    Text(Formatters.currency(item.transaction.displayAmount, format: .compact))
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: Spacing.xs) {
+                    Text(item.effectiveCategory?.displayName ?? "Uncategorized")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+
+                    Text(Formatters.displayTransactionDate(item.transaction.date))
+                        .microText()
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+
+                reasonChips
+            }
+        }
+    }
+
+    private var reasonChips: some View {
+        HStack(spacing: Spacing.xxs) {
+            ForEach(item.reasonCodes, id: \.self) { reason in
+                Label(reason.displayName, systemImage: symbolName(for: reason))
+                    .font(.caption2.weight(.semibold))
+                    .labelStyle(.titleAndIcon)
+                    .foregroundStyle(tint(for: reason))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(tint(for: reason).opacity(0.10), in: Capsule())
+                    .overlay {
+                        Capsule().stroke(tint(for: reason).opacity(0.18), lineWidth: 1)
+                    }
+            }
+        }
+    }
+
+    private var selectedControls: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: Spacing.xs) {
+                Button {
+                    onApprove()
+                } label: {
+                    Label("Approve", systemImage: "checkmark")
+                }
+                .keyboardShortcut("a", modifiers: [])
+                .help("Approve transaction")
+
+                categoryPicker
+
+                Button {
+                    transferAction()
+                } label: {
+                    Label(item.isTransfer ? "Not transfer" : "Transfer", systemImage: "arrow.left.arrow.right")
+                }
+                .keyboardShortcut("t", modifiers: [])
+                .help(item.isTransfer ? "Mark as spend" : "Mark transfer and exclude from budgets")
+
+                ruleMenu
+
+                Button {
+                    onIgnore()
+                } label: {
+                    Label("Ignore", systemImage: "eye.slash")
+                }
+                .keyboardShortcut("i", modifiers: [])
+                .help("Ignore unless materially changed")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+
+            HStack(spacing: Spacing.xs) {
+                TextField("Merchant name", text: $merchantDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption)
+                    .onSubmit(onRename)
+                    .accessibilityLabel("Normalized merchant name")
+
+                Button {
+                    onRename()
+                } label: {
+                    Label("Rename", systemImage: "textformat")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .keyboardShortcut("m", modifiers: [])
+                .help("Save merchant rename")
+            }
+        }
+    }
+
+    private var categoryPicker: some View {
+        Menu {
+            ForEach(SpendingCategory.allCases, id: \.self) { category in
+                Button {
+                    onCategory(category)
+                } label: {
+                    Label(category.displayName, systemImage: category.iconName)
+                }
+            }
+        } label: {
+            Label("Category", systemImage: "tag")
+        }
+        .keyboardShortcut("c", modifiers: [])
+        .help("Change local category")
+    }
+
+    private var ruleMenu: some View {
+        Menu {
+            if item.reasonCodes.contains(.possibleTransfer) || item.isTransfer {
+                Button {
+                    onTransferRule()
+                } label: {
+                    Label("Always mark transfer", systemImage: "arrow.left.arrow.right")
+                }
+            }
+
+            Menu {
+                ForEach(SpendingCategory.allCases, id: \.self) { category in
+                    Button {
+                        onCategoryRule(category)
+                    } label: {
+                        Label(category.displayName, systemImage: category.iconName)
+                    }
+                }
+            } label: {
+                Label("Always categorize as", systemImage: "tag")
+            }
+        } label: {
+            Label("Rule", systemImage: "wand.and.stars")
+        }
+        .keyboardShortcut("r", modifiers: [])
+        .help("Create a deterministic local rule for this merchant")
+    }
+
+    private func transferAction() {
+        item.isTransfer ? onNotTransfer() : onTransfer()
+    }
+
+    private var leadingSymbolName: String {
+        item.reasonCodes.first.map(symbolName(for:)) ?? "tray"
+    }
+
+    private var leadingTint: Color {
+        item.reasonCodes.contains(where: \.isHighPriority) ? SemanticColors.warning : .secondary
+    }
+
+    private var accessibilitySummary: String {
+        let reasons = item.reasonCodes.map(\.displayName).joined(separator: ", ")
+        let category = item.effectiveCategory?.displayName ?? "Uncategorized"
+        let amount = Formatters.currency(item.transaction.displayAmount, format: .full)
+        return "\(item.effectiveMerchantName), \(amount), \(category), reasons: \(reasons)"
+    }
+
+    private func symbolName(for reason: TransactionReviewReason) -> String {
+        switch reason {
+        case .uncategorized: "tag"
+        case .newMerchant: "person.crop.circle.badge.questionmark"
+        case .unusualAmount: "chart.line.uptrend.xyaxis"
+        case .possibleTransfer: "arrow.left.arrow.right"
+        case .recurringChanged: "calendar.badge.exclamationmark"
+        case .pendingChanged: "clock.badge.exclamationmark"
+        }
+    }
+
+    private func tint(for reason: TransactionReviewReason) -> Color {
+        reason.isHighPriority ? SemanticColors.warning : .secondary
+    }
+}

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+public enum TransactionReviewStatus: String, Codable, Sendable, Equatable, Hashable {
+    case needsReview
+    case reviewed
+    case ignored
+}
+
+public enum TransactionReviewReason: String, Codable, Sendable, CaseIterable, Equatable, Hashable {
+    case uncategorized
+    case newMerchant
+    case unusualAmount
+    case possibleTransfer
+    case recurringChanged
+    case pendingChanged
+
+    public var displayName: String {
+        switch self {
+        case .uncategorized: "Needs category"
+        case .newMerchant: "New merchant"
+        case .unusualAmount: "Large / unusual"
+        case .possibleTransfer: "Possible transfer"
+        case .recurringChanged: "Recurring changed"
+        case .pendingChanged: "Pending changed"
+        }
+    }
+
+    public var priority: Int {
+        switch self {
+        case .possibleTransfer, .pendingChanged, .recurringChanged: 0
+        case .unusualAmount: 1
+        case .uncategorized, .newMerchant: 2
+        }
+    }
+
+    public var isHighPriority: Bool {
+        priority == 0 || self == .unusualAmount
+    }
+}
+
+public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equatable {
+    public let id: String
+    public var status: TransactionReviewStatus
+    public var userCategory: SpendingCategory?
+    public var userMerchantName: String?
+    public var isTransferOverride: Bool?
+    public var excludedFromBudgets: Bool
+    public var reviewedAt: Date?
+    public var reviewReasonCodes: [TransactionReviewReason]
+    public var lastSeenAmount: Double?
+    public var lastSeenName: String?
+    public var lastSeenPending: Bool?
+
+    public init(
+        id: String,
+        status: TransactionReviewStatus = .needsReview,
+        userCategory: SpendingCategory? = nil,
+        userMerchantName: String? = nil,
+        isTransferOverride: Bool? = nil,
+        excludedFromBudgets: Bool = false,
+        reviewedAt: Date? = nil,
+        reviewReasonCodes: [TransactionReviewReason] = [],
+        lastSeenAmount: Double? = nil,
+        lastSeenName: String? = nil,
+        lastSeenPending: Bool? = nil
+    ) {
+        self.id = id
+        self.status = status
+        self.userCategory = userCategory
+        self.userMerchantName = userMerchantName
+        self.isTransferOverride = isTransferOverride
+        self.excludedFromBudgets = excludedFromBudgets
+        self.reviewedAt = reviewedAt
+        self.reviewReasonCodes = reviewReasonCodes
+        self.lastSeenAmount = lastSeenAmount
+        self.lastSeenName = lastSeenName
+        self.lastSeenPending = lastSeenPending
+    }
+}
+
+public struct TransactionRule: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var matchMerchantContains: String?
+    public var matchOriginalNameContains: String?
+    public var category: SpendingCategory?
+    public var merchantName: String?
+    public var isTransfer: Bool?
+    public var excludedFromBudgets: Bool?
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        matchMerchantContains: String? = nil,
+        matchOriginalNameContains: String? = nil,
+        category: SpendingCategory? = nil,
+        merchantName: String? = nil,
+        isTransfer: Bool? = nil,
+        excludedFromBudgets: Bool? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.matchMerchantContains = matchMerchantContains
+        self.matchOriginalNameContains = matchOriginalNameContains
+        self.category = category
+        self.merchantName = merchantName
+        self.isTransfer = isTransfer
+        self.excludedFromBudgets = excludedFromBudgets
+        self.createdAt = createdAt
+    }
+
+    public func matches(_ transaction: TransactionDTO) -> Bool {
+        let merchant = transaction.merchantName ?? transaction.name
+        let merchantMatched = matchMerchantContains.map {
+            merchant.localizedCaseInsensitiveContains($0)
+        } ?? false
+        let originalMatched = matchOriginalNameContains.map {
+            transaction.name.localizedCaseInsensitiveContains($0)
+        } ?? false
+        return merchantMatched || originalMatched
+    }
+}
+
+public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
+    public let id: String
+    public let transaction: TransactionDTO
+    public let status: TransactionReviewStatus
+    public let reasonCodes: [TransactionReviewReason]
+    public let effectiveCategory: SpendingCategory?
+    public let effectiveMerchantName: String
+    public let isTransfer: Bool
+    public let excludedFromBudgets: Bool
+    public let matchedRuleIds: [UUID]
+
+    public init(
+        transaction: TransactionDTO,
+        status: TransactionReviewStatus,
+        reasonCodes: [TransactionReviewReason],
+        effectiveCategory: SpendingCategory?,
+        effectiveMerchantName: String,
+        isTransfer: Bool,
+        excludedFromBudgets: Bool,
+        matchedRuleIds: [UUID]
+    ) {
+        self.id = transaction.id
+        self.transaction = transaction
+        self.status = status
+        self.reasonCodes = reasonCodes
+        self.effectiveCategory = effectiveCategory
+        self.effectiveMerchantName = effectiveMerchantName
+        self.isTransfer = isTransfer
+        self.excludedFromBudgets = excludedFromBudgets
+        self.matchedRuleIds = matchedRuleIds
+    }
+}
+
+public struct TransactionReviewInboxSnapshot: Sendable, Equatable {
+    public let items: [TransactionReviewItem]
+    public let totalCount: Int
+    public let highPriorityCount: Int
+
+    public init(items: [TransactionReviewItem]) {
+        self.items = items
+        self.totalCount = items.count
+        self.highPriorityCount = items.filter { item in
+            item.reasonCodes.contains(where: \.isHighPriority)
+        }.count
+    }
+}
+
+public enum TransactionReviewInbox {
+    public static func evaluate(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata],
+        rules: [TransactionRule],
+        recurring: [RecurringTransaction],
+        now: Date
+    ) -> TransactionReviewInboxSnapshot {
+        let metadataById = Dictionary(uniqueKeysWithValues: metadata.map { ($0.id, $0) })
+        let merchantCounts = Dictionary(grouping: transactions, by: normalizedMerchantKey)
+            .mapValues(\.count)
+        let spendTransactions = transactions.filter { !$0.isIncome }
+        let recurringByMerchant = Dictionary(grouping: recurring, by: { normalizedKey($0.merchantName) })
+
+        let items = transactions.compactMap { transaction -> TransactionReviewItem? in
+            let metadata = metadataById[transaction.id]
+            if metadata?.status == .reviewed || metadata?.status == .ignored {
+                return nil
+            }
+
+            let matchedRules = rules.filter { $0.matches(transaction) }
+            if !matchedRules.isEmpty {
+                return nil
+            }
+
+            let effectiveCategory = metadata?.userCategory ?? transaction.category
+            let effectiveMerchant = trimmedNonEmpty(metadata?.userMerchantName)
+                ?? trimmedNonEmpty(transaction.merchantName)
+                ?? transaction.name
+            let isTransfer = metadata?.isTransferOverride
+                ?? effectiveCategory.map(isTransferCategory)
+                ?? false
+
+            if transaction.isIncome, !looksLikeTransfer(transaction) {
+                return nil
+            }
+
+            var reasons: Set<TransactionReviewReason> = []
+            if effectiveCategory == nil || effectiveCategory == .other {
+                reasons.insert(.uncategorized)
+            }
+            if merchantNeedsReview(transaction: transaction, effectiveMerchant: effectiveMerchant) ||
+                merchantCounts[normalizedMerchantKey(transaction), default: 0] == 1 {
+                reasons.insert(.newMerchant)
+            }
+            if isUnusual(transaction, in: spendTransactions, category: effectiveCategory) {
+                reasons.insert(.unusualAmount)
+            }
+            if looksLikeTransfer(transaction), !isTransfer {
+                reasons.insert(.possibleTransfer)
+            }
+            if recurringChanged(transaction, recurringByMerchant: recurringByMerchant, now: now) {
+                reasons.insert(.recurringChanged)
+            }
+            if pendingChanged(transaction, metadata: metadata) {
+                reasons.insert(.pendingChanged)
+            }
+
+            let orderedReasons = reasons.sorted {
+                if $0.priority == $1.priority { return $0.rawValue < $1.rawValue }
+                return $0.priority < $1.priority
+            }
+            guard !orderedReasons.isEmpty else { return nil }
+
+            return TransactionReviewItem(
+                transaction: transaction,
+                status: metadata?.status ?? .needsReview,
+                reasonCodes: orderedReasons,
+                effectiveCategory: effectiveCategory,
+                effectiveMerchantName: effectiveMerchant,
+                isTransfer: isTransfer,
+                excludedFromBudgets: metadata?.excludedFromBudgets ?? isTransfer,
+                matchedRuleIds: matchedRules.map(\.id)
+            )
+        }
+        .sorted { lhs, rhs in
+            let lhsPriority = lhs.reasonCodes.map(\.priority).min() ?? Int.max
+            let rhsPriority = rhs.reasonCodes.map(\.priority).min() ?? Int.max
+            if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+            if lhs.transaction.date != rhs.transaction.date { return lhs.transaction.date > rhs.transaction.date }
+            return lhs.id < rhs.id
+        }
+
+        return TransactionReviewInboxSnapshot(items: items)
+    }
+
+    private static func normalizedMerchantKey(_ transaction: TransactionDTO) -> String {
+        normalizedKey(transaction.merchantName ?? transaction.name)
+    }
+
+    private static func normalizedKey(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private static func isTransferCategory(_ category: SpendingCategory) -> Bool {
+        category == .transfer || category == .transferOut
+    }
+
+    private static func merchantNeedsReview(transaction: TransactionDTO, effectiveMerchant: String) -> Bool {
+        if trimmedNonEmpty(transaction.merchantName) == nil { return true }
+        let raw = effectiveMerchant.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.count >= 2 else { return true }
+        let letters = raw.filter(\.isLetter)
+        let uppercaseLetters = letters.filter(\.isUppercase)
+        let hasDigits = raw.contains(where: \.isNumber)
+        return letters.count >= 4 && uppercaseLetters.count == letters.count && hasDigits
+    }
+
+    private static func isUnusual(
+        _ transaction: TransactionDTO,
+        in transactions: [TransactionDTO],
+        category: SpendingCategory?
+    ) -> Bool {
+        guard transaction.amount > 0 else { return false }
+        let merchantKey = normalizedMerchantKey(transaction)
+        var peers = transactions.filter {
+            $0.id != transaction.id &&
+                normalizedMerchantKey($0) == merchantKey &&
+                abs($0.amount) > 0
+        }
+        if peers.count < 3, let category {
+            peers = transactions.filter {
+                $0.id != transaction.id && $0.category == category && abs($0.amount) > 0
+            }
+        }
+        guard peers.count >= 3 else { return false }
+        let average = peers.map { abs($0.amount) }.reduce(0, +) / Double(peers.count)
+        return transaction.displayAmount >= max(average * 1.75, average + 50)
+    }
+
+    private static func looksLikeTransfer(_ transaction: TransactionDTO) -> Bool {
+        let text = "\(transaction.name) \(transaction.merchantName ?? "")".lowercased()
+        let keywords = [
+            "credit card payment",
+            "cc payment",
+            "card payment",
+            "payment thank you",
+            "autopay",
+            "ach transfer",
+            "online transfer",
+            "bank transfer",
+            "external transfer",
+            "venmo",
+            "zelle",
+            "cash app",
+            "paypal transfer",
+            "chase credit",
+        ]
+        return keywords.contains { text.contains($0) }
+    }
+
+    private static func recurringChanged(
+        _ transaction: TransactionDTO,
+        recurringByMerchant: [String: [RecurringTransaction]],
+        now: Date
+    ) -> Bool {
+        let merchantKey = normalizedMerchantKey(transaction)
+        guard let streams = recurringByMerchant[merchantKey] else { return false }
+        return streams.contains { recurring in
+            (recurring.lastDate == transaction.date && recurring.hasPriceIncrease) ||
+                recurring.isStale(asOf: now)
+        }
+    }
+
+    private static func pendingChanged(
+        _ transaction: TransactionDTO,
+        metadata: TransactionReviewMetadata?
+    ) -> Bool {
+        guard transaction.pending == false,
+              metadata?.lastSeenPending == true
+        else { return false }
+        let amountChanged = metadata?.lastSeenAmount.map { abs($0 - transaction.amount) >= 0.01 } ?? false
+        let nameChanged = metadata?.lastSeenName.map { $0 != transaction.name } ?? false
+        return amountChanged || nameChanged
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -77,6 +77,8 @@ public enum LocalDataStore {
     public static let serverConfigFilename = "server.conf"
     public static let accountCacheFilename = "accounts.json"
     public static let transactionCacheFilename = "transactions.json"
+    public static let transactionReviewMetadataFilename = "transaction-review-metadata.json"
+    public static let transactionRulesFilename = "transaction-rules.json"
     public static let pendingLinkSessionsFilename = "pending-link-sessions.json"
     public static let legacyMigrationResetMarkerFilename = ".legacy-migration-reset"
     /// Preserve the existing Keychain service while moving local files so
@@ -221,6 +223,8 @@ public enum LocalDataStore {
 
         if isAccountCacheFilename(filename) ||
             isTransactionCacheFilename(filename) ||
+            filename == transactionReviewMetadataFilename ||
+            filename == transactionRulesFilename ||
             isPendingLinkSessionsFilename(filename) {
             return true
         }
@@ -268,6 +272,8 @@ public enum LocalDataStore {
         filename == legacyMigrationResetMarkerFilename ||
             resetPreservedFilenames.contains(filename) ||
             filename == ServerAutoLaunchPlan.logFilename ||
+            filename == transactionReviewMetadataFilename ||
+            filename == transactionRulesFilename ||
             isAccountCacheFilename(filename) ||
             isTransactionCacheFilename(filename) ||
             isPendingLinkSessionsFilename(filename) ||
@@ -384,6 +390,18 @@ public enum LocalDataStore {
         in directory: URL = storageDirectoryURL()
     ) -> URL {
         directory.appendingPathComponent(authTokenFilename)
+    }
+
+    public static func transactionReviewMetadataURL(
+        in directory: URL = storageDirectoryURL()
+    ) -> URL {
+        directory.appendingPathComponent(transactionReviewMetadataFilename)
+    }
+
+    public static func transactionRulesURL(
+        in directory: URL = storageDirectoryURL()
+    ) -> URL {
+        directory.appendingPathComponent(transactionRulesFilename)
     }
 
     public static func prepareStorageDirectory(
@@ -637,6 +655,28 @@ public enum LocalDataStore {
         return cache.accounts
     }
 
+    public static func loadTransactionReviewMetadata(
+        from directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws -> [TransactionReviewMetadata] {
+        let url = transactionReviewMetadataURL(in: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return [] }
+
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode([TransactionReviewMetadata].self, from: data)
+    }
+
+    public static func loadTransactionRules(
+        from directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws -> [TransactionRule] {
+        let url = transactionRulesURL(in: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return [] }
+
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode([TransactionRule].self, from: data)
+    }
+
     public static func saveTransactions(
         _ transactions: [TransactionDTO],
         to directory: URL = storageDirectoryURL(),
@@ -663,6 +703,32 @@ public enum LocalDataStore {
         let url = accountCacheURL(in: directory, context: context)
         let cache = AccountCache(context: context, accounts: accounts)
         let data = try JSONEncoder().encode(cache)
+        try writePrivateCacheFile(data, to: url, fileManager: fileManager)
+        try setPrivateCacheFilePermissions(url, fileManager: fileManager)
+    }
+
+    public static func saveTransactionReviewMetadata(
+        _ metadata: [TransactionReviewMetadata],
+        to directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws {
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
+
+        let url = transactionReviewMetadataURL(in: directory)
+        let data = try JSONEncoder().encode(metadata.sorted { $0.id < $1.id })
+        try writePrivateCacheFile(data, to: url, fileManager: fileManager)
+        try setPrivateCacheFilePermissions(url, fileManager: fileManager)
+    }
+
+    public static func saveTransactionRules(
+        _ rules: [TransactionRule],
+        to directory: URL = storageDirectoryURL(),
+        fileManager: FileManager = .default
+    ) throws {
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
+
+        let url = transactionRulesURL(in: directory)
+        let data = try JSONEncoder().encode(rules.sorted { $0.createdAt < $1.createdAt })
         try writePrivateCacheFile(data, to: url, fileManager: fileManager)
         try setPrivateCacheFilePermissions(url, fileManager: fileManager)
     }

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Transaction Review Inbox Tests")
+struct TransactionReviewInboxTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test("Uncategorized transactions enter the inbox")
+    func uncategorizedTransactionEntersInbox() {
+        let transaction = tx(id: "uncategorized", category: nil, merchantName: "Corner Store")
+
+        let snapshot = evaluate([transaction])
+
+        #expect(snapshot.items.map(\.id) == ["uncategorized"])
+        #expect(snapshot.items.first?.reasonCodes.contains(.uncategorized) == true)
+    }
+
+    @Test("New merchant is reviewed without exposing provider identifiers")
+    func newMerchantReason() {
+        let transaction = tx(id: "new-merchant", category: .shopping, merchantName: "Desk Supply")
+
+        let snapshot = evaluate([transaction])
+
+        #expect(snapshot.totalCount == 1)
+        #expect(snapshot.items.first?.reasonCodes == [.newMerchant])
+    }
+
+    @Test("Unusual merchant amount is high priority")
+    func unusualAmountReason() {
+        let transactions = [
+            tx(id: "old-1", amount: 20, date: "2026-05-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-2", amount: 22, date: "2026-05-08", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-3", amount: 21, date: "2026-05-15", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "spike", amount: 120, date: "2026-06-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+        ]
+
+        let snapshot = evaluate(transactions)
+
+        #expect(snapshot.items.first(where: { $0.id == "spike" })?.reasonCodes.contains(.unusualAmount) == true)
+        #expect(snapshot.highPriorityCount >= 1)
+    }
+
+    @Test("Possible transfer is flagged until marked transfer")
+    func possibleTransferReason() {
+        let transaction = tx(
+            id: "transfer",
+            amount: 1_250,
+            name: "CHASE CREDIT CARD PAYMENT",
+            category: .other,
+            merchantName: "Chase Credit Card"
+        )
+
+        let snapshot = evaluate([transaction])
+        let reviewed = evaluate(
+            [transaction],
+            metadata: [
+                TransactionReviewMetadata(
+                    id: "transfer",
+                    isTransferOverride: true,
+                    excludedFromBudgets: true
+                ),
+            ]
+        )
+
+        #expect(snapshot.items.first?.reasonCodes.contains(.possibleTransfer) == true)
+        #expect(reviewed.items.first?.reasonCodes.contains(.possibleTransfer) == false)
+    }
+
+    @Test("Recurring price increase is flagged")
+    func recurringChangedReason() {
+        let transaction = tx(id: "stream-latest", amount: 18, date: "2026-06-01", category: .entertainment, merchantName: "StreamCo")
+        let recurring = RecurringTransaction(
+            merchantName: "StreamCo",
+            frequency: .monthly,
+            averageAmount: 14,
+            latestAmount: 18,
+            trailingAverageAmount: 12,
+            lastDate: "2026-06-01",
+            nextExpectedDate: "2026-07-01",
+            category: .entertainment,
+            transactionCount: 4,
+            confidence: 0.9
+        )
+
+        let snapshot = evaluate([transaction], recurring: [recurring])
+
+        #expect(snapshot.items.first?.reasonCodes.contains(.recurringChanged) == true)
+    }
+
+    @Test("Posted transaction with changed pending signature is flagged")
+    func pendingChangedReason() {
+        let transaction = tx(id: "posted", amount: 42, name: "MERCHANT FINAL", category: .shopping, merchantName: "Merchant")
+        let metadata = TransactionReviewMetadata(
+            id: "posted",
+            lastSeenAmount: 40,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([transaction], metadata: [metadata])
+
+        #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
+    }
+
+    @Test("Reviewed and ignored transactions stay out of inbox")
+    func reviewedAndIgnoredAreSuppressed() {
+        let reviewed = tx(id: "reviewed", category: nil, merchantName: "Needs Category")
+        let ignored = tx(id: "ignored", category: nil, merchantName: "Ignored")
+
+        let snapshot = evaluate(
+            [reviewed, ignored],
+            metadata: [
+                TransactionReviewMetadata(id: "reviewed", status: .reviewed),
+                TransactionReviewMetadata(id: "ignored", status: .ignored),
+            ]
+        )
+
+        #expect(snapshot.totalCount == 0)
+    }
+
+    @Test("Rule-matched transactions stay out of inbox")
+    func ruleMatchedTransactionsAreTrusted() {
+        let transaction = tx(id: "rule-match", category: nil, merchantName: "Known Merchant")
+        let rule = TransactionRule(
+            matchMerchantContains: "Known Merchant",
+            category: .shopping,
+            merchantName: "Known Merchant"
+        )
+
+        let snapshot = evaluate([transaction], rules: [rule])
+
+        #expect(snapshot.totalCount == 0)
+    }
+
+    @Test("Review metadata and rules persist as private local files")
+    func reviewStoragePersistsPrivately() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let metadata = [
+            TransactionReviewMetadata(
+                id: "synthetic-txn",
+                status: .reviewed,
+                userCategory: .shopping,
+                userMerchantName: "Synthetic Merchant",
+                reviewedAt: now
+            ),
+        ]
+        let rules = [
+            TransactionRule(
+                id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                matchMerchantContains: "Synthetic Merchant",
+                category: .shopping,
+                merchantName: "Synthetic Merchant",
+                createdAt: now
+            ),
+        ]
+
+        try LocalDataStore.saveTransactionReviewMetadata(metadata, to: directory)
+        try LocalDataStore.saveTransactionRules(rules, to: directory)
+
+        #expect(try LocalDataStore.loadTransactionReviewMetadata(from: directory) == metadata)
+        #expect(try LocalDataStore.loadTransactionRules(from: directory) == rules)
+        #expect(try posixPermissions(at: directory) == 0o700)
+        #expect(try posixPermissions(at: LocalDataStore.transactionReviewMetadataURL(in: directory)) == 0o600)
+        #expect(try posixPermissions(at: LocalDataStore.transactionRulesURL(in: directory)) == 0o600)
+
+        _ = try LocalDataStore.resetLocalData(at: directory, resetKeychainTokens: false)
+
+        #expect(try LocalDataStore.loadTransactionReviewMetadata(from: directory).isEmpty)
+        #expect(try LocalDataStore.loadTransactionRules(from: directory).isEmpty)
+    }
+
+    private func evaluate(
+        _ transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata] = [],
+        rules: [TransactionRule] = [],
+        recurring: [RecurringTransaction] = []
+    ) -> TransactionReviewInboxSnapshot {
+        TransactionReviewInbox.evaluate(
+            transactions: transactions,
+            metadata: metadata,
+            rules: rules,
+            recurring: recurring,
+            now: now
+        )
+    }
+
+    private func tx(
+        id: String,
+        amount: Double = 12,
+        date: String = "2026-06-01",
+        name: String = "MERCHANT",
+        category: SpendingCategory?,
+        merchantName: String?
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "test-account",
+            amount: amount,
+            date: date,
+            name: name,
+            merchantName: merchantName,
+            category: category
+        )
+    }
+
+    private func posixPermissions(at url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+}


### PR DESCRIPTION
Linear: https://linear.app/andeslab/issue/AND-399/build-transaction-review-inbox-for-categorization-merchant-cleanup-and

## Summary
- Adds local-only transaction review metadata, deterministic merchant rules, and a pure `TransactionReviewInbox` evaluator in PlaidBarCore.
- Persists review metadata and rules as private local JSON files under the active VaultPeek storage directory, separate from provider transaction fields.
- Adds a compact macOS review inbox surface with reason chips, approve/category/rename/transfer/ignore/rule actions, undo, arrow-key selection, and privacy-safe menu-bar review count.

## Tests
- `swift test --skip-update --filter TransactionReviewInboxTests` passed.
- `git diff --check` passed.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` passed.

## Risks
- This is the MVP popover review surface, not a full desktop transaction register.
- Review actions currently update local metadata/rules and suppress inbox rows; downstream budget/safe-to-spend consumers still need follow-on work to consume user-normalized fields everywhere.
- Undo is in-memory for the current app session; persisted metadata keeps reviewed timestamps and local overrides for audit/inspection.