### PR TITLE
AND-425: Batch transaction sync cache writes

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1102,6 +1102,7 @@ final class AppState {
         var removedCount = 0
         do {
             var hasMore = true
+            var batch = TransactionSyncBatch(transactions: transactions)
             while hasMore {
                 pageCount += 1
                 guard pageCount <= PlaidBarConstants.maxTransactionSyncPages else {
@@ -1113,25 +1114,23 @@ final class AppState {
                 addedCount += response.added.count
                 modifiedCount += response.modified.count
                 removedCount += response.removed.count
-                let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
-                // Assign before awaiting the cache write so a concurrent
-                // reentrant mutation (e.g. removeAccount filtering
-                // `transactions`) cannot be clobbered by the resumed sync
-                // overwriting it with a value reduced from the pre-suspension
-                // array. The cursor is still committed only after the cache
-                // write succeeds, preserving local-first durability.
-                transactions = updatedTransactions
-                seedReviewMetadataForNewTransactions(updatedTransactions)
+                batch.apply(response)
+                hasMore = response.hasMore
+            }
+            if batch.hasChanges {
+                // Assign once for the logical sync so downstream SwiftUI
+                // caches recompute only after all pages have been reduced.
+                transactions = batch.transactions
+                seedReviewMetadataForNewTransactions(batch.transactions)
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
                 try await saveTransactionsToCacheWithPerformance(
-                    updatedTransactions,
+                    batch.transactions,
                     to: cacheDirectory,
                     context: cacheContext
                 )
-                try await serverClient.commitSyncCursors(response.pendingCursors)
-                hasMore = response.hasMore
             }
+            try await serverClient.commitSyncCursors(batch.pendingCursors)
             lastSyncDate = Date()
             serverSyncedItemCount = statusItemCount
             await refreshItemStatuses()
@@ -1144,7 +1143,7 @@ final class AppState {
                     .transactionAddedCount: addedCount,
                     .transactionModifiedCount: modifiedCount,
                     .transactionRemovedCount: removedCount,
-                    .transactionTotalCount: transactions.count,
+                    .transactionTotalCount: batch.transactions.count,
                 ],
                 outcome: .success
             )

--- a/Sources/PlaidBarCore/Utilities/TransactionSyncBatch.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionSyncBatch.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public struct TransactionSyncBatch: Sendable {
+    public private(set) var transactions: [TransactionDTO]
+    public private(set) var pendingCursors: [String: String]
+    public private(set) var hasChanges: Bool
+
+    public init(
+        transactions: [TransactionDTO],
+        pendingCursors: [String: String] = [:],
+        hasChanges: Bool = false
+    ) {
+        self.transactions = transactions
+        self.pendingCursors = pendingCursors
+        self.hasChanges = hasChanges
+    }
+
+    public mutating func apply(_ response: SyncResponse) {
+        if !response.added.isEmpty || !response.modified.isEmpty || !response.removed.isEmpty {
+            let updatedTransactions = TransactionSyncReducer.applying(response, to: transactions)
+            if updatedTransactions != transactions {
+                transactions = updatedTransactions
+                hasChanges = true
+            }
+        }
+        pendingCursors.merge(response.pendingCursors) { _, latest in latest }
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1237,6 +1237,86 @@ struct PlaidBarCoreTests {
         #expect(transactions.first { $0.id == "new" }?.amount == 50)
     }
 
+    @Test("Transaction sync batch applies multi-page changes without duplicates or lost updates")
+    func transactionSyncBatchAppliesMultiPageChanges() {
+        let existing = [
+            TransactionDTO(id: "keep", accountId: "a", amount: 10, date: "2026-01-01", name: "Keep"),
+            TransactionDTO(id: "modify", accountId: "a", amount: 20, date: "2026-01-02", name: "Before"),
+            TransactionDTO(id: "remove", accountId: "a", amount: 30, date: "2026-01-03", name: "Remove")
+        ]
+        var batch = TransactionSyncBatch(transactions: existing)
+
+        batch.apply(SyncResponse(
+            added: [
+                TransactionDTO(id: "new-page-1", accountId: "a", amount: 40, date: "2026-01-04", name: "New 1"),
+                TransactionDTO(id: "modify", accountId: "a", amount: 25, date: "2026-01-02", name: "Page 1")
+            ],
+            modified: [],
+            removed: [],
+            hasMore: true,
+            pendingCursors: ["item_1": "cursor_page_1"]
+        ))
+        batch.apply(SyncResponse(
+            added: [
+                TransactionDTO(id: "new-page-2", accountId: "a", amount: 50, date: "2026-01-05", name: "New 2")
+            ],
+            modified: [
+                TransactionDTO(id: "modify", accountId: "a", amount: 35, date: "2026-01-02", name: "Page 2")
+            ],
+            removed: ["remove", "new-page-1"],
+            hasMore: false,
+            pendingCursors: ["item_1": "cursor_page_2", "item_2": "cursor_item_2"]
+        ))
+
+        #expect(batch.hasChanges)
+        #expect(batch.transactions.map(\.id) == ["keep", "modify", "new-page-2"])
+        #expect(batch.transactions.first { $0.id == "modify" }?.amount == 35)
+        #expect(Set(batch.transactions.map(\.id)).count == batch.transactions.count)
+        #expect(batch.pendingCursors == ["item_1": "cursor_page_2", "item_2": "cursor_item_2"])
+    }
+
+    @Test("Transaction sync batch tracks cursors without marking empty pages changed")
+    func transactionSyncBatchKeepsEmptyPagesUnchanged() {
+        let existing = [
+            TransactionDTO(id: "keep", accountId: "a", amount: 10, date: "2026-01-01", name: "Keep")
+        ]
+        var batch = TransactionSyncBatch(transactions: existing)
+
+        batch.apply(SyncResponse(
+            added: [],
+            modified: [],
+            removed: [],
+            hasMore: false,
+            pendingCursors: ["item_1": "cursor_empty"]
+        ))
+
+        #expect(!batch.hasChanges)
+        #expect(batch.transactions == existing)
+        #expect(batch.pendingCursors == ["item_1": "cursor_empty"])
+    }
+
+    @Test("Transaction sync batch treats equivalent non-empty deltas as unchanged")
+    func transactionSyncBatchIgnoresEquivalentDeltas() {
+        let existing = [
+            TransactionDTO(id: "keep", accountId: "a", amount: 10, date: "2026-01-01", name: "Keep")
+        ]
+        var batch = TransactionSyncBatch(transactions: existing)
+
+        batch.apply(SyncResponse(
+            added: [],
+            modified: [
+                TransactionDTO(id: "keep", accountId: "a", amount: 10, date: "2026-01-01", name: "Keep")
+            ],
+            removed: ["missing"],
+            hasMore: false,
+            pendingCursors: ["item_1": "cursor_equivalent"]
+        ))
+
+        #expect(!batch.hasChanges)
+        #expect(batch.transactions == existing)
+        #expect(batch.pendingCursors == ["item_1": "cursor_equivalent"])
+    }
+
     @Test("Net cashflow heatmap keeps Plaid amount signs")
     func netCashflowHeatmapKeepsSigns() {
         let day = Formatters.parseTransactionDate("2026-01-02")!


### PR DESCRIPTION
## Summary
- Batch transaction sync pages in memory with `TransactionSyncBatch`.
- Assign `transactions` once per logical sync only when content changes, reducing SwiftUI derived recomputation.
- Save the transaction cache only when transaction content changes, while still committing cursors after persistence requirements are satisfied.

## Tests
- `git diff --check`
- `swift test --disable-sandbox --skip-update --filter transactionSyncBatch` — 3 tests passed

Linear: AND-425