### PR TITLE
AND-385: Codex review follow-ups (activation refresh, reset widget reload, appex signing)

### DIFF
--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -29,6 +29,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 APP_DIR="$PROJECT_DIR/.build/VaultPeek.app"
 ENTITLEMENTS="$PROJECT_DIR/Sources/PlaidBar/Resources/PlaidBar.entitlements"
+WIDGET_APPEX="$APP_DIR/Contents/PlugIns/PlaidBarWidgetExtension.appex"
+WIDGET_ENTITLEMENTS="$PROJECT_DIR/Sources/PlaidBarWidgetExtension/Resources/PlaidBarWidgetExtension.entitlements"
 STAGING_DIR="$PROJECT_DIR/.build/notarize-staging"
 
 cd "$PROJECT_DIR"
@@ -103,6 +105,16 @@ codesign --force --options runtime --timestamp \
 codesign --force --options runtime --timestamp \
     --sign "$PLAIDBAR_SIGNING_IDENTITY" \
     "$APP_DIR/Contents/MacOS/PlaidBarServer"
+# The widget extension is a nested code bundle that package-app.sh only ad-hoc
+# signs. Re-sign it with the Developer ID identity, hardened runtime, and its
+# own entitlements BEFORE the outer app — otherwise the notarized bundle ships
+# a nested .appex with only the ad-hoc signature, which fails notarization /
+# Gatekeeper and leaves the widget undiscoverable (AND-385 Codex review).
+if [ -e "$WIDGET_APPEX" ]; then
+    codesign --force --options runtime --timestamp \
+        --entitlements "$WIDGET_ENTITLEMENTS" \
+        --sign "$PLAIDBAR_SIGNING_IDENTITY" "$WIDGET_APPEX"
+fi
 codesign --force --options runtime --timestamp \
     --entitlements "$ENTITLEMENTS" \
     --sign "$PLAIDBAR_SIGNING_IDENTITY" "$APP_DIR"

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2039,8 +2039,15 @@ final class AppState {
         try? GlanceSnapshotStore.clear()
     }
 
+    /// Consume a pending widget/control command (e.g. the "Refresh balances"
+    /// control) and run it. Reached from `loadInitialData()` and
+    /// `refreshDashboard()`, and — because the control opens the app via its
+    /// `openAppWhenRun` intent while the dashboard popover may be closed, so
+    /// neither of those runs — also from the app's activation hook
+    /// (`PlaidBarApp`). A no-op when no command file is pending, so calling it
+    /// on every app activation is cheap (AND-385).
     @discardableResult
-    private func consumePendingGlanceCommand() async -> Bool {
+    func consumePendingGlanceCommand() async -> Bool {
         guard let request = try? GlanceSnapshotStore.consumeCommand() else { return false }
         switch request.command {
         case .refreshBalances:
@@ -2056,6 +2063,14 @@ final class AppState {
         }
 
         await checkServerConnection()
+        if !serverConnected {
+            // The control can cold-launch the app with the popover closed, so
+            // `loadInitialData()` — which normally starts the bundled server —
+            // never ran. Start it (and wait for it to come up) here so the
+            // requested refresh actually reaches Plaid instead of being dropped
+            // by the not-connected guard below.
+            await startBundledServerIfAvailable()
+        }
         guard serverConnected, serverCredentialsConfigured != false else {
             // The refresh could not reach the server, so no balances were
             // fetched. Do not stamp the snapshot as freshly updated at the click

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2021,7 +2021,6 @@ final class AppState {
         // removed-account net worth until a later reset or successful write.
         guard !accounts.isEmpty else {
             clearGlanceSnapshot()
-            WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
             return
         }
         let snapshot = GlanceSnapshot.make(
@@ -2037,6 +2036,12 @@ final class AppState {
 
     private func clearGlanceSnapshot() {
         try? GlanceSnapshotStore.clear()
+        // Tell WidgetKit to drop the already-issued timeline entry so the widget
+        // surface stops showing pre-clear balances immediately. This covers
+        // every clear path — the explicit reset/data-wipe (`resetLocalData`) and
+        // removing the last institution — not just the empty-accounts write
+        // branch, which previously reloaded on its own (AND-385 Codex review).
+        WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
     }
 
     /// Consume a pending widget/control command (e.g. the "Refresh balances"

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import MenuBarExtraAccess
 import PlaidBarCore
 import Sparkle
@@ -145,6 +146,18 @@ struct PlaidBarApp: App {
                         return
                     }
                     appState.isPopoverPresented = true
+                }
+                // The "Refresh balances" widget control opens the app via an
+                // `openAppWhenRun` App Intent that writes a pending command but,
+                // unlike the widget's deep link above, opens neither the popover
+                // nor the detached window — so neither `loadInitialData()` nor a
+                // dashboard refresh runs to consume it, and the control feels
+                // inert. Consume it here on the always-mounted label whenever the
+                // app becomes active (the intent activates it, whether it was
+                // already running or freshly launched). A no-op when no command
+                // is pending, so it is cheap on every activation (AND-385).
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                    Task { await appState.consumePendingGlanceCommand() }
                 }
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in


### PR DESCRIPTION
## Summary

Addresses the open findings from the Codex review of #371. That review ran against the earlier commit `62f0e39`, so several findings were already fixed by `7e62b24` on the branch; this PR covers the ones that were still open. Stacks onto `otto/and-385-…` (PR #371's branch).

## Changes

- **Consume the pending widget command on app activation** (`PlaidBarApp.swift`, `AppState.swift`) — `df474cb`. The "Refresh balances" control opens the app via an `openAppWhenRun` App Intent without opening the popover/detached window, so neither `loadInitialData()` nor `refreshDashboard()` ran to consume `glance-command.json`. Now consumed on `NSApplication.didBecomeActiveNotification` from the always-mounted menu-bar label, independent of `MainPopover`. The glance refresh also starts the bundled server when not connected so a cold launch via the control still completes. (Codex P2 / #371 thread)
- **Reload the widget after wiping the snapshot** (`AppState.swift`) — `9476138`. `clearGlanceSnapshot()` now calls `WidgetCenter.reloadTimelines` after deleting the app-group file, so `resetLocalData` and last-institution removal drop the widget's issued timeline entry immediately instead of leaving pre-reset balances on the desktop. (Codex **P1**)
- **Sign the widget `.appex` during notarization** (`Scripts/notarize.sh`) — `9476138`. `package-app.sh` only ad-hoc signs the nested extension; `notarize.sh` now re-signs `Contents/PlugIns/PlaidBarWidgetExtension.appex` inside-out with the hardened runtime + widget entitlements before the outer app, so Developer ID builds pass notarization/Gatekeeper. (Codex P2)

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — **720 tests pass.**
- `bash -n Scripts/notarize.sh` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)