### PR TITLE
fix: record local ai fallback diagnostics

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -900,15 +900,11 @@ final class AppState {
             recurringTransactions: recurringTransactions
         )
         _cachedLocalAIActivitySummaries = result
-        recordPerformance(
-            .derivedSummaryRecompute,
+        recordLocalAIActivitySummaryPerformance(
             startedAt: start,
-            counts: [
-                .accountCount: accounts.count,
-                .transactionTotalCount: transactions.count,
-                .activitySummaryCount: result.count,
-            ],
-            outcome: .success
+            summaries: result,
+            accountCount: accounts.count,
+            transactionCount: transactions.count
         )
         return result
     }
@@ -940,6 +936,7 @@ final class AppState {
             }
             guard !Task.isCancelled else { return }
 
+            let start = performanceStart()
             let generated = await service.generatedActivitySummaries(
                 accounts: accountSnapshot,
                 transactions: transactionSnapshot,
@@ -947,6 +944,12 @@ final class AppState {
             )
             guard !Task.isCancelled else { return }
             _cachedLocalAIActivitySummaries = generated
+            recordLocalAIActivitySummaryPerformance(
+                startedAt: start,
+                summaries: generated,
+                accountCount: accountSnapshot.count,
+                transactionCount: transactionSnapshot.count
+            )
         }
     }
 
@@ -2057,6 +2060,24 @@ final class AppState {
             outcome: outcome
         )
         emitPerformanceTraceIfRequested()
