### PR TITLE
AND-325: Update VaultPeek repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ code (see [LICENSE](LICENSE)).
 
 1. **Clone the repo:**
    ```bash
-   git clone https://github.com/ftchvs/PlaidBar.git
-   cd PlaidBar
+   git clone https://github.com/ftchvs/VaultPeek.git
+   cd VaultPeek
    ```
 
 2. **Build:**

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ftchvs/PlaidBar/actions/workflows/ci.yml"><img src="https://github.com/ftchvs/PlaidBar/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/ftchvs/PlaidBar/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red.svg" alt="Proprietary License"></a>
+  <a href="https://github.com/ftchvs/VaultPeek/actions/workflows/ci.yml"><img src="https://github.com/ftchvs/VaultPeek/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/ftchvs/VaultPeek/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Proprietary-red.svg" alt="Proprietary License"></a>
   <img src="https://img.shields.io/badge/platform-macOS%2015%2B-lightgrey.svg" alt="macOS 15+">
   <img src="https://img.shields.io/badge/swift-6.0%2B-F05138.svg" alt="Swift 6.0+">
 </p>
@@ -258,7 +258,7 @@ few technical surfaces for compatibility, and those are not bugs:
 | Keychain service | `PlaidBar.PlaidAccessToken` | SQLite `keychain:<item_id>` references must keep resolving after the storage migration |
 | SQLite store filenames | `plaidbar-sandbox.sqlite`, `plaidbar-production.sqlite` | Renaming live database files is riskier than keeping them |
 | Legacy data directory | `~/.plaidbar/` | Migration source; left in place as rollback evidence (default is now `~/.vaultpeek/`) |
-| GitHub repository | `github.com/ftchvs/PlaidBar` | Repo rename is tracked separately; links in-app and in docs are correct today |
+| GitHub repository | `github.com/ftchvs/VaultPeek` | Repo rename has landed; old `ftchvs/PlaidBar` URLs should redirect to this slug |
 
 Rename history and upgrade guidance live in
 [docs/release-notes.md](docs/release-notes.md) and [CHANGELOG.md](CHANGELOG.md).
@@ -283,8 +283,8 @@ export PLAID_SECRET=your_sandbox_secret
 Building from source requires authorized access to this private repository.
 
 ```bash
-git clone https://github.com/ftchvs/PlaidBar.git
-cd PlaidBar
+git clone https://github.com/ftchvs/VaultPeek.git
+cd VaultPeek
 swift build
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,8 @@ an explicit migration plan:
 - SQLite store filenames: `plaidbar-sandbox.sqlite`,
   `plaidbar-production.sqlite`.
 - Legacy default data directory: `~/.plaidbar/` (migration source only).
-- GitHub repository slug `ftchvs/PlaidBar` until the repo rename lands.
+- GitHub repository slug: `ftchvs/VaultPeek`. The old `ftchvs/PlaidBar` slug
+  should redirect for compatibility.
 
 ## Status Endpoint Contract
 

--- a/docs/launch-metrics-plan.md
+++ b/docs/launch-metrics-plan.md
@@ -75,7 +75,7 @@ from any VaultPeek process.
 
 | Metric | Public/explicit source | Collection method | Cadence | Decision it informs |
 |---|---|---|---|---|
-| Stars | GitHub repo (`github.com/ftchvs/PlaidBar`, rename tracked separately per `README.md`) | Public GitHub REST/GraphQL API (read-only) or the repo's Insights tab, read manually | Weekly | Is top-of-funnel awareness growing after a launch post? Flat stars after outreach = the message isn't landing. |
+| Stars | GitHub repo (`github.com/ftchvs/VaultPeek`) | Public GitHub REST/GraphQL API (read-only) or the repo's Insights tab, read manually | Weekly | Is top-of-funnel awareness growing after a launch post? Flat stars after outreach = the message isn't landing. |
 | Forks | GitHub repo | Public GitHub API or Insights, manual | Weekly | Developer/contributor pull. High forks vs stars suggests the BYO-keys/source audience (the trust anchor in `docs/strategy/pricing-and-launch.md` §4) is who's showing up. |
 | Watchers | GitHub repo | Public GitHub API or Insights, manual | Weekly | Sustained-interest signal — who wants release notifications, distinct from a one-time star. |
 | Repository traffic (views, unique visitors, clones) | GitHub repo **Insights → Traffic** (owner-only, but it is GitHub-side metadata, not app instrumentation) | Read manually from Insights; GitHub retains a 14-day window, so it must be recorded on cadence or it is lost | Weekly | Did a specific launch channel (HN, a newsletter, a post) drive repo visits? Correlate spikes to outreach dates. |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -108,14 +108,15 @@ Intentional, kept for compatibility:
   `plaidbar-production.sqlite`.
 - Source-checkout helper `Scripts/plaidbar-run` remains a deprecated alias for
   `Scripts/vaultpeek-run`.
-- GitHub repository slug `ftchvs/PlaidBar` until the repo rename lands.
+- GitHub repository slug `ftchvs/VaultPeek`; old `ftchvs/PlaidBar` links should
+  redirect.
 
 ### Follow-Ups
 
 - Update the application display name/branding in the Plaid Dashboard so the
   Plaid Link consent screen shows VaultPeek.
-- Repo rename (`ftchvs/PlaidBar` -> VaultPeek) and the in-app GitHub links that
-  depend on it.
+- Any follow-up in-app or docs links still pointing at the pre-rename
+  `ftchvs/PlaidBar` slug.
 - Staged SwiftPM product/executable rename.
 
 ## Post-1.0 Design and Trust Roadmap - Active

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ Distribute the resulting DMG privately to licensed users.
 
 Use this when a published release is broken and must be withdrawn. VaultPeek
 distribution today is git/tag/DMG-based: a tag `v<version>`, a GitHub release on
-`ftchvs/PlaidBar`, and a privately distributed `VaultPeek-<version>.dmg`. There
+`ftchvs/VaultPeek`, and a privately distributed `VaultPeek-<version>.dmg`. There
 is no live auto-update channel, so rollback is a manual withdraw-and-redistribute
 of the prior good release. Notarization and Sparkle are deferred
 (`docs/distribution.md`), so the Sparkle step below is N/A until that runbook is
@@ -126,15 +126,15 @@ Work the steps in order.
 
 ### 1. Identify the bad release and the prior good one
 
-- Bad release: tag `v<bad-version>`, its GitHub release on `ftchvs/PlaidBar`, and
+- Bad release: tag `v<bad-version>`, its GitHub release on `ftchvs/VaultPeek`, and
   any distributed `VaultPeek-<bad-version>.dmg` (with its recorded SHA-256).
 - Prior good release: the last `v<good-version>` whose
   `docs/release-checklist.md` gates passed and whose DMG was clean-install
   verified.
 
 ```bash
