### PR TITLE
AND-410: Add Plaid webhook receiver

### DIFF
--- a/Sources/PlaidBarCore/Models/LinkResponse.swift
+++ b/Sources/PlaidBarCore/Models/LinkResponse.swift
@@ -13,16 +13,53 @@ public struct LinkResponse: Codable, Sendable {
 
 /// Response from token exchange (server internal, but also useful for status)
 public struct ItemStatus: Codable, Sendable, Identifiable {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case institutionName
+        case status
+        case lastSync
+        case lastWebhookAt
+        case lastWebhookEvent
+        case needsSync
+    }
+
     public let id: String        // item_id
     public let institutionName: String?
     public let status: ItemConnectionStatus
     public let lastSync: Date?
+    public let lastWebhookAt: Date?
+    public let lastWebhookEvent: String?
+    public let needsSync: Bool
 
-    public init(id: String, institutionName: String? = nil, status: ItemConnectionStatus, lastSync: Date? = nil) {
+    public init(
+        id: String,
+        institutionName: String? = nil,
+        status: ItemConnectionStatus,
+        lastSync: Date? = nil,
+        lastWebhookAt: Date? = nil,
+        lastWebhookEvent: String? = nil,
+        needsSync: Bool = false
+    ) {
         self.id = id
         self.institutionName = institutionName
         self.status = status
         self.lastSync = lastSync
+        self.lastWebhookAt = lastWebhookAt
+        self.lastWebhookEvent = lastWebhookEvent
+        self.needsSync = needsSync
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            institutionName: try container.decodeIfPresent(String.self, forKey: .institutionName),
+            status: try container.decode(ItemConnectionStatus.self, forKey: .status),
+            lastSync: try container.decodeIfPresent(Date.self, forKey: .lastSync),
+            lastWebhookAt: try container.decodeIfPresent(Date.self, forKey: .lastWebhookAt),
+            lastWebhookEvent: try container.decodeIfPresent(String.self, forKey: .lastWebhookEvent),
+            needsSync: try container.decodeIfPresent(Bool.self, forKey: .needsSync) ?? false
+        )
     }
 }
 

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -50,6 +50,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateCategoryBudgets())
         await fluent.migrations.add(CreateBillingSubscriptions())
+        await fluent.migrations.add(CreateWebhookEvents())
         try await fluent.migrate()
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)
 
@@ -57,6 +58,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         let tokenStore = TokenStore(fluent: fluent, logger: logger)
         let budgetStore = BudgetStore(fluent: fluent)
         let billingStore = BillingSubscriptionStore(fluent: fluent)
