### PR TITLE
AND-436: Add app lock presentation policy

### DIFF
--- a/Sources/PlaidBarCore/Models/AppLockPresentation.swift
+++ b/Sources/PlaidBarCore/Models/AppLockPresentation.swift
@@ -39,6 +39,8 @@ public enum NotificationPrivacyMode: String, CaseIterable, Sendable, Equatable {
     }
 
     public func usesGenericCopy(isPrivate: Bool) -> Bool {
+        guard !isPrivate else { return true }
+
         switch self {
         case .detailed, .offWhileLocked:
             return false

--- a/Sources/PlaidBarCore/Models/AppLockPresentation.swift
+++ b/Sources/PlaidBarCore/Models/AppLockPresentation.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+public enum PrivacyDisplayMode: Sendable, Equatable {
+    case normal
+    case masked
+    case locked
+}
+
+public enum NotificationPrivacyMode: String, CaseIterable, Sendable, Equatable {
+    case detailed
+    case genericWhenPrivate
+    case alwaysGeneric
+    case offWhileLocked
+
+    public var displayName: String {
+        switch self {
+        case .detailed: return "Detailed"
+        case .genericWhenPrivate: return "Generic when private"
+        case .alwaysGeneric: return "Always generic"
+        case .offWhileLocked: return "Off while locked"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .detailed:
+            return "Show merchant, account, and amount details when VaultPeek is not private."
+        case .genericWhenPrivate:
+            return "Hide notification details whenever Privacy Mask or App Lock is active."
+        case .alwaysGeneric:
+            return "Never show financial details in notifications."
+        case .offWhileLocked:
+            return "Suppress financial alerts until VaultPeek is unlocked."
+        }
+    }
+
+    public func shouldSend(isLocked: Bool) -> Bool {
+        !(self == .offWhileLocked && isLocked)
+    }
+
+    public func usesGenericCopy(isPrivate: Bool) -> Bool {
+        switch self {
+        case .detailed, .offWhileLocked:
+            return false
+        case .genericWhenPrivate:
+            return isPrivate
+        case .alwaysGeneric:
+            return true
+        }
+    }
+}
+
+public struct AppLockPreferences: Sendable, Equatable {
+    public static let defaultInactivityInterval: TimeInterval = 300
+    public static let allowedInactivityIntervals: [TimeInterval] = [60, 300, 900, 1_800]
+
+    public var privacyMaskEnabled: Bool
+    public var appLockEnabled: Bool
+    public var lockOnLaunch: Bool
+    public var lockAfterInactivityEnabled: Bool
+    public var lockAfterInactivityInterval: TimeInterval
+    public var lockWhenBackgrounded: Bool
+    public var notificationPrivacyMode: NotificationPrivacyMode
+    public var pauseRefreshWhileLocked: Bool
+
+    public init(
+        privacyMaskEnabled: Bool = false,
+        appLockEnabled: Bool = false,
+        lockOnLaunch: Bool = false,
+        lockAfterInactivityEnabled: Bool = true,
+        lockAfterInactivityInterval: TimeInterval = Self.defaultInactivityInterval,
+        lockWhenBackgrounded: Bool = true,
+        notificationPrivacyMode: NotificationPrivacyMode = .genericWhenPrivate,
+        pauseRefreshWhileLocked: Bool = false
+    ) {
+        self.privacyMaskEnabled = privacyMaskEnabled
+        self.appLockEnabled = appLockEnabled
+        self.lockOnLaunch = lockOnLaunch
+        self.lockAfterInactivityEnabled = lockAfterInactivityEnabled
+        self.lockAfterInactivityInterval = Self.normalizedInactivityInterval(lockAfterInactivityInterval)
+        self.lockWhenBackgrounded = lockWhenBackgrounded
+        self.notificationPrivacyMode = notificationPrivacyMode
+        self.pauseRefreshWhileLocked = pauseRefreshWhileLocked
+    }
+
+    public static func normalizedInactivityInterval(_ interval: TimeInterval) -> TimeInterval {
+        guard let nearest = allowedInactivityIntervals.min(by: { abs($0 - interval) < abs($1 - interval) }) else {
+            return defaultInactivityInterval
+        }
+        return nearest
+    }
+
+    public func effectiveDisplayMode(isAppLocked: Bool) -> PrivacyDisplayMode {
+        if appLockEnabled && isAppLocked { return .locked }
+        if privacyMaskEnabled { return .masked }
+        return .normal
+    }
+
+    public func menuBarText(currentText: String, isAppLocked: Bool, isIconOnly: Bool) -> String {
+        guard !isIconOnly else { return "" }
+        switch effectiveDisplayMode(isAppLocked: isAppLocked) {
+        case .normal:
+            return currentText
+        case .masked:
+            return "Private"
+        case .locked:
+            return "Locked"
+        }
+    }
+
+    public func shouldEvaluateFinancialNotifications(isAppLocked: Bool) -> Bool {
+        guard appLockEnabled && isAppLocked else { return true }
+        return notificationPrivacyMode != .offWhileLocked
+    }
+
+    public func shouldRefreshFinancialData(isAppLocked: Bool) -> Bool {
+        !(appLockEnabled && isAppLocked && pauseRefreshWhileLocked)
+    }
+}
+
+public enum AppLockAuthenticationMessage: Sendable, Equatable {
+    case failed
+    case canceled
+    case unavailable
+    case lockout
+
+    public var lockedSurfaceCopy: String {
+        switch self {
+        case .failed:
+            return "Could not unlock VaultPeek. Try again or use your Mac password."
+        case .canceled:
+            return "VaultPeek stayed locked."
+        case .unavailable:
+            return "Authentication is unavailable right now. VaultPeek will stay locked until macOS authentication is available again."
+        case .lockout:
+            return "Touch ID is locked. Use your Mac password to unlock VaultPeek."
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("App lock presentation policy")
+struct AppLockPresentationTests {
+    @Test("defaults match the app lock UX spec")
+    func defaultsMatchUXSpec() {
+        let preferences = AppLockPreferences()
+
+        #expect(preferences.privacyMaskEnabled == false)
+        #expect(preferences.appLockEnabled == false)
+        #expect(preferences.lockOnLaunch == false)
+        #expect(preferences.lockAfterInactivityEnabled == true)
+        #expect(preferences.lockAfterInactivityInterval == 300)
+        #expect(preferences.lockWhenBackgrounded == true)
+        #expect(preferences.notificationPrivacyMode == .genericWhenPrivate)
+        #expect(preferences.pauseRefreshWhileLocked == false)
+    }
+
+    @Test("locked wins over privacy mask and hides menu bar values")
+    func lockedWinsOverMask() {
+        let preferences = AppLockPreferences(privacyMaskEnabled: true, appLockEnabled: true)
+
+        #expect(preferences.effectiveDisplayMode(isAppLocked: true) == .locked)
+        #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: true, isIconOnly: false) == "Locked")
+        #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: true, isIconOnly: true) == "")
+    }
+
+    @Test("privacy mask hides values without locking")
+    func privacyMaskHidesValuesWithoutLocking() {
+        let preferences = AppLockPreferences(privacyMaskEnabled: true, appLockEnabled: false)
+
+        #expect(preferences.effectiveDisplayMode(isAppLocked: false) == .masked)
+        #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: false, isIconOnly: false) == "Private")
+    }
+
+    @Test("locked pause settings fail closed for refresh and notifications")
+    func lockedPauseSettingsFailClosed() {
+        let paused = AppLockPreferences(appLockEnabled: true, notificationPrivacyMode: .offWhileLocked, pauseRefreshWhileLocked: true)
+        let generic = AppLockPreferences(appLockEnabled: true, notificationPrivacyMode: .genericWhenPrivate, pauseRefreshWhileLocked: false)
+
+        #expect(paused.shouldRefreshFinancialData(isAppLocked: true) == false)
+        #expect(paused.shouldEvaluateFinancialNotifications(isAppLocked: true) == false)
+        #expect(generic.shouldRefreshFinancialData(isAppLocked: true) == true)
+        #expect(generic.shouldEvaluateFinancialNotifications(isAppLocked: true) == true)
+    }
+
+    @Test("inactivity intervals normalize to supported options")
+    func inactivityIntervalsNormalize() {
+        #expect(AppLockPreferences.normalizedInactivityInterval(75) == 60)
+        #expect(AppLockPreferences.normalizedInactivityInterval(301) == 300)
+        #expect(AppLockPreferences.normalizedInactivityInterval(1_600) == 1_800)
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -45,6 +45,15 @@ struct AppLockPresentationTests {
         #expect(generic.shouldEvaluateFinancialNotifications(isAppLocked: true) == true)
     }
 
+    @Test("notification modes use generic copy whenever the app is private")
+    func notificationModesUseGenericCopyWhenPrivate() {
+        #expect(NotificationPrivacyMode.detailed.usesGenericCopy(isPrivate: true) == true)
+        #expect(NotificationPrivacyMode.offWhileLocked.usesGenericCopy(isPrivate: true) == true)
+        #expect(NotificationPrivacyMode.detailed.usesGenericCopy(isPrivate: false) == false)
+        #expect(NotificationPrivacyMode.genericWhenPrivate.usesGenericCopy(isPrivate: false) == false)
+        #expect(NotificationPrivacyMode.alwaysGeneric.usesGenericCopy(isPrivate: false) == true)
+    }
+
     @Test("inactivity intervals normalize to supported options")
     func inactivityIntervalsNormalize() {
         #expect(AppLockPreferences.normalizedInactivityInterval(75) == 60)


### PR DESCRIPTION
## Summary
- add core AppLockPreferences presentation policy for locked/masked/normal display modes
- define notification privacy behavior and lock pause semantics for refresh/notification evaluation
- add user-facing authentication failure copy and interval normalization tests

## Tests
- `swift test --filter AppLockPresentationTests`

## Privacy/security notes
- This is a core policy/presentation slice only; it does not store credentials, access tokens, public tokens, raw Plaid payloads, or account data.
- Locked display mode wins over privacy mask and hides menu bar values.