### PR TITLE
AND-427: Coalesce status and item readiness fetch

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -778,22 +778,16 @@ final class AppState {
 
     func checkServerConnection() async {
         do {
-            let status = try await serverClient.getStatus()
+            let status = try await serverClient.getStatusIncludingItems()
             serverConnected = true
             error = nil
-            serverEnvironment = status.environment
-            serverVersion = status.version
-            serverItemCount = status.itemCount
-            serverCredentialsConfigured = status.credentialsConfigured
-            serverStoragePath = status.storagePath
-            serverSyncReady = status.syncReady
-            serverSyncedItemCount = status.syncedItemCount
-            lastSyncDate = status.lastSync
+            applyServerStatus(status)
             persistTransactionCacheContext()
             refreshSetupCompletionForActiveContext()
             refreshFirstRunSnapshotDismissalForActiveContext()
-            updateSetupCompletion()
-            if !(await refreshItemStatuses()) {
+            if let itemStatuses = status.itemStatuses {
+                applyItemStatuses(itemStatuses, itemCount: status.itemCount, syncReady: status.syncReady)
+            } else if !(await refreshItemStatuses()) {
                 itemStatuses = []
                 updateSetupCompletion()
             }
@@ -1551,10 +1545,26 @@ final class AppState {
         }
     }
 
-    private func applyItemStatuses(_ statuses: [ItemStatus]) {
+    private func applyServerStatus(_ status: ServerStatus) {
+        serverEnvironment = status.environment
+        serverVersion = status.version
+        serverItemCount = status.itemCount
+        serverCredentialsConfigured = status.credentialsConfigured
+        serverStoragePath = status.storagePath
+        serverSyncReady = status.syncReady
+        serverSyncedItemCount = status.syncedItemCount
+        lastSyncDate = status.lastSync
+        updateSetupCompletion()
+    }
+
+    private func applyItemStatuses(
+        _ statuses: [ItemStatus],
+        itemCount: Int? = nil,
+        syncReady: Bool? = nil
+    ) {
         itemStatuses = statuses
-        serverItemCount = statuses.count
-        serverSyncReady = !statuses.isEmpty
+        serverItemCount = itemCount ?? statuses.count
+        serverSyncReady = syncReady ?? !statuses.isEmpty
         updateSetupCompletion()
     }
 

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -27,7 +27,14 @@ actor ServerClient {
     }
 
     func getStatus() async throws -> ServerStatus {
-        guard let url = ServerEndpoint.url(baseURL: baseURL, path: "/api/status") else {
+        guard let url = ServerEndpoint.statusURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
+    }
+
+    func getStatusIncludingItems() async throws -> ServerStatus {
+        guard let url = ServerEndpoint.statusURL(baseURL: baseURL, includeItems: true) else {
             throw ServerClientError.requestFailed
         }
         return try await get(url)

--- a/Sources/PlaidBarCore/Models/ServerStatus.swift
+++ b/Sources/PlaidBarCore/Models/ServerStatus.swift
@@ -4,6 +4,8 @@ import Foundation
 ///
 /// Contract: readiness metadata only. Do not add secrets, account IDs,
 /// balances, transactions, Plaid tokens, or raw provider payloads here.
+/// `itemStatuses` is an opt-in coalesced snapshot using the same safe item
+/// health fields exposed by `/api/items`.
 public struct ServerStatus: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case version
@@ -14,6 +16,7 @@ public struct ServerStatus: Codable, Sendable {
         case storagePath
         case syncReady
         case syncedItemCount
+        case itemStatuses
     }
 
     public let version: String
@@ -24,6 +27,7 @@ public struct ServerStatus: Codable, Sendable {
     public let storagePath: String
     public let syncReady: Bool
     public let syncedItemCount: Int
+    public let itemStatuses: [ItemStatus]?
 
     public init(
         version: String,
@@ -33,7 +37,8 @@ public struct ServerStatus: Codable, Sendable {
         credentialsConfigured: Bool = true,
         storagePath: String = LocalDataStore.displayPath,
         syncReady: Bool? = nil,
-        syncedItemCount: Int? = nil
+        syncedItemCount: Int? = nil,
+        itemStatuses: [ItemStatus]? = nil
     ) {
         self.version = version
         self.environment = environment
@@ -43,6 +48,7 @@ public struct ServerStatus: Codable, Sendable {
         self.storagePath = storagePath
         self.syncReady = syncReady ?? (itemCount > 0)
         self.syncedItemCount = syncedItemCount ?? (lastSync == nil ? 0 : itemCount)
+        self.itemStatuses = itemStatuses
     }
 
     public init(from decoder: Decoder) throws {
@@ -55,6 +61,7 @@ public struct ServerStatus: Codable, Sendable {
         let storagePath = try container.decodeIfPresent(String.self, forKey: .storagePath)
         let syncReady = try container.decodeIfPresent(Bool.self, forKey: .syncReady)
         let syncedItemCount = try container.decodeIfPresent(Int.self, forKey: .syncedItemCount)
+        let itemStatuses = try container.decodeIfPresent([ItemStatus].self, forKey: .itemStatuses)
 
         self.init(
             version: version,
@@ -64,7 +71,8 @@ public struct ServerStatus: Codable, Sendable {
             credentialsConfigured: credentialsConfigured ?? true,
             storagePath: storagePath ?? LocalDataStore.displayPath,
             syncReady: syncReady,
-            syncedItemCount: syncedItemCount
+            syncedItemCount: syncedItemCount,
+            itemStatuses: itemStatuses
         )
     }
 }

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -16,6 +16,15 @@ public enum ServerEndpoint {
         return components.url
     }
 
+    public static func statusURL(baseURL: String, includeItems: Bool = false) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        components.path = "/api/status"
+        if includeItems {
+            components.percentEncodedQuery = "include=items"
+        }
+        return components.url
+    }
+
     public static func transactionCursorCommitURL(baseURL: String) -> URL? {
         url(baseURL: baseURL, path: "/api/transactions/sync/cursors")
     }

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -17,20 +17,7 @@ struct StatusRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        let itemCount = try await tokenStore.itemCount()
-        let lastSync = try await tokenStore.lastSyncDate()
-        let syncedItemCount = try await tokenStore.syncedItemCount()
-
-        let status = ServerStatus(
-            version: PlaidBarConstants.appVersion,
-            environment: config.plaidEnvironment,
-            itemCount: itemCount,
-            lastSync: lastSync,
-            credentialsConfigured: config.credentialsConfigured,
-            storagePath: config.dataDirectoryPath,
-            syncReady: itemCount > 0,
-            syncedItemCount: syncedItemCount
-        )
+        let status = try await statusSnapshot(includeItems: Self.includesItems(request))
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -42,20 +29,31 @@ struct StatusRoutes: Sendable {
         )
     }
 
+    func statusSnapshot(includeItems: Bool) async throws -> ServerStatus {
+        let itemCount = try await tokenStore.itemCount()
+        let lastSync = try await tokenStore.lastSyncDate()
+        let syncedItemCount = try await tokenStore.syncedItemCount()
+        let itemStatuses = includeItems ? try await safeItemStatuses() : nil
+
+        return ServerStatus(
+            version: PlaidBarConstants.appVersion,
+            environment: config.plaidEnvironment,
+            itemCount: itemCount,
+            lastSync: lastSync,
+            credentialsConfigured: config.credentialsConfigured,
+            storagePath: config.dataDirectoryPath,
+            syncReady: itemCount > 0,
+            syncedItemCount: syncedItemCount,
+            itemStatuses: itemStatuses
+        )
+    }
+
     @Sendable
     func listItems(
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
-        let items = try await tokenStore.getAllItems()
-        let dtos = items.map { item in
-            ItemStatus(
-                id: item.id ?? "",
-                institutionName: item.institutionName,
-                status: ItemConnectionStatus(rawValue: item.status) ?? .error,
-                lastSync: item.updatedAt
-            )
-        }
+        let dtos = try await safeItemStatuses()
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -65,5 +63,29 @@ struct StatusRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+
+    private func safeItemStatuses() async throws -> [ItemStatus] {
+        let items = try await tokenStore.getAllItems()
+        return items.map(Self.safeItemStatus)
+    }
+
+    private static func safeItemStatus(from item: ItemModel) -> ItemStatus {
+        ItemStatus(
+            id: item.id ?? "",
+            institutionName: item.institutionName,
+            status: ItemConnectionStatus(rawValue: item.status) ?? .error,
+            lastSync: item.updatedAt
+        )
+    }
+
+    static func includesItems(_ request: Request) -> Bool {
+        guard let include = request.uri.queryParameters.get("include") else {
+            return false
+        }
+        return include
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .contains("items")
     }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1195,11 +1195,15 @@ struct PlaidBarCoreTests {
         let itemId = "item with/slash?and&symbols"
 
         let syncURL = try #require(ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId))
+        let statusURL = try #require(ServerEndpoint.statusURL(baseURL: baseURL))
+        let coalescedStatusURL = try #require(ServerEndpoint.statusURL(baseURL: baseURL, includeItems: true))
         let cursorCommitURL = try #require(ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL))
         let updateURL = try #require(ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId))
         let removeURL = try #require(ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId))
 
         #expect(syncURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync?item_id=item%20with%2Fslash%3Fand%26symbols")
+        #expect(statusURL.absoluteString == "http://127.0.0.1:8484/api/status")
+        #expect(coalescedStatusURL.absoluteString == "http://127.0.0.1:8484/api/status?include=items")
         #expect(cursorCommitURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync/cursors")
         #expect(updateURL.absoluteString == "http://127.0.0.1:8484/api/link/update/item%20with%2Fslash%3Fand%26symbols")
         #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
@@ -1671,6 +1675,41 @@ struct PlaidBarCoreTests {
         #expect(decoded.syncedItemCount == 0)
     }
 
+    @Test("ServerStatus can include item readiness snapshot")
+    func serverStatusCanIncludeItemReadinessSnapshot() throws {
+        let lastSync = Date(timeIntervalSince1970: 1_800_000_010)
+        let status = ServerStatus(
+            version: "0.1.0",
+            environment: .sandbox,
+            itemCount: 2,
+            credentialsConfigured: true,
+            syncReady: true,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-login", institutionName: "Example Bank", status: .loginRequired, lastSync: lastSync),
+                ItemStatus(id: "item-error", institutionName: "Credit Union", status: .error),
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(status)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ServerStatus.self, from: data)
+
+        #expect(decoded.itemStatuses?.count == 2)
+        #expect(
+            decoded.itemStatuses?.map(\.status.rawValue) ==
+                [
+                    ItemConnectionStatus.loginRequired.rawValue,
+                    ItemConnectionStatus.error.rawValue,
+                ]
+        )
+        #expect(decoded.itemStatuses?.first?.institutionName == "Example Bank")
+        #expect(decoded.itemStatuses?.first?.lastSync != nil)
+    }
+
     @Test("ServerStatus decodes legacy payload without synced item count")
     func serverStatusLegacyPayload() throws {
         let json = """
@@ -1688,6 +1727,7 @@ struct PlaidBarCoreTests {
 
         #expect(decoded.itemCount == 2)
         #expect(decoded.syncedItemCount == 0)
+        #expect(decoded.itemStatuses == nil)
     }
 
     // MARK: - Balance History Reducer Tests

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -305,6 +305,110 @@ struct PlaidBarServerTests {
         }
     }
 
+    @Test(
+        "Status include items returns safe item readiness snapshot",
+        .enabled(if: plaidTokenVaultKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func statusIncludeItemsReturnsSafeItemReadinessSnapshot() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-status-items-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let loginItemId = "test_item_login_\(UUID().uuidString)"
+        let errorItemId = "test_item_error_\(UUID().uuidString)"
+        defer {
+            for itemId in [loginItemId, errorItemId] {
+                try? PlaidTokenVault.delete(
+                    storedToken: PlaidTokenVault.reference(for: itemId),
+                    fallbackItemId: itemId
+                )
+            }
+        }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-status-items.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.status-items")
+        let config = try setupStateConfig(in: directory)
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(
+                id: loginItemId,
+                accessToken: "access-sandbox-\(UUID().uuidString)",
+                institutionId: "ins_login",
+                institutionName: "Example Bank"
+            )
+            try await store.saveItem(
+                id: errorItemId,
+                accessToken: "access-sandbox-\(UUID().uuidString)",
+                institutionId: "ins_error",
+                institutionName: "Credit Union"
+            )
+            try await store.updateItemStatus(id: loginItemId, status: ItemConnectionStatus.loginRequired.rawValue)
+            try await store.updateItemStatus(id: errorItemId, status: ItemConnectionStatus.error.rawValue)
+
+            let routes = StatusRoutes(
+                tokenStore: store,
+                config: config
+            )
+            let includeItemsRequest = Self.makeRequest(path: "/api/status?include=items")
+            let status = try await routes.statusSnapshot(
+                includeItems: StatusRoutes.includesItems(includeItemsRequest)
+            )
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let payload = try #require(String(data: encoder.encode(status), encoding: .utf8))
+
+            #expect(StatusRoutes.includesItems(includeItemsRequest))
+            #expect(status.credentialsConfigured == false)
+            #expect(status.itemCount == 2)
+            #expect(status.syncReady)
+            #expect(status.itemStatuses?.count == 2)
+            #expect(
+                (status.itemStatuses?.map(\.status.rawValue).sorted() ?? []) ==
+                    [
+                        ItemConnectionStatus.error.rawValue,
+                        ItemConnectionStatus.loginRequired.rawValue,
+                    ]
+            )
+            #expect(Set(status.itemStatuses?.compactMap(\.institutionName) ?? []) == ["Example Bank", "Credit Union"])
+            #expect(!payload.contains("access-sandbox-"))
+            #expect(!payload.contains("access_token"))
+            #expect(!payload.contains("institutionId"))
+            #expect(!payload.contains("institution_id"))
+            #expect(!payload.contains("transaction"))
+            #expect(!payload.contains("balance"))
+        }
+    }
+
+    @Test("Status omits item readiness snapshot by default")
+    func statusOmitsItemReadinessSnapshotByDefault() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-status-default-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-status-default.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.status-default")
+        let config = try setupStateConfig(in: directory)
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let routes = StatusRoutes(
+                tokenStore: store,
+                config: config
+            )
+            let defaultStatusRequest = Self.makeRequest(path: "/api/status")
+            let status = try await routes.statusSnapshot(
+                includeItems: StatusRoutes.includesItems(defaultStatusRequest)
+            )
+            let object = try #require(
+                JSONSerialization.jsonObject(with: JSONEncoder().encode(status)) as? [String: Any]
+            )
+
+            #expect(!StatusRoutes.includesItems(defaultStatusRequest))
+            #expect(status.itemCount == 0)
+            #expect(status.itemStatuses == nil)
+            #expect(object["itemStatuses"] == nil)
+        }
+    }
+
     @Test func serverConfigLoadsExplicitConfigFile() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-config-\(UUID().uuidString)", isDirectory: true)
@@ -615,6 +719,18 @@ struct PlaidBarServerTests {
             head: HTTPRequest(method: .get, scheme: nil, authority: nil, path: path, headerFields: headers),
             body: RequestBody(buffer: ByteBuffer())
         )
+    }
+
+    private func setupStateConfig(in directory: URL) throws -> ServerConfig {
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=
+        PLAID_SECRET=
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        return try ServerConfig.load(from: configURL.path)
     }
 
     /// Runs `body` against a TokenStore backed by a temporary SQLite file,


### PR DESCRIPTION
## Summary
- Add `/api/status?include=items` for coalesced readiness + item-status fetches
- Keep default `/api/status` response minimal and backward-compatible
- Update app status check to use the coalesced endpoint with fallback behavior

## Tests
- `swift test --disable-sandbox --skip-update --filter "serverStatusCanIncludeItemReadinessSnapshot|endpointBuilders|statusIncludes|statusOmits|statusPayload"` — 3 passed
- `git diff --check`
- targeted Swift parse checks during worker integration

Linear: AND-427
