### PR TITLE
AND-446: Sanitize Local AI diagnostics

### DIFF
--- a/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
+++ b/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
@@ -131,7 +131,16 @@ struct OllamaLocalInsightModel: LocalInsightModel {
     private func requestDiagnostic(_ request: URLRequest) -> String {
         guard let url = request.url else { return "Ollama endpoint" }
         let host = url.host(percentEncoded: false) ?? "unknown-host"
-        return "\(host)\(url.path)"
+        let endpoint = Self.diagnosticEndpointPath(from: url)
+        return "\(host)\(endpoint)"
+    }
+
+    private static func diagnosticEndpointPath(from url: URL) -> String {
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard let apiIndex = components.lastIndex(of: "api"), components.indices.contains(apiIndex + 1) else {
+            return ""
+        }
+        return "/api/\(components[apiIndex + 1])"
     }
 
     private func transportDiagnostic(_ error: Error) -> String {


### PR DESCRIPTION
## Summary

- preserve Local AI fallback diagnostics when model calls fail or time out
- carry local Ollama transport details into unavailable-state diagnostics without exposing prompts or transaction data
- record async local AI fallback/performance context through the existing diagnostic path

## Verification

- `git diff --check`
- `swift test --filter LocalInsightModelRuntimeTests`
- `swift test --filter LocalAIRuntimeResolutionTests`

## Notes

No cloud AI path added. Diagnostics remain local and describe failure classes rather than raw prompt/transaction payloads.
