### PR TITLE
fix: add local ai remediation actions

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -252,6 +252,7 @@ final class AppState {
             invalidateLocalAIActivitySummaries()
         }
     }
+    var isCheckingLocalAIAvailability = false
 
     var launchAtLogin: Bool = false {
         didSet {
@@ -277,6 +278,7 @@ final class AppState {
     private var reviewUndoStack: [(metadata: [TransactionReviewMetadata], rules: [TransactionRule])] = []
     private var localAIEnabledPreference: Bool?
     private var localAIModelNamePreference: String?
+    private var localAIProbeAvailability: LocalAIAvailability?
     private var isLoadingLocalAISettings = false
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
@@ -411,6 +413,7 @@ final class AppState {
     }
 
     private func rebuildLocalAIInsightsService() {
+        localAIProbeAvailability = nil
         localAIInsightsService = LocalAIInsightsService(
             enabledPreference: localAIEnabledPreference,
             modelNamePreference: localAIModelNamePreference
@@ -1032,6 +1035,9 @@ final class AppState {
     }
 
     var localAIAvailability: LocalAIAvailability {
+        if let probeAvailability = localAIProbeAvailability {
+            return probeAvailability
+        }
         if let generatedAvailability = _cachedLocalAIActivitySummaries?
             .first(where: { $0.window == .lastMonth })?
             .availability
@@ -1063,8 +1069,16 @@ final class AppState {
     }
 
     private func invalidateLocalAIActivitySummaries() {
+        localAIProbeAvailability = nil
         _cachedLocalAIActivitySummaries = nil
         scheduleLocalAIActivitySummaryRefresh()
+    }
+
+    func checkLocalAIAvailability() async {
+        guard !isCheckingLocalAIAvailability else { return }
+        isCheckingLocalAIAvailability = true
+        defer { isCheckingLocalAIAvailability = false }
+        localAIProbeAvailability = await localAIInsightsService.probeAvailability()
     }
 
     private func scheduleLocalAIActivitySummaryRefresh() {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -279,6 +279,7 @@ final class AppState {
     private var localAIEnabledPreference: Bool?
     private var localAIModelNamePreference: String?
     private var localAIProbeAvailability: LocalAIAvailability?
+    private var localAIProbeGeneration = 0
     private var isLoadingLocalAISettings = false
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
@@ -413,6 +414,7 @@ final class AppState {
     }
 
     private func rebuildLocalAIInsightsService() {
+        localAIProbeGeneration += 1
         localAIProbeAvailability = nil
         localAIInsightsService = LocalAIInsightsService(
             enabledPreference: localAIEnabledPreference,
@@ -1035,6 +1037,13 @@ final class AppState {
     }
 
     var localAIAvailability: LocalAIAvailability {
+        if let generatedAvailability = _cachedLocalAIActivitySummaries?
+            .first(where: { $0.window == .lastMonth })?
+            .availability,
+            generatedAvailability.state == .available
+        {
+            return generatedAvailability
+        }
         if let probeAvailability = localAIProbeAvailability {
             return probeAvailability
         }
@@ -1069,6 +1078,7 @@ final class AppState {
     }
 
     private func invalidateLocalAIActivitySummaries() {
+        localAIProbeGeneration += 1
         localAIProbeAvailability = nil
         _cachedLocalAIActivitySummaries = nil
         scheduleLocalAIActivitySummaryRefresh()
@@ -1076,9 +1086,13 @@ final class AppState {
 
     func checkLocalAIAvailability() async {
         guard !isCheckingLocalAIAvailability else { return }
+        let generation = localAIProbeGeneration
+        let service = localAIInsightsService
         isCheckingLocalAIAvailability = true
         defer { isCheckingLocalAIAvailability = false }
-        localAIProbeAvailability = await localAIInsightsService.probeAvailability()
+        let availability = await service.probeAvailability()
+        guard generation == localAIProbeGeneration else { return }
+        localAIProbeAvailability = availability
     }
 
     private func scheduleLocalAIActivitySummaryRefresh() {

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -65,6 +65,58 @@ struct LocalAIInsightsService: Sendable {
         }
     }
 
+    func probeAvailability() async -> LocalAIAvailability {
+        let currentAvailability = availability
+        guard LocalAIRuntimeResolution.usesModel(for: currentAvailability.state), let model else {
+            return currentAvailability
+        }
+
+        do {
+            _ = try await model.summarize(
+                LocalInsightModelPrompt(
+                    system: "Reply with OK if the local runtime is available. Do not include financial data.",
+                    user: "Health check only."
+                ),
+                maxTokens: 8
+            )
+            return LocalAIRuntimeResolution.resolved(
+                base: currentAvailability,
+                usedModelOutput: true,
+                fallbackReason: nil
+            )
+        } catch let error as LocalInsightModelError {
+            let reason: LocalInsightModelFallbackReason
+            let diagnostic: String?
+            switch error {
+            case .runtimeUnavailable:
+                reason = .runtimeUnavailable
+                diagnostic = nil
+            case .runtimeUnavailableWithDiagnostic(let message):
+                reason = .runtimeUnavailable
+                diagnostic = message
+            case .noInstalledModel:
+                reason = .noInstalledModel
+                diagnostic = nil
+            case .unsupportedConfiguration:
+                reason = .unsupportedConfiguration
+                diagnostic = nil
+            }
+            return LocalAIRuntimeResolution.resolved(
+                base: currentAvailability,
+                usedModelOutput: false,
+                fallbackReason: reason,
+                fallbackDiagnostic: diagnostic
+            )
+        } catch {
+            return LocalAIRuntimeResolution.resolved(
+                base: currentAvailability,
+                usedModelOutput: false,
+                fallbackReason: .modelError,
+                fallbackDiagnostic: String(describing: error)
+            )
+        }
+    }
+
     func generatedActivitySummaries(
         accounts: [AccountDTO],
         transactions: [TransactionDTO],

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -72,13 +72,7 @@ struct LocalAIInsightsService: Sendable {
         }
 
         do {
-            _ = try await model.summarize(
-                LocalInsightModelPrompt(
-                    system: "Reply with OK if the local runtime is available. Do not include financial data.",
-                    user: "Health check only."
-                ),
-                maxTokens: 8
-            )
+            _ = try await boundedProbe(model: model)
             return LocalAIRuntimeResolution.resolved(
                 base: currentAvailability,
                 usedModelOutput: true,
@@ -114,6 +108,30 @@ struct LocalAIInsightsService: Sendable {
                 fallbackReason: .modelError,
                 fallbackDiagnostic: String(describing: error)
             )
+        }
+    }
+
+    private func boundedProbe(model: any LocalInsightModel) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await model.summarize(
+                    LocalInsightModelPrompt(
+                        system: "Reply with OK if the local runtime is available. Do not include financial data.",
+                        user: "Health check only."
+                    ),
+                    maxTokens: 8
+                )
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: generationConfiguration.timeoutNanoseconds)
+                throw LocalInsightModelError.runtimeUnavailableWithDiagnostic("Local AI health probe timed out.")
+            }
+
+            guard let result = try await group.next() else {
+                throw LocalInsightModelError.runtimeUnavailable
+            }
+            group.cancelAll()
+            return result
         }
     }
 

--- a/Sources/PlaidBar/Services/LocalAIRemediationActions.swift
+++ b/Sources/PlaidBar/Services/LocalAIRemediationActions.swift
@@ -8,7 +8,12 @@ enum LocalAIRemediationActions {
 
     static func pullCommand(modelName: String) -> String {
         let normalized = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return "ollama pull \(normalized.isEmpty ? "llama3.2" : normalized)"
+        let model = shellQuoted(normalized.isEmpty ? "llama3.2" : normalized)
+        return "ollama pull \(model)"
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 
     static func openInstallPage() {

--- a/Sources/PlaidBar/Services/LocalAIRemediationActions.swift
+++ b/Sources/PlaidBar/Services/LocalAIRemediationActions.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum LocalAIRemediationActions {
+    static let installURL = URL(string: "https://ollama.com/download")!
+    static let startCommand = "ollama serve"
+
+    static func pullCommand(modelName: String) -> String {
+        let normalized = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "ollama pull \(normalized.isEmpty ? "llama3.2" : normalized)"
+    }
+
+    static func openInstallPage() {
+        NSWorkspace.shared.open(installURL)
+    }
+
+    static func copyStartCommand() {
+        copy(startCommand)
+    }
+
+    static func copyPullCommand(modelName: String) {
+        copy(pullCommand(modelName: modelName))
+    }
+
+    private static func copy(_ string: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -309,6 +309,7 @@ struct GeneralSettingsView: View {
     @Environment(AppState.self) private var appState
     @AppStorage(DetachedDashboardPreferences.keepOnTopStorageKey) private var keepDashboardOnTop = false
     @State private var isShowingResetConfirmation = false
+    @State private var isShowingLocalAIProbeDetails = false
     @State private var resetResultMessage: String?
     @State private var resetErrorMessage: String?
 
@@ -405,24 +406,50 @@ struct GeneralSettingsView: View {
                             .iconName(for: appState.localAIAvailability.state))
                             .foregroundStyle(localAIAvailabilityTint)
                             .accessibilityHidden(true)
-                        Text(appState.localAIAvailability.state.displayName)
+                        Text(LocalAIAvailabilityPresentation.settingsLabel(for: appState.localAIAvailability))
                             .font(.body.weight(.medium))
                     }
                 }
                 .accessibilityElement(children: .combine)
 
                 LabeledContent("Runtime") {
-                    Text(appState.localAIAvailability.runtimeName ?? "None configured")
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
+                    VStack(alignment: .trailing, spacing: Spacing.xxs) {
+                        Text(appState.localAIAvailability.runtimeName ?? "None configured")
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+
+                        if let cause = LocalAIAvailabilityPresentation.causeLabel(for: appState.localAIAvailability) {
+                            Text(cause)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(localAIAvailabilityTint)
+                                .lineLimit(1)
+                        }
+                    }
                 }
+
+                localAIRemediationControls
 
                 Text(appState.localAIAvailability.detail)
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
 
-                localAIRemediationControls
+                if let probeErrorText = appState.localAIAvailability.probeErrorText, !probeErrorText.isEmpty {
+                    Button(isShowingLocalAIProbeDetails ? "Hide Probe Error" : "View Probe Error") {
+                        isShowingLocalAIProbeDetails.toggle()
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .help("Show the exact Ollama probe error captured during the local availability check.")
+
+                    if isShowingLocalAIProbeDetails {
+                        Text(probeErrorText)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
 
                 Text(
                     "VaultPeek does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged."
@@ -543,50 +570,119 @@ struct GeneralSettingsView: View {
 
     @ViewBuilder
     private var localAIRemediationControls: some View {
-        HStack(spacing: Spacing.sm) {
+        switch LocalAIAvailabilityPresentation.remediationCategory(for: appState.localAIAvailability) {
+        case .none:
+            EmptyView()
+        case .checking:
             Button {
                 Task { await appState.checkLocalAIAvailability() }
             } label: {
-                Label(
-                    appState.isCheckingLocalAIAvailability ? "Checking…" : "Retry Check",
-                    systemImage: "arrow.clockwise"
-                )
+                Label("Checking…", systemImage: "hourglass")
             }
+            .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(!appState.localAIEnabled || appState.isCheckingLocalAIAvailability)
-            .help("Probe the local Ollama runtime again without sending Plaid credentials, account IDs, or transaction IDs.")
-
+            .disabled(true)
+        case .disabled:
             Button {
                 LocalAIRemediationActions.openInstallPage()
             } label: {
-                Label("Install Ollama", systemImage: "arrow.down.app")
+                Label("Install or Open Ollama", systemImage: "arrow.down.app")
             }
+            .buttonStyle(.bordered)
             .controlSize(.small)
             .help("Open the Ollama download page in your browser.")
+        case .noInstalledModel:
+            HStack(spacing: Spacing.sm) {
+                Button {
+                    LocalAIRemediationActions.copyPullCommand(modelName: appState.localAIModelName)
+                } label: {
+                    Label("Copy Model Command", systemImage: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderedProminent)
+                .help("Copies: \(LocalAIRemediationActions.pullCommand(modelName: appState.localAIModelName))")
 
-            Button {
-                LocalAIRemediationActions.copyStartCommand()
-            } label: {
-                Label("Copy Start Command", systemImage: "terminal")
+                retryLocalAIButton
+
+                installOllamaButton
             }
             .controlSize(.small)
-            .help("Copies: \(LocalAIRemediationActions.startCommand)")
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Local AI remediation actions")
+        case .runtimeUnavailable:
+            HStack(spacing: Spacing.sm) {
+                retryLocalAIButton
+                    .buttonStyle(.borderedProminent)
 
-            Button {
-                LocalAIRemediationActions.copyPullCommand(modelName: appState.localAIModelName)
-            } label: {
-                Label("Copy Pull Command", systemImage: "square.and.arrow.down")
+                installOllamaButton
+
+                Button {
+                    LocalAIRemediationActions.copyStartCommand()
+                } label: {
+                    Label("Copy ollama serve", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+                .help("Copies: \(LocalAIRemediationActions.startCommand)")
             }
             .controlSize(.small)
-            .disabled(!appState.localAIEnabled)
-            .help("Copies: \(LocalAIRemediationActions.pullCommand(modelName: appState.localAIModelName))")
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Local AI remediation actions")
+        case .unsupportedConfiguration:
+            HStack(spacing: Spacing.sm) {
+                installOllamaButton
+
+                Button {
+                    LocalAIRemediationActions.copyStartCommand()
+                } label: {
+                    Label("Copy ollama serve", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+                .help("Copies: \(LocalAIRemediationActions.startCommand)")
+            }
+            .controlSize(.small)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Local AI remediation actions")
+        case .modelError:
+            HStack(spacing: Spacing.sm) {
+                retryLocalAIButton
+                    .buttonStyle(.borderedProminent)
+
+                installOllamaButton
+
+                Button {
+                    LocalAIRemediationActions.copyStartCommand()
+                } label: {
+                    Label("Copy ollama serve", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+                .help("Copies: \(LocalAIRemediationActions.startCommand)")
+            }
+            .controlSize(.small)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Local AI remediation actions")
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Local AI remediation actions")
+    }
 
-        Text("If Ollama is not installed, install it first. If it is installed but unavailable, start it with `ollama serve`, pull the selected model, then retry the check. The probe uses a synthetic health-check prompt only.")
-            .detailText()
-            .fixedSize(horizontal: false, vertical: true)
+    private var retryLocalAIButton: some View {
+        Button {
+            Task { await appState.checkLocalAIAvailability() }
+        } label: {
+            Label(
+                appState.isCheckingLocalAIAvailability ? "Checking…" : "Retry",
+                systemImage: "arrow.clockwise"
+            )
+        }
+        .disabled(!appState.localAIEnabled || appState.isCheckingLocalAIAvailability)
+        .help("Probe the local Ollama runtime again without sending Plaid credentials, account IDs, or transaction IDs.")
+    }
+
+    private var installOllamaButton: some View {
+        Button {
+            LocalAIRemediationActions.openInstallPage()
+        } label: {
+            Label("Install or Open Ollama", systemImage: "arrow.down.app")
+        }
+        .buttonStyle(.bordered)
+        .help("Open the Ollama download page in your browser.")
     }
 
     private func color(for tone: SettingsStatusTone) -> Color {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -422,6 +422,8 @@ struct GeneralSettingsView: View {
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
 
+                localAIRemediationControls
+
                 Text(
                     "VaultPeek does not send transaction data to cloud AI services. Local insight summaries are derived from local accounts, transactions, and recurring detections; raw Plaid transaction categories remain unchanged."
                 )
@@ -537,6 +539,54 @@ struct GeneralSettingsView: View {
 
     private var localAIAvailabilityTint: Color {
         color(for: LocalAIAvailabilityPresentation.tone(for: appState.localAIAvailability.state))
+    }
+
+    @ViewBuilder
+    private var localAIRemediationControls: some View {
+        HStack(spacing: Spacing.sm) {
+            Button {
+                Task { await appState.checkLocalAIAvailability() }
+            } label: {
+                Label(
+                    appState.isCheckingLocalAIAvailability ? "Checking…" : "Retry Check",
+                    systemImage: "arrow.clockwise"
+                )
+            }
+            .controlSize(.small)
+            .disabled(!appState.localAIEnabled || appState.isCheckingLocalAIAvailability)
+            .help("Probe the local Ollama runtime again without sending Plaid credentials, account IDs, or transaction IDs.")
+
+            Button {
+                LocalAIRemediationActions.openInstallPage()
+            } label: {
+                Label("Install Ollama", systemImage: "arrow.down.app")
+            }
+            .controlSize(.small)
+            .help("Open the Ollama download page in your browser.")
+
+            Button {
+                LocalAIRemediationActions.copyStartCommand()
+            } label: {
+                Label("Copy Start Command", systemImage: "terminal")
+            }
+            .controlSize(.small)
+            .help("Copies: \(LocalAIRemediationActions.startCommand)")
+
+            Button {
+                LocalAIRemediationActions.copyPullCommand(modelName: appState.localAIModelName)
+            } label: {
+                Label("Copy Pull Command", systemImage: "square.and.arrow.down")
+            }
+            .controlSize(.small)
+            .disabled(!appState.localAIEnabled)
+            .help("Copies: \(LocalAIRemediationActions.pullCommand(modelName: appState.localAIModelName))")
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Local AI remediation actions")
+
+        Text("If Ollama is not installed, install it first. If it is installed but unavailable, start it with `ollama serve`, pull the selected model, then retry the check. The probe uses a synthetic health-check prompt only.")
+            .detailText()
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     private func color(for tone: SettingsStatusTone) -> Color {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1013,6 +1013,7 @@ private struct BalanceHeatmapCell: View {
 
 private struct LocalInsightsCard: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
 
     private var summaries: [LocalAIActivitySummary] {
         appState.localAIActivitySummaries
@@ -1043,7 +1044,13 @@ private struct LocalInsightsCard: View {
 
                 Spacer()
 
-                LocalAIStatusPill(availability: availability)
+                LocalAIStatusPill(
+                    availability: availability,
+                    isChecking: appState.isCheckingLocalAIAvailability,
+                    modelName: appState.localAIModelName,
+                    onRetry: { Task { await appState.checkLocalAIAvailability() } },
+                    onOpenSettings: { openSettings() }
+                )
             }
 
             Text(receipt.headline)
@@ -1104,12 +1111,25 @@ private struct LocalInsightsCard: View {
 
 private struct LocalAIStatusPill: View {
     let availability: LocalAIAvailability
+    let isChecking: Bool
+    let modelName: String
+    let onRetry: () -> Void
+    let onOpenSettings: () -> Void
 
     var body: some View {
         HStack(spacing: Spacing.xs) {
-            Image(systemName: iconName)
+            statusCapsule
+
+            actionButton
+        }
+        .help(LocalAIAvailabilityPresentation.helpText(for: availability))
+    }
+
+    private var statusCapsule: some View {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: LocalAIAvailabilityPresentation.iconName(for: availability.state))
                 .font(.caption2.weight(.medium))
-            Text("Local - \(availability.state.displayName)")
+            Text(LocalAIAvailabilityPresentation.popoverLabel(for: availability))
                 .font(.caption.weight(.medium))
                 .lineLimit(1)
         }
@@ -1117,15 +1137,49 @@ private struct LocalAIStatusPill: View {
         .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.chipVertical)
         .background(.quinary, in: Capsule())
-        .help(availability.detail)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(LocalAIAvailabilityPresentation.popoverLabel(for: availability))
     }
 
-    private var iconName: String {
-        switch availability.state {
-        case .available: "cpu.fill"
-        case .disabled: "pause.circle.fill"
-        case .unavailable: "exclamationmark.triangle.fill"
-        case .checking: "hourglass"
+    @ViewBuilder
+    private var actionButton: some View {
+        switch LocalAIAvailabilityPresentation.remediationCategory(for: availability) {
+        case .noInstalledModel:
+            Button {
+                LocalAIRemediationActions.copyPullCommand(modelName: modelName)
+            } label: {
+                Label("Copy Command", systemImage: "doc.on.doc")
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("Copy the Ollama model install command")
+            .accessibilityLabel("Copy Ollama model command")
+        case .runtimeUnavailable, .modelError:
+            Button {
+                onRetry()
+            } label: {
+                Label(isChecking ? "Checking" : "Retry", systemImage: isChecking ? "hourglass" : "arrow.clockwise")
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .disabled(isChecking)
+            .help("Check Ollama again")
+            .accessibilityLabel("Retry Ollama connection")
+        case .unsupportedConfiguration:
+            Button {
+                onOpenSettings()
+            } label: {
+                Label("Settings", systemImage: "gearshape")
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("Open Local AI settings")
+            .accessibilityLabel("Open Local AI settings")
+        case .none, .disabled, .checking:
+            EmptyView()
         }
     }
 

--- a/Sources/PlaidBarCore/Utilities/SettingsPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/SettingsPresentation.swift
@@ -10,6 +10,20 @@ public enum SettingsStatusTone: String, Sendable {
     case secondary
 }
 
+/// User-facing remediation buckets for the optional Local AI runtime.
+///
+/// `LocalAIAvailability` intentionally stays small and stable; this helper keeps
+/// the view-layer copy centralized so Settings and the popover do not drift.
+public enum LocalAIRemediationCategory: String, Sendable {
+    case none
+    case disabled
+    case checking
+    case noInstalledModel
+    case runtimeUnavailable
+    case unsupportedConfiguration
+    case modelError
+}
+
 /// Maps local AI availability to settings status iconography.
 public enum LocalAIAvailabilityPresentation {
     public static func iconName(for state: LocalAIAvailabilityState) -> String {
@@ -27,6 +41,117 @@ public enum LocalAIAvailabilityPresentation {
         case .disabled: .secondary
         case .unavailable: .warning
         case .checking: .secondary
+        }
+    }
+
+    public static func remediationCategory(for availability: LocalAIAvailability) -> LocalAIRemediationCategory {
+        switch availability.state {
+        case .available:
+            return .none
+        case .disabled:
+            let normalizedDetail = availability.detail.lowercased()
+            if normalizedDetail.contains("not supported") || normalizedDetail.contains("non-local endpoint") {
+                return .unsupportedConfiguration
+            }
+            return .disabled
+        case .checking:
+            return .checking
+        case .unavailable:
+            break
+        }
+
+        let normalizedDetail = "\(availability.detail) \(availability.probeErrorText ?? "")"
+            .lowercased()
+        if normalizedDetail.contains("no installed local model") {
+            return .noInstalledModel
+        }
+        if normalizedDetail.contains("non-local endpoint")
+            || normalizedDetail.contains("unsupported local endpoint")
+            || normalizedDetail.contains("not supported")
+            || normalizedDetail.contains("no model adapter")
+        {
+            return .unsupportedConfiguration
+        }
+        if normalizedDetail.contains("not reachable")
+            || normalizedDetail.contains("timed out")
+            || normalizedDetail.contains("could not connect")
+            || normalizedDetail.contains("connection refused")
+        {
+            return .runtimeUnavailable
+        }
+        if normalizedDetail.contains("returned an error")
+            || normalizedDetail.contains("invalid or unsafe output")
+        {
+            return .modelError
+        }
+        return .runtimeUnavailable
+    }
+
+    public static func settingsLabel(for availability: LocalAIAvailability) -> String {
+        switch remediationCategory(for: availability) {
+        case .none:
+            return "Available"
+        case .disabled:
+            return "Disabled"
+        case .checking:
+            return "Checking…"
+        case .noInstalledModel:
+            return "Model Missing"
+        case .runtimeUnavailable:
+            return "Ollama Offline"
+        case .unsupportedConfiguration:
+            return "Needs Setup"
+        case .modelError:
+            return "Model Error"
+        }
+    }
+
+    public static func popoverLabel(for availability: LocalAIAvailability) -> String {
+        switch remediationCategory(for: availability) {
+        case .none:
+            return "Local On"
+        case .disabled:
+            return "Local Off"
+        case .checking:
+            return "Checking…"
+        case .noInstalledModel:
+            return "No Model"
+        case .runtimeUnavailable:
+            return "Local Offline"
+        case .unsupportedConfiguration:
+            return "Needs Setup"
+        case .modelError:
+            return "Local Error"
+        }
+    }
+
+    public static func causeLabel(for availability: LocalAIAvailability) -> String? {
+        switch remediationCategory(for: availability) {
+        case .none, .disabled, .checking:
+            return nil
+        case .noInstalledModel:
+            return "No local model installed"
+        case .runtimeUnavailable:
+            return "Ollama not reachable"
+        case .unsupportedConfiguration:
+            return "Unsupported local setup"
+        case .modelError:
+            return "Probe returned an error"
+        }
+    }
+
+    public static func helpText(for availability: LocalAIAvailability) -> String {
+        switch remediationCategory(for: availability) {
+        case .none, .disabled, .checking:
+            return availability.detail
+        case .noInstalledModel:
+            return "Install a local Ollama model to enable on-device summaries. \(availability.detail)"
+        case .runtimeUnavailable:
+            return "Start Ollama, then retry. \(availability.detail)"
+        case .unsupportedConfiguration:
+            return "Open Local AI settings to review the unsupported configuration. \(availability.detail)"
+        case .modelError:
+            return "Retry the local model probe or inspect the exact error in Settings. \(availability.detail)"
         }
     }
 }

--- a/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
@@ -81,6 +81,37 @@ struct SettingsPresentationTests {
         #expect(LocalAIAvailabilityPresentation.tone(for: availability.state) == .warning)
     }
 
+    @Test("Local AI remediation presentation distinguishes missing model from offline runtime")
+    func localAIRemediationPresentationDistinguishesMissingModelFromOfflineRuntime() {
+        let base = LocalAIRuntimeResolution.configuredAvailability(
+            rawValue: "ollama",
+            hasWiredModel: true,
+            endpointIsLocalhost: true
+        )
+        let missingModel = LocalAIRuntimeResolution.resolved(
+            base: base,
+            usedModelOutput: false,
+            fallbackReason: .noInstalledModel,
+            fallbackDiagnostic: "ollama list returned no supported model"
+        )
+        let offlineRuntime = LocalAIRuntimeResolution.resolved(
+            base: base,
+            usedModelOutput: false,
+            fallbackReason: .runtimeUnavailable,
+            fallbackDiagnostic: "connection refused"
+        )
+
+        #expect(LocalAIAvailabilityPresentation.remediationCategory(for: missingModel) == .noInstalledModel)
+        #expect(LocalAIAvailabilityPresentation.settingsLabel(for: missingModel) == "Model Missing")
+        #expect(LocalAIAvailabilityPresentation.popoverLabel(for: missingModel) == "No Model")
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: missingModel) == "No local model installed")
+
+        #expect(LocalAIAvailabilityPresentation.remediationCategory(for: offlineRuntime) == .runtimeUnavailable)
+        #expect(LocalAIAvailabilityPresentation.settingsLabel(for: offlineRuntime) == "Ollama Offline")
+        #expect(LocalAIAvailabilityPresentation.popoverLabel(for: offlineRuntime) == "Local Offline")
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: offlineRuntime) == "Ollama not reachable")
+    }
+
     @Test("Storage detail prefers the server path and abbreviates the home directory")
     func storageDetailPrefersServerPath() {
         let detail = LocalDataResetPresentation.storageDetail(


### PR DESCRIPTION
## Summary
- Add a retryable Local AI health probe using a synthetic prompt only.
- Add Settings remediation actions for Ollama: install page, copy `ollama serve`, copy selected-model pull command, and retry check.
- Surface probe state in `AppState` without sending Plaid credentials, raw payloads, account IDs, transaction IDs, balances, screenshots, or SQLite data to the model.

Fixes #391
Linear: AND-442

Stacked on #402 because this builds on the Local AI settings opt-in UI.

## Validation
- `git diff --cached --check`
- `swift test --filter LocalAIRuntimeResolutionTests --scratch-path /tmp/plaidbar-issue391-build`

Result: 11 focused tests passed.

## Safety
- Local AI remains opt-in/local-only.
- Health probe uses a synthetic non-financial prompt only.
- No cloud AI fallback added.
- Remediation controls only open Ollama's install page or copy local shell commands; they do not execute commands.
