### PR TITLE
GH #388: Fix paginated transaction sync cursor advancement

### DIFF
--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -44,6 +44,7 @@ public enum PlaidBarConstants {
     public static let maxRecentTransactions: Int = 50
     public static let initialSyncDays: Int = 90
     public static let maxTransactionSyncPages: Int = 100
+    public static let maxTransactionSyncMutationRestarts: Int = 2
 
     // Keychain
     public static let keychainServiceName: String = "com.ftchvs.PlaidBar"

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -142,8 +142,6 @@ struct TransactionRoutes: Sendable {
                 // Setup state affects every item identically: surface the 503
                 // credential guidance instead of marking items errored.
                 throw PlaidError.credentialsNotConfigured
-            } catch let error as HTTPError {
-                throw error
             } catch {
                 try await tokenStore.updateItemStatus(
                     id: itemId,
@@ -164,6 +162,30 @@ struct TransactionRoutes: Sendable {
     }
 
     private func syncItem(
+        itemId: String,
+        accessToken: String,
+        persistedCursor: String?
+    ) async throws -> (added: [TransactionDTO], modified: [TransactionDTO], removed: [String], nextCursor: String?) {
+        var mutationRestartCount = 0
+
+        while true {
+            do {
+                return try await syncItemPageSequence(
+                    itemId: itemId,
+                    accessToken: accessToken,
+                    persistedCursor: persistedCursor
+                )
+            } catch let error as PlaidError where Self.isTransactionsSyncMutationDuringPagination(error) {
+                mutationRestartCount += 1
+                guard mutationRestartCount <= PlaidBarConstants.maxTransactionSyncMutationRestarts else {
+                    throw error
+                }
+                continue
+            }
+        }
+    }
+
+    private func syncItemPageSequence(
         itemId: String,
         accessToken: String,
         persistedCursor: String?
@@ -202,6 +224,11 @@ struct TransactionRoutes: Sendable {
                 return (added, modified, removed, finalCursor)
             }
         }
+    }
+
+    private static func isTransactionsSyncMutationDuringPagination(_ error: PlaidError) -> Bool {
+        guard case PlaidError.apiError(_, _, let errorCode, _) = error else { return false }
+        return errorCode == "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION"
     }
 
     private static func toDTO(_ plaidTx: PlaidTransaction, itemId: String) -> TransactionDTO {

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -121,27 +121,29 @@ struct TransactionRoutes: Sendable {
             guard let itemId = item.id else { return .skipped }
 
             do {
-                let cursor = try await tokenStore.getSyncCursor(itemId: itemId)
                 let accessToken = try tokenStore.accessToken(for: item)
-                let response = try await plaidClient.syncTransactions(
+                let itemResult = try await syncItem(
+                    itemId: itemId,
                     accessToken: accessToken,
-                    cursor: cursor
+                    persistedCursor: try await tokenStore.getSyncCursor(itemId: itemId)
                 )
                 try await tokenStore.updateItemStatus(id: itemId, status: ItemConnectionStatus.connected.rawValue)
                 return ItemSyncResult(
                     itemId: itemId,
                     attempted: true,
                     succeeded: true,
-                    added: response.added.map { Self.toDTO($0, itemId: itemId) },
-                    modified: response.modified.map { Self.toDTO($0, itemId: itemId) },
-                    removed: response.removed.map(\.transactionId),
-                    hasMore: response.hasMore,
-                    nextCursor: response.nextCursor.isEmpty ? nil : response.nextCursor
+                    added: itemResult.added,
+                    modified: itemResult.modified,
+                    removed: itemResult.removed,
+                    hasMore: false,
+                    nextCursor: itemResult.nextCursor
                 )
             } catch PlaidError.credentialsNotConfigured {
                 // Setup state affects every item identically: surface the 503
                 // credential guidance instead of marking items errored.
                 throw PlaidError.credentialsNotConfigured
+            } catch let error as HTTPError {
+                throw error
             } catch {
                 try await tokenStore.updateItemStatus(
                     id: itemId,
@@ -157,6 +159,47 @@ struct TransactionRoutes: Sendable {
                     hasMore: false,
                     nextCursor: nil
                 )
+            }
+        }
+    }
+
+    private func syncItem(
+        itemId: String,
+        accessToken: String,
+        persistedCursor: String?
+    ) async throws -> (added: [TransactionDTO], modified: [TransactionDTO], removed: [String], nextCursor: String?) {
+        var cursor = persistedCursor
+        var pageCount = 0
+        var added: [TransactionDTO] = []
+        var modified: [TransactionDTO] = []
+        var removed: [String] = []
+        var finalCursor: String?
+
+        while true {
+            pageCount += 1
+            guard pageCount <= PlaidBarConstants.maxTransactionSyncPages else {
+                throw HTTPError(
+                    .badGateway,
+                    message: "Plaid transaction sync did not finish after \(PlaidBarConstants.maxTransactionSyncPages) pages"
+                )
+            }
+
+            let response = try await plaidClient.syncTransactions(
+                accessToken: accessToken,
+                cursor: cursor
+            )
+
+            added.append(contentsOf: response.added.map { Self.toDTO($0, itemId: itemId) })
+            modified.append(contentsOf: response.modified.map { Self.toDTO($0, itemId: itemId) })
+            removed.append(contentsOf: response.removed.map(\.transactionId))
+
+            if !response.nextCursor.isEmpty {
+                cursor = response.nextCursor
+                finalCursor = response.nextCursor
+            }
+
+            guard response.hasMore else {
+                return (added, modified, removed, finalCursor)
             }
         }
     }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -322,11 +322,20 @@ private actor DelayedRefreshPlaidClient: PlaidClientProtocol {
 }
 
 private actor PaginatedTransactionsPlaidClient: PlaidClientProtocol {
-    private var responses: [PlaidTransactionsSyncResponse]
+    enum Outcome: Sendable {
+        case response(PlaidTransactionsSyncResponse)
+        case error(any Error & Sendable)
+    }
+
+    private var outcomes: [Outcome]
     private var syncCalls: [(accessToken: String, cursor: String?)] = []
 
     init(responses: [PlaidTransactionsSyncResponse]) {
-        self.responses = responses
+        self.outcomes = responses.map(Outcome.response)
+    }
+
+    init(outcomes: [Outcome]) {
+        self.outcomes = outcomes
     }
 
     func createLinkToken(
@@ -365,8 +374,13 @@ private actor PaginatedTransactionsPlaidClient: PlaidClientProtocol {
         cursor: String?
     ) async throws -> PlaidTransactionsSyncResponse {
         syncCalls.append((accessToken: accessToken, cursor: cursor))
-        guard !responses.isEmpty else { throw PlaidError.invalidResponse }
-        return responses.removeFirst()
+        guard !outcomes.isEmpty else { throw PlaidError.invalidResponse }
+        switch outcomes.removeFirst() {
+        case let .response(response):
+            return response
+        case let .error(error):
+            throw error
+        }
     }
 
     func removeItem(accessToken _: String) async throws {
@@ -1729,6 +1743,102 @@ struct PlaidBarServerTests {
             #expect(response.hasMore == false)
             #expect(response.nextCursor == "cursor-2")
             #expect(response.pendingCursors == [itemId: "cursor-2"])
+        }
+    }
+
+    @Test("Transaction sync restarts pagination when Plaid reports a mutation")
+    func transactionSyncRestartsAfterPlaidPaginationMutation() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-paginated-mutation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.paginated-mutation")
+        let itemId = "test_item_\(UUID().uuidString)"
+        let accessToken = "test-access-token-\(UUID().uuidString)"
+        let mutation = PlaidError.apiError(
+            statusCode: 400,
+            errorType: "TRANSACTIONS_ERROR",
+            errorCode: "TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION",
+            errorMessage: "Transactions changed during pagination"
+        )
+        let client = PaginatedTransactionsPlaidClient(outcomes: [
+            .response(Self.syncResponse(transactionId: "stale-page", cursor: "stale-cursor", hasMore: true)),
+            .error(mutation),
+            .response(Self.syncResponse(transactionId: "fresh-page-1", cursor: "fresh-cursor-1", hasMore: true)),
+            .response(Self.syncResponse(transactionId: "fresh-page-2", cursor: "fresh-cursor-2")),
+        ])
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(
+                id: itemId,
+                accessToken: accessToken,
+                institutionId: "ins_test",
+                institutionName: "Test Bank"
+            )
+            try await store.saveSyncCursor(itemId: itemId, cursor: "persisted-cursor")
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            let httpResponse = try await route.syncTransactions(
+                request: Self.makeRequest(path: "/api/transactions/sync"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+            let calls = await client.recordedSyncCalls()
+
+            #expect(calls.map(\.cursor) == ["persisted-cursor", "stale-cursor", "persisted-cursor", "fresh-cursor-1"])
+            #expect(response.added.map(\.id) == ["fresh-page-1", "fresh-page-2"])
+            #expect(response.nextCursor == "fresh-cursor-2")
+            #expect(response.pendingCursors == [itemId: "fresh-cursor-2"])
+        }
+    }
+
+    @Test("Transaction sync page-limit failure preserves other item results")
+    func transactionSyncPageLimitFailurePreservesOtherItemResults() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-paginated-limit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.paginated-limit")
+        let client = PaginatedTransactionsPlaidClient(responses: [
+            Self.syncResponse(transactionId: "ok-page", cursor: "ok-cursor"),
+            Self.syncResponse(transactionId: "loop-page", cursor: "loop-cursor", hasMore: true),
+        ] + (0..<PlaidBarConstants.maxTransactionSyncPages).map { index in
+            Self.syncResponse(transactionId: "loop-page-\(index)", cursor: "loop-cursor-\(index)", hasMore: true)
+        })
+        defer {
+            for itemId in ["a-item-ok", "z-item-loop"] {
+                try? PlaidTokenVault.delete(
+                    storedToken: PlaidTokenVault.reference(for: itemId),
+                    fallbackItemId: itemId
+                )
+            }
+        }
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(id: "a-item-ok", accessToken: "token-ok", institutionId: "ins_ok", institutionName: "OK Bank")
+            try await store.saveItem(id: "z-item-loop", accessToken: "token-loop", institutionId: "ins_loop", institutionName: "Loop Bank")
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 1)
+
+            let httpResponse = try await route.syncTransactions(
+                request: Self.makeRequest(path: "/api/transactions/sync"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+
+            #expect(response.added.map(\.id) == ["ok-page"])
+            #expect(response.pendingCursors == ["a-item-ok": "ok-cursor"])
+            #expect(try await store.getItem(id: "a-item-ok")?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(try await store.getItem(id: "z-item-loop")?.status == ItemConnectionStatus.error.rawValue)
         }
     }
 

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -321,6 +321,63 @@ private actor DelayedRefreshPlaidClient: PlaidClientProtocol {
     }
 }
 
+private actor PaginatedTransactionsPlaidClient: PlaidClientProtocol {
+    private var responses: [PlaidTransactionsSyncResponse]
+    private var syncCalls: [(accessToken: String, cursor: String?)] = []
+
+    init(responses: [PlaidTransactionsSyncResponse]) {
+        self.responses = responses
+    }
+
+    func createLinkToken(
+        clientUserId _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func createUpdateLinkToken(
+        clientUserId _: String,
+        accessToken _: String,
+        completionRedirectUri _: String
+    ) async throws -> PlaidLinkTokenResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getLinkToken(_: String) async throws -> PlaidLinkTokenGetResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func exchangePublicToken(_: String) async throws -> PlaidTokenExchangeResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getAccounts(accessToken _: String) async throws -> PlaidAccountsResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func getBalances(accessToken _: String) async throws -> PlaidAccountsResponse {
+        throw PlaidError.invalidResponse
+    }
+
+    func syncTransactions(
+        accessToken: String,
+        cursor: String?
+    ) async throws -> PlaidTransactionsSyncResponse {
+        syncCalls.append((accessToken: accessToken, cursor: cursor))
+        guard !responses.isEmpty else { throw PlaidError.invalidResponse }
+        return responses.removeFirst()
+    }
+
+    func removeItem(accessToken _: String) async throws {
+        throw PlaidError.invalidResponse
+    }
+
+    func recordedSyncCalls() -> [(accessToken: String, cursor: String?)] {
+        syncCalls
+    }
+}
+
 @Suite("PlaidBarServer")
 struct PlaidBarServerTests {
     @Test func accountTypes() {
@@ -1015,7 +1072,8 @@ struct PlaidBarServerTests {
 
     private static func syncResponse(
         transactionId: String,
-        cursor: String
+        cursor: String,
+        hasMore: Bool = false
     ) -> PlaidTransactionsSyncResponse {
         PlaidTransactionsSyncResponse(
             added: [
@@ -1034,7 +1092,7 @@ struct PlaidBarServerTests {
             modified: [],
             removed: [],
             nextCursor: cursor,
-            hasMore: false,
+            hasMore: hasMore,
             requestId: "request-\(transactionId)"
         )
     }
@@ -1623,6 +1681,54 @@ struct PlaidBarServerTests {
             #expect(calls.syncs.sorted() == ["token-a", "token-b", "token-c"])
             #expect(calls.maxActive == 2)
             #expect(try await store.getItem(id: "item-b")?.status == ItemConnectionStatus.error.rawValue)
+        }
+    }
+
+    @Test("Paginated transaction sync advances with each page cursor")
+    func paginatedTransactionSyncAdvancesWithEachPageCursor() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-paginated-sync-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.paginated-sync")
+        let itemId = "test_item_\(UUID().uuidString)"
+        let accessToken = "test-access-token-\(UUID().uuidString)"
+        let client = PaginatedTransactionsPlaidClient(responses: [
+            Self.syncResponse(transactionId: "tx-page-1", cursor: "cursor-1", hasMore: true),
+            Self.syncResponse(transactionId: "tx-page-2", cursor: "cursor-2"),
+        ])
+        defer {
+            try? PlaidTokenVault.delete(
+                storedToken: PlaidTokenVault.reference(for: itemId),
+                fallbackItemId: itemId
+            )
+        }
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            try await store.saveItem(
+                id: itemId,
+                accessToken: accessToken,
+                institutionId: "ins_test",
+                institutionName: "Test Bank"
+            )
+            try await store.saveSyncCursor(itemId: itemId, cursor: "persisted-cursor")
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            let httpResponse = try await route.syncTransactions(
+                request: Self.makeRequest(path: "/api/transactions/sync"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+            let calls = await client.recordedSyncCalls()
+
+            #expect(calls.map(\.accessToken) == [accessToken, accessToken])
+            #expect(calls.map(\.cursor) == ["persisted-cursor", "cursor-1"])
+            #expect(response.added.map(\.id) == ["tx-page-1", "tx-page-2"])
+            #expect(response.hasMore == false)
+            #expect(response.nextCursor == "cursor-2")
+            #expect(response.pendingCursors == [itemId: "cursor-2"])
         }
     }
 


### PR DESCRIPTION
## Summary
- Ships a focused fix slice from the VaultPeek Kanban/Linear queue.
- Scope: Fix paginated transaction sync cursor advancement

## Links
Fixes #388

## Validation
- `git diff --check origin/main...HEAD` in `/Users/otto/workspace/plaidbar-issue-prs/issue-388-pagination-sync` passed before PR creation.

## Review notes
- Opened autonomously for Felipe's 10am review window.
- Do not merge until reviewed; branch intentionally left open.
