### PR TITLE
AND-434: Add strong privacy mask formatter

### DIFF
--- a/Sources/PlaidBarCore/Utilities/StrongMaskFormatter.swift
+++ b/Sources/PlaidBarCore/Utilities/StrongMaskFormatter.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// Deterministic strong masking helpers for screen-share/privacy presentation.
+///
+/// These helpers intentionally return fixed mask strings instead of preserving
+/// input length, prefixes, suffixes, last-four digits, dates, or exact numeric
+/// magnitude. Missing values pass through as unavailable placeholders so the UI
+/// does not imply hidden private data exists when the source value is nil/empty.
+public enum StrongMaskFormatter {
+    public enum TextSlot: Sendable {
+        case primaryLabel
+        case secondaryLabel
+        case metadata
+        case longDescription
+        case identifier
+
+        public var mask: String {
+            switch self {
+            case .primaryLabel:
+                return "••••••"
+            case .secondaryLabel:
+                return "•••• ••••"
+            case .metadata:
+                return "••••"
+            case .longDescription:
+                return "•••••• ••••••"
+            case .identifier:
+                return "••••••••"
+            }
+        }
+    }
+
+    public enum AccessibilityHiddenValue: Sendable {
+        case accountName
+        case institution
+        case merchant
+        case description
+        case amount
+        case date
+        case identifier
+        case accountMask
+        case percentage
+        case count
+
+        fileprivate var label: String {
+            switch self {
+            case .accountName:
+                return "Account name hidden"
+            case .institution:
+                return "Institution hidden"
+            case .merchant:
+                return "Merchant hidden"
+            case .description:
+                return "Transaction description hidden"
+            case .amount:
+                return "Amount hidden"
+            case .date:
+                return "Date hidden"
+            case .identifier:
+                return "Identifier hidden"
+            case .accountMask:
+                return "Account number hidden"
+            case .percentage:
+                return "Percentage hidden"
+            case .count:
+                return "Count hidden"
+            }
+        }
+    }
+
+    public static let unavailable = "—"
+    public static let maskedMoney = "$••••"
+    public static let maskedPercent = "••%"
+    public static let maskedDate = "••/••/••"
+    public static let maskedDateRange = "••• •• – ••• ••"
+
+    /// Masks a present sensitive string with the fixed placeholder for its UI slot.
+    /// Nil, empty, and whitespace-only values return `unavailable` instead of bullets.
+    public static func text(_ value: String?, slot: TextSlot, unavailable: String = Self.unavailable) -> String {
+        guard hasVisibleContent(value) else { return unavailable }
+        return slot.mask
+    }
+
+    public static func accountName(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .primaryLabel, unavailable: unavailable)
+    }
+
+    public static func officialAccountName(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .secondaryLabel, unavailable: unavailable)
+    }
+
+    public static func institutionName(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .primaryLabel, unavailable: unavailable)
+    }
+
+    public static func merchantName(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .primaryLabel, unavailable: unavailable)
+    }
+
+    public static func transactionDescription(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .longDescription, unavailable: unavailable)
+    }
+
+    /// Masks the displayed transaction label using merchant copy when present,
+    /// otherwise falling back to the raw transaction name/description slot.
+    public static func transactionDisplayName(
+        merchantName: String?,
+        name: String?,
+        unavailable: String = Self.unavailable
+    ) -> String {
+        if hasVisibleContent(merchantName) {
+            return self.merchantName(merchantName, unavailable: unavailable)
+        }
+        return transactionDescription(name, unavailable: unavailable)
+    }
+
+    public static func identifier(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .identifier, unavailable: unavailable)
+    }
+
+    public static func accountLastFour(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        text(value, slot: .metadata, unavailable: unavailable)
+    }
+
+    public static func money(
+        _ value: Double?,
+        preservesSign: Bool = false,
+        unavailable: String = Self.unavailable
+    ) -> String {
+        guard let value, value.isFinite else { return unavailable }
+        guard preservesSign else { return maskedMoney }
+        if value < 0 { return "-\(maskedMoney)" }
+        if value > 0 { return "+\(maskedMoney)" }
+        return maskedMoney
+    }
+
+    /// Masks a decimal money value without preserving magnitude, cents, or width.
+    public static func money(
+        _ value: Decimal?,
+        preservesSign: Bool = false,
+        unavailable: String = Self.unavailable
+    ) -> String {
+        guard let value else { return unavailable }
+        guard preservesSign else { return maskedMoney }
+        if value < 0 { return "-\(maskedMoney)" }
+        if value > 0 { return "+\(maskedMoney)" }
+        return maskedMoney
+    }
+
+    public static func percent(_ value: Double?, unavailable: String = Self.unavailable) -> String {
+        guard let value, value.isFinite else { return unavailable }
+        return maskedPercent
+    }
+
+    public static func count(_ value: Int?, label: String, unavailable: String = Self.unavailable) -> String {
+        guard value != nil else { return unavailable }
+        let suffix = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !suffix.isEmpty else { return "••" }
+        return "•• \(suffix)"
+    }
+
+    public static func date(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        guard hasVisibleContent(value) else { return unavailable }
+        return maskedDate
+    }
+
+    public static func date(_ value: Date?, unavailable: String = Self.unavailable) -> String {
+        guard value != nil else { return unavailable }
+        return maskedDate
+    }
+
+    public static func dateRange(_ start: String?, _ end: String?, unavailable: String = Self.unavailable) -> String {
+        guard hasVisibleContent(start) || hasVisibleContent(end) else { return unavailable }
+        return maskedDateRange
+    }
+
+    public static func freshness(prefix: String, value: String?, unavailable: String = Self.unavailable) -> String {
+        guard hasVisibleContent(value) else { return unavailable }
+        let safePrefix = prefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !safePrefix.isEmpty else { return "•••" }
+        return "\(safePrefix) •••"
+    }
+
+    /// Pass-through for lower-sensitivity labels such as account type, category,
+    /// pending/posted status, or generic recovery copy.
+    public static func generic(_ value: String?, unavailable: String = Self.unavailable) -> String {
+        guard let value, hasVisibleContent(value) else { return unavailable }
+        return value
+    }
+
+    public static func accessibilityLabel(for hiddenValue: AccessibilityHiddenValue) -> String {
+        hiddenValue.label
+    }
+
+    private static func hasVisibleContent(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/StrongMaskFormatter.swift
+++ b/Sources/PlaidBarCore/Utilities/StrongMaskFormatter.swift
@@ -140,7 +140,7 @@ public enum StrongMaskFormatter {
         preservesSign: Bool = false,
         unavailable: String = Self.unavailable
     ) -> String {
-        guard let value else { return unavailable }
+        guard let value, !value.isNaN else { return unavailable }
         guard preservesSign else { return maskedMoney }
         if value < 0 { return "-\(maskedMoney)" }
         if value > 0 { return "+\(maskedMoney)" }

--- a/Tests/PlaidBarCoreTests/StrongMaskFormatterTests.swift
+++ b/Tests/PlaidBarCoreTests/StrongMaskFormatterTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Strong mask formatter")
+struct StrongMaskFormatterTests {
+    @Test("text masks use fixed slots and do not leak length or Unicode content")
+    func textMasksUseFixedSlots() {
+        #expect(StrongMaskFormatter.text("Uber", slot: .primaryLabel) == "••••••")
+        #expect(StrongMaskFormatter.text("Whole Foods Market", slot: .primaryLabel) == "••••••")
+        #expect(StrongMaskFormatter.text("東京カード🌉", slot: .longDescription) == "•••••• ••••••")
+        #expect(StrongMaskFormatter.text("acc_3PnX9e", slot: .identifier) == "••••••••")
+    }
+
+    @Test("nil empty and whitespace values keep unavailable placeholders")
+    func unavailableValuesKeepPlaceholders() {
+        #expect(StrongMaskFormatter.text(nil, slot: .primaryLabel) == "—")
+        #expect(StrongMaskFormatter.text("", slot: .primaryLabel) == "—")
+        #expect(StrongMaskFormatter.text("   \n\t", slot: .primaryLabel, unavailable: "Unknown") == "Unknown")
+        #expect(StrongMaskFormatter.accountLastFour(nil) == "—")
+        #expect(StrongMaskFormatter.accountLastFour("    ") == "—")
+        #expect(StrongMaskFormatter.money(nil as Double?) == "—")
+        #expect(StrongMaskFormatter.date(nil as String?) == "—")
+    }
+
+    @Test("account names institutions merchants descriptions and identifiers use semantic helpers")
+    func semanticTextHelpersMaskSensitiveStrings() {
+        #expect(StrongMaskFormatter.accountName("Chase Total Checking") == "••••••")
+        #expect(StrongMaskFormatter.officialAccountName("PLAID CHECKING") == "•••• ••••")
+        #expect(StrongMaskFormatter.institutionName("Plaid Bank") == "••••••")
+        #expect(StrongMaskFormatter.merchantName("Whole Foods Market") == "••••••")
+        #expect(StrongMaskFormatter.transactionDescription("WHOLEFDS LOS ANGELES CA 320104") == "•••••• ••••••")
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: "Uber", name: "UBER TRIP HELP.UBER.COM") == "••••••")
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: nil, name: "SQ *COFFEE BAR") == "•••••• ••••••")
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: " ", name: nil) == "—")
+        #expect(StrongMaskFormatter.identifier("transaction-id-123") == "••••••••")
+        #expect(StrongMaskFormatter.accountLastFour("1234") == "••••")
+    }
+
+    @Test("money percent counts and dates hide exact values while preserving shape")
+    func numericAndDateMasksPreserveShape() {
+        #expect(StrongMaskFormatter.money(4_823.19) == "$••••")
+        #expect(StrongMaskFormatter.money(-87.42, preservesSign: true) == "-$••••")
+        #expect(StrongMaskFormatter.money(Decimal(12_000), preservesSign: true) == "+$••••")
+        #expect(StrongMaskFormatter.money(Decimal(-22.99), preservesSign: true) == "-$••••")
+        #expect(StrongMaskFormatter.money(Double.nan) == "—")
+        #expect(StrongMaskFormatter.money(Double.infinity) == "—")
+        #expect(StrongMaskFormatter.money(3_250.0, preservesSign: true) == "+$••••")
+        #expect(StrongMaskFormatter.money(0.0, preservesSign: true) == "$••••")
+        #expect(StrongMaskFormatter.percent(43.2) == "••%")
+        #expect(StrongMaskFormatter.count(3, label: "pending") == "•• pending")
+        #expect(StrongMaskFormatter.date("2026-06-14") == "••/••/••")
+        #expect(StrongMaskFormatter.dateRange("Jun 1", "Jun 30") == "••• •• – ••• ••")
+        #expect(StrongMaskFormatter.freshness(prefix: "Updated", value: "2m ago") == "Updated •••")
+    }
+
+    @Test("generic account type category status and unavailable values can remain visible")
+    func genericValuesRemainVisible() {
+        #expect(StrongMaskFormatter.generic("Checking") == "Checking")
+        #expect(StrongMaskFormatter.generic("Food & Drink") == "Food & Drink")
+        #expect(StrongMaskFormatter.generic("Pending") == "Pending")
+        #expect(StrongMaskFormatter.generic(nil) == "—")
+    }
+
+    @Test("accessibility labels announce hidden semantics instead of bullet characters")
+    func accessibilityLabelsDescribeHiddenValues() {
+        #expect(StrongMaskFormatter.accessibilityLabel(for: .accountName) == "Account name hidden")
+        #expect(StrongMaskFormatter.accessibilityLabel(for: .merchant) == "Merchant hidden")
+        #expect(StrongMaskFormatter.accessibilityLabel(for: .amount) == "Amount hidden")
+        #expect(StrongMaskFormatter.accessibilityLabel(for: .identifier) == "Identifier hidden")
+    }
+}

