### PR TITLE
AND-411: Model Plaid consent repair states

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -587,11 +587,11 @@ final class AppState {
     }
 
     var connectedItemCount: Int {
-        itemStatuses.filter { $0.status == .connected }.count
+        itemStatuses.filter { !$0.status.isDegraded }.count
     }
 
     var needsLoginItemCount: Int {
-        itemStatuses.filter { $0.status == .loginRequired }.count
+        itemStatuses.filter { $0.status.needsUpdateMode }.count
     }
 
     var erroredItemCount: Int {
@@ -601,7 +601,7 @@ final class AppState {
     var degradedItemIds: Set<String> {
         Set(
             itemStatuses
-                .filter { $0.status == .loginRequired || $0.status == .error }
+                .filter { $0.status.isDegraded }
                 .map(\.id)
         )
     }
@@ -609,7 +609,7 @@ final class AppState {
     var diagnosticsSummary: String {
         if isDemoStatusRecoveryScenario {
             if erroredItemCount > 0 { return "\(erroredItemCount) demo item\(erroredItemCount == 1 ? "" : "s") need attention" }
-            if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(needsLoginItemCount == 1 ? "" : "s") need login" }
+            if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(needsLoginItemCount == 1 ? "" : "s") need update" }
         }
         let serverPresentation = serverConnectionPresentation
         if isDemoMode { return serverPresentation.diagnosticsSummary }
@@ -621,7 +621,7 @@ final class AppState {
         }
         if statusItemCount == 0 { return "No Plaid items connected" }
         if erroredItemCount > 0 { return "\(erroredItemCount) item\(erroredItemCount == 1 ? "" : "s") need attention" }
-        if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(needsLoginItemCount == 1 ? "" : "s") need login" }
+        if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(needsLoginItemCount == 1 ? "" : "s") need update" }
         if serverPresentation.issue == .error { return serverPresentation.diagnosticsSummary }
         return "Plaid connection healthy"
     }

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -280,6 +280,8 @@ public struct AttentionQueue: Equatable, Sendable {
             switch item.status {
             case .connected:
                 return nil
+            case .loginRepaired:
+                return nil
             case .error:
                 return AttentionQueueRow(
                     id: "item-error-\(index)",
@@ -292,9 +294,9 @@ public struct AttentionQueue: Equatable, Sendable {
                     targetItemId: item.id,
                     accessibilityHint: "Reconnects this institution through Plaid Link."
                 )
-            case .loginRequired:
+            case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable:
                 return AttentionQueueRow(
-                    id: "item-login-\(index)",
+                    id: "item-repair-\(index)",
                     severity: .warning,
                     title: itemTitle(item, fallback: "Fresh login needed"),
                     detail: itemDetail(item, fallback: "Plaid requires a fresh bank login before sync can continue."),
@@ -397,10 +399,18 @@ public struct AttentionQueue: Equatable, Sendable {
     private static func itemTitle(_ item: ItemStatus, fallback: String) -> String {
         guard let institutionName = normalizedInstitutionName(item.institutionName) else { return fallback }
         switch item.status {
-        case .connected:
+        case .connected, .loginRepaired:
             return institutionName
         case .loginRequired:
             return "\(institutionName) needs login"
+        case .pendingExpiration:
+            return "\(institutionName) login expiring"
+        case .pendingDisconnect:
+            return "\(institutionName) needs consent"
+        case .permissionRevoked:
+            return "\(institutionName) permission revoked"
+        case .newAccountsAvailable:
+            return "\(institutionName) has new accounts"
         case .error:
             return "\(institutionName) needs attention"
         }
@@ -409,10 +419,18 @@ public struct AttentionQueue: Equatable, Sendable {
     private static func itemDetail(_ item: ItemStatus, fallback: String) -> String {
         guard let institutionName = normalizedInstitutionName(item.institutionName) else { return fallback }
         switch item.status {
-        case .connected:
+        case .connected, .loginRepaired:
             return "Connected."
         case .loginRequired:
             return "Plaid requires a fresh \(institutionName) login before sync can continue."
+        case .pendingExpiration:
+            return "Plaid says \(institutionName) login will expire soon. Update this item to keep sync healthy."
+        case .pendingDisconnect:
+            return "Plaid says \(institutionName) needs renewed consent. Update this item before sync disconnects."
+        case .permissionRevoked:
+            return "Plaid says \(institutionName) permission was revoked. Update this item to restore access."
+        case .newAccountsAvailable:
+            return "\(institutionName) has newly available accounts. Update this item to choose what VaultPeek can access."
         case .error:
             return "Plaid reported an item error for \(institutionName). Reconnect, then refresh."
         }
@@ -501,7 +519,7 @@ public struct AttentionQueue: Equatable, Sendable {
         case "credentials-missing": return 2
         default:
             if row.id.hasPrefix("item-error-") { return 4 }
-            if row.id.hasPrefix("item-login-") { return 5 }
+            if row.id.hasPrefix("item-repair-") { return 5 }
             switch row.id {
             case "server-mode-mismatch": return 3
             case "recent-error": return 6

--- a/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
+++ b/Sources/PlaidBarCore/Models/DashboardChangeReceipt.swift
@@ -45,7 +45,7 @@ public struct DashboardChangeReceipt: Equatable, Sendable {
 
         guard let latest = points.last else { return nil }
 
-        let degradedItemCount = itemStatuses.count { $0.status == .loginRequired || $0.status == .error }
+        let degradedItemCount = itemStatuses.count { $0.status.isDegraded }
 
         guard points.count >= 2 else {
             var rows = [Row(

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -161,10 +161,10 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 level: .warning,
                 title: itemRecoveryTitle(
                     count: needsLoginItemCount,
-                    singularAction: "needs login",
-                    pluralAction: "need login"
+                    singularAction: "needs update",
+                    pluralAction: "need update"
                 ),
-                detail: "One or more institutions need an updated login before sync can stay healthy.",
+                detail: "One or more institutions need Plaid Link update mode for login, consent, or account selection.",
                 primaryAction: .reconnect
             )
         }

--- a/Sources/PlaidBarCore/Models/LinkResponse.swift
+++ b/Sources/PlaidBarCore/Models/LinkResponse.swift
@@ -66,5 +66,37 @@ public struct ItemStatus: Codable, Sendable, Identifiable {
 public enum ItemConnectionStatus: String, Codable, Sendable {
     case connected
     case loginRequired = "login_required"
+    case pendingExpiration = "pending_expiration"
+    case pendingDisconnect = "pending_disconnect"
+    case permissionRevoked = "permission_revoked"
+    case newAccountsAvailable = "new_accounts_available"
+    case loginRepaired = "login_repaired"
     case error
+
+    public var needsUpdateMode: Bool {
+        switch self {
+        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable:
+            true
+        case .connected, .loginRepaired, .error:
+            false
+        }
+    }
+
+    public var isDegraded: Bool {
+        switch self {
+        case .connected, .loginRepaired:
+            false
+        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable, .error:
+            true
+        }
+    }
+
+    public func applyingLoginRepaired() -> ItemConnectionStatus {
+        switch self {
+        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked:
+            .loginRepaired
+        case .connected, .newAccountsAvailable, .loginRepaired, .error:
+            self
+        }
+    }
 }

--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -369,7 +369,7 @@ public enum WeeklyReviewBuilder {
             // A login-required item needs the reconnect/update-link flow, not
             // another refresh — treat it as reconnectable alongside errors so
             // the checklist action can actually recover it.
-            let needsReconnect = itemStatuses.contains { $0.status == .error || $0.status == .loginRequired }
+            let needsReconnect = itemStatuses.contains { $0.status == .error || $0.status.needsUpdateMode }
             let blocked = itemStatuses.contains { $0.status == .error }
             items.append(WeeklyReviewItem(
                 id: "weekly-review.connection-health",

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -87,23 +87,26 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 itemLastSyncRelative: itemLastSyncRelative,
                 unknownItem: false
             )
-        case .loginRequired:
+        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable:
             let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
             return AccountConnectionPresentation(
                 level: .loginRequired,
-                rowLabel: reconnectActionTitle(institutionName: institutionName),
-                detailLabel: itemDetailLabel(
-                    institutionName: institutionName,
-                    fallback: "Login required",
-                    suffix: "login required"
-                ),
-                signalLabel: "Login",
-                iconName: "person.crop.circle.badge.exclamationmark.fill",
+                rowLabel: repairActionTitle(status: itemStatus, institutionName: institutionName),
+                detailLabel: repairDetailLabel(status: itemStatus, institutionName: institutionName),
+                signalLabel: repairSignalLabel(status: itemStatus),
+                iconName: repairIconName(status: itemStatus),
                 showsRecoveryActions: true,
-                recoveryActionTitle: reconnectActionTitle(institutionName: institutionName),
+                recoveryActionTitle: repairActionTitle(status: itemStatus, institutionName: institutionName),
                 itemSyncLabel: itemSyncLabel,
-                statusFilterSubtitle: "Login required • \(itemSyncLabel)",
-                recoveryDetailLabel: loginRecoveryDetailLabel(institutionName: institutionName)
+                statusFilterSubtitle: "\(repairSubtitle(status: itemStatus)) • \(itemSyncLabel)",
+                recoveryDetailLabel: repairRecoveryDetailLabel(status: itemStatus, institutionName: institutionName)
+            )
+        case .loginRepaired:
+            return AccountConnectionPresentation.synced(
+                isSyncStale: isSyncStale,
+                statusSyncText: statusSyncText,
+                itemLastSyncRelative: itemLastSyncRelative,
+                unknownItem: false
             )
         case .error:
             let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
@@ -194,6 +197,74 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
         return "Reconnect \(institutionName)"
     }
 
+    private static func repairActionTitle(status: ItemConnectionStatus?, institutionName: String?) -> String {
+        guard status == .newAccountsAvailable else {
+            return reconnectActionTitle(institutionName: institutionName)
+        }
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            return "Update Item"
+        }
+        return "Update \(institutionName)"
+    }
+
+    private static func repairDetailLabel(status: ItemConnectionStatus?, institutionName: String?) -> String {
+        switch status {
+        case .pendingExpiration:
+            return itemDetailLabel(institutionName: institutionName, fallback: "Login expiring", suffix: "login expiring")
+        case .pendingDisconnect:
+            return itemDetailLabel(institutionName: institutionName, fallback: "Consent needed", suffix: "consent needed")
+        case .permissionRevoked:
+            return itemDetailLabel(institutionName: institutionName, fallback: "Permission revoked", suffix: "permission revoked")
+        case .newAccountsAvailable:
+            return itemDetailLabel(institutionName: institutionName, fallback: "New accounts available", suffix: "new accounts available")
+        case .connected, .loginRepaired, .loginRequired, .error, nil:
+            return itemDetailLabel(institutionName: institutionName, fallback: "Login required", suffix: "login required")
+        }
+    }
+
+    private static func repairSignalLabel(status: ItemConnectionStatus?) -> String {
+        switch status {
+        case .pendingExpiration:
+            "Expiring"
+        case .pendingDisconnect:
+            "Consent"
+        case .permissionRevoked:
+            "Revoked"
+        case .newAccountsAvailable:
+            "New"
+        case .connected, .loginRepaired, .loginRequired, .error, nil:
+            "Login"
+        }
+    }
+
+    private static func repairSubtitle(status: ItemConnectionStatus?) -> String {
+        switch status {
+        case .pendingExpiration:
+            "Login expiring"
+        case .pendingDisconnect:
+            "Consent needed"
+        case .permissionRevoked:
+            "Permission revoked"
+        case .newAccountsAvailable:
+            "New accounts available"
+        case .connected, .loginRepaired, .loginRequired, .error, nil:
+            "Login required"
+        }
+    }
+
+    private static func repairIconName(status: ItemConnectionStatus?) -> String {
+        switch status {
+        case .pendingExpiration:
+            "clock.badge.exclamationmark.fill"
+        case .pendingDisconnect, .permissionRevoked:
+            "hand.raised.fill"
+        case .newAccountsAvailable:
+            "plus.circle.fill"
+        case .connected, .loginRepaired, .loginRequired, .error, nil:
+            "person.crop.circle.badge.exclamationmark.fill"
+        }
+    }
+
     private static func itemDetailLabel(
         institutionName: String?,
         fallback: String,
@@ -210,6 +281,36 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             return "Plaid requires a fresh bank login. Reconnect this item, then refresh."
         }
         return "Plaid requires a fresh \(institutionName) login. Reconnect this item, then refresh."
+    }
+
+    private static func repairRecoveryDetailLabel(status: ItemConnectionStatus?, institutionName: String?) -> String {
+        guard let institutionName = normalizedInstitutionName(institutionName) else {
+            switch status {
+            case .pendingExpiration:
+                return "Plaid says this login will expire soon. Reconnect this item to keep sync healthy."
+            case .pendingDisconnect:
+                return "Plaid says this item needs renewed consent. Reconnect this item to keep sync healthy."
+            case .permissionRevoked:
+                return "Plaid says permission was revoked. Reconnect this item to restore access."
+            case .newAccountsAvailable:
+                return "New accounts are available. Update this item to choose what VaultPeek can access."
+            case .connected, .loginRepaired, .loginRequired, .error, nil:
+                return loginRecoveryDetailLabel(institutionName: nil)
+            }
+        }
+
+        switch status {
+        case .pendingExpiration:
+            return "Plaid says \(institutionName) login will expire soon. Reconnect this item to keep sync healthy."
+        case .pendingDisconnect:
+            return "Plaid says \(institutionName) needs renewed consent. Reconnect this item to keep sync healthy."
+        case .permissionRevoked:
+            return "Plaid says \(institutionName) permission was revoked. Reconnect this item to restore access."
+        case .newAccountsAvailable:
+            return "\(institutionName) has newly available accounts. Update this item to choose what VaultPeek can access."
+        case .connected, .loginRepaired, .loginRequired, .error, nil:
+            return loginRecoveryDetailLabel(institutionName: institutionName)
+        }
     }
 
     private static func errorRecoveryDetailLabel(institutionName: String?) -> String {

--- a/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
+++ b/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum ItemRecoveryTarget {
     public static func item(from statuses: [ItemStatus]) -> ItemStatus? {
         statuses.first { $0.status == .error }
-            ?? statuses.first { $0.status == .loginRequired }
+            ?? statuses.first { $0.status.needsUpdateMode }
     }
 
     public static func itemId(from statuses: [ItemStatus]) -> String? {
@@ -13,9 +13,9 @@ public enum ItemRecoveryTarget {
     public static func actionTitle(from statuses: [ItemStatus]) -> String? {
         guard let item = item(from: statuses) else { return nil }
         guard let institutionName = normalizedInstitutionName(item.institutionName) else {
-            return "Reconnect Item"
+            return actionFallback(for: item.status)
         }
-        return "Reconnect \(institutionName)"
+        return "\(actionVerb(for: item.status)) \(institutionName)"
     }
 
     public static func recoveryDetail(from statuses: [ItemStatus]) -> String? {
@@ -27,13 +27,51 @@ public enum ItemRecoveryTarget {
                 return "Plaid requires a fresh \(institutionName) login before account rows can be recovered."
             }
             return "Plaid requires a fresh bank login before account rows can be recovered."
+        case .pendingExpiration:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "Plaid says \(institutionName) login will expire soon. Update it before account rows stop syncing."
+            }
+            return "Plaid says this login will expire soon. Update the item before account rows stop syncing."
+        case .pendingDisconnect:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "Plaid says \(institutionName) needs renewed consent before account rows stop syncing."
+            }
+            return "Plaid says this item needs renewed consent before account rows stop syncing."
+        case .permissionRevoked:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "Plaid says \(institutionName) permission was revoked. Update it to restore account rows."
+            }
+            return "Plaid says item permission was revoked. Update it to restore account rows."
+        case .newAccountsAvailable:
+            if let institutionName = normalizedInstitutionName(item.institutionName) {
+                return "\(institutionName) has newly available accounts. Update it to choose what VaultPeek can access."
+            }
+            return "New accounts are available. Update the item to choose what VaultPeek can access."
         case .error:
             if let institutionName = normalizedInstitutionName(item.institutionName) {
                 return "Plaid reported an item error for \(institutionName). Reconnect it, then refresh balances."
             }
             return "Plaid reported an item error. Reconnect the item, then refresh balances."
-        case .connected:
+        case .connected, .loginRepaired:
             return nil
+        }
+    }
+
+    private static func actionVerb(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .newAccountsAvailable:
+            "Update"
+        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .error:
+            "Reconnect"
+        }
+    }
+
+    private static func actionFallback(for status: ItemConnectionStatus) -> String {
+        switch status {
+        case .newAccountsAvailable:
+            "Update Item"
+        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .error:
+            "Reconnect Item"
         }
     }
 

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -142,7 +142,7 @@ public enum NotificationTriggerSelection {
         }
 
         if config.loginRequired {
-            for item in itemStatuses where item.status == .loginRequired {
+            for item in itemStatuses where item.status.needsUpdateMode {
                 append(loginRequiredDecision(for: item))
             }
         }

--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -136,7 +136,10 @@ struct AccountRoutes: Sendable {
                 // reporting a misleading per-item refresh failure.
                 throw PlaidError.credentialsNotConfigured
             } catch {
-                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                try await tokenStore.updateItemStatus(
+                    id: itemId,
+                    status: ItemStatusMapping.status(forAPIError: error).rawValue
+                )
                 return AccountRefreshResult(attempted: true, succeeded: false, accounts: [])
             }
         }
@@ -191,11 +194,4 @@ struct AccountRoutes: Sendable {
         )
     }
 
-    private func itemStatus(for error: Error) -> ItemConnectionStatus {
-        if case PlaidError.apiError(_, _, let errorCode, _) = error,
-           errorCode == "ITEM_LOGIN_REQUIRED" {
-            return .loginRequired
-        }
-        return .error
-    }
 }

--- a/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
+++ b/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
@@ -1,0 +1,45 @@
+import Foundation
+import PlaidBarCore
+
+enum ItemStatusMapping {
+    static func status(forAPIError error: Error) -> ItemConnectionStatus {
+        guard case PlaidError.apiError(_, _, let errorCode, _) = error else {
+            return .error
+        }
+        return status(forPlaidCode: errorCode) ?? .error
+    }
+
+    static func status(forWebhookCode code: String, currentStatus: ItemConnectionStatus) -> ItemConnectionStatus? {
+        let normalized = normalize(code)
+        switch normalized {
+        case "LOGIN_REPAIRED":
+            return currentStatus.applyingLoginRepaired()
+        default:
+            return status(forPlaidCode: normalized)
+        }
+    }
+
+    private static func status(forPlaidCode code: String?) -> ItemConnectionStatus? {
+        switch normalize(code) {
+        case "ITEM_LOGIN_REQUIRED":
+            return .loginRequired
+        case "PENDING_EXPIRATION", "ITEM_PENDING_EXPIRATION":
+            return .pendingExpiration
+        case "PENDING_DISCONNECT", "ITEM_PENDING_DISCONNECT":
+            return .pendingDisconnect
+        case "USER_PERMISSION_REVOKED", "ITEM_PERMISSION_REVOKED", "ITEM_NOT_ACCESSIBLE":
+            return .permissionRevoked
+        case "NEW_ACCOUNTS_AVAILABLE":
+            return .newAccountsAvailable
+        default:
+            return nil
+        }
+    }
+
+    private static func normalize(_ code: String?) -> String {
+        code?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+            ?? ""
+    }
+}

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -143,7 +143,10 @@ struct TransactionRoutes: Sendable {
                 // credential guidance instead of marking items errored.
                 throw PlaidError.credentialsNotConfigured
             } catch {
-                try await tokenStore.updateItemStatus(id: itemId, status: itemStatus(for: error).rawValue)
+                try await tokenStore.updateItemStatus(
+                    id: itemId,
+                    status: ItemStatusMapping.status(forAPIError: error).rawValue
+                )
                 return ItemSyncResult(
                     itemId: itemId,
                     attempted: true,
@@ -177,11 +180,4 @@ struct TransactionRoutes: Sendable {
         )
     }
 
-    private func itemStatus(for error: Error) -> ItemConnectionStatus {
-        if case PlaidError.apiError(_, _, let errorCode, _) = error,
-           errorCode == "ITEM_LOGIN_REQUIRED" {
-            return .loginRequired
-        }
-        return .error
-    }
 }

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -285,11 +285,35 @@ struct AttentionQueueTests {
         )
 
         #expect(queue.rows.map(\.id) == [
-            "item-login-0",
+            "item-repair-0",
             "sync-stale",
             "financial-low-cash",
         ])
         #expect(queue.rows.first?.action == .reconnect)
+    }
+
+    @Test("Queue routes new accounts available to update mode")
+    func routesNewAccountsAvailableToUpdateMode() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-new-accounts", institutionName: "Example Bank", status: .newAccountsAvailable),
+            ],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil
+        )
+
+        #expect(queue.rows.first?.id == "item-repair-0")
+        #expect(queue.rows.first?.title == "Example Bank has new accounts")
+        #expect(queue.rows.first?.detail == "Example Bank has newly available accounts. Update this item to choose what VaultPeek can access.")
+        #expect(queue.rows.first?.action == .reconnect)
+        #expect(queue.rows.first?.targetItemId == "item-new-accounts")
     }
 
     @Test("Financial attention threshold edges are inclusive where configured")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1046,6 +1046,24 @@ struct PlaidBarCoreTests {
         #expect(loginRequired.recoveryDetailLabel == "Plaid requires a fresh bank login. Reconnect this item, then refresh.")
         #expect(loginRequired.showsRecoveryActions)
 
+        let newAccounts = AccountConnectionPresentation.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            isSyncStale: false,
+            statusSyncText: "2m ago",
+            itemStatus: .newAccountsAvailable,
+            institutionName: "Chase"
+        )
+
+        #expect(newAccounts.level == .loginRequired)
+        #expect(newAccounts.rowLabel == "Update Chase")
+        #expect(newAccounts.detailLabel == "Chase new accounts available")
+        #expect(newAccounts.signalLabel == "New")
+        #expect(newAccounts.recoveryActionTitle == "Update Chase")
+        #expect(newAccounts.statusFilterSubtitle == "New accounts available • No sync recorded")
+        #expect(newAccounts.recoveryDetailLabel == "Chase has newly available accounts. Update this item to choose what VaultPeek can access.")
+        #expect(newAccounts.showsRecoveryActions)
+
         let errored = AccountConnectionPresentation.evaluate(
             isDemoMode: false,
             serverConnected: true,
@@ -3068,7 +3086,7 @@ struct PlaidBarCoreTests {
 
         #expect(readiness.level == .warning)
         #expect(readiness.primaryAction == .reconnect)
-        #expect(readiness.title == "1 item needs login")
+        #expect(readiness.title == "1 item needs update")
     }
 
     @Test("Dashboard status readiness pluralizes multiple login recovery items")
@@ -3087,7 +3105,7 @@ struct PlaidBarCoreTests {
             errorMessage: nil
         )
 
-        #expect(readiness.title == "2 items need login")
+        #expect(readiness.title == "2 items need update")
     }
 
     @Test("Dashboard status readiness keeps item recovery ahead of recent action failure")
@@ -3108,7 +3126,7 @@ struct PlaidBarCoreTests {
 
         #expect(readiness.level == .warning)
         #expect(readiness.primaryAction == .reconnect)
-        #expect(readiness.title == "1 item needs login")
+        #expect(readiness.title == "1 item needs update")
     }
 
     @Test("Dashboard status readiness detects incomplete first sync")
@@ -3345,12 +3363,31 @@ struct PlaidBarCoreTests {
 
     @Test("ItemConnectionStatus all values")
     func itemConnectionStatuses() throws {
-        let statuses: [ItemConnectionStatus] = [.connected, .loginRequired, .error]
+        let statuses: [ItemConnectionStatus] = [
+            .connected,
+            .loginRequired,
+            .pendingExpiration,
+            .pendingDisconnect,
+            .permissionRevoked,
+            .newAccountsAvailable,
+            .loginRepaired,
+            .error,
+        ]
         for status in statuses {
             let data = try JSONEncoder().encode(status)
             let decoded = try JSONDecoder().decode(ItemConnectionStatus.self, from: data)
             #expect(decoded == status)
         }
+    }
+
+    @Test("LOGIN_REPAIRED clears stale repair states without clearing unrelated warnings")
+    func loginRepairedClearsOnlyStaleRepairStates() {
+        #expect(ItemConnectionStatus.loginRequired.applyingLoginRepaired() == .loginRepaired)
+        #expect(ItemConnectionStatus.pendingExpiration.applyingLoginRepaired() == .loginRepaired)
+        #expect(ItemConnectionStatus.pendingDisconnect.applyingLoginRepaired() == .loginRepaired)
+        #expect(ItemConnectionStatus.permissionRevoked.applyingLoginRepaired() == .loginRepaired)
+        #expect(ItemConnectionStatus.newAccountsAvailable.applyingLoginRepaired() == .newAccountsAvailable)
+        #expect(ItemConnectionStatus.error.applyingLoginRepaired() == .error)
     }
 
     // MARK: - PlaidEnvironment Tests

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1449,7 +1449,7 @@ struct PlaidBarServerTests {
         #expect(!TransactionRoutes.shouldFailSync(attemptedItemCount: 3, successfulItemCount: 3))
     }
 
-    @Test("Account refresh preserves partial success and deterministic aggregation while bounded")
+    @Test("Account refresh maps API repair errors while preserving partial success")
     func accountRefreshRunsWithBoundedConcurrencyAndStableAggregation() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-account-refresh-\(UUID().uuidString)", isDirectory: true)
@@ -1463,8 +1463,8 @@ struct PlaidBarServerTests {
             "token-b": .failure(PlaidError.apiError(
                 statusCode: 400,
                 errorType: "ITEM_ERROR",
-                errorCode: "ITEM_LOGIN_REQUIRED",
-                errorMessage: "login required"
+                errorCode: "PENDING_EXPIRATION",
+                errorMessage: "synthetic repair state"
             ), delayNanoseconds: 50_000_000),
             "token-c": .success(Self.accountsResponse(accountId: "acct-c"), delayNanoseconds: 10_000_000),
         ])
@@ -1485,9 +1485,21 @@ struct PlaidBarServerTests {
             #expect(calls.accounts.sorted() == ["token-a", "token-b", "token-c"])
             #expect(calls.maxActive == 2)
             #expect(try await store.getItem(id: "item-a")?.status == ItemConnectionStatus.connected.rawValue)
-            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.loginRequired.rawValue)
+            #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.pendingExpiration.rawValue)
             #expect(try await store.getItem(id: "item-c")?.status == ItemConnectionStatus.connected.rawValue)
         }
+    }
+
+    @Test("Webhook item status mapping repairs only stale repair prompts")
+    func webhookItemStatusMappingRepairsOnlyStaleRepairPrompts() {
+        #expect(ItemStatusMapping.status(forWebhookCode: "ITEM_LOGIN_REQUIRED", currentStatus: .connected) == .loginRequired)
+        #expect(ItemStatusMapping.status(forWebhookCode: "PENDING_DISCONNECT", currentStatus: .connected) == .pendingDisconnect)
+        #expect(ItemStatusMapping.status(forWebhookCode: "USER_PERMISSION_REVOKED", currentStatus: .connected) == .permissionRevoked)
+        #expect(ItemStatusMapping.status(forWebhookCode: "NEW_ACCOUNTS_AVAILABLE", currentStatus: .connected) == .newAccountsAvailable)
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .loginRequired) == .loginRepaired)
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .pendingExpiration) == .loginRepaired)
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .newAccountsAvailable) == .newAccountsAvailable)
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .error) == .error)
     }
 
     @Test("Balance refresh all-failure behavior is unchanged while bounded")
