### PR TITLE
AND-459: Wire app lock privacy rendering

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -28,6 +28,11 @@ final class AppState {
         static let notifyRecurringChargeChanged = "notifyRecurringChargeChanged"
         static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
         static let notifyBrokenConnection = "notifyBrokenConnection"
+        static let privacyMaskEnabled = "privacyMaskEnabled"
+        static let appLockEnabled = "appLockEnabled"
+        static let appLockIsLocked = "appLock.isLocked"
+        static let appLockNotificationPrivacyMode = "appLock.notificationPrivacyMode"
+        static let appLockPauseRefreshWhileLocked = "appLock.pauseRefreshWhileLocked"
         static let localAIEnabled = "localAIEnabled"
         static let localAIModelName = "localAIModelName"
         static let setupCompletedOnce = "setup.completedOnce"
@@ -229,6 +234,28 @@ final class AppState {
         }
     }
 
+    var appLockPreferences = AppLockPreferences() {
+        didSet {
+            guard appLockPreferences != oldValue else { return }
+            persistAppLockPreferences()
+        }
+    }
+
+    var isAppLocked = false {
+        didSet {
+            guard isAppLocked != oldValue else { return }
+            UserDefaults.standard.set(isAppLocked, forKey: Keys.appLockIsLocked)
+        }
+    }
+
+    var financialPrivacyDisplayMode: PrivacyDisplayMode {
+        appLockPreferences.effectiveDisplayMode(isAppLocked: isAppLocked)
+    }
+
+    var shouldMaskFinancialValues: Bool {
+        financialPrivacyDisplayMode != .normal
+    }
+
     var localAIEnabled: Bool = false {
         didSet {
             guard localAIEnabled != oldValue, !isLoadingLocalAISettings else { return }
@@ -364,6 +391,7 @@ final class AppState {
         if defaults.object(forKey: Keys.notifyBrokenConnection) != nil {
             notifyBrokenConnection = defaults.bool(forKey: Keys.notifyBrokenConnection)
         }
+        loadAppLockPreferences(defaults: defaults)
         loadLocalAISettings(defaults: defaults)
         // Balance history
         loadPersistedBalanceHistory()
@@ -383,6 +411,33 @@ final class AppState {
             storedValue: storedDetached,
             isRenderingSnapshot: CommandLineOptions.isRenderingSnapshot()
         )
+    }
+
+    private func loadAppLockPreferences(defaults: UserDefaults) {
+        appLockPreferences = AppLockPreferences(
+            privacyMaskEnabled: defaults.object(forKey: Keys.privacyMaskEnabled) != nil
+                ? defaults.bool(forKey: Keys.privacyMaskEnabled)
+                : appLockPreferences.privacyMaskEnabled,
+            appLockEnabled: defaults.object(forKey: Keys.appLockEnabled) != nil
+                ? defaults.bool(forKey: Keys.appLockEnabled)
+                : appLockPreferences.appLockEnabled,
+            notificationPrivacyMode: defaults.string(forKey: Keys.appLockNotificationPrivacyMode)
+                .flatMap(NotificationPrivacyMode.init(rawValue:))
+                ?? appLockPreferences.notificationPrivacyMode,
+            pauseRefreshWhileLocked: defaults.object(forKey: Keys.appLockPauseRefreshWhileLocked) != nil
+                ? defaults.bool(forKey: Keys.appLockPauseRefreshWhileLocked)
+                : appLockPreferences.pauseRefreshWhileLocked
+        )
+        if defaults.object(forKey: Keys.appLockIsLocked) != nil {
+            isAppLocked = defaults.bool(forKey: Keys.appLockIsLocked)
+        }
+    }
+
+    private func persistAppLockPreferences() {
+        UserDefaults.standard.set(appLockPreferences.privacyMaskEnabled, forKey: Keys.privacyMaskEnabled)
+        UserDefaults.standard.set(appLockPreferences.appLockEnabled, forKey: Keys.appLockEnabled)
+        UserDefaults.standard.set(appLockPreferences.notificationPrivacyMode.rawValue, forKey: Keys.appLockNotificationPrivacyMode)
+        UserDefaults.standard.set(appLockPreferences.pauseRefreshWhileLocked, forKey: Keys.appLockPauseRefreshWhileLocked)
     }
 
     private func loadLocalAISettings(defaults: UserDefaults) {
@@ -496,12 +551,18 @@ final class AppState {
     }
 
     var menuBarText: String {
-        MenuBarSummary.text(
+        let rawText = MenuBarSummary.text(
             mode: menuBarSummaryMode,
             accounts: accounts,
             transactions: transactions,
             currencyFormat: balanceFormat,
-            isInitialLoad: isBootLoadInFlight
+            isInitialLoad: isBootLoadInFlight,
+            privacyMaskEnabled: shouldMaskFinancialValues
+        )
+        return appLockPreferences.menuBarText(
+            currentText: rawText,
+            isAppLocked: isAppLocked,
+            isIconOnly: menuBarSummaryMode == .iconOnly
         )
     }
 
@@ -1708,8 +1769,12 @@ final class AppState {
         refreshTask?.cancel()
         refreshTask = Task {
             while !Task.isCancelled {
-                await refreshDashboard()
-                await evaluateNotifications()
+                if appLockPreferences.shouldRefreshFinancialData(isAppLocked: isAppLocked) {
+                    await refreshDashboard()
+                }
+                if appLockPreferences.shouldEvaluateFinancialNotifications(isAppLocked: isAppLocked) {
+                    await evaluateNotifications()
+                }
                 try? await Task.sleep(for: .seconds(refreshInterval))
             }
         }
@@ -1717,6 +1782,7 @@ final class AppState {
 
     private func evaluateNotifications() async {
         guard notificationsEnabled else { return }
+        guard appLockPreferences.shouldEvaluateFinancialNotifications(isAppLocked: isAppLocked) else { return }
         let config = NotificationTriggers(
             largeTransaction: notifyLargeTransaction,
             lowBalance: notifyLowBalance,

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -29,8 +29,7 @@ final class AppState {
         static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
         static let notifyBrokenConnection = "notifyBrokenConnection"
         static let privacyMaskEnabled = "privacyMaskEnabled"
-        static let appLockEnabled = "appLockEnabled"
-        static let appLockIsLocked = "appLock.isLocked"
+        static let appLockEnabled = UserDefaultsAppLockSettingsStore.defaultStorageKey
         static let appLockNotificationPrivacyMode = "appLock.notificationPrivacyMode"
         static let appLockPauseRefreshWhileLocked = "appLock.pauseRefreshWhileLocked"
         static let localAIEnabled = "localAIEnabled"
@@ -241,12 +240,7 @@ final class AppState {
         }
     }
 
-    var isAppLocked = false {
-        didSet {
-            guard isAppLocked != oldValue else { return }
-            UserDefaults.standard.set(isAppLocked, forKey: Keys.appLockIsLocked)
-        }
-    }
+    var isAppLocked = false
 
     var financialPrivacyDisplayMode: PrivacyDisplayMode {
         appLockPreferences.effectiveDisplayMode(isAppLocked: isAppLocked)
@@ -296,6 +290,7 @@ final class AppState {
     // MARK: - Services
     private let serverClient = ServerClient()
     private let localDataCache = LocalDataCacheService()
+    private let appLockService = AppLockService()
     private var localAIInsightsService = LocalAIInsightsService()
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
@@ -428,9 +423,7 @@ final class AppState {
                 ? defaults.bool(forKey: Keys.appLockPauseRefreshWhileLocked)
                 : appLockPreferences.pauseRefreshWhileLocked
         )
-        if defaults.object(forKey: Keys.appLockIsLocked) != nil {
-            isAppLocked = defaults.bool(forKey: Keys.appLockIsLocked)
-        }
+        isAppLocked = appLockService.isLocked
     }
 
     private func persistAppLockPreferences() {
@@ -577,7 +570,7 @@ final class AppState {
             needsLoginItemCount: needsLoginItemCount,
             isSyncStale: isSyncStale,
             hasEverSynced: lastSyncDate != nil,
-            financialAttentionText: firstMenuBarAttentionText,
+            financialAttentionText: shouldMaskFinancialValues ? nil : firstMenuBarAttentionText,
             iconStyle: menuBarIconStyle
         )
     }

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -54,7 +54,8 @@ struct AccountDetailFlyout: View {
             for: account,
             activitySnapshot: snapshot,
             itemStatus: itemConnectionStatus,
-            fallbackFreshnessLabel: connection.signalLabel
+            fallbackFreshnessLabel: connection.signalLabel,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
         )
         let recent = Array(snapshot.transactions.prefix(6))
 
@@ -71,21 +72,26 @@ struct AccountDetailFlyout: View {
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
                     balancesSection(summary: summary)
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
-                    changesSection(insights: insights)
+                    if appState.shouldMaskFinancialValues {
+                        privateDetailsPlaceholder()
+                            .scrollEdgeDepth(reduceMotion: reduceMotion)
+                    } else {
+                        changesSection(insights: insights)
+                            .scrollEdgeDepth(reduceMotion: reduceMotion)
+                        if !insights.reviewItems.isEmpty {
+                            reviewSection(insights: insights)
+                                .scrollEdgeDepth(reduceMotion: reduceMotion)
+                        }
+                        if !insights.topCategories.isEmpty {
+                            categoriesSection(insights: insights)
+                                .scrollEdgeDepth(reduceMotion: reduceMotion)
+                        }
+                        activitySection(
+                            recent: recent,
+                            emptyState: emptyState(snapshot: snapshot, connection: connection)
+                        )
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
-                    if !insights.reviewItems.isEmpty {
-                        reviewSection(insights: insights)
-                            .scrollEdgeDepth(reduceMotion: reduceMotion)
                     }
-                    if !insights.topCategories.isEmpty {
-                        categoriesSection(insights: insights)
-                            .scrollEdgeDepth(reduceMotion: reduceMotion)
-                    }
-                    activitySection(
-                        recent: recent,
-                        emptyState: emptyState(snapshot: snapshot, connection: connection)
-                    )
-                    .scrollEdgeDepth(reduceMotion: reduceMotion)
                     actionsSection(summary: summary)
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
                 }
@@ -101,7 +107,7 @@ struct AccountDetailFlyout: View {
         }
         .frame(maxHeight: .infinity, alignment: .top)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Account details for \(summary.displayName)")
+        .accessibilityLabel(summary.accessibilityLabel(privacyMaskEnabled: appState.shouldMaskFinancialValues))
         .confirmationDialog(
             "Remove \(institutionRemovalName)?",
             isPresented: $isConfirmingAccountRemoval,
@@ -200,13 +206,21 @@ struct AccountDetailFlyout: View {
         HStack(alignment: .top, spacing: Spacing.lg) {
             DetailValue(
                 title: summary.availableTitle,
-                value: Formatters.currency(summary.availableBalance, format: .compact),
+                value: PrivacyMaskPresentation.currency(
+                    summary.availableBalance,
+                    format: .compact,
+                    isEnabled: appState.shouldMaskFinancialValues
+                ),
                 tint: AppearanceTextColors.primary,
                 reduceMotion: reduceMotion
             )
             DetailValue(
                 title: summary.currentTitle,
-                value: Formatters.currency(summary.currentBalance, format: .compact),
+                value: PrivacyMaskPresentation.currency(
+                    summary.currentBalance,
+                    format: .compact,
+                    isEnabled: appState.shouldMaskFinancialValues
+                ),
                 tint: AppearanceTextColors.primary,
                 reduceMotion: reduceMotion
             )
@@ -217,7 +231,8 @@ struct AccountDetailFlyout: View {
             if account.balances.utilizationPercent != nil,
                let utilizationText = AccountPresentation.dashboardUtilizationDetailText(
                    for: account,
-                   threshold: appState.creditUtilizationThreshold
+                   threshold: appState.creditUtilizationThreshold,
+                   privacyMaskEnabled: appState.shouldMaskFinancialValues
                )
             {
                 DetailValue(
@@ -230,6 +245,18 @@ struct AccountDetailFlyout: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Balances for \(summary.displayName)")
+    }
+
+    private func privateDetailsPlaceholder() -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            FlyoutSectionLabel("Private")
+            Text("Detailed balances, activity, and transaction history are hidden while Privacy Mask or App Lock is active.")
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Private details hidden while VaultPeek is private")
     }
 
     // MARK: Changes (30D vs prior 30D)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1691,7 +1691,12 @@ private struct AccountRowWithDrilldown: View {
         // dashboard (mounted by MainPopover), not an inline panel below. The
         // left rail stays in place; only the right inspector toggles.
         Button(action: onSelect) {
-            DashboardAccountRow(account: account, isStatusFilter: isStatusFilter, isSelected: isSelected)
+            DashboardAccountRow(
+                account: account,
+                isStatusFilter: isStatusFilter,
+                isSelected: isSelected,
+                privacyMaskEnabled: appState.shouldMaskFinancialValues
+            )
         }
         .buttonStyle(.plain)
         .focused(focusBinding, equals: account.id)
@@ -1706,11 +1711,15 @@ private struct AccountRowWithDrilldown: View {
     private var accountAccessibilityLabel: String {
         let label = AccountPresentation.rowAccessibilityLabel(
             for: account,
-            amountText: AccountPresentation.rowAmountText(for: account),
+            amountText: AccountPresentation.rowAmountText(
+                for: account,
+                privacyMaskEnabled: appState.shouldMaskFinancialValues
+            ),
             connectionLabel: connectionPresentation.rowLabel,
             pendingCount: pendingCount,
             isSelected: isSelected,
-            utilizationThreshold: appState.creditUtilizationThreshold
+            utilizationThreshold: appState.creditUtilizationThreshold,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
         )
         guard let demoTrend else { return label }
         return "\(label). \(accountTrendAccessibility(demoTrend))"
@@ -1884,6 +1893,7 @@ private struct DashboardAccountRow: View {
     let account: AccountDTO
     let isStatusFilter: Bool
     let isSelected: Bool
+    let privacyMaskEnabled: Bool
 
     var body: some View {
         HStack(spacing: Spacing.compactRowContentSpacing) {
@@ -2000,12 +2010,13 @@ private struct DashboardAccountRow: View {
         AccountPresentation.dashboardRowSubtitle(
             for: account,
             connectionLabel: isStatusFilter ? connectionPresentation.statusFilterSubtitle : statusText,
-            pendingCount: pendingCount
-        )
+            pendingCount: pendingCount,
+            privacyMaskEnabled: privacyMaskEnabled)
+
     }
 
     private var amountText: String {
-        AccountPresentation.rowAmountText(for: account)
+        AccountPresentation.rowAmountText(for: account, privacyMaskEnabled: privacyMaskEnabled)
     }
 
     private var pendingCount: Int {
@@ -2039,7 +2050,8 @@ private struct DashboardAccountRow: View {
     private var trailingDetailText: String {
         AccountPresentation.dashboardTrailingDetailText(
             for: account,
-            connectionLabel: statusText
+            connectionLabel: statusText,
+            privacyMaskEnabled: privacyMaskEnabled
         )
     }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -637,9 +637,20 @@ private struct RecentSpendChip: View {
 
                 Spacer(minLength: Spacing.sm)
 
-                Text(Formatters.currency(appState.recentSpend, format: .compact))
+                Text(PrivacyMaskPresentation.currency(
+                    appState.recentSpend,
+                    format: .compact,
+                    isEnabled: appState.shouldMaskFinancialValues
+                ))
                     .font(.caption.weight(.semibold))
-                    .rollingTabularNumber(Formatters.currency(appState.recentSpend, format: .compact), reduceMotion: reduceMotion)
+                    .rollingTabularNumber(
+                        PrivacyMaskPresentation.currency(
+                            appState.recentSpend,
+                            format: .compact,
+                            isEnabled: appState.shouldMaskFinancialValues
+                        ),
+                        reduceMotion: reduceMotion
+                    )
                     .lineLimit(1)
             }
             .padding(.horizontal, Spacing.sm)
@@ -647,7 +658,7 @@ private struct RecentSpendChip: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(.quinary, in: Capsule())
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("7 day spend: \(Formatters.currency(appState.recentSpend, format: .full))")
+            .accessibilityLabel("7 day spend: \(PrivacyMaskPresentation.currency(appState.recentSpend, format: .full, isEnabled: appState.shouldMaskFinancialValues))")
         }
     }
 }
@@ -655,6 +666,7 @@ private struct RecentSpendChip: View {
 // MARK: - 365 Day Heatmap
 
 private struct BalanceActivityHeatmap: View {
+    @Environment(AppState.self) private var appState
     let transactions: [TransactionDTO]
     var loadState: DashboardLoadState?
 
@@ -912,6 +924,9 @@ private struct BalanceActivityHeatmap: View {
     }
 
     private func totalLabel(for layout: SpendingHeatmapLayout) -> String {
+        guard !appState.shouldMaskFinancialValues else {
+            return PrivacyMaskPresentation.compactValue
+        }
         guard layout.mode == .netCashflow else {
             return Formatters.currency(layout.totalValue, format: .compact)
         }
@@ -927,6 +942,9 @@ private struct BalanceActivityHeatmap: View {
     }
 
     private func cashflowText(for value: Double) -> String {
+        guard !appState.shouldMaskFinancialValues else {
+            return PrivacyMaskPresentation.compactValue
+        }
         let displayAmount = SpendingHeatmap.displayCashflowAmount(value)
         let prefix = displayAmount > 0 ? "+" : displayAmount < 0 ? "-" : ""
         return "\(prefix)\(Formatters.currency(abs(displayAmount), format: .compact))"

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -15,6 +15,9 @@ import SwiftUI
 struct RecurringObligationsSection: View {
     let presentation: RecurringObligationsPresentation
     var onOpenSubscriptions: (() -> Void)?
+    /// When true, recurring amounts and the monthly total are masked while
+    /// Privacy Mask or App Lock is active.
+    var privacyMaskEnabled: Bool = false
 
     /// Keep the narrow column dense: show the most relevant few, summarize the
     /// rest. Attention-first ordering means flagged items are never hidden
@@ -28,7 +31,7 @@ struct RecurringObligationsSection: View {
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     ForEach(Array(presentation.items.prefix(visibleLimit))) { item in
-                        RecurringObligationRow(item: item)
+                        RecurringObligationRow(item: item, privacyMaskEnabled: privacyMaskEnabled)
                     }
                 }
 
@@ -53,7 +56,7 @@ struct RecurringObligationsSection: View {
 
             Spacer(minLength: Spacing.sm)
 
-            Text("~\(Formatters.currency(presentation.estimatedMonthlyTotal, format: .compact))/mo")
+            Text("~\(PrivacyMaskPresentation.currency(presentation.estimatedMonthlyTotal, format: .compact, isEnabled: privacyMaskEnabled))/mo")
                 .microText()
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
@@ -76,7 +79,11 @@ struct RecurringObligationsSection: View {
 
     private var accessibilitySummary: String {
         let countText = "\(presentation.count) recurring \(presentation.count == 1 ? "charge" : "charges")"
-        let total = Formatters.currency(presentation.estimatedMonthlyTotal, format: .full)
+        let total = PrivacyMaskPresentation.currency(
+            presentation.estimatedMonthlyTotal,
+            format: .full,
+            isEnabled: privacyMaskEnabled
+        )
         let attention = presentation.attentionCount > 0
             ? " \(presentation.attentionCount) need attention."
             : ""
@@ -86,6 +93,7 @@ struct RecurringObligationsSection: View {
 
 private struct RecurringObligationRow: View {
     let item: RecurringObligationsPresentation.Item
+    var privacyMaskEnabled: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.xxs) {
@@ -102,7 +110,7 @@ private struct RecurringObligationRow: View {
 
                 Spacer(minLength: Spacing.sm)
 
-                Text(Formatters.currency(item.expectedAmount, format: .compact))
+                Text(PrivacyMaskPresentation.currency(item.expectedAmount, format: .compact, isEnabled: privacyMaskEnabled))
                     .font(.subheadline.weight(.semibold))
                     .monospacedDigit()
                     .foregroundStyle(AppearanceTextColors.primary)
@@ -139,7 +147,7 @@ private struct RecurringObligationRow: View {
         var parts = [
             item.merchantName,
             item.frequency.displayName,
-            "expected \(Formatters.currency(item.expectedAmount, format: .full))",
+            "expected \(PrivacyMaskPresentation.currency(item.expectedAmount, format: .full, isEnabled: privacyMaskEnabled))",
             "next \(Formatters.displayTransactionDate(item.nextExpectedDate))",
         ]
         parts.append(contentsOf: orderedFlags.map(\.accessibilityDescription))

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -26,7 +26,10 @@ struct ReviewInboxView: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
 
-                VStack(spacing: Spacing.xs) {
+                if appState.shouldMaskFinancialValues {
+                    privateInboxPlaceholder
+                } else {
+                    VStack(spacing: Spacing.xs) {
                     ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                         ReviewInboxRow(
                             item: item,
@@ -66,6 +69,7 @@ struct ReviewInboxView: View {
                                 appState.ignoreReviewItem(item.id)
                             }
                         )
+                    }
                     }
                 }
             }
@@ -119,6 +123,18 @@ struct ReviewInboxView: View {
             .help("Undo last review action")
             .accessibilityLabel("Undo last review action")
         }
+    }
+
+    private var privateInboxPlaceholder: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("Review items, merchants, and amounts are hidden while Privacy Mask or App Lock is active.")
+                .detailText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Review inbox items hidden while VaultPeek is private")
     }
 
     private func merchantDraftBinding(for item: TransactionReviewItem) -> Binding<String> {

--- a/Sources/PlaidBar/Views/SafeToSpendCard.swift
+++ b/Sources/PlaidBar/Views/SafeToSpendCard.swift
@@ -11,6 +11,9 @@ struct SafeToSpendCard: View {
     let result: SafeToSpendResult
     /// Relative "last updated" text (e.g. "2 minutes ago"). Nil hides the line.
     var lastUpdatedRelative: String?
+    /// When true, every currency figure (headline + breakdown) is masked while
+    /// Privacy Mask or App Lock is active.
+    var privacyMaskEnabled: Bool = false
 
     @State private var isBreakdownExpanded = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -50,13 +53,19 @@ struct SafeToSpendCard: View {
     }
 
     private var amountRow: some View {
-        Text(Formatters.currency(result.amount, format: .full))
+        let amount = PrivacyMaskPresentation.currency(
+            result.amount,
+            format: .full,
+            isEnabled: privacyMaskEnabled,
+            style: .hero
+        )
+        return Text(amount)
             .dataText()
             .foregroundStyle(amountTint)
             .contentTransition(.numericText())
             .lineLimit(1)
             .minimumScaleFactor(0.7)
-            .accessibilityLabel("\(Formatters.currency(result.amount, format: .full)) safe to spend through \(horizonText)")
+            .accessibilityLabel("\(amount) safe to spend through \(horizonText)")
     }
 
     private var confidenceCue: some View {
@@ -98,7 +107,7 @@ struct SafeToSpendCard: View {
             if isBreakdownExpanded {
                 VStack(alignment: .leading, spacing: Spacing.xxs) {
                     ForEach(result.visibleComponents) { component in
-                        SafeToSpendBreakdownRow(component: component)
+                        SafeToSpendBreakdownRow(component: component, privacyMaskEnabled: privacyMaskEnabled)
                     }
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))
@@ -135,7 +144,12 @@ struct SafeToSpendCard: View {
     }
 
     private var accessibilitySummary: String {
-        let amount = Formatters.currency(result.amount, format: .full)
+        let amount = PrivacyMaskPresentation.currency(
+            result.amount,
+            format: .full,
+            isEnabled: privacyMaskEnabled,
+            style: .hero
+        )
         let updated = lastUpdatedRelative.map { " Updated \($0)." } ?? " Not yet updated."
         return "Safe to spend \(amount) through \(horizonText). Confidence: \(result.confidence.label).\(updated)"
     }
@@ -143,6 +157,7 @@ struct SafeToSpendCard: View {
 
 private struct SafeToSpendBreakdownRow: View {
     let component: SafeToSpendComponent
+    var privacyMaskEnabled: Bool = false
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
@@ -170,10 +185,12 @@ private struct SafeToSpendBreakdownRow: View {
     }
 
     private var amountText: String {
-        signPrefix + Formatters.currency(abs(component.amount), format: .compact)
+        guard !privacyMaskEnabled else { return PrivacyMaskPresentation.compactValue }
+        return signPrefix + Formatters.currency(abs(component.amount), format: .compact)
     }
 
     private var accessibilityAmountText: String {
+        guard !privacyMaskEnabled else { return PrivacyMaskPresentation.compactValue }
         let magnitude = Formatters.currency(abs(component.amount), format: .full)
         if component.amount > 0 { return "plus \(magnitude)" }
         if component.amount < 0 { return "minus \(magnitude)" }

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -30,9 +30,10 @@ struct WealthSummaryFlyout: View {
 
     var body: some View {
         let presentation = presentation
+        let privacyMaskEnabled = appState.shouldMaskFinancialValues
 
         VStack(spacing: 0) {
-            header(presentation)
+            header(presentation, privacyMaskEnabled: privacyMaskEnabled)
                 .padding(Spacing.md)
 
             Divider()
@@ -40,15 +41,15 @@ struct WealthSummaryFlyout: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: Spacing.lg) {
-                    WealthMetricGrid(presentation: presentation)
+                    WealthMetricGrid(presentation: presentation, privacyMaskEnabled: privacyMaskEnabled)
                         .loadingRedaction(appState.loadState(for: .summaryCards))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
-                    WealthBalanceMixSection(presentation: presentation)
+                    WealthBalanceMixSection(presentation: presentation, privacyMaskEnabled: privacyMaskEnabled)
                         .loadingRedaction(appState.loadState(for: .summaryCards))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
-                    WealthCashflowSection(cashflow: presentation.cashflow)
+                    WealthCashflowSection(cashflow: presentation.cashflow, privacyMaskEnabled: privacyMaskEnabled)
                         .loadingRedaction(appState.loadState(for: .transactions))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
@@ -59,7 +60,8 @@ struct WealthSummaryFlyout: View {
                             cashflow: presentation.cashflow,
                             asOf: Date()
                         ),
-                        lastUpdatedRelative: appState.lastSyncRelative
+                        lastUpdatedRelative: appState.lastSyncRelative,
+                        privacyMaskEnabled: privacyMaskEnabled
                     )
                     .loadingRedaction(appState.loadState(for: .summaryCards))
                     .scrollEdgeDepth(reduceMotion: reduceMotion)
@@ -73,14 +75,16 @@ struct WealthSummaryFlyout: View {
                             from: appState.recurringTransactions,
                             asOf: Date()
                         ),
-                        onOpenSubscriptions: onOpenSubscriptions
+                        onOpenSubscriptions: onOpenSubscriptions,
+                        privacyMaskEnabled: privacyMaskEnabled
                     )
                     .loadingRedaction(appState.loadState(for: .transactions))
                     .scrollEdgeDepth(reduceMotion: reduceMotion)
 
                     WealthCreditSection(
                         summary: presentation.creditUtilization,
-                        threshold: appState.creditUtilizationThreshold
+                        threshold: appState.creditUtilizationThreshold,
+                        privacyMaskEnabled: privacyMaskEnabled
                     )
                         .loadingRedaction(appState.loadState(for: .credit))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
@@ -108,11 +112,20 @@ struct WealthSummaryFlyout: View {
         }
         .frame(maxHeight: .infinity, alignment: .top)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(accessibilitySummary(presentation))
+        .accessibilityLabel(accessibilitySummary(presentation, privacyMaskEnabled: privacyMaskEnabled))
     }
 
-    private func header(_ presentation: WealthSummaryPresentation) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+    private func header(
+        _ presentation: WealthSummaryPresentation,
+        privacyMaskEnabled: Bool
+    ) -> some View {
+        let netWorthText = PrivacyMaskPresentation.currency(
+            presentation.netWorth,
+            format: .full,
+            isEnabled: privacyMaskEnabled,
+            style: .hero
+        )
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(alignment: .firstTextBaseline) {
                 Text("Wealth Summary")
                     .font(.headline.weight(.semibold))
@@ -128,22 +141,34 @@ struct WealthSummaryFlyout: View {
                     .sectionTitle()
                     .foregroundStyle(.secondary)
 
-                Text(Formatters.currency(presentation.netWorth, format: .full))
+                Text(netWorthText)
                     .displayBalance()
-                    .rollingTabularNumber(Formatters.currency(presentation.netWorth, format: .full), reduceMotion: reduceMotion)
+                    .rollingTabularNumber(netWorthText, reduceMotion: reduceMotion)
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
 
-                WealthNetWorthTrendBlock(trend: presentation.netWorthTrend)
+                if !privacyMaskEnabled {
+                    WealthNetWorthTrendBlock(trend: presentation.netWorthTrend)
+                }
             }
             .padding(Spacing.sm)
             .heroAccentSurface()
         }
     }
 
-    private func accessibilitySummary(_ presentation: WealthSummaryPresentation) -> String {
-        let netWorth = Formatters.currency(presentation.netWorth, format: .full)
-        let netCashflow = cashflowText(presentation.cashflow.net, format: .full)
+    private func accessibilitySummary(
+        _ presentation: WealthSummaryPresentation,
+        privacyMaskEnabled: Bool
+    ) -> String {
+        let netWorth = PrivacyMaskPresentation.currency(
+            presentation.netWorth,
+            format: .full,
+            isEnabled: privacyMaskEnabled,
+            style: .hero
+        )
+        let netCashflow = privacyMaskEnabled
+            ? PrivacyMaskPresentation.compactValue
+            : cashflowText(presentation.cashflow.net, format: .full)
         return "Wealth summary. Net worth \(netWorth). 30 day net cashflow \(netCashflow). \(presentation.syncHealth.title). \(presentation.attention.detail)"
     }
 }
@@ -227,6 +252,7 @@ private struct WealthSyncPill: View {
 private struct WealthMetricGrid: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let presentation: WealthSummaryPresentation
+    let privacyMaskEnabled: Bool
 
     private var columns: [GridItem] {
         [
@@ -239,7 +265,7 @@ private struct WealthMetricGrid: View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: Spacing.sm) {
             WealthMetricTile(
                 title: "Assets",
-                value: Formatters.currency(presentation.totalAssets, format: .compact),
+                value: PrivacyMaskPresentation.currency(presentation.totalAssets, format: .compact, isEnabled: privacyMaskEnabled),
                 detail: "\(presentation.accountCount) accounts",
                 systemImage: "building.columns.fill",
                 reduceMotion: reduceMotion
@@ -247,7 +273,7 @@ private struct WealthMetricGrid: View {
 
             WealthMetricTile(
                 title: "Debt",
-                value: Formatters.currency(presentation.totalDebt, format: .compact),
+                value: PrivacyMaskPresentation.currency(presentation.totalDebt, format: .compact, isEnabled: privacyMaskEnabled),
                 detail: presentation.totalDebt > 0 ? "Credit and loans" : "No debt synced",
                 systemImage: "creditcard.fill",
                 tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : AppearanceTextColors.secondary,
@@ -301,6 +327,7 @@ private struct WealthMetricTile: View {
 
 private struct WealthBalanceMixSection: View {
     let presentation: WealthSummaryPresentation
+    let privacyMaskEnabled: Bool
 
     private var barSegments: [BalanceCompositionBarSegment] {
         presentation.balanceMix.segments.map { segment in
@@ -327,7 +354,11 @@ private struct WealthBalanceMixSection: View {
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     ForEach(presentation.balanceMix.segments) { segment in
-                        WealthMixLegendRow(segment: segment, tint: tint(for: segment.id))
+                        WealthMixLegendRow(
+                            segment: segment,
+                            tint: tint(for: segment.id),
+                            privacyMaskEnabled: privacyMaskEnabled
+                        )
                     }
                 }
             }
@@ -355,6 +386,11 @@ private struct WealthMixLegendRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let segment: BalanceCompositionPresentation.Segment
     let tint: Color
+    let privacyMaskEnabled: Bool
+
+    private var compactValue: String {
+        PrivacyMaskPresentation.currency(segment.value, format: .compact, isEnabled: privacyMaskEnabled)
+    }
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
@@ -370,9 +406,9 @@ private struct WealthMixLegendRow: View {
 
             Spacer(minLength: Spacing.sm)
 
-            Text(Formatters.currency(segment.value, format: .compact))
+            Text(compactValue)
                 .font(.caption.weight(.semibold))
-                .rollingTabularNumber(Formatters.currency(segment.value, format: .compact), reduceMotion: reduceMotion)
+                .rollingTabularNumber(compactValue, reduceMotion: reduceMotion)
                 .lineLimit(1)
 
             Text(percentText(segment.share))
@@ -382,7 +418,7 @@ private struct WealthMixLegendRow: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(
-            "\(segment.title): \(Formatters.currency(segment.value, format: .full)), \(percentText(segment.share))"
+            "\(segment.title): \(PrivacyMaskPresentation.currency(segment.value, format: .full, isEnabled: privacyMaskEnabled)), \(percentText(segment.share))"
         )
     }
 }
@@ -390,6 +426,7 @@ private struct WealthMixLegendRow: View {
 private struct WealthCashflowSection: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let cashflow: WealthSummaryPresentation.CashflowSummary
+    let privacyMaskEnabled: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -402,9 +439,9 @@ private struct WealthCashflowSection: View {
             }
 
             VStack(spacing: Spacing.xs) {
-                WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income, reduceMotion: reduceMotion)
-                WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending, reduceMotion: reduceMotion)
-                WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net, reduceMotion: reduceMotion)
+                WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
+                WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
+                WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
             }
         }
         .accessibilityElement(children: .contain)
@@ -421,6 +458,7 @@ private struct WealthCashflowRow: View {
     let title: String
     let amount: Double
     let role: WealthCashflowRole
+    var privacyMaskEnabled: Bool = false
     var reduceMotion: Bool = false
 
     var body: some View {
@@ -453,20 +491,22 @@ private struct WealthCashflowRow: View {
     }
 
     private var amountText: String {
+        guard !privacyMaskEnabled else { return PrivacyMaskPresentation.compactValue }
         switch role {
         case .income, .net:
-            cashflowText(amount, format: .compact)
+            return cashflowText(amount, format: .compact)
         case .spending:
-            Formatters.currency(amount, format: .compact)
+            return Formatters.currency(amount, format: .compact)
         }
     }
 
     private var accessibilityAmountText: String {
+        guard !privacyMaskEnabled else { return PrivacyMaskPresentation.compactValue }
         switch role {
         case .income, .net:
-            cashflowText(amount, format: .full)
+            return cashflowText(amount, format: .full)
         case .spending:
-            Formatters.currency(amount, format: .full)
+            return Formatters.currency(amount, format: .full)
         }
     }
 
@@ -487,6 +527,7 @@ private struct WealthCashflowRow: View {
 private struct WealthCreditSection: View {
     let summary: WealthSummaryPresentation.CreditUtilizationSummary?
     let threshold: Double
+    let privacyMaskEnabled: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -500,19 +541,19 @@ private struct WealthCreditSection: View {
                         .frame(width: Sizing.iconInline, height: Sizing.iconInline)
 
                     VStack(alignment: .leading, spacing: Spacing.xxs) {
-                        Text("\(Formatters.percent(summary.percent, decimals: 0)) utilization, \(summary.statusLabel.lowercased())")
+                        Text("\(percentValue(summary)) utilization, \(summary.statusLabel.lowercased())")
                             .font(.caption.weight(.semibold))
                             .lineLimit(1)
                             .minimumScaleFactor(0.82)
 
-                        Text("\(Formatters.currency(summary.usedCredit, format: .compact)) used of \(Formatters.currency(summary.totalLimit, format: .compact)) limit")
+                        Text("\(usedValue(summary, format: .compact)) used of \(limitValue(summary, format: .compact)) limit")
                             .detailText()
                             .lineLimit(2)
                     }
                 }
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(
-                    "Credit utilization \(Formatters.percent(summary.percent, decimals: 0)), \(summary.statusLabel). \(Formatters.currency(summary.usedCredit, format: .full)) used of \(Formatters.currency(summary.totalLimit, format: .full)) limit."
+                    "Credit utilization \(percentValue(summary)), \(summary.statusLabel). \(usedValue(summary, format: .full)) used of \(limitValue(summary, format: .full)) limit."
                 )
             } else {
                 Label("No credit utilization available", systemImage: "creditcard")
@@ -520,6 +561,24 @@ private struct WealthCreditSection: View {
                     .foregroundStyle(.secondary)
             }
         }
+    }
+
+    private func percentValue(_ summary: WealthSummaryPresentation.CreditUtilizationSummary) -> String {
+        PrivacyMaskPresentation.percent(summary.percent, decimals: 0, isEnabled: privacyMaskEnabled)
+    }
+
+    private func usedValue(
+        _ summary: WealthSummaryPresentation.CreditUtilizationSummary,
+        format: CurrencyFormat
+    ) -> String {
+        PrivacyMaskPresentation.currency(summary.usedCredit, format: format, isEnabled: privacyMaskEnabled)
+    }
+
+    private func limitValue(
+        _ summary: WealthSummaryPresentation.CreditUtilizationSummary,
+        format: CurrencyFormat
+    ) -> String {
+        PrivacyMaskPresentation.currency(summary.totalLimit, format: format, isEnabled: privacyMaskEnabled)
     }
 
     private func tint(_ summary: WealthSummaryPresentation.CreditUtilizationSummary) -> Color {

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -180,16 +180,19 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
             subtitle,
             "\(availableTitle) \(PrivacyMaskPresentation.currency(availableBalance, format: .full, isEnabled: privacyMaskEnabled))",
             "\(currentTitle) \(PrivacyMaskPresentation.currency(currentBalance, format: .full, isEnabled: privacyMaskEnabled))",
-            "\(transactionCount) synced transaction\(transactionCount == 1 ? "" : "s")",
-            "\(pendingTransactionCount) pending transaction\(pendingTransactionCount == 1 ? "" : "s")",
             "Sync \(freshnessLabel)",
         ]
+
+        if !privacyMaskEnabled {
+            parts.append("\(transactionCount) synced transaction\(transactionCount == 1 ? "" : "s")")
+            parts.append("\(pendingTransactionCount) pending transaction\(pendingTransactionCount == 1 ? "" : "s")")
+        }
 
         if let utilizationPercent {
             parts.append("Utilization \(PrivacyMaskPresentation.percent(utilizationPercent, decimals: 0, isEnabled: privacyMaskEnabled))")
         }
 
-        if let latestTransactionDate {
+        if let latestTransactionDate, !privacyMaskEnabled {
             parts.append("Latest transaction \(Formatters.displayTransactionDate(latestTransactionDate))")
         }
 

--- a/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
+++ b/Sources/PlaidBarCore/Models/DashboardDrillInSurface.swift
@@ -170,19 +170,23 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
     public let freshnessLabel: String
 
     public var accessibilityLabel: String {
+        accessibilityLabel(privacyMaskEnabled: false)
+    }
+
+    public func accessibilityLabel(privacyMaskEnabled: Bool) -> String {
         var parts = [
             "Selected account drill-in",
             displayName,
             subtitle,
-            "\(availableTitle) \(Formatters.currency(availableBalance, format: .full))",
-            "\(currentTitle) \(Formatters.currency(currentBalance, format: .full))",
+            "\(availableTitle) \(PrivacyMaskPresentation.currency(availableBalance, format: .full, isEnabled: privacyMaskEnabled))",
+            "\(currentTitle) \(PrivacyMaskPresentation.currency(currentBalance, format: .full, isEnabled: privacyMaskEnabled))",
             "\(transactionCount) synced transaction\(transactionCount == 1 ? "" : "s")",
             "\(pendingTransactionCount) pending transaction\(pendingTransactionCount == 1 ? "" : "s")",
             "Sync \(freshnessLabel)",
         ]
 
         if let utilizationPercent {
-            parts.append("Utilization \(Formatters.percent(utilizationPercent, decimals: 0))")
+            parts.append("Utilization \(PrivacyMaskPresentation.percent(utilizationPercent, decimals: 0, isEnabled: privacyMaskEnabled))")
         }
 
         if let latestTransactionDate {
@@ -196,13 +200,15 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
         for account: AccountDTO,
         transactions: [TransactionDTO],
         itemStatus: ItemStatus?,
-        fallbackFreshnessLabel: String
+        fallbackFreshnessLabel: String,
+        privacyMaskEnabled: Bool = false
     ) -> Self {
         presentation(
             for: account,
             activitySnapshot: AccountTransactionFeed.activitySnapshot(forAccountId: account.id, in: transactions),
             itemStatus: itemStatus,
-            fallbackFreshnessLabel: fallbackFreshnessLabel
+            fallbackFreshnessLabel: fallbackFreshnessLabel,
+            privacyMaskEnabled: privacyMaskEnabled
         )
     }
 
@@ -210,11 +216,12 @@ public struct DashboardAccountDrillInSummary: Sendable, Equatable {
         for account: AccountDTO,
         activitySnapshot: AccountTransactionFeed.AccountActivitySnapshot,
         itemStatus: ItemStatus?,
-        fallbackFreshnessLabel: String
+        fallbackFreshnessLabel: String,
+        privacyMaskEnabled: Bool = false
     ) -> Self {
         Self(
             displayName: AccountPresentation.displayName(for: account),
-            subtitle: AccountPresentation.subtitle(for: account),
+            subtitle: AccountPresentation.subtitle(for: account, privacyMaskEnabled: privacyMaskEnabled),
             availableTitle: AccountPresentation.dashboardAvailableTitle(for: account),
             availableBalance: AccountPresentation.availableBalance(for: account),
             currentTitle: AccountPresentation.dashboardCurrentTitle(for: account),

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -854,6 +854,9 @@ struct PlaidBarCoreTests {
         #expect(label.contains("$520.00") == false)
         #expect(label.contains("••••"))
         #expect(label.contains("Ending in 1234") == false)
+        #expect(label.contains("synced transaction") == false)
+        #expect(label.contains("pending transaction") == false)
+        #expect(label.contains("Latest transaction") == false)
     }
 
     @Test("Drill-in action accessibility labels include display names only")

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -828,6 +828,34 @@ struct PlaidBarCoreTests {
         #expect(!summary.accessibilityLabel.contains(account.itemId))
     }
 
+    @Test("Account drill-in summary masks values for private display mode")
+    func accountDrillInSummaryMasksPrivateValues() {
+        let account = AccountDTO(
+            id: "acct-private-123",
+            itemId: "item-private-456",
+            name: "Everyday",
+            type: .depository,
+            subtype: "checking",
+            mask: "1234",
+            balances: BalanceDTO(available: 500, current: 520),
+            institutionName: "Chase"
+        )
+        let summary = DashboardAccountDrillInSummary.presentation(
+            for: account,
+            transactions: [],
+            itemStatus: nil,
+            fallbackFreshnessLabel: "Fresh",
+            privacyMaskEnabled: true
+        )
+        let label = summary.accessibilityLabel(privacyMaskEnabled: true)
+
+        #expect(summary.subtitle == "Depository • Checking ••••")
+        #expect(label.contains("$500.00") == false)
+        #expect(label.contains("$520.00") == false)
+        #expect(label.contains("••••"))
+        #expect(label.contains("Ending in 1234") == false)
+    }
+
     @Test("Drill-in action accessibility labels include display names only")
     func drillInActionAccessibilityLabelsUseDisplayNamesOnly() {
         let displayName = "Everyday Checking"


### PR DESCRIPTION
## Summary
- wire AppState app-lock/privacy preferences into menu bar rendering and background refresh/notification evaluation
- pass privacy-mask state into dashboard account rows, drill-in balances, subtitles, and accessibility labels
- add a regression covering private drill-in summary values and account-ending masking

Fixes #431
Linear: AND-459
Kanban: t_2797be8a

## Verification
- `git diff --check` — passed
- `swift test --filter AppLockPresentation` — 6 tests passed
- `swift test --filter PlaidBarCoreTests/accountDrillInSummaryMasksPrivateValues` — 1 test passed
- `swift build --target PlaidBar` — passed
- `swift test --filter PlaidBarCoreTests` — failed on pre-existing/flaky `GlanceSnapshotTests.swift:129` debouncer timing expectation; all app-lock/privacy-related tests passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — failed on existing `Sources/PlaidBar/Services/LocalAIInsightsService.swift:136` strict-concurrency issue tracked by #425/#426

## Privacy/security
- no Plaid credentials/tokens/provider payloads added to app/docs/tests
- app target continues using local presentation data only; no cloud AI path added
- locked/private mode now suppresses displayed financial values in the wired surfaces
