### PR TITLE
fix: hydrate category budgets in app state

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,12 @@ let package = Package(
         ),
         .testTarget(
             name: "PlaidBarServerTests",
-            dependencies: ["PlaidBarCore", "PlaidBarServer", swiftTestingTestDependency],
+            dependencies: [
+                "PlaidBarCore",
+                "PlaidBarServer",
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
+                swiftTestingTestDependency,
+            ],
             path: "Tests/PlaidBarServerTests",
             swiftSettings: [.swiftLanguageMode(.v5)],
             linkerSettings: swiftTestingLinkerSettings

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -104,6 +104,10 @@ final class AppState {
     var serverSyncedItemCount: Int?
     var billingSubscription: BillingSubscription?
     var itemStatuses: [ItemStatus] = []
+    /// User-set category budget limits hydrated from `/api/budgets`.
+    /// Suggestions remain a local fallback/complement, but this cache wins for
+    /// categories the user explicitly saved on the server.
+    var categoryBudgets: [SpendingCategory: Double] = [:]
     var isDemoMode = false
     var isDemoStatusRecoveryScenario = false
     var lastSyncDate: Date?
@@ -742,13 +746,72 @@ final class AppState {
             recurringTransactions: recurringTransactions,
             safeToSpend: safeToSpend,
             previousSafeToSpendAmount: persistedPreviousSafeToSpendAmount,
-            categoryBudgets: CategoryBudgetPlanner.suggestedPresentation(
-                from: transactions,
-                asOf: Date()
-            ),
+            categoryBudgets: categoryBudgetPresentation,
             itemStatuses: itemStatuses,
             isSyncStale: isSyncStale
         )
+    }
+
+    var categoryBudgetPresentation: CategoryBudgetPresentation {
+        let now = Date()
+        let suggestedBudgets = CategoryBudgetPlanner.suggestedBudgets(
+            from: transactions,
+            asOf: now
+        )
+        let suggestedPresentation = CategoryBudgetPlanner.presentation(
+            budgets: suggestedBudgets.filter { categoryBudgets[$0.key] == nil },
+            transactions: transactions,
+            asOf: now,
+            areSuggested: true
+        )
+
+        guard !categoryBudgets.isEmpty else { return suggestedPresentation }
+
+        let serverPresentation = CategoryBudgetPlanner.presentation(
+            budgets: categoryBudgets,
+            transactions: transactions,
+            asOf: now
+        )
+        return Self.mergeCategoryBudgetPresentations(
+            serverPresentation,
+            suggestedPresentation
+        )
+    }
+
+    private static func mergeCategoryBudgetPresentations(
+        _ explicit: CategoryBudgetPresentation,
+        _ suggested: CategoryBudgetPresentation
+    ) -> CategoryBudgetPresentation {
+        let explicitCategoryIds = Set(explicit.items.map(\.id))
+        let items = (explicit.items + suggested.items.filter { !explicitCategoryIds.contains($0.id) })
+            .sorted { lhs, rhs in
+                if lhs.status != rhs.status {
+                    return categoryBudgetStatusRank(lhs.status) < categoryBudgetStatusRank(rhs.status)
+                }
+                if lhs.fractionUsed != rhs.fractionUsed {
+                    return lhs.fractionUsed > rhs.fractionUsed
+                }
+                if lhs.isSuggested != rhs.isSuggested {
+                    return !lhs.isSuggested
+                }
+                return lhs.category.displayName < rhs.category.displayName
+            }
+
+        return CategoryBudgetPresentation(
+            items: items,
+            totalLimit: items.reduce(0) { $0 + $1.monthlyLimit },
+            totalSpent: items.reduce(0) { $0 + $1.spent },
+            overBudgetCount: items.reduce(0) { $0 + ($1.status == .over ? 1 : 0) },
+            nearingCount: items.reduce(0) { $0 + ($1.status == .nearing ? 1 : 0) }
+        )
+    }
+
+    private static func categoryBudgetStatusRank(_ status: CategoryBudgetStatus) -> Int {
+        switch status {
+        case .over: 0
+        case .nearing: 1
+        case .under: 2
+        }
     }
 
     private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {
@@ -1175,6 +1238,58 @@ final class AppState {
         }
     }
 
+    func refreshCategoryBudgets() async {
+        guard !isDemoMode else { return }
+        do {
+            let budgets = try await serverClient.listCategoryBudgets()
+            categoryBudgets = Dictionary(
+                budgets.map { ($0.category, $0.monthlyLimit) }
+            ) { first, _ in first }
+        } catch {
+            // Keep the last-known in-memory budgets (or local suggestions) visible
+            // when the companion server is offline or the endpoint errors; never
+            // replace a valid UI state with an empty cache on refresh failure.
+            self.error = error.localizedDescription
+        }
+    }
+
+    func setCategoryBudget(_ category: SpendingCategory, amount: Double) async {
+        guard !CategoryBudgetPlanner.excludedCategories.contains(category) else {
+            error = "Income and transfer categories cannot be budgeted."
+            return
+        }
+        guard amount > 0 else {
+            await removeCategoryBudget(category)
+            return
+        }
+
+        let previousBudgets = categoryBudgets
+        categoryBudgets[category] = amount
+        error = nil
+        do {
+            let saved = try await serverClient.saveCategoryBudget(
+                categoryId: category.rawValue,
+                amount: amount
+            )
+            categoryBudgets[saved.category] = saved.monthlyLimit
+        } catch {
+            categoryBudgets = previousBudgets
+            self.error = error.localizedDescription
+        }
+    }
+
+    func removeCategoryBudget(_ category: SpendingCategory) async {
+        let previousBudgets = categoryBudgets
+        categoryBudgets.removeValue(forKey: category)
+        error = nil
+        do {
+            try await serverClient.deleteCategoryBudget(categoryId: category.rawValue)
+        } catch {
+            categoryBudgets = previousBudgets
+            self.error = error.localizedDescription
+        }
+    }
+
     func addAccount() async {
         error = nil
 
@@ -1200,6 +1315,7 @@ final class AppState {
             transactionReviewMetadata = []
             transactionRules = []
             itemStatuses = []
+            categoryBudgets = [:]
             // loadDemoData() replaced the in-memory balance history with a
             // synthetic 60-day series. Restore persisted real history when it
             // exists so the first real snapshot cannot persist a demo trend.
@@ -1287,6 +1403,9 @@ final class AppState {
             await refreshAccounts()
             await syncTransactions()
         }
+        if serverConnected {
+            await refreshCategoryBudgets()
+        }
         recordPerformance(
             .dashboardRefresh,
             startedAt: dashboardStart,
@@ -1356,6 +1475,7 @@ final class AppState {
         }
 
         await syncTransactions()
+        await refreshCategoryBudgets()
         updateSetupCompletion()
         return firstRunCompletionState.isReady
     }
@@ -1598,6 +1718,7 @@ final class AppState {
                 await refreshAccounts()
                 await syncTransactions()
             }
+            await refreshCategoryBudgets()
             startBackgroundRefresh()
         } else {
             // Offline cold start: the background refresh loop (the usual caller
@@ -2405,6 +2526,7 @@ final class AppState {
         transactions = DemoFixtures.transactions()
         transactionReviewMetadata = []
         transactionRules = []
+        categoryBudgets = [:]
         balanceHistory = DemoFixtures.balanceHistory()
 
         isSetupComplete = true

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -32,6 +32,7 @@ final class AppState {
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
+        static let categoryBudgetCache = "cache.categoryBudgets"
         static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
     }
 
@@ -120,6 +121,11 @@ final class AppState {
         }
     }
     @ObservationIgnored private var performanceTrace = PerformanceTrace()
+
+    private struct CategoryBudgetCache: Codable {
+        let context: TransactionCacheContext
+        let budgets: [String: Double]
+    }
 
     // MARK: - Settings (persisted to UserDefaults)
     var menuBarSummaryMode: MenuBarSummaryMode = .netWorth {
@@ -1245,6 +1251,7 @@ final class AppState {
             categoryBudgets = Dictionary(
                 budgets.map { ($0.category, $0.monthlyLimit) }
             ) { first, _ in first }
+            persistCategoryBudgetCache()
         } catch {
             // Keep the last-known in-memory budgets (or local suggestions) visible
             // when the companion server is offline or the endpoint errors; never
@@ -1263,7 +1270,7 @@ final class AppState {
             return
         }
 
-        let previousBudgets = categoryBudgets
+        let previousValue = categoryBudgets[category]
         categoryBudgets[category] = amount
         error = nil
         do {
@@ -1272,20 +1279,29 @@ final class AppState {
                 amount: amount
             )
             categoryBudgets[saved.category] = saved.monthlyLimit
+            persistCategoryBudgetCache()
         } catch {
-            categoryBudgets = previousBudgets
+            if let previousValue {
+                categoryBudgets[category] = previousValue
+            } else {
+                categoryBudgets.removeValue(forKey: category)
+            }
             self.error = error.localizedDescription
         }
     }
 
     func removeCategoryBudget(_ category: SpendingCategory) async {
-        let previousBudgets = categoryBudgets
+        let previousValue = categoryBudgets[category]
         categoryBudgets.removeValue(forKey: category)
         error = nil
         do {
             try await serverClient.deleteCategoryBudget(categoryId: category.rawValue)
+            categoryBudgets.removeValue(forKey: category)
+            persistCategoryBudgetCache()
         } catch {
-            categoryBudgets = previousBudgets
+            if let previousValue {
+                categoryBudgets[category] = previousValue
+            }
             self.error = error.localizedDescription
         }
     }
@@ -1551,6 +1567,7 @@ final class AppState {
         serverSyncReady = nil
         serverSyncedItemCount = nil
         lastSyncDate = nil
+        clearCategoryBudgetCache()
         UserDefaults.standard.set(false, forKey: resetSetupCompletionDefaultsKey)
         UserDefaults.standard.removeObject(forKey: firstRunSnapshotDismissalDefaultsKey)
         isSetupComplete = false
@@ -1858,6 +1875,7 @@ final class AppState {
         ) {
             transactionRules = cachedRules
         }
+        loadCategoryBudgetCache(for: context)
     }
 
     private func preconnectCacheDirectory(for context: TransactionCacheContext) -> URL? {
@@ -1947,7 +1965,44 @@ final class AppState {
         UserDefaults.standard.set(data, forKey: Keys.lastTransactionCacheContext)
     }
 
-    // MARK: - Balance History
+    private func persistCategoryBudgetCache() {
+        guard let transactionCacheContext else { return }
+        let rawBudgets = Dictionary(
+            categoryBudgets.map { ($0.key.rawValue, $0.value) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        guard let data = try? JSONEncoder().encode(
+            CategoryBudgetCache(context: normalizedCacheContext(transactionCacheContext), budgets: rawBudgets)
+        ) else { return }
+        UserDefaults.standard.set(data, forKey: Keys.categoryBudgetCache)
+    }
+
+    private func loadCategoryBudgetCacheForActiveContext() {
+        guard let transactionCacheContext else { return }
+        loadCategoryBudgetCache(for: transactionCacheContext)
+    }
+
+    private func loadCategoryBudgetCache(for context: TransactionCacheContext) {
+        guard let data = UserDefaults.standard.data(forKey: Keys.categoryBudgetCache),
+              let cache = try? JSONDecoder().decode(CategoryBudgetCache.self, from: data),
+              cache.context == normalizedCacheContext(context)
+        else { return }
+
+        categoryBudgets = Dictionary(
+            cache.budgets.compactMap { rawCategory, monthlyLimit in
+                guard let category = SpendingCategory(rawValue: rawCategory) else { return nil }
+                return (category, monthlyLimit)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    private func clearCategoryBudgetCache() {
+        categoryBudgets = [:]
+        UserDefaults.standard.removeObject(forKey: Keys.categoryBudgetCache)
+    }
+
+    // MARK: - Local Caches
 
     private func loadCachedAccounts() async {
         do {

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -79,6 +79,28 @@ actor ServerClient {
         return try await get(url)
     }
 
+    func listCategoryBudgets() async throws -> [CategoryBudgetDTO] {
+        guard let url = ServerEndpoint.categoryBudgetsURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        let response: CategoryBudgetsResponse = try await get(url)
+        return response.budgets
+    }
+
+    func saveCategoryBudget(categoryId: String, amount: Double) async throws -> CategoryBudgetDTO {
+        guard let url = ServerEndpoint.saveCategoryBudgetURL(baseURL: baseURL, categoryId: categoryId) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await put(url, body: SaveCategoryBudgetRequest(monthlyLimit: amount))
+    }
+
+    func deleteCategoryBudget(categoryId: String) async throws {
+        guard let url = ServerEndpoint.deleteCategoryBudgetURL(baseURL: baseURL, categoryId: categoryId) else {
+            throw ServerClientError.requestFailed
+        }
+        try await delete(url)
+    }
+
     func syncTransactions(itemId: String? = nil) async throws -> SyncResponse {
         guard let url = ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId) else {
             throw ServerClientError.requestFailed
@@ -154,6 +176,13 @@ actor ServerClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(body)
+        let (data, response) = try await data(for: request)
+        try Self.validateHTTPResponse(response, data: data)
+    }
+
+    private func delete(_ url: URL) async throws {
+        var request = try authorizedRequest(url: url)
+        request.httpMethod = "DELETE"
         let (data, response) = try await data(for: request)
         try Self.validateHTTPResponse(response, data: data)
     }

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -37,6 +37,18 @@ public enum ServerEndpoint {
         url(baseURL: baseURL, path: "/api/accounts/\(percentEncodedPathComponent(itemId))")
     }
 
+    public static func categoryBudgetsURL(baseURL: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets")
+    }
+
+    public static func saveCategoryBudgetURL(baseURL: String, categoryId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets/\(percentEncodedPathComponent(categoryId))")
+    }
+
+    public static func deleteCategoryBudgetURL(baseURL: String, categoryId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets/\(percentEncodedPathComponent(categoryId))")
+    }
+
     private static func percentEncodedPathComponent(_ value: String) -> String {
         var allowed = CharacterSet.urlPathAllowed
         allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1218,6 +1218,9 @@ struct PlaidBarCoreTests {
         let cursorCommitURL = try #require(ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL))
         let updateURL = try #require(ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId))
         let removeURL = try #require(ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId))
+        let budgetListURL = try #require(ServerEndpoint.categoryBudgetsURL(baseURL: baseURL))
+        let budgetSaveURL = try #require(ServerEndpoint.saveCategoryBudgetURL(baseURL: baseURL, categoryId: itemId))
+        let budgetDeleteURL = try #require(ServerEndpoint.deleteCategoryBudgetURL(baseURL: baseURL, categoryId: itemId))
 
         #expect(syncURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync?item_id=item%20with%2Fslash%3Fand%26symbols")
         #expect(statusURL.absoluteString == "http://127.0.0.1:8484/api/status")
@@ -1225,6 +1228,9 @@ struct PlaidBarCoreTests {
         #expect(cursorCommitURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync/cursors")
         #expect(updateURL.absoluteString == "http://127.0.0.1:8484/api/link/update/item%20with%2Fslash%3Fand%26symbols")
         #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
+        #expect(budgetListURL.absoluteString == "http://127.0.0.1:8484/api/budgets")
+        #expect(budgetSaveURL.absoluteString == "http://127.0.0.1:8484/api/budgets/item%20with%2Fslash%3Fand%26symbols")
+        #expect(budgetDeleteURL.absoluteString == "http://127.0.0.1:8484/api/budgets/item%20with%2Fslash%3Fand%26symbols")
     }
 
     @Test("Transaction sync reducer upserts and removes transactions")

--- a/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
+++ b/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
@@ -3,6 +3,7 @@ import FluentKit
 import FluentSQLiteDriver
 import Hummingbird
 import HummingbirdFluent
+import HummingbirdTesting
 import Logging
 @testable import PlaidBarCore
 @testable import PlaidBarServer
@@ -10,6 +11,8 @@ import Testing
 
 @Suite("Category budget persistence (AND-402)")
 struct CategoryBudgetStoreTests {
+    private let apiToken = "local-budget-token"
+
     /// Runs `body` against a BudgetStore backed by a temporary SQLite file, then
     /// always shuts Fluent down so the test does not hold database files.
     private func withBudgetStore(_ body: (BudgetStore) async throws -> Void) async throws {
@@ -33,6 +36,60 @@ struct CategoryBudgetStoreTests {
         }
         try await fluent.shutdown()
         if let bodyError { throw bodyError }
+    }
+
+    /// Runs `body` against the real `/api/budgets` route registered behind the
+    /// same bearer-token middleware shape as the server. The temporary SQLite
+    /// database is migrated first so these tests fail if the budget table is not
+    /// available to the wired route/store contract.
+    private func withBudgetAPI(_ body: @Sendable (any TestClientProtocol) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-budget-api-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("budgets.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.budget-api")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateCategoryBudgets())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+
+            let router = Router()
+            let api = router.group("api")
+            api.add(middleware: APITokenMiddleware(authToken: apiToken))
+            BudgetRoutes(budgetStore: BudgetStore(fluent: fluent))
+                .register(with: api)
+
+            let app = Application(router: router, logger: logger)
+            try await app.test(.router) { client in
+                try await body(client)
+            }
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    private var authorizedJSONHeaders: HTTPFields {
+        var headers = HTTPFields()
+        headers[.authorization] = "Bearer \(apiToken)"
+        headers[.contentType] = "application/json"
+        return headers
+    }
+
+    private func encodeBudgetRequest(monthlyLimit: Double) throws -> ByteBuffer {
+        ByteBuffer(data: try JSONEncoder().encode(SaveCategoryBudgetRequest(monthlyLimit: monthlyLimit)))
+    }
+
+    private func decodeResponse<T: Decodable>(_ type: T.Type, from response: TestResponse) throws -> T {
+        var body = response.body
+        let data = body.readData(length: body.readableBytes) ?? Data()
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     // MARK: - Storage round-trip
@@ -83,6 +140,77 @@ struct CategoryBudgetStoreTests {
         }
     }
 
+    // MARK: - API contract round-trip
+
+    @Test("GET /api/budgets starts empty after the category budget migration")
+    func apiListBudgetsStartsEmptyAfterMigration() async throws {
+        try await withBudgetAPI { client in
+            let response = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+
+            #expect(response.status == .ok)
+            let payload = try decodeResponse(CategoryBudgetsResponse.self, from: response)
+            #expect(payload.budgets.isEmpty)
+        }
+    }
+
+    @Test("PUT/GET/DELETE /api/budgets/{category} round-trips the client payload shape")
+    func apiBudgetRoundTripContract() async throws {
+        try await withBudgetAPI { client in
+            let create = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encodeBudgetRequest(monthlyLimit: 125.50)
+            )
+            #expect(create.status == .ok)
+            let created = try decodeResponse(CategoryBudgetDTO.self, from: create)
+            #expect(created.category == .foodAndDrink)
+            #expect(created.monthlyLimit == 125.50)
+
+            let update = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encodeBudgetRequest(monthlyLimit: 150.75)
+            )
+            #expect(update.status == .ok)
+            let updated = try decodeResponse(CategoryBudgetDTO.self, from: update)
+            #expect(updated.category == .foodAndDrink)
+            #expect(updated.monthlyLimit == 150.75)
+
+            let listAfterUpdate = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+            #expect(listAfterUpdate.status == .ok)
+            let persisted = try decodeResponse(CategoryBudgetsResponse.self, from: listAfterUpdate)
+            #expect(persisted.budgets == [
+                CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 150.75),
+            ])
+
+            let delete = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .delete,
+                headers: authorizedJSONHeaders
+            )
+            #expect(delete.status == .noContent)
+
+            let listAfterDelete = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+            #expect(listAfterDelete.status == .ok)
+            let deleted = try decodeResponse(CategoryBudgetsResponse.self, from: listAfterDelete)
+            #expect(deleted.budgets.isEmpty)
+        }
+    }
+
     // MARK: - Route validation
 
     @Test("Path category parameter parses, with bad/missing/excluded values rejected")
@@ -113,5 +241,25 @@ struct CategoryBudgetStoreTests {
             CategoryBudgetDTO(category: .shopping, monthlyLimit: 200),
         ])
         #expect(response.byCategory == [.foodAndDrink: 500, .shopping: 200])
+    }
+
+    @Test("Budget route payloads use the documented JSON contract")
+    func payloadJSONContract() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
+
+        let saveData = try encoder.encode(SaveCategoryBudgetRequest(monthlyLimit: 123.45))
+        #expect(String(data: saveData, encoding: .utf8) == "{\"monthlyLimit\":123.45}")
+        let decodedSave = try decoder.decode(SaveCategoryBudgetRequest.self, from: saveData)
+        #expect(decodedSave.monthlyLimit == 123.45)
+
+        let response = CategoryBudgetsResponse(budgets: [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500),
+        ])
+        let responseData = try encoder.encode(response)
+        #expect(String(data: responseData, encoding: .utf8) == "{\"budgets\":[{\"category\":\"FOOD_AND_DRINK\",\"monthlyLimit\":500}]}")
+        let decodedResponse = try decoder.decode(CategoryBudgetsResponse.self, from: responseData)
+        #expect(decodedResponse.budgets == response.budgets)
     }
 }


### PR DESCRIPTION
## Summary
- Hydrate explicit category budgets from the server into `AppState` during startup/refresh.
- Overlay saved server budgets on local suggested category budgets so user-set budgets win and survive relaunch.
- Persist budget save/delete edits through `ServerClient`, with UI rollback if the server operation fails.

Refs #393
Linear: AND-444

Stacked on #399 because this consumes the category budget API/client methods from that PR.

## Validation
- `git diff --check`
- `swift test --filter CategoryBudgetStoreTests --scratch-path /tmp/plaidbar-issue393-appstate-build`

Result: 10 focused tests passed.

## Notes
- First validation attempt caught two Swift dictionary-literal mistakes (`[]` vs `[:]`) in AppState reset paths; fixed before this PR was opened.
- No Plaid credentials, provider tokens, raw payloads, real account IDs, transaction IDs, balances, local SQLite data, logs, or screenshots added.
