### PR TITLE
AND-433: Add MVP privacy mask presentation

### DIFF
--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -54,24 +54,30 @@ public enum AccountPresentation {
     }
 
     public static func subtitle(for account: AccountDTO) -> String {
+        subtitle(for: account, privacyMaskEnabled: false)
+    }
+
+    public static func subtitle(for account: AccountDTO, privacyMaskEnabled: Bool) -> String {
         let subtype = account.subtype?.capitalized ?? account.type.rawValue.capitalized
-        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        let mask = account.mask.map { privacyMaskEnabled ? " ••••" : " •••• \($0)" } ?? ""
         return "\(account.type.rawValue.capitalized) • \(subtype)\(mask)"
     }
 
     public static func rowAmountText(
         for account: AccountDTO,
-        format: CurrencyFormat = .full
+        format: CurrencyFormat = .full,
+        privacyMaskEnabled: Bool = false
     ) -> String {
-        Formatters.currency(displayBalance(for: account), format: format)
+        PrivacyMaskPresentation.currency(displayBalance(for: account), format: format, isEnabled: privacyMaskEnabled)
     }
 
     public static func dashboardRowSubtitle(
         for account: AccountDTO,
         connectionLabel: String,
-        pendingCount: Int = 0
+        pendingCount: Int = 0,
+        privacyMaskEnabled: Bool = false
     ) -> String {
-        let mask = account.mask.map { " •••• \($0)" } ?? ""
+        let mask = account.mask.map { privacyMaskEnabled ? " ••••" : " •••• \($0)" } ?? ""
         let pending = pendingCount > 0 ? " • \(pendingCount) pending" : ""
         return "\(account.institutionName ?? account.type.rawValue.capitalized)\(mask) • \(connectionLabel)\(pending)"
     }
