### PR TITLE
AND-414: Add managed bank-link broker enforcement

### DIFF
--- a/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
+++ b/Sources/PlaidBarCore/Models/SubscriptionPlan.swift
@@ -120,3 +120,75 @@ public struct InstitutionUsage: Sendable, Equatable {
         return "\(connectedCount) \(institutionWord) connected"
     }
 }
+
+public enum ManagedLinkBlockReason: String, Codable, Sendable, Equatable {
+    case managedBridgeUnavailable = "managed_bridge_unavailable"
+    case subscriptionRequired = "subscription_required"
+    case subscriptionDegraded = "subscription_degraded"
+    case institutionLimitReached = "institution_limit_reached"
+
+    public var safeMessage: String {
+        switch self {
+        case .managedBridgeUnavailable:
+            "Managed bank linking is available only on the hosted bridge path. Demo and BYO-key linking stay available locally."
+        case .subscriptionRequired:
+            "Choose an eligible managed plan before connecting a bank through VaultPeek."
+        case .subscriptionDegraded:
+            "Your subscription needs attention before a new managed bank can be connected. Local data is not deleted."
+        case .institutionLimitReached:
+            "Your managed institution limit has been reached. Disconnect an institution or choose a higher plan before connecting another bank."
+        }
+    }
+}
+
+/// Secret-free entitlement and usage state returned to clients. This object is
+/// intentionally limited to plan/status/counts/reasons: never add Plaid tokens,
+/// provider secrets, raw provider payloads, account IDs, balances, transactions,
+/// or local database paths.
+public struct ManagedLinkEntitlementSummary: Codable, Sendable, Equatable {
+    public let plan: SubscriptionPlan
+    public let status: BillingSubscriptionStatus?
+    public let institutionLimit: Int
+    public let activeInstitutionCount: Int
+    public let canCreateManagedLink: Bool
+    public let blockReason: ManagedLinkBlockReason?
+    public let message: String?
+
+    public init(
+        plan: SubscriptionPlan,
+        status: BillingSubscriptionStatus?,
+        institutionLimit: Int,
+        activeInstitutionCount: Int,
+        canCreateManagedLink: Bool,
+        blockReason: ManagedLinkBlockReason?,
+        message: String? = nil
+    ) {
+        self.plan = plan
+        self.status = status
+        self.institutionLimit = institutionLimit
+        self.activeInstitutionCount = activeInstitutionCount
+        self.canCreateManagedLink = canCreateManagedLink
+        self.blockReason = blockReason
+        self.message = message ?? blockReason?.safeMessage
+    }
+}
+
+public struct ManagedLinkSessionResponse: Codable, Sendable, Equatable {
+    public let linkUrl: String
+    public let entitlement: ManagedLinkEntitlementSummary
+
+    public init(linkUrl: String, entitlement: ManagedLinkEntitlementSummary) {
+        self.linkUrl = linkUrl
+        self.entitlement = entitlement
+    }
+}
+
+public struct ManagedLinkErrorResponse: Codable, Sendable, Equatable {
+    public let error: String
+    public let entitlement: ManagedLinkEntitlementSummary
+
+    public init(error: String, entitlement: ManagedLinkEntitlementSummary) {
+        self.error = error
+        self.entitlement = entitlement
+    }
+}

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -47,6 +47,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         // Register migrations
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateCategoryBudgets())
         await fluent.migrations.add(CreateBillingSubscriptions())
