### PR TITLE
AND-408: Add managed OAuth redirect readiness gates

### DIFF
--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -22,6 +22,7 @@ struct ServerConfig: Sendable {
     let databasePath: String
     let pendingLinkSessionsPath: String
     let redirectUri: String
+    let oauthRedirect: OAuthRedirectConfiguration
     let authToken: String
     let linkClientUserId: String
     let link: PlaidLinkConfiguration
@@ -129,6 +130,12 @@ struct ServerConfig: Sendable {
         // until the owner provisions them (see consumer-production-checklist.md).
         let deployment = DeploymentMode.resolved(from: environmentValues)
         let remoteBridge = RemoteBridgeConfig.resolved(from: environmentValues)
+        let oauthRedirect = try OAuthRedirectConfiguration.resolved(
+            from: environmentValues,
+            deployment: deployment,
+            plaidEnvironment: environment,
+            port: resolvedPort
+        )
 
         return ServerConfig(
             port: resolvedPort,
@@ -143,7 +150,8 @@ struct ServerConfig: Sendable {
             pendingLinkSessionsPath: URL(fileURLWithPath: dataDir, isDirectory: true)
                 .appendingPathComponent(pendingLinkSessionsFilename)
                 .path,
-            redirectUri: "http://localhost:\(resolvedPort)/oauth/callback",
+            redirectUri: oauthRedirect.uri,
+            oauthRedirect: oauthRedirect,
             authToken: authToken,
             linkClientUserId: linkClientUserId,
             link: link,
@@ -877,6 +885,9 @@ enum ServerConfigError: LocalizedError {
     case invalidEnvironmentVariable(String, String)
     case invalidConfigLine(path: String, line: Int)
     case invalidPort(Int)
+    case missingManagedRedirectURI
+    case invalidManagedRedirectURI
+    case appRedirectRequiresHTTPS
 
     var errorDescription: String? {
         switch self {
@@ -886,7 +897,84 @@ enum ServerConfigError: LocalizedError {
             "Invalid config line \(line) in \(path)"
         case .invalidPort(let port):
             "Invalid server port \(port): must be between 1 and 65535"
+        case .missingManagedRedirectURI:
+            "Managed production Hosted Link requires PLAIDBAR_OAUTH_REDIRECT_URI to be configured"
+        case .invalidManagedRedirectURI:
+            "Managed production Hosted Link redirect URI must be configured as HTTPS"
+        case .appRedirectRequiresHTTPS:
+            "App or Universal Link OAuth redirect mode requires an HTTPS Universal Link callback"
         }
+    }
+}
+
+enum OAuthRedirectMode: String, Sendable, Equatable, CaseIterable {
+    case local
+    case managed
+    case app
+
+    static let environmentVariable = "PLAIDBAR_OAUTH_REDIRECT_MODE"
+
+    static func resolved(from environment: [String: String], deployment: DeploymentMode) -> OAuthRedirectMode {
+        guard let rawValue = environment[environmentVariable]?.trimmedNonEmpty else {
+            return deployment == .hostedBridge ? .managed : .local
+        }
+        return OAuthRedirectMode(rawValue: rawValue) ?? (deployment == .hostedBridge ? .managed : .local)
+    }
+}
+
+struct OAuthRedirectConfiguration: Sendable, Equatable {
+    static let uriEnvironmentVariable = "PLAIDBAR_OAUTH_REDIRECT_URI"
+
+    let mode: OAuthRedirectMode
+    let uri: String
+
+    var isProductionReadyForHostedLink: Bool {
+        switch mode {
+        case .local:
+            return false
+        case .managed, .app:
+            return Self.isHTTPS(uri)
+        }
+    }
+
+    static func resolved(
+        from environment: [String: String],
+        deployment: DeploymentMode,
+        plaidEnvironment: PlaidEnvironment,
+        port: Int
+    ) throws -> OAuthRedirectConfiguration {
+        let mode = OAuthRedirectMode.resolved(from: environment, deployment: deployment)
+        let configuredURI = environment[uriEnvironmentVariable]?.trimmedNonEmpty
+
+        switch mode {
+        case .local:
+            return OAuthRedirectConfiguration(
+                mode: .local,
+                uri: configuredURI ?? "http://localhost:\(port)/oauth/callback"
+            )
+        case .managed:
+            guard let configuredURI else {
+                throw ServerConfigError.missingManagedRedirectURI
+            }
+            if deployment == .hostedBridge, plaidEnvironment == .production, !isHTTPS(configuredURI) {
+                throw ServerConfigError.invalidManagedRedirectURI
+            }
+            return OAuthRedirectConfiguration(mode: .managed, uri: configuredURI)
+        case .app:
+            guard let configuredURI else {
+                throw ServerConfigError.missingManagedRedirectURI
+            }
+            guard isHTTPS(configuredURI) else {
+                throw ServerConfigError.appRedirectRequiresHTTPS
+            }
+            return OAuthRedirectConfiguration(mode: .app, uri: configuredURI)
+        }
+    }
+
+    private static func isHTTPS(_ uri: String) -> Bool {
+        guard let components = URLComponents(string: uri) else { return false }
+        return components.scheme?.lowercased() == "https"
+            && components.host?.isEmpty == false
     }
 }
 

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -22,6 +22,7 @@ struct LinkRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
+        try ensureProductionHostedLinkRedirectIsReady()
         let state = await pendingLinkSessions.issueState()
         let plaidResponse = try await Self.mappingPlaidError {
             try await plaidClient.createLinkToken(
@@ -49,6 +50,7 @@ struct LinkRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> Response {
+        try ensureProductionHostedLinkRedirectIsReady()
         guard let itemId = context.parameters.get("itemId") else {
             throw HTTPError(.badRequest, message: "Missing itemId parameter")
         }
@@ -178,6 +180,33 @@ struct LinkRoutes: Sendable {
         queryItems.append(URLQueryItem(name: "state", value: state))
         components.queryItems = queryItems
         return components.string ?? config.redirectUri
+    }
+
+    private func ensureProductionHostedLinkRedirectIsReady() throws {
+        if let error = Self.productionHostedLinkRedirectReadinessError(
+            deployment: config.deployment,
+            plaidEnvironment: config.plaidEnvironment,
+            oauthRedirect: config.oauthRedirect
+        ) {
+            throw error
+        }
+    }
+
+    static func productionHostedLinkRedirectReadinessError(
+        deployment: DeploymentMode,
+        plaidEnvironment: PlaidEnvironment,
+        oauthRedirect: OAuthRedirectConfiguration
+    ) -> HTTPError? {
+        guard deployment == .hostedBridge,
+              plaidEnvironment == .production,
+              !oauthRedirect.isProductionReadyForHostedLink
+        else {
+            return nil
+        }
+        return HTTPError(
+            .serviceUnavailable,
+            message: "Managed production Hosted Link requires a configured HTTPS OAuth redirect URI"
+        )
     }
 }
 

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -206,6 +206,130 @@ struct LinkTokenRequestTests {
     }
 }
 
+@Suite("Hosted Link OAuth redirect readiness")
+struct HostedLinkOAuthRedirectReadinessTests {
+    @Test("Local sandbox BYO config allows localhost callback")
+    func localSandboxAllowsLocalhostCallback() throws {
+        let config = try loadConfig([
+            "PLAID_CLIENT_ID=client",
+            "PLAID_SECRET=secret",
+            "PLAID_ENV=sandbox",
+            "PLAIDBAR_DEPLOYMENT=local",
+            "PLAIDBAR_OAUTH_REDIRECT_MODE=local",
+            "PLAIDBAR_SERVER_PORT=9494",
+        ])
+
+        #expect(config.deployment == .local)
+        #expect(config.oauthRedirect.mode == .local)
+        #expect(config.redirectUri == "http://localhost:9494/oauth/callback")
+    }
+
+    @Test("Managed production rejects localhost callback")
+    func managedProductionRejectsLocalhostCallback() throws {
+        #expect(throws: ServerConfigError.self) {
+            _ = try loadConfig([
+                "PLAID_CLIENT_ID=client",
+                "PLAID_SECRET=secret",
+                "PLAID_ENV=production",
+                "PLAIDBAR_DEPLOYMENT=hosted-bridge",
+                "PLAIDBAR_OAUTH_REDIRECT_MODE=managed",
+                "PLAIDBAR_OAUTH_REDIRECT_URI=http://localhost:8484/oauth/callback",
+            ])
+        }
+    }
+
+    @Test("Managed production accepts configured HTTPS callback")
+    func managedProductionAcceptsHTTPSCallback() throws {
+        let config = try loadConfig([
+            "PLAID_CLIENT_ID=client",
+            "PLAID_SECRET=secret",
+            "PLAID_ENV=production",
+            "PLAIDBAR_DEPLOYMENT=hosted-bridge",
+            "PLAIDBAR_OAUTH_REDIRECT_MODE=managed",
+            "PLAIDBAR_OAUTH_REDIRECT_URI=https://link.vaultpeek.example/oauth/callback",
+        ])
+
+        #expect(config.deployment == .hostedBridge)
+        #expect(config.oauthRedirect.mode == .managed)
+        #expect(config.redirectUri == "https://link.vaultpeek.example/oauth/callback")
+        #expect(config.oauthRedirect.isProductionReadyForHostedLink)
+    }
+
+    @Test("Link route readiness guard blocks only managed production without HTTPS")
+    func linkRouteReadinessGuardBlocksOnlyManagedProductionWithoutHTTPS() {
+        let localhostRedirect = OAuthRedirectConfiguration(
+            mode: .managed,
+            uri: "http://localhost:8484/oauth/callback"
+        )
+        let httpsRedirect = OAuthRedirectConfiguration(
+            mode: .managed,
+            uri: "https://link.vaultpeek.example/oauth/callback"
+        )
+
+        #expect(LinkRoutes.productionHostedLinkRedirectReadinessError(
+            deployment: .local,
+            plaidEnvironment: .sandbox,
+            oauthRedirect: localhostRedirect
+        ) == nil)
+        #expect(LinkRoutes.productionHostedLinkRedirectReadinessError(
+            deployment: .hostedBridge,
+            plaidEnvironment: .production,
+            oauthRedirect: localhostRedirect
+        ) != nil)
+        #expect(LinkRoutes.productionHostedLinkRedirectReadinessError(
+            deployment: .hostedBridge,
+            plaidEnvironment: .production,
+            oauthRedirect: httpsRedirect
+        ) == nil)
+    }
+
+    @Test("Future app callback mode requires HTTPS Universal Link shape")
+    func appModeRequiresUniversalLinkShape() throws {
+        #expect(throws: ServerConfigError.self) {
+            _ = try loadConfig([
+                "PLAID_CLIENT_ID=client",
+                "PLAID_SECRET=secret",
+                "PLAID_ENV=production",
+                "PLAIDBAR_DEPLOYMENT=hosted-bridge",
+                "PLAIDBAR_OAUTH_REDIRECT_MODE=app",
+                "PLAIDBAR_OAUTH_REDIRECT_URI=vaultpeek://oauth/callback",
+            ])
+        }
+
+        let config = try loadConfig([
+            "PLAID_CLIENT_ID=client",
+            "PLAID_SECRET=secret",
+            "PLAID_ENV=production",
+            "PLAIDBAR_DEPLOYMENT=hosted-bridge",
+            "PLAIDBAR_OAUTH_REDIRECT_MODE=app",
+            "PLAIDBAR_OAUTH_REDIRECT_URI=https://vaultpeek.example/app/oauth/callback",
+        ])
+
+        #expect(config.oauthRedirect.mode == .app)
+        #expect(config.redirectUri == "https://vaultpeek.example/app/oauth/callback")
+        #expect(config.oauthRedirect.isProductionReadyForHostedLink)
+    }
+
+    private func loadConfig(_ lines: [String]) throws -> ServerConfig {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-redirect-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("server.conf")
+        let contents = (lines + ["PLAIDBAR_DATA_DIR=\(dataDirectory.path)"])
+            .joined(separator: "\n")
+        try contents.write(to: configURL, atomically: true, encoding: .utf8)
+        do {
+            let config = try ServerConfig.load(from: configURL.path)
+            try? FileManager.default.removeItem(at: directory)
+            return config
+        } catch {
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
+    }
+}
+
 /// Plaid API errors from the Link flow must surface an actionable, secret-free
 /// message instead of a bare HTTP 500 — and without echoing Plaid's raw,
 /// provider-controlled `error_message` into the SwiftUI app (see `AGENTS.md`).

