### PR TITLE
fix: keep pending reconciliation out of transaction cache

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2823,6 +2823,7 @@ final class AppState {
         updateReviewMetadata(id: id) { metadata, transaction in
             metadata.status = .ignored
             metadata.reviewedAt = Date()
+            metadata.reviewReasonCodes = []
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
@@ -2936,8 +2937,14 @@ final class AppState {
             )
             changed = true
         }
+        let seeded = byId.values.sorted { $0.id < $1.id }
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: transactions,
+            metadata: seeded
+        )
+        if reconciled != seeded { changed = true }
         guard changed else { return }
-        transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
+        transactionReviewMetadata = reconciled
         persistReviewStorage()
     }
 

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -182,28 +182,9 @@ public enum TransactionReviewInbox {
         let recurringByMerchant = Dictionary(grouping: recurring, by: { normalizedKey($0.merchantName) })
 
         let items = transactions.compactMap { transaction -> TransactionReviewItem? in
-            let ownMetadata = metadataById[transaction.id]
-            // When Plaid posts a previously-pending charge it arrives under a
-            // brand-new transaction id that links back to the pending id via
-            // pending_transaction_id. The pending-phase record (the user's
-            // category/transfer choices and the last-seen amount/name) still lives
-            // under that old id, so carry it forward to reconcile the two.
-            let priorPendingMetadata = transaction.pendingTransactionId.flatMap { metadataById[$0] }
-            // Production seeds a fresh `.needsReview` record under the posted id
-            // before this runs, so `ownMetadata` almost always exists. Treat the
-            // posted charge as resolved on its own only once the user has acted on
-            // it directly (reviewed/ignored under the posted id). Until then the
-            // own record is just the seeded baseline, so prefer the pending-phase
-            // record — otherwise the seeded `.needsReview` would mask a charge the
-            // user already reviewed while pending, dropping its status and overrides.
-            let ownResolved = ownMetadata.map { $0.status == .reviewed || $0.status == .ignored } ?? false
-            let metadata = ownResolved ? ownMetadata : (priorPendingMetadata ?? ownMetadata)
+            let metadata = metadataById[transaction.id]
             let isAlreadyResolved = metadata?.status == .reviewed || metadata?.status == .ignored
-            // The pending baseline only matters until the charge is resolved under
-            // its posted id. After that, comparing the posted amount against the old
-            // pending amount would re-flag `.pendingChanged` and reopen it on every
-            // refresh, so stop falling back to the prior pending record.
-            let pendingBaseline = ownResolved ? nil : pendingBaseline(own: ownMetadata, prior: priorPendingMetadata)
+            let pendingBaseline = pendingBaseline(own: metadata)
             let matchedRules = rules.filter { $0.matches(transaction) }
 
             let effectiveCategory = metadata?.userCategory ?? transaction.category
@@ -218,7 +199,7 @@ public enum TransactionReviewInbox {
                 return nil
             }
 
-            var reasons: Set<TransactionReviewReason> = []
+            var reasons = Set(metadata?.reviewReasonCodes ?? [])
             if effectiveCategory == nil || effectiveCategory == .other {
                 reasons.insert(.uncategorized)
             }
@@ -362,15 +343,13 @@ public enum TransactionReviewInbox {
         }
     }
 
-    /// The record that captured this charge while it was pending. Prefer the
-    /// transaction's own history; fall back to the record carried over from a
-    /// prior pending transaction id when Plaid posts the charge under a new id.
+    /// The record that captured this charge while it was pending. Posted↔pending
+    /// id migration happens before evaluation, so this only uses the transaction's
+    /// own metadata and never requires persisting Plaid's raw pending id.
     private static func pendingBaseline(
-        own: TransactionReviewMetadata?,
-        prior: TransactionReviewMetadata?
+        own: TransactionReviewMetadata?
     ) -> TransactionReviewMetadata? {
         if own?.lastSeenPending == true { return own }
-        if prior?.lastSeenPending == true { return prior }
         return nil
     }
 

--- a/Sources/PlaidBarCore/Models/TransactionReviewMetadataReconciler.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReviewMetadataReconciler.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum TransactionReviewMetadataReconciler {
+    public static func reconcilePostedPendingTransactions(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]
+    ) -> [TransactionReviewMetadata] {
+        var byId = Dictionary(uniqueKeysWithValues: metadata.map { ($0.id, $0) })
+        var changed = false
+
+        for transaction in transactions where transaction.pending == false {
+            guard let pendingId = transaction.pendingTransactionId,
+                  pendingId != transaction.id,
+                  let pendingMetadata = byId[pendingId]
+            else { continue }
+
+            var postedMetadata = byId[transaction.id] ?? TransactionReviewMetadata(id: transaction.id)
+            let hadPostedResolution = postedMetadata.status == .reviewed || postedMetadata.status == .ignored
+            guard !hadPostedResolution else { continue }
+
+            let didSettleDifferently = pendingSettledDifferently(transaction, baseline: pendingMetadata)
+            postedMetadata.status = didSettleDifferently ? .needsReview : pendingMetadata.status
+            postedMetadata.userCategory = pendingMetadata.userCategory
+            postedMetadata.userMerchantName = pendingMetadata.userMerchantName
+            postedMetadata.isTransferOverride = pendingMetadata.isTransferOverride
+            postedMetadata.excludedFromBudgets = pendingMetadata.excludedFromBudgets
+            postedMetadata.reviewedAt = didSettleDifferently ? nil : pendingMetadata.reviewedAt
+            postedMetadata.reviewReasonCodes = didSettleDifferently ? [.pendingChanged] : pendingMetadata.reviewReasonCodes
+            postedMetadata.lastSeenAmount = transaction.amount
+            postedMetadata.lastSeenName = transaction.name
+            postedMetadata.lastSeenPending = transaction.pending
+
+            byId[transaction.id] = postedMetadata
+            byId.removeValue(forKey: pendingId)
+            changed = true
+        }
+
+        guard changed else { return metadata.sorted { $0.id < $1.id } }
+        return byId.values.sorted { $0.id < $1.id }
+    }
+
+    private static func pendingSettledDifferently(
+        _ transaction: TransactionDTO,
+        baseline: TransactionReviewMetadata
+    ) -> Bool {
+        guard baseline.lastSeenPending == true else { return false }
+        let amountChanged = baseline.lastSeenAmount.map { abs($0 - transaction.amount) >= 0.01 } ?? false
+        let nameChanged = baseline.lastSeenName.map { $0 != transaction.name } ?? false
+        return amountChanged || nameChanged
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -696,7 +696,25 @@ public enum LocalDataStore {
         try ensurePrivateDirectory(directory, fileManager: fileManager)
 
         let url = transactionCacheURL(in: directory, context: context)
-        let cache = TransactionCache(context: context, transactions: transactions)
+        // `pendingTransactionId` is needed only transiently while reconciling a
+        // freshly-synced posted transaction with its pending phase. Do not persist
+        // that second raw Plaid transaction identifier in the app cache.
+        let cacheTransactions = transactions.map { transaction in
+            TransactionDTO(
+                id: transaction.id,
+                itemId: transaction.itemId,
+                accountId: transaction.accountId,
+                amount: transaction.amount,
+                date: transaction.date,
+                name: transaction.name,
+                merchantName: transaction.merchantName,
+                category: transaction.category,
+                pending: transaction.pending,
+                pendingTransactionId: nil,
+                isoCurrencyCode: transaction.isoCurrencyCode
+            )
+        }
+        let cache = TransactionCache(context: context, transactions: cacheTransactions)
         let data = try JSONEncoder().encode(cache)
         try writePrivateCacheFile(data, to: url, fileManager: fileManager)
         try setPrivateCacheFilePermissions(url, fileManager: fileManager)

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3933,6 +3933,38 @@ struct PlaidBarCoreTests {
         ).isEmpty)
     }
 
+
+    @Test("Transaction cache does not persist pending transaction identifiers")
+    func transactionCacheDoesNotPersistPendingTransactionIdentifiers() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent(".vaultpeek", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let context = TransactionCacheContext(environment: .sandbox, storagePath: directory.path)
+        try LocalDataStore.saveTransactions(
+            [TransactionDTO(
+                id: "posted-new",
+                accountId: "checking",
+                amount: 58,
+                date: "2026-06-01",
+                name: "Merchant final",
+                pending: false,
+                pendingTransactionId: "pending-old"
+            )],
+            to: directory,
+            context: context
+        )
+
+        let cacheURL = LocalDataStore.transactionCacheURL(in: directory, context: context)
+        let rawCache = try String(contentsOf: cacheURL, encoding: .utf8)
+        let loaded = try LocalDataStore.loadTransactions(from: directory, context: context)
+
+        #expect(!rawCache.contains("pending-old"))
+        #expect(!rawCache.contains("pendingTransactionId"))
+        #expect(loaded.first?.pendingTransactionId == nil)
+    }
+
     @Test("Local data migration does not restore reset-cleared legacy data")
     func localDataMigrationDoesNotRestoreResetClearedLegacyData() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -123,8 +123,13 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [pendingMetadata])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [pendingMetadata]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
