### PR TITLE
fix: reconcile posted↔pending review state and serialize storage writes (AND-399)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -291,6 +291,7 @@ final class AppState {
     private let serverClient = ServerClient()
     private let localDataCache = LocalDataCacheService()
     private let appLockService = AppLockService()
+    private let reviewStorageWriter = ReviewStorageWriter()
     private var localAIInsightsService = LocalAIInsightsService()
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
@@ -2953,16 +2954,22 @@ final class AppState {
         let cacheDirectory = activeStorageDirectoryURL
         let cacheContext = transactionCacheContext
         let cache = localDataCache
-        Task {
+        // Hand the full snapshot to the serial writer instead of spawning an
+        // independent Task. Independent tasks could complete out of order, letting
+        // a stale write overwrite a newer one; the writer applies snapshots in
+        // enqueue order so the last logical state always wins on disk.
+        reviewStorageWriter.enqueue { [weak self] in
             do {
                 try await cache.saveTransactionReviewMetadata(metadata, to: cacheDirectory, context: cacheContext)
                 try await cache.saveTransactionRules(rules, to: cacheDirectory, context: cacheContext)
             } catch {
-                await MainActor.run {
-                    self.error = "Review inbox storage failed to save: \(error.localizedDescription)"
-                }
+                await self?.reportReviewStorageFailure(error.localizedDescription)
             }
         }
+    }
+
+    private func reportReviewStorageFailure(_ description: String) {
+        error = "Review inbox storage failed to save: \(description)"
     }
 
 }

--- a/Sources/PlaidBar/Services/ReviewStorageWriter.swift
+++ b/Sources/PlaidBar/Services/ReviewStorageWriter.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Serializes transaction-review storage writes so the most recent in-memory
+/// state always wins on disk.
+///
+/// Every review action (approve / ignore / rule edit / undo) hands the writer a
+/// closure that persists a *complete* snapshot of the review metadata and rules.
+/// A single consumer applies those closures strictly in the order they were
+/// enqueued, so a slow earlier write can never land after a newer one and
+/// resurrect stale JSON. Because each write carries the full state, rapid bursts
+/// are coalesced to the newest snapshot — intermediate ones are dropped rather
+/// than queued, which is both correct and cheaper than writing every keystroke.
+///
+/// `enqueue` is synchronous and `Sendable`, so it can be called directly from the
+/// `@MainActor` without spawning an unstructured `Task` per action (the previous
+/// approach, where independent tasks could finish out of order and race).
+final class ReviewStorageWriter: Sendable {
+    typealias Write = @Sendable () async -> Void
+
+    private let continuation: AsyncStream<Write>.Continuation
+    private let consumer: Task<Void, Never>
+
+    init() {
+        let (stream, continuation) = AsyncStream<Write>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        self.continuation = continuation
+        self.consumer = Task {
+            for await write in stream {
+                await write()
+            }
+        }
+    }
+
+    deinit {
+        continuation.finish()
+        consumer.cancel()
+    }
+
+    /// Enqueue a snapshot write. Returns immediately; the write runs on the serial
+    /// consumer. If newer snapshots are enqueued before this one starts, it is
+    /// superseded and skipped — the latest snapshot is what reaches disk.
+    func enqueue(_ write: @escaping Write) {
+        continuation.yield(write)
+    }
+}

--- a/Sources/PlaidBarCore/Models/TransactionDTO.swift
+++ b/Sources/PlaidBarCore/Models/TransactionDTO.swift
@@ -10,6 +10,11 @@ public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
     public let merchantName: String? // Cleaned merchant name
     public let category: SpendingCategory?
     public let pending: Bool
+    /// Plaid `pending_transaction_id`: when a pending charge posts, Plaid removes
+    /// the pending transaction and adds a new posted one that points back to the
+    /// pending id through this field. Privacy-sensitive like every other id — keep
+    /// it out of UI and logs; it exists only to reconcile pending → posted state.
+    public let pendingTransactionId: String?
     public let isoCurrencyCode: String?
 
     public init(
@@ -22,6 +27,7 @@ public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
         merchantName: String? = nil,
         category: SpendingCategory? = nil,
         pending: Bool = false,
+        pendingTransactionId: String? = nil,
         isoCurrencyCode: String? = nil
     ) {
         self.id = id
@@ -33,6 +39,7 @@ public struct TransactionDTO: Codable, Sendable, Identifiable, Hashable {
         self.merchantName = merchantName
         self.category = category
         self.pending = pending
+        self.pendingTransactionId = pendingTransactionId
         self.isoCurrencyCode = isoCurrencyCode
     }
 

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -182,8 +182,16 @@ public enum TransactionReviewInbox {
         let recurringByMerchant = Dictionary(grouping: recurring, by: { normalizedKey($0.merchantName) })
 
         let items = transactions.compactMap { transaction -> TransactionReviewItem? in
-            let metadata = metadataById[transaction.id]
+            let ownMetadata = metadataById[transaction.id]
+            // When Plaid posts a previously-pending charge it arrives under a
+            // brand-new transaction id that links back to the pending id via
+            // pending_transaction_id. The pending-phase record (the user's
+            // category/transfer choices and the last-seen amount/name) still lives
+            // under that old id, so carry it forward to reconcile the two.
+            let priorPendingMetadata = transaction.pendingTransactionId.flatMap { metadataById[$0] }
+            let metadata = ownMetadata ?? priorPendingMetadata
             let isAlreadyResolved = metadata?.status == .reviewed || metadata?.status == .ignored
+            let pendingBaseline = pendingBaseline(own: ownMetadata, prior: priorPendingMetadata)
             let matchedRules = rules.filter { $0.matches(transaction) }
 
             let effectiveCategory = metadata?.userCategory ?? transaction.category
@@ -215,7 +223,8 @@ public enum TransactionReviewInbox {
             if recurringChanged(transaction, recurringByMerchant: recurringByMerchant, now: now) {
                 reasons.insert(.recurringChanged)
             }
-            if pendingChanged(transaction, metadata: metadata) {
+            let didSettleDifferently = pendingSettledDifferently(transaction, baseline: pendingBaseline)
+            if didSettleDifferently {
                 reasons.insert(.pendingChanged)
             }
 
@@ -233,9 +242,15 @@ public enum TransactionReviewInbox {
                 guard orderedReasons.contains(where: \.isHighPriority) else { return nil }
             }
 
+            // A charge that settled with a different amount or name after its
+            // pending phase was already approved/ignored is effectively reopened —
+            // present it as needing review rather than as still resolved.
+            let reportedStatus: TransactionReviewStatus =
+                (didSettleDifferently && isAlreadyResolved) ? .needsReview : (metadata?.status ?? .needsReview)
+
             return TransactionReviewItem(
                 transaction: transaction,
-                status: metadata?.status ?? .needsReview,
+                status: reportedStatus,
                 reasonCodes: orderedReasons,
                 effectiveCategory: effectiveCategory,
                 effectiveMerchantName: effectiveMerchant,
@@ -335,15 +350,26 @@ public enum TransactionReviewInbox {
         }
     }
 
-    private static func pendingChanged(
+    /// The record that captured this charge while it was pending. Prefer the
+    /// transaction's own history; fall back to the record carried over from a
+    /// prior pending transaction id when Plaid posts the charge under a new id.
+    private static func pendingBaseline(
+        own: TransactionReviewMetadata?,
+        prior: TransactionReviewMetadata?
+    ) -> TransactionReviewMetadata? {
+        if own?.lastSeenPending == true { return own }
+        if prior?.lastSeenPending == true { return prior }
+        return nil
+    }
+
+    private static func pendingSettledDifferently(
         _ transaction: TransactionDTO,
-        metadata: TransactionReviewMetadata?
+        baseline: TransactionReviewMetadata?
     ) -> Bool {
-        guard transaction.pending == false,
-              metadata?.lastSeenPending == true
+        guard transaction.pending == false, let baseline, baseline.lastSeenPending == true
         else { return false }
-        let amountChanged = metadata?.lastSeenAmount.map { abs($0 - transaction.amount) >= 0.01 } ?? false
-        let nameChanged = metadata?.lastSeenName.map { $0 != transaction.name } ?? false
+        let amountChanged = baseline.lastSeenAmount.map { abs($0 - transaction.amount) >= 0.01 } ?? false
+        let nameChanged = baseline.lastSeenName.map { $0 != transaction.name } ?? false
         return amountChanged || nameChanged
     }
 

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -189,9 +189,21 @@ public enum TransactionReviewInbox {
             // category/transfer choices and the last-seen amount/name) still lives
             // under that old id, so carry it forward to reconcile the two.
             let priorPendingMetadata = transaction.pendingTransactionId.flatMap { metadataById[$0] }
-            let metadata = ownMetadata ?? priorPendingMetadata
+            // Production seeds a fresh `.needsReview` record under the posted id
+            // before this runs, so `ownMetadata` almost always exists. Treat the
+            // posted charge as resolved on its own only once the user has acted on
+            // it directly (reviewed/ignored under the posted id). Until then the
+            // own record is just the seeded baseline, so prefer the pending-phase
+            // record — otherwise the seeded `.needsReview` would mask a charge the
+            // user already reviewed while pending, dropping its status and overrides.
+            let ownResolved = ownMetadata.map { $0.status == .reviewed || $0.status == .ignored } ?? false
+            let metadata = ownResolved ? ownMetadata : (priorPendingMetadata ?? ownMetadata)
             let isAlreadyResolved = metadata?.status == .reviewed || metadata?.status == .ignored
-            let pendingBaseline = pendingBaseline(own: ownMetadata, prior: priorPendingMetadata)
+            // The pending baseline only matters until the charge is resolved under
+            // its posted id. After that, comparing the posted amount against the old
+            // pending amount would re-flag `.pendingChanged` and reopen it on every
+            // refresh, so stop falling back to the prior pending record.
+            let pendingBaseline = ownResolved ? nil : pendingBaseline(own: ownMetadata, prior: priorPendingMetadata)
             let matchedRules = rules.filter { $0.matches(transaction) }
 
             let effectiveCategory = metadata?.userCategory ?? transaction.category

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -242,6 +242,12 @@ struct PlaidTransaction: Decodable, Sendable {
     let name: String
     let merchantName: String?
     let pending: Bool
+    // Present only on posted transactions that were previously pending; links
+    // back to the now-removed pending transaction id. Decoded from
+    // `pending_transaction_id` via the client's convertFromSnakeCase strategy.
+    // `var … = nil` (not `let`) so it stays in Decodable synthesis while the
+    // synthesized memberwise init keeps it optional for call sites that omit it.
+    var pendingTransactionId: String? = nil
     let isoCurrencyCode: String?
     let personalFinanceCategory: PlaidCategory?
 }

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -246,6 +246,7 @@ struct TransactionRoutes: Sendable {
             merchantName: plaidTx.merchantName,
             category: category,
             pending: plaidTx.pending,
+            pendingTransactionId: plaidTx.pendingTransactionId,
             isoCurrencyCode: plaidTx.isoCurrencyCode
         )
     }

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -103,6 +103,140 @@ struct TransactionReviewInboxTests {
         #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
     }
 
+    @Test("Posted transaction reconciles against pending metadata stored under the pending id")
+    func postedTransactionReconcilesViaPendingTransactionId() {
+        // Plaid posts a pending charge as a brand-new transaction id that points
+        // back to the pending id. The pending-phase metadata lives under that old
+        // id, so the change must be detected across the id boundary.
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let pendingMetadata = TransactionReviewMetadata(
+            id: "pending-old",
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [pendingMetadata])
+
+        #expect(snapshot.items.map(\.id) == ["posted-new"])
+        #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
+    }
+
+    @Test("Posted transaction that settled identically stays out of the inbox")
+    func postedTransactionUnchangedStaysSettled() {
+        // Same amount and name as the pending phase, which was already reviewed:
+        // a benign posting should not resurface the charge.
+        let posted = tx(
+            id: "posted-new",
+            amount: 50,
+            name: "MERCHANT PENDING",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let pendingMetadata = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [pendingMetadata])
+
+        #expect(snapshot.totalCount == 0)
+    }
+
+    @Test("Approving while pending does not block a changed posted charge from reopening")
+    func approvedPendingChargeReopensWhenPostedDifferently() {
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let approvedPending = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [approvedPending])
+
+        let item = snapshot.items.first { $0.id == "posted-new" }
+        #expect(item != nil)
+        #expect(item?.reasonCodes.contains(.pendingChanged) == true)
+        // A reopened charge is actionable again rather than reading as settled.
+        #expect(item?.status == .needsReview)
+    }
+
+    @Test("Ignoring while pending does not block a changed posted charge from reopening")
+    func ignoredPendingChargeReopensWhenPostedDifferently() {
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let ignoredPending = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .ignored,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [ignoredPending])
+
+        let item = snapshot.items.first { $0.id == "posted-new" }
+        #expect(item != nil)
+        #expect(item?.reasonCodes.contains(.pendingChanged) == true)
+    }
+
+    @Test("Posted charge with its own fresh metadata still detects the pending change")
+    func postedTransactionWithSeededMetadataStillReconciles() {
+        // Mirrors production: the posted charge is seeded with its own fresh
+        // metadata (pending = false) while the pending-phase record survives under
+        // the old id. The change must still be detected via the prior record.
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let seededPosted = TransactionReviewMetadata(
+            id: "posted-new",
+            lastSeenAmount: 58,
+            lastSeenName: "MERCHANT FINAL",
+            lastSeenPending: false
+        )
+        let pendingMetadata = TransactionReviewMetadata(
+            id: "pending-old",
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [seededPosted, pendingMetadata])
+
+        #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
+    }
+
     @Test("Reviewed and ignored transactions stay out of inbox")
     func reviewedAndIgnoredAreSuppressed() {
         let reviewed = tx(id: "reviewed", category: nil, merchantName: "Needs Category")
@@ -247,7 +381,9 @@ struct TransactionReviewInboxTests {
         date: String = "2026-06-01",
         name: String = "MERCHANT",
         category: SpendingCategory?,
-        merchantName: String?
+        merchantName: String?,
+        pending: Bool = false,
+        pendingTransactionId: String? = nil
     ) -> TransactionDTO {
         TransactionDTO(
             id: id,
@@ -256,7 +392,9 @@ struct TransactionReviewInboxTests {
             date: date,
             name: name,
             merchantName: merchantName,
-            category: category
+            category: category,
+            pending: pending,
+            pendingTransactionId: pendingTransactionId
         )
     }
 

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -237,6 +237,73 @@ struct TransactionReviewInboxTests {
         #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
     }
 
+    @Test("Posted charge that settled unchanged keeps the pending-phase review even with a seeded own record")
+    func postedUnchangedWithSeededOwnRecordStaysReviewed() {
+        // Production seeds a fresh `.needsReview` record under the posted id before
+        // the evaluator runs. A charge the user already reviewed while pending, that
+        // then posts unchanged, must stay settled — the seeded baseline must not
+        // mask the carried-forward review (regression for the lost-status bug).
+        let posted = tx(
+            id: "posted-new",
+            amount: 50,
+            name: "MERCHANT PENDING",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let seededPosted = TransactionReviewMetadata(
+            id: "posted-new",
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: false
+        )
+        let reviewedPending = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            userCategory: .foodAndDrink,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [seededPosted, reviewedPending])
+
+        #expect(snapshot.totalCount == 0)
+    }
+
+    @Test("Posted charge resolved under its own id does not reopen from the stale pending baseline")
+    func resolvedPostedDoesNotReopenFromPendingBaseline() {
+        // After a changed charge posts and the user reviews it under the posted id,
+        // the old pending record (different amount, lastSeenPending) must no longer
+        // drive `.pendingChanged`, or the charge reopens on every refresh forever.
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let resolvedPosted = TransactionReviewMetadata(
+            id: "posted-new",
+            status: .reviewed,
+            lastSeenAmount: 58,
+            lastSeenName: "MERCHANT FINAL",
+            lastSeenPending: false
+        )
+        let pendingOld = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let snapshot = evaluate([posted], metadata: [resolvedPosted, pendingOld])
+
+        #expect(snapshot.items.contains { $0.id == "posted-new" } == false)
+    }
+
     @Test("Reviewed and ignored transactions stay out of inbox")
     func reviewedAndIgnoredAreSuppressed() {
         let reviewed = tx(id: "reviewed", category: nil, merchantName: "Needs Category")


### PR DESCRIPTION
## What

Forward-ports **AND-399** (two P2 follow-ups from PR #370, transaction review inbox) onto current `main`. The work existed only on the stale `worktree-fix+and-399-pending-reconciliation` branch (authored 2026-06-14); it was never merged and is **not** present on `main` today. Rebased/cherry-picked onto `234f261` with conflicts resolved.

### 1. Posted↔pending reconciliation
When Plaid posts a pending charge it removes the pending transaction and adds a new posted one linked by `pending_transaction_id`. The evaluator's metadata lookup under the *posted* id missed the `lastSeenPending`/amount/name recorded under the old *pending* id — so the "settled with a different amount or name" review never fired for the common posting flow.

- `TransactionDTO` and `PlaidTransaction` now carry `pendingTransactionId` (optional, privacy-safe, kept out of UI/logs, decoded from Plaid via `convertFromSnakeCase`).
- The evaluator falls back to the prior pending record as the change baseline; a charge whose pending phase was already approved/ignored reopens (`status → needsReview`) when it settles materially differently.

### 2. Serialize review-storage writes
`persistReviewStorage()` spawned an unstructured `Task` per action, so rapid approve/undo/rule actions could land out of order and overwrite the JSON with stale state. Writes now go through a serial `ReviewStorageWriter` (`AsyncStream`, `bufferingNewest(1)`) that applies full snapshots in enqueue order and coalesces bursts to the latest — last logical state always wins on disk. `MainActor`-safe and strict-concurrency clean.

## Forward-port note
The original branch declared `PlaidTransaction.pendingTransactionId` as `let` with no default, which made it a **required** memberwise-init parameter. A newer `main` test (`PlaidBarServerTests.swift:1107`, added after the branch was cut) constructs `PlaidTransaction` without it. Changed to `var pendingTransactionId: String? = nil` so the field (a) stays in `Decodable` synthesis — a `let … = nil` would be silently excluded from decoding and break reconciliation — and (b) is optional in the synthesized memberwise init. This matches how `TransactionDTO` already defaults the parameter.

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- `swift test` — **827 tests pass** (incl. the 5 new posted↔pending reconciliation tests in `TransactionReviewInboxTests`)
- `git diff --check` clean; changed-line secret scan clean (the new id field is privacy-safe and kept out of UI/logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
