### PR TITLE
AND-435: Add LocalAuthentication app lock foundation

### DIFF
--- a/Sources/PlaidBarCore/Utilities/AppLockService.swift
+++ b/Sources/PlaidBarCore/Utilities/AppLockService.swift
@@ -79,6 +79,7 @@ public final class AppLockService {
 
     private let settingsStore: any AppLockSettingsStoring
     private let authenticator: any AppLockAuthenticating
+    private var inFlightAuthenticationTask: Task<AppLockAuthenticationResult, Never>?
 
     public var isLocked: Bool {
         state == .locked
@@ -98,11 +99,24 @@ public final class AppLockService {
         authenticator.authenticationCapability()
     }
 
-    public func setLockEnabled(_ isEnabled: Bool) {
-        guard isLockEnabled != isEnabled else { return }
+    @discardableResult
+    public func setLockEnabled(_ isEnabled: Bool) -> AppLockCapability {
+        if isEnabled {
+            let capability = authenticator.authenticationCapability()
+            guard case .available = capability else {
+                isLockEnabled = false
+                settingsStore.isLockEnabled = false
+                state = .unlocked
+                return capability
+            }
+        }
+
+        let capability: AppLockCapability = isEnabled ? authenticator.authenticationCapability() : .available(biometry: .none)
+        guard isLockEnabled != isEnabled else { return capability }
         isLockEnabled = isEnabled
         settingsStore.isLockEnabled = isEnabled
         state = isEnabled ? .locked : .unlocked
+        return capability
     }
 
     public func lock() {
@@ -128,7 +142,17 @@ public final class AppLockService {
             return .unavailable(reason)
         }
 
-        let result = await authenticator.authenticate(reason: reason)
+        if let inFlightAuthenticationTask {
+            return await inFlightAuthenticationTask.value
+        }
+
+        let task = Task { @MainActor [authenticator] in
+            await authenticator.authenticate(reason: reason)
+        }
+        inFlightAuthenticationTask = task
+        let result = await task.value
+        inFlightAuthenticationTask = nil
+
         switch result {
         case .success:
             state = .unlocked
@@ -145,6 +169,7 @@ public final class LocalAuthenticationAppLockAuthenticator: AppLockAuthenticatin
 
     public func authenticationCapability() -> AppLockCapability {
         let context = LAContext()
+        _ = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
         var error: NSError?
         guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
             return .unavailable(Self.unavailableReason(from: error))

--- a/Sources/PlaidBarCore/Utilities/AppLockService.swift
+++ b/Sources/PlaidBarCore/Utilities/AppLockService.swift
@@ -1,0 +1,225 @@
+import Foundation
+import LocalAuthentication
+import Observation
+
+public enum AppLockState: Equatable, Sendable {
+    case locked
+    case unlocked
+}
+
+public enum AppLockBiometryType: Equatable, Sendable {
+    case none
+    case touchID
+    case faceID
+    case opticID
+    case unknown
+}
+
+public enum AppLockUnavailableReason: Equatable, Sendable {
+    case passcodeNotSet
+    case biometryNotAvailable
+    case biometryNotEnrolled
+    case biometryLockout
+    case notInteractive
+    case unknown(String)
+}
+
+public enum AppLockFailureReason: Equatable, Sendable {
+    case authenticationFailed
+    case systemError(String)
+}
+
+public enum AppLockCapability: Equatable, Sendable {
+    case available(biometry: AppLockBiometryType)
+    case unavailable(AppLockUnavailableReason)
+}
+
+public enum AppLockAuthenticationResult: Equatable, Sendable {
+    case success
+    case cancelled
+    case unavailable(AppLockUnavailableReason)
+    case failure(AppLockFailureReason)
+}
+
+@MainActor
+public protocol AppLockAuthenticating: AnyObject {
+    func authenticationCapability() -> AppLockCapability
+    func authenticate(reason: String) async -> AppLockAuthenticationResult
+}
+
+public protocol AppLockSettingsStoring: AnyObject {
+    var isLockEnabled: Bool { get set }
+}
+
+public final class UserDefaultsAppLockSettingsStore: AppLockSettingsStoring {
+    public static let defaultStorageKey = "appLock.isEnabled"
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+
+    public init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = UserDefaultsAppLockSettingsStore.defaultStorageKey
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    public var isLockEnabled: Bool {
+        get { defaults.bool(forKey: storageKey) }
+        set { defaults.set(newValue, forKey: storageKey) }
+    }
+}
+
+@Observable
+@MainActor
+public final class AppLockService {
+    public private(set) var state: AppLockState
+    public private(set) var isLockEnabled: Bool
+
+    private let settingsStore: any AppLockSettingsStoring
+    private let authenticator: any AppLockAuthenticating
+
+    public var isLocked: Bool {
+        state == .locked
+    }
+
+    public init(
+        settingsStore: any AppLockSettingsStoring = UserDefaultsAppLockSettingsStore(),
+        authenticator: (any AppLockAuthenticating)? = nil
+    ) {
+        self.settingsStore = settingsStore
+        self.authenticator = authenticator ?? LocalAuthenticationAppLockAuthenticator()
+        self.isLockEnabled = settingsStore.isLockEnabled
+        self.state = settingsStore.isLockEnabled ? .locked : .unlocked
+    }
+
+    public func authenticationCapability() -> AppLockCapability {
+        authenticator.authenticationCapability()
+    }
+
+    public func setLockEnabled(_ isEnabled: Bool) {
+        guard isLockEnabled != isEnabled else { return }
+        isLockEnabled = isEnabled
+        settingsStore.isLockEnabled = isEnabled
+        state = isEnabled ? .locked : .unlocked
+    }
+
+    public func lock() {
+        guard isLockEnabled else {
+            state = .unlocked
+            return
+        }
+        state = .locked
+    }
+
+    @discardableResult
+    public func authenticate(reason: String) async -> AppLockAuthenticationResult {
+        guard isLockEnabled else {
+            state = .unlocked
+            return .success
+        }
+
+        switch authenticator.authenticationCapability() {
+        case .available:
+            break
+        case .unavailable(let reason):
+            state = .locked
+            return .unavailable(reason)
+        }
+
+        let result = await authenticator.authenticate(reason: reason)
+        switch result {
+        case .success:
+            state = .unlocked
+        case .cancelled, .unavailable, .failure:
+            state = .locked
+        }
+        return result
+    }
+}
+
+@MainActor
+public final class LocalAuthenticationAppLockAuthenticator: AppLockAuthenticating {
+    public init() {}
+
+    public func authenticationCapability() -> AppLockCapability {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
+            return .unavailable(Self.unavailableReason(from: error))
+        }
+        return .available(biometry: Self.biometryType(from: context.biometryType))
+    }
+
+    public func authenticate(reason: String) async -> AppLockAuthenticationResult {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
+            return .unavailable(Self.unavailableReason(from: error))
+        }
+
+        do {
+            let authenticated = try await context.evaluatePolicy(
+                .deviceOwnerAuthentication,
+                localizedReason: reason
+            )
+            return authenticated ? .success : .failure(.authenticationFailed)
+        } catch {
+            return Self.authenticationResult(from: error)
+        }
+    }
+
+    private static func authenticationResult(from error: Error) -> AppLockAuthenticationResult {
+        guard let laError = error as? LAError else {
+            return .failure(.systemError(error.localizedDescription))
+        }
+
+        switch laError.code {
+        case .userCancel, .userFallback, .appCancel, .systemCancel:
+            return .cancelled
+        case .authenticationFailed:
+            return .failure(.authenticationFailed)
+        case .passcodeNotSet, .biometryNotAvailable, .biometryNotEnrolled, .biometryLockout, .notInteractive:
+            return .unavailable(unavailableReason(from: laError))
+        default:
+            return .failure(.systemError(laError.localizedDescription))
+        }
+    }
+
+    private static func unavailableReason(from error: Error?) -> AppLockUnavailableReason {
+        guard let laError = error as? LAError else {
+            return .unknown(error?.localizedDescription ?? "Local authentication is unavailable.")
+        }
+
+        switch laError.code {
+        case .passcodeNotSet:
+            return .passcodeNotSet
+        case .biometryNotAvailable:
+            return .biometryNotAvailable
+        case .biometryNotEnrolled:
+            return .biometryNotEnrolled
+        case .biometryLockout:
+            return .biometryLockout
+        case .notInteractive:
+            return .notInteractive
+        default:
+            return .unknown(laError.localizedDescription)
+        }
+    }
+
+    private static func biometryType(from type: LABiometryType) -> AppLockBiometryType {
+        switch type {
+        case .none:
+            return .none
+        case .touchID:
+            return .touchID
+        case .faceID:
+            return .faceID
+        case .opticID:
+            return .opticID
+        @unknown default:
+            return .unknown
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
@@ -20,6 +20,22 @@ struct AppLockServiceTests {
         #expect(service.state == .locked)
     }
 
+    @Test("Unavailable authentication capability does not enable app lock")
+    func unavailableCapabilityDoesNotEnableLock() {
+        let store = InMemoryAppLockSettingsStore(isLockEnabled: false)
+        let service = AppLockService(
+            settingsStore: store,
+            authenticator: StubAppLockAuthenticator(capability: .unavailable(.biometryNotEnrolled))
+        )
+
+        let capability = service.setLockEnabled(true)
+
+        #expect(capability == .unavailable(.biometryNotEnrolled))
+        #expect(store.isLockEnabled == false)
+        #expect(service.isLockEnabled == false)
+        #expect(service.state == .unlocked)
+    }
+
     @Test("UserDefaults settings store persists enabled state")
     func userDefaultsSettingsStorePersistsEnabledState() throws {
         let suiteName = "AppLockServiceTests.\(UUID().uuidString)"
@@ -105,6 +121,24 @@ struct AppLockServiceTests {
         #expect(service.state == .unlocked)
         #expect(authenticator.authenticateCallCount == 0)
     }
+
+    @Test("Overlapping authentication attempts share one system prompt")
+    func overlappingAuthenticationAttemptsCoalesce() async {
+        let authenticator = StubAppLockAuthenticator(result: .success, delayNanoseconds: 50_000_000)
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: authenticator
+        )
+
+        async let first = service.authenticate(reason: "Unlock VaultPeek")
+        async let second = service.authenticate(reason: "Unlock VaultPeek")
+
+        let results = await [first, second]
+
+        #expect(results == [.success, .success])
+        #expect(authenticator.authenticateCallCount == 1)
+        #expect(service.state == .unlocked)
+    }
 }
 
 @MainActor
@@ -112,13 +146,16 @@ private final class StubAppLockAuthenticator: AppLockAuthenticating {
     var capability: AppLockCapability
     var result: AppLockAuthenticationResult
     var authenticateCallCount = 0
+    var delayNanoseconds: UInt64
 
     init(
         capability: AppLockCapability = .available(biometry: .none),
-        result: AppLockAuthenticationResult = .success
+        result: AppLockAuthenticationResult = .success,
+        delayNanoseconds: UInt64 = 0
     ) {
         self.capability = capability
         self.result = result
+        self.delayNanoseconds = delayNanoseconds
     }
 
     func authenticationCapability() -> AppLockCapability {
@@ -127,6 +164,9 @@ private final class StubAppLockAuthenticator: AppLockAuthenticating {
 
     func authenticate(reason: String) async -> AppLockAuthenticationResult {
         authenticateCallCount += 1
+        if delayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+        }
         return result
     }
 }

--- a/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
@@ -1,0 +1,140 @@
+@testable import PlaidBarCore
+import Foundation
+import Testing
+
+@Suite("App Lock Service Tests")
+@MainActor
+struct AppLockServiceTests {
+    @Test("Lock enabled state persists and enabling locks the service")
+    func lockEnabledStatePersists() {
+        let store = InMemoryAppLockSettingsStore(isLockEnabled: false)
+        let service = AppLockService(settingsStore: store, authenticator: StubAppLockAuthenticator())
+
+        #expect(service.isLockEnabled == false)
+        #expect(service.state == .unlocked)
+
+        service.setLockEnabled(true)
+
+        #expect(store.isLockEnabled == true)
+        #expect(service.isLockEnabled == true)
+        #expect(service.state == .locked)
+    }
+
+    @Test("UserDefaults settings store persists enabled state")
+    func userDefaultsSettingsStorePersistsEnabledState() throws {
+        let suiteName = "AppLockServiceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let key = "appLock.enabled"
+        let store = UserDefaultsAppLockSettingsStore(defaults: defaults, storageKey: key)
+
+        #expect(store.isLockEnabled == false)
+
+        store.isLockEnabled = true
+
+        let reloadedStore = UserDefaultsAppLockSettingsStore(defaults: defaults, storageKey: key)
+        #expect(reloadedStore.isLockEnabled == true)
+    }
+
+    @Test("Successful authentication unlocks the service")
+    func successfulAuthenticationUnlocks() async {
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: StubAppLockAuthenticator(
+                capability: .available(biometry: .touchID),
+                result: .success
+            )
+        )
+
+        let result = await service.authenticate(reason: "Unlock VaultPeek")
+
+        #expect(result == .success)
+        #expect(service.state == .unlocked)
+    }
+
+    @Test("Unavailable authentication returns typed reason and remains locked")
+    func unavailableAuthenticationRemainsLocked() async {
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: StubAppLockAuthenticator(capability: .unavailable(.passcodeNotSet))
+        )
+
+        let result = await service.authenticate(reason: "Unlock VaultPeek")
+
+        #expect(result == .unavailable(.passcodeNotSet))
+        #expect(service.state == .locked)
+    }
+
+    @Test("User cancellation returns cancellation and remains locked")
+    func userCancellationRemainsLocked() async {
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: StubAppLockAuthenticator(result: .cancelled)
+        )
+
+        let result = await service.authenticate(reason: "Unlock VaultPeek")
+
+        #expect(result == .cancelled)
+        #expect(service.state == .locked)
+    }
+
+    @Test("Failed authentication returns failure and remains locked")
+    func failedAuthenticationRemainsLocked() async {
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: StubAppLockAuthenticator(result: .failure(.authenticationFailed))
+        )
+
+        let result = await service.authenticate(reason: "Unlock VaultPeek")
+
+        #expect(result == .failure(.authenticationFailed))
+        #expect(service.state == .locked)
+    }
+
+    @Test("Disabled lock treats authenticate as already unlocked")
+    func disabledLockSkipsAuthentication() async {
+        let authenticator = StubAppLockAuthenticator(result: .failure(.systemError("should not be called")))
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: false),
+            authenticator: authenticator
+        )
+
+        let result = await service.authenticate(reason: "Unlock VaultPeek")
+
+        #expect(result == .success)
+        #expect(service.state == .unlocked)
+        #expect(authenticator.authenticateCallCount == 0)
+    }
+}
+
+@MainActor
+private final class StubAppLockAuthenticator: AppLockAuthenticating {
+    var capability: AppLockCapability
+    var result: AppLockAuthenticationResult
+    var authenticateCallCount = 0
+
+    init(
+        capability: AppLockCapability = .available(biometry: .none),
+        result: AppLockAuthenticationResult = .success
+    ) {
+        self.capability = capability
+        self.result = result
+    }
+
+    func authenticationCapability() -> AppLockCapability {
+        capability
+    }
+
+    func authenticate(reason: String) async -> AppLockAuthenticationResult {
+        authenticateCallCount += 1
+        return result
+    }
+}
+
+private final class InMemoryAppLockSettingsStore: AppLockSettingsStoring {
+    var isLockEnabled: Bool
+
+    init(isLockEnabled: Bool) {
+        self.isLockEnabled = isLockEnabled
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `PlaidBarCore` app-lock service backed by LocalAuthentication.
- Persists the lock-enabled preference via a small UserDefaults store.
- Covers enable/disable, success, cancellation, unavailable, and failure paths with Swift Testing.

## Links
Linear: AND-435

## Validation
- `git diff --check`
- `swift test --filter AppLockServiceTests` — 7 tests passed

## Review notes
- Local-first only; no Plaid credentials, tokens, account IDs, transactions, balances, screenshots, or telemetry paths added.
- This is the foundation slice; UI wiring remains separate work for AND-436 / follow-up cards.
