### PR TITLE
AND-438: Add privacy release QA gates

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -120,15 +120,18 @@ Examples in documentation use placeholders only.
 Public screenshots, bug reports, tests, and fixtures should use demo, sandbox,
 or synthetic financial data.
 
-Privacy Mask and App Lock are display-safety controls, not storage controls:
+The in-flight Privacy Mask and App Lock work is planned as display-safety
+controls, not storage controls. Until the corresponding app controls ship, this
+section is a release gate for that work rather than a claim about the current
+published build:
 
-- **Privacy Mask** hides balances, account endings, utilization values,
+- **Privacy Mask** should hide balances, account endings, utilization values,
   transaction amounts, merchant names, and other financial details from the app
   chrome while keeping the dashboard usable on a shared desktop.
-- **App Lock** blocks access until local macOS authentication succeeds. When the
-  app is locked, refresh and notification behavior must follow the user's lock
-  policy and must fail closed when a safe policy is unavailable.
-- **Notification privacy** must not include account names, balances,
+- **App Lock** should block access until local macOS authentication succeeds.
+  When the app is locked, refresh and notification behavior must follow the
+  user's lock policy and must fail closed when a safe policy is unavailable.
+- **Notification privacy** should not include account names, balances,
   transaction amounts, merchants, utilization status, or recovery details while
   Privacy Mask or App Lock is active. Use generic copy instead.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -120,6 +120,22 @@ Examples in documentation use placeholders only.
 Public screenshots, bug reports, tests, and fixtures should use demo, sandbox,
 or synthetic financial data.
 
+Privacy Mask and App Lock are display-safety controls, not storage controls:
+
+- **Privacy Mask** hides balances, account endings, utilization values,
+  transaction amounts, merchant names, and other financial details from the app
+  chrome while keeping the dashboard usable on a shared desktop.
+- **App Lock** blocks access until local macOS authentication succeeds. When the
+  app is locked, refresh and notification behavior must follow the user's lock
+  policy and must fail closed when a safe policy is unavailable.
+- **Notification privacy** must not include account names, balances,
+  transaction amounts, merchants, utilization status, or recovery details while
+  Privacy Mask or App Lock is active. Use generic copy instead.
+
+These controls do not delete local data and do not change where data is stored.
+They reduce accidental disclosure on-screen, in notifications, and in public QA
+artifacts.
+
 Do not publish:
 
 - real Plaid credentials
@@ -155,7 +171,13 @@ should also review Plaid Dashboard and bank-side permission settings.
 - README privacy claims match implementation.
 - Setup copy explains local storage before Plaid Link opens.
 - Settings shows the local storage path.
+- Privacy Mask and App Lock copy states the difference between on-screen
+  masking, local authentication, and local data retention.
+- Notification previews and release notes use generic copy when private; no
+  release artifact claims sensitive notification detail is shown while masked or
+  locked.
 - Reset/remove actions explain local-vs-Plaid-vs-bank boundaries.
 - Status endpoints do not expose secrets.
 - Logs do not print secrets or raw financial exports.
-- Screenshots contain no real financial data.
+- Screenshots contain no real financial data and any privacy/app-lock screenshot
+  uses demo, sandbox, or synthetic values only.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -69,6 +69,17 @@ the (not yet performed) signing and notarization runbook.
   platform supports them.
 - [ ] All screenshots, fixtures, examples, and docs use demo, sandbox, or
   synthetic data only.
+- [ ] Privacy Mask QA passed for menu bar, dashboard balances, account endings,
+  utilization labels, transaction rows, accessibility labels, and screenshots:
+  no real balances, merchants, account IDs, or transaction details leak while
+  masked.
+- [ ] App Lock QA passed for launch lock, manual lock/unlock, failed/cancelled
+  local authentication, background/focus-loss locking where configured, and
+  locked-state menu bar/popover copy.
+- [ ] Notification privacy QA passed: when Privacy Mask or App Lock is active,
+  notification titles and bodies use generic copy and do not expose account
+  names, balances, transaction amounts, merchants, utilization status, or
+  recovery details.
 
 ## Accessibility
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -69,17 +69,18 @@ the (not yet performed) signing and notarization runbook.
   platform supports them.
 - [ ] All screenshots, fixtures, examples, and docs use demo, sandbox, or
   synthetic data only.
