### PR TITLE
AND-334: Refresh VaultPeek automation runbooks

### DIFF
--- a/commands/vaultpeek-prod-loop.md
+++ b/commands/vaultpeek-prod-loop.md
@@ -35,19 +35,17 @@ The default goal is:
 /vaultpeek-prod-loop "RepoBar-style finance dashboard" --hours=4
 ```
 
-For Codex CLI non-interactive runs (the local checkout path keeps the
-`PlaidBar` directory name until the GitHub repo rename lands; update the
-`--cd` path when the checkout moves):
+For Codex CLI non-interactive runs, use a VaultPeek-named checkout or worktree:
 
 ```bash
-codex exec --cd /Users/otto/.openclaw/workspace/repos/PlaidBar \
+codex exec --cd /Users/otto/workspace/VaultPeek \
   "$(cat commands/vaultpeek-prod-loop.md)"
 ```
 
 For a focused autonomous iteration:
 
 ```bash
-codex exec --cd /Users/otto/.openclaw/workspace/repos/PlaidBar \
+codex exec --cd /Users/otto/workspace/VaultPeek \
   "Read commands/vaultpeek-prod-loop.md and complete the next unfinished task from docs/autonomous-loop-backlog.md for: <focus>"
 ```
 

--- a/docs/agent-collaboration.md
+++ b/docs/agent-collaboration.md
@@ -41,12 +41,12 @@ as the only source of truth for a branch.
 ## Worktree Ownership
 
 - Hermes should work from its own builder-owned checkout or temporary worktree,
-  such as `/Users/otto/.openclaw/workspace/repos/PlaidBar` when launched via
-  the Codex CLI examples in `commands/vaultpeek-prod-loop.md`. Local checkout
-  paths keep the `PlaidBar` directory name until the GitHub repo rename lands;
-  update them when the checkout moves.
+  such as `/Users/otto/workspace/VaultPeek` when launched via the Codex CLI
+  examples in `commands/vaultpeek-prod-loop.md`. Legacy local checkouts may
+  still keep the `PlaidBar` directory name, but new automation examples should
+  use VaultPeek-named paths.
 - Otto should review and fix from a separate operator-owned checkout or worktree,
-  such as `/private/tmp/PlaidBar-otto` for this scheduled loop.
+  such as `/private/tmp/VaultPeek-otto` for this scheduled loop.
 - Do not mutate another agent's active worktree.
 - Before pushing to a branch another agent owns, verify that agent is not
   actively editing or running a write step on the same branch.

--- a/docs/autonomous-roadmap.md
+++ b/docs/autonomous-roadmap.md
@@ -32,8 +32,10 @@ with its local-first menu bar finance vision. It complements `GOAL.md`,
 
 ## Loop Cadence
 
-The OpenClaw cron job `d6eb6833-969a-4436-af06-0fd0f1bd94e2` runs an isolated
-VaultPeek production-readiness loop every four hours. Each run should:
+VaultPeek production-readiness loops should run from a VaultPeek-named checkout
+or disposable worktree. Older OpenClaw cron IDs may exist in operator history,
+but this repository does not treat those external schedules as authoritative.
+Each autonomous run should:
 
 1. Inspect `git status --short --branch` and recent commits.
 2. Read `GOAL.md`, `commands/vaultpeek-prod-loop.md`,


### PR DESCRIPTION
## Summary

- update VaultPeek production-loop runbook examples to use VaultPeek-named checkout paths
- refresh agent collaboration worktree examples away from stale PlaidBar/OpenClaw paths
- stop treating an old external OpenClaw cron ID as authoritative repo policy

## Verification

- `git diff --check`

## Notes

Docs-only automation/runbook cleanup. Compatibility names such as SwiftPM targets, executables, and `PLAIDBAR_*` environment variables are intentionally unchanged.
