### PR TITLE
GH #393 / AND-444: Wire category budget client API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,12 @@ let package = Package(
         ),
         .testTarget(
             name: "PlaidBarServerTests",
-            dependencies: ["PlaidBarCore", "PlaidBarServer", swiftTestingTestDependency],
+            dependencies: [
+                "PlaidBarCore",
+                "PlaidBarServer",
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
+                swiftTestingTestDependency,
+            ],
             path: "Tests/PlaidBarServerTests",
             swiftSettings: [.swiftLanguageMode(.v5)],
             linkerSettings: swiftTestingLinkerSettings

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -79,6 +79,28 @@ actor ServerClient {
         return try await get(url)
     }
 
+    func listCategoryBudgets() async throws -> [CategoryBudgetDTO] {
+        guard let url = ServerEndpoint.categoryBudgetsURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        let response: CategoryBudgetsResponse = try await get(url)
+        return response.budgets
+    }
+
+    func saveCategoryBudget(categoryId: String, amount: Double) async throws -> CategoryBudgetDTO {
+        guard let url = ServerEndpoint.saveCategoryBudgetURL(baseURL: baseURL, categoryId: categoryId) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await put(url, body: SaveCategoryBudgetRequest(monthlyLimit: amount))
+    }
+
+    func deleteCategoryBudget(categoryId: String) async throws {
+        guard let url = ServerEndpoint.deleteCategoryBudgetURL(baseURL: baseURL, categoryId: categoryId) else {
+            throw ServerClientError.requestFailed
+        }
+        try await delete(url)
+    }
+
     func syncTransactions(itemId: String? = nil) async throws -> SyncResponse {
         guard let url = ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId) else {
             throw ServerClientError.requestFailed
@@ -154,6 +176,13 @@ actor ServerClient {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(body)
+        let (data, response) = try await data(for: request)
+        try Self.validateHTTPResponse(response, data: data)
+    }
+
+    private func delete(_ url: URL) async throws {
+        var request = try authorizedRequest(url: url)
+        request.httpMethod = "DELETE"
         let (data, response) = try await data(for: request)
         try Self.validateHTTPResponse(response, data: data)
     }

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -37,6 +37,18 @@ public enum ServerEndpoint {
         url(baseURL: baseURL, path: "/api/accounts/\(percentEncodedPathComponent(itemId))")
     }
 
+    public static func categoryBudgetsURL(baseURL: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets")
+    }
+
+    public static func saveCategoryBudgetURL(baseURL: String, categoryId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets/\(percentEncodedPathComponent(categoryId))")
+    }
+
+    public static func deleteCategoryBudgetURL(baseURL: String, categoryId: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/budgets/\(percentEncodedPathComponent(categoryId))")
+    }
+
     private static func percentEncodedPathComponent(_ value: String) -> String {
         var allowed = CharacterSet.urlPathAllowed
         allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1218,6 +1218,9 @@ struct PlaidBarCoreTests {
         let cursorCommitURL = try #require(ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL))
         let updateURL = try #require(ServerEndpoint.updateLinkTokenURL(baseURL: baseURL, itemId: itemId))
         let removeURL = try #require(ServerEndpoint.removeItemURL(baseURL: baseURL, itemId: itemId))
+        let budgetListURL = try #require(ServerEndpoint.categoryBudgetsURL(baseURL: baseURL))
+        let budgetSaveURL = try #require(ServerEndpoint.saveCategoryBudgetURL(baseURL: baseURL, categoryId: itemId))
+        let budgetDeleteURL = try #require(ServerEndpoint.deleteCategoryBudgetURL(baseURL: baseURL, categoryId: itemId))
 
         #expect(syncURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync?item_id=item%20with%2Fslash%3Fand%26symbols")
         #expect(statusURL.absoluteString == "http://127.0.0.1:8484/api/status")
@@ -1225,6 +1228,9 @@ struct PlaidBarCoreTests {
         #expect(cursorCommitURL.absoluteString == "http://127.0.0.1:8484/api/transactions/sync/cursors")
         #expect(updateURL.absoluteString == "http://127.0.0.1:8484/api/link/update/item%20with%2Fslash%3Fand%26symbols")
         #expect(removeURL.absoluteString == "http://127.0.0.1:8484/api/accounts/item%20with%2Fslash%3Fand%26symbols")
+        #expect(budgetListURL.absoluteString == "http://127.0.0.1:8484/api/budgets")
+        #expect(budgetSaveURL.absoluteString == "http://127.0.0.1:8484/api/budgets/item%20with%2Fslash%3Fand%26symbols")
+        #expect(budgetDeleteURL.absoluteString == "http://127.0.0.1:8484/api/budgets/item%20with%2Fslash%3Fand%26symbols")
     }
 
     @Test("Transaction sync reducer upserts and removes transactions")

--- a/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
+++ b/Tests/PlaidBarServerTests/CategoryBudgetStoreTests.swift
@@ -3,6 +3,7 @@ import FluentKit
 import FluentSQLiteDriver
 import Hummingbird
 import HummingbirdFluent
+import HummingbirdTesting
 import Logging
 @testable import PlaidBarCore
 @testable import PlaidBarServer
@@ -10,6 +11,8 @@ import Testing
 
 @Suite("Category budget persistence (AND-402)")
 struct CategoryBudgetStoreTests {
+    private let apiToken = "local-budget-token"
+
     /// Runs `body` against a BudgetStore backed by a temporary SQLite file, then
     /// always shuts Fluent down so the test does not hold database files.
     private func withBudgetStore(_ body: (BudgetStore) async throws -> Void) async throws {
@@ -33,6 +36,60 @@ struct CategoryBudgetStoreTests {
         }
         try await fluent.shutdown()
         if let bodyError { throw bodyError }
+    }
+
+    /// Runs `body` against the real `/api/budgets` route registered behind the
+    /// same bearer-token middleware shape as the server. The temporary SQLite
+    /// database is migrated first so these tests fail if the budget table is not
+    /// available to the wired route/store contract.
+    private func withBudgetAPI(_ body: @Sendable (any TestClientProtocol) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-budget-api-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("budgets.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.budget-api")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateCategoryBudgets())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+
+            let router = Router()
+            let api = router.group("api")
+            api.add(middleware: APITokenMiddleware(authToken: apiToken))
+            BudgetRoutes(budgetStore: BudgetStore(fluent: fluent))
+                .register(with: api)
+
+            let app = Application(router: router, logger: logger)
+            try await app.test(.router) { client in
+                try await body(client)
+            }
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    private var authorizedJSONHeaders: HTTPFields {
+        var headers = HTTPFields()
+        headers[.authorization] = "Bearer \(apiToken)"
+        headers[.contentType] = "application/json"
+        return headers
+    }
+
+    private func encodeBudgetRequest(monthlyLimit: Double) throws -> ByteBuffer {
+        ByteBuffer(data: try JSONEncoder().encode(SaveCategoryBudgetRequest(monthlyLimit: monthlyLimit)))
+    }
+
+    private func decodeResponse<T: Decodable>(_ type: T.Type, from response: TestResponse) throws -> T {
+        var body = response.body
+        let data = body.readData(length: body.readableBytes) ?? Data()
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     // MARK: - Storage round-trip
@@ -83,6 +140,77 @@ struct CategoryBudgetStoreTests {
         }
     }
 
+    // MARK: - API contract round-trip
+
+    @Test("GET /api/budgets starts empty after the category budget migration")
+    func apiListBudgetsStartsEmptyAfterMigration() async throws {
+        try await withBudgetAPI { client in
+            let response = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+
+            #expect(response.status == .ok)
+            let payload = try decodeResponse(CategoryBudgetsResponse.self, from: response)
+            #expect(payload.budgets.isEmpty)
+        }
+    }
+
+    @Test("PUT/GET/DELETE /api/budgets/{category} round-trips the client payload shape")
+    func apiBudgetRoundTripContract() async throws {
+        try await withBudgetAPI { client in
+            let create = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encodeBudgetRequest(monthlyLimit: 125.50)
+            )
+            #expect(create.status == .ok)
+            let created = try decodeResponse(CategoryBudgetDTO.self, from: create)
+            #expect(created.category == .foodAndDrink)
+            #expect(created.monthlyLimit == 125.50)
+
+            let update = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encodeBudgetRequest(monthlyLimit: 150.75)
+            )
+            #expect(update.status == .ok)
+            let updated = try decodeResponse(CategoryBudgetDTO.self, from: update)
+            #expect(updated.category == .foodAndDrink)
+            #expect(updated.monthlyLimit == 150.75)
+
+            let listAfterUpdate = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+            #expect(listAfterUpdate.status == .ok)
+            let persisted = try decodeResponse(CategoryBudgetsResponse.self, from: listAfterUpdate)
+            #expect(persisted.budgets == [
+                CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 150.75),
+            ])
+
+            let delete = try await client.execute(
+                uri: "/api/budgets/FOOD_AND_DRINK",
+                method: .delete,
+                headers: authorizedJSONHeaders
+            )
+            #expect(delete.status == .noContent)
+
+            let listAfterDelete = try await client.execute(
+                uri: "/api/budgets",
+                method: .get,
+                headers: authorizedJSONHeaders
+            )
+            #expect(listAfterDelete.status == .ok)
+            let deleted = try decodeResponse(CategoryBudgetsResponse.self, from: listAfterDelete)
+            #expect(deleted.budgets.isEmpty)
+        }
+    }
+
     // MARK: - Route validation
 
     @Test("Path category parameter parses, with bad/missing/excluded values rejected")
