### PR TITLE
AND-385: Add VaultPeek widget extension

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
     products: [
         .executable(name: "PlaidBar", targets: ["PlaidBar"]),
         .executable(name: "PlaidBarServer", targets: ["PlaidBarServer"]),
+        .executable(name: "PlaidBarWidgetExtension", targets: ["PlaidBarWidgetExtension"]),
         .executable(name: "plaidbar-cli", targets: ["PlaidBarCLI"]),
         .library(name: "PlaidBarCore", targets: ["PlaidBarCore"]),
     ],
@@ -60,6 +61,20 @@ let package = Package(
                 "Resources/AppIcon.icns",
                 "Resources/Info.plist",
                 "Resources/PlaidBar.entitlements",
+            ],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
+
+        // MARK: - PlaidBar Widget Extension (WidgetKit/App Intents)
+        .executableTarget(
+            name: "PlaidBarWidgetExtension",
+            dependencies: [
+                "PlaidBarCore",
+            ],
+            path: "Sources/PlaidBarWidgetExtension",
+            exclude: [
+                "Resources/Info.plist",
+                "Resources/PlaidBarWidgetExtension.entitlements",
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -10,8 +10,14 @@ APP_DIR="${PLAIDBAR_PACKAGE_APP_DIR:-$PROJECT_DIR/.build/VaultPeek.app}"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
+PLUGINS_DIR="$CONTENTS_DIR/PlugIns"
 RESOURCES_DIR="$PROJECT_DIR/Sources/PlaidBar/Resources"
+WIDGET_RESOURCES_DIR="$PROJECT_DIR/Sources/PlaidBarWidgetExtension/Resources"
 APP_BINARY="$MACOS_DIR/PlaidBar"
+WIDGET_EXTENSION_DIR="$PLUGINS_DIR/PlaidBarWidgetExtension.appex"
+WIDGET_EXTENSION_CONTENTS_DIR="$WIDGET_EXTENSION_DIR/Contents"
+WIDGET_EXTENSION_MACOS_DIR="$WIDGET_EXTENSION_CONTENTS_DIR/MacOS"
+WIDGET_EXTENSION_BINARY="$WIDGET_EXTENSION_MACOS_DIR/PlaidBarWidgetExtension"
 
 if [ "$CONFIGURATION" = "release" ]; then
     BUILD_FLAGS=(-c release)
@@ -33,28 +39,43 @@ if [ ! -x "$BUILD_DIR/PlaidBarServer" ]; then
     exit 1
 fi
 
+if [ ! -x "$BUILD_DIR/PlaidBarWidgetExtension" ]; then
+    echo "PlaidBarWidgetExtension binary not found at $BUILD_DIR/PlaidBarWidgetExtension" >&2
+    exit 1
+fi
+
 if [ ! -d "$BUILD_DIR/Sparkle.framework" ]; then
     echo "Sparkle.framework not found at $BUILD_DIR/Sparkle.framework" >&2
     exit 1
 fi
 
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$FRAMEWORKS_DIR" "$CONTENTS_DIR/Resources"
+mkdir -p "$MACOS_DIR" "$FRAMEWORKS_DIR" "$CONTENTS_DIR/Resources" "$WIDGET_EXTENSION_MACOS_DIR"
 
 cp "$BUILD_DIR/PlaidBar" "$APP_BINARY"
 cp "$BUILD_DIR/PlaidBarServer" "$MACOS_DIR/PlaidBarServer"
+cp "$BUILD_DIR/PlaidBarWidgetExtension" "$WIDGET_EXTENSION_BINARY"
 cp "$RESOURCES_DIR/Info.plist" "$CONTENTS_DIR/Info.plist"
 cp "$RESOURCES_DIR/AppIcon.icns" "$CONTENTS_DIR/Resources/AppIcon.icns"
+cp "$WIDGET_RESOURCES_DIR/Info.plist" "$WIDGET_EXTENSION_CONTENTS_DIR/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable PlaidBar" "$CONTENTS_DIR/Info.plist" 2>/dev/null \
     || /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string PlaidBar" "$CONTENTS_DIR/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable PlaidBarWidgetExtension" "$WIDGET_EXTENSION_CONTENTS_DIR/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string PlaidBarWidgetExtension" "$WIDGET_EXTENSION_CONTENTS_DIR/Info.plist"
 ditto "$BUILD_DIR/Sparkle.framework" "$FRAMEWORKS_DIR/Sparkle.framework"
-chmod +x "$APP_BINARY" "$MACOS_DIR/PlaidBarServer"
+chmod +x "$APP_BINARY" "$MACOS_DIR/PlaidBarServer" "$WIDGET_EXTENSION_BINARY"
 
 if ! otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_BINARY"
 fi
 
 codesign --force --deep --sign - "$APP_DIR" >/dev/null
+codesign --force --sign - \
+    --entitlements "$WIDGET_RESOURCES_DIR/PlaidBarWidgetExtension.entitlements" \
+    "$WIDGET_EXTENSION_DIR" >/dev/null
+codesign --force --sign - \
+    --entitlements "$RESOURCES_DIR/PlaidBar.entitlements" \
+    "$APP_DIR" >/dev/null
 
 "$SCRIPT_DIR/validate-app-bundle.sh" "$APP_DIR"
 

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PlaidBarCore
 import Combine
+import WidgetKit
 @preconcurrency import UserNotifications
 
 @Observable
@@ -1013,6 +1014,7 @@ final class AppState {
     func refreshDashboard() async {
         if refreshDemoDataIfNeeded() { return }
 
+        if await consumePendingGlanceCommand() { return }
         await checkServerConnection()
         // Setup state (credentials missing) cannot refresh anything from
         // Plaid; the status surfaces guide the user instead of surfacing a
@@ -1152,6 +1154,7 @@ final class AppState {
 
         balanceHistory = []
         UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
+        clearGlanceSnapshot()
         UserDefaults.standard.removeObject(forKey: Keys.lastTransactionCacheContext)
         notificationService.resetDeduplicationState()
 
@@ -1222,6 +1225,7 @@ final class AppState {
             if accounts.isEmpty { loadDemoData() }
             return
         }
+        _ = await consumePendingGlanceCommand()
         // Returning users see cached last-known data immediately: the cache
         // loads before the connectivity check (which can take seconds while
         // a bundled server boots) instead of after it.
@@ -1678,6 +1682,49 @@ final class AppState {
         if let data = try? JSONEncoder().encode(balanceHistory) {
             UserDefaults.standard.set(data, forKey: Keys.balanceHistory)
         }
+        writeGlanceSnapshot()
+    }
+
+    private func writeGlanceSnapshot(updatedAt: Date = Date()) {
+        guard !accounts.isEmpty else { return }
+        let snapshot = GlanceSnapshot.make(
+            netWorth: netBalance,
+            balanceHistory: balanceHistory,
+            updatedAt: updatedAt,
+            isDemo: isDemoMode
+        )
+        if (try? GlanceSnapshotStore.save(snapshot)) != nil {
+            WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
+        }
+    }
+
+    private func clearGlanceSnapshot() {
+        try? GlanceSnapshotStore.clear()
+    }
+
+    @discardableResult
+    private func consumePendingGlanceCommand() async -> Bool {
+        guard let request = try? GlanceSnapshotStore.consumeCommand() else { return false }
+        switch request.command {
+        case .refreshBalances:
+            await refreshDashboardFromGlanceCommand(requestedAt: request.requestedAt)
+        }
+        return true
+    }
+
+    private func refreshDashboardFromGlanceCommand(requestedAt: Date) async {
+        guard !isDemoMode else {
+            loadDemoData()
+            return
+        }
+
+        await checkServerConnection()
+        guard serverConnected, serverCredentialsConfigured != false else {
+            writeGlanceSnapshot(updatedAt: requestedAt)
+            return
+        }
+        await refreshAccounts()
+        await syncTransactions()
     }
 
     // MARK: - Demo Data
@@ -1714,6 +1761,7 @@ final class AppState {
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),
         ]
         lastSyncDate = isDemoStatusRecoveryScenario ? recoveredSync : Date()
+        writeGlanceSnapshot(updatedAt: lastSyncDate ?? Date())
     }
 
 }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1310,6 +1310,9 @@ final class AppState {
             } catch {
                 self.error = "Local cache failed to save: \(error.localizedDescription)"
             }
+            // Refresh (or clear, when the last institution is gone) the widget
+            // snapshot so it never shows balances for just-removed accounts.
+            writeGlanceSnapshot()
         } catch {
             self.error = error.localizedDescription
         }
@@ -2012,7 +2015,15 @@ final class AppState {
     }
 
     private func writeGlanceSnapshot(updatedAt: Date = Date()) {
-        guard !accounts.isEmpty else { return }
+        // With no accounts (e.g. the user just disconnected their last
+        // institution), clear the app-group snapshot instead of leaving the
+        // previous balances on disk — otherwise the widget would keep showing
+        // removed-account net worth until a later reset or successful write.
+        guard !accounts.isEmpty else {
+            clearGlanceSnapshot()
+            WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
+            return
+        }
         let snapshot = GlanceSnapshot.make(
             netWorth: netBalance,
             balanceHistory: balanceHistory,
@@ -2046,7 +2057,10 @@ final class AppState {
 
         await checkServerConnection()
         guard serverConnected, serverCredentialsConfigured != false else {
-            writeGlanceSnapshot(updatedAt: requestedAt)
+            // The refresh could not reach the server, so no balances were
+            // fetched. Do not stamp the snapshot as freshly updated at the click
+            // time — that would present stale data as current. Leave the
+            // last-success snapshot (and its real timestamp) in place.
             return
         }
         await refreshAccounts()

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -135,6 +135,17 @@ struct PlaidBarApp: App {
                         reduceMotion: reduceMotion
                     )
                 }
+                .onOpenURL { url in
+                    guard url.scheme == "vaultpeek" else { return }
+                    if detachedDashboard.handleMenuBarActivation(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme,
+                        reduceMotion: reduceMotion
+                    ) {
+                        return
+                    }
+                    appState.isPopoverPresented = true
+                }
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
             statusItemContextMenuController.configure(

--- a/Sources/PlaidBar/Resources/Info.plist
+++ b/Sources/PlaidBar/Resources/Info.plist
@@ -14,6 +14,17 @@
     <string>AppIcon</string>
     <key>CFBundleIdentifier</key>
     <string>com.ftchvs.PlaidBar</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>VaultPeek Dashboard</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>vaultpeek</string>
+            </array>
+        </dict>
+    </array>
     <key>CFBundleVersion</key>
     <string>10</string>
     <key>CFBundleShortVersionString</key>

--- a/Sources/PlaidBar/Resources/PlaidBar.entitlements
+++ b/Sources/PlaidBar/Resources/PlaidBar.entitlements
@@ -8,6 +8,10 @@
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.ftchvs.PlaidBar</string>
+    </array>
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
     <array>
         <string>/.vaultpeek/</string>

--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+public struct GlanceSnapshot: Codable, Sendable, Equatable {
+    public enum ChangeDirection: String, Codable, Sendable {
+        case up
+        case down
+        case flat
+
+        public var glyph: String {
+            switch self {
+            case .up: "▲"
+            case .down: "▼"
+            case .flat: "■"
+            }
+        }
+
+        public static func evaluate(_ value: Double) -> ChangeDirection {
+            if value > 0 { return .up }
+            if value < 0 { return .down }
+            return .flat
+        }
+    }
+
+    public static let appGroupIdentifier = "group.com.ftchvs.PlaidBar"
+    public static let filename = "glance-snapshot.json"
+    public static let commandFilename = "glance-command.json"
+    public static let deepLinkURL = "vaultpeek://dashboard"
+
+    public let netWorth: Double
+    public let todayChange: Double
+    public let updatedAt: Date
+    public let sparkline: [Double]
+    public let isDemo: Bool
+
+    public var changeDirection: ChangeDirection {
+        ChangeDirection.evaluate(todayChange)
+    }
+
+    public var signedChangeText: String {
+        if todayChange > 0 {
+            return "+\(Formatters.currency(todayChange, format: .compact))"
+        }
+        return Formatters.currency(todayChange, format: .compact)
+    }
+
+    public var accessibilitySummary: String {
+        let source = isDemo ? "Demo data. " : ""
+        return "\(source)Net worth \(Formatters.currency(netWorth, format: .full)). Today's change \(changeDirection.glyph) \(signedChangeText)."
+    }
+
+    public init(
+        netWorth: Double,
+        todayChange: Double,
+        updatedAt: Date,
+        sparkline: [Double],
+        isDemo: Bool
+    ) {
+        self.netWorth = netWorth
+        self.todayChange = todayChange
+        self.updatedAt = updatedAt
+        self.sparkline = sparkline
+        self.isDemo = isDemo
+    }
+
+    public static func make(
+        netWorth: Double,
+        balanceHistory: [BalanceSnapshot],
+        updatedAt: Date,
+        isDemo: Bool,
+        calendar: Calendar = .current
+    ) -> GlanceSnapshot {
+        GlanceSnapshot(
+            netWorth: netWorth,
+            todayChange: todayChange(from: balanceHistory, currentNetWorth: netWorth, now: updatedAt, calendar: calendar),
+            updatedAt: updatedAt,
+            sparkline: normalizedSparkline(from: balanceHistory, currentNetWorth: netWorth),
+            isDemo: isDemo
+        )
+    }
+
+    public static func placeholder(updatedAt: Date = Date()) -> GlanceSnapshot {
+        GlanceSnapshot(
+            netWorth: 0,
+            todayChange: 0,
+            updatedAt: updatedAt,
+            sparkline: [],
+            isDemo: false
+        )
+    }
+
+    private static func todayChange(
+        from history: [BalanceSnapshot],
+        currentNetWorth: Double,
+        now: Date,
+        calendar: Calendar
+    ) -> Double {
+        let sorted = history.sorted { $0.date < $1.date }
+        guard let prior = sorted.last(where: { !calendar.isDate($0.date, inSameDayAs: now) }) else {
+            return 0
+        }
+        return currentNetWorth - prior.balance
+    }
+
+    private static func normalizedSparkline(
+        from history: [BalanceSnapshot],
+        currentNetWorth: Double,
+        maximumPointCount: Int = 30
+    ) -> [Double] {
+        var values = history
+            .sorted { $0.date < $1.date }
+            .suffix(maximumPointCount)
+            .map(\.balance)
+        if values.last != currentNetWorth {
+            values.append(currentNetWorth)
+        }
+        return AccountSparkline.normalize(values)
+    }
+}
+
+public enum GlanceCommand: String, Codable, Sendable, Equatable {
+    case refreshBalances
+}
+
+public struct GlanceCommandRequest: Codable, Sendable, Equatable {
+    public let command: GlanceCommand
+    public let requestedAt: Date
+
+    public init(command: GlanceCommand, requestedAt: Date) {
+        self.command = command
+        self.requestedAt = requestedAt
+    }
+}
+
+public enum GlanceSnapshotStore {
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    public static func snapshotDirectory(
+        fileManager: FileManager = .default,
+        appGroupIdentifier: String = GlanceSnapshot.appGroupIdentifier
+    ) -> URL {
+        if let url = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) {
+            return url
+        }
+        return LocalDataStore.storageDirectoryURL()
+    }
+
+    public static func snapshotURL(directory: URL) -> URL {
+        directory.appendingPathComponent(GlanceSnapshot.filename)
+    }
+
+    public static func commandURL(directory: URL) -> URL {
+        directory.appendingPathComponent(GlanceSnapshot.commandFilename)
+    }
+
+    public static func save(
+        _ snapshot: GlanceSnapshot,
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        try write(snapshot, to: snapshotURL(directory: directory), fileManager: fileManager)
+    }
+
+    public static func load(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws -> GlanceSnapshot {
+        let data = try Data(contentsOf: snapshotURL(directory: directory))
+        return try decoder.decode(GlanceSnapshot.self, from: data)
+    }
+
+    public static func clear(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        let url = snapshotURL(directory: directory)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    public static func saveCommand(
+        _ request: GlanceCommandRequest,
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        try write(request, to: commandURL(directory: directory), fileManager: fileManager)
+    }
+
+    public static func consumeCommand(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws -> GlanceCommandRequest? {
+        let url = commandURL(directory: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        try fileManager.removeItem(at: url)
+        return try decoder.decode(GlanceCommandRequest.self, from: data)
+    }
+
+    private static func write(_ value: some Encodable, to url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try encoder.encode(value)
+        try data.write(to: url, options: [.atomic])
+        #if os(macOS)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        #endif
+    }
+}

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -6,25 +6,42 @@ import WidgetKit
 private struct GlanceEntry: TimelineEntry {
     let date: Date
     let snapshot: GlanceSnapshot
+    /// True when no real snapshot exists yet (first install, post-reset, or a
+    /// failed app-group read). The view shows a setup/unavailable state instead
+    /// of a misleading "$0 · Updated now".
+    var isUnavailable = false
 }
 
 private struct GlanceTimelineProvider: TimelineProvider {
     func placeholder(in context: Context) -> GlanceEntry {
-        GlanceEntry(date: Date(), snapshot: .placeholder())
+        GlanceEntry(date: Date(), snapshot: .placeholder(), isUnavailable: true)
     }
 
     func getSnapshot(in context: Context, completion: @escaping (GlanceEntry) -> Void) {
-        completion(entry())
+        // Preview/gallery contexts (Add Widget) must not render the user's real
+        // net worth before the widget is placed — use the redacted placeholder.
+        if context.isPreview {
+            completion(GlanceEntry(date: Date(), snapshot: .placeholder(), isUnavailable: true))
+        } else {
+            completion(entry())
+        }
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<GlanceEntry>) -> Void) {
         let current = entry()
-        let nextRefresh = Calendar.current.date(byAdding: .minute, value: 15, to: current.date) ?? current.date
+        // Schedule the next reload relative to now, not the snapshot's
+        // last-success time — otherwise a snapshot older than 15 minutes yields
+        // an already-past refresh date and WidgetKit throttles/loops.
+        let nextRefresh = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date().addingTimeInterval(900)
         completion(Timeline(entries: [current], policy: .after(nextRefresh)))
     }
 
     private func entry() -> GlanceEntry {
-        let snapshot = (try? GlanceSnapshotStore.load()) ?? .placeholder()
+        // Distinguish "no snapshot yet" from a real zero balance so the widget
+        // shows a setup state rather than a misleading "$0 · Updated now".
+        guard let snapshot = try? GlanceSnapshotStore.load() else {
+            return GlanceEntry(date: Date(), snapshot: .placeholder(), isUnavailable: true)
+        }
         return GlanceEntry(date: snapshot.updatedAt, snapshot: snapshot)
     }
 }
@@ -49,6 +66,38 @@ private struct GlanceWidgetView: View {
     let entry: GlanceEntry
 
     var body: some View {
+        if entry.isUnavailable {
+            unavailableState
+        } else {
+            dataState
+        }
+    }
+
+    private var unavailableState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "lock.shield")
+                    .imageScale(.small)
+                Text("VaultPeek")
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            Spacer(minLength: 0)
+            Text("Open VaultPeek")
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+            Text("Connect an account to see your net worth here.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("VaultPeek. Open the app and connect an account to see your net worth.")
+    }
+
+    private var dataState: some View {
         VStack(alignment: .leading, spacing: family == .systemSmall ? 8 : 10) {
             HStack(spacing: 6) {
                 Image(systemName: "lock.shield")

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -1,0 +1,167 @@
+import AppIntents
+import PlaidBarCore
+import SwiftUI
+import WidgetKit
+
+private struct GlanceEntry: TimelineEntry {
+    let date: Date
+    let snapshot: GlanceSnapshot
+}
+
+private struct GlanceTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> GlanceEntry {
+        GlanceEntry(date: Date(), snapshot: .placeholder())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (GlanceEntry) -> Void) {
+        completion(entry())
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<GlanceEntry>) -> Void) {
+        let current = entry()
+        let nextRefresh = Calendar.current.date(byAdding: .minute, value: 15, to: current.date) ?? current.date
+        completion(Timeline(entries: [current], policy: .after(nextRefresh)))
+    }
+
+    private func entry() -> GlanceEntry {
+        let snapshot = (try? GlanceSnapshotStore.load()) ?? .placeholder()
+        return GlanceEntry(date: snapshot.updatedAt, snapshot: snapshot)
+    }
+}
+
+private struct PlaidBarGlanceWidget: Widget {
+    let kind = "PlaidBarGlanceWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: GlanceTimelineProvider()) { entry in
+            GlanceWidgetView(entry: entry)
+                .containerBackground(.background, for: .widget)
+                .widgetURL(URL(string: GlanceSnapshot.deepLinkURL))
+        }
+        .configurationDisplayName("VaultPeek")
+        .description("Glance at net worth and today's change from local VaultPeek data.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+private struct GlanceWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: GlanceEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: family == .systemSmall ? 8 : 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "lock.shield")
+                    .imageScale(.small)
+                Text(entry.snapshot.isDemo ? "VaultPeek Demo" : "VaultPeek")
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+
+            Text(Formatters.currency(entry.snapshot.netWorth, format: .compact))
+                .font(family == .systemSmall ? .system(size: 30, weight: .bold) : .system(size: 36, weight: .bold))
+                .minimumScaleFactor(0.72)
+                .lineLimit(1)
+                .accessibilityLabel("Net worth \(Formatters.currency(entry.snapshot.netWorth, format: .full))")
+
+            HStack(spacing: 5) {
+                Text(entry.snapshot.changeDirection.glyph)
+                    .font(.caption.weight(.bold))
+                Text(entry.snapshot.signedChangeText)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+                Text("today")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .accessibilityLabel("Today's change \(entry.snapshot.changeDirection.glyph) \(entry.snapshot.signedChangeText)")
+
+            if family == .systemMedium {
+                SparklineView(values: entry.snapshot.sparkline)
+                    .frame(height: 38)
+                    .accessibilityLabel("Net worth sparkline")
+            }
+
+            Spacer(minLength: 0)
+
+            Text("Updated \(entry.snapshot.updatedAt, style: .time)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(entry.snapshot.accessibilitySummary + " Updated \(entry.snapshot.updatedAt.formatted(date: .omitted, time: .shortened)).")
+    }
+}
+
+private struct SparklineView: View {
+    let values: [Double]
+
+    var body: some View {
+        GeometryReader { proxy in
+            Path { path in
+                let points = makePoints(size: proxy.size)
+                guard let first = points.first else { return }
+                path.move(to: first)
+                for point in points.dropFirst() {
+                    path.addLine(to: point)
+                }
+            }
+            .stroke(.primary, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+        }
+    }
+
+    private func makePoints(size: CGSize) -> [CGPoint] {
+        guard values.count > 1 else { return [] }
+        let width = max(size.width, 1)
+        let height = max(size.height, 1)
+        return values.enumerated().map { index, value in
+            let x = width * CGFloat(index) / CGFloat(values.count - 1)
+            let y = height - (height * CGFloat(min(max(value, 0), 1)))
+            return CGPoint(x: x, y: y)
+        }
+    }
+}
+
+@available(macOS 15.0, *)
+struct RefreshBalancesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Refresh balances"
+    static let description = IntentDescription("Ask VaultPeek to refresh local balances.")
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        try GlanceSnapshotStore.saveCommand(
+            GlanceCommandRequest(command: .refreshBalances, requestedAt: Date())
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+        return .result()
+    }
+}
+
+@available(macOS 26.0, *)
+private struct PlaidBarRefreshControl: ControlWidget {
+    let kind = "PlaidBarRefreshControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: kind) {
+            ControlWidgetButton(action: RefreshBalancesIntent()) {
+                Label("Refresh balances", systemImage: "arrow.clockwise")
+            }
+        }
+        .displayName("Refresh balances")
+        .description("Ask VaultPeek to refresh balances through the local app.")
+    }
+}
+
+@main
+struct PlaidBarWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        PlaidBarGlanceWidget()
+        if #available(macOS 26.0, *) {
+            PlaidBarRefreshControl()
+        }
+    }
+}

--- a/Sources/PlaidBarWidgetExtension/Resources/Info.plist
+++ b/Sources/PlaidBarWidgetExtension/Resources/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>VaultPeek Widget</string>
+    <key>CFBundleExecutable</key>
+    <string>PlaidBarWidgetExtension</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.ftchvs.PlaidBar.WidgetExtension</string>
+    <key>CFBundleName</key>
+    <string>VaultPeek Widget</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>10</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/Sources/PlaidBarWidgetExtension/Resources/PlaidBarWidgetExtension.entitlements
+++ b/Sources/PlaidBarWidgetExtension/Resources/PlaidBarWidgetExtension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.ftchvs.PlaidBar</string>
+    </array>
+</dict>
+</plist>

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -1,0 +1,80 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Glance snapshot")
+struct GlanceSnapshotTests {
+    @Test("Builds display-safe aggregate snapshot")
+    func buildsDisplaySafeAggregateSnapshot() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let previous = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let snapshot = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: [
+                BalanceSnapshot(date: previous, balance: 1_000),
+                BalanceSnapshot(date: now, balance: 1_250),
+            ],
+            updatedAt: now,
+            isDemo: false
+        )
+
+        #expect(snapshot.netWorth == 1_250)
+        #expect(snapshot.todayChange == 250)
+        #expect(snapshot.changeDirection == .up)
+        #expect(snapshot.signedChangeText == "+$250")
+        #expect(snapshot.sparkline.count >= 2)
+        #expect(!snapshot.accessibilitySummary.contains("account"))
+        #expect(!snapshot.accessibilitySummary.contains("item"))
+        #expect(!snapshot.accessibilitySummary.contains("transaction"))
+        #expect(!snapshot.accessibilitySummary.contains("token"))
+    }
+
+    @Test("Snapshot JSON excludes Plaid identifiers and raw payload fields")
+    func snapshotJSONExcludesPrivateFields() throws {
+        let directory = temporaryDirectory()
+        let snapshot = GlanceSnapshot(
+            netWorth: 17_604.24,
+            todayChange: -42,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            sparkline: [0, 0.5, 1],
+            isDemo: true
+        )
+
+        try GlanceSnapshotStore.save(snapshot, directory: directory)
+        let json = try String(
+            contentsOf: GlanceSnapshotStore.snapshotURL(directory: directory),
+            encoding: .utf8
+        )
+
+        #expect(json.contains("\"netWorth\""))
+        #expect(json.contains("\"todayChange\""))
+        #expect(json.contains("\"sparkline\""))
+        #expect(!json.contains("access_token"))
+        #expect(!json.contains("client_secret"))
+        #expect(!json.contains("public_token"))
+        #expect(!json.contains("account_id"))
+        #expect(!json.contains("item_id"))
+        #expect(!json.contains("transaction_id"))
+        #expect(!json.contains("transactions"))
+        #expect(!json.contains("accounts"))
+    }
+
+    @Test("Command request is consumed once")
+    func commandRequestIsConsumedOnce() throws {
+        let directory = temporaryDirectory()
+        let requestedAt = Date(timeIntervalSince1970: 1_780_000_000)
+        try GlanceSnapshotStore.saveCommand(
+            GlanceCommandRequest(command: .refreshBalances, requestedAt: requestedAt),
+            directory: directory
+        )
+
+        let request = try #require(try GlanceSnapshotStore.consumeCommand(directory: directory))
+        #expect(request.command == .refreshBalances)
+        #expect(request.requestedAt == requestedAt)
+        #expect(try GlanceSnapshotStore.consumeCommand(directory: directory) == nil)
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlanceSnapshotTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}


### PR DESCRIPTION
## Summary

- Linear: https://linear.app/andeslab/issue/AND-385/add-a-glanceable-macos-widget-and-control-center-control-via-a-widget
- Adds a WidgetKit extension target with small/medium VaultPeek glance widgets backed by a display-safe app-group snapshot.
- Writes aggregate net worth, today's change, updated-at, demo flag, and normalized sparkline data after app refresh/demo loads; no Plaid tokens, account IDs, transaction IDs, raw payloads, or per-account records are included.
- Adds a Refresh balances AppIntent and a macOS 26-gated ControlWidget button; the intent writes a local app-group command that the app consumes through the existing local server refresh path.
- Registers vaultpeek://dashboard deep links and packages the widget extension bundle with app-group-only extension entitlements.

## Tests

- PASS: git diff --check
- PASS: bash -n Scripts/package-app.sh
- PASS: swift build --target PlaidBar --skip-update --disable-keychain
- PASS: swift build --target PlaidBarWidgetExtension --skip-update --disable-keychain
- PASS: swift build --skip-update --disable-keychain -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
- PASS: swift test --skip-update --filter GlanceSnapshotTests
- PASS: ./Scripts/package-app.sh
- PASS: codesign -d --entitlements :- .build/VaultPeek.app/Contents/PlugIns/PlaidBarWidgetExtension.appex | plutil -p -

## Risks

- The local SDK marks ControlWidget APIs as macOS 26.0+, so the ControlWidget registration is gated to macOS 26 while the RefreshBalancesIntent remains available on macOS 15.
- Widget installation/placement was build/package validated locally, but not exercised through a notarized Developer ID distribution flow in this worktree.

## Autonomous task IDs

- Task ID(s): AND-385
- Backlog slice: Widget Extension native surfaces
- Scope note: One focused slice for display-safe snapshot plumbing, WidgetKit glance UI, ControlWidget/AppIntent command handoff, and packaging metadata.

## Agent coordination

- Builder agent: Codex
- Builder branch/worktree: otto/and-385-add-a-glanceable-macos-widget-and-control-ce / /Users/otto/workspace/plaidbar-linear-worktrees/and-385
- Reviewer/merge steward: Otto
- Coordination note: PR left open; do not merge from this agent run.

## Changed files

- Package.swift
- Scripts/package-app.sh
- Sources/PlaidBar/App/AppState.swift
- Sources/PlaidBar/App/PlaidBarApp.swift
- Sources/PlaidBar/Resources/Info.plist
- Sources/PlaidBar/Resources/PlaidBar.entitlements
- Sources/PlaidBarCore/Models/GlanceSnapshot.swift
- Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
- Sources/PlaidBarWidgetExtension/Resources/Info.plist
- Sources/PlaidBarWidgetExtension/Resources/PlaidBarWidgetExtension.entitlements
- Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift

## Local gates

- [x] git diff --check
- [x] swift build --target PlaidBar --skip-update --disable-keychain
- [x] swift build --target PlaidBarServer --skip-update --disable-keychain not run separately; strict full-package build covered PlaidBarServer.
- [x] Focused tests: swift test --skip-update --filter GlanceSnapshotTests
- [x] Secret scan completed for changed source, resources, tests, and packaging script.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] CI / build is green before merge.
- [ ] Claude Code Review / claude-review is green before merge.
- [ ] Codex Code Review / codex-review is green before merge.
- [ ] otto-openclaw-merge-gate is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude/Codex review auth/token/session/setup-only failures are documented as blocking unless Felipe explicitly grants a one-off override.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [x] Merge is within Felipe's explicit request for AND-385 in this worktree.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.