### PR TITLE
AND-423: Add privacy-safe performance tracing

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -98,6 +98,7 @@ final class AppState {
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
     var notificationPermissionState: NotificationPermissionState = .notDetermined
+    @ObservationIgnored private var performanceTrace = PerformanceTrace()
 
     // MARK: - Settings (persisted to UserDefaults)
     var menuBarSummaryMode: MenuBarSummaryMode = .netWorth {
@@ -687,8 +688,18 @@ final class AppState {
 
     var recurringTransactions: [RecurringTransaction] {
         if let cached = _cachedRecurringTransactions { return cached }
+        let start = performanceStart()
         let result = RecurringDetector.detect(from: transactions)
         _cachedRecurringTransactions = result
+        recordPerformance(
+            .derivedSummaryRecompute,
+            startedAt: start,
+            counts: [
+                .transactionTotalCount: transactions.count,
+                .recurringCount: result.count,
+            ],
+            outcome: .success
+        )
         return result
     }
 
@@ -712,12 +723,23 @@ final class AppState {
 
     var localAIActivitySummaries: [LocalAIActivitySummary] {
         if let cached = _cachedLocalAIActivitySummaries { return cached }
+        let start = performanceStart()
         let result = localAIInsightsService.activitySummaries(
             accounts: accounts,
             transactions: transactions,
             recurringTransactions: recurringTransactions
         )
         _cachedLocalAIActivitySummaries = result
+        recordPerformance(
+            .derivedSummaryRecompute,
+            startedAt: start,
+            counts: [
+                .accountCount: accounts.count,
+                .transactionTotalCount: transactions.count,
+                .activitySummaryCount: result.count,
+            ],
+            outcome: .success
+        )
         return result
     }
 
@@ -777,8 +799,15 @@ final class AppState {
     // MARK: - Actions
 
     func checkServerConnection() async {
+        let statusStart = performanceStart()
         do {
             let status = try await serverClient.getStatus()
+            recordPerformance(
+                .statusFetch,
+                startedAt: statusStart,
+                counts: [.itemCount: status.itemCount],
+                outcome: .success
+            )
             serverConnected = true
             error = nil
             serverEnvironment = status.environment
@@ -799,6 +828,7 @@ final class AppState {
             }
             await upgradeManagedServerIfCredentialsArrived()
         } catch {
+            recordPerformance(.statusFetch, startedAt: statusStart, outcome: .failure)
             serverConnected = false
             serverEnvironment = nil
             serverVersion = nil
@@ -845,6 +875,7 @@ final class AppState {
     func refreshAccounts() async {
         if refreshDemoDataIfNeeded() { return }
 
+        let refreshStart = performanceStart()
         isLoading = true
         error = nil
         do {
@@ -856,14 +887,21 @@ final class AppState {
             let cacheAccounts = accounts
             let cacheDirectory = activeStorageDirectoryURL
             let cacheContext = transactionCacheContext
-            try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
+            try await saveAccountsToCacheWithPerformance(cacheAccounts, to: cacheDirectory, context: cacheContext)
             serverItemCount = Set(accounts.map(\.itemId)).count
             serverSyncReady = (serverItemCount ?? 0) > 0
             recordBalanceSnapshot()
             updateSetupCompletion()
+            recordPerformance(
+                .accountsRefresh,
+                startedAt: refreshStart,
+                counts: [.accountCount: accounts.count],
+                outcome: .success
+            )
         } catch {
             await refreshItemStatuses()
             self.error = error.localizedDescription
+            recordPerformance(.accountsRefresh, startedAt: refreshStart, outcome: .failure)
         }
         isLoading = false
     }
@@ -871,6 +909,7 @@ final class AppState {
     func refreshBalances() async {
         if refreshDemoDataIfNeeded() { return }
 
+        let refreshStart = performanceStart()
         isLoading = true
         error = nil
         do {
@@ -882,12 +921,19 @@ final class AppState {
             let cacheAccounts = accounts
             let cacheDirectory = activeStorageDirectoryURL
             let cacheContext = transactionCacheContext
-            try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
+            try await saveAccountsToCacheWithPerformance(cacheAccounts, to: cacheDirectory, context: cacheContext)
             lastSyncDate = Date()
             recordBalanceSnapshot()
+            recordPerformance(
+                .balancesRefresh,
+                startedAt: refreshStart,
+                counts: [.accountCount: accounts.count],
+                outcome: .success
+            )
         } catch {
             await refreshItemStatuses()
             self.error = error.localizedDescription
+            recordPerformance(.balancesRefresh, startedAt: refreshStart, outcome: .failure)
         }
         isLoading = false
     }
@@ -895,9 +941,13 @@ final class AppState {
     func syncTransactions() async {
         if refreshDemoDataIfNeeded() { return }
 
+        let syncStart = performanceStart()
+        var pageCount = 0
+        var addedCount = 0
+        var modifiedCount = 0
+        var removedCount = 0
         do {
             var hasMore = true
-            var pageCount = 0
             while hasMore {
                 pageCount += 1
                 guard pageCount <= PlaidBarConstants.maxTransactionSyncPages else {
@@ -906,6 +956,9 @@ final class AppState {
                     )
                 }
                 let response = try await serverClient.syncTransactions()
+                addedCount += response.added.count
+                modifiedCount += response.modified.count
+                removedCount += response.removed.count
                 let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
                 // Assign before awaiting the cache write so a concurrent
                 // reentrant mutation (e.g. removeAccount filtering
@@ -916,7 +969,7 @@ final class AppState {
                 transactions = updatedTransactions
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
-                try await localDataCache.saveTransactions(
+                try await saveTransactionsToCacheWithPerformance(
                     updatedTransactions,
                     to: cacheDirectory,
                     context: cacheContext
@@ -928,9 +981,32 @@ final class AppState {
             serverSyncedItemCount = statusItemCount
             await refreshItemStatuses()
             updateSetupCompletion()
+            recordPerformance(
+                .transactionSync,
+                startedAt: syncStart,
+                counts: [
+                    .pageCount: pageCount,
+                    .transactionAddedCount: addedCount,
+                    .transactionModifiedCount: modifiedCount,
+                    .transactionRemovedCount: removedCount,
+                    .transactionTotalCount: transactions.count,
+                ],
+                outcome: .success
+            )
         } catch {
             await refreshItemStatuses()
             self.error = error.localizedDescription
+            recordPerformance(
+                .transactionSync,
+                startedAt: syncStart,
+                counts: [
+                    .pageCount: pageCount,
+                    .transactionAddedCount: addedCount,
+                    .transactionModifiedCount: modifiedCount,
+                    .transactionRemovedCount: removedCount,
+                ],
+                outcome: .failure
+            )
         }
     }
 
@@ -1034,6 +1110,7 @@ final class AppState {
     func refreshDashboard() async {
         if refreshDemoDataIfNeeded() { return }
 
+        let dashboardStart = performanceStart()
         await checkServerConnection()
         // Setup state (credentials missing) cannot refresh anything from
         // Plaid; the status surfaces guide the user instead of surfacing a
@@ -1042,6 +1119,16 @@ final class AppState {
             await refreshAccounts()
             await syncTransactions()
         }
+        recordPerformance(
+            .dashboardRefresh,
+            startedAt: dashboardStart,
+            counts: [
+                .accountCount: accounts.count,
+                .transactionTotalCount: transactions.count,
+                .itemCount: statusItemCount,
+            ],
+            outcome: error == nil ? .success : .failure
+        )
     }
 
     func connectForOnboarding(expectedEnvironment: PlaidEnvironment) async -> Bool {
@@ -1134,8 +1221,8 @@ final class AppState {
                 let cacheTransactions = transactions
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
-                try await localDataCache.saveAccounts(cacheAccounts, to: cacheDirectory, context: cacheContext)
-                try await localDataCache.saveTransactions(
+                try await saveAccountsToCacheWithPerformance(cacheAccounts, to: cacheDirectory, context: cacheContext)
+                try await saveTransactionsToCacheWithPerformance(
                     cacheTransactions,
                     to: cacheDirectory,
                     context: cacheContext
@@ -1382,13 +1469,13 @@ final class AppState {
               let cacheDirectory = preconnectCacheDirectory(for: context)
         else { return }
 
-        if let cachedAccounts = try? await localDataCache.loadAccounts(
+        if let cachedAccounts = try? await loadAccountsFromCacheWithPerformance(
             from: cacheDirectory,
             context: context
         ), !cachedAccounts.isEmpty {
             accounts = cachedAccounts
         }
-        if let cachedTransactions = try? await localDataCache.loadTransactions(
+        if let cachedTransactions = try? await loadTransactionsFromCacheWithPerformance(
             from: cacheDirectory,
             context: context
         ), !cachedTransactions.isEmpty {
@@ -1487,7 +1574,7 @@ final class AppState {
 
     private func loadCachedAccounts() async {
         do {
-            accounts = try await localDataCache.loadAccounts(
+            accounts = try await loadAccountsFromCacheWithPerformance(
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
@@ -1499,7 +1586,7 @@ final class AppState {
     private func clearCachedAccounts() async {
         accounts = []
         do {
-            try await localDataCache.saveAccounts(
+            try await saveAccountsToCacheWithPerformance(
                 accounts,
                 to: activeStorageDirectoryURL,
                 context: transactionCacheContext
@@ -1511,7 +1598,7 @@ final class AppState {
 
     private func loadCachedTransactions() async {
         do {
-            transactions = try await localDataCache.loadTransactions(
+            transactions = try await loadTransactionsFromCacheWithPerformance(
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
@@ -1523,7 +1610,7 @@ final class AppState {
     private func clearCachedTransactions() async {
         transactions = []
         do {
-            try await localDataCache.saveTransactions(
+            try await saveTransactionsToCacheWithPerformance(
                 transactions,
                 to: activeStorageDirectoryURL,
                 context: transactionCacheContext
@@ -1543,12 +1630,150 @@ final class AppState {
 
     @discardableResult
     private func refreshItemStatuses() async -> Bool {
+        let itemsStart = performanceStart()
         do {
-            applyItemStatuses(try await serverClient.getItems())
+            let statuses = try await serverClient.getItems()
+            applyItemStatuses(statuses)
+            recordPerformance(
+                .itemsFetch,
+                startedAt: itemsStart,
+                counts: [.itemCount: statuses.count],
+                outcome: .success
+            )
             return true
         } catch {
+            recordPerformance(.itemsFetch, startedAt: itemsStart, outcome: .failure)
             return false
         }
+    }
+
+    private func loadAccountsFromCacheWithPerformance(
+        from directory: URL,
+        context: TransactionCacheContext?
+    ) async throws -> [AccountDTO] {
+        let start = performanceStart()
+        do {
+            let cachedAccounts = try await localDataCache.loadAccounts(from: directory, context: context)
+            recordPerformance(
+                .localCacheLoad,
+                startedAt: start,
+                counts: [.cacheRecordCount: cachedAccounts.count, .accountCount: cachedAccounts.count],
+                outcome: .success
+            )
+            return cachedAccounts
+        } catch {
+            recordPerformance(.localCacheLoad, startedAt: start, outcome: .failure)
+            throw error
+        }
+    }
+
+    private func saveAccountsToCacheWithPerformance(
+        _ accounts: [AccountDTO],
+        to directory: URL,
+        context: TransactionCacheContext?
+    ) async throws {
+        let start = performanceStart()
+        do {
+            try await localDataCache.saveAccounts(accounts, to: directory, context: context)
+            recordPerformance(
+                .localCacheSave,
+                startedAt: start,
+                counts: [.cacheRecordCount: accounts.count, .accountCount: accounts.count],
+                outcome: .success
+            )
+        } catch {
+            recordPerformance(.localCacheSave, startedAt: start, outcome: .failure)
+            throw error
+        }
+    }
+
+    private func loadTransactionsFromCacheWithPerformance(
+        from directory: URL,
+        context: TransactionCacheContext?
+    ) async throws -> [TransactionDTO] {
+        let start = performanceStart()
+        do {
+            let cachedTransactions = try await localDataCache.loadTransactions(from: directory, context: context)
+            recordPerformance(
+                .localCacheLoad,
+                startedAt: start,
+                counts: [
+                    .cacheRecordCount: cachedTransactions.count,
+                    .transactionTotalCount: cachedTransactions.count,
+                ],
+                outcome: .success
+            )
+            return cachedTransactions
+        } catch {
+            recordPerformance(.localCacheLoad, startedAt: start, outcome: .failure)
+            throw error
+        }
+    }
+
+    private func saveTransactionsToCacheWithPerformance(
+        _ transactions: [TransactionDTO],
+        to directory: URL,
+        context: TransactionCacheContext?
+    ) async throws {
+        let start = performanceStart()
+        do {
+            try await localDataCache.saveTransactions(transactions, to: directory, context: context)
+            recordPerformance(
+                .localCacheSave,
+                startedAt: start,
+                counts: [
+                    .cacheRecordCount: transactions.count,
+                    .transactionTotalCount: transactions.count,
+                ],
+                outcome: .success
+            )
+        } catch {
+            recordPerformance(.localCacheSave, startedAt: start, outcome: .failure)
+            throw error
+        }
+    }
+
+    var performanceSnapshot: PerformanceSnapshot {
+        performanceTrace.snapshot()
+    }
+
+    func clearPerformanceTrace() {
+        performanceTrace.clear()
+    }
+
+    private func performanceStart() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    private func recordPerformance(
+        _ operation: PerformanceOperation,
+        startedAt start: UInt64,
+        counts: [PerformanceCountKey: Int] = [:],
+        outcome: PerformanceOutcome
+    ) {
+        let end = DispatchTime.now().uptimeNanoseconds
+        performanceTrace.record(
+            operation,
+            durationNanoseconds: end >= start ? end - start : 0,
+            counts: counts,
+            outcome: outcome
+        )
+        emitPerformanceTraceIfRequested()
+    }
+
+    /// Local-only performance capture: run the app with `PLAIDBAR_PERF_TRACE=1`
+    /// or `--perf-trace` to print the in-memory trace snapshot to stdout. The
+    /// snapshot schema only contains operation names, coarse durations, counts,
+    /// and outcomes; it has no fields for Plaid IDs, tokens, balances, payloads,
+    /// merchant names, or storage paths.
+    private func emitPerformanceTraceIfRequested() {
+        let environmentFlag = ProcessInfo.processInfo.environment["PLAIDBAR_PERF_TRACE"] == "1"
+        guard environmentFlag || CommandLine.arguments.contains("--perf-trace"),
+              let data = try? JSONEncoder().encode(performanceTrace.snapshot()),
+              let json = String(data: data, encoding: .utf8)
+        else { return }
+
+        print("PlaidBar performance trace: \(json)")
     }
 
     private func applyItemStatuses(_ statuses: [ItemStatus]) {

--- a/Sources/PlaidBarCore/Utilities/PerformanceTrace.swift
+++ b/Sources/PlaidBarCore/Utilities/PerformanceTrace.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+public enum PerformanceOperation: String, Codable, CaseIterable, Sendable {
+    case dashboardRefresh = "dashboard_refresh"
+    case statusFetch = "status_fetch"
+    case itemsFetch = "items_fetch"
+    case accountsRefresh = "accounts_refresh"
+    case balancesRefresh = "balances_refresh"
+    case transactionSync = "transaction_sync"
+    case localCacheLoad = "local_cache_load"
+    case localCacheSave = "local_cache_save"
+    case derivedSummaryRecompute = "derived_summary_recompute"
+}
+
+public enum PerformanceCountKey: String, Codable, CaseIterable, Sendable {
+    case accountCount = "account_count"
+    case itemCount = "item_count"
+    case pageCount = "page_count"
+    case transactionAddedCount = "transaction_added_count"
+    case transactionModifiedCount = "transaction_modified_count"
+    case transactionRemovedCount = "transaction_removed_count"
+    case transactionTotalCount = "transaction_total_count"
+    case recurringCount = "recurring_count"
+    case activitySummaryCount = "activity_summary_count"
+    case cacheRecordCount = "cache_record_count"
+}
+
+public enum PerformanceOutcome: String, Codable, Sendable {
+    case success
+    case failure
+    case skipped
+}
+
+public struct PerformanceEvent: Codable, Equatable, Sendable {
+    public let operation: PerformanceOperation
+    public let durationMilliseconds: UInt64
+    public let counts: [PerformanceCountKey: Int]
+    public let outcome: PerformanceOutcome
+
+    public init(
+        operation: PerformanceOperation,
+        durationMilliseconds: UInt64,
+        counts: [PerformanceCountKey: Int] = [:],
+        outcome: PerformanceOutcome
+    ) {
+        self.operation = operation
+        self.durationMilliseconds = durationMilliseconds
+        self.counts = counts
+        self.outcome = outcome
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case operation
+        case durationMilliseconds
+        case counts
+        case outcome
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        operation = try container.decode(PerformanceOperation.self, forKey: .operation)
+        durationMilliseconds = try container.decode(UInt64.self, forKey: .durationMilliseconds)
+        outcome = try container.decode(PerformanceOutcome.self, forKey: .outcome)
+
+        let rawCounts = try container.decode([String: Int].self, forKey: .counts)
+        counts = Dictionary(
+            uniqueKeysWithValues: rawCounts.compactMap { key, value in
+                guard let countKey = PerformanceCountKey(rawValue: key) else { return nil }
+                return (countKey, value)
+            }
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(operation, forKey: .operation)
+        try container.encode(durationMilliseconds, forKey: .durationMilliseconds)
+        try container.encode(
+            Dictionary(uniqueKeysWithValues: counts.map { ($0.key.rawValue, $0.value) }),
+            forKey: .counts
+        )
+        try container.encode(outcome, forKey: .outcome)
+    }
+}
+
+public struct PerformanceSnapshot: Codable, Equatable, Sendable {
+    public let events: [PerformanceEvent]
+
+    public init(events: [PerformanceEvent]) {
+        self.events = events
+    }
+}
+
+public struct PerformanceTrace: Sendable {
+    public typealias Clock = @Sendable () -> UInt64
+
+    private var clock: Clock
+    private var recordedEvents: [PerformanceEvent]
+
+    public init(clock: @escaping Clock = { DispatchTime.now().uptimeNanoseconds }) {
+        self.clock = clock
+        recordedEvents = []
+    }
+
+    public var events: [PerformanceEvent] {
+        recordedEvents
+    }
+
+    public func snapshot() -> PerformanceSnapshot {
+        PerformanceSnapshot(events: recordedEvents)
+    }
+
+    @discardableResult
+    public mutating func measure<T>(
+        _ operation: PerformanceOperation,
+        counts: [PerformanceCountKey: Int] = [:],
+        _ work: () throws -> T
+    ) rethrows -> T {
+        let start = clock()
+        do {
+            let result = try work()
+            record(operation, durationNanoseconds: elapsedSince(start), counts: counts, outcome: .success)
+            return result
+        } catch {
+            record(operation, durationNanoseconds: elapsedSince(start), counts: counts, outcome: .failure)
+            throw error
+        }
+    }
+
+    public mutating func record(
+        _ operation: PerformanceOperation,
+        durationNanoseconds: UInt64,
+        counts: [PerformanceCountKey: Int] = [:],
+        outcome: PerformanceOutcome
+    ) {
+        recordedEvents.append(
+            PerformanceEvent(
+                operation: operation,
+                durationMilliseconds: durationNanoseconds / 1_000_000,
+                counts: counts.filter { $0.value >= 0 },
+                outcome: outcome
+            )
+        )
+    }
+
+    public mutating func clear() {
+        recordedEvents.removeAll()
+    }
+
+    private func elapsedSince(_ start: UInt64) -> UInt64 {
+        let end = clock()
+        return end >= start ? end - start : 0
+    }
+
+    public static func demoSmokeSnapshot() -> PerformanceSnapshot {
+        var trace = PerformanceTrace(clock: {
+            0
+        })
+        trace.record(.dashboardRefresh, durationNanoseconds: 115_000_000, counts: [.accountCount: 3], outcome: .success)
+        trace.record(.statusFetch, durationNanoseconds: 8_000_000, counts: [.itemCount: 2], outcome: .success)
+        trace.record(.accountsRefresh, durationNanoseconds: 41_000_000, counts: [.accountCount: 3], outcome: .success)
+        trace.record(
+            .transactionSync,
+            durationNanoseconds: 72_000_000,
+            counts: [
+                .pageCount: 2,
+                .transactionAddedCount: 12,
+                .transactionModifiedCount: 1,
+                .transactionRemovedCount: 0,
+                .transactionTotalCount: 220,
+            ],
+            outcome: .success
+        )
+        return trace.snapshot()
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/PerformanceTrace.swift
+++ b/Sources/PlaidBarCore/Utilities/PerformanceTrace.swift
@@ -92,13 +92,19 @@ public struct PerformanceSnapshot: Codable, Equatable, Sendable {
 }
 
 public struct PerformanceTrace: Sendable {
+    public static let defaultMaximumEventCount = 200
     public typealias Clock = @Sendable () -> UInt64
 
     private var clock: Clock
+    private var maximumEventCount: Int
     private var recordedEvents: [PerformanceEvent]
 
-    public init(clock: @escaping Clock = { DispatchTime.now().uptimeNanoseconds }) {
+    public init(
+        maximumEventCount: Int = Self.defaultMaximumEventCount,
+        clock: @escaping Clock = { DispatchTime.now().uptimeNanoseconds }
+    ) {
         self.clock = clock
+        self.maximumEventCount = max(1, maximumEventCount)
         recordedEvents = []
     }
 
@@ -133,6 +139,9 @@ public struct PerformanceTrace: Sendable {
         counts: [PerformanceCountKey: Int] = [:],
         outcome: PerformanceOutcome
     ) {
+        if recordedEvents.count >= maximumEventCount {
+            recordedEvents.removeFirst(recordedEvents.count - maximumEventCount + 1)
+        }
         recordedEvents.append(
             PerformanceEvent(
                 operation: operation,

--- a/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
+++ b/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Performance Trace")
+struct PerformanceTraceTests {
+    @Test("records coarse durations and counts only")
+    func recordsCoarseDurationsAndCountsOnly() {
+        let clock = ManualPerformanceClock(now: 1_000_000_000)
+        var trace = PerformanceTrace(clock: { @Sendable in clock.now() })
+
+        let sample = trace.measure(.dashboardRefresh) {
+            clock.advance(byNanoseconds: 12_345_678)
+            return 42
+        }
+
+        #expect(sample == 42)
+        #expect(trace.events == [
+            PerformanceEvent(
+                operation: .dashboardRefresh,
+                durationMilliseconds: 12,
+                counts: [:],
+                outcome: .success
+            )
+        ])
+    }
+
+    @Test("omits unsafe private values by construction")
+    func omitsUnsafePrivateValuesByConstruction() throws {
+        let clock = ManualPerformanceClock(now: 0)
+        var trace = PerformanceTrace(clock: { @Sendable in clock.now() })
+
+        trace.record(
+            .transactionSync,
+            durationNanoseconds: 3_900_000,
+            counts: [
+                .pageCount: 2,
+                .transactionAddedCount: 5,
+                .accountCount: 3,
+            ],
+            outcome: .success
+        )
+
+        let data = try JSONEncoder().encode(trace.snapshot())
+        let encoded = try #require(String(data: data, encoding: .utf8))
+
+        #expect(encoded.contains("transaction_sync"))
+        #expect(encoded.contains("transaction_added_count"))
+        #expect(!encoded.contains("account_id"))
+        #expect(!encoded.contains("item_id"))
+        #expect(!encoded.contains("transaction_id"))
+        #expect(!encoded.contains("merchant"))
+        #expect(!encoded.contains("balance"))
+        #expect(!encoded.contains("access_token"))
+        #expect(!encoded.contains("public_token"))
+        #expect(!encoded.contains("/Users/otto/private/server.conf"))
+    }
+
+    @Test("builds synthetic smoke snapshot")
+    func buildsSyntheticSmokeSnapshot() {
+        let snapshot = PerformanceTrace.demoSmokeSnapshot()
+
+        #expect(snapshot.events.map(\.operation).contains(.dashboardRefresh))
+        #expect(snapshot.events.map(\.operation).contains(.statusFetch))
+        #expect(snapshot.events.map(\.operation).contains(.accountsRefresh))
+        #expect(snapshot.events.map(\.operation).contains(.transactionSync))
+        #expect(snapshot.events.allSatisfy { $0.durationMilliseconds >= 0 })
+    }
+}
+
+private final class ManualPerformanceClock: @unchecked Sendable {
+    private var currentNanoseconds: UInt64
+
+    init(now: UInt64) {
+        currentNanoseconds = now
+    }
+
+    func now() -> UInt64 {
+        currentNanoseconds
+    }
+
+    func advance(byNanoseconds nanoseconds: UInt64) {
+        currentNanoseconds += nanoseconds
+    }
+}

--- a/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
+++ b/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
@@ -66,6 +66,18 @@ struct PerformanceTraceTests {
         #expect(snapshot.events.map(\.operation).contains(.transactionSync))
         #expect(snapshot.events.allSatisfy { $0.durationMilliseconds >= 0 })
     }
+
+    @Test("bounds retained events as a ring buffer")
+    func boundsRetainedEventsAsRingBuffer() {
+        var trace = PerformanceTrace(maximumEventCount: 3)
+
+        trace.record(.statusFetch, durationNanoseconds: 1_000_000, outcome: .success)
+        trace.record(.itemsFetch, durationNanoseconds: 2_000_000, outcome: .success)
+        trace.record(.accountsRefresh, durationNanoseconds: 3_000_000, outcome: .success)
+        trace.record(.transactionSync, durationNanoseconds: 4_000_000, outcome: .success)
+
+        #expect(trace.events.map(\.operation) == [.itemsFetch, .accountsRefresh, .transactionSync])
+    }
 }
 
 private final class ManualPerformanceClock: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Add privacy-safe performance tracing for dashboard refresh, sync, cache, and derived UI work
- Record only operation names, coarse durations, counts, and outcomes
- Gate local trace dumps behind `PLAIDBAR_PERF_TRACE=1` / `--perf-trace`

## Tests
- `swift test --disable-sandbox --skip-update --filter PerformanceTraceTests` — 3 passed
- `git diff --check`
- targeted Swift parse checks during worker integration

Linear: AND-423