@@ -82,10 +83,9 @@ struct PlaidBarServer: AsyncParsableCommand {
         // API routes
         let api = router.group("api")
         api.add(middleware: APITokenMiddleware(authToken: serverConfig.authToken))
-        // Entitlement seam (foundation only): enforces nothing today — always
-        // allows — and is a no-op in `.local` mode. Placed between auth and
-        // setup-state so the gated consumer (Hosted Link) track has a fixed
-        // place to add Stripe-backed checks without re-threading the router.
+        // Entitlement seam: remains store-free and route-agnostic here. Managed
+        // Link creation enforces plan limits in `LinkRoutes`, where billing and
+        // item-count state are available, while BYO/local paths stay ungated.
         api.add(middleware: EntitlementMiddleware(deployment: serverConfig.deployment))
         api.add(middleware: SetupStateMiddleware(
             credentialDiagnosis: serverConfig.credentialDiagnosis,
@@ -95,6 +95,7 @@ struct PlaidBarServer: AsyncParsableCommand {
             plaidClient: plaidClient,
             tokenStore: tokenStore,
             pendingLinkSessions: pendingLinkSessions,
+            billingStore: billingStore,
             config: serverConfig
         )
         .register(with: api)
@@ -119,7 +120,12 @@ struct PlaidBarServer: AsyncParsableCommand {
             plaidClient: plaidClient,
             tokenStore: tokenStore,
             pendingLinkSessions: pendingLinkSessions,
-            hostedLinkCompletions: hostedLinkCompletions
+            hostedLinkCompletions: hostedLinkCompletions,
+            entitlementService: ManagedLinkEntitlementService(
+                deployment: serverConfig.deployment,
+                billingStore: billingStore,
+                tokenStore: tokenStore
+            )
         )
         .register(with: router)
         WebhookRoutes(

--- a/Sources/PlaidBarServer/Auth/ManagedLinkEntitlementService.swift
+++ b/Sources/PlaidBarServer/Auth/ManagedLinkEntitlementService.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import PlaidBarCore
+
+struct ManagedLinkEntitlementService: Sendable {
+    let deployment: DeploymentMode
+    let billingStore: BillingSubscriptionStore
+    let tokenStore: TokenStore
+
+    func summary() async throws -> ManagedLinkEntitlementSummary {
+        let subscription = try await billingStore.currentSubscription()
+        let activeInstitutionCount = try await tokenStore.activeInstitutionCount(origin: .managed)
+        return Self.summary(
+            deployment: deployment,
+            subscription: subscription,
+            activeInstitutionCount: activeInstitutionCount
+        )
+    }
+
+    static func summary(
+        deployment: DeploymentMode,
+        subscription: BillingSubscription?,
+        activeInstitutionCount: Int
+    ) -> ManagedLinkEntitlementSummary {
+        let plan = subscription?.plan ?? .free
+        let status = subscription?.status
+        let institutionLimit = plan.institutionLimit
+        let blockReason: ManagedLinkBlockReason?
+
+        switch deployment {
+        case .local:
+            blockReason = .managedBridgeUnavailable
+        case .hostedBridge:
+            if let status, !status.allowsPaidFeatures {
+                blockReason = .subscriptionDegraded
+            } else if subscription == nil {
+                blockReason = .subscriptionRequired
+            } else if activeInstitutionCount >= institutionLimit {
+                blockReason = .institutionLimitReached
+            } else {
+                blockReason = nil
+            }
+        }
+
+        return ManagedLinkEntitlementSummary(
+            plan: plan,
+            status: status,
+            institutionLimit: institutionLimit,
+            activeInstitutionCount: activeInstitutionCount,
+            canCreateManagedLink: blockReason == nil,
+            blockReason: blockReason
+        )
+    }
+
+    static var paymentRequired: HTTPResponse.Status {
+        HTTPResponse.Status(code: 402, reasonPhrase: "Payment Required")
+    }
+
+    static func blockedResponse(summary: ManagedLinkEntitlementSummary) throws -> Response {
+        let message = summary.message ?? "Managed bank linking is unavailable."
+        let body = try JSONEncoder().encode(
+            ManagedLinkErrorResponse(error: message, entitlement: summary)
+        )
+        return Response(
+            status: paymentRequired,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: body))
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
+++ b/Sources/PlaidBarServer/Auth/PendingLinkSessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PlaidBarCore
 #if canImport(Darwin)
 import Darwin
 #endif
@@ -32,11 +33,17 @@ actor PendingLinkSessionStore {
         return UUID().uuidString.lowercased()
     }
 
-    func save(state: String, linkToken: String, updateItemId: String? = nil) {
+    func save(
+        state: String,
+        linkToken: String,
+        updateItemId: String? = nil,
+        origin: ItemOrigin = .bringYourOwn
+    ) {
         purgeExpired()
         sessions[state] = PendingLinkSession(
             linkToken: linkToken,
             updateItemId: updateItemId,
+            origin: origin,
             createdAt: now()
         )
         completionLeases.removeValue(forKey: state)
@@ -219,6 +226,7 @@ actor PendingLinkSessionStore {
 struct PendingLinkSession: Codable, Sendable {
     let linkToken: String
     let updateItemId: String?
+    let origin: ItemOrigin
     let createdAt: Date
     /// Stable, token-free identities of results already consumed (their
     /// single-use public token exchanged). Tracking by identity — not an ordinal
@@ -229,11 +237,13 @@ struct PendingLinkSession: Codable, Sendable {
     init(
         linkToken: String,
         updateItemId: String?,
+        origin: ItemOrigin = .bringYourOwn,
         createdAt: Date,
         completedResultIdentities: Set<String> = []
     ) {
         self.linkToken = linkToken
         self.updateItemId = updateItemId
+        self.origin = origin
         self.createdAt = createdAt
         self.completedResultIdentities = completedResultIdentities
     }
@@ -242,6 +252,7 @@ struct PendingLinkSession: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         linkToken = try container.decode(String.self, forKey: .linkToken)
         updateItemId = try container.decodeIfPresent(String.self, forKey: .updateItemId)
+        origin = try container.decodeIfPresent(ItemOrigin.self, forKey: .origin) ?? .bringYourOwn
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         // Backward compatible: sessions persisted by an earlier build carry no
         // identity set (and the legacy ordinal count is intentionally dropped —

--- a/Sources/PlaidBarServer/Middleware/EntitlementMiddleware.swift
+++ b/Sources/PlaidBarServer/Middleware/EntitlementMiddleware.swift
@@ -3,26 +3,19 @@ import Hummingbird
 import NIOCore
 import PlaidBarCore
 
-/// Entitlement enforcement seam for the consumer (Hosted Link) track.
+/// Store-free entitlement seam for the consumer (Hosted Link) track.
 ///
-/// FOUNDATION ONLY — **this middleware enforces nothing.** It is inserted into
-/// the `/api` chain between `APITokenMiddleware` (authentication) and
-/// `SetupStateMiddleware` (credential-readiness) so the gated managed-consumer
-/// work has a fixed, reviewed place to add Stripe-backed entitlement checks
-/// later, without re-threading the router.
+/// This middleware still enforces nothing directly: it evaluates to `.allow`
+/// for every request and calls `next` unchanged. It stays in the `/api` chain
+/// between `APITokenMiddleware` (authentication) and `SetupStateMiddleware`
+/// (credential-readiness) so future request-signed entitlement checks have a
+/// reviewed insertion point without re-threading the router.
 ///
-/// Today it evaluates to `.allow` for every request and calls `next` unchanged,
-/// so the request path is byte-for-byte identical to before it existed. In
-/// `.local` (BYO-keys) mode it is wired but always allows; entitlements doc D3
-/// keeps BYO fully ungated, so even when enforcement is built it must stay a
-/// no-op in `.local` mode. There are **no Stripe calls, no token verification,
-/// and no network access** here.
-///
-/// When the gated work lands, `evaluate` gains: parse the device-signed
-/// entitlement, verify the embedded Ed25519 signature
-/// (`RemoteBridgeConfig.entitlementPublicKeyBase64`), check TTL/grace, and map
-/// managed-only routes to `.entitlementRequired` / `.limitReached`. The decision
-/// type (`EntitlementDecision`) already models those outcomes.
+/// AND-414's managed Link checks live in `LinkRoutes` instead of here because
+/// they need `BillingSubscriptionStore` plus `TokenStore` counts. In `.local`
+/// (BYO-keys) mode this middleware is wired but always allows; BYO/demo paths
+/// remain ungated. There are **no Stripe calls, no token verification, and no
+/// network access** here.
 struct EntitlementMiddleware<Context: RequestContext>: RouterMiddleware {
     let deployment: DeploymentMode
 

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -8,11 +8,15 @@ struct LinkRoutes: Sendable {
     let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
     let pendingLinkSessions: PendingLinkSessionStore
+    let billingStore: BillingSubscriptionStore
     let config: ServerConfig
 
     func register(with group: RouterGroup<some RequestContext>) {
         let link = group.group("link")
         link.post("create", use: createLinkToken)
+        let managed = link.group("managed")
+        managed.get("entitlement", use: managedEntitlement)
+        managed.post("create", use: createManagedLinkSession)
         link.group("update")
             .post("{itemId}", use: createUpdateLinkToken)
     }
@@ -43,6 +47,47 @@ struct LinkRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+
+    @Sendable
+    func managedEntitlement(
+        request: Request,
+        context: some RequestContext
+    ) async throws -> Response {
+        let summary = try await entitlementService.summary()
+        return try Self.jsonResponse(summary)
+    }
+
+    @Sendable
+    func createManagedLinkSession(
+        request: Request,
+        context: some RequestContext
+    ) async throws -> Response {
+        try ensureProductionHostedLinkRedirectIsReady()
+        let summary = try await entitlementService.summary()
+        guard summary.canCreateManagedLink else {
+            return try ManagedLinkEntitlementService.blockedResponse(summary: summary)
+        }
+
+        let state = await pendingLinkSessions.issueState()
+        let plaidResponse = try await Self.mappingPlaidError {
+            try await plaidClient.createLinkToken(
+                clientUserId: config.linkClientUserId,
+                completionRedirectUri: callbackURL(state: state)
+            )
+        }
+
+        guard let linkUrl = plaidResponse.hostedLinkUrl else {
+            throw HTTPError(.internalServerError, message: "Plaid did not return a hosted Link URL")
+        }
+        await pendingLinkSessions.save(
+            state: state,
+            linkToken: plaidResponse.linkToken,
+            origin: .managed
+        )
+        let dto = ManagedLinkSessionResponse(linkUrl: linkUrl, entitlement: summary)
+
+        return try Self.jsonResponse(dto)
     }
 
     @Sendable
@@ -79,6 +124,23 @@ struct LinkRoutes: Sendable {
         let dto = LinkResponse(linkToken: plaidResponse.linkToken, linkUrl: linkUrl)
 
         let data = try JSONEncoder().encode(dto)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+
+    private var entitlementService: ManagedLinkEntitlementService {
+        ManagedLinkEntitlementService(
+            deployment: config.deployment,
+            billingStore: billingStore,
+            tokenStore: tokenStore
+        )
+    }
+
+    private static func jsonResponse(_ value: some Encodable) throws -> Response {
+        let data = try JSONEncoder().encode(value)
         return Response(
             status: .ok,
             headers: [.contentType: "application/json"],
@@ -217,6 +279,7 @@ struct OAuthCallbackRoute: Sendable {
     let tokenStore: TokenStore
     let pendingLinkSessions: PendingLinkSessionStore
     let hostedLinkCompletions: HostedLinkCompletionStore
+    let entitlementService: ManagedLinkEntitlementService?
     private let storePublicTokenResult: (@Sendable (PlaidPublicTokenResult) async -> StoreResultOutcome)?
 
     init(
@@ -224,12 +287,14 @@ struct OAuthCallbackRoute: Sendable {
         tokenStore: TokenStore,
         pendingLinkSessions: PendingLinkSessionStore,
         hostedLinkCompletions: HostedLinkCompletionStore = HostedLinkCompletionStore(),
+        entitlementService: ManagedLinkEntitlementService? = nil,
         storePublicTokenResult: (@Sendable (PlaidPublicTokenResult) async -> StoreResultOutcome)? = nil
     ) {
         self.plaidClient = plaidClient
         self.tokenStore = tokenStore
         self.pendingLinkSessions = pendingLinkSessions
         self.hostedLinkCompletions = hostedLinkCompletions
+        self.entitlementService = entitlementService
         self.storePublicTokenResult = storePublicTokenResult
     }
 
@@ -305,11 +370,24 @@ struct OAuthCallbackRoute: Sendable {
                     continue
                 }
 
+                if pendingSession.origin == .managed {
+                    let summary = try await managedEntitlementSummary()
+                    guard summary.canCreateManagedLink else {
+                        _ = await pendingLinkSessions.consume(state: state)
+                        return Self.errorResponse(
+                            summary.message ?? "Managed bank linking is unavailable."
+                        )
+                    }
+                }
+
                 let outcome: StoreResultOutcome
                 if let storePublicTokenResult {
                     outcome = await storePublicTokenResult(publicTokenResult)
                 } else {
-                    outcome = await storeResult(publicTokenResult: publicTokenResult)
+                    outcome = await storeResult(
+                        publicTokenResult: publicTokenResult,
+                        origin: pendingSession.origin
+                    )
                 }
                 switch outcome {
                 case .stored:
@@ -407,7 +485,21 @@ struct OAuthCallbackRoute: Sendable {
     /// pre-exchange failure (token unspent → retryable) from a post-exchange
     /// failure (token spent → not retryable, must report failure), so the caller
     /// never both consumes a token AND tells the user the account connected.
-    private func storeResult(publicTokenResult: PlaidPublicTokenResult) async -> StoreResultOutcome {
+    private func managedEntitlementSummary() async throws -> ManagedLinkEntitlementSummary {
+        guard let entitlementService else {
+            return ManagedLinkEntitlementService.summary(
+                deployment: .local,
+                subscription: nil,
+                activeInstitutionCount: 0
+            )
+        }
+        return try await entitlementService.summary()
+    }
+
+    private func storeResult(
+        publicTokenResult: PlaidPublicTokenResult,
+        origin: ItemOrigin
+    ) async -> StoreResultOutcome {
         let exchangeResponse: PlaidTokenExchangeResponse
         do {
             exchangeResponse = try await plaidClient.exchangePublicToken(publicTokenResult.publicToken)
@@ -433,7 +525,8 @@ struct OAuthCallbackRoute: Sendable {
                 id: exchangeResponse.itemId,
                 accessToken: exchangeResponse.accessToken,
                 institutionId: institutionId,
-                institutionName: publicTokenResult.institution?.normalizedName
+                institutionName: publicTokenResult.institution?.normalizedName,
+                origin: origin
             )
         } catch {
             return .spentButNotStored

--- a/Sources/PlaidBarServer/Storage/Database.swift
+++ b/Sources/PlaidBarServer/Storage/Database.swift
@@ -1,5 +1,6 @@
 import FluentKit
 import Foundation
+import PlaidBarCore
 
 // MARK: - Item Model (Fluent)
 
@@ -24,6 +25,9 @@ final class ItemModel: Model, @unchecked Sendable {
     @OptionalField(key: "provider")
     var provider: String?
 
+    @OptionalField(key: "origin")
+    var origin: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
@@ -37,7 +41,8 @@ final class ItemModel: Model, @unchecked Sendable {
         accessToken: String,
         institutionId: String? = nil,
         institutionName: String? = nil,
-        providerID: ProviderID = .plaid
+        providerID: ProviderID = .plaid,
+        origin: ItemOrigin = .bringYourOwn
     ) {
         self.id = id
         self.accessToken = accessToken
@@ -45,10 +50,15 @@ final class ItemModel: Model, @unchecked Sendable {
         self.institutionName = institutionName
         self.status = "connected"
         self.provider = providerID.rawValue
+        self.origin = origin.rawValue
     }
 
     var providerID: ProviderID {
         ProviderID(rawValue: provider ?? "") ?? .plaid
+    }
+
+    var itemOrigin: ItemOrigin {
+        ItemOrigin(rawValue: origin ?? "") ?? .bringYourOwn
     }
 }
 
@@ -113,17 +123,25 @@ struct AddProviderToItems: AsyncMigration {
         try await database.schema("items")
             .field("provider", .string)
             .update()
-
-        let rows = try await ItemModel.query(on: database).all()
-        for row in rows where row.provider == nil {
-            row.provider = ProviderID.plaid.rawValue
-            try await row.save(on: database)
-        }
     }
 
     func revert(on database: Database) async throws {
         try await database.schema("items")
             .deleteField("provider")
+            .update()
+    }
+}
+
+struct AddOriginToItems: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("items")
+            .field("origin", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("items")
+            .deleteField("origin")
             .update()
     }
 }

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -2,6 +2,7 @@ import FluentKit
 import HummingbirdFluent
 import Foundation
 import Logging
+import PlaidBarCore
 
 actor TokenStore {
     private let fluent: Fluent
@@ -19,7 +20,8 @@ actor TokenStore {
         accessToken: String,
         institutionId: String?,
         institutionName: String?,
-        providerID: ProviderID = .plaid
+        providerID: ProviderID = .plaid,
+        origin: ItemOrigin = .bringYourOwn
     ) async throws {
         let storedAccessToken = try PlaidTokenVault.store(
             accessToken: accessToken,
@@ -30,7 +32,8 @@ actor TokenStore {
             accessToken: storedAccessToken,
             institutionId: institutionId,
             institutionName: institutionName,
-            providerID: providerID
+            providerID: providerID,
+            origin: origin
         )
         try await item.save(on: fluent.db())
     }
@@ -95,6 +98,19 @@ actor TokenStore {
 
     func itemCount() async throws -> Int {
         try await ItemModel.query(on: fluent.db()).count()
+    }
+
+    func activeInstitutionCount(origin: ItemOrigin) async throws -> Int {
+        let items = try await ItemModel.query(on: fluent.db())
+            .filter(\.$origin == origin.rawValue)
+            .all()
+        let activeInstitutionKeys = items.compactMap { item -> String? in
+            if item.status == ItemConnectionStatus.pendingDisconnect.rawValue {
+                return nil
+            }
+            return item.institutionId ?? item.id
+        }
+        return Set(activeInstitutionKeys).count
     }
 
     func lastSyncDate() async throws -> Date? {

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -289,6 +289,259 @@ struct ConsumerFoundationTests {
         }
     }
 
+    // MARK: - Managed Link Broker
+
+    @Test("Allowed managed link session returns only hosted URL and entitlement summary")
+    func allowedManagedLinkSessionOmitsProviderSecrets() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(status: .active, plan: .plus))
+            let plaidClient = ManagedLinkStubPlaidClient()
+            let routes = LinkRoutes(
+                plaidClient: plaidClient,
+                tokenStore: tokenStore,
+                pendingLinkSessions: PendingLinkSessionStore(),
+                billingStore: billingStore,
+                config: try Self.hostedBridgeConfig()
+            )
+
+            let response = try await routes.createManagedLinkSession(
+                request: Self.makeRequest(path: "/api/link/managed/create"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let body = try await Self.responseString(response)
+            let decoded = try JSONDecoder().decode(ManagedLinkSessionResponse.self, from: Data(body.utf8))
+            let calls = await plaidClient.recordedCreateCompletionRedirectURIs()
+
+            #expect(response.status == .ok)
+            #expect(decoded.linkUrl == "https://link.example.test/session")
+            #expect(decoded.entitlement.plan == .plus)
+            #expect(decoded.entitlement.status == .active)
+            #expect(decoded.entitlement.institutionLimit == 8)
+            #expect(decoded.entitlement.activeInstitutionCount == 0)
+            #expect(decoded.entitlement.canCreateManagedLink)
+            #expect(calls.count == 1)
+            #expect(calls.first?.contains("/oauth/callback?state=") == true)
+            #expect(!body.contains("linkToken"))
+            #expect(!body.contains("link-token-server-only"))
+            #expect(!body.localizedCaseInsensitiveContains("secret"))
+            #expect(!body.localizedCaseInsensitiveContains("access"))
+            #expect(!body.localizedCaseInsensitiveContains("public"))
+        }
+    }
+
+    @Test(".local mode always blocks managed link creation regardless of plan or subscription")
+    func localModeAlwaysBlocksManagedLinkCreation() {
+        // The entire safety case for shipping this gated broker in the default
+        // local-first beta rests on `.local` NEVER allowing a managed link. Lock it
+        // as a pure-function invariant: even a fully-paid, active Plus subscription
+        // with spare capacity is blocked with `.managedBridgeUnavailable` (the
+        // route at LinkRoutes gates on exactly this `canCreateManagedLink`).
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let subscriptions: [BillingSubscription?] = [
+            nil,
+            BillingSubscription(status: .active, plan: .plus, updatedAt: updatedAt),
+            BillingSubscription(status: .trialing, plan: .plus, updatedAt: updatedAt),
+        ]
+        for subscription in subscriptions {
+            let summary = ManagedLinkEntitlementService.summary(
+                deployment: .local,
+                subscription: subscription,
+                activeInstitutionCount: 0
+            )
+            #expect(summary.canCreateManagedLink == false)
+            #expect(summary.blockReason == .managedBridgeUnavailable)
+        }
+    }
+
+    @Test("Over-limit managed link creation is blocked before Plaid is called")
+    func overLimitManagedLinkIsBlocked() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(status: .active, plan: .plus))
+            for index in 0 ..< SubscriptionPlan.plus.institutionLimit {
+                try await ItemModel(
+                    id: "managed-item-\(index)",
+                    accessToken: "keychain:managed-item-\(index)",
+                    institutionId: "ins_managed_\(index)",
+                    origin: .managed
+                ).save(on: fluent.db())
+            }
+            let plaidClient = ManagedLinkStubPlaidClient()
+            let routes = LinkRoutes(
+                plaidClient: plaidClient,
+                tokenStore: tokenStore,
+                pendingLinkSessions: PendingLinkSessionStore(),
+                billingStore: billingStore,
+                config: try Self.hostedBridgeConfig()
+            )
+
+            let response = try await routes.createManagedLinkSession(
+                request: Self.makeRequest(path: "/api/link/managed/create"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let body = try await Self.responseString(response)
+            let decoded = try JSONDecoder().decode(ManagedLinkErrorResponse.self, from: Data(body.utf8))
+            let calls = await plaidClient.recordedCreateCompletionRedirectURIs()
+
+            #expect(response.status == ManagedLinkEntitlementService.paymentRequired)
+            #expect(decoded.entitlement.blockReason == .institutionLimitReached)
+            #expect(decoded.entitlement.activeInstitutionCount == 8)
+            #expect(decoded.entitlement.canCreateManagedLink == false)
+            #expect(decoded.error.contains("limit"))
+            #expect(calls.isEmpty)
+            #expect(!body.contains("link-token-server-only"))
+            #expect(!body.localizedCaseInsensitiveContains("secret"))
+        }
+    }
+
+    @Test("Disconnect removes managed item from active entitlement count without counting BYO")
+    func disconnectUpdatesManagedInstitutionCount() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(status: .active, plan: .plus))
+            try await ItemModel(
+                id: "managed-item-disconnect",
+                accessToken: "keychain:managed-item-disconnect",
+                institutionId: "ins_managed_disconnect",
+                origin: .managed
+            ).save(on: fluent.db())
+            try await ItemModel(
+                id: "byo-item-ignored",
+                accessToken: "keychain:byo-item-ignored",
+                institutionId: "ins_byo_ignored",
+                origin: .bringYourOwn
+            ).save(on: fluent.db())
+            let service = ManagedLinkEntitlementService(
+                deployment: .hostedBridge,
+                billingStore: billingStore,
+                tokenStore: tokenStore
+            )
+
+            let before = try await service.summary()
+            try await tokenStore.deleteItem(id: "managed-item-disconnect")
+            let after = try await service.summary()
+
+            #expect(before.activeInstitutionCount == 1)
+            #expect(before.canCreateManagedLink)
+            #expect(after.activeInstitutionCount == 0)
+            #expect(after.canCreateManagedLink)
+            #expect(try await tokenStore.getItem(id: "byo-item-ignored") != nil)
+        }
+    }
+
+    @Test("Degraded entitlement blocks managed link creation without deleting local data")
+    func degradedEntitlementBlocksManagedLinkCreation() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(status: .pastDue, plan: .plus))
+            try await ItemModel(
+                id: "managed-item-kept",
+                accessToken: "keychain:managed-item-kept",
+                institutionId: "ins_managed_kept",
+                origin: .managed
+            ).save(on: fluent.db())
+            let plaidClient = ManagedLinkStubPlaidClient()
+            let routes = LinkRoutes(
+                plaidClient: plaidClient,
+                tokenStore: tokenStore,
+                pendingLinkSessions: PendingLinkSessionStore(),
+                billingStore: billingStore,
+                config: try Self.hostedBridgeConfig()
+            )
+
+            let response = try await routes.createManagedLinkSession(
+                request: Self.makeRequest(path: "/api/link/managed/create"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let body = try await Self.responseString(response)
+            let decoded = try JSONDecoder().decode(ManagedLinkErrorResponse.self, from: Data(body.utf8))
+            let calls = await plaidClient.recordedCreateCompletionRedirectURIs()
+
+            #expect(response.status == ManagedLinkEntitlementService.paymentRequired)
+            #expect(decoded.entitlement.blockReason == .subscriptionDegraded)
+            #expect(decoded.entitlement.status == .pastDue)
+            #expect(decoded.entitlement.activeInstitutionCount == 1)
+            #expect(calls.isEmpty)
+            #expect(try await tokenStore.getItem(id: "managed-item-kept") != nil)
+        }
+    }
+
+    @Test("Managed OAuth callback enforces limit before public-token exchange")
+    func managedCallbackBlocksWhenLimitReachedBeforeExchange() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(status: .active, plan: .plus))
+            for index in 0 ..< SubscriptionPlan.plus.institutionLimit {
+                try await ItemModel(
+                    id: "managed-callback-item-\(index)",
+                    accessToken: "keychain:managed-callback-item-\(index)",
+                    institutionId: "ins_managed_callback_\(index)",
+                    origin: .managed
+                ).save(on: fluent.db())
+            }
+            let linkToken = "managed-callback-link-token"
+            let plaidClient = ManagedLinkStubPlaidClient(
+                linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                    linkToken: linkToken,
+                    linkSessions: [
+                        PlaidLinkSession(
+                            linkSessionId: "managed-callback-session",
+                            results: PlaidLinkResults(
+                                itemAddResults: [
+                                    PlaidLinkItemAddResult(
+                                        publicToken: "managed-callback-public-token",
+                                        institution: PlaidLinkInstitution(
+                                            name: "Example Bank",
+                                            institutionId: "ins_new_blocked"
+                                        )
+                                    ),
+                                ]
+                            )
+                        ),
+                    ],
+                    onSuccess: nil,
+                    results: nil
+                )
+            )
+            let pendingLinkSessions = PendingLinkSessionStore()
+            let state = await pendingLinkSessions.issueState()
+            await pendingLinkSessions.save(
+                state: state,
+                linkToken: linkToken,
+                origin: .managed
+            )
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: tokenStore,
+                pendingLinkSessions: pendingLinkSessions,
+                entitlementService: ManagedLinkEntitlementService(
+                    deployment: .hostedBridge,
+                    billingStore: billingStore,
+                    tokenStore: tokenStore
+                )
+            )
+
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let body = try await Self.responseString(response)
+            let calls = await plaidClient.recordedCalls()
+
+            #expect(response.status == .internalServerError)
+            #expect(body.contains("institution limit"))
+            #expect(calls.linkTokens == [linkToken])
+            #expect(calls.publicTokens.isEmpty)
+            #expect(try await tokenStore.activeInstitutionCount(origin: .managed) == 8)
+        }
+    }
+
     // MARK: - Helpers
 
     private static func makeRequest(path: String) -> Request {
@@ -296,6 +549,55 @@ struct ConsumerFoundationTests {
             head: HTTPRequest(method: .get, scheme: nil, authority: nil, path: path),
             body: RequestBody(buffer: ByteBuffer())
         )
+    }
+
+    private static func responseString(_ response: Response) async throws -> String {
+        let collector = ResponseBodyCollector()
+        let writer = CollectingResponseBodyWriter(collector: collector)
+        try await response.body.write(writer)
+        var buffer = await collector.collectedBuffer()
+        return buffer.readString(length: buffer.readableBytes) ?? ""
+    }
+
+    private static func hostedBridgeConfig() throws -> ServerConfig {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-managed-link-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let configURL = directory.appendingPathComponent("server.conf")
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        try """
+        PLAID_CLIENT_ID=test-client-id
+        PLAID_SECRET=test-secret-placeholder
+        PLAID_ENV=sandbox
+        PLAIDBAR_DEPLOYMENT=hosted-bridge
+        PLAID_LINK_WEBHOOK_URL=https://vaultpeek.example.test/webhooks/plaid/hosted-link
+        PLAIDBAR_OAUTH_REDIRECT_URI=https://link.vaultpeek.example.test/oauth/callback
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        return try ServerConfig.load(from: configURL.path)
+    }
+
+    private actor ResponseBodyCollector {
+        private var buffer = ByteBuffer()
+
+        func append(_ chunk: ByteBuffer) {
+            var copy = chunk
+            buffer.writeBuffer(&copy)
+        }
+
+        func collectedBuffer() -> ByteBuffer {
+            buffer
+        }
+    }
+
+    private struct CollectingResponseBodyWriter: ResponseBodyWriter {
+        let collector: ResponseBodyCollector
+
+        mutating func write(_ buffer: ByteBuffer) async throws {
+            await collector.append(buffer)
+        }
+
+        consuming func finish(_ trailingHeaders: HTTPFields?) async throws {}
     }
 
     private static func makeJSONRequest(
@@ -324,6 +626,7 @@ struct ConsumerFoundationTests {
         fluent.databases.use(.sqlite(.memory), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateBillingSubscriptions())
 
@@ -354,5 +657,81 @@ private struct TestRequestContext: RequestContext {
 
     init(source: TestRequestContextSource) {
         coreContext = CoreRequestContextStorage(source: source)
+    }
+}
+
+private actor ManagedLinkStubPlaidClient: PlaidClientProtocol {
+    private let linkTokenGetResponse: PlaidLinkTokenGetResponse
+    private var createCompletionRedirectURIs: [String] = []
+    private var requestedLinkTokens: [String] = []
+    private var exchangedPublicTokens: [String] = []
+
+    init(
+        linkTokenGetResponse: PlaidLinkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: nil,
+            linkSessions: nil,
+            onSuccess: nil,
+            results: nil
+        )
+    ) {
+        self.linkTokenGetResponse = linkTokenGetResponse
+    }
+
+    func createLinkToken(
+        clientUserId _: String,
+        completionRedirectUri: String
+    ) async throws -> PlaidLinkTokenResponse {
+        createCompletionRedirectURIs.append(completionRedirectUri)
+        return PlaidLinkTokenResponse(
+            linkToken: "link-token-server-only",
+            expiration: nil,
+            requestId: nil,
+            hostedLinkUrl: "https://link.example.test/session"
+        )
+    }
+
+    func createUpdateLinkToken(
+        clientUserId _: String,
+        accessToken _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getLinkToken(_ linkToken: String) async throws -> PlaidLinkTokenGetResponse {
+        requestedLinkTokens.append(linkToken)
+        return linkTokenGetResponse
+    }
+
+    func exchangePublicToken(_ publicToken: String) async throws -> PlaidTokenExchangeResponse {
+        exchangedPublicTokens.append(publicToken)
+        throw PlaidError.invalidResponse
+    }
+
+    func getAccounts(accessToken _: String) async throws -> PlaidAccountsResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getBalances(accessToken _: String) async throws -> PlaidAccountsResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func syncTransactions(
+        accessToken _: String,
+        cursor _: String?
+    ) async throws -> PlaidTransactionsSyncResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func removeItem(accessToken _: String) async throws {
+        throw PlaidError.invalidResponse
+    }
+
+    func recordedCreateCompletionRedirectURIs() -> [String] {
+        createCompletionRedirectURIs
+    }
+
+    func recordedCalls() -> (linkTokens: [String], publicTokens: [String]) {
+        (requestedLinkTokens, exchangedPublicTokens)
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1060,6 +1060,7 @@ struct PlaidBarServerTests {
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?
@@ -1084,6 +1085,7 @@ struct PlaidBarServerTests {
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateBillingSubscriptions())
 

--- a/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
+++ b/Tests/PlaidBarServerTests/SandboxReliabilityTests.swift
@@ -329,6 +329,7 @@ struct SandboxReliabilityTests {
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?

--- a/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
+++ b/Tests/PlaidBarServerTests/TokenStorageSafetyTests.swift
@@ -271,6 +271,7 @@ struct TokenStorageSafetyTests {
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
 
         var bodyError: Error?

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -224,6 +224,7 @@ struct WebhookReceiverTests {
         fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
         await fluent.migrations.add(CreateItems())
         await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
         await fluent.migrations.add(CreateSyncCursors())
         await fluent.migrations.add(CreateBillingSubscriptions())
         await fluent.migrations.add(CreateWebhookEvents())

--- a/docs/strategy/managed-link-broker-enforcement.md
+++ b/docs/strategy/managed-link-broker-enforcement.md
@@ -1,0 +1,81 @@
+---
+title: Managed Link Broker Enforcement Notes
+status: implementation-note
+linear: AND-414
+date: 2026-06-14
+---
+
+# Managed Link Broker Enforcement Notes
+
+AND-414 introduces the first server-side enforcement path for managed bank
+linking. The implementation is deliberately narrow: it adds authenticated
+localhost API endpoints for managed link-session creation and a secret-free
+entitlement summary. It does not add Stripe Checkout, a customer portal, hosted
+sync jobs, or any provider-secret handoff to the SwiftUI app.
+
+## Implemented server boundary
+
+- `GET /api/link/managed/entitlement` returns plan/status/institution count,
+  institution limit, whether another managed link can be created, and a safe
+  block reason when creation is unavailable.
+- `POST /api/link/managed/create` checks that summary before asking Plaid for a
+  Hosted Link session. Blocked requests return HTTP 402 with the same summary
+  and do not call Plaid.
+- Existing `/api/link/create` and `/api/link/update/{itemId}` remain the BYO
+  and repair paths. Demo and BYO-key mode are not gated by managed-plan limits.
+- OAuth callback handling checks managed entitlement again before exchanging a
+  Hosted Link result, so a user cannot exceed the limit if their entitlement or
+  active count changes between session creation and callback completion.
+
+All of these routes sit under `/api`, so they inherit the existing local bearer
+token authentication. The managed endpoints are for the backend/server boundary;
+the SwiftUI app receives only the hosted URL plus entitlement/institution
+summary state.
+
+## Institution counting
+
+Linked items now carry an `origin` marker:
+
+- `managed` counts toward the managed institution limit.
+- `byo` is the default for existing and local-user-created items.
+
+Counts are derived from active stored managed items, keyed by institution ID
+when available and by item ID as a fallback. Deleting an item removes it from
+the count naturally. BYO items stay outside the count even when a managed
+subscription exists.
+
+Current self-serve limits:
+
+- Free: 0 managed institutions.
+- Plus: 8 managed institutions.
+
+Past-due, canceled, and expired billing states block new managed link creation.
+They do not delete local rows, Keychain entries, cached financial data, or BYO
+connections.
+
+## Token and provider-secret handling
+
+The managed entitlement summary intentionally contains no provider secrets,
+Plaid public tokens, Plaid access tokens, account IDs, balances, transaction
+data, raw provider payloads, local database paths, or screenshots.
+
+The server remains responsible for:
+
+- Creating Hosted Link sessions.
+- Holding the Plaid client credentials in server configuration only.
+- Exchanging Hosted Link results server-side.
+- Storing access-token bytes through the server token vault, with SQLite holding
+  only token references.
+- Marking managed items with `origin = managed` at storage time.
+
+The SwiftUI app must not receive or persist Plaid provider secrets, public
+tokens, access tokens, or raw Plaid payloads. It may receive only the hosted
+bank-link URL and the secret-free entitlement/institution summary.
+
+## Remaining scope
+
+AND-414 does not implement hosted identity, live Stripe Checkout/Portal, signed
+remote entitlement documents, or the future blind data-plane relay. Those remain
+separate work items and must preserve the same division: local financial data
+and token custody stay out of app UI surfaces and documentation artifacts, while
+server enforcement owns managed-plan limits.


### PR DESCRIPTION
## Summary

Implements AND-414 as the next stacked managed-link slice on top of #382:

- adds a backend-only managed link broker endpoint at `/api/link/managed/create`
- adds `/api/link/managed/entitlement` for safe plan/status/usage summaries
- enforces managed institution limits server-side before Plaid Link creation and again before OAuth callback token exchange
- records managed vs BYO item origin, defaulting existing/local rows to BYO so demo/BYO mode remains ungated
- keeps Plaid public tokens/access tokens/provider secrets entirely server-side; managed create response returns only Hosted Link URL + entitlement summary
- documents managed bridge responsibilities and token-handling boundaries

Stacking note: this PR is based on `otto/and-411-managed-link` / #382 because the broker depends on the managed OAuth/webhook/status stack.

## Verification

```text
git diff --check
swift test --disable-sandbox --skip-update --filter 'ConsumerFoundationTests|SubscriptionPlanTests|LinkTokenRequestTests'
# Test run with 55 tests passed

swift build --target PlaidBarServer --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# Build of target: 'PlaidBarServer' complete
```

## Privacy / security

- No Plaid access tokens, public tokens, client secrets, raw provider payloads, account IDs, balances, transactions, local SQLite data, logs, or screenshots are exposed to the SwiftUI app.
- Managed entitlement responses are limited to plan/status/count/reason fields.
- BYO/demo/local mode remains ungated.

Linear: AND-414
