### PR TITLE
fix: add local ai settings opt-in

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -231,13 +231,12 @@ final class AppState {
     var localAIModelName: String = "llama3.2" {
         didSet {
             let normalized = Self.normalizedLocalAIModelName(localAIModelName) ?? "llama3.2"
-            guard normalized == localAIModelName else {
+            if normalized != localAIModelName {
                 localAIModelName = normalized
-                return
             }
-            guard localAIModelName != oldValue, !isLoadingLocalAISettings else { return }
-            localAIModelNamePreference = localAIModelName
-            UserDefaults.standard.set(localAIModelName, forKey: Keys.localAIModelName)
+            guard normalized != oldValue, !isLoadingLocalAISettings else { return }
+            localAIModelNamePreference = normalized
+            UserDefaults.standard.set(normalized, forKey: Keys.localAIModelName)
             rebuildLocalAIInsightsService()
             invalidateLocalAIActivitySummaries()
         }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -28,6 +28,8 @@ final class AppState {
         static let notifyRecurringChargeChanged = "notifyRecurringChargeChanged"
         static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
         static let notifyBrokenConnection = "notifyBrokenConnection"
+        static let localAIEnabled = "localAIEnabled"
+        static let localAIModelName = "localAIModelName"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
@@ -216,6 +218,31 @@ final class AppState {
         }
     }
 
+    var localAIEnabled: Bool = false {
+        didSet {
+            guard localAIEnabled != oldValue, !isLoadingLocalAISettings else { return }
+            localAIEnabledPreference = localAIEnabled
+            UserDefaults.standard.set(localAIEnabled, forKey: Keys.localAIEnabled)
+            rebuildLocalAIInsightsService()
+            invalidateLocalAIActivitySummaries()
+        }
+    }
+
+    var localAIModelName: String = "llama3.2" {
+        didSet {
+            let normalized = Self.normalizedLocalAIModelName(localAIModelName) ?? "llama3.2"
+            guard normalized == localAIModelName else {
+                localAIModelName = normalized
+                return
+            }
+            guard localAIModelName != oldValue, !isLoadingLocalAISettings else { return }
+            localAIModelNamePreference = localAIModelName
+            UserDefaults.standard.set(localAIModelName, forKey: Keys.localAIModelName)
+            rebuildLocalAIInsightsService()
+            invalidateLocalAIActivitySummaries()
+        }
+    }
+
     var launchAtLogin: Bool = false {
         didSet {
             guard launchAtLogin != oldValue else { return }
@@ -231,13 +258,16 @@ final class AppState {
     // MARK: - Services
     private let serverClient = ServerClient()
     private let localDataCache = LocalDataCacheService()
-    private let localAIInsightsService = LocalAIInsightsService()
+    private var localAIInsightsService = LocalAIInsightsService()
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
     private var localAISummaryRefreshTask: Task<Void, Never>?
     private let glanceSnapshotWriteDebouncer = GlanceSnapshotWriteDebouncer()
     private var glanceSnapshotWriteGeneration = 0
     private var reviewUndoStack: [(metadata: [TransactionReviewMetadata], rules: [TransactionRule])] = []
+    private var localAIEnabledPreference: Bool?
+    private var localAIModelNamePreference: String?
+    private var isLoadingLocalAISettings = false
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
     private var lastAttemptedCredentialUpgradeConfig: String?
@@ -321,6 +351,7 @@ final class AppState {
         if defaults.object(forKey: Keys.notifyBrokenConnection) != nil {
             notifyBrokenConnection = defaults.bool(forKey: Keys.notifyBrokenConnection)
         }
+        loadLocalAISettings(defaults: defaults)
         // Balance history
         loadPersistedBalanceHistory()
         loadPersistedWeeklyReviewState()
@@ -339,6 +370,46 @@ final class AppState {
             storedValue: storedDetached,
             isRenderingSnapshot: CommandLineOptions.isRenderingSnapshot()
         )
+    }
+
+    private func loadLocalAISettings(defaults: UserDefaults) {
+        isLoadingLocalAISettings = true
+        defer {
+            isLoadingLocalAISettings = false
+            rebuildLocalAIInsightsService()
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        if defaults.object(forKey: Keys.localAIEnabled) != nil {
+            let enabled = defaults.bool(forKey: Keys.localAIEnabled)
+            localAIEnabledPreference = enabled
+            localAIEnabled = enabled
+        } else {
+            localAIEnabledPreference = nil
+            localAIEnabled = LocalAIRuntimeResolution.isOptedIn(
+                rawValue: environment[LocalAIRuntimeResolution.optInEnvironmentKey]
+            )
+        }
+
+        if let storedModelName = Self.normalizedLocalAIModelName(defaults.string(forKey: Keys.localAIModelName)) {
+            localAIModelNamePreference = storedModelName
+            localAIModelName = storedModelName
+        } else {
+            localAIModelNamePreference = nil
+            localAIModelName = Self.normalizedLocalAIModelName(environment["PLAIDBAR_LOCAL_AI_MODEL"]) ?? "llama3.2"
+        }
+    }
+
+    private func rebuildLocalAIInsightsService() {
+        localAIInsightsService = LocalAIInsightsService(
+            enabledPreference: localAIEnabledPreference,
+            modelNamePreference: localAIModelNamePreference
+        )
+    }
+
+    private static func normalizedLocalAIModelName(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     // MARK: - Computed

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -154,14 +154,13 @@ struct LocalAIInsightsService: Sendable {
     private static func configuredModelName(
         modelNamePreference: String?,
         environment: [String: String]
-    ) -> String {
+    ) -> String? {
         modelNamePreference?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .nilIfEmpty
             ?? environment[EnvironmentKeys.ollamaModel]?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .nilIfEmpty
-            ?? "llama3.2"
     }
 
     /// Whether a configured custom endpoint (if any) is localhost. A missing or

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -10,21 +10,30 @@ struct LocalAIInsightsService: Sendable {
 
     private let model: (any LocalInsightModel)?
     private let environment: [String: String]
+    private let enabledPreference: Bool?
     private let generationConfiguration: LocalInsightModelGenerationConfiguration
 
     init(
         model: (any LocalInsightModel)? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
+        enabledPreference: Bool? = nil,
+        modelNamePreference: String? = nil,
         autoDiscoverModel: Bool = true,
         generationConfiguration: LocalInsightModelGenerationConfiguration = .default
     ) {
         self.environment = environment
-        self.model = model ?? (autoDiscoverModel ? Self.makeDefaultModel(environment: environment) : nil)
+        self.enabledPreference = enabledPreference
+        self.model = model ?? (autoDiscoverModel ? Self.makeDefaultModel(
+            environment: environment,
+            enabledPreference: enabledPreference,
+            modelNamePreference: modelNamePreference
+        ) : nil)
         self.generationConfiguration = generationConfiguration
     }
 
     var availability: LocalAIAvailability {
         LocalAIRuntimeResolution.configuredAvailability(
+            enabledPreference: enabledPreference,
             rawValue: environment[EnvironmentKeys.localRuntime],
             hasWiredModel: model != nil,
             endpointIsLocalhost: Self.endpointIsLocalhost(environment: environment)
@@ -110,11 +119,19 @@ struct LocalAIInsightsService: Sendable {
     }
 
     /// Construct the on-device model ONLY when the user has explicitly opted in
-    /// (`PLAIDBAR_LOCAL_AI_RUNTIME=ollama`/`auto`) and the endpoint is localhost.
-    /// An unset variable yields `nil` — no transaction-derived prompt data is
-    /// routed to any process listening on localhost without consent.
-    private static func makeDefaultModel(environment: [String: String]) -> (any LocalInsightModel)? {
-        guard LocalAIRuntimeResolution.isOptedIn(rawValue: environment[EnvironmentKeys.localRuntime]) else {
+    /// via persisted app settings or (`PLAIDBAR_LOCAL_AI_RUNTIME=ollama`/`auto`)
+    /// and the endpoint is localhost. An unset app setting plus unset variable
+    /// yields `nil` — no transaction-derived prompt data is routed to any process
+    /// listening on localhost without consent.
+    private static func makeDefaultModel(
+        environment: [String: String],
+        enabledPreference: Bool?,
+        modelNamePreference: String?
+    ) -> (any LocalInsightModel)? {
+        guard LocalAIRuntimeResolution.isOptedIn(
+            enabledPreference: enabledPreference,
+            rawValue: environment[EnvironmentKeys.localRuntime]
+        ) else {
             return nil
         }
 
@@ -127,8 +144,24 @@ struct LocalAIInsightsService: Sendable {
 
         return OllamaLocalInsightModel(
             baseURL: baseURL,
-            configuredModelName: environment[EnvironmentKeys.ollamaModel]
+            configuredModelName: Self.configuredModelName(
+                modelNamePreference: modelNamePreference,
+                environment: environment
+            )
         )
+    }
+
+    private static func configuredModelName(
+        modelNamePreference: String?,
+        environment: [String: String]
+    ) -> String {
+        modelNamePreference?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+            ?? environment[EnvironmentKeys.ollamaModel]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+            ?? "llama3.2"
     }
 
     /// Whether a configured custom endpoint (if any) is localhost. A missing or
@@ -198,5 +231,11 @@ struct LocalAIInsightsService: Sendable {
     private static func signedCurrency(_ amount: Double) -> String {
         let prefix = amount > 0 ? "+" : amount < 0 ? "-" : ""
         return "\(prefix)\(Formatters.currency(abs(amount), format: .compact))"
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -389,6 +389,16 @@ struct GeneralSettingsView: View {
             }
 
             Section("Local AI") {
+                Toggle("Enable Local AI", isOn: $state.localAIEnabled)
+
+                LabeledContent("Model") {
+                    TextField("llama3.2", text: $state.localAIModelName)
+                        .multilineTextAlignment(.trailing)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 180)
+                        .disabled(!appState.localAIEnabled)
+                }
+
                 LabeledContent("Availability") {
                     HStack(spacing: Spacing.xs) {
                         Image(systemName: LocalAIAvailabilityPresentation

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -23,17 +23,20 @@ public struct LocalAIAvailability: Codable, Sendable, Hashable {
     public let runtimeName: String?
     public let detail: String
     public let supportsCloudModels: Bool
+    public let probeErrorText: String?
 
     public init(
         state: LocalAIAvailabilityState,
         runtimeName: String? = nil,
         detail: String,
-        supportsCloudModels: Bool = false
+        supportsCloudModels: Bool = false,
+        probeErrorText: String? = nil
     ) {
         self.state = state
         self.runtimeName = runtimeName
         self.detail = detail
         self.supportsCloudModels = supportsCloudModels
+        self.probeErrorText = probeErrorText
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
@@ -36,10 +36,23 @@ public enum LocalAIRuntimeResolution {
         return supportedRuntimes.contains(name)
     }
 
+    /// App settings take precedence over environment variables. A `nil`
+    /// preference means no persisted app choice exists yet, so environment
+    /// fallback can still opt in for CLI/debug launches.
+    public static func isOptedIn(enabledPreference: Bool?, rawValue: String?) -> Bool {
+        if let enabledPreference { return enabledPreference }
+        return isOptedIn(rawValue: rawValue)
+    }
+
     /// True only when the user set the variable to an explicit "off" value, as
     /// opposed to leaving it unset (also off, but opt-in copy differs).
     public static func isExplicitlyDisabled(rawValue: String?) -> Bool {
         disabledValues.contains(runtimeName(from: rawValue).lowercased())
+    }
+
+    public static func isExplicitlyDisabled(enabledPreference: Bool?, rawValue: String?) -> Bool {
+        if let enabledPreference { return !enabledPreference }
+        return isExplicitlyDisabled(rawValue: rawValue)
     }
 
     /// True when a non-empty value names a runtime this build does not support
@@ -55,14 +68,18 @@ public enum LocalAIRuntimeResolution {
     /// opted-in, statically valid runtime reports `.checking` until
     /// `resolved(...)` upgrades it from an actual generation.
     public static func configuredAvailability(
+        enabledPreference: Bool? = nil,
         rawValue: String?,
         hasWiredModel: Bool,
         endpointIsLocalhost: Bool
     ) -> LocalAIAvailability {
-        let runtime = runtimeName(from: rawValue)
+        let runtime = enabledPreference == true ? "ollama" : runtimeName(from: rawValue)
 
-        guard isOptedIn(rawValue: rawValue) else {
-            return LocalAIAvailability(state: .disabled, detail: disabledDetail(rawValue: rawValue))
+        guard isOptedIn(enabledPreference: enabledPreference, rawValue: rawValue) else {
+            return LocalAIAvailability(
+                state: .disabled,
+                detail: disabledDetail(enabledPreference: enabledPreference, rawValue: rawValue)
+            )
         }
 
         guard endpointIsLocalhost else {
@@ -130,8 +147,8 @@ public enum LocalAIRuntimeResolution {
 
     // MARK: - Copy
 
-    static func disabledDetail(rawValue: String?) -> String {
-        if isExplicitlyDisabled(rawValue: rawValue) {
+    static func disabledDetail(enabledPreference: Bool? = nil, rawValue: String?) -> String {
+        if isExplicitlyDisabled(enabledPreference: enabledPreference, rawValue: rawValue) {
             return "Local AI is disabled. VaultPeek is using deterministic local summaries and category hints only."
         }
         if isUnsupportedRuntime(rawValue: rawValue) {

--- a/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
@@ -94,7 +94,8 @@ public enum LocalAIRuntimeResolution {
     public static func resolved(
         base: LocalAIAvailability,
         usedModelOutput: Bool,
-        fallbackReason: LocalInsightModelFallbackReason?
+        fallbackReason: LocalInsightModelFallbackReason?,
+        fallbackDiagnostic: String? = nil
     ) -> LocalAIAvailability {
         guard base.state == .checking || base.state == .available else { return base }
 
@@ -102,7 +103,8 @@ public enum LocalAIRuntimeResolution {
             return LocalAIAvailability(
                 state: .available,
                 runtimeName: base.runtimeName,
-                detail: availableDetail(runtimeName: base.runtimeName)
+                detail: availableDetail(runtimeName: base.runtimeName),
+                probeErrorText: nil
             )
         }
 
@@ -111,7 +113,12 @@ public enum LocalAIRuntimeResolution {
         return LocalAIAvailability(
             state: .unavailable,
             runtimeName: base.runtimeName,
-            detail: fallbackDetail(runtimeName: base.runtimeName, reason: fallbackReason)
+            detail: fallbackDetail(
+                runtimeName: base.runtimeName,
+                reason: fallbackReason,
+                diagnostic: fallbackDiagnostic
+            ),
+            probeErrorText: fallbackDiagnostic
         )
     }
 
@@ -140,7 +147,8 @@ public enum LocalAIRuntimeResolution {
 
     static func fallbackDetail(
         runtimeName: String?,
-        reason: LocalInsightModelFallbackReason
+        reason: LocalInsightModelFallbackReason,
+        diagnostic: String? = nil
     ) -> String {
         let runtime = runtimeName.map { "Local runtime '\($0)'" } ?? "The configured local runtime"
         let reasonText = switch reason {
@@ -159,6 +167,10 @@ public enum LocalAIRuntimeResolution {
         case .invalidOutput:
             "returned invalid or unsafe output"
         }
-        return "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
+        var detail = "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
+        if let diagnostic, !diagnostic.isEmpty {
+            detail += " Probe error: \(diagnostic)"
+        }
+        return detail
     }
 }

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
@@ -32,6 +32,7 @@ public protocol LocalInsightModel: Sendable {
 
 public enum LocalInsightModelError: Error, Sendable, Hashable {
     case runtimeUnavailable
+    case runtimeUnavailableWithDiagnostic(String)
     case noInstalledModel
     case unsupportedConfiguration
 }

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 public struct LocalInsightModelGenerationConfiguration: Sendable, Equatable {
     public static let `default` = LocalInsightModelGenerationConfiguration()
@@ -32,15 +33,18 @@ public struct LocalInsightModelGenerationResult: Sendable, Equatable {
     public let summary: String
     public let usedModelOutput: Bool
     public let fallbackReason: LocalInsightModelFallbackReason?
+    public let fallbackDiagnostic: String?
 
     public init(
         summary: String,
         usedModelOutput: Bool,
-        fallbackReason: LocalInsightModelFallbackReason?
+        fallbackReason: LocalInsightModelFallbackReason?,
+        fallbackDiagnostic: String? = nil
     ) {
         self.summary = summary
         self.usedModelOutput = usedModelOutput
         self.fallbackReason = fallbackReason
+        self.fallbackDiagnostic = fallbackDiagnostic
     }
 }
 
@@ -294,6 +298,11 @@ public enum LocalInsightModelOutputValidator {
 }
 
 public enum LocalInsightModelRuntime {
+    private static let logger = Logger(
+        subsystem: "com.ftchvs.PlaidBar",
+        category: "LocalInsightModelRuntime"
+    )
+
     public static func generateSummary(
         input: LocalAIActivitySummaryInput,
         model: (any LocalInsightModel)?,
@@ -310,6 +319,9 @@ public enum LocalInsightModelRuntime {
         }
 
         let prompt = LocalInsightPromptBuilder.make(from: input)
+        let actionName = "generateSummary"
+        let modelID = String(reflecting: type(of: model))
+        let startedAt = Date()
         let rawOutput: String
 
         do {
@@ -317,18 +329,40 @@ public enum LocalInsightModelRuntime {
                 try await model.summarize(prompt, maxTokens: configuration.maxTokens)
             }
         } catch is LocalInsightModelTimeoutError {
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: .timeout
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
                 fallbackReason: .timeout
             )
         } catch let error as LocalInsightModelError {
+            let reason = error.fallbackReason
+            let diagnostic = error.diagnostic
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: reason,
+                diagnostic: diagnostic
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
-                fallbackReason: error.fallbackReason
+                fallbackReason: reason,
+                fallbackDiagnostic: diagnostic
             )
         } catch {
+            recordModelFailure(
+                actionName: actionName,
+                modelID: modelID,
+                elapsedMilliseconds: elapsedMilliseconds(since: startedAt),
+                reason: .modelError
+            )
             return LocalInsightModelGenerationResult(
                 summary: fallback,
                 usedModelOutput: false,
@@ -354,6 +388,28 @@ public enum LocalInsightModelRuntime {
                 fallbackReason: .invalidOutput
             )
         }
+    }
+
+    private static func recordModelFailure(
+        actionName: String,
+        modelID: String,
+        elapsedMilliseconds: Int,
+        reason: LocalInsightModelFallbackReason,
+        diagnostic: String? = nil
+    ) {
+        if let diagnostic {
+            logger.warning(
+                "local_insight_model_failure action=\(actionName, privacy: .public) model_id=\(modelID, privacy: .public) elapsed_ms=\(elapsedMilliseconds) reason=\(reason.rawValue, privacy: .public) diagnostic=\(diagnostic, privacy: .public)"
+            )
+        } else {
+            logger.warning(
+                "local_insight_model_failure action=\(actionName, privacy: .public) model_id=\(modelID, privacy: .public) elapsed_ms=\(elapsedMilliseconds) reason=\(reason.rawValue, privacy: .public)"
+            )
+        }
+    }
+
+    private static func elapsedMilliseconds(since startedAt: Date) -> Int {
+        max(0, Int(Date().timeIntervalSince(startedAt) * 1_000))
     }
 
     private static func withTimeout<T: Sendable>(
@@ -456,12 +512,21 @@ private struct LocalInsightModelTimeoutError: Error {}
 private extension LocalInsightModelError {
     var fallbackReason: LocalInsightModelFallbackReason {
         switch self {
-        case .runtimeUnavailable:
+        case .runtimeUnavailable, .runtimeUnavailableWithDiagnostic:
             .runtimeUnavailable
         case .noInstalledModel:
             .noInstalledModel
         case .unsupportedConfiguration:
             .unsupportedConfiguration
+        }
+    }
+
+    var diagnostic: String? {
+        switch self {
+        case .runtimeUnavailableWithDiagnostic(let diagnostic):
+            diagnostic
+        case .runtimeUnavailable, .noInstalledModel, .unsupportedConfiguration:
+            nil
         }
     }
 }

--- a/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
@@ -109,10 +109,13 @@ struct LocalAIRuntimeResolutionTests {
         let resolved = LocalAIRuntimeResolution.resolved(
             base: base,
             usedModelOutput: false,
-            fallbackReason: .runtimeUnavailable
+            fallbackReason: .runtimeUnavailable,
+            fallbackDiagnostic: "Connection refused"
         )
         #expect(resolved.state == .unavailable)
         #expect(resolved.detail.contains("not reachable"))
+        #expect(resolved.detail.contains("Connection refused"))
+        #expect(resolved.probeErrorText == "Connection refused")
     }
 
     @Test("Terminal states pass through resolution unchanged")

--- a/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
@@ -70,6 +70,21 @@ struct LocalAIRuntimeResolutionTests {
         #expect(availability.state == .unavailable)
     }
 
+    @Test("App enablement preference takes precedence over runtime environment")
+    func appEnablementPreferenceTakesPrecedenceOverEnvironment() {
+        #expect(LocalAIRuntimeResolution.isOptedIn(enabledPreference: true, rawValue: nil) == true)
+        #expect(LocalAIRuntimeResolution.isOptedIn(enabledPreference: true, rawValue: "off") == true)
+        #expect(LocalAIRuntimeResolution.isOptedIn(enabledPreference: false, rawValue: "ollama") == false)
+
+        let disabled = LocalAIRuntimeResolution.configuredAvailability(
+            enabledPreference: false,
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        #expect(disabled.state == .disabled)
+    }
+
     @Test("Unsupported runtime value is disabled with a clear reason")
     func unsupportedRuntimeIsDisabled() {
         let availability = LocalAIRuntimeResolution.configuredAvailability(

--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -137,6 +137,26 @@ struct LocalInsightModelRuntimeTests {
         #expect(result.summary == "deterministic fallback")
         #expect(result.usedModelOutput == false)
         #expect(result.fallbackReason == .runtimeUnavailable)
+        #expect(result.fallbackDiagnostic == nil)
+    }
+
+    @Test("Runtime preserves local model availability diagnostics")
+    func runtimePreservesLocalModelAvailabilityDiagnostics() async {
+        let diagnostic = "URLError(.cannotConnectToHost) - connection refused"
+        let model = StubLocalInsightModel(result: .failure(
+            LocalInsightModelError.runtimeUnavailableWithDiagnostic(diagnostic)
+        ))
+
+        let result = await LocalInsightModelRuntime.generateSummary(
+            input: input(),
+            model: model,
+            fallbackSummary: { _ in "deterministic fallback" }
+        )
+
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .runtimeUnavailable)
+        #expect(result.fallbackDiagnostic == diagnostic)
     }
 
     @Test("Runtime falls back when model exceeds timeout")


### PR DESCRIPTION
## Summary
- Add persisted app-level Local AI enablement and model-name settings.
- Make explicit app preferences take precedence over `PLAIDBAR_LOCAL_AI_RUNTIME`, while preserving the environment fallback when no app preference exists.
- Rebuild LocalAIInsightsService and refresh summaries when Local AI settings change.

Fixes #390
Linear: AND-441

Stacked on #401 because it reuses the Local AI diagnostic/availability fields from that PR.

## Validation
- `git diff --cached --check`
- `swift test --filter LocalAIRuntimeResolutionTests --scratch-path /tmp/plaidbar-issue390-build`

Result: 11 focused tests passed.

## Safety
- Local AI remains opt-in/local-only.
- No cloud AI fallback added.
- No Plaid credentials, provider tokens, raw payloads, real account IDs, transaction IDs, balances, local SQLite data, logs, or screenshots added.
