### PR TITLE
fix: review fixes for managed-link stack (AND-408/409/411)

### DIFF
--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -364,7 +364,10 @@ public enum WeeklyReviewBuilder {
             ))
         }
 
-        let unhealthyItems = itemStatuses.filter { $0.status != .connected }.count
+        // `.loginRepaired` is a healthy, non-degraded state; counting it via
+        // `!= .connected` produced a false "needs a check" nag right after a
+        // successful repair. Use the shared degraded predicate instead.
+        let unhealthyItems = itemStatuses.filter { $0.status.isDegraded }.count
         if unhealthyItems > 0 || isSyncStale {
             // A login-required item needs the reconnect/update-link flow, not
             // another refresh — treat it as reconnectable alongside errors so

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -962,7 +962,12 @@ struct OAuthRedirectConfiguration: Sendable, Equatable {
             guard let configuredURI else {
                 throw ServerConfigError.missingManagedRedirectURI
             }
-            if deployment == .hostedBridge, plaidEnvironment == .production, !isHTTPS(configuredURI) {
+            // Production OAuth redirect URIs must be HTTPS regardless of
+            // deployment mode (mirrors the `.app` branch): a plaintext callback
+            // would carry the one-time `state` over http. Gating on `.hostedBridge`
+            // alone left managed + local deployment + production accepting an
+            // http:// redirect — a TLS-downgrade hole.
+            if plaidEnvironment == .production, !isHTTPS(configuredURI) {
                 throw ServerConfigError.invalidManagedRedirectURI
             }
             return OAuthRedirectConfiguration(mode: .managed, uri: configuredURI)

--- a/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
+++ b/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
@@ -14,6 +14,19 @@ enum ItemStatusMapping {
         switch normalized {
         case "LOGIN_REPAIRED":
             return currentStatus.applyingLoginRepaired()
+        case "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS":
+            // Login was repaired AND Plaid has newly available accounts to grant;
+            // surface the actionable new-accounts state rather than silently
+            // clearing the prompt. Like the sibling `LOGIN_REPAIRED` branch (and
+            // `applyingLoginRepaired()`), a repair signal must never clobber a hard
+            // `.error` this receiver cannot resolve — the item still needs a full
+            // reconnect, so preserve `.error` instead of downgrading it.
+            return currentStatus == .error ? .error : .newAccountsAvailable
+        case "ERROR":
+            // A bare ITEM `ERROR` webhook whose granular `error.error_code` this
+            // receiver does not yet parse: keep the item degraded (login needed)
+            // rather than dropping the signal, preserving prior behavior.
+            return .loginRequired
         default:
             return status(forPlaidCode: normalized)
         }

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -466,18 +466,34 @@ struct OAuthCallbackRoute: Sendable {
             return [PlaidPublicTokenResult(publicToken: String(publicToken), institution: nil)]
         }
 
-        let state = request.uri.queryParameters.get("state").map { String($0) }
-        let linkSessionId = request.uri.queryParameters.get("link_session_id").map { String($0) }
-        if let completion = await hostedLinkCompletions.completion(
-            state: state,
-            linkToken: pendingSession.linkToken,
-            linkSessionId: linkSessionId
-        ), completion.status != HostedLinkCompletionStatus.success {
+        // The authoritative source of truth for whether a Hosted Link session
+        // produced a usable token is Plaid's own link-session lookup — never the
+        // `/webhooks/plaid/hosted-link` receiver, which is unauthenticated. Fetch
+        // it first so a forged "failure" completion can never veto a genuine
+        // success.
+        let linkSession = try await plaidClient.getLinkToken(pendingSession.linkToken)
+        let results = linkSession.publicTokenResults
+        if !results.isEmpty {
+            return results
+        }
+
+        // Plaid returned no public token. Only then consult completion metadata to
+        // surface a precise failure message — and ONLY when it is bound to the
+        // unguessable, single-use `state`. The `link_token`/`link_session_id` keys
+        // are handed to the client and surfaced by Plaid's UI, so trusting them
+        // here would let any local caller poison the shared completion store to
+        // grief a known link session.
+        if let state = request.uri.queryParameters.get("state").map({ String($0) }),
+           let completion = await hostedLinkCompletions.completion(
+               state: state,
+               linkToken: nil,
+               linkSessionId: nil
+           ),
+           completion.status != HostedLinkCompletionStatus.success {
             throw HostedLinkCompletionError.status(completion.status)
         }
 
-        let linkSession = try await plaidClient.getLinkToken(pendingSession.linkToken)
-        return linkSession.publicTokenResults
+        return results
     }
 
     /// Exchanges the result's public token and persists the item, returning an

--- a/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
@@ -154,22 +154,8 @@ struct PlaidWebhookEvent: Decodable, Sendable {
             ),
             eventAt: timestamp,
             receivedAt: receivedAt,
-            status: Self.statusSignal(webhookCode: webhookCode),
             needsSync: Self.needsSync(webhookCode: webhookCode)
         )
-    }
-
-    static func statusSignal(webhookCode: String) -> WebhookItemStatusSignal {
-        switch webhookCode {
-        case "ERROR", "ITEM_LOGIN_REQUIRED":
-            return .loginRequired
-        case "LOGIN_REPAIRED", "PENDING_EXPIRATION":
-            return .connected
-        case "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS":
-            return .connected
-        default:
-            return .unchanged
-        }
     }
 
     static func needsSync(webhookCode: String) -> Bool {
@@ -260,18 +246,22 @@ struct WebhookRoutes: Sendable {
         return try Self.jsonResponse(WebhookReceiveResponse(disposition: result.disposition.rawValue))
     }
 
+    /// Resolves the webhook code against the item's *current* status through the
+    /// single source of truth (`ItemStatusMapping`) and persists the result. The
+    /// current status must be read here because consent-repair codes such as
+    /// `LOGIN_REPAIRED` are status-relative (a repair must not clobber a hard
+    /// `.error`), so the resulting status cannot be precomputed when the signal is
+    /// built.
     private func apply(_ signal: WebhookItemSignal) async throws {
-        guard try await tokenStore.getItem(id: signal.itemId) != nil else { return }
-        switch signal.status {
-        case .connected:
-            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.connected.rawValue)
-        case .loginRequired:
-            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.loginRequired.rawValue)
-        case .error:
-            try await tokenStore.updateItemStatus(id: signal.itemId, status: ItemConnectionStatus.error.rawValue)
-        case .unchanged:
-            break
+        guard let item = try await tokenStore.getItem(id: signal.itemId) else { return }
+        let current = ItemConnectionStatus(rawValue: item.status) ?? .error
+        guard let resolved = ItemStatusMapping.status(
+            forWebhookCode: signal.webhookCode,
+            currentStatus: current
+        ), resolved != current else {
+            return
         }
+        try await tokenStore.updateItemStatus(id: signal.itemId, status: resolved.rawValue)
     }
 
     private static let maxBodyBytes = 128 * 1024

--- a/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
+++ b/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
@@ -79,19 +79,11 @@ struct WebhookItemSignal: Sendable {
     let idempotencyHash: String
     let eventAt: Date?
     let receivedAt: Date
-    let status: WebhookItemStatusSignal
     let needsSync: Bool
 
     var effectiveDate: Date {
         eventAt ?? receivedAt
     }
-}
-
-enum WebhookItemStatusSignal: Sendable, Equatable {
-    case connected
-    case loginRequired
-    case error
-    case unchanged
 }
 
 struct WebhookStoreResult: Sendable, Equatable {
@@ -154,7 +146,6 @@ actor WebhookEventStore {
 
     private static func signal(from model: WebhookEventModel) -> WebhookItemSignal? {
         guard let receivedAt = model.receivedAt else { return nil }
-        let status = PlaidWebhookEvent.statusSignal(webhookCode: model.webhookCode)
         return WebhookItemSignal(
             itemId: model.itemId,
             webhookType: model.webhookType,
@@ -163,7 +154,6 @@ actor WebhookEventStore {
             idempotencyHash: model.idempotencyHash,
             eventAt: model.eventAt,
             receivedAt: receivedAt,
-            status: status,
             needsSync: PlaidWebhookEvent.needsSync(webhookCode: model.webhookCode)
         )
     }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3390,6 +3390,32 @@ struct PlaidBarCoreTests {
         #expect(ItemConnectionStatus.error.applyingLoginRepaired() == .error)
     }
 
+    @Test("Degraded and update-mode predicates classify every item status")
+    func itemStatusDegradedAndUpdateModePredicates() {
+        // `.loginRepaired` is healthy (no weekly-review nag, no degraded count);
+        // every other non-connected state is degraded. This locks the predicate
+        // that WeeklyReview and DashboardChangeReceipt now filter on.
+        #expect(ItemConnectionStatus.connected.isDegraded == false)
+        #expect(ItemConnectionStatus.loginRepaired.isDegraded == false)
+        #expect(ItemConnectionStatus.loginRequired.isDegraded)
+        #expect(ItemConnectionStatus.pendingExpiration.isDegraded)
+        #expect(ItemConnectionStatus.pendingDisconnect.isDegraded)
+        #expect(ItemConnectionStatus.permissionRevoked.isDegraded)
+        #expect(ItemConnectionStatus.newAccountsAvailable.isDegraded)
+        #expect(ItemConnectionStatus.error.isDegraded)
+
+        // Update mode recovers consent/login states; `.error` needs a full
+        // reconnect, and `.connected`/`.loginRepaired` need nothing.
+        #expect(ItemConnectionStatus.loginRequired.needsUpdateMode)
+        #expect(ItemConnectionStatus.pendingExpiration.needsUpdateMode)
+        #expect(ItemConnectionStatus.pendingDisconnect.needsUpdateMode)
+        #expect(ItemConnectionStatus.permissionRevoked.needsUpdateMode)
+        #expect(ItemConnectionStatus.newAccountsAvailable.needsUpdateMode)
+        #expect(ItemConnectionStatus.connected.needsUpdateMode == false)
+        #expect(ItemConnectionStatus.loginRepaired.needsUpdateMode == false)
+        #expect(ItemConnectionStatus.error.needsUpdateMode == false)
+    }
+
     // MARK: - PlaidEnvironment Tests
 
     @Test("PlaidEnvironment raw values")

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -352,6 +352,23 @@ struct HostedLinkOAuthRedirectReadinessTests {
         #expect(config.oauthRedirect.isProductionReadyForHostedLink)
     }
 
+    @Test("Managed production rejects http redirect even without hosted-bridge deployment")
+    func managedProductionRejectsHTTPRedirectInLocalDeployment() throws {
+        // Before the fix the HTTPS gate keyed on `.hostedBridge`, so managed mode
+        // + local deployment + production accepted a plaintext redirect carrying
+        // the one-time state. It must reject regardless of deployment mode.
+        #expect(throws: ServerConfigError.self) {
+            _ = try loadConfig([
+                "PLAID_CLIENT_ID=client",
+                "PLAID_SECRET=secret",
+                "PLAID_ENV=production",
+                "PLAIDBAR_DEPLOYMENT=local",
+                "PLAIDBAR_OAUTH_REDIRECT_MODE=managed",
+                "PLAIDBAR_OAUTH_REDIRECT_URI=http://broker.vaultpeek.example/oauth/callback",
+            ])
+        }
+    }
+
     private func loadConfig(_ lines: [String]) throws -> ServerConfig {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("plaidbar-oauth-redirect-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1504,6 +1504,21 @@ struct PlaidBarServerTests {
         #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .error) == .error)
     }
 
+    @Test("Webhook ERROR and repaired-with-new-accounts codes map correctly and preserve hard errors")
+    func webhookItemStatusMappingHandlesErrorAndRepairedWithNewAccounts() {
+        // A bare ITEM `ERROR` keeps the item degraded (login needed) rather than
+        // dropping the signal — independent of the current status.
+        #expect(ItemStatusMapping.status(forWebhookCode: "ERROR", currentStatus: .connected) == .loginRequired)
+        #expect(ItemStatusMapping.status(forWebhookCode: "ERROR", currentStatus: .pendingExpiration) == .loginRequired)
+
+        // `LOGIN_REPAIRED_WITH_NEW_ACCOUNTS` surfaces the actionable new-accounts
+        // state from any non-error baseline...
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS", currentStatus: .connected) == .newAccountsAvailable)
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS", currentStatus: .pendingDisconnect) == .newAccountsAvailable)
+        // ...but, like `LOGIN_REPAIRED`, it must not clobber a hard `.error`.
+        #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED_WITH_NEW_ACCOUNTS", currentStatus: .error) == .error)
+    }
+
     @Test("Balance refresh all-failure behavior is unchanged while bounded")
     func balanceRefreshAllFailureStillThrowsBadGateway() async throws {
         let directory = FileManager.default.temporaryDirectory
@@ -1980,6 +1995,99 @@ struct PlaidBarServerTests {
             #expect(response.status == .ok)
             #expect(calls.linkTokens == [linkToken])
             #expect(calls.publicTokens.isEmpty)
+            #expect(storedPublicTokens == [publicToken])
+        }
+    }
+
+    @Test("Forged hosted-link completion keyed by link_token cannot veto a real success")
+    func forgedHostedLinkCompletionCannotVetoRealSuccess() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-hosted-link-poison-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let linkToken = "poison-link-token"
+        let publicToken = "poison-public-token"
+        let linkSessionId = "poison-link-session"
+        let linkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: linkToken,
+            linkSessions: [
+                PlaidLinkSession(
+                    linkSessionId: linkSessionId,
+                    results: PlaidLinkResults(
+                        itemAddResults: [
+                            PlaidLinkItemAddResult(
+                                publicToken: publicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Honest Bank",
+                                    institutionId: "ins_honest"
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            onSuccess: nil,
+            results: nil
+        )
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: "unused-access-token",
+                itemId: "unused-item",
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: "unused-item",
+                    institutionId: "ins_honest",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let hostedLinkCompletions = HostedLinkCompletionStore()
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+
+        // Attacker pre-seeds a non-success completion keyed only by the non-secret
+        // link_token (no unguessable `state`), exactly as an unauthenticated POST
+        // to /webhooks/plaid/hosted-link could.
+        await hostedLinkCompletions.record(HostedLinkCompletionRecord(
+            state: nil,
+            linkToken: linkToken,
+            linkSessionId: nil,
+            status: .userExit
+        ))
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.hosted-link-poison")
+        let recorder = HostedLinkCompletionResultRecorder()
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions,
+                hostedLinkCompletions: hostedLinkCompletions,
+                storePublicTokenResult: { result in
+                    await recorder.store(result)
+                }
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)&link_session_id=\(linkSessionId)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let storedPublicTokens = await recorder.recordedPublicTokens()
+
+            // The authoritative Plaid session lookup wins; the forged failure,
+            // keyed only by the non-secret link_token, cannot veto it.
+            #expect(response.status == .ok)
             #expect(storedPublicTokens == [publicToken])
         }
     }

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -164,7 +164,7 @@ struct WebhookReceiverTests {
             let status = try await statusRoutes.statusSnapshot(includeItems: true)
             let item = try #require(status.itemStatuses?.first)
 
-            #expect(item.status == .connected)
+            #expect(item.status == .loginRepaired)
             #expect(item.lastWebhookEvent == "ITEM.LOGIN_REPAIRED")
             #expect(item.lastWebhookAt != nil)
             #expect(item.needsSync == false)
@@ -182,7 +182,6 @@ struct WebhookReceiverTests {
                 idempotencyHash: "sync-\(UUID().uuidString)",
                 eventAt: Date(),
                 receivedAt: Date(),
-                status: .unchanged,
                 needsSync: true
             )
             _ = try await eventStore.record(signal)
@@ -199,6 +198,57 @@ struct WebhookReceiverTests {
             try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
             let refreshed = try await statusRoutes.statusSnapshot(includeItems: true)
             #expect(!((try #require(refreshed.itemStatuses?.first)).needsSync))
+        }
+    }
+
+    @Test("Consent-repair webhook codes persist their modeled item status")
+    func consentRepairWebhookCodesPersistModeledStatus() async throws {
+        let scenarios: [(code: String, expected: ItemConnectionStatus)] = [
+            ("PENDING_EXPIRATION", .pendingExpiration),
+            ("PENDING_DISCONNECT", .pendingDisconnect),
+            ("USER_PERMISSION_REVOKED", .permissionRevoked),
+            ("NEW_ACCOUNTS_AVAILABLE", .newAccountsAvailable),
+        ]
+        for scenario in scenarios {
+            try await Self.withStores { tokenStore, eventStore in
+                // The fresh item defaults to `.connected`; the consent code must
+                // move it to its modeled repair state, not silently no-op or get
+                // flattened to `.connected` by the old coarse mapper.
+                let route = WebhookRoutes(
+                    verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                    tokenStore: tokenStore,
+                    eventStore: eventStore,
+                    now: { Date(timeIntervalSince1970: 1_800_000_000) }
+                )
+                let body = Self.payload(webhookCode: scenario.code)
+                _ = try await route.receive(
+                    request: Self.request(body: body, jwt: Self.jwt(iat: 1_800_000_000, body: Data(body.utf8))),
+                    context: WebhookTestContext(source: WebhookTestContextSource())
+                )
+                let persisted = try await tokenStore.getItem(id: "item-webhook")?.status
+                #expect(persisted == scenario.expected.rawValue, "webhook \(scenario.code)")
+            }
+        }
+    }
+
+    @Test("LOGIN_REPAIRED does not clobber a hard item error")
+    func loginRepairedDoesNotClobberError() async throws {
+        try await Self.withStores { tokenStore, eventStore in
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.error.rawValue)
+            let route = WebhookRoutes(
+                verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            let body = Self.payload(webhookCode: "LOGIN_REPAIRED")
+            _ = try await route.receive(
+                request: Self.request(body: body, jwt: Self.jwt(iat: 1_800_000_000, body: Data(body.utf8))),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+            // A repair must not flip a hard error to connected/repaired; the item
+            // still needs a full reconnect.
+            #expect(try await tokenStore.getItem(id: "item-webhook")?.status == ItemConnectionStatus.error.rawValue)
         }
     }
 


### PR DESCRIPTION
## Why

An adversarial multi-agent review of the `otto/and-408..411` managed-link stack (PRs #379–#382) surfaced confirmed defects that ship inside a green build. This PR stacks on **#382** and resolves the **fix-before-merge blockers** plus the one **live-in-beta** finding. It does not change merge readiness of the underlying stack — it makes it mergeable.

The full strict-concurrency build (3 targets, `-warnings-as-errors`) and the complete suite (**766 tests**) pass locally with these changes.

## Fixes

### 1. Blocker — webhook status mis-mapping / dead mapper (AND-411)
The live receiver mapped status via the coarse `statusSignal`, which sent `PENDING_EXPIRATION → .connected`, silently dropped `PENDING_DISCONNECT` / `USER_PERMISSION_REVOKED` / `NEW_ACCOUNTS_AVAILABLE`, and clobbered a hard `.error` on `LOGIN_REPAIRED` — while the correct `ItemStatusMapping` had **zero production callers** and only the dead path was tested. `apply()` now routes through `ItemStatusMapping` against the item's *current* status, and the redundant `WebhookItemStatusSignal`/`statusSignal` is removed (single source of truth). Preserved `ERROR → loginRequired`; mapped `LOGIN_REPAIRED_WITH_NEW_ACCOUNTS → newAccountsAvailable`.

### 2. Blocker — Hosted Link completion-webhook poisoning (AND-409)
The unauthenticated `/webhooks/plaid/hosted-link` receiver writes into the first-writer-wins completion store the OAuth callback reads to gate token exchange. Keyed on the non-secret `link_token`/`link_session_id`, a forged non-success record could veto a victim's genuine link. `publicTokenResults` now fetches Plaid's authoritative link-session result first and prefers a real success; it consults completion metadata only when bound to the unguessable single-use `state`.

### 3. Live-in-beta — WeeklyReview false-nag (AND-411)
`WeeklyReview` counted unhealthy items via `status != .connected`, so a freshly repaired `.loginRepaired` item produced a false "needs a check" nag. Now filters on the shared `.isDegraded` predicate.

### 4. Defense-in-depth — managed-redirect TLS gate (AND-408)
The managed-mode HTTPS requirement keyed on `deployment == .hostedBridge`, so managed + local deployment + production accepted a plaintext `http://` redirect carrying the one-time `state`. Now gates on `production` regardless of deployment (mirrors the `.app` branch).

## Tests added
- Receiver-level: each of the four consent codes persists its modeled `ItemConnectionStatus`; `LOGIN_REPAIRED` does not clobber `.error`.
- Adversarial: a forged `user_exit` keyed by `link_token` cannot veto a real Plaid success.
- Predicate matrix: `isDegraded` / `needsUpdateMode` for all 8 statuses.
- Config: managed + local + production + `http://` now throws.

## Deferred (documented follow-ups, not blockers)
- `HostedLinkCompletionStore` TTL/size-cap/eviction + O(n²) per-insert index rebuild.
- `needsPollingSync` staleness (latest-SYNC-bearing event; compare vs sync-cursor commit time, not `item.updatedAt`).
- Verifier adversarial regression tests (`alg:"none"`, 2-/4-segment tokens, future `iat`, undecodable segment) + missing-header 401 + a doc/tracking marker on `UnconfiguredPlaidWebhookSignatureValidator`.

## Provenance
Generated by an automated PR-review loop. **Hold for human merge decision** — security-sensitive OAuth/webhook code; the underlying stack has no CI gate and no prior human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)