-gh release list --repo ftchvs/PlaidBar
-gh release view "v<bad-version>" --repo ftchvs/PlaidBar
+gh release list --repo ftchvs/VaultPeek
+gh release view "v<bad-version>" --repo ftchvs/VaultPeek
 git ls-remote --tags origin "v<bad-version>"
 ```
 
@@ -145,7 +145,7 @@ Reverse exactly what `./Scripts/release.sh --publish` did (it runs `git tag -a`,
 
 ```bash
 # Delete (or yank) the GitHub release so it stops being offered.
-gh release delete "v<bad-version>" --repo ftchvs/PlaidBar --yes
+gh release delete "v<bad-version>" --repo ftchvs/VaultPeek --yes
 
 # Delete the bad tag on origin, then locally.
 git push origin :refs/tags/v<bad-version>
@@ -157,7 +157,7 @@ delete the GitHub release so it is not the published artifact. Confirm the prior
 good tag `v<good-version>` is now the effective latest:
 
 ```bash
-gh release list --repo ftchvs/PlaidBar   # newest non-prerelease should be v<good-version>
+gh release list --repo ftchvs/VaultPeek   # newest non-prerelease should be v<good-version>
 git ls-remote --tags origin              # v<bad-version> gone from origin
 ```
 
@@ -212,7 +212,7 @@ Re-run the relevant `docs/release-checklist.md` gates against the restored
   other than the build machine; SHA-256 recorded and matching.
 - Privacy And Security: secret scan, `/api/status` contract test, `/api/*` auth
   tests pass on the restored build.
-- Confirm `gh release list --repo ftchvs/PlaidBar` shows `v<good-version>` as the
+- Confirm `gh release list --repo ftchvs/VaultPeek` shows `v<good-version>` as the
   effective latest and the bad release/tag are gone.
 
 ## Distribution Scope


### PR DESCRIPTION
## Summary

- update README badges, source-build clone instructions, and contributing setup to `ftchvs/VaultPeek`
- update architecture, release, release notes, and launch metrics docs now that the repo slug is VaultPeek
- keep deliberate PlaidBar compatibility references for SwiftPM targets, env vars, Keychain service, SQLite filenames, and legacy data paths

## Verification

- `git diff --check`

## Notes

Docs-only repo-link cleanup. No destructive GitHub repo action performed.
