### PR TITLE
fix: unblock live weekly review state

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -752,16 +752,21 @@ final class AppState {
     }
 
     private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {
-        // AND-403 is intentionally gated on AND-399. Production must provide
-        // trusted/unreviewed transaction state before this returns a value; raw
-        // Plaid transactions alone are not treated as reviewed. Demo mode uses
-        // synthetic ids so the checklist surface remains locally exercisable.
-        guard isDemoMode else { return nil }
-        let unreviewed = Set(transactions.filter(\.pending).map(\.id))
-        let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
-        return WeeklyReviewTransactionState(
-            trustedTransactionIds: trusted,
-            unreviewedTransactionIds: unreviewed
+        // AND-403 is intentionally gated on AND-399 review metadata. Raw Plaid
+        // transactions alone are not treated as reviewed; demo mode keeps using
+        // pending flags so the checklist surface remains locally exercisable.
+        guard !isDemoMode else {
+            let unreviewed = Set(transactions.filter(\.pending).map(\.id))
+            let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
+            return WeeklyReviewTransactionState(
+                trustedTransactionIds: trusted,
+                unreviewedTransactionIds: unreviewed
+            )
+        }
+
+        return WeeklyReviewTransactionState.derived(
+            from: transactions,
+            metadata: transactionReviewMetadata
         )
     }
 

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -48,6 +48,7 @@ final class AppState {
     }
     var transactionReviewMetadata: [TransactionReviewMetadata] = []
     var transactionRules: [TransactionRule] = []
+    var hasLoadedTransactionReviewStorage = false
     var isLoading = false
     /// True from launch until the first `loadInitialData()` pass completes.
     /// While booting, data surfaces render loading/skeleton states instead
@@ -752,9 +753,10 @@ final class AppState {
     }
 
     private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {
-        // AND-403 is intentionally gated on AND-399 review metadata. Raw Plaid
-        // transactions alone are not treated as reviewed; demo mode keeps using
-        // pending flags so the checklist surface remains locally exercisable.
+        // Production weekly reviews require loaded transaction-review metadata.
+        // Raw Plaid transactions alone are not treated as reviewed; demo mode
+        // keeps using pending flags so the checklist surface remains locally
+        // exercisable.
         guard !isDemoMode else {
             let unreviewed = Set(transactions.filter(\.pending).map(\.id))
             let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
@@ -764,9 +766,16 @@ final class AppState {
             )
         }
 
-        return WeeklyReviewTransactionState.derived(
-            from: transactions,
-            metadata: transactionReviewMetadata
+        guard hasLoadedTransactionReviewStorage,
+              !transactions.isEmpty
+        else { return nil }
+
+        let inbox = transactionReviewInboxSnapshot
+        let unreviewed = Set(inbox.items.map(\.id))
+        let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
+        return WeeklyReviewTransactionState(
+            trustedTransactionIds: trusted,
+            unreviewedTransactionIds: unreviewed
         )
     }
 
@@ -1524,8 +1533,8 @@ final class AppState {
     func performWeeklyReviewAction(_ item: WeeklyReviewItem) {
         switch item.action {
         case .openReviewInbox:
-            // The transaction review inbox (AND-399) is available now, so route
-            // the user to it rather than reporting it as missing.
+            // The transaction review inbox is available now, so route the user
+            // to it rather than reporting it as missing.
             weeklyReviewNavigation = .reviewInbox
         case .inspectCategory:
             error = "Category budget drill-in is not available in this slice yet."
@@ -1735,6 +1744,7 @@ final class AppState {
             context: context
         ) {
             transactionReviewMetadata = cachedMetadata
+            hasLoadedTransactionReviewStorage = true
         }
         if let cachedRules = try? await localDataCache.loadTransactionRules(
             from: cacheDirectory,
@@ -1895,6 +1905,7 @@ final class AppState {
     }
 
     private func loadTransactionReviewStorage() async {
+        hasLoadedTransactionReviewStorage = false
         do {
             transactionReviewMetadata = try await localDataCache.loadTransactionReviewMetadata(
                 from: activeStorageDirectoryURL,
@@ -1905,7 +1916,9 @@ final class AppState {
                 context: transactionCacheContext
             )
             seedReviewMetadataForNewTransactions(transactions)
+            hasLoadedTransactionReviewStorage = true
         } catch {
+            hasLoadedTransactionReviewStorage = false
             self.error = "Review inbox storage failed to load: \(error.localizedDescription)"
         }
     }

--- a/Sources/PlaidBar/Views/WeeklyReviewCard.swift
+++ b/Sources/PlaidBar/Views/WeeklyReviewCard.swift
@@ -49,15 +49,15 @@ struct WeeklyReviewCard: View {
 
     private var dependencyState: some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
-            Text("Weekly review unlocks after the transaction review inbox can say which transactions are trusted.")
+            Text("Weekly review will appear once transaction data is ready.")
                 .microText()
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Label("Waiting for AND-399 review state", systemImage: "checklist")
+            Label("Waiting for transaction data", systemImage: "clock")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(SemanticColors.warning)
-                .accessibilityLabel("Waiting for transaction review state")
+                .accessibilityLabel("Waiting for transaction data")
         }
         .padding(Spacing.sm)
         .nativeInsetSurface()
@@ -65,34 +65,36 @@ struct WeeklyReviewCard: View {
 
     private func positiveState(_ presentation: WeeklyReviewPresentation) -> some View {
         HStack(alignment: .top, spacing: Spacing.sm) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(SemanticColors.positive)
+            Image(systemName: presentation.outcome == .notReady ? "clock" : "checkmark.circle.fill")
+                .foregroundStyle(presentation.outcome == .notReady ? .secondary : SemanticColors.positive)
                 .frame(width: 22, height: 22)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text("Nothing needs review")
+                Text(presentation.outcome == .notReady ? "Weekly review not ready" : "Nothing needs review")
                     .font(.caption.weight(.semibold))
                 Text(nextReviewText(presentation))
                     .microText()
                     .foregroundStyle(.secondary)
             }
 
-            Spacer(minLength: Spacing.sm)
+            if presentation.outcome != .notReady {
+                Spacer(minLength: Spacing.sm)
 
-            Button {
-                appState.completeWeeklyReview()
-            } label: {
-                Label("Complete", systemImage: "checkmark")
-                    .labelStyle(.iconOnly)
+                Button {
+                    appState.completeWeeklyReview()
+                } label: {
+                    Label("Complete", systemImage: "checkmark")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .help("Complete weekly review")
+                .accessibilityLabel("Complete weekly review")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.mini)
-            .help("Complete weekly review")
-            .accessibilityLabel("Complete weekly review")
         }
         .padding(Spacing.sm)
-        .nativeInsetSurface(stroke: SemanticColors.positive.opacity(0.18))
+        .nativeInsetSurface(stroke: (presentation.outcome == .notReady ? Color.secondary : SemanticColors.positive).opacity(0.18))
     }
 
     private func checklist(_ presentation: WeeklyReviewPresentation) -> some View {
@@ -135,6 +137,9 @@ struct WeeklyReviewCard: View {
     }
 
     private func nextReviewText(_ presentation: WeeklyReviewPresentation) -> String {
+        if presentation.outcome == .notReady {
+            return "Weekly review will appear once transaction data is ready."
+        }
         guard let nextReviewDueAt = presentation.nextReviewDueAt else {
             return "Complete this review to start the weekly cadence."
         }
@@ -150,6 +155,7 @@ struct WeeklyReviewCard: View {
 
     private func outcomeIcon(_ outcome: WeeklyReviewOutcome) -> String {
         switch outcome {
+        case .notReady: "clock"
         case .looksGood: "checkmark.circle.fill"
         case .reviewItems: "exclamationmark.circle.fill"
         case .payAttention: "exclamationmark.triangle.fill"
@@ -159,6 +165,7 @@ struct WeeklyReviewCard: View {
 
     private func outcomeTint(_ outcome: WeeklyReviewOutcome) -> Color {
         switch outcome {
+        case .notReady: .secondary
         case .looksGood: SemanticColors.positive
         case .reviewItems, .waitingForTransactionReview: SemanticColors.warning
         case .payAttention: SemanticColors.negative

--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -52,9 +52,33 @@ public struct WeeklyReviewTransactionState: Sendable, Equatable {
         self.trustedTransactionIds = trustedTransactionIds
         self.unreviewedTransactionIds = unreviewedTransactionIds
     }
+
+    public static func derived(
+        from transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]
+    ) -> WeeklyReviewTransactionState {
+        let metadataById = Dictionary(metadata.map { ($0.id, $0) }) { _, latest in latest }
+        var trustedTransactionIds = Set<String>()
+        var unreviewedTransactionIds = Set<String>()
+
+        for transaction in transactions {
+            switch metadataById[transaction.id]?.status ?? .needsReview {
+            case .reviewed, .ignored:
+                trustedTransactionIds.insert(transaction.id)
+            case .needsReview:
+                unreviewedTransactionIds.insert(transaction.id)
+            }
+        }
+
+        return WeeklyReviewTransactionState(
+            trustedTransactionIds: trustedTransactionIds,
+            unreviewedTransactionIds: unreviewedTransactionIds
+        )
+    }
 }
 
 public enum WeeklyReviewOutcome: String, Sendable, Equatable {
+    case notReady
     case looksGood
     case reviewItems
     case payAttention
@@ -62,6 +86,7 @@ public enum WeeklyReviewOutcome: String, Sendable, Equatable {
 
     public var title: String {
         switch self {
+        case .notReady: "Not ready yet"
         case .looksGood: "Looks good"
         case .reviewItems: "Review these few items"
         case .payAttention: "Pay attention"
@@ -195,11 +220,25 @@ public struct WeeklyReviewPresentation: Sendable, Equatable {
     }
 
     public var notificationBody: String {
+        if outcome == .notReady {
+            return "Weekly review will appear once transaction data is ready."
+        }
         if remainingCount > 0 {
             return "VaultPeek found \(remainingCount) private item\(remainingCount == 1 ? "" : "s") to review."
         }
         return "Open VaultPeek to complete your private weekly review."
     }
+
+    public static let transactionDataNotReady = WeeklyReviewPresentation(
+        outcome: .notReady,
+        isDue: false,
+        nextReviewDueAt: nil,
+        completedCount: 0,
+        totalCount: 0,
+        reviewedTransactionCount: 0,
+        items: [],
+        isBlockedByTransactionReviewDependency: false
+    )
 
     public static let waitingForTransactionReview = WeeklyReviewPresentation(
         outcome: .waitingForTransactionReview,
@@ -231,7 +270,7 @@ public enum WeeklyReviewBuilder {
         calendar: Calendar = .current
     ) -> WeeklyReviewPresentation {
         guard let transactionState else {
-            return .waitingForTransactionReview
+            return .transactionDataNotReady
         }
 
         let isDue = state.isDue(asOf: date, calendar: calendar)
@@ -301,7 +340,7 @@ public enum WeeklyReviewBuilder {
                 id: "weekly-review.transactions",
                 kind: .transactionReview,
                 severity: .warning,
-                title: "\(count) transaction\(count == 1 ? "" : "s") need review",
+                title: "\(count) transaction\(count == 1 ? " needs" : "s need") review",
                 detail: "Approve or categorize the latest inbox items before closing the week.",
                 action: .openReviewInbox,
                 accessibilityHint: "Opens the transaction review inbox."

--- a/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
+++ b/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
@@ -6,8 +6,8 @@ struct WeeklyReviewTests {
     private let calendar = Calendar(identifier: .gregorian)
     private let now = Date(timeIntervalSince1970: 1_781_510_400) // 2026-06-14
 
-    @Test("Review waits for transaction review state instead of raw transactions")
-    func waitsForTransactionReviewState() {
+    @Test("Review degrades neutrally while transaction data is not ready")
+    func waitsNeutrallyForTransactionData() {
         let presentation = WeeklyReviewBuilder.evaluate(
             state: .empty,
             transactionState: nil,
@@ -18,10 +18,34 @@ struct WeeklyReviewTests {
             calendar: calendar
         )
 
-        #expect(presentation.outcome == .waitingForTransactionReview)
-        #expect(presentation.isBlockedByTransactionReviewDependency)
+        #expect(presentation.outcome == .notReady)
+        #expect(presentation.isBlockedByTransactionReviewDependency == false)
         #expect(presentation.items.isEmpty)
         #expect(presentation.menuBarPrompt == nil)
+        #expect(presentation.notificationBody == "Weekly review will appear once transaction data is ready.")
+    }
+
+    @Test("Transaction review item still gives a clear user action")
+    func transactionReviewItemGivesUserAction() {
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: WeeklyReviewTransactionState(
+                trustedTransactionIds: [],
+                unreviewedTransactionIds: ["tx-unreviewed"]
+            ),
+            transactions: [],
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(presentation.outcome == .reviewItems)
+        #expect(presentation.items.count == 1)
+        #expect(presentation.items.first?.kind == .transactionReview)
+        #expect(presentation.items.first?.title == "1 transaction needs review")
+        #expect(presentation.items.first?.detail == "Approve or categorize the latest inbox items before closing the week.")
+        #expect(presentation.items.first?.action == .openReviewInbox)
     }
 
     @Test("Derived items summarize review inbox, budgets, recurring, safe-to-spend, and connection health")
@@ -80,6 +104,89 @@ struct WeeklyReviewTests {
             .connectionHealth,
         ])
         #expect(presentation.menuBarPrompt == "6 items to review")
+    }
+
+    @Test("Transaction review metadata derives trusted and unreviewed weekly state")
+    func transactionReviewMetadataDerivesWeeklyTransactionState() {
+        let state = WeeklyReviewTransactionState.derived(
+            from: [
+                transaction(id: "reviewed", date: "2026-06-14"),
+                transaction(id: "ignored", date: "2026-06-14"),
+                transaction(id: "needs-review", date: "2026-06-14"),
+            ],
+            metadata: [
+                TransactionReviewMetadata(id: "reviewed", status: .reviewed),
+                TransactionReviewMetadata(id: "ignored", status: .ignored),
+                TransactionReviewMetadata(id: "needs-review", status: .needsReview),
+                TransactionReviewMetadata(id: "stale-reviewed", status: .reviewed),
+            ]
+        )
+
+        #expect(state.trustedTransactionIds == ["reviewed", "ignored"])
+        #expect(state.unreviewedTransactionIds == ["needs-review"])
+    }
+
+    @Test("Transactions without metadata are not treated as trusted")
+    func missingTransactionReviewMetadataRequiresReview() {
+        let state = WeeklyReviewTransactionState.derived(
+            from: [transaction(id: "missing-metadata", date: "2026-06-14")],
+            metadata: []
+        )
+
+        #expect(state.trustedTransactionIds.isEmpty)
+        #expect(state.unreviewedTransactionIds == ["missing-metadata"])
+    }
+
+    @Test("Reviewed and ignored transaction metadata unblock weekly review")
+    func reviewedAndIgnoredTransactionMetadataUnblocksWeeklyReview() {
+        let transactions = [
+            transaction(id: "reviewed", date: "2026-06-14"),
+            transaction(id: "ignored", date: "2026-06-14"),
+        ]
+        let transactionState = WeeklyReviewTransactionState.derived(
+            from: transactions,
+            metadata: [
+                TransactionReviewMetadata(id: "reviewed", status: .reviewed),
+                TransactionReviewMetadata(id: "ignored", status: .ignored),
+            ]
+        )
+
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: transactionState,
+            transactions: transactions,
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(!presentation.isBlockedByTransactionReviewDependency)
+        #expect(!presentation.items.contains { $0.kind == .transactionReview })
+        #expect(presentation.reviewedTransactionCount == 2)
+    }
+
+    @Test("Needs-review transaction metadata creates actionable weekly review item")
+    func needsReviewTransactionMetadataCreatesActionableWeeklyReviewItem() {
+        let transactions = [transaction(id: "needs-review", date: "2026-06-14")]
+        let transactionState = WeeklyReviewTransactionState.derived(
+            from: transactions,
+            metadata: [TransactionReviewMetadata(id: "needs-review", status: .needsReview)]
+        )
+
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: transactionState,
+            transactions: transactions,
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            asOf: now,
+            calendar: calendar
+        )
+
+        #expect(!presentation.isBlockedByTransactionReviewDependency)
+        #expect(presentation.items.map(\.kind) == [.transactionReview])
+        #expect(presentation.items.first?.action == .openReviewInbox)
     }
 
     @Test("Completing all derived items in the current cycle yields positive empty state")


### PR DESCRIPTION
## Summary
- Derive live Weekly Review transaction state from transaction-review metadata instead of blocking outside demo mode.
- Treat reviewed/ignored metadata as trusted and needs-review/missing metadata as actionable review work.
- Replace internal `AND-399` blocker copy with neutral not-ready messaging when transaction data is unavailable.

Fixes #392
Linear: AND-443

## Validation
- `git diff --check`
- `grep -R "AND-" -n Sources/PlaidBarCore/Models/WeeklyReview.swift Sources/PlaidBar/Views/WeeklyReviewCard.swift` returns no matches
- `swift test --filter WeeklyReviewTests --scratch-path /tmp/plaidbar-issue392-build`

## Safety
- No Plaid credentials, provider tokens, raw payloads, account IDs, transaction IDs, balances, SQLite data, or logs added.
- User-facing weekly-review copy avoids internal ticket IDs and remains privacy-preserving.