--- a/docs/strategy/consumer-production-checklist.md
+++ b/docs/strategy/consumer-production-checklist.md
@@ -88,10 +88,14 @@ approval record:
 8. **Register production redirect / allowed URIs** in the Plaid dashboard:
    - The bridge HTTPS completion redirect (replaces today's
      `http://localhost:8484/oauth/callback`; localhost is a sandbox-only
-     affordance — architecture doc §5.5).
+     affordance — architecture doc §5.5). This must exactly match the
+     production `PLAIDBAR_OAUTH_REDIRECT_URI`.
    - Any OAuth-institution redirect URIs Plaid requires for prod.
-   - Confirm the `vaultpeek://link/complete` deep-link bounce / associated-domains
-     fallback (open question O2).
+   - For future app/universal-link callback mode, register only HTTPS Universal
+     Link redirect URIs with Plaid and verify Apple Associated Domains plus the
+     host's `apple-app-site-association` file before enabling the mode. Custom
+     URL schemes such as `vaultpeek://link/complete` are only post-callback app
+     bounces, not Plaid production OAuth redirect URIs.
 9. **Resolve open question O1 with Plaid:** can an Item be administratively
    removed (to stop per-Item billing) **without** the access token, given device
    custody? The answer decides the orphan runbook vs forcing the token-vault