+        #expect(reconciled.map(\.id) == ["posted-new"])
         #expect(snapshot.items.map(\.id) == ["posted-new"])
         #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
     }
@@ -149,8 +154,14 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [pendingMetadata])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [pendingMetadata]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
+        #expect(reconciled.map(\.id) == ["posted-new"])
+        #expect(reconciled.first?.status == .reviewed)
         #expect(snapshot.totalCount == 0)
     }
 
@@ -172,7 +183,11 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [approvedPending])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [approvedPending]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
         let item = snapshot.items.first { $0.id == "posted-new" }
         #expect(item != nil)
@@ -199,7 +214,11 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [ignoredPending])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [ignoredPending]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
         let item = snapshot.items.first { $0.id == "posted-new" }
         #expect(item != nil)
@@ -232,8 +251,13 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [seededPosted, pendingMetadata])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [seededPosted, pendingMetadata]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
+        #expect(reconciled.map(\.id) == ["posted-new"])
         #expect(snapshot.items.first?.reasonCodes.contains(.pendingChanged) == true)
     }
 
@@ -266,8 +290,14 @@ struct TransactionReviewInboxTests {
             lastSeenPending: true
         )
 
-        let snapshot = evaluate([posted], metadata: [seededPosted, reviewedPending])
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [seededPosted, reviewedPending]
+        )
+        let snapshot = evaluate([posted], metadata: reconciled)
 