-- [ ] Privacy Mask QA passed for menu bar, dashboard balances, account endings,
-  utilization labels, transaction rows, accessibility labels, and screenshots:
-  no real balances, merchants, account IDs, or transaction details leak while
-  masked.
-- [ ] App Lock QA passed for launch lock, manual lock/unlock, failed/cancelled
-  local authentication, background/focus-loss locking where configured, and
-  locked-state menu bar/popover copy.
-- [ ] Notification privacy QA passed: when Privacy Mask or App Lock is active,
-  notification titles and bodies use generic copy and do not expose account
-  names, balances, transaction amounts, merchants, utilization status, or
-  recovery details.
+- [ ] If Privacy Mask is included in this release, QA passed for menu bar,
+  dashboard balances, account endings, utilization labels, transaction rows,
+  accessibility labels, and screenshots: no real balances, merchants, account
+  IDs, or transaction details leak while masked.
+- [ ] If App Lock is included in this release, QA passed for launch lock,
+  manual lock/unlock, failed/cancelled local authentication,
+  background/focus-loss locking where configured, and locked-state menu
+  bar/popover copy.
+- [ ] If notification privacy controls are included in this release, masked or
+  locked notification titles and bodies use generic copy and do not expose
+  account names, balances, transaction amounts, merchants, utilization status,
+  or recovery details.
 
 ## Accessibility
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -7,6 +7,11 @@ current design system, realistic states, and public-safe data.
 
 Only use demo, sandbox, or synthetic financial data in screenshots.
 
+Privacy/app-lock screenshots are safest when captured from demo data with the
+mask or lock control already enabled. They should prove the privacy state with
+generic labels such as "Private" or "Locked" and fixed placeholders, not by
+showing real values beside masked values.
+
 Do not publish screenshots containing:
 
 - real account balances
@@ -14,6 +19,9 @@ Do not publish screenshots containing:
 - real transaction history
 - Plaid item IDs or account IDs
 - terminal output containing credentials or tokens
+- notification banners containing account names, balances, merchants,
+  utilization status, or recovery details while Privacy Mask or App Lock is
+  active
 
 ## Generate Screenshots
 
@@ -114,6 +122,9 @@ when the menu-bar popover is positioned outside the active display bounds.
 - Screenshots match the current design system.
 - Text is readable at README display sizes.
 - No real personal finance data appears.
+- Privacy Mask/App Lock screenshots show only generic copy or fixed
+  placeholders for balances, account endings, transactions, utilization, and
+  notifications.
 - Empty/degraded states are represented where relevant.
 - `dashboard-status.png` shows the recovery fixture, not a real Plaid error.
 - Peekaboo/AX validation can find local insight receipt text saying
@@ -122,6 +133,9 @@ when the menu-bar popover is positioned outside the active display bounds.
 - Button labels and status copy match the current app.
 - Settings screenshots show useful controls, not blank tabs.
 - Screenshots do not include unrelated desktop windows or notifications.
+- Captions and alt text claim only what is visible in the image. VoiceOver or
+  below-the-fold privacy checks should be recorded as validation notes, not as
+  screenshot-visible claims.
 
 ## When To Regenerate
 
@@ -134,5 +148,7 @@ Regenerate screenshots when a change affects:
 - settings tabs
 - local data copy
 - notification controls
+- Privacy Mask or App Lock controls, locked-state copy, masking copy, or
+  notification privacy behavior
 - design tokens
 - README screenshot tables

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -7,10 +7,11 @@ current design system, realistic states, and public-safe data.
 
 Only use demo, sandbox, or synthetic financial data in screenshots.
 
-Privacy/app-lock screenshots are safest when captured from demo data with the
-mask or lock control already enabled. They should prove the privacy state with
-generic labels such as "Private" or "Locked" and fixed placeholders, not by
-showing real values beside masked values.
+When Privacy Mask or App Lock screenshots become part of the release set, they
+must be captured from demo data with the mask or lock control already enabled.
+They should prove the privacy state with generic labels such as "Private" or
+"Locked" and fixed placeholders, not by showing real values beside masked
+values.
 
 Do not publish screenshots containing:
 
@@ -21,7 +22,7 @@ Do not publish screenshots containing:
 - terminal output containing credentials or tokens
 - notification banners containing account names, balances, merchants,
   utilization status, or recovery details while Privacy Mask or App Lock is
-  active
+  active in a build that includes those controls
 
 ## Generate Screenshots
 


### PR DESCRIPTION
## Summary

- document Privacy Mask vs App Lock as display-safety controls, not storage controls
- add screenshot-safety rules for privacy/app-lock and notification privacy states
- extend release checklist with privacy mask, app lock, and notification privacy QA gates

## Verification

- `git diff --check`

## Notes

Docs-only PR. No screenshots regenerated and no runtime behavior changed.