--- a/docs/strategy/managed-link-architecture.md
+++ b/docs/strategy/managed-link-architecture.md
@@ -198,7 +198,9 @@ sequenceDiagram
     end
 ```
 
-Notes: the broker callback replaces today's `http://localhost:8484/oauth/callback` (Plaid production OAuth requires registered HTTPS redirect URIs — the localhost redirect is a sandbox affordance). The one-time-state + TTL + single-attempt-exchange discipline is lifted directly from `PendingLinkSessionStore` and `PlaidClient`'s `.singleAttempt` retry policy. The token-claim handoff is device-signed and single-use; an unclaimed session expires and the broker removes the Item (no orphan billing from abandoned links).
+Notes: the broker callback replaces today's `http://localhost:8484/oauth/callback` (Plaid production OAuth requires registered HTTPS redirect URIs — the localhost redirect is a sandbox/BYO affordance). Before managed production link-token creation is enabled, the exact broker HTTPS callback configured as `PLAIDBAR_OAUTH_REDIRECT_URI` must be registered in the Plaid Dashboard for the production application; a mismatch should be treated as a release blocker, not a runtime warning. The one-time-state + TTL + single-attempt-exchange discipline is lifted directly from `PendingLinkSessionStore` and `PlaidClient`'s `.singleAttempt` retry policy. The token-claim handoff is device-signed and single-use; an unclaimed session expires and the broker removes the Item (no orphan billing from abandoned links).
+
+Future app/universal-link callback mode is distinct from the managed broker callback. Plaid OAuth redirect URIs for native app return paths must still be HTTPS Universal Links, registered in the Plaid Dashboard, and backed by Apple Associated Domains plus a valid `apple-app-site-association` file on the callback host. Custom URL schemes such as `vaultpeek://` can be used only after the HTTPS callback has completed and bounced control back to the app; they are not production Plaid OAuth redirect URIs.
 
 ### 5.6 Steady-state sync (sequence)
 


### PR DESCRIPTION
## Summary
- Add production OAuth redirect readiness configuration for managed Hosted Link.
- Require HTTPS callback configuration for hosted-bridge production and future app/universal-link mode.
- Add docs/checklist coverage for Plaid Dashboard redirect registration and Universal Link/AASA caveats.

## Tests
- `git diff --check`
- `swift test --filter LinkTokenRequestTests --skip-update --disable-keychain` — 16 tests passed

Linear: AND-408