### PR TITLE
AND-426: Add shared transaction derived index

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -41,6 +41,7 @@ final class AppState {
     }
     var transactions: [TransactionDTO] = [] {
         didSet {
+            _cachedTransactionDerivedIndex = nil
             _cachedRecurringTransactions = nil
             invalidateLocalAIActivitySummaries()
         }
@@ -826,7 +827,7 @@ final class AppState {
     }
 
     var recentTransactions: [TransactionDTO] {
-        Array(transactions.sorted { $0.date > $1.date }.prefix(PlaidBarConstants.maxRecentTransactions))
+        transactionDerivedIndex.recentFeedEntries.map(\.transaction)
     }
 
     var transactionsByDate: [(String, [TransactionDTO])] {
@@ -842,13 +843,23 @@ final class AppState {
         spendingByCategory.reduce(0) { $0 + $1.1 }
     }
 
+    /// Cached transaction index — invalidated via transactions.didSet.
+    private var _cachedTransactionDerivedIndex: TransactionDerivedIndex?
+
+    var transactionDerivedIndex: TransactionDerivedIndex {
+        if let cached = _cachedTransactionDerivedIndex { return cached }
+        let index = TransactionDerivedIndex(transactions: transactions)
+        _cachedTransactionDerivedIndex = index
+        return index
+    }
+
     /// Cached recurring detection — invalidated via transactions.didSet
     private var _cachedRecurringTransactions: [RecurringTransaction]?
 
     var recurringTransactions: [RecurringTransaction] {
         if let cached = _cachedRecurringTransactions { return cached }
         let start = performanceStart()
-        let result = RecurringDetector.detect(from: transactions)
+        let result = RecurringDetector.detect(from: transactionDerivedIndex)
         _cachedRecurringTransactions = result
         recordPerformance(
             .derivedSummaryRecompute,
@@ -944,14 +955,14 @@ final class AppState {
     }
 
     func accountActivitySnapshot(for accountId: String) -> AccountTransactionFeed.AccountActivitySnapshot {
-        AccountTransactionFeed.activitySnapshot(forAccountId: accountId, in: transactions)
+        AccountTransactionFeed.activitySnapshot(forAccountId: accountId, in: transactionDerivedIndex)
     }
 
     func transactionsForMerchant(_ merchantName: String, excluding transactionId: String) -> [TransactionDTO] {
         AccountTransactionFeed.relatedMerchantTransactions(
             merchantName: merchantName,
             excluding: transactionId,
-            in: transactions
+            in: transactionDerivedIndex
         )
     }
 

--- a/Sources/PlaidBarCore/Utilities/AccountActivitySummary.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountActivitySummary.swift
@@ -27,45 +27,62 @@ public struct AccountActivitySummary: Sendable, Equatable {
         calendar: Calendar = .current,
         days: Int = 30
     ) -> AccountActivitySummary {
-        let referenceDate = now ?? latestTransactionDate(in: transactions) ?? Date()
+        recent(
+            from: TransactionDerivedIndex(transactions: transactions),
+            now: now,
+            calendar: calendar,
+            days: days
+        )
+    }
+
+    public static func recent(
+        from index: TransactionDerivedIndex,
+        now: Date? = nil,
+        calendar: Calendar = .current,
+        days: Int = 30
+    ) -> AccountActivitySummary {
+        recent(from: index.entries, now: now, calendar: calendar, days: days)
+    }
+
+    public static func recent(
+        from entries: [TransactionDerivedIndex.Entry],
+        now: Date? = nil,
+        calendar: Calendar = .current,
+        days: Int = 30
+    ) -> AccountActivitySummary {
+        let referenceDate = now ?? latestTransactionDate(in: entries) ?? Date()
         let startDate = calendar.startOfDay(
             for: calendar.date(byAdding: .day, value: -(days - 1), to: referenceDate) ?? referenceDate
         )
 
-        let recentTransactions = transactions.filter { transaction in
-            guard let date = Formatters.parseTransactionDate(transaction.date) else { return false }
+        let recentEntries = entries.filter { entry in
+            guard let date = entry.parsedDate else { return false }
             return date >= startDate && date <= referenceDate
         }
 
         var inflowTotal = 0.0
         var outflowTotal = 0.0
 
-        for transaction in recentTransactions where !transaction.isTransfer {
-            if transaction.isIncome {
-                inflowTotal += transaction.displayAmount
+        for entry in recentEntries where !entry.isTransfer {
+            if entry.isIncome {
+                inflowTotal += entry.displayAmount
             } else {
-                outflowTotal += transaction.displayAmount
+                outflowTotal += entry.displayAmount
             }
         }
 
         return AccountActivitySummary(
-            transactionCount: recentTransactions.count,
-            pendingCount: recentTransactions.filter(\.pending).count,
+            transactionCount: recentEntries.count,
+            pendingCount: recentEntries.count(where: { $0.transaction.pending }),
             inflowTotal: inflowTotal,
             outflowTotal: outflowTotal,
             days: days
         )
     }
 
-    private static func latestTransactionDate(in transactions: [TransactionDTO]) -> Date? {
-        transactions
-            .compactMap { Formatters.parseTransactionDate($0.date) }
+    private static func latestTransactionDate(in entries: [TransactionDerivedIndex.Entry]) -> Date? {
+        entries
+            .compactMap(\.parsedDate)
             .max()
-    }
-}
-
-private extension TransactionDTO {
-    var isTransfer: Bool {
-        category == .transfer || category == .transferOut
     }
 }

--- a/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountTransactionFeed.swift
@@ -13,11 +13,16 @@ public enum AccountTransactionFeed {
         }
 
         public init(transactions: [TransactionDTO]) {
-            self.transactions = AccountTransactionFeed.sortedForFeed(transactions)
-            self.transactionCount = transactions.count
-            self.pendingTransactionCount = transactions.count(where: \.pending)
-            self.latestTransactionDate = transactions.latestTransactionDate
-            self.recentSummary = AccountActivitySummary.recent(from: self.transactions)
+            self.init(entries: TransactionDerivedIndex(transactions: transactions).entries)
+        }
+
+        public init(entries: [TransactionDerivedIndex.Entry]) {
+            let sortedEntries = entries.sorted(by: TransactionDerivedIndex.isPreferredInFeed)
+            self.transactions = sortedEntries.map(\.transaction)
+            self.transactionCount = entries.count
+            self.pendingTransactionCount = entries.count(where: { $0.transaction.pending })
+            self.latestTransactionDate = entries.latestTransactionDate
+            self.recentSummary = AccountActivitySummary.recent(from: sortedEntries)
         }
     }
 
@@ -25,7 +30,17 @@ public enum AccountTransactionFeed {
         forAccountId accountId: String,
         in transactions: [TransactionDTO]
     ) -> AccountActivitySnapshot {
-        AccountActivitySnapshot(transactions: transactions.filter { $0.accountId == accountId })
+        activitySnapshot(
+            forAccountId: accountId,
+            in: TransactionDerivedIndex(transactions: transactions)
+        )
+    }
+
+    public static func activitySnapshot(
+        forAccountId accountId: String,
+        in index: TransactionDerivedIndex
+    ) -> AccountActivitySnapshot {
+        AccountActivitySnapshot(entries: index.entries(forAccountId: accountId))
     }
 
     public static func transactions(
@@ -40,46 +55,35 @@ public enum AccountTransactionFeed {
         excluding transactionId: String,
         in transactions: [TransactionDTO]
     ) -> [TransactionDTO] {
-        sortedForFeed(
-            transactions.filter {
-                $0.merchantName == merchantName && $0.id != transactionId
-            }
+        relatedMerchantTransactions(
+            merchantName: merchantName,
+            excluding: transactionId,
+            in: TransactionDerivedIndex(transactions: transactions)
         )
     }
 
-    public static func sortedForFeed(_ transactions: [TransactionDTO]) -> [TransactionDTO] {
-        transactions.sorted(by: isPreferredInFeed)
+    public static func relatedMerchantTransactions(
+        merchantName: String,
+        excluding transactionId: String,
+        in index: TransactionDerivedIndex
+    ) -> [TransactionDTO] {
+        index.sortedForFeed(
+            index.entries(forMerchantName: merchantName).filter { $0.transaction.id != transactionId }
+        )
+        .map(\.transaction)
     }
 
-    private static func isPreferredInFeed(_ lhs: TransactionDTO, _ rhs: TransactionDTO) -> Bool {
-        let lhsDate = Formatters.parseTransactionDate(lhs.date) ?? .distantPast
-        let rhsDate = Formatters.parseTransactionDate(rhs.date) ?? .distantPast
-        if lhsDate != rhsDate {
-            return lhsDate > rhsDate
-        }
-
-        if lhs.pending != rhs.pending {
-            return lhs.pending
-        }
-
-        if lhs.displayAmount != rhs.displayAmount {
-            return lhs.displayAmount > rhs.displayAmount
-        }
-
-        let nameComparison = lhs.displayName.localizedStandardCompare(rhs.displayName)
-        if nameComparison != .orderedSame {
-            return nameComparison == .orderedAscending
-        }
-
-        return lhs.id < rhs.id
+    public static func sortedForFeed(_ transactions: [TransactionDTO]) -> [TransactionDTO] {
+        let index = TransactionDerivedIndex(transactions: transactions)
+        return index.sortedForFeed(index.entries).map(\.transaction)
     }
 }
 
-private extension Array where Element == TransactionDTO {
+private extension Array where Element == TransactionDerivedIndex.Entry {
     var latestTransactionDate: String? {
-        compactMap { transaction -> (raw: String, parsed: Date)? in
-            guard let parsed = Formatters.parseTransactionDate(transaction.date) else { return nil }
-            return (transaction.date, parsed)
+        compactMap { entry -> (raw: String, parsed: Date)? in
+            guard let parsed = entry.parsedDate else { return nil }
+            return (entry.rawDate, parsed)
         }
         .max { $0.parsed < $1.parsed }?
         .raw

--- a/Sources/PlaidBarCore/Utilities/RecurringDetector.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringDetector.swift
@@ -4,18 +4,22 @@ public enum RecurringDetector {
     /// Detect recurring transactions from a list of transactions.
     /// Groups by merchantName, computes date intervals, classifies frequency.
     public static func detect(from transactions: [TransactionDTO]) -> [RecurringTransaction] {
+        detect(from: TransactionDerivedIndex(transactions: transactions))
+    }
+
+    public static func detect(from index: TransactionDerivedIndex) -> [RecurringTransaction] {
         // Group by merchantName (non-nil only), excluding income
-        let grouped = Dictionary(grouping: transactions.filter {
-            $0.merchantName != nil && !$0.isIncome
-        }) { $0.merchantName! }
+        let grouped = index.merchantBuckets.mapValues { entries in
+            entries.filter { !$0.isIncome }
+        }
 
         var results: [RecurringTransaction] = []
 
-        for (merchant, txns) in grouped {
-            guard txns.count >= 2 else { continue }
+        for (merchant, entries) in grouped {
+            guard entries.count >= 2 else { continue }
 
             // Sort by date ascending
-            let sorted = txns.sorted { $0.date < $1.date }
+            let sorted = entries.sorted { $0.rawDate < $1.rawDate }
 
             // Compute intervals in days between consecutive transactions
             let intervals = computeIntervals(sorted)
@@ -40,7 +44,7 @@ public enum RecurringDetector {
                 ? nil
                 : previousTransactions.reduce(0.0) { $0 + $1.displayAmount } / Double(previousTransactions.count)
             let latestAmount = sorted.last!.displayAmount
-            let lastDate = sorted.last!.date
+            let lastDate = sorted.last!.rawDate
             let nextExpected = computeNextDate(from: lastDate, frequency: frequency)
             let category = sorted.last!.category
 
@@ -64,11 +68,30 @@ public enum RecurringDetector {
     // MARK: - Private Helpers
 
     static func computeIntervals(_ sorted: [TransactionDTO]) -> [Double] {
+        computeIntervals(
+            sorted.map {
+                TransactionDerivedIndex.EntryForRecurring(
+                    rawDate: $0.date,
+                    parsedDate: Formatters.parseTransactionDate($0.date)
+                )
+            }
+        )
+    }
+
+    static func computeIntervals(_ sorted: [TransactionDerivedIndex.Entry]) -> [Double] {
+        computeIntervals(
+            sorted.map {
+                TransactionDerivedIndex.EntryForRecurring(rawDate: $0.rawDate, parsedDate: $0.parsedDate)
+            }
+        )
+    }
+
+    private static func computeIntervals(_ sorted: [TransactionDerivedIndex.EntryForRecurring]) -> [Double] {
         guard sorted.count >= 2 else { return [] }
         var intervals: [Double] = []
         for i in 1..<sorted.count {
-            guard let d1 = Formatters.parseTransactionDate(sorted[i - 1].date),
-                  let d2 = Formatters.parseTransactionDate(sorted[i].date) else { continue }
+            guard let d1 = sorted[i - 1].parsedDate,
+                  let d2 = sorted[i].parsedDate else { continue }
             let days = d2.timeIntervalSince(d1) / 86400.0
             if days > 0 { intervals.append(days) }
         }
@@ -121,5 +144,12 @@ public enum RecurringDetector {
             next = calendar.date(byAdding: .year, value: 1, to: date)
         }
         return Formatters.transactionDateString(next ?? date)
+    }
+}
+
+private extension TransactionDerivedIndex {
+    struct EntryForRecurring {
+        let rawDate: String
+        let parsedDate: Date?
     }
 }

--- a/Sources/PlaidBarCore/Utilities/TransactionDerivedIndex.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionDerivedIndex.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+public struct TransactionDerivedIndex: Sendable {
+    public struct Entry: Sendable, Hashable {
+        public let transaction: TransactionDTO
+        public let parsedDate: Date?
+        public let isIncome: Bool
+        public let isTransfer: Bool
+        public let isExpense: Bool
+        public let displayAmount: Double
+
+        public var rawDate: String { transaction.date }
+        public var accountId: String { transaction.accountId }
+        public var itemId: String? { transaction.itemId }
+        public var merchantName: String? { transaction.merchantName }
+        public var category: SpendingCategory? { transaction.category }
+
+        fileprivate init(transaction: TransactionDTO, parsedDate: Date?) {
+            self.transaction = transaction
+            self.parsedDate = parsedDate
+            self.isIncome = transaction.isIncome
+            self.isTransfer = transaction.category == .transfer || transaction.category == .transferOut
+            self.isExpense = !transaction.isIncome && transaction.category != .transfer && transaction.category != .transferOut
+            self.displayAmount = transaction.displayAmount
+        }
+    }
+
+    public let entries: [Entry]
+    public let accountBuckets: [String: [Entry]]
+    public let itemBuckets: [String: [Entry]]
+    public let merchantBuckets: [String: [Entry]]
+    public let categoryTotals: [SpendingCategory: Double]
+    public let recentFeedEntries: [Entry]
+    public let latestTransactionDate: Date?
+
+    public init(
+        transactions: [TransactionDTO],
+        recentLimit: Int = PlaidBarConstants.maxRecentTransactions,
+        parseDate: (String) -> Date? = Formatters.parseTransactionDate
+    ) {
+        var entries: [Entry] = []
+        entries.reserveCapacity(transactions.count)
+
+        var accountBuckets: [String: [Entry]] = [:]
+        var itemBuckets: [String: [Entry]] = [:]
+        var merchantBuckets: [String: [Entry]] = [:]
+        var categoryTotals: [SpendingCategory: Double] = [:]
+        var latestTransactionDate: Date?
+
+        for transaction in transactions {
+            let entry = Entry(transaction: transaction, parsedDate: parseDate(transaction.date))
+            entries.append(entry)
+
+            accountBuckets[entry.accountId, default: []].append(entry)
+            if let itemId = entry.itemId {
+                itemBuckets[itemId, default: []].append(entry)
+            }
+            if let merchantName = entry.merchantName {
+                merchantBuckets[merchantName, default: []].append(entry)
+            }
+            if entry.isExpense {
+                categoryTotals[entry.category ?? .other, default: 0] += entry.displayAmount
+            }
+            if let parsedDate = entry.parsedDate,
+               latestTransactionDate.map({ parsedDate > $0 }) ?? true {
+                latestTransactionDate = parsedDate
+            }
+        }
+
+        self.entries = entries
+        self.accountBuckets = accountBuckets
+        self.itemBuckets = itemBuckets
+        self.merchantBuckets = merchantBuckets
+        self.categoryTotals = categoryTotals
+        self.recentFeedEntries = Array(entries.sorted(by: Self.isPreferredInFeed).prefix(recentLimit))
+        self.latestTransactionDate = latestTransactionDate
+    }
+
+    public func entries(forAccountId accountId: String) -> [Entry] {
+        accountBuckets[accountId] ?? []
+    }
+
+    public func entries(forItemId itemId: String) -> [Entry] {
+        itemBuckets[itemId] ?? []
+    }
+
+    public func entries(forMerchantName merchantName: String) -> [Entry] {
+        merchantBuckets[merchantName] ?? []
+    }
+
+    public func recentEntries(
+        from startDate: Date,
+        through endDate: Date
+    ) -> [Entry] {
+        entries(in: entries, from: startDate, through: endDate)
+    }
+
+    public func entries(
+        in source: [Entry],
+        from startDate: Date,
+        through endDate: Date
+    ) -> [Entry] {
+        source.filter { entry in
+            guard let date = entry.parsedDate else { return false }
+            return date >= startDate && date <= endDate
+        }
+    }
+
+    public func sortedForFeed(_ source: [Entry]) -> [Entry] {
+        source.sorted(by: Self.isPreferredInFeed)
+    }
+
+    public static func isPreferredInFeed(_ lhs: Entry, _ rhs: Entry) -> Bool {
+        let lhsDate = lhs.parsedDate ?? .distantPast
+        let rhsDate = rhs.parsedDate ?? .distantPast
+        if lhsDate != rhsDate {
+            return lhsDate > rhsDate
+        }
+
+        if lhs.transaction.pending != rhs.transaction.pending {
+            return lhs.transaction.pending
+        }
+
+        if lhs.displayAmount != rhs.displayAmount {
+            return lhs.displayAmount > rhs.displayAmount
+        }
+
+        let nameComparison = lhs.transaction.displayName.localizedStandardCompare(rhs.transaction.displayName)
+        if nameComparison != .orderedSame {
+            return nameComparison == .orderedAscending
+        }
+
+        return lhs.transaction.id < rhs.transaction.id
+    }
+}
+
+public struct FinanceDerivedSnapshot: Sendable {
+    public let accounts: [AccountDTO]
+    public let accountsById: [String: AccountDTO]
+    public let transactionIndex: TransactionDerivedIndex
+
+    public init(accounts: [AccountDTO], transactions: [TransactionDTO]) {
+        self.accounts = accounts
+        self.accountsById = accounts.reduce(into: [:]) { result, account in
+            result[account.id] = account
+        }
+        self.transactionIndex = TransactionDerivedIndex(transactions: transactions)
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionDerivedIndexTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionDerivedIndexTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("TransactionDerivedIndex")
+struct TransactionDerivedIndexTests {
+    @Test("Index precomputes buckets, flags, dates, and category totals")
+    func precomputesBucketsFlagsDatesAndTotals() throws {
+        let transactions = [
+            Self.tx("coffee", accountId: "checking", itemId: "item-a", amount: 6, date: "2026-06-10", merchant: "Cafe", category: .foodAndDrink),
+            Self.tx("payroll", accountId: "checking", itemId: "item-a", amount: -2_000, date: "2026-06-09", merchant: "Acme", category: .income),
+            Self.tx("transfer", accountId: "savings", itemId: "item-b", amount: 250, date: "2026-06-08", merchant: "Bank", category: .transferOut),
+            Self.tx("invalid", accountId: "checking", itemId: "item-a", amount: 12, date: "not-a-date", merchant: "Cafe", category: nil),
+        ]
+
+        let index = TransactionDerivedIndex(transactions: transactions)
+
+        #expect(index.entries.count == 4)
+        #expect(index.entries(forAccountId: "checking").map(\.transaction.id) == ["coffee", "payroll", "invalid"])
+        #expect(index.entries(forItemId: "item-b").map(\.transaction.id) == ["transfer"])
+        #expect(index.entries(forMerchantName: "Cafe").map(\.transaction.id) == ["coffee", "invalid"])
+        #expect(index.categoryTotals[.foodAndDrink] == 6)
+        #expect(index.categoryTotals[.other] == 12)
+        #expect(index.categoryTotals[.income] == nil)
+        #expect(index.recentFeedEntries.map(\.transaction.id) == ["coffee", "payroll", "transfer", "invalid"])
+        #expect(index.latestTransactionDate == Formatters.parseTransactionDate("2026-06-10"))
+        #expect(index.entries.first?.isExpense == true)
+        #expect(index.entries[1].isIncome == true)
+        #expect(index.entries[2].isTransfer == true)
+        #expect(index.entries[3].parsedDate == nil)
+    }
+
+    @Test("Account activity summary and feed output match indexed adapter")
+    func accountActivitySummaryAndFeedUseIndex() {
+        let transactions = [
+            Self.tx("old", accountId: "checking", amount: 10, date: "2026-01-13", category: .foodAndDrink),
+            Self.tx("other", accountId: "credit", amount: 999, date: "2026-01-16", category: .shopping),
+            Self.tx("pending", accountId: "checking", amount: 30, date: "2026-01-15", category: .foodAndDrink, pending: true),
+            Self.tx("income", accountId: "checking", amount: -100, date: "2026-01-14", category: .income),
+            Self.tx("invalid", accountId: "checking", amount: 8, date: "not-a-date", category: .other),
+        ]
+        let index = TransactionDerivedIndex(transactions: transactions)
+
+        let arraySummary = AccountActivitySummary.recent(
+            from: transactions.filter { $0.accountId == "checking" },
+            now: Formatters.parseTransactionDate("2026-01-15"),
+            days: 3
+        )
+        let indexedSummary = AccountActivitySummary.recent(
+            from: index.entries(forAccountId: "checking"),
+            now: Formatters.parseTransactionDate("2026-01-15"),
+            days: 3
+        )
+        let snapshot = AccountTransactionFeed.activitySnapshot(forAccountId: "checking", in: index)
+
+        #expect(indexedSummary == arraySummary)
+        #expect(snapshot.transactions.map(\.id) == ["pending", "income", "old", "invalid"])
+        #expect(snapshot.latestTransactionDate == "2026-01-15")
+        #expect(snapshot.recentSummary == AccountActivitySummary.recent(from: snapshot.transactions))
+    }
+
+    @Test("Recurring detector accepts a shared transaction index")
+    func recurringDetectorAcceptsIndex() throws {
+        let transactions = [
+            Self.tx("jan", amount: 10, date: "2026-01-15", merchant: "StreamCo", category: .subscriptions),
+            Self.tx("feb", amount: 10, date: "2026-02-15", merchant: "StreamCo", category: .subscriptions),
+            Self.tx("mar", amount: 11, date: "2026-03-15", merchant: "StreamCo", category: .subscriptions),
+            Self.tx("income", amount: -100, date: "2026-03-15", merchant: "StreamCo", category: .income),
+        ]
+
+        let recurring = try #require(RecurringDetector.detect(from: TransactionDerivedIndex(transactions: transactions)).first)
+
+        #expect(recurring.merchantName == "StreamCo")
+        #expect(recurring.frequency == .monthly)
+        #expect(recurring.transactionCount == 3)
+        #expect(abs(recurring.averageAmount - (31.0 / 3.0)) < 0.001)
+        #expect(recurring.latestAmount == 11)
+        #expect(recurring.lastDate == "2026-03-15")
+        #expect(recurring.nextExpectedDate == "2026-04-15")
+    }
+
+    @Test("Synthetic 5k transaction index parses dates once during reusable construction")
+    func syntheticIndexParsesDatesOnce() {
+        let transactions = (0..<5_200).map { offset in
+            let day = (offset % 28) + 1
+            return Self.tx(
+                "tx-\(offset)",
+                accountId: offset.isMultiple(of: 2) ? "checking" : "card",
+                amount: offset.isMultiple(of: 17) ? -2_000 : Double((offset % 90) + 1),
+                date: String(format: "2026-05-%02d", day),
+                merchant: "Merchant \(offset % 40)",
+                category: offset.isMultiple(of: 17) ? .income : .foodAndDrink,
+                pending: offset.isMultiple(of: 23)
+            )
+        }
+        let counter = ParseCounter()
+
+        let index = TransactionDerivedIndex(transactions: transactions) { rawDate in
+            counter.increment()
+            return Formatters.parseTransactionDate(rawDate)
+        }
+
+        #expect(counter.value == transactions.count)
+        _ = AccountActivitySummary.recent(from: index, now: Formatters.parseTransactionDate("2026-05-28"))
+        _ = AccountTransactionFeed.activitySnapshot(forAccountId: "checking", in: index)
+        _ = RecurringDetector.detect(from: index)
+        _ = index.categoryTotals
+        #expect(counter.value == transactions.count)
+        #expect(index.entries.count == 5_200)
+        #expect(index.accountBuckets.count == 2)
+        #expect(index.merchantBuckets.count == 40)
+    }
+
+    private static func tx(
+        _ id: String,
+        accountId: String = "checking",
+        itemId: String? = "item",
+        amount: Double,
+        date: String,
+        merchant: String? = nil,
+        category: SpendingCategory? = nil,
+        pending: Bool = false
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            itemId: itemId,
+            accountId: accountId,
+            amount: amount,
+            date: date,
+            name: merchant ?? id,
+            merchantName: merchant,
+            category: category,
+            pending: pending
+        )
+    }
+}
+
+private final class ParseCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary
- Add a pure `TransactionDerivedIndex` / `FinanceDerivedSnapshot` in PlaidBarCore.
- Reuse parsed transaction dates and buckets for recurring detection, account activity snapshots, merchant-related feeds, and recent transactions.
- Add a synthetic 5,200-transaction parse-count test proving shared adapters do not reparse dates after index construction.

## Tests
- `git diff --check`
- `swift test --disable-sandbox --skip-update --filter TransactionDerivedIndex` — 4 tests passed
- `swift test --disable-sandbox --skip-update --filter accountActivity` — 11 tests passed
- `swift test --disable-sandbox --skip-update --filter detect` — 10 tests passed

Linear: AND-426