+        let webhookEventStore = WebhookEventStore(fluent: fluent)
         do {
             try await tokenStore.pruneOrphanedKeychainTokens()
         } catch {
@@ -100,7 +102,12 @@ struct PlaidBarServer: AsyncParsableCommand {
             .register(with: api)
         TransactionRoutes(plaidClient: plaidClient, tokenStore: tokenStore)
             .register(with: api)
-        StatusRoutes(tokenStore: tokenStore, billingStore: billingStore, config: serverConfig)
+        StatusRoutes(
+            tokenStore: tokenStore,
+            billingStore: billingStore,
+            webhookEventStore: webhookEventStore,
+            config: serverConfig
+        )
             .register(with: api)
         BudgetRoutes(budgetStore: budgetStore)
             .register(with: api)
@@ -113,6 +120,12 @@ struct PlaidBarServer: AsyncParsableCommand {
             tokenStore: tokenStore,
             pendingLinkSessions: pendingLinkSessions,
             hostedLinkCompletions: hostedLinkCompletions
+        )
+        .register(with: router)
+        WebhookRoutes(
+            verifier: StrictPlaidWebhookVerifier(),
+            tokenStore: tokenStore,
+            eventStore: webhookEventStore
         )
         .register(with: router)
         HostedLinkWebhookRoute(hostedLinkCompletions: hostedLinkCompletions)

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -6,6 +6,7 @@ import PlaidBarCore
 struct StatusRoutes: Sendable {
     let tokenStore: TokenStore
     let billingStore: BillingSubscriptionStore
+    var webhookEventStore: WebhookEventStore? = nil
     let config: ServerConfig
 
     func register(with group: RouterGroup<some RequestContext>) {
@@ -70,16 +71,26 @@ struct StatusRoutes: Sendable {
 
     private func safeItemStatuses() async throws -> [ItemStatus] {
         let items = try await tokenStore.getAllItems()
-        return items.map(Self.safeItemStatus)
+        let webhookEvents = try await webhookEventStore?.latestEventsByItem() ?? [:]
+        return items.map { Self.safeItemStatus(from: $0, webhookEvent: webhookEvents[$0.id ?? ""]) }
     }
 
-    private static func safeItemStatus(from item: ItemModel) -> ItemStatus {
+    private static func safeItemStatus(from item: ItemModel, webhookEvent: WebhookItemSignal? = nil) -> ItemStatus {
         ItemStatus(
             id: item.id ?? "",
             institutionName: item.institutionName,
             status: ItemConnectionStatus(rawValue: item.status) ?? .error,
-            lastSync: item.updatedAt
+            lastSync: item.updatedAt,
+            lastWebhookAt: webhookEvent?.effectiveDate,
+            lastWebhookEvent: webhookEvent.map { "\($0.webhookType).\($0.webhookCode)" },
+            needsSync: Self.needsPollingSync(item: item, webhookEvent: webhookEvent)
         )
+    }
+
+    private static func needsPollingSync(item: ItemModel, webhookEvent: WebhookItemSignal?) -> Bool {
+        guard let webhookEvent, webhookEvent.needsSync else { return false }
+        guard let lastSync = item.updatedAt else { return true }
+        return lastSync < webhookEvent.effectiveDate
     }
 
     static func includesItems(_ request: Request) -> Bool {

--- a/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
@@ -1,0 +1,307 @@
+import CryptoKit
+import Foundation
+import Hummingbird
+import HTTPTypes
+import NIOCore
+import PlaidBarCore
+
+protocol PlaidWebhookVerifier: Sendable {
+    func verify(jwt: String, body: Data, now: Date) async throws
+}
+
+protocol PlaidWebhookSignatureValidator: Sendable {
+    func validate(jwt: String, header: PlaidWebhookJWTHeader, claims: PlaidWebhookJWTClaims) async throws
+}
+
+struct UnconfiguredPlaidWebhookSignatureValidator: PlaidWebhookSignatureValidator {
+    func validate(jwt: String, header: PlaidWebhookJWTHeader, claims: PlaidWebhookJWTClaims) async throws {
+        throw PlaidWebhookVerificationError.signatureVerificationUnavailable
+    }
+}
+
+struct StrictPlaidWebhookVerifier: PlaidWebhookVerifier {
+    var maxClockSkew: TimeInterval = 5 * 60
+    var signatureValidator: any PlaidWebhookSignatureValidator = UnconfiguredPlaidWebhookSignatureValidator()
+
+    func verify(jwt: String, body: Data, now: Date = Date()) async throws {
+        let components = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 3 else {
+            throw PlaidWebhookVerificationError.malformedJWT
+        }
+
+        let decoder = JSONDecoder()
+        let header = try decoder.decode(
+            PlaidWebhookJWTHeader.self,
+            from: Self.base64URLDecode(String(components[0]))
+        )
+        guard header.alg == "ES256" else {
+            throw PlaidWebhookVerificationError.unsupportedAlgorithm
+        }
+
+        let claims = try decoder.decode(
+            PlaidWebhookJWTClaims.self,
+            from: Self.base64URLDecode(String(components[1]))
+        )
+        guard abs(now.timeIntervalSince1970 - TimeInterval(claims.iat)) <= maxClockSkew else {
+            throw PlaidWebhookVerificationError.staleIssuedAt
+        }
+
+        guard let bodyHash = claims.requestBodySHA256 ?? claims.bodySHA256,
+              bodyHash == Self.sha256Hex(body)
+        else {
+            throw PlaidWebhookVerificationError.bodyHashMismatch
+        }
+
+        try await signatureValidator.validate(jwt: jwt, header: header, claims: claims)
+    }
+
+    private static func base64URLDecode(_ value: String) throws -> Data {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = (4 - base64.count % 4) % 4
+        base64.append(String(repeating: "=", count: padding))
+        guard let data = Data(base64Encoded: base64) else {
+            throw PlaidWebhookVerificationError.malformedJWT
+        }
+        return data
+    }
+
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct PlaidWebhookJWTHeader: Decodable, Sendable {
+    let alg: String
+    let kid: String?
+}
+
+struct PlaidWebhookJWTClaims: Decodable, Sendable {
+    let iat: Int
+    let requestBodySHA256: String?
+    let bodySHA256: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case iat
+        case requestBodySHA256 = "request_body_sha256"
+        case bodySHA256 = "body_hash"
+    }
+}
+
+enum PlaidWebhookVerificationError: Error, Equatable {
+    case malformedJWT
+    case unsupportedAlgorithm
+    case staleIssuedAt
+    case bodyHashMismatch
+    case signatureVerificationUnavailable
+}
+
+struct PlaidWebhookEvent: Decodable, Sendable {
+    let webhookType: String
+    let webhookCode: String
+    let itemId: String
+    let requestId: String?
+    let timestamp: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case webhookType = "webhook_type"
+        case webhookCode = "webhook_code"
+        case itemId = "item_id"
+        case requestId = "request_id"
+        case timestamp
+        case eventTime = "event_time"
+        case updatedAt = "updated_at"
+    }
+
+    init(
+        webhookType: String,
+        webhookCode: String,
+        itemId: String,
+        requestId: String? = nil,
+        timestamp: Date? = nil
+    ) {
+        self.webhookType = webhookType
+        self.webhookCode = webhookCode
+        self.itemId = itemId
+        self.requestId = requestId
+        self.timestamp = timestamp
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        webhookType = try container.decode(String.self, forKey: .webhookType)
+        webhookCode = try container.decode(String.self, forKey: .webhookCode)
+        itemId = try container.decode(String.self, forKey: .itemId)
+        requestId = try container.decodeIfPresent(String.self, forKey: .requestId)
+
+        timestamp = try Self.decodeDate(container, keys: [.timestamp, .eventTime, .updatedAt])
+    }
+
+    func signal(receivedAt: Date, bodyHash: String) -> WebhookItemSignal {
+        WebhookItemSignal(
+            itemId: itemId,
+            webhookType: webhookType,
+            webhookCode: webhookCode,
+            requestId: requestId,
+            idempotencyHash: Self.idempotencyHash(
+                itemId: itemId,
+                webhookType: webhookType,
+                webhookCode: webhookCode,
+                requestId: requestId,
+                eventAt: timestamp,
+                bodyHash: bodyHash
+            ),
+            eventAt: timestamp,
+            receivedAt: receivedAt,
+            status: Self.statusSignal(webhookCode: webhookCode),
+            needsSync: Self.needsSync(webhookCode: webhookCode)
+        )
+    }
+
+    static func statusSignal(webhookCode: String) -> WebhookItemStatusSignal {
+        switch webhookCode {
+        case "ERROR", "ITEM_LOGIN_REQUIRED":
+            return .loginRequired
+        case "LOGIN_REPAIRED", "PENDING_EXPIRATION":
+            return .connected
+        case "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS":
+            return .connected
+        default:
+            return .unchanged
+        }
+    }
+
+    static func needsSync(webhookCode: String) -> Bool {
+        [
+            "DEFAULT_UPDATE",
+            "HISTORICAL_UPDATE",
+            "INITIAL_UPDATE",
+            "TRANSACTIONS_REMOVED",
+            "SYNC_UPDATES_AVAILABLE",
+        ].contains(webhookCode)
+    }
+
+    static func idempotencyHash(
+        itemId: String,
+        webhookType: String,
+        webhookCode: String,
+        requestId: String?,
+        eventAt: Date?,
+        bodyHash: String
+    ) -> String {
+        let material = [
+            itemId,
+            webhookType,
+            webhookCode,
+            requestId ?? "",
+            eventAt.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+            bodyHash,
+        ].joined(separator: "\u{1f}")
+        return StrictPlaidWebhookVerifier.sha256Hex(Data(material.utf8))
+    }
+
+    private static func decodeDate(
+        _ container: KeyedDecodingContainer<CodingKeys>,
+        keys: [CodingKeys]
+    ) throws -> Date? {
+        for key in keys {
+            guard let value = try container.decodeIfPresent(String.self, forKey: key) else { continue }
+            if let date = ISO8601DateFormatter().date(from: value) {
+                return date
+            }
+        }
+        return nil
+    }
+}
+
+struct WebhookRoutes: Sendable {
+    let verifier: any PlaidWebhookVerifier
+    let tokenStore: TokenStore
+    let eventStore: WebhookEventStore
+    var now: @Sendable () -> Date = { Date() }
+
+    func register(with router: Router<some RequestContext>) {
+        router.group("webhooks")
+            .post("plaid", use: receive)
+    }
+
+    @Sendable
+    func receive(
+        request: Request,
+        context: some RequestContext
+    ) async throws -> Response {
+        guard let headerName = HTTPField.Name("Plaid-Verification"),
+              let jwt = request.headers[headerName]
+        else {
+            throw HTTPError(.unauthorized, message: "Missing Plaid webhook verification header")
+        }
+
+        let buffer = try await request.body.collect(upTo: Self.maxBodyBytes)
+        let body = Data(buffer: buffer)
+        try await verifier.verify(jwt: jwt, body: body, now: now())
+
+        let event: PlaidWebhookEvent
+        do {
+            event = try Self.decoder.decode(PlaidWebhookEvent.self, from: body)
+        } catch {
+            throw HTTPError(.badRequest, message: "Invalid Plaid webhook payload")
+        }
+
+        let signal = event.signal(
+            receivedAt: now(),
+            bodyHash: StrictPlaidWebhookVerifier.sha256Hex(body)
+        )
+        let result = try await eventStore.record(signal)
+        if result.disposition == .stored {
+            try await apply(signal)
+        }
+
+        return try Self.jsonResponse(WebhookReceiveResponse(disposition: result.disposition.rawValue))
+    }
+
+    private func apply(_ signal: WebhookItemSignal) async throws {
+        guard try await tokenStore.getItem(id: signal.itemId) != nil else { return }
+        switch signal.status {
+        case .connected:
+            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.connected.rawValue)
+        case .loginRequired:
+            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.loginRequired.rawValue)
+        case .error:
+            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.error.rawValue)
+        case .unchanged:
+            break
+        }
+    }
+
+    private static let maxBodyBytes = 128 * 1024
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static func jsonResponse(_ value: some Encodable) throws -> Response {
+        let data = try JSONEncoder().encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+}
+
+private struct WebhookReceiveResponse: Encodable {
+    let disposition: String
+}
+
+private extension WebhookStoreResult.Disposition {
+    var rawValue: String {
+        switch self {
+        case .stored: "stored"
+        case .duplicate: "duplicate"
+        case .outOfOrder: "out_of_order"
+        }
+    }
+}

--- a/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
+++ b/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
@@ -1,0 +1,170 @@
+import FluentKit
+import Foundation
+import HummingbirdFluent
+
+final class WebhookEventModel: Model, @unchecked Sendable {
+    static let schema = "webhook_events"
+
+    @ID(custom: "id", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "item_id")
+    var itemId: String
+
+    @Field(key: "webhook_type")
+    var webhookType: String
+
+    @Field(key: "webhook_code")
+    var webhookCode: String
+
+    @OptionalField(key: "request_id")
+    var requestId: String?
+
+    @Field(key: "idempotency_hash")
+    var idempotencyHash: String
+
+    @Timestamp(key: "event_at", on: .none)
+    var eventAt: Date?
+
+    @Timestamp(key: "received_at", on: .none)
+    var receivedAt: Date?
+
+    init() {}
+
+    init(
+        itemId: String,
+        webhookType: String,
+        webhookCode: String,
+        requestId: String?,
+        idempotencyHash: String,
+        eventAt: Date?,
+        receivedAt: Date
+    ) {
+        self.id = idempotencyHash
+        self.itemId = itemId
+        self.webhookType = webhookType
+        self.webhookCode = webhookCode
+        self.requestId = requestId
+        self.idempotencyHash = idempotencyHash
+        self.eventAt = eventAt
+        self.receivedAt = receivedAt
+    }
+}
+
+struct CreateWebhookEvents: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(WebhookEventModel.schema)
+            .field("id", .string, .identifier(auto: false))
+            .field("item_id", .string, .required)
+            .field("webhook_type", .string, .required)
+            .field("webhook_code", .string, .required)
+            .field("request_id", .string)
+            .field("idempotency_hash", .string, .required)
+            .field("event_at", .datetime)
+            .field("received_at", .datetime)
+            .unique(on: "idempotency_hash")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(WebhookEventModel.schema).delete()
+    }
+}
+
+struct WebhookItemSignal: Sendable {
+    let itemId: String
+    let webhookType: String
+    let webhookCode: String
+    let requestId: String?
+    let idempotencyHash: String
+    let eventAt: Date?
+    let receivedAt: Date
+    let status: WebhookItemStatusSignal
+    let needsSync: Bool
+
+    var effectiveDate: Date {
+        eventAt ?? receivedAt
+    }
+}
+
+enum WebhookItemStatusSignal: Sendable, Equatable {
+    case connected
+    case loginRequired
+    case error
+    case unchanged
+}
+
+struct WebhookStoreResult: Sendable, Equatable {
+    enum Disposition: Sendable, Equatable {
+        case stored
+        case duplicate
+        case outOfOrder
+    }
+
+    let disposition: Disposition
+}
+
+actor WebhookEventStore {
+    private let fluent: Fluent
+
+    init(fluent: Fluent) {
+        self.fluent = fluent
+    }
+
+    func record(_ signal: WebhookItemSignal) async throws -> WebhookStoreResult {
+        if try await WebhookEventModel.find(signal.idempotencyHash, on: fluent.db()) != nil {
+            return WebhookStoreResult(disposition: .duplicate)
+        }
+
+        let latest = try await latestEvent(itemId: signal.itemId)
+        let isOutOfOrder = latest.map { $0.effectiveDate > signal.effectiveDate } ?? false
+        let model = WebhookEventModel(
+            itemId: signal.itemId,
+            webhookType: signal.webhookType,
+            webhookCode: signal.webhookCode,
+            requestId: signal.requestId,
+            idempotencyHash: signal.idempotencyHash,
+            eventAt: signal.eventAt,
+            receivedAt: signal.receivedAt
+        )
+        try await model.save(on: fluent.db())
+        return WebhookStoreResult(disposition: isOutOfOrder ? .outOfOrder : .stored)
+    }
+
+    func latestEvent(itemId: String) async throws -> WebhookItemSignal? {
+        try await WebhookEventModel.query(on: fluent.db())
+            .filter(\.$itemId == itemId)
+            .all()
+            .compactMap(Self.signal(from:))
+            .max { $0.effectiveDate < $1.effectiveDate }
+    }
+
+    func latestEventsByItem() async throws -> [String: WebhookItemSignal] {
+        let events = try await WebhookEventModel.query(on: fluent.db()).all()
+        return events.compactMap(Self.signal(from:)).reduce(into: [:]) { result, signal in
+            guard let existing = result[signal.itemId] else {
+                result[signal.itemId] = signal
+                return
+            }
+            if existing.effectiveDate < signal.effectiveDate {
+                result[signal.itemId] = signal
+            }
+        }
+    }
+
+    private static func signal(from model: WebhookEventModel) -> WebhookItemSignal? {
+        guard let receivedAt = model.receivedAt else { return nil }
+        let status = PlaidWebhookEvent.statusSignal(webhookCode: model.webhookCode)
+        return WebhookItemSignal(
+            itemId: model.itemId,
+            webhookType: model.webhookType,
+            webhookCode: model.webhookCode,
+            requestId: model.requestId,
+            idempotencyHash: model.idempotencyHash,
+            eventAt: model.eventAt,
+            receivedAt: receivedAt,
+            status: status,
+            needsSync: PlaidWebhookEvent.needsSync(webhookCode: model.webhookCode)
+        )
+    }
+}

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -1,0 +1,302 @@
+import FluentKit
+import FluentSQLiteDriver
+import Foundation
+import Hummingbird
+import HummingbirdFluent
+import HTTPTypes
+import Logging
+import NIOCore
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+private struct WebhookTestContextSource: RequestContextSource {
+    let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.webhooks")
+}
+
+private struct WebhookTestContext: RequestContext {
+    typealias Source = WebhookTestContextSource
+
+    var coreContext: CoreRequestContextStorage
+
+    init(source: WebhookTestContextSource) {
+        coreContext = CoreRequestContextStorage(source: source)
+    }
+}
+
+private struct AcceptingSignatureValidator: PlaidWebhookSignatureValidator {
+    func validate(jwt: String, header: PlaidWebhookJWTHeader, claims: PlaidWebhookJWTClaims) async throws {}
+}
+
+private struct RejectingVerifier: PlaidWebhookVerifier {
+    func verify(jwt: String, body: Data, now: Date) async throws {
+        throw PlaidWebhookVerificationError.bodyHashMismatch
+    }
+}
+
+@Suite("Plaid webhook receiver")
+struct WebhookReceiverTests {
+    @Test("Verifier rejects non-ES256, stale iat, bad hash, and unavailable signature validation")
+    func verifierRejectsInvalidInputs() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data(Self.payload(webhookCode: "SYNC_UPDATES_AVAILABLE").utf8)
+        let verifier = StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator())
+
+        await #expect(throws: PlaidWebhookVerificationError.unsupportedAlgorithm) {
+            try await verifier.verify(jwt: Self.jwt(alg: "HS256", iat: Int(now.timeIntervalSince1970), body: body), body: body, now: now)
+        }
+        await #expect(throws: PlaidWebhookVerificationError.staleIssuedAt) {
+            try await verifier.verify(jwt: Self.jwt(iat: Int(now.addingTimeInterval(-301).timeIntervalSince1970), body: body), body: body, now: now)
+        }
+        await #expect(throws: PlaidWebhookVerificationError.bodyHashMismatch) {
+            try await verifier.verify(jwt: Self.jwt(iat: Int(now.timeIntervalSince1970), body: Data("{}".utf8)), body: body, now: now)
+        }
+
+        let strictDefault = StrictPlaidWebhookVerifier()
+        await #expect(throws: PlaidWebhookVerificationError.signatureVerificationUnavailable) {
+            try await strictDefault.verify(jwt: Self.jwt(iat: Int(now.timeIntervalSince1970), body: body), body: body, now: now)
+        }
+    }
+
+    @Test("Duplicate delivery is idempotent and stores metadata only")
+    func duplicateDeliveryIsIdempotent() async throws {
+        try await Self.withStores { tokenStore, eventStore in
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            let route = WebhookRoutes(
+                verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            let body = Self.payload(webhookCode: "ITEM_LOGIN_REQUIRED")
+            let jwt = Self.jwt(iat: 1_800_000_000, body: Data(body.utf8))
+
+            _ = try await route.receive(
+                request: Self.request(body: body, jwt: jwt),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+            _ = try await route.receive(
+                request: Self.request(body: body, jwt: jwt),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+
+            #expect(try await tokenStore.getItem(id: "item-webhook")?.status == ItemConnectionStatus.loginRequired.rawValue)
+            let latest = try await eventStore.latestEvent(itemId: "item-webhook")
+            #expect(latest?.webhookCode == "ITEM_LOGIN_REQUIRED")
+            #expect(latest?.requestId == "request-safe")
+            #expect(latest?.idempotencyHash.contains("ITEM_LOGIN_REQUIRED") == false)
+        }
+    }
+
+    @Test("Out-of-order webhook metadata is retained without regressing item status")
+    func outOfOrderDeliveryDoesNotRegressStatus() async throws {
+        try await Self.withStores { tokenStore, eventStore in
+            let route = WebhookRoutes(
+                verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            let repaired = Self.payload(webhookCode: "LOGIN_REPAIRED", timestamp: "2026-06-14T12:10:00Z")
+            let olderLoginRequired = Self.payload(webhookCode: "ITEM_LOGIN_REQUIRED", timestamp: "2026-06-14T12:00:00Z")
+
+            _ = try await route.receive(
+                request: Self.request(body: repaired, jwt: Self.jwt(iat: 1_800_000_000, body: Data(repaired.utf8))),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+            _ = try await route.receive(
+                request: Self.request(body: olderLoginRequired, jwt: Self.jwt(iat: 1_800_000_000, body: Data(olderLoginRequired.utf8))),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+
+            #expect(try await tokenStore.getItem(id: "item-webhook")?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(try await eventStore.latestEvent(itemId: "item-webhook")?.webhookCode == "LOGIN_REPAIRED")
+        }
+    }
+
+    @Test("Invalid verification is rejected before storage")
+    func invalidVerificationRejectsRequest() async throws {
+        try await Self.withStores { tokenStore, eventStore in
+            let route = WebhookRoutes(
+                verifier: RejectingVerifier(),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            let body = Self.payload(webhookCode: "ITEM_LOGIN_REQUIRED")
+
+            await #expect(throws: PlaidWebhookVerificationError.bodyHashMismatch) {
+                _ = try await route.receive(
+                    request: Self.request(body: body, jwt: "bad.jwt.signature"),
+                    context: WebhookTestContext(source: WebhookTestContextSource())
+                )
+            }
+
+            let itemStatus = try await tokenStore.getItem(id: "item-webhook")?.status
+            let latestEvent = try await eventStore.latestEvent(itemId: "item-webhook")
+            #expect(itemStatus == ItemConnectionStatus.connected.rawValue)
+            #expect(latestEvent == nil)
+        }
+    }
+
+    @Test("LOGIN_REPAIRED clears stale repair prompt and status includes safe webhook flags")
+    func loginRepairedClearsStalePromptAndStatusIncludesFlags() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.loginRequired.rawValue)
+            let route = WebhookRoutes(
+                verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            let body = Self.payload(webhookCode: "LOGIN_REPAIRED")
+            _ = try await route.receive(
+                request: Self.request(body: body, jwt: Self.jwt(iat: 1_800_000_000, body: Data(body.utf8))),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+            let status = try await statusRoutes.statusSnapshot(includeItems: true)
+            let item = try #require(status.itemStatuses?.first)
+
+            #expect(item.status == .connected)
+            #expect(item.lastWebhookEvent == "ITEM.LOGIN_REPAIRED")
+            #expect(item.lastWebhookAt != nil)
+            #expect(item.needsSync == false)
+        }
+    }
+
+    @Test("Status polling marks sync-needed webhook only until item refresh advances")
+    func statusPollingSyncFlagClearsAfterRefresh() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            let signal = WebhookItemSignal(
+                itemId: "item-webhook",
+                webhookType: "TRANSACTIONS",
+                webhookCode: "SYNC_UPDATES_AVAILABLE",
+                requestId: "request-sync",
+                idempotencyHash: "sync-\(UUID().uuidString)",
+                eventAt: Date(),
+                receivedAt: Date(),
+                status: .unchanged,
+                needsSync: true
+            )
+            _ = try await eventStore.record(signal)
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+            let pending = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(try #require(pending.itemStatuses?.first).needsSync)
+
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            let refreshed = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(!((try #require(refreshed.itemStatuses?.first)).needsSync))
+        }
+    }
+
+    private static func withStores(
+        _ body: (TokenStore, WebhookEventStore) async throws -> Void
+    ) async throws {
+        try await withStatusStores { tokenStore, _, eventStore, _ in
+            try await body(tokenStore, eventStore)
+        }
+    }
+
+    private static func withStatusStores(
+        _ body: (TokenStore, BillingSubscriptionStore, WebhookEventStore, ServerConfig) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-webhooks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.webhooks")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(CreateSyncCursors())
+        await fluent.migrations.add(CreateBillingSubscriptions())
+        await fluent.migrations.add(CreateWebhookEvents())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await ItemModel(
+                id: "item-webhook",
+                accessToken: "token-webhook",
+                institutionId: "ins-webhook",
+                institutionName: "Webhook Bank"
+            ).save(on: fluent.db())
+            try await body(
+                TokenStore(fluent: fluent, logger: logger),
+                BillingSubscriptionStore(fluent: fluent),
+                WebhookEventStore(fluent: fluent),
+                try setupStateConfig(in: directory)
+            )
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+
+    private static func setupStateConfig(in directory: URL) throws -> ServerConfig {
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=
+        PLAID_SECRET=
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        return try ServerConfig.load(from: configURL.path)
+    }
+
+    private static func request(body: String, jwt: String) -> Request {
+        var headers = HTTPFields()
+        headers[HTTPField.Name("Plaid-Verification")!] = jwt
+        headers[.contentType] = "application/json"
+        return Request(
+            head: HTTPRequest(method: .post, scheme: nil, authority: nil, path: "/webhooks/plaid", headerFields: headers),
+            body: RequestBody(buffer: ByteBuffer(data: Data(body.utf8)))
+        )
+    }
+
+    private static func payload(
+        webhookCode: String,
+        timestamp: String = "2026-06-14T12:00:00Z"
+    ) -> String {
+        """
+        {"webhook_type":"ITEM","webhook_code":"\(webhookCode)","item_id":"item-webhook","request_id":"request-safe","timestamp":"\(timestamp)"}
+        """
+    }
+
+    private static func jwt(alg: String = "ES256", iat: Int, body: Data) -> String {
+        let header = #"{"alg":"\#(alg)","kid":"kid-safe"}"#
+        let claims = #"{"iat":\#(iat),"request_body_sha256":"\#(StrictPlaidWebhookVerifier.sha256Hex(body))"}"#
+        return [
+            base64URL(Data(header.utf8)),
+            base64URL(Data(claims.utf8)),
+            "signature",
+        ].joined(separator: ".")
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}


### PR DESCRIPTION
## Summary
- Add metadata-only Plaid webhook receiver and storage for safe item webhook signals.
- Add strict testable verifier shape that rejects malformed/stale/hash-mismatched webhooks and fails closed without a real signature validator.
- Expose safe webhook polling flags in item status snapshots.

## Tests
- `git diff --check`
- `swift test --filter 'WebhookReceiverTests|LinkTokenRequestTests|oauthCallbackUsesRedirectPublicTokenWithoutSessionLookup|hostedLinkWebhookSuccessAllowsSessionLookup|hostedLinkCompletionStoreIsIdempotentByAnyIdentifier|oauthCallbackDistinguishesUserExitExpiredAndRetryableProviderFailure|hostedBridgeRequiresWebhookURL' --skip-update --disable-keychain` — 27 tests passed
- `swift build --target PlaidBarServer --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

Note: default verifier fails closed until a real Plaid JWK/ES256 signature validator is wired.

Linear: AND-410