@@ -2242,6 +2254,76 @@ struct PlaidBarServerTests {
             #expect(calls.linkTokens == [linkToken, linkToken])
             #expect(calls.publicTokens == [publicToken, publicToken])
             #expect(calls.accountAccessTokens == [accessToken])
+        }
+    }
+
+    @Test("OAuth update completion clears new account prompt")
+    func oauthUpdateCompletionClearsNewAccountPrompt() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-update-completion-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let itemId = "synthetic_update_item_\(UUID().uuidString)"
+        let accessToken = "synthetic-update-access-token-\(UUID().uuidString)"
+
+        let linkToken = "synthetic-update-link-token"
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                linkToken: linkToken,
+                linkSessions: nil,
+                onSuccess: nil,
+                results: nil
+            ),
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: accessToken,
+                itemId: itemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: itemId,
+                    institutionId: "ins_update",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken, updateItemId: itemId)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-update-completion")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await ItemModel(
+                id: itemId,
+                accessToken: accessToken,
+                institutionId: "ins_update",
+                institutionName: "Example Bank"
+            ).save(on: fluent.db())
+            try await store.updateItemStatus(id: itemId, status: ItemConnectionStatus.newAccountsAvailable.rawValue)
+
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let calls = await plaidClient.recordedCalls()
+
+            #expect(response.status == .ok)
+            #expect(try await store.getItem(id: itemId)?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(calls.linkTokens == [linkToken])
+            #expect(calls.publicTokens.isEmpty)
+            #expect(calls.accountAccessTokens.isEmpty)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add Plaid consent/update-mode item states: pending expiration, pending disconnect, permission revoked, new accounts available, and login repaired.
- Route account/transaction API errors and webhook codes through a pure item-status mapper.
- Update app/core presentation, attention queue, recovery targeting, diagnostics, notifications, weekly review, and OAuth update completion behavior for repair states.

## Tests
- `git diff --check`
- `swift test --skip-update --disable-keychain --filter 'accountConnectionPresentation|dashboardStatusReadiness|itemConnectionStatuses|loginRepaired|itemRecoveryTarget|AttentionQueue|accountRefreshRuns|webhookItemStatus|oauthUpdateCompletion|transactionSyncRuns|WebhookReceiverTests|LinkTokenRequestTests|hostedLink'` — 81 tests passed
- `swift build --target PlaidBarServer --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

Linear: AND-411