### PR TITLE
fix: close managed-broker + Stripe un-gating security holes (AND-414/AND-348)

### DIFF
--- a/Sources/PlaidBarServer/Routes/BillingRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/BillingRoutes.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Hummingbird
+import HTTPTypes
 import NIOCore
 import PlaidBarCore
 
@@ -14,17 +15,23 @@ struct BillingRoutes: Sendable {
     let tokenStore: TokenStore?
     let deployment: DeploymentMode
     let webhookEvents: StripeBillingEventStore
+    let verifier: any StripeWebhookVerifier
+    let now: @Sendable () -> Date
 
     init(
         billingStore: BillingSubscriptionStore,
         tokenStore: TokenStore? = nil,
         deployment: DeploymentMode = .local,
-        webhookEvents: StripeBillingEventStore = StripeBillingEventStore()
+        webhookEvents: StripeBillingEventStore = StripeBillingEventStore(),
+        verifier: any StripeWebhookVerifier = UnconfiguredStripeWebhookVerifier(),
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.billingStore = billingStore
         self.tokenStore = tokenStore
         self.deployment = deployment
         self.webhookEvents = webhookEvents
+        self.verifier = verifier
+        self.now = now
     }
 
     func register(with group: RouterGroup<some RequestContext>) {
@@ -91,10 +98,21 @@ struct BillingRoutes: Sendable {
 
     @Sendable
     func handleStripeWebhook(request: Request, context: some RequestContext) async throws -> Response {
-        let event: StripeBillingWebhookEvent = try await Self.decodeBody(
-            request,
-            errorMessage: "Invalid Stripe billing webhook payload"
-        )
+        // Verify authenticity over the EXACT received bytes BEFORE decoding or
+        // applying anything. The default verifier is fail-closed, so an unsigned
+        // or forged event mutates nothing — mirroring the Plaid webhook path and
+        // closing the free-premium / cap-raise hole once this route is exposed.
+        let buffer = try await request.body.collect(upTo: Self.maxBodyBytes)
+        let payload = Data(buffer: buffer)
+        let signatureHeader = HTTPField.Name("Stripe-Signature").flatMap { request.headers[$0] }
+        try await verifier.verify(payload: payload, signatureHeader: signatureHeader, now: now())
+
+        let event: StripeBillingWebhookEvent
+        do {
+            event = try Self.webhookDecoder.decode(StripeBillingWebhookEvent.self, from: payload)
+        } catch {
+            throw HTTPError(.badRequest, message: "Invalid Stripe billing webhook payload")
+        }
         let inserted = await webhookEvents.recordIfNew(event.id)
         if inserted {
             _ = try await billingStore.save(SaveBillingSubscriptionRequest(
@@ -158,6 +176,12 @@ struct BillingRoutes: Sendable {
 
     /// Upper bound for the small JSON billing payload.
     private static let maxBodyBytes = 64 * 1024
+
+    private static let webhookDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 
     private static func jsonResponse(_ value: some Encodable) throws -> Response {
         let encoder = JSONEncoder()

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -370,6 +370,7 @@ struct OAuthCallbackRoute: Sendable {
                     continue
                 }
 
+                var managedInstitutionLimit: Int?
                 if pendingSession.origin == .managed {
                     let summary = try await managedEntitlementSummary()
                     guard summary.canCreateManagedLink else {
@@ -378,6 +379,12 @@ struct OAuthCallbackRoute: Sendable {
                             summary.message ?? "Managed bank linking is unavailable."
                         )
                     }
+                    // The pre-check avoids spending a single-use token on a
+                    // degraded/absent subscription; the authoritative cap is
+                    // re-checked atomically at insert time
+                    // (TokenStore.saveManagedItemEnforcingLimit), which closes the
+                    // concurrent check-then-insert overshoot.
+                    managedInstitutionLimit = summary.institutionLimit
                 }
 
                 let outcome: StoreResultOutcome
@@ -386,7 +393,8 @@ struct OAuthCallbackRoute: Sendable {
                 } else {
                     outcome = await storeResult(
                         publicTokenResult: publicTokenResult,
-                        origin: pendingSession.origin
+                        origin: pendingSession.origin,
+                        institutionLimit: managedInstitutionLimit
                     )
                 }
                 switch outcome {
@@ -514,7 +522,8 @@ struct OAuthCallbackRoute: Sendable {
 
     private func storeResult(
         publicTokenResult: PlaidPublicTokenResult,
-        origin: ItemOrigin
+        origin: ItemOrigin,
+        institutionLimit: Int?
     ) async -> StoreResultOutcome {
         let exchangeResponse: PlaidTokenExchangeResponse
         do {
@@ -537,13 +546,27 @@ struct OAuthCallbackRoute: Sendable {
         let institutionId = publicTokenResult.institution?.institutionId ?? accountsItemInstitutionId
 
         do {
-            try await tokenStore.saveItem(
-                id: exchangeResponse.itemId,
-                accessToken: exchangeResponse.accessToken,
-                institutionId: institutionId,
-                institutionName: publicTokenResult.institution?.normalizedName,
-                origin: origin
-            )
+            if origin == .managed, let institutionLimit {
+                // Atomic count-check-and-insert: a concurrent managed completion
+                // that won the last slot makes this throw `.limitReached`. The
+                // token is already spent, so report spent-but-not-stored (re-link)
+                // rather than overshooting the institution cap.
+                try await tokenStore.saveManagedItemEnforcingLimit(
+                    id: exchangeResponse.itemId,
+                    accessToken: exchangeResponse.accessToken,
+                    institutionId: institutionId,
+                    institutionName: publicTokenResult.institution?.normalizedName,
+                    institutionLimit: institutionLimit
+                )
+            } else {
+                try await tokenStore.saveItem(
+                    id: exchangeResponse.itemId,
+                    accessToken: exchangeResponse.accessToken,
+                    institutionId: institutionId,
+                    institutionName: publicTokenResult.institution?.normalizedName,
+                    origin: origin
+                )
+            }
         } catch {
             return .spentButNotStored
         }

--- a/Sources/PlaidBarServer/Routes/StripeWebhookVerifier.swift
+++ b/Sources/PlaidBarServer/Routes/StripeWebhookVerifier.swift
@@ -1,0 +1,102 @@
+import CryptoKit
+import Foundation
+
+/// Verifies the authenticity of an incoming Stripe webhook before its normalized
+/// projection is applied to billing state.
+///
+/// Mirrors the Plaid webhook path: the default implementation is **fail-closed**
+/// (`UnconfiguredStripeWebhookVerifier`), so the seam rejects every event until a
+/// real signing-secret-backed verifier is wired. This prevents a forged or
+/// unsigned event from granting premium or raising the managed-link institution
+/// limit once the route is exposed for real Stripe delivery.
+protocol StripeWebhookVerifier: Sendable {
+    /// Verifies `payload` (the EXACT received request bytes) against
+    /// `signatureHeader` (the `Stripe-Signature` header). Throws on any failure;
+    /// the caller must mutate no state when this throws.
+    func verify(payload: Data, signatureHeader: String?, now: Date) async throws
+}
+
+enum StripeWebhookVerificationError: Error, Equatable {
+    case signatureVerificationUnavailable
+    case missingSignatureHeader
+    case malformedSignatureHeader
+    case timestampOutOfTolerance
+    case signatureMismatch
+}
+
+/// Fail-closed default: rejects every webhook until a signing-secret-backed
+/// verifier is configured. This is the production default until Stripe webhook
+/// signature verification is wired (see `docs/strategy/stripe-entitlement-seam.md`).
+struct UnconfiguredStripeWebhookVerifier: StripeWebhookVerifier {
+    func verify(payload: Data, signatureHeader: String?, now: Date) async throws {
+        throw StripeWebhookVerificationError.signatureVerificationUnavailable
+    }
+}
+
+/// Verifies Stripe's `Stripe-Signature` header by recomputing the HMAC-SHA256 of
+/// `"{t}.{rawBody}"` with the endpoint signing secret, over the EXACT received
+/// bytes — never a re-serialized projection. Rejects stale timestamps (replay)
+/// and any signature that does not match. Wire this with the configured signing
+/// secret to make the seam production-ready.
+struct StripeSignatureWebhookVerifier: StripeWebhookVerifier {
+    let signingSecret: String
+    var tolerance: TimeInterval = 5 * 60
+
+    func verify(payload: Data, signatureHeader: String?, now: Date = Date()) async throws {
+        guard let signatureHeader else {
+            throw StripeWebhookVerificationError.missingSignatureHeader
+        }
+        let parsed = try Self.parse(signatureHeader)
+        guard abs(now.timeIntervalSince1970 - parsed.timestamp) <= tolerance else {
+            throw StripeWebhookVerificationError.timestampOutOfTolerance
+        }
+        var signedPayload = Data(parsed.timestampField.utf8)
+        signedPayload.append(0x2e) // "."
+        signedPayload.append(payload)
+        let mac = HMAC<SHA256>.authenticationCode(
+            for: signedPayload,
+            using: SymmetricKey(data: Data(signingSecret.utf8))
+        )
+        let expected = mac.map { String(format: "%02x", $0) }.joined()
+        guard parsed.signatures.contains(where: { Self.constantTimeEquals($0, expected) }) else {
+            throw StripeWebhookVerificationError.signatureMismatch
+        }
+    }
+
+    private static func parse(
+        _ header: String
+    ) throws -> (timestampField: String, timestamp: TimeInterval, signatures: [String]) {
+        var timestampField: String?
+        var signatures: [String] = []
+        for element in header.split(separator: ",") {
+            let pair = element.split(separator: "=", maxSplits: 1)
+            guard pair.count == 2 else { continue }
+            let key = pair[0].trimmingCharacters(in: .whitespaces)
+            let value = pair[1].trimmingCharacters(in: .whitespaces)
+            switch key {
+            case "t": timestampField = value
+            case "v1": signatures.append(value)
+            default: break
+            }
+        }
+        guard let timestampField,
+              let timestamp = TimeInterval(timestampField),
+              !signatures.isEmpty
+        else {
+            throw StripeWebhookVerificationError.malformedSignatureHeader
+        }
+        return (timestampField, timestamp, signatures)
+    }
+
+    /// Length-checked, constant-time hex comparison.
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        guard lhsBytes.count == rhsBytes.count else { return false }
+        var difference: UInt8 = 0
+        for (left, right) in zip(lhsBytes, rhsBytes) {
+            difference |= left ^ right
+        }
+        return difference == 0
+    }
+}

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -13,6 +13,14 @@ actor TokenStore {
         self.logger = logger
     }
 
+    // Serializes managed-item inserts so the institution-limit check and the
+    // insert are not interleaved by actor reentrancy at `await` points (Fluent
+    // calls suspend, so an actor method alone is not atomic across them). The
+    // companion server is a single local process, so an in-process FIFO gate
+    // fully orders managed inserts.
+    private var managedInsertLocked = false
+    private var managedInsertWaiters: [CheckedContinuation<Void, Never>] = []
+
     // MARK: - Items
 
     func saveItem(
@@ -36,6 +44,65 @@ actor TokenStore {
             origin: origin
         )
         try await item.save(on: fluent.db())
+    }
+
+    /// Atomically enforces the managed institution limit and persists the item.
+    /// The count read and the insert run under an in-process serialization lock,
+    /// so two concurrent managed link completions cannot both observe
+    /// `count < limit` and both insert (a TOCTOU overshoot of the cap). Throws
+    /// `ManagedLinkEnforcementError.limitReached` when already at capacity, which
+    /// the OAuth callback maps to a spent-but-not-stored result (the user re-links).
+    func saveManagedItemEnforcingLimit(
+        id: String,
+        accessToken: String,
+        institutionId: String?,
+        institutionName: String?,
+        providerID: ProviderID = .plaid,
+        institutionLimit: Int
+    ) async throws {
+        await acquireManagedInsertLock()
+        let outcome: Result<Void, Error>
+        do {
+            let existingInstitutionKeys = try await activeInstitutionKeys(origin: .managed)
+            let incomingInstitutionKey = institutionId ?? id
+            if existingInstitutionKeys.count >= institutionLimit,
+               !existingInstitutionKeys.contains(incomingInstitutionKey) {
+                outcome = .failure(ManagedLinkEnforcementError.limitReached)
+            } else {
+                try await saveItem(
+                    id: id,
+                    accessToken: accessToken,
+                    institutionId: institutionId,
+                    institutionName: institutionName,
+                    providerID: providerID,
+                    origin: .managed
+                )
+                outcome = .success(())
+            }
+        } catch {
+            outcome = .failure(error)
+        }
+        releaseManagedInsertLock()
+        try outcome.get()
+    }
+
+    private func acquireManagedInsertLock() async {
+        if !managedInsertLocked {
+            managedInsertLocked = true
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            managedInsertWaiters.append(continuation)
+        }
+        // Resumed: the lock was handed off to us; `managedInsertLocked` stays true.
+    }
+
+    private func releaseManagedInsertLock() {
+        if managedInsertWaiters.isEmpty {
+            managedInsertLocked = false
+        } else {
+            managedInsertWaiters.removeFirst().resume()
+        }
     }
 
     func getItem(id: String) async throws -> ItemModel? {
@@ -101,6 +168,10 @@ actor TokenStore {
     }
 
     func activeInstitutionCount(origin: ItemOrigin) async throws -> Int {
+        try await activeInstitutionKeys(origin: origin).count
+    }
+
+    private func activeInstitutionKeys(origin: ItemOrigin) async throws -> Set<String> {
         let items = try await ItemModel.query(on: fluent.db())
             .filter(\.$origin == origin.rawValue)
             .all()
@@ -110,7 +181,7 @@ actor TokenStore {
             }
             return item.institutionId ?? item.id
         }
-        return Set(activeInstitutionKeys).count
+        return Set(activeInstitutionKeys)
     }
 
     func lastSyncDate() async throws -> Date? {
@@ -127,4 +198,11 @@ actor TokenStore {
     nonisolated func accessToken(for item: ItemModel) throws -> String {
         try PlaidTokenVault.resolve(storedToken: item.accessToken)
     }
+}
+
+/// Raised when a managed bank-link insert would exceed the plan's institution
+/// limit at the moment of insertion (after the entitlement pre-check), closing
+/// the check-then-insert race.
+enum ManagedLinkEnforcementError: Error, Equatable {
+    case limitReached
 }

--- a/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
+++ b/Tests/PlaidBarServerTests/ConsumerFoundationTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import FluentKit
 import FluentSQLiteDriver
@@ -9,6 +10,23 @@ import NIOCore
 @testable import PlaidBarCore
 @testable import PlaidBarServer
 import Testing
+
+private let consumerTestsKeychainAvailable: Bool = {
+    let itemId = "consumer_keychain_probe_\(UUID().uuidString)"
+    do {
+        let storedToken = try PlaidTokenVault.store(accessToken: "probe-token", itemId: itemId)
+        try PlaidTokenVault.delete(storedToken: storedToken, fallbackItemId: itemId)
+        return true
+    } catch {
+        return false
+    }
+}()
+
+/// Accepting verifier for tests that exercise webhook *application* logic; the
+/// fail-closed default is asserted separately.
+private struct AcceptingStripeWebhookVerifier: StripeWebhookVerifier {
+    func verify(payload: Data, signatureHeader: String?, now: Date) async throws {}
+}
 
 /// Foundation tests for the consumer (Hosted Link) deployment seam. These prove
 /// the seam is inert: `.local` is the default, the bridge holds no live
@@ -591,7 +609,8 @@ struct ConsumerFoundationTests {
             let routes = BillingRoutes(
                 billingStore: billingStore,
                 tokenStore: tokenStore,
-                deployment: .hostedBridge
+                deployment: .hostedBridge,
+                verifier: AcceptingStripeWebhookVerifier()
             )
             let trialEnd = Date(timeIntervalSince1970: 1_800_000_000)
             let webhook = StripeBillingWebhookEvent(
@@ -640,7 +659,8 @@ struct ConsumerFoundationTests {
             let routes = BillingRoutes(
                 billingStore: billingStore,
                 tokenStore: tokenStore,
-                deployment: .hostedBridge
+                deployment: .hostedBridge,
+                verifier: AcceptingStripeWebhookVerifier()
             )
             try await ItemModel(
                 id: "managed-kept-after-cancel",
@@ -675,6 +695,175 @@ struct ConsumerFoundationTests {
             #expect(decoded.managedLink.blockReason == .subscriptionDegraded)
             #expect(decoded.features.isEmpty)
             #expect(try await tokenStore.getItem(id: "managed-kept-after-cancel") != nil)
+        }
+    }
+
+    @Test("Stripe webhook fails closed by default: an unverified event mutates no billing state")
+    func stripeWebhookFailsClosedByDefault() async throws {
+        try await withFluent { fluent in
+            let billingStore = BillingSubscriptionStore(fluent: fluent)
+            // Default verifier is UnconfiguredStripeWebhookVerifier (fail-closed).
+            let routes = BillingRoutes(billingStore: billingStore, deployment: .hostedBridge)
+            await #expect(throws: StripeWebhookVerificationError.signatureVerificationUnavailable) {
+                _ = try await routes.handleStripeWebhook(
+                    request: try Self.makeJSONRequest(
+                        method: .post,
+                        path: "/api/billing/webhook",
+                        body: StripeBillingWebhookEvent(
+                            id: "evt_forged_active",
+                            type: "customer.subscription.updated",
+                            status: .active,
+                            plan: .plus
+                        )
+                    ),
+                    context: TestRequestContext(source: TestRequestContextSource())
+                )
+            }
+            // A forged event granted nothing.
+            let granted = try await billingStore.currentSubscription()
+            #expect(granted == nil)
+        }
+    }
+
+    @Test("Unconfigured Stripe verifier rejects every event")
+    func unconfiguredStripeVerifierRejects() async {
+        await #expect(throws: StripeWebhookVerificationError.signatureVerificationUnavailable) {
+            try await UnconfiguredStripeWebhookVerifier().verify(
+                payload: Data("{}".utf8),
+                signatureHeader: "t=1,v1=abc",
+                now: Date(timeIntervalSince1970: 1)
+            )
+        }
+    }
+
+    @Test("HMAC Stripe verifier accepts a correctly signed payload and rejects tampering")
+    func hmacStripeVerifierAcceptsValidRejectsInvalid() async throws {
+        let secret = "whsec_test_secret"
+        let verifier = StripeSignatureWebhookVerifier(signingSecret: secret)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let payload = Data(#"{"id":"evt_1","type":"customer.subscription.updated"}"#.utf8)
+        let timestamp = String(Int(now.timeIntervalSince1970))
+        var signed = Data(timestamp.utf8)
+        signed.append(0x2e)
+        signed.append(payload)
+        let mac = HMAC<SHA256>.authenticationCode(for: signed, using: SymmetricKey(data: Data(secret.utf8)))
+        let signature = mac.map { String(format: "%02x", $0) }.joined()
+
+        // Correctly signed payload passes.
+        try await verifier.verify(payload: payload, signatureHeader: "t=\(timestamp),v1=\(signature)", now: now)
+        // Wrong signature rejected.
+        await #expect(throws: StripeWebhookVerificationError.signatureMismatch) {
+            try await verifier.verify(payload: payload, signatureHeader: "t=\(timestamp),v1=deadbeef", now: now)
+        }
+        // Missing header rejected.
+        await #expect(throws: StripeWebhookVerificationError.missingSignatureHeader) {
+            try await verifier.verify(payload: payload, signatureHeader: nil, now: now)
+        }
+        // Stale timestamp (replay) rejected.
+        await #expect(throws: StripeWebhookVerificationError.timestampOutOfTolerance) {
+            try await verifier.verify(
+                payload: payload,
+                signatureHeader: "t=\(timestamp),v1=\(signature)",
+                now: now.addingTimeInterval(3600)
+            )
+        }
+    }
+
+    @Test(
+        "Concurrent managed inserts never exceed the institution limit",
+        .enabled(if: consumerTestsKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func concurrentManagedInsertsRespectLimit() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let limit = SubscriptionPlan.plus.institutionLimit
+            // Seed limit-1 managed institutions, leaving exactly one open slot.
+            for index in 0 ..< (limit - 1) {
+                try await ItemModel(
+                    id: "seed-managed-\(index)",
+                    accessToken: "keychain:seed-managed-\(index)",
+                    institutionId: "ins_seed_\(index)",
+                    origin: .managed
+                ).save(on: fluent.db())
+            }
+            // Drive `limit` concurrent inserts, each a distinct new institution. Only
+            // one may win the last slot; without atomic enforcement they would all
+            // observe count == limit-1 and overshoot.
+            let successes = await withTaskGroup(of: Bool.self) { group -> Int in
+                for index in 0 ..< limit {
+                    group.addTask {
+                        do {
+                            try await tokenStore.saveManagedItemEnforcingLimit(
+                                id: "race-item-\(index)",
+                                accessToken: "race-access-\(index)",
+                                institutionId: "ins_race_\(index)",
+                                institutionName: "Race Bank \(index)",
+                                institutionLimit: limit
+                            )
+                            return true
+                        } catch {
+                            return false
+                        }
+                    }
+                }
+                var count = 0
+                for await stored in group where stored { count += 1 }
+                return count
+            }
+
+            let finalCount = try await tokenStore.activeInstitutionCount(origin: .managed)
+            #expect(successes == 1)
+            #expect(finalCount == limit)
+        }
+    }
+
+    @Test(
+        "Concurrent managed same-institution inserts are allowed at the institution cap",
+        .enabled(if: consumerTestsKeychainAvailable, "macOS Keychain accepts test writes")
+    )
+    func concurrentManagedSameInstitutionInsertsDoNotSpendExtraSlots() async throws {
+        try await withFluent { fluent in
+            let tokenStore = TokenStore(fluent: fluent)
+            let limit = SubscriptionPlan.plus.institutionLimit
+            // Seed limit-1 unique managed institutions, leaving one open slot.
+            for index in 0 ..< (limit - 1) {
+                try await ItemModel(
+                    id: "same-seed-managed-\(index)",
+                    accessToken: "keychain:same-seed-managed-\(index)",
+                    institutionId: "ins_same_seed_\(index)",
+                    origin: .managed
+                ).save(on: fluent.db())
+            }
+
+            let sharedInstitutionId = "ins_shared_race"
+            let successes = await withTaskGroup(of: Bool.self) { group -> Int in
+                for index in 0 ..< 2 {
+                    group.addTask {
+                        do {
+                            try await tokenStore.saveManagedItemEnforcingLimit(
+                                id: "same-race-item-\(index)",
+                                accessToken: "same-race-access-\(index)",
+                                institutionId: sharedInstitutionId,
+                                institutionName: "Shared Race Bank",
+                                institutionLimit: limit
+                            )
+                            return true
+                        } catch {
+                            return false
+                        }
+                    }
+                }
+                var count = 0
+                for await stored in group where stored { count += 1 }
+                return count
+            }
+
+            let finalCount = try await tokenStore.activeInstitutionCount(origin: .managed)
+            let storedItems = try await tokenStore.getAllItems(providerID: .plaid)
+                .filter { $0.origin == ItemOrigin.managed.rawValue && $0.institutionId == sharedInstitutionId }
+            #expect(successes == 2)
+            #expect(finalCount == limit)
+            #expect(storedItems.count == 2)
         }
     }
 


### PR DESCRIPTION
## Why

The adversarial review of the gated broker (#383) + Stripe (#384) stack flagged two **must-fix-before-un-gating** P1s. This PR stacks on **#384** and fixes both, with tests. It does not change the gating decision — both features remain config-gated and inert in the local-first beta; this makes them safe to un-gate later.

Full strict-concurrency build (3 targets, `-warnings-as-errors`) + the complete suite (**773 tests**) pass locally.

## Fix 1 — managed institution-limit TOCTOU race (#383 / AND-414)

The cap was a non-atomic check-then-insert: the OAuth callback read `activeInstitutionCount` via the entitlement summary, then inserted via a *separate* `TokenStore.saveItem` actor call. Because Fluent calls suspend, **actor reentrancy** let two concurrent managed completions at `count == limit-1` both observe room and both insert (overshoot by N-1).

- New `TokenStore.saveManagedItemEnforcingLimit(...)` runs the count check + insert under an **in-process FIFO lock held across both `await` points** (single local server), throwing `.limitReached` at capacity.
- The OAuth callback keeps the entitlement pre-check (so a degraded subscription never spends a token) but now enforces the cap **atomically at insert**; a race-loser becomes spent-but-not-stored ("re-link").
- Regression test: seed `limit-1`, fire `limit` concurrent inserts → exactly one wins, count never exceeds the limit.

## Fix 2 — Stripe webhook fail-open (#384 / AND-348)

`handleStripeWebhook` applied any decoded event to billing state with **zero signature verification**. Once exposed for real Stripe delivery, a forged `{status:active, plan:plus}` POST would be a remote unauthenticated **free-premium / cap-raise**.

- New `StripeWebhookVerifier` protocol; default `UnconfiguredStripeWebhookVerifier` **throws** until a real validator is wired (mirrors the Plaid `Unconfigured…SignatureValidator` fail-closed default; this is the production default).
- Production-ready `StripeSignatureWebhookVerifier`: HMAC-SHA256 of `"{t}.{rawBody}"` from the `Stripe-Signature` header over the **exact received bytes**, with timestamp tolerance + constant-time compare.
- `handleStripeWebhook` now collects the **raw body → verifies → then decodes/applies** (the wire-contract change). An unsigned/forged event mutates nothing.
- Tests: fail-closed default rejects + grants nothing; verifier accepts valid / rejects wrong-sig, missing header, stale timestamp; the two lifecycle webhook tests inject an accepting verifier (they test application logic).

## Still deferred (documented follow-ups, NOT in scope here)
- `PUT /api/billing/subscription` second unverified entitlement-write path (local-auth-only today).
- Monotonicity/ordering guard on billing apply (stale `active` after `canceled`).
- Durable Stripe idempotency ledger (currently in-memory).
- Checkout/portal redirect-URL allowlist; tie signature-verification to route exposure.

## Provenance
Automated PR-review loop, at the user's direction to fix the two un-gating blockers. **Hold for human merge** — security-sensitive billing/broker code; the underlying stack has no CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)