+        #expect(reconciled.map(\.id) == ["posted-new"])
+        #expect(reconciled.first?.status == .reviewed)
         #expect(snapshot.totalCount == 0)
     }
 
@@ -302,6 +332,96 @@ struct TransactionReviewInboxTests {
         let snapshot = evaluate([posted], metadata: [resolvedPosted, pendingOld])
 
         #expect(snapshot.items.contains { $0.id == "posted-new" } == false)
+    }
+
+
+    @Test("Sync-time reconciliation migrates pending review state to posted id")
+    func syncReconciliationMigratesPendingReviewStateToPostedId() {
+        let posted = tx(
+            id: "posted-new",
+            amount: 50,
+            name: "MERCHANT PENDING",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let reviewedPending = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            userCategory: .foodAndDrink,
+            userMerchantName: "Merchant",
+            isTransferOverride: false,
+            reviewedAt: now,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [reviewedPending]
+        )
+
+        #expect(reconciled.map(\.id) == ["posted-new"])
+        #expect(reconciled.first?.status == .reviewed)
+        #expect(reconciled.first?.userCategory == .foodAndDrink)
+        #expect(reconciled.first?.reviewedAt == now)
+        #expect(reconciled.first?.lastSeenAmount == 50)
+        #expect(reconciled.first?.lastSeenPending == false)
+        #expect(evaluate([posted], metadata: reconciled).totalCount == 0)
+    }
+
+    @Test("Sync-time reconciliation durably reopens changed posted charge once")
+    func syncReconciliationReopensChangedPostedChargeOnce() {
+        let posted = tx(
+            id: "posted-new",
+            amount: 58,
+            name: "MERCHANT FINAL",
+            category: .shopping,
+            merchantName: "Merchant",
+            pendingTransactionId: "pending-old"
+        )
+        let reviewedPending = TransactionReviewMetadata(
+            id: "pending-old",
+            status: .reviewed,
+            userCategory: .foodAndDrink,
+            reviewedAt: now,
+            lastSeenAmount: 50,
+            lastSeenName: "MERCHANT PENDING",
+            lastSeenPending: true
+        )
+
+        let reconciled = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: [reviewedPending]
+        )
+        let reopened = evaluate([posted], metadata: reconciled)
+        let item = reopened.items.first { $0.id == "posted-new" }
+
+        #expect(reconciled.map(\.id) == ["posted-new"])
+        #expect(reconciled.first?.status == .needsReview)
+        #expect(reconciled.first?.reviewReasonCodes == [.pendingChanged])
+        #expect(reconciled.first?.reviewedAt == nil)
+        #expect(item?.status == .needsReview)
+        #expect(item?.reasonCodes.contains(.pendingChanged) == true)
+
+        let resolvedMetadata = [TransactionReviewMetadata(
+            id: "posted-new",
+            status: .reviewed,
+            userCategory: .foodAndDrink,
+            reviewedAt: now,
+            reviewReasonCodes: [],
+            lastSeenAmount: 58,
+            lastSeenName: "MERCHANT FINAL",
+            lastSeenPending: false
+        )]
+        let afterResolution = TransactionReviewMetadataReconciler.reconcilePostedPendingTransactions(
+            transactions: [posted],
+            metadata: resolvedMetadata
+        )
+
+        #expect(afterResolution == resolvedMetadata)
+        #expect(evaluate([posted], metadata: afterResolution).items.contains { $0.id == "posted-new" } == false)
     }
 
     @Test("Reviewed and ignored transactions stay out of inbox")


### PR DESCRIPTION
## Summary

- moves posted↔pending transaction review reconciliation from evaluator-time fallback to sync-time metadata migration
- strips Plaid `pending_transaction_id` from the persisted transaction cache while preserving transient server DTO support
- persists changed-posted-charge reopen state via `TransactionReviewMetadata.reviewReasonCodes` so it survives restart and clears after user resolution

Fixes #435
Linear: AND-476
Kanban: `t_98d1bd91`

## Verification

- `git diff --check`
- `swift test --filter TransactionReviewInboxTests` — 20 tests passed
- `swift test --filter transactionCacheDoesNotPersistPendingTransactionIdentifiers` — 1 test passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed
- `swift test --filter PlaidBarCoreTests` — 641 tests passed

## Privacy/security

No Plaid credentials, access tokens, public tokens, account IDs, transaction IDs, balances, raw payloads, prompts, or response bodies were printed or added to docs/tests. The app remains local-first; this change removes a raw Plaid pending transaction identifier from the persisted app transaction cache.