@@ -79,20 +85,21 @@ public enum AccountPresentation {
     public static func dashboardTrailingDetailText(
         for account: AccountDTO,
         connectionLabel: String,
-        format: CurrencyFormat = .compact
+        format: CurrencyFormat = .compact,
+        privacyMaskEnabled: Bool = false
     ) -> String {
         guard account.type == .credit else {
             return connectionLabel
         }
 
-        let availableText = "\(Formatters.currency(availableBalance(for: account), format: format)) available"
+        let availableText = "\(PrivacyMaskPresentation.currency(availableBalance(for: account), format: format, isEnabled: privacyMaskEnabled)) available"
         let dueText = creditDueMetadataText(for: account)
 
         guard let utilization = account.balances.utilizationPercent else {
             return "\(availableText) • \(dueText)"
         }
 
-        return "\(Formatters.percent(utilization, decimals: 0)) • \(availableText) • \(dueText)"
+        return "\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)) • \(availableText) • \(dueText)"
     }
 
     public static func creditDueMetadataText(for account: AccountDTO) -> String {
@@ -115,7 +122,8 @@ public enum AccountPresentation {
     public static func dashboardUtilizationDetailText(
         for account: AccountDTO,
         threshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
-        format: CurrencyFormat = .compact
+        format: CurrencyFormat = .compact,
+        privacyMaskEnabled: Bool = false
     ) -> String? {
         guard let utilization = account.balances.utilizationPercent else {
             return nil
@@ -123,10 +131,10 @@ public enum AccountPresentation {
 
         let status = utilizationStatusLabel(for: utilization, threshold: threshold)
         guard let limit = account.balances.limit, limit > 0 else {
-            return "\(Formatters.percent(utilization, decimals: 0)), \(status)"
+            return "\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)), \(status)"
         }
 
-        return "\(Formatters.percent(utilization, decimals: 0)) of \(Formatters.currency(limit, format: format)), \(status)"
+        return "\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)) of \(PrivacyMaskPresentation.currency(limit, format: format, isEnabled: privacyMaskEnabled)), \(status)"
     }
 
     public static func rowAccessibilityLabel(
@@ -135,7 +143,8 @@ public enum AccountPresentation {
         connectionLabel: String? = nil,
         pendingCount: Int = 0,
         isSelected: Bool? = nil,
-        utilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
+        utilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        privacyMaskEnabled: Bool = false
     ) -> String {
         var components = [String]()
         components.append(account.name)
@@ -143,15 +152,15 @@ public enum AccountPresentation {
             components.append(institutionName)
         }
         components.append(account.type.rawValue.capitalized)
-        if let mask = account.mask {
+        if let mask = account.mask, !privacyMaskEnabled {
             components.append("Ending in \(mask)")
         }
 
-        let balance = amountText ?? rowAmountText(for: account)
+        let balance = amountText ?? rowAmountText(for: account, privacyMaskEnabled: privacyMaskEnabled)
         components.append("\(balance)\(isDebt(account) ? " owed" : "")")
 
         if let utilization = account.balances.utilizationPercent {
-            components.append("\(Formatters.percent(utilization, decimals: 0)) utilization")
+            components.append("\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)) utilization")
             components.append(utilizationStatusLabel(
                 for: utilization,
                 threshold: utilizationThreshold
@@ -159,7 +168,7 @@ public enum AccountPresentation {
         }
 
         if account.type == .credit {
-            components.append("\(Formatters.currency(availableBalance(for: account))) available credit")
+            components.append("\(PrivacyMaskPresentation.currency(availableBalance(for: account), isEnabled: privacyMaskEnabled)) available credit")
             components.append(creditDueMetadataText(for: account))
         }
 

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -129,12 +129,19 @@ public enum AccountPresentation {
             return nil
         }
 
-        let status = utilizationStatusLabel(for: utilization, threshold: threshold)
-        guard let limit = account.balances.limit, limit > 0 else {
-            return "\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)), \(status)"
+        if privacyMaskEnabled {
+            guard let limit = account.balances.limit, limit > 0 else {
+                return PrivacyMaskPresentation.compactValue
+            }
+            return "\(PrivacyMaskPresentation.compactValue) of \(PrivacyMaskPresentation.currency(limit, format: format, isEnabled: true))"
         }
 
-        return "\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)) of \(PrivacyMaskPresentation.currency(limit, format: format, isEnabled: privacyMaskEnabled)), \(status)"
+        let status = utilizationStatusLabel(for: utilization, threshold: threshold)
+        guard let limit = account.balances.limit, limit > 0 else {
+            return "\(Formatters.percent(utilization, decimals: 0)), \(status)"
+        }
+
+        return "\(Formatters.percent(utilization, decimals: 0)) of \(Formatters.currency(limit, format: format)), \(status)"
     }
 
     public static func rowAccessibilityLabel(
@@ -156,15 +163,19 @@ public enum AccountPresentation {
             components.append("Ending in \(mask)")
         }
 
-        let balance = amountText ?? rowAmountText(for: account, privacyMaskEnabled: privacyMaskEnabled)
+        let balance = privacyMaskEnabled
+            ? PrivacyMaskPresentation.compactValue
+            : (amountText ?? rowAmountText(for: account))
         components.append("\(balance)\(isDebt(account) ? " owed" : "")")
 
         if let utilization = account.balances.utilizationPercent {
             components.append("\(PrivacyMaskPresentation.percent(utilization, decimals: 0, isEnabled: privacyMaskEnabled)) utilization")
-            components.append(utilizationStatusLabel(
-                for: utilization,
-                threshold: utilizationThreshold
-            ))
+            if !privacyMaskEnabled {
+                components.append(utilizationStatusLabel(
+                    for: utilization,
+                    threshold: utilizationThreshold
+                ))
+            }
         }
 
         if account.type == .credit {

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -182,8 +182,13 @@ public enum MenuBarSummary {
         accounts: [AccountDTO],
         transactions: [TransactionDTO],
         currencyFormat: CurrencyFormat,
-        isInitialLoad: Bool = false
+        isInitialLoad: Bool = false,
+        privacyMaskEnabled: Bool = false
     ) -> String {
+        if privacyMaskEnabled, mode != .iconOnly {
+            return PrivacyMaskPresentation.heroValue
+        }
+
         switch mode {
         case .netWorth:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -185,23 +185,23 @@ public enum MenuBarSummary {
         isInitialLoad: Bool = false,
         privacyMaskEnabled: Bool = false
     ) -> String {
-        if privacyMaskEnabled, mode != .iconOnly {
-            return PrivacyMaskPresentation.heroValue
-        }
-
         switch mode {
         case .netWorth:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.currency(netWorth(from: accounts), format: currencyFormat)
         case .netCash:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.currency(netCash(from: accounts), format: currencyFormat)
         case .totalCash:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.currency(totalCash(from: accounts), format: currencyFormat)
         case .creditUtilization:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.percent(utilization, decimals: 0)
         case .recentSpend:
             // During the boot fetch an empty history is unknown, not zero:
@@ -209,6 +209,7 @@ public enum MenuBarSummary {
             guard !transactions.isEmpty else {
                 return isInitialLoad ? PlaidBarConstants.appName : "No spend"
             }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.currency(recentSpend(from: transactions), format: currencyFormat)
         case .iconOnly:
             return ""

--- a/Sources/PlaidBarCore/Utilities/PrivacyMaskPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/PrivacyMaskPresentation.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public enum PrivacyMaskPresentation {
+    public enum Style: Sendable {
+        case compact
+        case hero
+        case detail
+    }
+
+    public static let compactValue = "••••"
+    public static let heroValue = "Private"
+    public static let detailValue = "Hidden while Privacy Mask is on"
+
+    public static func value(
+        _ unmaskedValue: String,
+        isEnabled: Bool,
+        style: Style = .compact
+    ) -> String {
+        guard isEnabled else { return unmaskedValue }
+
+        switch style {
+        case .compact:
+            return compactValue
+        case .hero:
+            return heroValue
+        case .detail:
+            return detailValue
+        }
+    }
+
+    public static func currency(
+        _ amount: Double,
+        format: CurrencyFormat = .full,
+        isEnabled: Bool,
+        style: Style = .compact
+    ) -> String {
+        value(Formatters.currency(amount, format: format), isEnabled: isEnabled, style: style)
+    }
+
+    public static func percent(
+        _ percent: Double,
+        decimals: Int = 0,
+        isEnabled: Bool,
+        style: Style = .compact
+    ) -> String {
+        value(Formatters.percent(percent, decimals: decimals), isEnabled: isEnabled, style: style)
+    }
+
+    public static func maskedHelpText(isEnabled: Bool) -> String? {
+        isEnabled ? detailValue : nil
+    }
+}

--- a/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Privacy Mask Presentation Tests")
+struct PrivacyMaskPresentationTests {
+    @Test("Menu bar privacy mask replaces selected summary values and preserves icon-only")
+    func menuBarPrivacyMask() {
+        let accounts = [
+            AccountDTO(id: "checking", itemId: "item", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+        ]
+
+        #expect(MenuBarSummary.text(
+            mode: .netWorth,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact,
+            privacyMaskEnabled: true
+        ) == "Private")
+
+        #expect(MenuBarSummary.text(
+            mode: .iconOnly,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact,
+            privacyMaskEnabled: true
+        ) == "")
+    }
+
+    @Test("Account presentation masks balances, utilization, account endings, and accessibility values")
+    func accountPrivacyMask() {
+        let account = AccountDTO(
+            id: "visa",
+            itemId: "item",
+            name: "Visa",
+            officialName: "Rewards Visa",
+            type: .credit,
+            subtype: "credit card",
+            mask: "1234",
+            balances: BalanceDTO(available: 3_750, current: -1_250, limit: 5_000)
+        )
+
+        #expect(AccountPresentation.subtitle(for: account, privacyMaskEnabled: true) == "Credit • Credit Card ••••")
+        #expect(AccountPresentation.rowAmountText(for: account, privacyMaskEnabled: true) == "••••")
+        #expect(AccountPresentation.dashboardRowSubtitle(
+            for: account,
+            connectionLabel: "Synced",
+            privacyMaskEnabled: true
+        ) == "Credit •••• • Synced")
+        #expect(AccountPresentation.dashboardTrailingDetailText(
+            for: account,
+            connectionLabel: "Synced",
+            privacyMaskEnabled: true
+        ) == "•••• • •••• available • due not synced")
+
+        let label = AccountPresentation.rowAccessibilityLabel(
+            for: account,
+            connectionLabel: "Synced",
+            privacyMaskEnabled: true
+        )
+        #expect(label.contains("Ending in 1234") == false)
+        #expect(label.contains("•••• owed"))
+        #expect(label.contains("•••• available credit"))
+        #expect(label.contains("•••• utilization"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
@@ -52,15 +52,51 @@ struct PrivacyMaskPresentationTests {
             connectionLabel: "Synced",
             privacyMaskEnabled: true
         ) == "•••• • •••• available • due not synced")
+        #expect(AccountPresentation.dashboardUtilizationDetailText(
+            for: account,
+            privacyMaskEnabled: true
+        ) == "•••• of ••••")
 
         let label = AccountPresentation.rowAccessibilityLabel(
             for: account,
+            amountText: "$1,250.00",
             connectionLabel: "Synced",
             privacyMaskEnabled: true
         )
         #expect(label.contains("Ending in 1234") == false)
+        #expect(label.contains("$1,250.00") == false)
         #expect(label.contains("•••• owed"))
         #expect(label.contains("•••• available credit"))
         #expect(label.contains("•••• utilization"))
+        #expect(label.contains("Good") == false)
+        #expect(label.contains("Warning") == false)
+        #expect(label.contains("High") == false)
+    }
+
+    @Test("Menu bar privacy mask preserves non-sensitive empty states")
+    func menuBarPrivacyMaskPreservesEmptyStates() {
+        #expect(MenuBarSummary.text(
+            mode: .netWorth,
+            accounts: [],
+            transactions: [],
+            currencyFormat: .compact,
+            privacyMaskEnabled: true
+        ) == PlaidBarConstants.appName)
+
+        #expect(MenuBarSummary.text(
+            mode: .creditUtilization,
+            accounts: [AccountDTO(id: "checking", itemId: "item", name: "Checking", type: .depository, balances: BalanceDTO(current: 120))],
+            transactions: [],
+            currencyFormat: .compact,
+            privacyMaskEnabled: true
+        ) == "No credit")
+
+        #expect(MenuBarSummary.text(
+            mode: .recentSpend,
+            accounts: [],
+            transactions: [],
+            currencyFormat: .compact,
+            privacyMaskEnabled: true
+        ) == "No spend")
     }
 }


### PR DESCRIPTION
## Summary
- add MVP PrivacyMaskPresentation helpers for compact/hero/detail masking
- thread privacy-mask options through menu bar summary and account presentation helpers
- preserve icon-only menu bar behavior and avoid exposing account endings/balances/utilization in masked accessibility copy

## Tests
- `swift test --filter PrivacyMaskPresentationTests`

## Privacy/security notes
- This is presentation-layer masking only; it does not move Plaid credentials/tokens/raw payloads into the SwiftUI app.
- Account endings, balances, utilization, and available credit are hidden when privacy mask is enabled.