@@ -113,5 +241,25 @@ struct CategoryBudgetStoreTests {
             CategoryBudgetDTO(category: .shopping, monthlyLimit: 200),
         ])
         #expect(response.byCategory == [.foodAndDrink: 500, .shopping: 200])
+    }
+
+    @Test("Budget route payloads use the documented JSON contract")
+    func payloadJSONContract() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
+
+        let saveData = try encoder.encode(SaveCategoryBudgetRequest(monthlyLimit: 123.45))
+        #expect(String(data: saveData, encoding: .utf8) == "{\"monthlyLimit\":123.45}")
+        let decodedSave = try decoder.decode(SaveCategoryBudgetRequest.self, from: saveData)
+        #expect(decodedSave.monthlyLimit == 123.45)
+
+        let response = CategoryBudgetsResponse(budgets: [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500),
+        ])
+        let responseData = try encoder.encode(response)
+        #expect(String(data: responseData, encoding: .utf8) == "{\"budgets\":[{\"category\":\"FOOD_AND_DRINK\",\"monthlyLimit\":500}]}")
+        let decodedResponse = try decoder.decode(CategoryBudgetsResponse.self, from: responseData)
+        #expect(decodedResponse.budgets == response.budgets)
     }
 }


### PR DESCRIPTION
## Summary
- Ships a focused fix slice from the VaultPeek Kanban/Linear queue.
- Scope: Wire category budget client API

## Links
Fixes #393
Linear: AND-444

## Validation
- `git diff --check origin/main...HEAD` in `/Users/otto/workspace/plaidbar-issue-prs/issue-393-budgets-api` passed before PR creation.

## Review notes
- Opened autonomously for Felipe's 10am review window.
- Do not merge until reviewed; branch intentionally left open.
