### PR TITLE
fix: clear stuck review banner (#428) and count needs-review transactions (#429)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -968,12 +968,15 @@ final class AppState {
               !transactions.isEmpty
         else { return nil }
 
-        let inbox = transactionReviewInboxSnapshot
-        let unreviewed = Set(inbox.items.map(\.id))
-        let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
-        return WeeklyReviewTransactionState(
-            trustedTransactionIds: trusted,
-            unreviewedTransactionIds: unreviewed
+        // Classify by the tested trust contract (metadata status), not by the
+        // Review Inbox snapshot. `TransactionReviewInbox.evaluate` only emits an
+        // item when a transaction trips a heuristic reason, so a transaction the
+        // user never reviewed (status `.needsReview`, or no metadata yet) that
+        // happens to trip no heuristic would otherwise be miscounted as trusted,
+        // under-reporting the "needs review" count.
+        return WeeklyReviewTransactionState.derived(
+            from: transactions,
+            metadata: transactionReviewMetadata
         )
     }
 

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -7,6 +7,10 @@ struct ReviewInboxView: View {
     @State private var selectedIndex = 0
     @State private var merchantDrafts: [String: String] = [:]
     @State private var actionConfirmation: ReviewActionConfirmation?
+    /// Monotonic token so a queued auto-dismiss only clears the banner it was
+    /// scheduled for — a newer action (which bumps the token) is never wiped by
+    /// an older timer.
+    @State private var confirmationGeneration = 0
 
     private var snapshot: TransactionReviewInboxSnapshot {
         appState.transactionReviewInboxSnapshot
@@ -81,8 +85,14 @@ struct ReviewInboxView: View {
                 isFocused = true
                 clampSelection()
             }
-            .onChange(of: snapshot.totalCount) { _, _ in
+            .onChange(of: snapshot.totalCount) { _, newCount in
                 clampSelection()
+                // When the queue drains to empty, drop any lingering confirmation
+                // banner so the inbox can collapse out of the popover instead of
+                // sitting in an empty "0 items" state with a stuck banner.
+                if newCount == 0 {
+                    withAnimation(.snappy(duration: 0.18)) { actionConfirmation = nil }
+                }
             }
             .onMoveCommand(perform: moveSelection)
             .accessibilityElement(children: .contain)
@@ -164,8 +174,17 @@ struct ReviewInboxView: View {
     }
 
     private func recordAction(_ action: ReviewActionConfirmation.Action, for item: TransactionReviewItem) {
+        confirmationGeneration &+= 1
+        let generation = confirmationGeneration
         withAnimation(.snappy(duration: 0.18)) {
             actionConfirmation = ReviewActionConfirmation(action: action, merchantName: item.effectiveMerchantName)
+        }
+        // Auto-dismiss so the banner never persists indefinitely. The generation
+        // guard means a newer action's banner is not cleared by this older timer.
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2.5))
+            guard confirmationGeneration == generation else { return }
+            withAnimation(.snappy(duration: 0.18)) { actionConfirmation = nil }
         }
     }
 }

--- a/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
+++ b/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
@@ -137,6 +137,53 @@ struct WeeklyReviewTests {
         #expect(state.unreviewedTransactionIds == ["missing-metadata"])
     }
 
+    /// Regression for the Weekly Review under-count: a transaction whose metadata
+    /// is `.needsReview` but which trips no Review Inbox heuristic must still be
+    /// counted as unreviewed. The old production path derived the count from the
+    /// inbox snapshot, which emits no item for such a transaction — silently
+    /// counting a genuinely-unreviewed transaction as trusted. `derived(...)`
+    /// (the contract production now uses) classifies strictly by metadata status.
+    @Test("Needs-review transaction tripping no inbox heuristic is still unreviewed")
+    func needsReviewWithoutHeuristicIsCountedUnreviewed() {
+        // Three identical, well-categorized charges for one established merchant:
+        // categorized (no `.uncategorized`), merchant count > 1 (no `.newMerchant`),
+        // uniform amount (no `.unusualAmount`), not income/transfer/pending. This
+        // trips none of the inbox heuristics.
+        let transactions = (0..<3).map { index in
+            TransactionDTO(
+                id: "grocery-\(index)",
+                accountId: "acct-grocery",
+                amount: 42.50,
+                date: "2026-06-1\(index)",
+                name: "WHOLE FOODS",
+                merchantName: "Whole Foods",
+                category: .foodAndDrink
+            )
+        }
+        // Two settled as reviewed; the third left needing review.
+        let metadata = [
+            TransactionReviewMetadata(id: "grocery-0", status: .reviewed),
+            TransactionReviewMetadata(id: "grocery-1", status: .reviewed),
+            TransactionReviewMetadata(id: "grocery-2", status: .needsReview),
+        ]
+
+        // The inbox emits no item for the needs-review transaction — this is the
+        // exact gap that made the old production count miss it.
+        let inbox = TransactionReviewInbox.evaluate(
+            transactions: transactions,
+            metadata: metadata,
+            rules: [],
+            recurring: [],
+            now: now
+        )
+        #expect(inbox.items.contains { $0.id == "grocery-2" } == false)
+
+        // The tested contract still counts it as unreviewed.
+        let state = WeeklyReviewTransactionState.derived(from: transactions, metadata: metadata)
+        #expect(state.unreviewedTransactionIds == ["grocery-2"])
+        #expect(state.trustedTransactionIds == ["grocery-0", "grocery-1"])
+    }
+
     @Test("Reviewed and ignored transaction metadata unblock weekly review")
     func reviewedAndIgnoredTransactionMetadataUnblocksWeeklyReview() {
         let transactions = [


### PR DESCRIPTION
## Summary
Fixes two post-merge regressions in the review surface, both found in the open-issue backlog.

- **#428** — Review Inbox confirmation banner never cleared, so the inbox stayed visible in an empty "0 items" state with a stuck "Approved: <merchant>" banner after the queue drained.
- **#429** — Weekly Review under-counted unreviewed transactions because production derived the count from the Review Inbox snapshot (heuristic-gated) instead of the tested metadata-status contract.

## Changes
- **`Sources/PlaidBar/Views/ReviewInboxView.swift`** — auto-dismiss the confirmation banner after 2.5s, guarded by a monotonic generation token so a newer action's banner is never wiped by an older timer; also clear it immediately when `snapshot.totalCount` hits 0 so the inbox can collapse out of the popover.
- **`Sources/PlaidBar/App/AppState.swift`** — `weeklyReviewTransactionState` (non-demo path) now calls `WeeklyReviewTransactionState.derived(from:metadata:)`, classifying by metadata status (`.reviewed`/`.ignored` → trusted; `.needsReview`/missing → unreviewed) instead of the inbox snapshot. Demo mode is unchanged.
- **`Tests/PlaidBarCoreTests/WeeklyReviewTests.swift`** — regression test proving `TransactionReviewInbox.evaluate` emits no item for a `.needsReview` transaction that trips no heuristic, while `derived(...)` still counts it as unreviewed.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` — 822 tests pass (incl. new regression test)
- [x] `git diff --check` clean; changed-line secret scan clean

Closes #428
Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)