### PR TITLE
AND-424: Bound multi-item refresh concurrency

### DIFF
--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -21,6 +21,15 @@ protocol PlaidClientProtocol: Sendable {
     func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse
 
     func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse
+
+    func getBalances(accessToken: String) async throws -> PlaidAccountsResponse
+
+    func syncTransactions(
+        accessToken: String,
+        cursor: String?
+    ) async throws -> PlaidTransactionsSyncResponse
+
+    func removeItem(accessToken: String) async throws
 }
 
 actor PlaidClient: PlaidClientProtocol {

--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -4,8 +4,9 @@ import NIOCore
 import PlaidBarCore
 
 struct AccountRoutes: Sendable {
-    let plaidClient: PlaidClient
+    let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
+    var maxConcurrentItemRefreshes = Self.defaultMaxConcurrentItemRefreshes
 
     func register(with group: RouterGroup<some RequestContext>) {
         group.group("accounts")
@@ -19,59 +20,18 @@ struct AccountRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        let items = try await tokenStore.getAllItems()
-        var allAccounts: [AccountDTO] = []
-        var attemptedItemCount = 0
-        var successfulItemCount = 0
-
-        for item in items {
-            guard let itemId = item.id else { continue }
-            attemptedItemCount += 1
-
-            let response: PlaidAccountsResponse
-            do {
-                let accessToken = try tokenStore.accessToken(for: item)
-                response = try await plaidClient.getAccounts(
-                    accessToken: accessToken
-                )
-                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
-                successfulItemCount += 1
-            } catch PlaidError.credentialsNotConfigured {
-                // Setup state affects every item identically: surface the 503
-                // credential guidance instead of marking items errored and
-                // reporting a misleading per-item refresh failure.
-                throw PlaidError.credentialsNotConfigured
-            } catch {
-                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
-                continue
-            }
-
-            let accounts = response.accounts.map { account in
-                AccountDTO(
-                    id: account.accountId,
-                    itemId: itemId,
-                    name: account.name,
-                    officialName: account.officialName,
-                    type: AccountType(rawValue: account.type) ?? .other,
-                    subtype: account.subtype,
-                    mask: account.mask,
-                    balances: BalanceDTO(
-                        available: account.balances.available,
-                        current: account.balances.current,
-                        limit: account.balances.limit,
-                        isoCurrencyCode: account.balances.isoCurrencyCode
-                    ),
-                    institutionName: item.institutionName
-                )
-            }
-            allAccounts.append(contentsOf: accounts)
+        let items = Self.deterministicItems(try await tokenStore.getAllItems())
+        let results = try await refreshAccounts(items: items) { accessToken in
+            try await plaidClient.getAccounts(accessToken: accessToken)
         }
+        let attemptedItemCount = results.filter(\.attempted).count
+        let successfulItemCount = results.filter(\.succeeded).count
 
         if Self.shouldFailRefresh(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
             throw HTTPError(.badGateway, message: "Plaid account refresh failed for every linked item")
         }
 
-        return try Self.jsonResponse(allAccounts)
+        return try Self.jsonResponse(results.flatMap(\.accounts))
     }
 
     @Sendable
@@ -79,56 +39,18 @@ struct AccountRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        let items = try await tokenStore.getAllItems()
-        var allAccounts: [AccountDTO] = []
-        var attemptedItemCount = 0
-        var successfulItemCount = 0
-
-        for item in items {
-            guard let itemId = item.id else { continue }
-            attemptedItemCount += 1
-
-            let response: PlaidAccountsResponse
-            do {
-                let accessToken = try tokenStore.accessToken(for: item)
-                response = try await plaidClient.getBalances(
-                    accessToken: accessToken
-                )
-                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
-                successfulItemCount += 1
-            } catch PlaidError.credentialsNotConfigured {
-                throw PlaidError.credentialsNotConfigured
-            } catch {
-                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
-                continue
-            }
-
-            let accounts = response.accounts.map { account in
-                AccountDTO(
-                    id: account.accountId,
-                    itemId: itemId,
-                    name: account.name,
-                    officialName: account.officialName,
-                    type: AccountType(rawValue: account.type) ?? .other,
-                    subtype: account.subtype,
-                    mask: account.mask,
-                    balances: BalanceDTO(
-                        available: account.balances.available,
-                        current: account.balances.current,
-                        limit: account.balances.limit,
-                        isoCurrencyCode: account.balances.isoCurrencyCode
-                    ),
-                    institutionName: item.institutionName
-                )
-            }
-            allAccounts.append(contentsOf: accounts)
+        let items = Self.deterministicItems(try await tokenStore.getAllItems())
+        let results = try await refreshAccounts(items: items) { accessToken in
+            try await plaidClient.getBalances(accessToken: accessToken)
         }
+        let attemptedItemCount = results.filter(\.attempted).count
+        let successfulItemCount = results.filter(\.succeeded).count
 
         if Self.shouldFailRefresh(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
             throw HTTPError(.badGateway, message: "Plaid balance refresh failed for every linked item")
         }
 
-        return try Self.jsonResponse(allAccounts)
+        return try Self.jsonResponse(results.flatMap(\.accounts))
     }
 
     @Sendable
@@ -177,7 +99,88 @@ struct AccountRoutes: Sendable {
         attemptedItemCount > 0 && successfulItemCount == 0
     }
 
+    static var defaultMaxConcurrentItemRefreshes: Int {
+        let rawValue = ProcessInfo.processInfo.environment["PLAIDBAR_MAX_CONCURRENT_ITEM_REFRESHES"]
+        return rawValue.flatMap(Int.init).map { max(1, $0) } ?? 4
+    }
+
     // MARK: - Helpers
+
+    private struct AccountRefreshResult: Sendable {
+        let attempted: Bool
+        let succeeded: Bool
+        let accounts: [AccountDTO]
+
+        static let skipped = AccountRefreshResult(attempted: false, succeeded: false, accounts: [])
+    }
+
+    private func refreshAccounts(
+        items: [ItemModel],
+        fetch: @escaping @Sendable (String) async throws -> PlaidAccountsResponse
+    ) async throws -> [AccountRefreshResult] {
+        try await BoundedConcurrency.map(items, limit: maxConcurrentItemRefreshes) { item in
+            guard let itemId = item.id else { return .skipped }
+
+            do {
+                let accessToken = try tokenStore.accessToken(for: item)
+                let response = try await fetch(accessToken)
+                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+                return AccountRefreshResult(
+                    attempted: true,
+                    succeeded: true,
+                    accounts: Self.accountDTOs(from: response, item: item, itemId: itemId)
+                )
+            } catch PlaidError.credentialsNotConfigured {
+                // Setup state affects every item identically: surface the 503
+                // credential guidance instead of marking items errored and
+                // reporting a misleading per-item refresh failure.
+                throw PlaidError.credentialsNotConfigured
+            } catch {
+                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                return AccountRefreshResult(attempted: true, succeeded: false, accounts: [])
+            }
+        }
+    }
+
+    private static func accountDTOs(
+        from response: PlaidAccountsResponse,
+        item: ItemModel,
+        itemId: String
+    ) -> [AccountDTO] {
+        response.accounts.map { account in
+            AccountDTO(
+                id: account.accountId,
+                itemId: itemId,
+                name: account.name,
+                officialName: account.officialName,
+                type: AccountType(rawValue: account.type) ?? .other,
+                subtype: account.subtype,
+                mask: account.mask,
+                balances: BalanceDTO(
+                    available: account.balances.available,
+                    current: account.balances.current,
+                    limit: account.balances.limit,
+                    isoCurrencyCode: account.balances.isoCurrencyCode
+                ),
+                institutionName: item.institutionName
+            )
+        }
+    }
+
+    static func deterministicItems(_ items: [ItemModel]) -> [ItemModel] {
+        items.sorted { lhs, rhs in
+            switch (lhs.createdAt, rhs.createdAt) {
+            case let (left?, right?) where left != right:
+                return left < right
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                return (lhs.id ?? "") < (rhs.id ?? "")
+            }
+        }
+    }
 
     private static func jsonResponse<T: Encodable>(_ value: T) throws -> Response {
         let data = try JSONEncoder().encode(value)

--- a/Sources/PlaidBarServer/Routes/BoundedConcurrency.swift
+++ b/Sources/PlaidBarServer/Routes/BoundedConcurrency.swift
@@ -1,0 +1,38 @@
+enum BoundedConcurrency {
+    static func map<T: Sendable, U: Sendable>(
+        _ values: [T],
+        limit: Int,
+        operation: @escaping @Sendable (T) async throws -> U
+    ) async throws -> [U] {
+        guard !values.isEmpty else { return [] }
+
+        let boundedLimit = max(1, min(limit, values.count))
+        var results = Array<U?>(repeating: nil, count: values.count)
+        var nextIndex = 0
+
+        return try await withThrowingTaskGroup(of: (Int, U).self) { group in
+            while nextIndex < boundedLimit {
+                let index = nextIndex
+                let value = values[index]
+                group.addTask {
+                    (index, try await operation(value))
+                }
+                nextIndex += 1
+            }
+
+            while let (index, result) = try await group.next() {
+                results[index] = result
+                if nextIndex < values.count {
+                    let index = nextIndex
+                    let value = values[index]
+                    group.addTask {
+                        (index, try await operation(value))
+                    }
+                    nextIndex += 1
+                }
+            }
+
+            return results.compactMap { $0 }
+        }
+    }
+}

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -27,7 +27,7 @@ struct TransactionRoutes: Sendable {
             if let item = try await tokenStore.getItem(id: itemId) {
                 items = [item]
             } else {
-                items = []
+                throw HTTPError(.notFound, message: "Unknown Plaid item")
             }
         } else {
             items = AccountRoutes.deterministicItems(try await tokenStore.getAllItems())

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -4,8 +4,9 @@ import NIOCore
 import PlaidBarCore
 
 struct TransactionRoutes: Sendable {
-    let plaidClient: PlaidClient
+    let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
+    var maxConcurrentItemRefreshes = AccountRoutes.defaultMaxConcurrentItemRefreshes
 
     func register(with group: RouterGroup<some RequestContext>) {
         group.group("transactions")
@@ -22,75 +23,36 @@ struct TransactionRoutes: Sendable {
         let items: [ItemModel]
 
         if let itemIdParam {
-            // An explicit item filter for an id we don't have is a caller error
-            // (typo or stale id), not an empty no-op sync. Surface it as a 404 so
-            // the app/CLI can distinguish a bad filter from a clean sync with no
-            // updates. The unfiltered path below stays a successful empty sync.
             let itemId = String(itemIdParam)
-            guard let item = try await tokenStore.getItem(id: itemId) else {
-                throw HTTPError(.notFound, message: "Plaid item not found")
+            if let item = try await tokenStore.getItem(id: itemId) {
+                items = [item]
+            } else {
+                items = []
             }
-            items = [item]
         } else {
-            items = try await tokenStore.getAllItems()
+            items = AccountRoutes.deterministicItems(try await tokenStore.getAllItems())
         }
 
-        var allAdded: [TransactionDTO] = []
-        var allModified: [TransactionDTO] = []
-        var allRemoved: [String] = []
-        var hasMore = false
-        var latestCursor: String?
-        var pendingCursors: [String: String] = [:]
-        var attemptedItemCount = 0
-        var successfulItemCount = 0
-
-        for item in items {
-            guard let itemId = item.id else { continue }
-            attemptedItemCount += 1
-
-            let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
-            let response: PlaidTransactionsSyncResponse
-            do {
-                let accessToken = try tokenStore.accessToken(for: item)
-                response = try await plaidClient.syncTransactions(
-                    accessToken: accessToken,
-                    cursor: cursor
-                )
-                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
-                successfulItemCount += 1
-            } catch PlaidError.credentialsNotConfigured {
-                // Setup state affects every item identically: surface the 503
-                // credential guidance instead of marking items errored.
-                throw PlaidError.credentialsNotConfigured
-            } catch {
-                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
-                continue
-            }
-
-            allAdded.append(contentsOf: response.added.map { Self.toDTO($0, itemId: itemId) })
-            allModified.append(contentsOf: response.modified.map { Self.toDTO($0, itemId: itemId) })
-            allRemoved.append(contentsOf: response.removed.map(\.transactionId))
-
-            if !response.nextCursor.isEmpty {
-                latestCursor = response.nextCursor
-                pendingCursors[itemId] = response.nextCursor
-            }
-
-            if response.hasMore {
-                hasMore = true
-            }
-        }
+        let results = try await syncItems(items)
+        let attemptedItemCount = results.filter(\.attempted).count
+        let successfulItemCount = results.filter(\.succeeded).count
 
         if Self.shouldFailSync(attemptedItemCount: attemptedItemCount, successfulItemCount: successfulItemCount) {
             throw HTTPError(.badGateway, message: "Plaid transaction sync failed for every linked item")
         }
 
+        let successfulResults = results.filter(\.succeeded)
+        let pendingCursors = successfulResults.reduce(into: [String: String]()) { cursors, result in
+            guard let nextCursor = result.nextCursor, !nextCursor.isEmpty else { return }
+            cursors[result.itemId] = nextCursor
+        }
+
         let syncResponse = SyncResponse(
-            added: allAdded,
-            modified: allModified,
-            removed: allRemoved,
-            hasMore: hasMore,
-            nextCursor: latestCursor,
+            added: successfulResults.flatMap(\.added),
+            modified: successfulResults.flatMap(\.modified),
+            removed: successfulResults.flatMap(\.removed),
+            hasMore: successfulResults.contains(where: \.hasMore),
+            nextCursor: successfulResults.last(where: { ($0.nextCursor?.isEmpty == false) })?.nextCursor,
             pendingCursors: pendingCursors
         )
 
@@ -130,6 +92,70 @@ struct TransactionRoutes: Sendable {
     static func normalizedCommittableCursor(_ cursor: String) -> String? {
         let trimmed = cursor.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private struct ItemSyncResult: Sendable {
+        let itemId: String
+        let attempted: Bool
+        let succeeded: Bool
+        let added: [TransactionDTO]
+        let modified: [TransactionDTO]
+        let removed: [String]
+        let hasMore: Bool
+        let nextCursor: String?
+
+        static let skipped = ItemSyncResult(
+            itemId: "",
+            attempted: false,
+            succeeded: false,
+            added: [],
+            modified: [],
+            removed: [],
+            hasMore: false,
+            nextCursor: nil
+        )
+    }
+
+    private func syncItems(_ items: [ItemModel]) async throws -> [ItemSyncResult] {
+        try await BoundedConcurrency.map(items, limit: maxConcurrentItemRefreshes) { item in
+            guard let itemId = item.id else { return .skipped }
+
+            do {
+                let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
+                let accessToken = try tokenStore.accessToken(for: item)
+                let response = try await plaidClient.syncTransactions(
+                    accessToken: accessToken,
+                    cursor: cursor
+                )
+                try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
+                return ItemSyncResult(
+                    itemId: itemId,
+                    attempted: true,
+                    succeeded: true,
+                    added: response.added.map { Self.toDTO($0, itemId: itemId) },
+                    modified: response.modified.map { Self.toDTO($0, itemId: itemId) },
+                    removed: response.removed.map(\.transactionId),
+                    hasMore: response.hasMore,
+                    nextCursor: response.nextCursor.isEmpty ? nil : response.nextCursor
+                )
+            } catch PlaidError.credentialsNotConfigured {
+                // Setup state affects every item identically: surface the 503
+                // credential guidance instead of marking items errored.
+                throw PlaidError.credentialsNotConfigured
+            } catch {
+                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                return ItemSyncResult(
+                    itemId: itemId,
+                    attempted: true,
+                    succeeded: false,
+                    added: [],
+                    modified: [],
+                    removed: [],
+                    hasMore: false,
+                    nextCursor: nil
+                )
+            }
+        }
     }
 
     private static func toDTO(_ plaidTx: PlaidTransaction, itemId: String) -> TransactionDTO {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -136,6 +136,21 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
         return accountsResponse
     }
 
+    func getBalances(accessToken _: String) async throws -> PlaidAccountsResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func syncTransactions(
+        accessToken _: String,
+        cursor _: String?
+    ) async throws -> PlaidTransactionsSyncResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func removeItem(accessToken _: String) async throws {
+        throw PlaidError.invalidResponse
+    }
+
     func recordedCalls() -> (
         linkTokens: [String],
         publicTokens: [String],
@@ -146,6 +161,150 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
             exchangedPublicTokens,
             requestedAccountAccessTokens
         )
+    }
+}
+
+private enum RefreshStubError: Error {
+    case failed
+}
+
+private actor DelayedRefreshPlaidClient: PlaidClientProtocol {
+    struct AccountOutcome: Sendable {
+        var response: PlaidAccountsResponse?
+        var error: (any Error & Sendable)?
+        var delayNanoseconds: UInt64
+
+        static func success(
+            _ response: PlaidAccountsResponse,
+            delayNanoseconds: UInt64 = 0
+        ) -> AccountOutcome {
+            AccountOutcome(response: response, error: nil, delayNanoseconds: delayNanoseconds)
+        }
+
+        static func failure(
+            _ error: any Error & Sendable = RefreshStubError.failed,
+            delayNanoseconds: UInt64 = 0
+        ) -> AccountOutcome {
+            AccountOutcome(response: nil, error: error, delayNanoseconds: delayNanoseconds)
+        }
+    }
+
+    struct SyncOutcome: Sendable {
+        var response: PlaidTransactionsSyncResponse?
+        var error: (any Error & Sendable)?
+        var delayNanoseconds: UInt64
+
+        static func success(
+            _ response: PlaidTransactionsSyncResponse,
+            delayNanoseconds: UInt64 = 0
+        ) -> SyncOutcome {
+            SyncOutcome(response: response, error: nil, delayNanoseconds: delayNanoseconds)
+        }
+
+        static func failure(
+            _ error: any Error & Sendable = RefreshStubError.failed,
+            delayNanoseconds: UInt64 = 0
+        ) -> SyncOutcome {
+            SyncOutcome(response: nil, error: error, delayNanoseconds: delayNanoseconds)
+        }
+    }
+
+    private let accountOutcomes: [String: AccountOutcome]
+    private let balanceOutcomes: [String: AccountOutcome]
+    private let syncOutcomes: [String: SyncOutcome]
+    private var activeCalls = 0
+    private var maxActiveCalls = 0
+    private var accountAccessTokens: [String] = []
+    private var balanceAccessTokens: [String] = []
+    private var syncAccessTokens: [String] = []
+
+    init(
+        accountOutcomes: [String: AccountOutcome] = [:],
+        balanceOutcomes: [String: AccountOutcome] = [:],
+        syncOutcomes: [String: SyncOutcome] = [:]
+    ) {
+        self.accountOutcomes = accountOutcomes
+        self.balanceOutcomes = balanceOutcomes
+        self.syncOutcomes = syncOutcomes
+    }
+
+    func createLinkToken(
+        clientUserId _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func createUpdateLinkToken(
+        clientUserId _: String,
+        accessToken _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getLinkToken(_: String) async throws -> PlaidLinkTokenGetResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func exchangePublicToken(_: String) async throws -> PlaidTokenExchangeResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getAccounts(accessToken: String) async throws -> PlaidAccountsResponse {
+        accountAccessTokens.append(accessToken)
+        return try await resolve(accountOutcomes[accessToken] ?? .failure())
+    }
+
+    func getBalances(accessToken: String) async throws -> PlaidAccountsResponse {
+        balanceAccessTokens.append(accessToken)
+        return try await resolve(balanceOutcomes[accessToken] ?? .failure())
+    }
+
+    func syncTransactions(
+        accessToken: String,
+        cursor _: String?
+    ) async throws -> PlaidTransactionsSyncResponse {
+        syncAccessTokens.append(accessToken)
+        let outcome = syncOutcomes[accessToken] ?? .failure()
+        activeCalls += 1
+        maxActiveCalls = max(maxActiveCalls, activeCalls)
+        let delay = outcome.delayNanoseconds
+        if delay > 0 {
+            try await Task.sleep(nanoseconds: delay)
+        }
+        activeCalls -= 1
+        if let error = outcome.error {
+            throw error
+        }
+        return outcome.response!
+    }
+
+    func removeItem(accessToken _: String) async throws {
+        throw PlaidError.invalidResponse
+    }
+
+    func recordedCalls() -> (
+        accounts: [String],
+        balances: [String],
+        syncs: [String],
+        maxActive: Int
+    ) {
+        (accountAccessTokens, balanceAccessTokens, syncAccessTokens, maxActiveCalls)
+    }
+
+    private func resolve(_ outcome: AccountOutcome) async throws -> PlaidAccountsResponse {
+        activeCalls += 1
+        maxActiveCalls = max(maxActiveCalls, activeCalls)
+        let delay = outcome.delayNanoseconds
+        if delay > 0 {
+            try await Task.sleep(nanoseconds: delay)
+        }
+        activeCalls -= 1
+        if let error = outcome.error {
+            throw error
+        }
+        return outcome.response!
     }
 }
 
@@ -617,12 +776,125 @@ struct PlaidBarServerTests {
         )
     }
 
+    private static func decodeBody<T: Decodable>(_ response: Response) async throws -> T {
+        let collector = ResponseBodyCollector()
+        let writer = CollectingResponseBodyWriter(collector: collector)
+        try await response.body.write(writer)
+        var buffer = await collector.collectedBuffer()
+        let data = buffer.readData(length: buffer.readableBytes) ?? Data()
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private actor ResponseBodyCollector {
+        private var buffer = ByteBuffer()
+
+        func append(_ chunk: ByteBuffer) {
+            var copy = chunk
+            buffer.writeBuffer(&copy)
+        }
+
+        func collectedBuffer() -> ByteBuffer {
+            buffer
+        }
+    }
+
+    private struct CollectingResponseBodyWriter: ResponseBodyWriter {
+        let collector: ResponseBodyCollector
+
+        mutating func write(_ buffer: ByteBuffer) async throws {
+            await collector.append(buffer)
+        }
+
+        consuming func finish(_ trailingHeaders: HTTPFields?) async throws {}
+    }
+
+    private static func saveRefreshItems(on fluent: Fluent) async throws {
+        try await ItemModel(
+            id: "item-a",
+            accessToken: "token-a",
+            institutionId: "ins-a",
+            institutionName: "Institution A"
+        ).save(on: fluent.db())
+        try await ItemModel(
+            id: "item-b",
+            accessToken: "token-b",
+            institutionId: "ins-b",
+            institutionName: "Institution B"
+        ).save(on: fluent.db())
+        try await ItemModel(
+            id: "item-c",
+            accessToken: "token-c",
+            institutionId: "ins-c",
+            institutionName: "Institution C"
+        ).save(on: fluent.db())
+    }
+
+    private static func accountsResponse(accountId: String) -> PlaidAccountsResponse {
+        PlaidAccountsResponse(
+            accounts: [
+                PlaidAccount(
+                    accountId: accountId,
+                    balances: PlaidBalances(
+                        available: 100,
+                        current: 125,
+                        limit: nil,
+                        isoCurrencyCode: "USD",
+                        unofficialCurrencyCode: nil
+                    ),
+                    mask: "0000",
+                    name: accountId,
+                    officialName: nil,
+                    type: "depository",
+                    subtype: "checking"
+                ),
+            ],
+            item: nil,
+            requestId: "request-\(accountId)"
+        )
+    }
+
+    private static func syncResponse(
+        transactionId: String,
+        cursor: String
+    ) -> PlaidTransactionsSyncResponse {
+        PlaidTransactionsSyncResponse(
+            added: [
+                PlaidTransaction(
+                    transactionId: transactionId,
+                    accountId: "account-\(transactionId)",
+                    amount: 12,
+                    date: "2026-06-01",
+                    name: transactionId,
+                    merchantName: nil,
+                    pending: false,
+                    isoCurrencyCode: "USD",
+                    personalFinanceCategory: nil
+                ),
+            ],
+            modified: [],
+            removed: [],
+            nextCursor: cursor,
+            hasMore: false,
+            requestId: "request-\(transactionId)"
+        )
+    }
+
     /// Runs `body` against a TokenStore backed by a temporary SQLite file,
     /// and always shuts Fluent down so the test does not hold database files.
     private func withTokenStore(
         databasePath: String,
         logger: Logger,
         _ body: (TokenStore) async throws -> Void
+    ) async throws {
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, _ in
+            try await body(store)
+        }
+    }
+
+    private func withTokenStore(
+        databasePath: String,
+        logger: Logger,
+        _ body: (TokenStore, Fluent) async throws -> Void
     ) async throws {
         let fluent = Fluent(logger: logger)
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
@@ -633,7 +905,7 @@ struct PlaidBarServerTests {
         var bodyError: Error?
         do {
             try await fluent.migrate()
-            try await body(TokenStore(fluent: fluent, logger: logger))
+            try await body(TokenStore(fluent: fluent, logger: logger), fluent)
         } catch {
             bodyError = error
         }
@@ -989,45 +1261,151 @@ struct PlaidBarServerTests {
         #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 3))
     }
 
-    @Test func transactionSyncRejectsUnknownExplicitItemFilter() async throws {
+    @Test("Account refresh preserves partial success and deterministic aggregation while bounded")
+    func accountRefreshRunsWithBoundedConcurrencyAndStableAggregation() async throws {
         let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("plaidbar-sync-item-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("plaidbar-account-refresh-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        let configURL = directory.appendingPathComponent("plaidbar.conf")
-        try """
-        PLAID_CLIENT_ID=test-client
-        PLAID_SECRET=test-secret
-        PLAID_ENV=sandbox
-        PLAIDBAR_DATA_DIR=\(directory.appendingPathComponent("data").path)
-        """.write(to: configURL, atomically: true, encoding: .utf8)
-        let config = try ServerConfig.load(from: configURL.path)
-        let plaidClient = PlaidClient(config: config)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.account-refresh")
+        let client = DelayedRefreshPlaidClient(accountOutcomes: [
+            "token-a": .success(Self.accountsResponse(accountId: "acct-a"), delayNanoseconds: 150_000_000),
+            "token-b": .failure(PlaidError.apiError(
+                statusCode: 400,
+                errorType: "ITEM_ERROR",
+                errorCode: "ITEM_LOGIN_REQUIRED",
+                errorMessage: "login required"
+            ), delayNanoseconds: 50_000_000),
+            "token-c": .success(Self.accountsResponse(accountId: "acct-c"), delayNanoseconds: 10_000_000),
+        ])
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await Self.saveRefreshItems(on: fluent)
+            let route = AccountRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            let response = try await route.listAccounts(
+                request: Self.makeRequest(path: "/api/accounts"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+
+            let accounts: [AccountDTO] = try await Self.decodeBody(response)
+            #expect(accounts.map(\.id) == ["acct-a", "acct-c"])
+            #expect(accounts.map(\.itemId) == ["item-a", "item-c"])
+            let calls = await client.recordedCalls()
+            #expect(calls.accounts.sorted() == ["token-a", "token-b", "token-c"])
+            #expect(calls.maxActive == 2)
+            #expect(try await store.getItem(id: "item-a")?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.loginRequired.rawValue)
+            #expect(try await store.getItem(id: "item-c")?.status == ItemConnectionStatus.connected.rawValue)
+        }
+    }
+
+    @Test("Balance refresh all-failure behavior is unchanged while bounded")
+    func balanceRefreshAllFailureStillThrowsBadGateway() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-balance-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
 
         let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
-        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.sync-item")
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.balance-refresh")
+        let client = DelayedRefreshPlaidClient(balanceOutcomes: [
+            "token-a": .failure(delayNanoseconds: 120_000_000),
+            "token-b": .failure(delayNanoseconds: 120_000_000),
+            "token-c": .failure(delayNanoseconds: 10_000_000),
+        ])
 
-        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
-            let route = TransactionRoutes(plaidClient: plaidClient, tokenStore: store)
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await Self.saveRefreshItems(on: fluent)
+            let route = AccountRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
 
-            // An explicit filter for an unknown item id is a 404, not a silent
-            // 200 empty sync that looks like a clean no-op. The Plaid client is
-            // never reached because the guard throws first.
-            let unknownError = await #expect(throws: HTTPError.self) {
-                _ = try await route.syncTransactions(
-                    request: Self.makeRequest(path: "/api/transactions/sync?item_id=does-not-exist"),
+            let error = await #expect(throws: HTTPError.self) {
+                _ = try await route.getBalances(
+                    request: Self.makeRequest(path: "/api/accounts/balances"),
                     context: TestRequestContext(source: TestRequestContextSource())
                 )
             }
-            #expect(unknownError?.status == .notFound)
 
-            // The unfiltered path against an empty store stays a successful empty sync.
+            #expect(error?.status == .badGateway)
+            let calls = await client.recordedCalls()
+            #expect(calls.balances.sorted() == ["token-a", "token-b", "token-c"])
+            #expect(calls.maxActive == 2)
+            #expect(try await store.getItem(id: "item-a")?.status == ItemConnectionStatus.error.rawValue)
+            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.error.rawValue)
+            #expect(try await store.getItem(id: "item-c")?.status == ItemConnectionStatus.error.rawValue)
+        }
+    }
+
+    @Test("Credentials-not-configured remains a global setup error")
+    func credentialsNotConfiguredDoesNotBecomePerItemFailure() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-credentials-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.credentials-refresh")
+        let client = DelayedRefreshPlaidClient(accountOutcomes: [
+            "token-a": .failure(PlaidError.credentialsNotConfigured),
+            "token-b": .failure(PlaidError.credentialsNotConfigured),
+            "token-c": .failure(PlaidError.credentialsNotConfigured),
+        ])
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await Self.saveRefreshItems(on: fluent)
+            let route = AccountRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            let error = await #expect(throws: PlaidError.self) {
+                _ = try await route.listAccounts(
+                    request: Self.makeRequest(path: "/api/accounts"),
+                    context: TestRequestContext(source: TestRequestContextSource())
+                )
+            }
+
+            #expect(error == PlaidError.credentialsNotConfigured)
+            #expect(try await store.getItem(id: "item-a")?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(try await store.getItem(id: "item-c")?.status == ItemConnectionStatus.connected.rawValue)
+        }
+    }
+
+    @Test("Transaction sync preserves partial success and deterministic aggregation while bounded")
+    func transactionSyncRunsWithBoundedConcurrencyAndStableAggregation() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-transaction-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.transaction-refresh")
+        let client = DelayedRefreshPlaidClient(syncOutcomes: [
+            "token-a": .success(Self.syncResponse(transactionId: "tx-a", cursor: "cursor-a"), delayNanoseconds: 150_000_000),
+            "token-b": .failure(delayNanoseconds: 50_000_000),
+            "token-c": .success(Self.syncResponse(transactionId: "tx-c", cursor: "cursor-c"), delayNanoseconds: 10_000_000),
+        ])
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await Self.saveRefreshItems(on: fluent)
+            try await store.saveSyncCursor(itemId: "item-a", cursor: "old-a")
+            try await store.saveSyncCursor(itemId: "item-c", cursor: "old-c")
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
             let response = try await route.syncTransactions(
                 request: Self.makeRequest(path: "/api/transactions/sync"),
                 context: TestRequestContext(source: TestRequestContextSource())
             )
-            #expect(response.status == .ok)
+
+            let sync: SyncResponse = try await Self.decodeBody(response)
+            #expect(sync.added.map(\.id) == ["tx-a", "tx-c"])
+            #expect(sync.added.map(\.itemId) == ["item-a", "item-c"])
+            #expect(sync.nextCursor == "cursor-c")
+            #expect(sync.pendingCursors == ["item-a": "cursor-a", "item-c": "cursor-c"])
+            let calls = await client.recordedCalls()
+            #expect(calls.syncs.sorted() == ["token-a", "token-b", "token-c"])
+            #expect(calls.maxActive == 2)
+            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.error.rawValue)
         }
     }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1409,6 +1409,33 @@ struct PlaidBarServerTests {
         }
     }
 
+    @Test("Transaction sync rejects unknown explicit item id")
+    func transactionSyncRejectsUnknownExplicitItemId() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-transaction-unknown-item-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.transaction-unknown-item")
+        let client = DelayedRefreshPlaidClient()
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            let error = await #expect(throws: HTTPError.self) {
+                _ = try await route.syncTransactions(
+                    request: Self.makeRequest(path: "/api/transactions/sync?item_id=missing-item"),
+                    context: TestRequestContext(source: TestRequestContextSource())
+                )
+            }
+
+            #expect(error?.status == .notFound)
+            let calls = await client.recordedCalls()
+            #expect(calls.syncs.isEmpty)
+        }
+    }
+
     @Test func linkResponseCodable() throws {
         let response = LinkResponse(linkToken: "token_123", linkUrl: "https://example.com/link")
         let data = try JSONEncoder().encode(response)


### PR DESCRIPTION
## Summary
- Bound multi-item Plaid account, balance, and transaction refreshes with deterministic aggregation
- Preserve partial-success/all-failure semantics and global credential setup errors
- Add route-level tests using plaintext test fixture tokens to avoid Keychain dependence

## Tests
- `swift test --disable-sandbox --skip-update --filter "accountRefreshRunsWithBoundedConcurrencyAndStableAggregation|balanceRefreshAllFailureStillThrowsBadGateway|credentialsNotConfiguredDoesNotBecomePerItemFailure|transactionSyncRunsWithBoundedConcurrencyAndStableAggregation"` — 4 passed
- `git diff --check`

Linear: AND-424
