### PR TITLE
feat: harden Hosted Link completion handling (#380)

### DIFF
--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -67,6 +67,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         let pendingLinkSessions = PendingLinkSessionStore(
             storageURL: URL(fileURLWithPath: serverConfig.pendingLinkSessionsPath)
         )
+        let hostedLinkCompletions = HostedLinkCompletionStore()
 
         // Build router
         let router = Router()
@@ -110,9 +111,12 @@ struct PlaidBarServer: AsyncParsableCommand {
         OAuthCallbackRoute(
             plaidClient: plaidClient,
             tokenStore: tokenStore,
-            pendingLinkSessions: pendingLinkSessions
+            pendingLinkSessions: pendingLinkSessions,
+            hostedLinkCompletions: hostedLinkCompletions
         )
         .register(with: router)
+        HostedLinkWebhookRoute(hostedLinkCompletions: hostedLinkCompletions)
+            .register(with: router)
 
         // Build and run application
         var app = Application(

--- a/Sources/PlaidBarServer/Auth/HostedLinkCompletionStore.swift
+++ b/Sources/PlaidBarServer/Auth/HostedLinkCompletionStore.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+actor HostedLinkCompletionStore {
+    private var recordsById: [String: HostedLinkCompletionRecord] = [:]
+    private var idByState: [String: String] = [:]
+    private var idByLinkToken: [String: String] = [:]
+    private var idByLinkSessionId: [String: String] = [:]
+
+    @discardableResult
+    func record(_ record: HostedLinkCompletionRecord) -> HostedLinkCompletionRecord {
+        purgeEmptyIndexes()
+        if let existing = existingRecord(for: record) {
+            return existing
+        }
+
+        let id = record.identity
+        recordsById[id] = record
+        if let state = record.state {
+            idByState[state] = id
+        }
+        if let linkToken = record.linkToken {
+            idByLinkToken[linkToken] = id
+        }
+        if let linkSessionId = record.linkSessionId {
+            idByLinkSessionId[linkSessionId] = id
+        }
+        return record
+    }
+
+    func completion(
+        state: String?,
+        linkToken: String?,
+        linkSessionId: String? = nil
+    ) -> HostedLinkCompletionRecord? {
+        if let state, let id = idByState[state] {
+            return recordsById[id]
+        }
+        if let linkToken, let id = idByLinkToken[linkToken] {
+            return recordsById[id]
+        }
+        if let linkSessionId, let id = idByLinkSessionId[linkSessionId] {
+            return recordsById[id]
+        }
+        return nil
+    }
+
+    private func existingRecord(for record: HostedLinkCompletionRecord) -> HostedLinkCompletionRecord? {
+        completion(
+            state: record.state,
+            linkToken: record.linkToken,
+            linkSessionId: record.linkSessionId
+        )
+    }
+
+    private func purgeEmptyIndexes() {
+        idByState = idByState.filter { recordsById[$0.value] != nil }
+        idByLinkToken = idByLinkToken.filter { recordsById[$0.value] != nil }
+        idByLinkSessionId = idByLinkSessionId.filter { recordsById[$0.value] != nil }
+    }
+}
+
+struct HostedLinkCompletionRecord: Equatable, Sendable {
+    let state: String?
+    let linkToken: String?
+    let linkSessionId: String?
+    let status: HostedLinkCompletionStatus
+    let receivedAt: Date
+
+    init(
+        state: String?,
+        linkToken: String?,
+        linkSessionId: String?,
+        status: HostedLinkCompletionStatus,
+        receivedAt: Date = Date()
+    ) {
+        self.state = state?.trimmedCompletionIdentifier
+        self.linkToken = linkToken?.trimmedCompletionIdentifier
+        self.linkSessionId = linkSessionId?.trimmedCompletionIdentifier
+        self.status = status
+        self.receivedAt = receivedAt
+    }
+
+    var identity: String {
+        if let linkSessionId {
+            return "link-session:\(linkSessionId)"
+        }
+        if let linkToken {
+            return "link-token:\(linkToken)"
+        }
+        if let state {
+            return "state:\(state)"
+        }
+        return "received:\(receivedAt.timeIntervalSince1970)"
+    }
+}
+
+enum HostedLinkCompletionStatus: String, Codable, Equatable, Sendable {
+    case success
+    case userExit
+    case expired
+    case retryableProviderFailure
+    case providerFailure
+}
+
+private extension String {
+    var trimmedCompletionIdentifier: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -130,6 +130,9 @@ struct ServerConfig: Sendable {
         // until the owner provisions them (see consumer-production-checklist.md).
         let deployment = DeploymentMode.resolved(from: environmentValues)
         let remoteBridge = RemoteBridgeConfig.resolved(from: environmentValues)
+        if deployment == .hostedBridge, link.webhookURL == nil {
+            throw ServerConfigError.missingManagedLinkWebhookURL
+        }
         let oauthRedirect = try OAuthRedirectConfiguration.resolved(
             from: environmentValues,
             deployment: deployment,
@@ -885,6 +888,7 @@ enum ServerConfigError: LocalizedError {
     case invalidEnvironmentVariable(String, String)
     case invalidConfigLine(path: String, line: Int)
     case invalidPort(Int)
+    case missingManagedLinkWebhookURL
     case missingManagedRedirectURI
     case invalidManagedRedirectURI
     case appRedirectRequiresHTTPS
@@ -897,6 +901,8 @@ enum ServerConfigError: LocalizedError {
             "Invalid config line \(line) in \(path)"
         case .invalidPort(let port):
             "Invalid server port \(port): must be between 1 and 65535"
+        case .missingManagedLinkWebhookURL:
+            "PLAID_LINK_WEBHOOK_URL is required when PLAIDBAR_DEPLOYMENT=hosted-bridge"
         case .missingManagedRedirectURI:
             "Managed production Hosted Link requires PLAIDBAR_OAUTH_REDIRECT_URI to be configured"
         case .invalidManagedRedirectURI:

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -216,6 +216,22 @@ struct OAuthCallbackRoute: Sendable {
     let plaidClient: any PlaidClientProtocol
     let tokenStore: TokenStore
     let pendingLinkSessions: PendingLinkSessionStore
+    let hostedLinkCompletions: HostedLinkCompletionStore
+    private let storePublicTokenResult: (@Sendable (PlaidPublicTokenResult) async -> StoreResultOutcome)?
+
+    init(
+        plaidClient: any PlaidClientProtocol,
+        tokenStore: TokenStore,
+        pendingLinkSessions: PendingLinkSessionStore,
+        hostedLinkCompletions: HostedLinkCompletionStore = HostedLinkCompletionStore(),
+        storePublicTokenResult: (@Sendable (PlaidPublicTokenResult) async -> StoreResultOutcome)? = nil
+    ) {
+        self.plaidClient = plaidClient
+        self.tokenStore = tokenStore
+        self.pendingLinkSessions = pendingLinkSessions
+        self.hostedLinkCompletions = hostedLinkCompletions
+        self.storePublicTokenResult = storePublicTokenResult
+    }
 
     func register(with router: Router<some RequestContext>) {
         router.get("oauth/callback", use: handleCallback)
@@ -236,12 +252,21 @@ struct OAuthCallbackRoute: Sendable {
             )
         }
         let state = String(stateParam)
+        if let redirectStatus = Self.completionStatus(from: request) {
+            await hostedLinkCompletions.record(HostedLinkCompletionRecord(
+                state: state,
+                linkToken: nil,
+                linkSessionId: request.uri.queryParameters.get("link_session_id").map { String($0) },
+                status: redirectStatus
+            ))
+            return Self.completionResponse(for: redirectStatus)
+        }
         guard let pendingSession = await pendingLinkSessions.beginCompletion(state: state) else {
             return Response(
                 status: .badRequest,
                 headers: [.contentType: "text/html"],
                 body: .init(byteBuffer: ByteBuffer(
-                    string: Self.errorPage("Missing or expired link session state")
+                    string: Self.expiredPage()
                 ))
             )
         }
@@ -280,7 +305,12 @@ struct OAuthCallbackRoute: Sendable {
                     continue
                 }
 
-                let outcome = await storeResult(publicTokenResult: publicTokenResult)
+                let outcome: StoreResultOutcome
+                if let storePublicTokenResult {
+                    outcome = await storePublicTokenResult(publicTokenResult)
+                } else {
+                    outcome = await storeResult(publicTokenResult: publicTokenResult)
+                }
                 switch outcome {
                 case .stored:
                     // Fully persisted — mark finalized so a retry skips it.
@@ -331,7 +361,7 @@ struct OAuthCallbackRoute: Sendable {
 
     /// The outcome of attempting to exchange + store a single Link result, which
     /// determines both whether the result may be retried and what the user sees.
-    private enum StoreResultOutcome {
+    enum StoreResultOutcome {
         /// Exchanged and persisted locally; safe to mark finalized.
         case stored
         /// The public-token exchange itself failed; the token is unspent and the
@@ -356,6 +386,16 @@ struct OAuthCallbackRoute: Sendable {
     ) async throws -> [PlaidPublicTokenResult] {
         if let publicToken = request.uri.queryParameters.get("public_token") {
             return [PlaidPublicTokenResult(publicToken: String(publicToken), institution: nil)]
+        }
+
+        let state = request.uri.queryParameters.get("state").map { String($0) }
+        let linkSessionId = request.uri.queryParameters.get("link_session_id").map { String($0) }
+        if let completion = await hostedLinkCompletions.completion(
+            state: state,
+            linkToken: pendingSession.linkToken,
+            linkSessionId: linkSessionId
+        ), completion.status != HostedLinkCompletionStatus.success {
+            throw HostedLinkCompletionError.status(completion.status)
         }
 
         let linkSession = try await plaidClient.getLinkToken(pendingSession.linkToken)
@@ -415,6 +455,41 @@ struct OAuthCallbackRoute: Sendable {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
+    private static func completionStatus(from request: Request) -> HostedLinkCompletionStatus? {
+        let query = request.uri.queryParameters
+        let status = query.get("status").map { String($0) }
+        let errorCode = query.get("error_code").map { String($0) }
+        let errorType = query.get("error_type").map { String($0) }
+        return HostedLinkCompletionStatus.classify(status: status, errorCode: errorCode, errorType: errorType)
+    }
+
+    private static func completionResponse(for status: HostedLinkCompletionStatus) -> Response {
+        switch status {
+        case .success:
+            Response(
+                status: .ok,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(string: successPage()))
+            )
+        case .userExit:
+            Response(
+                status: .ok,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(string: userExitPage()))
+            )
+        case .expired:
+            Response(
+                status: .badRequest,
+                headers: [.contentType: "text/html"],
+                body: .init(byteBuffer: ByteBuffer(string: expiredPage()))
+            )
+        case .retryableProviderFailure:
+            errorResponse("The bank connection provider had a temporary problem. Please try again.")
+        case .providerFailure:
+            errorResponse("The bank connection provider could not finish this connection. Please try again.")
+        }
+    }
+
     // MARK: - HTML Pages
 
     private static func successPage() -> String {
@@ -445,6 +520,148 @@ struct OAuthCallbackRoute: Sendable {
         </body>
         </html>
         """
+    }
+
+    private static func userExitPage() -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head><title>VaultPeek -- Connection Canceled</title></head>
+        <body style="font-family: -apple-system, sans-serif; text-align: center; padding: 60px;">
+            <h1>Connection Canceled</h1>
+            <p>No account was linked because the bank connection was closed before completion.</p>
+            <p>You can close this tab and start again from VaultPeek.</p>
+        </body>
+        </html>
+        """
+    }
+
+    private static func expiredPage() -> String {
+        errorPage("This bank connection link expired or was already used. Please start a fresh connection from VaultPeek.")
+    }
+}
+
+private enum HostedLinkCompletionError: LocalizedError {
+    case status(HostedLinkCompletionStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case let .status(status):
+            switch status {
+            case .success:
+                "Plaid Link completed, but no public token was available yet. Please try again."
+            case .userExit:
+                "No account was linked because the bank connection was closed before completion."
+            case .expired:
+                "This bank connection link expired. Please start a fresh connection from VaultPeek."
+            case .retryableProviderFailure:
+                "The bank connection provider had a temporary problem. Please try again."
+            case .providerFailure:
+                "The bank connection provider could not finish this connection. Please try again."
+            }
+        }
+    }
+}
+
+struct HostedLinkWebhookRoute: Sendable {
+    private static let maxBodyBytes = 16 * 1024
+
+    let hostedLinkCompletions: HostedLinkCompletionStore
+
+    func register(with router: Router<some RequestContext>) {
+        router.post("webhooks/plaid/hosted-link", use: receive)
+    }
+
+    @Sendable
+    func receive(request: Request, context _: some RequestContext) async throws -> HTTPResponse.Status {
+        let buffer = try await request.body.collect(upTo: Self.maxBodyBytes)
+        let data = Data(buffer: buffer)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let payload: HostedLinkCompletionWebhookPayload
+        do {
+            payload = try decoder.decode(HostedLinkCompletionWebhookPayload.self, from: data)
+        } catch {
+            throw HTTPError(.badRequest, message: "Invalid Hosted Link completion payload")
+        }
+
+        guard payload.hasStableIdentifier else {
+            throw HTTPError(.badRequest, message: "Hosted Link completion payload is missing a stable identifier")
+        }
+
+        await hostedLinkCompletions.record(HostedLinkCompletionRecord(
+            state: payload.state,
+            linkToken: payload.linkToken,
+            linkSessionId: payload.linkSessionId,
+            status: payload.completionStatus
+        ))
+        return .ok
+    }
+}
+
+struct HostedLinkCompletionWebhookPayload: Decodable, Sendable {
+    let linkToken: String?
+    let linkSessionId: String?
+    let state: String?
+    let status: String?
+    let webhookCode: String?
+    let errorType: String?
+    let errorCode: String?
+
+    var hasStableIdentifier: Bool {
+        linkToken?.trimmedHostedLinkValue != nil
+            || linkSessionId?.trimmedHostedLinkValue != nil
+            || state?.trimmedHostedLinkValue != nil
+    }
+
+    var completionStatus: HostedLinkCompletionStatus {
+        HostedLinkCompletionStatus.classify(
+            status: status ?? webhookCode,
+            errorCode: errorCode,
+            errorType: errorType
+        ) ?? .success
+    }
+}
+
+extension HostedLinkCompletionStatus {
+    static func classify(
+        status: String?,
+        errorCode: String?,
+        errorType: String?
+    ) -> HostedLinkCompletionStatus? {
+        let candidates = [status, errorCode, errorType]
+            .compactMap { $0?.trimmedHostedLinkValue?.uppercased() }
+        guard !candidates.isEmpty else { return nil }
+
+        if candidates.contains(where: { ["SUCCESS", "COMPLETED", "LINK_SESSION_FINISHED"].contains($0) }) {
+            return .success
+        }
+        if candidates.contains(where: { ["USER_EXIT", "USER_CLOSED", "EXIT", "CANCELED", "CANCELLED"].contains($0) }) {
+            return .userExit
+        }
+        if candidates.contains(where: { ["EXPIRED", "LINK_TOKEN_EXPIRED", "INVALID_LINK_TOKEN"].contains($0) }) {
+            return .expired
+        }
+        if candidates.contains(where: { retryableProviderCodes.contains($0) }) {
+            return .retryableProviderFailure
+        }
+        return .providerFailure
+    }
+
+    private static let retryableProviderCodes: Set<String> = [
+        "API_ERROR",
+        "INTERNAL_SERVER_ERROR",
+        "INSTITUTION_DOWN",
+        "INSTITUTION_NOT_RESPONDING",
+        "PLANNED_MAINTENANCE",
+        "RATE_LIMIT_EXCEEDED",
+    ]
+}
+
+private extension String {
+    var trimmedHostedLinkValue: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 }
 

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -106,6 +106,45 @@ struct LinkTokenRequestTests {
         #expect(hostedLink["is_mobile_app"] as? Bool == true)
     }
 
+    @Test("Hosted-bridge config requires a Link webhook URL")
+    func hostedBridgeRequiresWebhookURL() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-hosted-webhook-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let missingWebhookConfig = directory.appendingPathComponent("missing.conf")
+        let configuredWebhookConfig = directory.appendingPathComponent("configured.conf")
+        let missingDataDirectory = directory.appendingPathComponent("missing-data", isDirectory: true)
+        let configuredDataDirectory = directory.appendingPathComponent("configured-data", isDirectory: true)
+
+        try """
+        PLAID_CLIENT_ID=client-id
+        PLAID_SECRET=secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DEPLOYMENT=hosted-bridge
+        PLAIDBAR_OAUTH_REDIRECT_URI=https://link.vaultpeek.example/oauth/callback
+        PLAIDBAR_DATA_DIR=\(missingDataDirectory.path)
+        """.write(to: missingWebhookConfig, atomically: true, encoding: .utf8)
+        try """
+        PLAID_CLIENT_ID=client-id
+        PLAID_SECRET=secret
+        PLAID_ENV=sandbox
+        PLAIDBAR_DEPLOYMENT=hosted-bridge
+        PLAID_LINK_WEBHOOK_URL=https://vaultpeek.example/webhooks/plaid/hosted-link
+        PLAIDBAR_OAUTH_REDIRECT_URI=https://link.vaultpeek.example/oauth/callback
+        PLAIDBAR_DATA_DIR=\(configuredDataDirectory.path)
+        """.write(to: configuredWebhookConfig, atomically: true, encoding: .utf8)
+
+        #expect(throws: ServerConfigError.self) {
+            _ = try ServerConfig.load(from: missingWebhookConfig.path)
+        }
+
+        let configured = try ServerConfig.load(from: configuredWebhookConfig.path)
+        #expect(configured.deployment == .hostedBridge)
+        #expect(configured.link.webhookURL == "https://vaultpeek.example/webhooks/plaid/hosted-link")
+    }
+
     @Test("Link configuration rejects unsupported values before calling Plaid")
     func linkConfigurationValidation() {
         #expect(throws: PlaidLinkConfigurationError.self) {
@@ -247,6 +286,7 @@ struct HostedLinkOAuthRedirectReadinessTests {
             "PLAIDBAR_DEPLOYMENT=hosted-bridge",
             "PLAIDBAR_OAUTH_REDIRECT_MODE=managed",
             "PLAIDBAR_OAUTH_REDIRECT_URI=https://link.vaultpeek.example/oauth/callback",
+            "PLAID_LINK_WEBHOOK_URL=https://vaultpeek.example/webhooks/plaid/hosted-link",
         ])
 
         #expect(config.deployment == .hostedBridge)
@@ -293,6 +333,7 @@ struct HostedLinkOAuthRedirectReadinessTests {
                 "PLAIDBAR_DEPLOYMENT=hosted-bridge",
                 "PLAIDBAR_OAUTH_REDIRECT_MODE=app",
                 "PLAIDBAR_OAUTH_REDIRECT_URI=vaultpeek://oauth/callback",
+                "PLAID_LINK_WEBHOOK_URL=https://vaultpeek.example/webhooks/plaid/hosted-link",
             ])
         }
 
@@ -303,6 +344,7 @@ struct HostedLinkOAuthRedirectReadinessTests {
             "PLAIDBAR_DEPLOYMENT=hosted-bridge",
             "PLAIDBAR_OAUTH_REDIRECT_MODE=app",
             "PLAIDBAR_OAUTH_REDIRECT_URI=https://vaultpeek.example/app/oauth/callback",
+            "PLAID_LINK_WEBHOOK_URL=https://vaultpeek.example/webhooks/plaid/hosted-link",
         ])
 
         #expect(config.oauthRedirect.mode == .app)

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -164,6 +164,19 @@ private actor HostedLinkStubPlaidClient: PlaidClientProtocol {
     }
 }
 
+private actor HostedLinkCompletionResultRecorder {
+    private var publicTokens: [String] = []
+
+    func store(_ result: PlaidPublicTokenResult) -> OAuthCallbackRoute.StoreResultOutcome {
+        publicTokens.append(result.publicToken)
+        return .stored
+    }
+
+    func recordedPublicTokens() -> [String] {
+        publicTokens
+    }
+}
+
 private enum RefreshStubError: Error {
     case failed
 }
@@ -893,6 +906,16 @@ struct PlaidBarServerTests {
         )
     }
 
+    private static func makeJSONRequest(path: String, body: [String: String]) throws -> Request {
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json"
+        let data = try JSONEncoder().encode(body)
+        return Request(
+            head: HTTPRequest(method: .post, scheme: nil, authority: nil, path: path, headerFields: headers),
+            body: RequestBody(buffer: ByteBuffer(data: data))
+        )
+    }
+
     private func setupStateConfig(in directory: URL) throws -> ServerConfig {
         let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
         let configURL = directory.appendingPathComponent("plaidbar.conf")
@@ -912,6 +935,14 @@ struct PlaidBarServerTests {
         var buffer = await collector.collectedBuffer()
         let data = buffer.readData(length: buffer.readableBytes) ?? Data()
         return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func responseString(_ response: Response) async throws -> String {
+        let collector = ResponseBodyCollector()
+        let writer = CollectingResponseBodyWriter(collector: collector)
+        try await response.body.write(writer)
+        var buffer = await collector.collectedBuffer()
+        return buffer.readString(length: buffer.readableBytes) ?? ""
     }
 
     private actor ResponseBodyCollector {
@@ -1778,6 +1809,247 @@ struct PlaidBarServerTests {
         #expect(response.publicTokens == ["public-sandbox-one", "public-sandbox-two"])
         #expect(response.publicTokenResults.first?.institution?.name == "Example Credit Union")
         #expect(response.publicTokenResults.first?.institution?.institutionId == "ins_example_credit_union")
+    }
+
+    @Test("OAuth callback exchanges public token delivered on redirect")
+    func oauthCallbackUsesRedirectPublicTokenWithoutSessionLookup() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-redirect-token-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let linkToken = "redirect-link-token"
+        let publicToken = "redirect-public-token"
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                linkToken: linkToken,
+                linkSessions: nil,
+                onSuccess: nil,
+                results: nil
+            ),
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: "unused-access-token",
+                itemId: "unused-item",
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: "unused-item",
+                    institutionId: "ins_redirect",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-redirect-token")
+        let recorder = HostedLinkCompletionResultRecorder()
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions,
+                storePublicTokenResult: { result in
+                    await recorder.store(result)
+                }
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)&public_token=\(publicToken)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let calls = await plaidClient.recordedCalls()
+            let storedPublicTokens = await recorder.recordedPublicTokens()
+
+            #expect(response.status == .ok)
+            #expect(calls.linkTokens.isEmpty)
+            #expect(calls.publicTokens.isEmpty)
+            #expect(calls.accountAccessTokens.isEmpty)
+            #expect(storedPublicTokens == [publicToken])
+        }
+    }
+
+    @Test("Hosted Link webhook success allows callback to fetch public token from session lookup")
+    func hostedLinkWebhookSuccessAllowsSessionLookup() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-webhook-session-token-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let linkToken = "webhook-link-token"
+        let publicToken = "webhook-public-token"
+        let linkSessionId = "webhook-link-session"
+        let linkTokenGetResponse = PlaidLinkTokenGetResponse(
+            linkToken: linkToken,
+            linkSessions: [
+                PlaidLinkSession(
+                    linkSessionId: linkSessionId,
+                    results: PlaidLinkResults(
+                        itemAddResults: [
+                            PlaidLinkItemAddResult(
+                                publicToken: publicToken,
+                                institution: PlaidLinkInstitution(
+                                    name: "Webhook Credit Union",
+                                    institutionId: "ins_webhook"
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ],
+            onSuccess: nil,
+            results: nil
+        )
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: linkTokenGetResponse,
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: "unused-access-token",
+                itemId: "unused-item",
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: "unused-item",
+                    institutionId: "ins_accounts_fallback",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let hostedLinkCompletions = HostedLinkCompletionStore()
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.webhook-session-token")
+        let recorder = HostedLinkCompletionResultRecorder()
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let webhook = HostedLinkWebhookRoute(hostedLinkCompletions: hostedLinkCompletions)
+            let webhookResponse = try await webhook.receive(
+                request: Self.makeJSONRequest(path: "/webhooks/plaid/hosted-link", body: [
+                    "link_token": linkToken,
+                    "link_session_id": linkSessionId,
+                    "state": state,
+                    "status": "success",
+                ]),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions,
+                hostedLinkCompletions: hostedLinkCompletions,
+                storePublicTokenResult: { result in
+                    await recorder.store(result)
+                }
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)&link_session_id=\(linkSessionId)"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let calls = await plaidClient.recordedCalls()
+            let storedPublicTokens = await recorder.recordedPublicTokens()
+
+            #expect(webhookResponse == .ok)
+            #expect(response.status == .ok)
+            #expect(calls.linkTokens == [linkToken])
+            #expect(calls.publicTokens.isEmpty)
+            #expect(storedPublicTokens == [publicToken])
+        }
+    }
+
+    @Test func hostedLinkCompletionStoreIsIdempotentByAnyIdentifier() async {
+        let store = HostedLinkCompletionStore()
+        let first = HostedLinkCompletionRecord(
+            state: "state-one",
+            linkToken: "link-token-one",
+            linkSessionId: "session-one",
+            status: .success,
+            receivedAt: Date(timeIntervalSince1970: 1)
+        )
+        let duplicate = HostedLinkCompletionRecord(
+            state: nil,
+            linkToken: "link-token-one",
+            linkSessionId: nil,
+            status: .retryableProviderFailure,
+            receivedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        let stored = await store.record(first)
+        let storedAgain = await store.record(duplicate)
+        let byState = await store.completion(state: "state-one", linkToken: nil)
+        let byLinkToken = await store.completion(state: nil, linkToken: "link-token-one")
+        let bySession = await store.completion(state: nil, linkToken: nil, linkSessionId: "session-one")
+
+        #expect(stored == first)
+        #expect(storedAgain == first)
+        #expect(byState == first)
+        #expect(byLinkToken == first)
+        #expect(bySession == first)
+    }
+
+    @Test func oauthCallbackDistinguishesUserExitExpiredAndRetryableProviderFailure() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-outcome-copy-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-outcome-copy")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: HostedLinkStubPlaidClient(
+                    linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                        linkToken: "unused",
+                        linkSessions: nil,
+                        onSuccess: nil,
+                        results: nil
+                    ),
+                    exchangeResponse: PlaidTokenExchangeResponse(
+                        accessToken: "unused-access-token",
+                        itemId: "unused-item",
+                        requestId: nil
+                    ),
+                    accountsResponse: PlaidAccountsResponse(accounts: [], item: nil, requestId: nil)
+                ),
+                tokenStore: store,
+                pendingLinkSessions: PendingLinkSessionStore()
+            )
+            let context = TestRequestContext(source: TestRequestContextSource())
+
+            let userExit = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=exit-state&error_code=USER_EXIT"),
+                context: context
+            )
+            let expired = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=expired-state&error_code=LINK_TOKEN_EXPIRED"),
+                context: context
+            )
+            let retryable = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=retry-state&error_code=INSTITUTION_DOWN"),
+                context: context
+            )
+
+            #expect(userExit.status == .ok)
+            #expect(try await Self.responseString(userExit).contains("Connection Canceled"))
+            #expect(expired.status == .badRequest)
+            #expect(try await Self.responseString(expired).contains("expired"))
+            #expect(retryable.status == .internalServerError)
+            #expect(try await Self.responseString(retryable).contains("temporary problem"))
+        }
     }
 
     @Test(


### PR DESCRIPTION
Re-lands the content of #380 (AND-409), which GitHub auto-closed when its stacked base branch `otto/and-408` was deleted during the managed-link stack merge. Same diff, reviewed twice. Metadata-only Hosted Link completion store + unauthenticated 127.0.0.1 webhook receiver + redirect-completion recovery, gated behind PLAID_LINK_WEBHOOK_URL (unset by default). Inert in default .local mode.

Supersedes #380.