--- a/Tests/PlaidBarCoreTests/StrongMaskFormatterTests.swift
+++ b/Tests/PlaidBarCoreTests/StrongMaskFormatterTests.swift
@@ -43,6 +43,7 @@ struct StrongMaskFormatterTests {
         #expect(StrongMaskFormatter.money(-87.42, preservesSign: true) == "-$••••")
         #expect(StrongMaskFormatter.money(Decimal(12_000), preservesSign: true) == "+$••••")
         #expect(StrongMaskFormatter.money(Decimal(-22.99), preservesSign: true) == "-$••••")
+        #expect(StrongMaskFormatter.money(Decimal.nan) == "—")
         #expect(StrongMaskFormatter.money(Double.nan) == "—")
         #expect(StrongMaskFormatter.money(Double.infinity) == "—")
         #expect(StrongMaskFormatter.money(3_250.0, preservesSign: true) == "+$••••")


### PR DESCRIPTION
## Summary
- add a deterministic StrongMaskFormatter for account, merchant, transaction, date, money, percentage, identifier, and accessibility masking
- ensure missing/blank values render as unavailable instead of implying hidden private data
- cover fixed-slot masking so private value length, suffixes, and exact magnitude do not leak

## Tests
- `swift test --filter StrongMaskFormatterTests`

## Privacy/security notes
- Formatter returns fixed placeholders and semantic accessibility labels only.
- No Plaid credentials, account IDs, transaction IDs, balances, raw payloads, or local database data are introduced.