### PR TITLE
AND-348: Add Stripe subscription entitlement seam

### DIFF
--- a/Sources/PlaidBarCore/Models/BillingSubscription.swift
+++ b/Sources/PlaidBarCore/Models/BillingSubscription.swift
@@ -93,6 +93,102 @@ public struct SaveBillingSubscriptionRequest: Codable, Sendable, Equatable {
     }
 }
 
+public struct BillingCheckoutSessionRequest: Codable, Sendable, Equatable {
+    public let plan: SubscriptionPlan
+    public let successURL: String
+    public let cancelURL: String
+
+    public init(plan: SubscriptionPlan, successURL: String, cancelURL: String) {
+        self.plan = plan
+        self.successURL = successURL
+        self.cancelURL = cancelURL
+    }
+}
+
+public struct BillingCheckoutSessionResponse: Codable, Sendable, Equatable {
+    public let checkoutURL: String
+    public let plan: SubscriptionPlan
+    public let mode: String
+
+    public init(checkoutURL: String, plan: SubscriptionPlan, mode: String = "subscription") {
+        self.checkoutURL = checkoutURL
+        self.plan = plan
+        self.mode = mode
+    }
+}
+
+public struct BillingPortalSessionRequest: Codable, Sendable, Equatable {
+    public let returnURL: String
+
+    public init(returnURL: String) {
+        self.returnURL = returnURL
+    }
+}
+
+public struct BillingPortalSessionResponse: Codable, Sendable, Equatable {
+    public let portalURL: String
+
+    public init(portalURL: String) {
+        self.portalURL = portalURL
+    }
+}
+
+/// Safe Stripe webhook projection. It intentionally carries only normalized
+/// subscription metadata; never raw Stripe payloads, signatures, customer email,
+/// payment-method details, invoices, or secrets.
+public struct StripeBillingWebhookEvent: Codable, Sendable, Equatable {
+    public let id: String
+    public let type: String
+    public let status: BillingSubscriptionStatus
+    public let plan: SubscriptionPlan
+    public let currentPeriodEnd: Date?
+    public let trialEndsAt: Date?
+
+    public init(
+        id: String,
+        type: String,
+        status: BillingSubscriptionStatus,
+        plan: SubscriptionPlan,
+        currentPeriodEnd: Date? = nil,
+        trialEndsAt: Date? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.status = status
+        self.plan = plan
+        self.currentPeriodEnd = currentPeriodEnd
+        self.trialEndsAt = trialEndsAt
+    }
+}
+
+public struct BillingEntitlementSummary: Codable, Sendable, Equatable {
+    public let plan: SubscriptionPlan
+    public let status: BillingSubscriptionStatus?
+    public let institutionLimit: Int
+    public let activeInstitutionCount: Int
+    public let trialEndsAt: Date?
+    public let features: [String]
+    public let managedLink: ManagedLinkEntitlementSummary
+
+    public init(
+        plan: SubscriptionPlan,
+        status: BillingSubscriptionStatus?,
+        institutionLimit: Int,
+        activeInstitutionCount: Int,
+        trialEndsAt: Date?,
+        features: [String],
+        managedLink: ManagedLinkEntitlementSummary
+    ) {
+        self.plan = plan
+        self.status = status
+        self.institutionLimit = institutionLimit
+        self.activeInstitutionCount = activeInstitutionCount
+        self.trialEndsAt = trialEndsAt
+        self.features = features
+        self.managedLink = managedLink
+    }
+}
+
 public struct BillingFeatureLock: Sendable, Equatable {
     public let title: String
     public let message: String

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -112,7 +112,11 @@ struct PlaidBarServer: AsyncParsableCommand {
             .register(with: api)
         BudgetRoutes(budgetStore: budgetStore)
             .register(with: api)
-        BillingRoutes(billingStore: billingStore)
+        BillingRoutes(
+            billingStore: billingStore,
+            tokenStore: tokenStore,
+            deployment: serverConfig.deployment
+        )
             .register(with: api)
 
         // OAuth callback (top-level, not under /api)

--- a/Sources/PlaidBarServer/Routes/BillingRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/BillingRoutes.swift
@@ -3,17 +3,38 @@ import Hummingbird
 import NIOCore
 import PlaidBarCore
 
-/// `/api/billing/subscription` — local subscription lifecycle metadata.
+/// `/api/billing/*` — subscription lifecycle, Stripe-shaped session seams, and
+/// the secret-free entitlement summary used by managed linking.
 ///
-/// This endpoint receives already-normalized lifecycle state. It does not talk
-/// to Stripe, verify webhooks, or store provider secrets/payloads.
+/// These endpoints receive/return normalized metadata only. They do not store
+/// Stripe secrets, raw webhook payloads, payment-method details, invoices, Plaid
+/// tokens, account identifiers, balances, or transactions.
 struct BillingRoutes: Sendable {
     let billingStore: BillingSubscriptionStore
+    let tokenStore: TokenStore?
+    let deployment: DeploymentMode
+    let webhookEvents: StripeBillingEventStore
+
+    init(
+        billingStore: BillingSubscriptionStore,
+        tokenStore: TokenStore? = nil,
+        deployment: DeploymentMode = .local,
+        webhookEvents: StripeBillingEventStore = StripeBillingEventStore()
+    ) {
+        self.billingStore = billingStore
+        self.tokenStore = tokenStore
+        self.deployment = deployment
+        self.webhookEvents = webhookEvents
+    }
 
     func register(with group: RouterGroup<some RequestContext>) {
-        group.group("billing")
-            .get("subscription", use: getSubscription)
-            .put("subscription", use: saveSubscription)
+        let billing = group.group("billing")
+        billing.get("subscription", use: getSubscription)
+        billing.put("subscription", use: saveSubscription)
+        billing.get("entitlement", use: getEntitlement)
+        billing.post("checkout", use: createCheckoutSession)
+        billing.post("portal", use: createPortalSession)
+        billing.post("webhook", use: handleStripeWebhook)
     }
 
     @Sendable
@@ -24,28 +45,121 @@ struct BillingRoutes: Sendable {
 
     @Sendable
     func saveSubscription(request: Request, context: some RequestContext) async throws -> Response {
-        // The app client encodes billing dates with `.iso8601`
-        // (ServerClient.encoder), but Hummingbird's default request decoder
-        // expects numeric `Date`s, so a non-nil trial/period-end date would fail
-        // to decode. Decode the raw body with a matching ISO-8601 decoder.
+        let body: SaveBillingSubscriptionRequest = try await Self.decodeBody(
+            request,
+            errorMessage: "Invalid billing subscription payload"
+        )
+        let subscription = try await billingStore.save(body)
+        return try Self.jsonResponse(subscription)
+    }
+
+    @Sendable
+    func getEntitlement(request: Request, context: some RequestContext) async throws -> Response {
+        let summary = try await billingEntitlementSummary()
+        return try Self.jsonResponse(summary)
+    }
+
+    @Sendable
+    func createCheckoutSession(request: Request, context: some RequestContext) async throws -> Response {
+        let body: BillingCheckoutSessionRequest = try await Self.decodeBody(
+            request,
+            errorMessage: "Invalid billing checkout payload"
+        )
+        guard body.plan != .free else {
+            throw HTTPError(.badRequest, message: "Stripe Checkout is only available for paid managed plans")
+        }
+        let encodedPlan = body.plan.rawValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body.plan.rawValue
+        let encodedSuccess = body.successURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body.successURL
+        let encodedCancel = body.cancelURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body.cancelURL
+        return try Self.jsonResponse(BillingCheckoutSessionResponse(
+            checkoutURL: "https://billing.stripe.local/checkout?plan=\(encodedPlan)&success_url=\(encodedSuccess)&cancel_url=\(encodedCancel)",
+            plan: body.plan
+        ))
+    }
+
+    @Sendable
+    func createPortalSession(request: Request, context: some RequestContext) async throws -> Response {
+        let body: BillingPortalSessionRequest = try await Self.decodeBody(
+            request,
+            errorMessage: "Invalid billing portal payload"
+        )
+        let encodedReturn = body.returnURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body.returnURL
+        return try Self.jsonResponse(BillingPortalSessionResponse(
+            portalURL: "https://billing.stripe.local/portal?return_url=\(encodedReturn)"
+        ))
+    }
+
+    @Sendable
+    func handleStripeWebhook(request: Request, context: some RequestContext) async throws -> Response {
+        let event: StripeBillingWebhookEvent = try await Self.decodeBody(
+            request,
+            errorMessage: "Invalid Stripe billing webhook payload"
+        )
+        let inserted = await webhookEvents.recordIfNew(event.id)
+        if inserted {
+            _ = try await billingStore.save(SaveBillingSubscriptionRequest(
+                status: event.status,
+                plan: event.plan,
+                currentPeriodEnd: event.currentPeriodEnd,
+                trialEndsAt: event.trialEndsAt
+            ))
+        }
+        return try Self.jsonResponse(["status": inserted ? "processed" : "duplicate"])
+    }
+
+    private func billingEntitlementSummary() async throws -> BillingEntitlementSummary {
+        let subscription = try await billingStore.currentSubscription()
+        let managedSummary: ManagedLinkEntitlementSummary
+        if let tokenStore {
+            managedSummary = try await ManagedLinkEntitlementService(
+                deployment: deployment,
+                billingStore: billingStore,
+                tokenStore: tokenStore
+            ).summary()
+        } else {
+            managedSummary = ManagedLinkEntitlementService.summary(
+                deployment: deployment,
+                subscription: subscription,
+                activeInstitutionCount: 0
+            )
+        }
+        return BillingEntitlementSummary(
+            plan: managedSummary.plan,
+            status: managedSummary.status,
+            institutionLimit: managedSummary.institutionLimit,
+            activeInstitutionCount: managedSummary.activeInstitutionCount,
+            trialEndsAt: subscription?.trialEndsAt,
+            features: Self.allowedPremiumFeatures(subscription: subscription),
+            managedLink: managedSummary
+        )
+    }
+
+    private static func allowedPremiumFeatures(subscription: BillingSubscription?) -> [String] {
+        guard let subscription, subscription.status.allowsPaidFeatures else { return [] }
+        switch subscription.plan {
+        case .free:
+            return []
+        case .plus:
+            return ["managed_linking", "managed_institution_limit_8"]
+        }
+    }
+
+    private static func decodeBody<T: Decodable>(_ request: Request, errorMessage: String) async throws -> T {
         let buffer = try await request.body.collect(upTo: Self.maxBodyBytes)
         let data = Data(buffer: buffer)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let body: SaveBillingSubscriptionRequest
         do {
-            body = try decoder.decode(SaveBillingSubscriptionRequest.self, from: data)
+            return try decoder.decode(T.self, from: data)
         } catch {
-            throw HTTPError(.badRequest, message: "Invalid billing subscription payload")
+            throw HTTPError(.badRequest, message: errorMessage)
         }
-        let subscription = try await billingStore.save(body)
-        return try Self.jsonResponse(subscription)
     }
 
     /// Upper bound for the small JSON billing payload.
     private static let maxBodyBytes = 64 * 1024
 
-    private static func jsonResponse(_ value: (some Encodable)?) throws -> Response {
+    private static func jsonResponse(_ value: some Encodable) throws -> Response {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(value)
@@ -54,5 +168,13 @@ struct BillingRoutes: Sendable {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
+    }
+}
+
+actor StripeBillingEventStore {
+    private var processedEventIDs: Set<String> = []
+
+    func recordIfNew(_ eventID: String) -> Bool {
+        processedEventIDs.insert(eventID).inserted
     }
 }

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -542,6 +542,142 @@ struct ConsumerFoundationTests {
         }
     }
 
+    // MARK: - Stripe Entitlements
+
+    @Test("Checkout and portal endpoints return Stripe-shaped session URLs without secrets")
+    func checkoutAndPortalSessionEndpointsAreSecretFree() async throws {
+        try await withFluent { fluent in
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            let routes = BillingRoutes(billingStore: billingStore)
+            let checkout = try await routes.createCheckoutSession(
+                request: try Self.makeJSONRequest(
+                    method: .post,
+                    path: "/api/billing/checkout",
+                    body: BillingCheckoutSessionRequest(
+                        plan: .plus,
+                        successURL: "vaultpeek://billing/success",
+                        cancelURL: "vaultpeek://billing/cancel"
+                    )
+                ),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let portal = try await routes.createPortalSession(
+                request: try Self.makeJSONRequest(
+                    method: .post,
+                    path: "/api/billing/portal",
+                    body: BillingPortalSessionRequest(returnURL: "vaultpeek://billing/return")
+                ),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let checkoutBody = try await Self.responseString(checkout)
+            let portalBody = try await Self.responseString(portal)
+            let decodedCheckout = try JSONDecoder().decode(BillingCheckoutSessionResponse.self, from: Data(checkoutBody.utf8))
+            let decodedPortal = try JSONDecoder().decode(BillingPortalSessionResponse.self, from: Data(portalBody.utf8))
+
+            #expect(checkout.status == .ok)
+            #expect(decodedCheckout.plan == .plus)
+            #expect(decodedCheckout.checkoutURL.contains("billing.stripe.local/checkout"))
+            #expect(decodedPortal.portalURL.contains("billing.stripe.local/portal"))
+            #expect(!checkoutBody.localizedCaseInsensitiveContains("secret"))
+            #expect(!portalBody.localizedCaseInsensitiveContains("secret"))
+        }
+    }
+
+    @Test("Stripe webhook metadata updates billing and entitlement summary")
+    func stripeWebhookUpdatesBillingEntitlementSummary() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            let routes = BillingRoutes(
+                billingStore: billingStore,
+                tokenStore: tokenStore,
+                deployment: .hostedBridge
+            )
+            let trialEnd = Date(timeIntervalSince1970: 1_800_000_000)
+            let webhook = StripeBillingWebhookEvent(
+                id: "evt_test_subscription_updated",
+                type: "customer.subscription.updated",
+                status: .trialing,
+                plan: .plus,
+                trialEndsAt: trialEnd
+            )
+
+            let first = try await routes.handleStripeWebhook(
+                request: try Self.makeJSONRequest(method: .post, path: "/api/billing/webhook", body: webhook),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let duplicate = try await routes.handleStripeWebhook(
+                request: try Self.makeJSONRequest(method: .post, path: "/api/billing/webhook", body: webhook),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let entitlement = try await routes.getEntitlement(
+                request: Self.makeRequest(path: "/api/billing/entitlement"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let entitlementBody = try await Self.responseString(entitlement)
+            let entitlementDecoder = JSONDecoder()
+            entitlementDecoder.dateDecodingStrategy = .iso8601
+            let decoded = try entitlementDecoder.decode(BillingEntitlementSummary.self, from: Data(entitlementBody.utf8))
+
+            #expect(first.status == .ok)
+            #expect(try await Self.responseString(duplicate).contains("duplicate"))
+            #expect(decoded.plan == .plus)
+            #expect(decoded.status == .trialing)
+            #expect(decoded.institutionLimit == 8)
+            #expect(decoded.activeInstitutionCount == 0)
+            #expect(decoded.trialEndsAt == trialEnd)
+            #expect(decoded.features.contains("managed_linking"))
+            #expect(decoded.managedLink.canCreateManagedLink)
+            #expect(!entitlementBody.localizedCaseInsensitiveContains("secret"))
+        }
+    }
+
+    @Test("Canceled Stripe entitlement blocks future managed linking without deleting data")
+    func canceledStripeEntitlementBlocksManagedLinking() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            let routes = BillingRoutes(
+                billingStore: billingStore,
+                tokenStore: tokenStore,
+                deployment: .hostedBridge
+            )
+            try await ItemModel(
+                id: "managed-kept-after-cancel",
+                accessToken: "keychain:managed-kept-after-cancel",
+                institutionId: "ins_cancel_kept",
+                origin: .managed
+            ).save(on: fluent.db())
+            _ = try await routes.handleStripeWebhook(
+                request: try Self.makeJSONRequest(
+                    method: .post,
+                    path: "/api/billing/webhook",
+                    body: StripeBillingWebhookEvent(
+                        id: "evt_test_subscription_deleted",
+                        type: "customer.subscription.deleted",
+                        status: .canceled,
+                        plan: .plus
+                    )
+                ),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+
+            let entitlement = try await routes.getEntitlement(
+                request: Self.makeRequest(path: "/api/billing/entitlement"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let decoded = try JSONDecoder().decode(
+                BillingEntitlementSummary.self,
+                from: Data(try await Self.responseString(entitlement).utf8)
+            )
+
+            #expect(decoded.managedLink.canCreateManagedLink == false)
+            #expect(decoded.managedLink.blockReason == .subscriptionDegraded)
+            #expect(decoded.features.isEmpty)
+            #expect(try await tokenStore.getItem(id: "managed-kept-after-cancel") != nil)
+        }
+    }
+
     // MARK: - Helpers
 
     private static func makeRequest(path: String) -> Request {

--- a/docs/strategy/stripe-entitlement-seam.md
+++ b/docs/strategy/stripe-entitlement-seam.md
@@ -1,0 +1,39 @@
+# Stripe entitlement seam notes
+
+AND-348 adds the first backend Stripe-shaped subscription entitlement seam for the managed-link path. The implementation is intentionally metadata-only and local-testable: it does not require Stripe credentials, does not call Stripe over the network, and does not move billing or Plaid secrets into the SwiftUI app.
+
+## Server endpoints
+
+Authenticated `/api/billing/*` endpoints now include:
+
+- `POST /api/billing/checkout` — creates a Stripe-shaped subscription checkout session response for paid managed plans.
+- `POST /api/billing/portal` — creates a Stripe-shaped customer portal session response for card updates, cancellation, and invoices.
+- `POST /api/billing/webhook` — accepts a bounded normalized webhook projection and updates local subscription status/plan/trial metadata idempotently by event ID.
+- `GET /api/billing/entitlement` — returns the safe entitlement view used by clients: plan, subscription status, institution limit, active managed institution count, trial end, allowed feature identifiers, and managed-link eligibility.
+
+The existing `GET/PUT /api/billing/subscription` endpoint remains for already-normalized local lifecycle state.
+
+## Institution limits and cancellation
+
+The managed-link broker from AND-414 remains the enforcement point for future bank linking:
+
+- Free / missing subscription: managed linking blocked.
+- Plus active/trialing: managed linking allowed up to the managed institution limit.
+- Past due / canceled / expired: future managed linking is blocked.
+- Existing local data is not deleted by cancellation or degraded subscription state.
+- BYO/demo/local connections remain ungated.
+
+## Privacy/security boundary
+
+The entitlement API and webhook store only normalized metadata:
+
+- event ID and type
+- subscription status and plan
+- current period/trial dates
+- safe plan/count/features summary
+
+Never store or return Stripe secrets, webhook signatures, raw Stripe payloads, customer email, card/payment-method details, invoices, Plaid public tokens, Plaid access tokens, client secrets, raw Plaid payloads, account IDs, balances, transactions, database paths, logs, or screenshots.
+
+## Follow-up needed for production Stripe
+
+This PR creates the tested API and entitlement contract. A production Stripe integration still needs real Checkout/Portal session creation, webhook signature verification, Stripe product/price IDs, and durable webhook event storage in the hosted bridge environment.


### PR DESCRIPTION
## Summary

Implements AND-348 as a stacked Stripe-entitlement seam on top of #383 / AND-414:

- adds Stripe-shaped checkout and customer portal session endpoints under `/api/billing`
- adds a normalized metadata-only Stripe webhook endpoint that updates subscription status/plan/trial state idempotently by event ID
- adds `/api/billing/entitlement` returning plan, subscription status, institution limit, active managed institution count, trial state, allowed premium features, and managed-link eligibility
- wires billing entitlement into the AND-414 managed-link count/limit path so canceled/degraded subscriptions block future managed linking without deleting data
- documents Stripe/entitlement privacy boundaries and production follow-ups

Stacking note: this PR is based on `otto/and-414-managed-broker` / #383 because the entitlement API reuses the managed-link broker summary and institution-count enforcement.

## Verification

```text
git diff --check
swift test --disable-sandbox --skip-update --filter 'ConsumerFoundationTests|SubscriptionPlanTests|LinkTokenRequestTests'
# Test run with 58 tests passed

swift build --target PlaidBarServer --skip-update -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# Build of target: 'PlaidBarServer' complete
```

## Privacy / security

- Stripe webhook handling stores normalized metadata only: event ID/type, status, plan, and period/trial dates.
- No Stripe secrets, webhook signatures, raw Stripe payloads, customer emails, card/payment details, invoices, Plaid tokens, raw Plaid payloads, account IDs, balances, transactions, database paths, logs, or screenshots are exposed to the app.
- BYO/demo/local mode remains ungated.

## Limitations

This is the tested local/server contract for billing entitlements. Production still needs real Stripe Checkout/Portal API calls, webhook signature verification, Stripe product/price IDs, and durable hosted-bridge webhook event storage.

Linear: AND-348
