### PR TITLE
AND-428: Debounce widget snapshot writes

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -188,6 +188,7 @@ final class AppState {
     private var refreshTask: Task<Void, Never>?
     private var localAISummaryRefreshTask: Task<Void, Never>?
     private let glanceSnapshotWriteDebouncer = GlanceSnapshotWriteDebouncer()
+    private var glanceSnapshotWriteGeneration = 0
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
     private var lastAttemptedCredentialUpgradeConfig: String?
@@ -1155,7 +1156,7 @@ final class AppState {
 
         balanceHistory = []
         UserDefaults.standard.removeObject(forKey: Keys.balanceHistory)
-        clearGlanceSnapshot()
+        await clearGlanceSnapshot()
         UserDefaults.standard.removeObject(forKey: Keys.lastTransactionCacheContext)
         notificationService.resetDeduplicationState()
 
@@ -1688,6 +1689,8 @@ final class AppState {
 
     private func writeGlanceSnapshot(updatedAt: Date = Date()) {
         guard !accounts.isEmpty else { return }
+        glanceSnapshotWriteGeneration += 1
+        let generation = glanceSnapshotWriteGeneration
         let snapshot = GlanceSnapshot.make(
             netWorth: netBalance,
             balanceHistory: balanceHistory,
@@ -1695,7 +1698,8 @@ final class AppState {
             isDemo: isDemoMode
         )
         let debouncer = glanceSnapshotWriteDebouncer
-        Task { [snapshot, debouncer] in
+        Task { [snapshot, debouncer, generation] in
+            guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }
             await debouncer.schedule(snapshot) { snapshot in
                 guard (try? GlanceSnapshotStore.saveIfChanged(snapshot)) == true else { return }
                 await MainActor.run {
@@ -1705,12 +1709,10 @@ final class AppState {
         }
     }
 
-    private func clearGlanceSnapshot() {
-        let debouncer = glanceSnapshotWriteDebouncer
-        Task { [debouncer] in
-            await debouncer.cancel()
-            try? GlanceSnapshotStore.clear()
-        }
+    private func clearGlanceSnapshot() async {
+        glanceSnapshotWriteGeneration += 1
+        await glanceSnapshotWriteDebouncer.cancel()
+        try? GlanceSnapshotStore.clear()
     }
 
     @discardableResult

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -187,6 +187,7 @@ final class AppState {
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
     private var localAISummaryRefreshTask: Task<Void, Never>?
+    private let glanceSnapshotWriteDebouncer = GlanceSnapshotWriteDebouncer()
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
     private var lastAttemptedCredentialUpgradeConfig: String?
@@ -1693,13 +1694,23 @@ final class AppState {
             updatedAt: updatedAt,
             isDemo: isDemoMode
         )
-        if (try? GlanceSnapshotStore.save(snapshot)) != nil {
-            WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
+        let debouncer = glanceSnapshotWriteDebouncer
+        Task { [snapshot, debouncer] in
+            await debouncer.schedule(snapshot) { snapshot in
+                guard (try? GlanceSnapshotStore.saveIfChanged(snapshot)) == true else { return }
+                await MainActor.run {
+                    WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
+                }
+            }
         }
     }
 
     private func clearGlanceSnapshot() {
-        try? GlanceSnapshotStore.clear()
+        let debouncer = glanceSnapshotWriteDebouncer
+        Task { [debouncer] in
+            await debouncer.cancel()
+            try? GlanceSnapshotStore.clear()
+        }
     }
 
     @discardableResult

--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -51,6 +51,7 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
     public func hasSameDisplayContent(as other: GlanceSnapshot) -> Bool {
         netWorth == other.netWorth &&
             todayChange == other.todayChange &&
+            updatedAt == other.updatedAt &&
             sparkline == other.sparkline &&
             isDemo == other.isDemo
     }

--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -48,6 +48,13 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
         return "\(source)Net worth \(Formatters.currency(netWorth, format: .full)). Today's change \(changeDirection.glyph) \(signedChangeText)."
     }
 
+    public func hasSameDisplayContent(as other: GlanceSnapshot) -> Bool {
+        netWorth == other.netWorth &&
+            todayChange == other.todayChange &&
+            sparkline == other.sparkline &&
+            isDemo == other.isDemo
+    }
+
     public init(
         netWorth: Double,
         todayChange: Double,
@@ -131,6 +138,40 @@ public struct GlanceCommandRequest: Codable, Sendable, Equatable {
     }
 }
 
+public actor GlanceSnapshotWriteDebouncer {
+    private let delay: Duration
+    private var pendingTask: Task<Void, Never>?
+
+    public init(delay: Duration = .milliseconds(400)) {
+        self.delay = delay
+    }
+
+    deinit {
+        pendingTask?.cancel()
+    }
+
+    public func schedule(
+        _ snapshot: GlanceSnapshot,
+        operation: @escaping @Sendable (GlanceSnapshot) async -> Void
+    ) {
+        pendingTask?.cancel()
+        pendingTask = Task { [delay] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await operation(snapshot)
+        }
+    }
+
+    public func cancel() {
+        pendingTask?.cancel()
+        pendingTask = nil
+    }
+}
+
 public enum GlanceSnapshotStore {
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -169,6 +210,22 @@ public enum GlanceSnapshotStore {
         fileManager: FileManager = .default
     ) throws {
         try write(snapshot, to: snapshotURL(directory: directory), fileManager: fileManager)
+    }
+
+    @discardableResult
+    public static func saveIfChanged(
+        _ snapshot: GlanceSnapshot,
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        let url = snapshotURL(directory: directory)
+        if fileManager.fileExists(atPath: url.path),
+           let existing = try? load(directory: directory, fileManager: fileManager),
+           existing.hasSameDisplayContent(as: snapshot) {
+            return false
+        }
+        try write(snapshot, to: url, fileManager: fileManager)
+        return true
     }
 
     public static func load(

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import PlaidBarCore
 
@@ -58,6 +59,77 @@ struct GlanceSnapshotTests {
         #expect(!json.contains("accounts"))
     }
 
+    @Test("Identical display snapshots do not rewrite the file")
+    func identicalDisplaySnapshotsDoNotRewriteFile() throws {
+        let directory = temporaryDirectory()
+        let original = GlanceSnapshot(
+            netWorth: 17_604.24,
+            todayChange: -42,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            sparkline: [0, 0.5, 1],
+            isDemo: false
+        )
+        let timestampOnlyChange = GlanceSnapshot(
+            netWorth: original.netWorth,
+            todayChange: original.todayChange,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_300),
+            sparkline: original.sparkline,
+            isDemo: original.isDemo
+        )
+
+        #expect(try GlanceSnapshotStore.saveIfChanged(original, directory: directory))
+        let url = GlanceSnapshotStore.snapshotURL(directory: directory)
+        let firstData = try Data(contentsOf: url)
+        let firstAttributes = try FileManager.default.attributesOfItem(atPath: url.path)
+
+        #expect(!(try GlanceSnapshotStore.saveIfChanged(timestampOnlyChange, directory: directory)))
+        #expect(try Data(contentsOf: url) == firstData)
+        #expect(try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date == firstAttributes[.modificationDate] as? Date)
+    }
+
+    @Test("Meaningful display changes rewrite the file")
+    func meaningfulDisplayChangesRewriteFile() throws {
+        let directory = temporaryDirectory()
+        let original = GlanceSnapshot(
+            netWorth: 17_604.24,
+            todayChange: -42,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            sparkline: [0, 0.5, 1],
+            isDemo: false
+        )
+        let changed = GlanceSnapshot(
+            netWorth: 17_650,
+            todayChange: 3.74,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_300),
+            sparkline: [0.1, 0.4, 1],
+            isDemo: false
+        )
+
+        #expect(try GlanceSnapshotStore.saveIfChanged(original, directory: directory))
+        #expect(try GlanceSnapshotStore.saveIfChanged(changed, directory: directory))
+        #expect(try GlanceSnapshotStore.load(directory: directory) == changed)
+    }
+
+    @Test("Debouncer coalesces burst writes to the latest snapshot")
+    func debouncerCoalescesBurstWritesToLatestSnapshot() async throws {
+        let debouncer = GlanceSnapshotWriteDebouncer(delay: .milliseconds(25))
+        let recorder = SnapshotWriteRecorder()
+
+        await debouncer.schedule(firstSnapshot(netWorth: 100)) { snapshot in
+            await recorder.record(snapshot)
+        }
+        await debouncer.schedule(firstSnapshot(netWorth: 200)) { snapshot in
+            await recorder.record(snapshot)
+        }
+        await debouncer.schedule(firstSnapshot(netWorth: 300)) { snapshot in
+            await recorder.record(snapshot)
+        }
+
+        try await Task.sleep(for: .milliseconds(80))
+        let snapshots = await recorder.snapshots
+        #expect(snapshots.map(\.netWorth) == [300])
+    }
+
     @Test("Command request is consumed once")
     func commandRequestIsConsumedOnce() throws {
         let directory = temporaryDirectory()
@@ -76,5 +148,23 @@ struct GlanceSnapshotTests {
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("GlanceSnapshotTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func firstSnapshot(netWorth: Double) -> GlanceSnapshot {
+        GlanceSnapshot(
+            netWorth: netWorth,
+            todayChange: 0,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            sparkline: [0, 1],
+            isDemo: false
+        )
+    }
+}
+
+private actor SnapshotWriteRecorder {
+    private(set) var snapshots: [GlanceSnapshot] = []
+
+    func record(_ snapshot: GlanceSnapshot) {
+        snapshots.append(snapshot)
     }
 }

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -59,8 +59,8 @@ struct GlanceSnapshotTests {
         #expect(!json.contains("accounts"))
     }
 
-    @Test("Identical display snapshots do not rewrite the file")
-    func identicalDisplaySnapshotsDoNotRewriteFile() throws {
+    @Test("Timestamp display changes rewrite the file")
+    func timestampDisplayChangesRewriteFile() throws {
         let directory = temporaryDirectory()
         let original = GlanceSnapshot(
             netWorth: 17_604.24,
@@ -80,11 +80,10 @@ struct GlanceSnapshotTests {
         #expect(try GlanceSnapshotStore.saveIfChanged(original, directory: directory))
         let url = GlanceSnapshotStore.snapshotURL(directory: directory)
         let firstData = try Data(contentsOf: url)
-        let firstAttributes = try FileManager.default.attributesOfItem(atPath: url.path)
 
-        #expect(!(try GlanceSnapshotStore.saveIfChanged(timestampOnlyChange, directory: directory)))
-        #expect(try Data(contentsOf: url) == firstData)
-        #expect(try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date == firstAttributes[.modificationDate] as? Date)
+        #expect(try GlanceSnapshotStore.saveIfChanged(timestampOnlyChange, directory: directory))
+        #expect(try Data(contentsOf: url) != firstData)
+        #expect(try GlanceSnapshotStore.load(directory: directory) == timestampOnlyChange)
     }
 
     @Test("Meaningful display changes rewrite the file")


### PR DESCRIPTION
## Summary
- Debounce widget/glance snapshot writes during bursts
- Skip rewrites for display-equivalent snapshots, including timestamp-only churn
- Keep widget reloads tied to actual display-content writes

## Tests
- `swift test --disable-sandbox --skip-update --filter GlanceSnapshotTests` — 6 passed
- `git diff --check`
- targeted Swift parse checks during worker integration

Linear: AND-428

Stacked on #371 / `otto/and-385-add-a-glanceable-macos-widget-and-control-ce`.