+    }
+
+    private func recordLocalAIActivitySummaryPerformance(
+        startedAt start: UInt64,
+        summaries: [LocalAIActivitySummary],
+        accountCount: Int,
+        transactionCount: Int
+    ) {
+        recordPerformance(
+            .derivedSummaryRecompute,
+            startedAt: start,
+            counts: [
+                .accountCount: accountCount,
+                .transactionTotalCount: transactionCount,
+                .activitySummaryCount: summaries.count,
+            ],
+            outcome: .success
+        )
     }
 
     /// Local-only performance capture: run the app with `PLAIDBAR_PERF_TRACE=1`

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -92,7 +92,8 @@ struct LocalAIInsightsService: Sendable {
             let summaryAvailability = LocalAIRuntimeResolution.resolved(
                 base: currentAvailability,
                 usedModelOutput: generated.usedModelOutput,
-                fallbackReason: generated.fallbackReason
+                fallbackReason: generated.fallbackReason,
+                fallbackDiagnostic: generated.fallbackDiagnostic
             )
             summaries.append(
                 LocalAIActivitySummary(

--- a/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
+++ b/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
@@ -86,19 +86,31 @@ struct OllamaLocalInsightModel: LocalInsightModel {
         do {
             let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw LocalInsightModelError.runtimeUnavailable
+                throw LocalInsightModelError.runtimeUnavailableWithDiagnostic(
+                    "Ollama returned a non-HTTP response from \(requestDiagnostic(request))."
+                )
             }
             guard (200 ..< 300).contains(httpResponse.statusCode) else {
                 if httpResponse.statusCode == 404 {
                     throw LocalInsightModelError.noInstalledModel
                 }
-                throw LocalInsightModelError.runtimeUnavailable
+                throw LocalInsightModelError.runtimeUnavailableWithDiagnostic(
+                    "Ollama request to \(requestDiagnostic(request)) failed with HTTP \(httpResponse.statusCode)."
+                )
             }
-            return try JSONDecoder().decode(Response.self, from: data)
+            do {
+                return try JSONDecoder().decode(Response.self, from: data)
+            } catch {
+                throw LocalInsightModelError.runtimeUnavailableWithDiagnostic(
+                    "Ollama response from \(requestDiagnostic(request)) could not be decoded as \(Response.self)."
+                )
+            }
         } catch let error as LocalInsightModelError {
             throw error
         } catch {
-            throw LocalInsightModelError.runtimeUnavailable
+            throw LocalInsightModelError.runtimeUnavailableWithDiagnostic(
+                "Ollama request to \(requestDiagnostic(request)) failed: \(transportDiagnostic(error))."
+            )
         }
     }
 
@@ -115,6 +127,17 @@ struct OllamaLocalInsightModel: LocalInsightModel {
         "qwen2.5",
         "phi3",
     ]
+
+    private func requestDiagnostic(_ request: URLRequest) -> String {
+        guard let url = request.url else { return "Ollama endpoint" }
+        let host = url.host(percentEncoded: false) ?? "unknown-host"
+        return "\(host)\(url.path)"
+    }
+
+    private func transportDiagnostic(_ error: Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain) code \(nsError.code)"
+    }
 
     static func isLocalhost(_ url: URL) -> Bool {
         guard let host = url.host(percentEncoded: false)?.lowercased() else { return false }

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -23,17 +23,20 @@ public struct LocalAIAvailability: Codable, Sendable, Hashable {
     public let runtimeName: String?
     public let detail: String
     public let supportsCloudModels: Bool
+    public let probeErrorText: String?
 
     public init(
         state: LocalAIAvailabilityState,
         runtimeName: String? = nil,
         detail: String,
-        supportsCloudModels: Bool = false
+        supportsCloudModels: Bool = false,
+        probeErrorText: String? = nil
     ) {
         self.state = state
         self.runtimeName = runtimeName
         self.detail = detail
         self.supportsCloudModels = supportsCloudModels
+        self.probeErrorText = probeErrorText
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
@@ -94,7 +94,8 @@ public enum LocalAIRuntimeResolution {
     public static func resolved(
         base: LocalAIAvailability,
         usedModelOutput: Bool,
-        fallbackReason: LocalInsightModelFallbackReason?
+        fallbackReason: LocalInsightModelFallbackReason?,
+        fallbackDiagnostic: String? = nil
     ) -> LocalAIAvailability {
         guard base.state == .checking || base.state == .available else { return base }
 
@@ -102,7 +103,8 @@ public enum LocalAIRuntimeResolution {
             return LocalAIAvailability(
                 state: .available,
                 runtimeName: base.runtimeName,
-                detail: availableDetail(runtimeName: base.runtimeName)
+                detail: availableDetail(runtimeName: base.runtimeName),
+                probeErrorText: nil
             )
         }
 
@@ -111,7 +113,12 @@ public enum LocalAIRuntimeResolution {
         return LocalAIAvailability(
             state: .unavailable,
             runtimeName: base.runtimeName,
-            detail: fallbackDetail(runtimeName: base.runtimeName, reason: fallbackReason)
+            detail: fallbackDetail(
+                runtimeName: base.runtimeName,
+                reason: fallbackReason,
+                diagnostic: fallbackDiagnostic
+            ),
+            probeErrorText: fallbackDiagnostic
         )
     }
 
@@ -140,7 +147,8 @@ public enum LocalAIRuntimeResolution {
 
     static func fallbackDetail(
         runtimeName: String?,
-        reason: LocalInsightModelFallbackReason
+        reason: LocalInsightModelFallbackReason,
+        diagnostic: String? = nil
     ) -> String {
         let runtime = runtimeName.map { "Local runtime '\($0)'" } ?? "The configured local runtime"
         let reasonText = switch reason {
@@ -159,6 +167,10 @@ public enum LocalAIRuntimeResolution {
         case .invalidOutput:
             "returned invalid or unsafe output"
         }
-        return "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
+        var detail = "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
+        if let diagnostic, !diagnostic.isEmpty {
+            detail += " Probe error: \(diagnostic)"
+        }
+        return detail
     }
 }

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
@@ -32,6 +32,7 @@ public protocol LocalInsightModel: Sendable {
 
 public enum LocalInsightModelError: Error, Sendable, Hashable {
     case runtimeUnavailable
+    case runtimeUnavailableWithDiagnostic(String)
     case noInstalledModel
     case unsupportedConfiguration
 }

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 public struct LocalInsightModelGenerationConfiguration: Sendable, Equatable {
     public static let `default` = LocalInsightModelGenerationConfiguration()
@@ -32,15 +33,18 @@ public struct LocalInsightModelGenerationResult: Sendable, Equatable {
     public let summary: String
     public let usedModelOutput: Bool
     public let fallbackReason: LocalInsightModelFallbackReason?
+    public let fallbackDiagnostic: String?
 
     public init(
         summary: String,
         usedModelOutput: Bool,
-        fallbackReason: LocalInsightModelFallbackReason?
+        fallbackReason: LocalInsightModelFallbackReason?,
+        fallbackDiagnostic: String? = nil
     ) {
         self.summary = summary
         self.usedModelOutput = usedModelOutput
         self.fallbackReason = fallbackReason
+        self.fallbackDiagnostic = fallbackDiagnostic
     }
 }
 
@@ -294,6 +298,11 @@ public enum LocalInsightModelOutputValidator {
 }
 
 public enum LocalInsightModelRuntime {
+    private static let logger = Logger(
+        subsystem: "com.ftchvs.PlaidBar",
+        category: "LocalInsightModelRuntime"
+    )
+
     public static func generateSummary(
         input: LocalAIActivitySummaryInput,
         model: (any LocalInsightModel)?,
@@ -310,6 +319,9 @@ public enum LocalInsightModelRuntime {
         }
 
         let prompt = LocalInsightPromptBuilder.make(from: input)
+        let actionName = "generateSummary"
+        let modelID = String(reflecting: type(of: model))
+        let startedAt = Date()
         let rawOutput: String
 
         do {
@@ -317,18 +329,40 @@ public enum LocalInsightModelRuntime {
                 try await model.summarize(prompt, maxTokens: configuration.maxTokens)
             }
         } catch is LocalInsightModelTimeoutError {
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: .timeout
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
                 fallbackReason: .timeout
             )
         } catch let error as LocalInsightModelError {
+            let reason = error.fallbackReason
+            let diagnostic = error.diagnostic
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: reason,
+                diagnostic: diagnostic
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
-                fallbackReason: error.fallbackReason
+                fallbackReason: reason,
+                fallbackDiagnostic: diagnostic
             )
         } catch {
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: .modelError
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
@@ -354,6 +388,28 @@ public enum LocalInsightModelRuntime {
                 fallbackReason: .invalidOutput
             )
         }
+    }
+
+    private static func recordModelFailure(
+        actionName: String,
+        modelID: String,
+        elapsedMilliseconds: Int,
+        reason: LocalInsightModelFallbackReason,
+        diagnostic: String? = nil
+    ) {
+        if let diagnostic {
+            logger.warning(
+                "local_insight_model_failure action=\(actionName, privacy: .public) model_id=\(modelID, privacy: .public) elapsed_ms=\(elapsedMilliseconds) reason=\(reason.rawValue, privacy: .public) diagnostic=\(diagnostic, privacy: .public)"
+            )
+        } else {
+            logger.warning(
+                "local_insight_model_failure action=\(actionName, privacy: .public) model_id=\(modelID, privacy: .public) elapsed_ms=\(elapsedMilliseconds) reason=\(reason.rawValue, privacy: .public)"
+            )
+        }
+    }
+
+    private static func elapsedMilliseconds(since startedAt: Date) -> Int {
+        max(0, Int(Date().timeIntervalSince(startedAt) * 1_000))
     }
 
     private static func withTimeout<T: Sendable>(
@@ -456,12 +512,21 @@ private struct LocalInsightModelTimeoutError: Error {}
 private extension LocalInsightModelError {
     var fallbackReason: LocalInsightModelFallbackReason {
         switch self {
-        case .runtimeUnavailable:
+        case .runtimeUnavailable, .runtimeUnavailableWithDiagnostic:
             .runtimeUnavailable
         case .noInstalledModel:
             .noInstalledModel
         case .unsupportedConfiguration:
             .unsupportedConfiguration
+        }
+    }
+
+    var diagnostic: String? {
+        switch self {
+        case .runtimeUnavailableWithDiagnostic(let diagnostic):
+            diagnostic
+        case .runtimeUnavailable, .noInstalledModel, .unsupportedConfiguration:
+            nil
         }
     }
 }

--- a/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
@@ -109,10 +109,13 @@ struct LocalAIRuntimeResolutionTests {
         let resolved = LocalAIRuntimeResolution.resolved(
             base: base,
             usedModelOutput: false,
-            fallbackReason: .runtimeUnavailable
+            fallbackReason: .runtimeUnavailable,
+            fallbackDiagnostic: "Connection refused"
         )
         #expect(resolved.state == .unavailable)
         #expect(resolved.detail.contains("not reachable"))
+        #expect(resolved.detail.contains("Connection refused"))
+        #expect(resolved.probeErrorText == "Connection refused")
     }
 
     @Test("Terminal states pass through resolution unchanged")

--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -137,6 +137,26 @@ struct LocalInsightModelRuntimeTests {
         #expect(result.summary == "deterministic fallback")
         #expect(result.usedModelOutput == false)
         #expect(result.fallbackReason == .runtimeUnavailable)
+        #expect(result.fallbackDiagnostic == nil)
+    }
+
+    @Test("Runtime preserves local model availability diagnostics")
+    func runtimePreservesLocalModelAvailabilityDiagnostics() async {
+        let diagnostic = "URLError(.cannotConnectToHost) - connection refused"
+        let model = StubLocalInsightModel(result: .failure(
+            LocalInsightModelError.runtimeUnavailableWithDiagnostic(diagnostic)
+        ))
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .runtimeUnavailable)
+        #expect(result.fallbackDiagnostic == diagnostic)
     }
 
     @Test("Runtime falls back when model exceeds timeout")


### PR DESCRIPTION
## Summary
- Add structured OSLog diagnostics for local-model timeout, typed LocalInsightModelError, and generic fallback paths.
- Preserve runtime probe diagnostics through generation and LocalAI availability resolution so support can see why a local model is unavailable.
- Keep user-facing behavior graceful: deterministic fallback output remains the UI path; no errors are rethrown.

Fixes #395
Linear: AND-446

## Validation
- `git diff --cached --check`
- `swift test --filter 'LocalInsightModelRuntimeTests|LocalAIRuntimeResolutionTests' --scratch-path /tmp/plaidbar-issue395-build`

Result: 23 focused tests passed.

## Safety
- No Plaid credentials, provider tokens, raw payloads, account IDs, transaction IDs, balances, local SQLite data, screenshots, or prompt text added to diagnostics.
- Local AI remains opt-in/local-only; no cloud fallback added.
