### PR TITLE
refactor: centralize repo URL in PlaidBarCore constants (AND-468)

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1343,21 +1343,21 @@ struct AboutView: View {
                 supportLink(
                     "Troubleshooting",
                     systemImage: "wrench.and.screwdriver",
-                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/troubleshooting.md",
+                    url: PlaidBarConstants.repositoryFileURL("docs/troubleshooting.md"),
                     detail: "Setup, server, Plaid Link, notifications, and screenshot fixes."
                 )
 
                 supportLink(
                     "Privacy",
                     systemImage: "lock.shield",
-                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md",
+                    url: PlaidBarConstants.repositoryFileURL("docs/privacy.md"),
                     detail: "What stays local, what calls Plaid, and what not to share."
                 )
 
                 supportLink(
                     "Security",
                     systemImage: "exclamationmark.shield",
-                    url: "https://github.com/ftchvs/PlaidBar/blob/main/SECURITY.md",
+                    url: PlaidBarConstants.repositoryFileURL("SECURITY.md"),
                     detail: "Private reporting path for token, credential, or data exposure."
                 )
             }
@@ -1366,21 +1366,21 @@ struct AboutView: View {
                 supportLink(
                     "GitHub Repository",
                     systemImage: "chevron.left.forwardslash.chevron.right",
-                    url: "https://github.com/ftchvs/PlaidBar",
+                    url: PlaidBarConstants.repositoryURL,
                     detail: "Source, issues, and releases (private repository)."
                 )
 
                 supportLink(
                     "1.0 Roadmap",
                     systemImage: "map",
-                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/v1.0-roadmap.md",
+                    url: PlaidBarConstants.repositoryFileURL("docs/v1.0-roadmap.md"),
                     detail: "Product, design, system, security, and release plan."
                 )
 
                 supportLink(
                     "Release Notes",
                     systemImage: "doc.text",
-                    url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/release-notes.md",
+                    url: PlaidBarConstants.repositoryFileURL("docs/release-notes.md"),
                     detail: "Curated release summary for current and upcoming versions."
                 )
             }

--- a/Sources/PlaidBar/Views/ManagedPlanShell.swift
+++ b/Sources/PlaidBar/Views/ManagedPlanShell.swift
@@ -137,7 +137,7 @@ struct InstitutionUsageWidget: View {
         .glassSurface(.inset)
         .alert("Managed plans are coming soon", isPresented: $showUpgradeNote) {
             Button("OK", role: .cancel) {}
-            if let docsURL = URL(string: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md") {
+            if let docsURL = URL(string: PlaidBarConstants.repositoryFileURL("docs/privacy.md")) {
                 Link("Learn more", destination: docsURL)
             }
         } message: {

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -446,19 +446,19 @@ private struct SetupSupportLinks: View {
             supportLink(
                 "Troubleshooting",
                 systemImage: "wrench.and.screwdriver",
-                url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/troubleshooting.md"
+                url: PlaidBarConstants.repositoryFileURL("docs/troubleshooting.md")
             )
 
             supportLink(
                 "Privacy",
                 systemImage: "lock.shield",
-                url: "https://github.com/ftchvs/PlaidBar/blob/main/docs/privacy.md"
+                url: PlaidBarConstants.repositoryFileURL("docs/privacy.md")
             )
 
             supportLink(
                 "Security",
                 systemImage: "exclamationmark.shield",
-                url: "https://github.com/ftchvs/PlaidBar/blob/main/SECURITY.md"
+                url: PlaidBarConstants.repositoryFileURL("SECURITY.md")
             )
         }
         .font(.caption)

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -54,6 +54,16 @@ public enum PlaidBarConstants {
     public static let appVersion: String = "1.0.0"
     public static let appName: String = "VaultPeek"
 
+    // Repository
+    public static let repositoryURL: String = "https://github.com/ftchvs/VaultPeek"
+
+    /// Builds an absolute URL to a file on the default branch of the repository.
+    /// Pass a repo-relative path (e.g. `"docs/privacy.md"`); leading slashes are ignored.
+    public static func repositoryFileURL(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return "\(repositoryURL)/blob/main/\(trimmed)"
+    }
+
     // Plaid
     public static var plaidSandboxRedirectUri: String {
         "http://localhost:\(serverPort)/oauth/callback"

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3476,6 +3476,19 @@ struct PlaidBarCoreTests {
         #expect(PlaidBarConstants.defaultServerHost == "127.0.0.1")
     }
 
+    @Test("Repository URL helper builds VaultPeek doc URLs")
+    func repositoryFileURL() {
+        #expect(PlaidBarConstants.repositoryURL == "https://github.com/ftchvs/VaultPeek")
+        #expect(
+            PlaidBarConstants.repositoryFileURL("docs/privacy.md")
+                == "https://github.com/ftchvs/VaultPeek/blob/main/docs/privacy.md"
+        )
+        #expect(
+            PlaidBarConstants.repositoryFileURL("/SECURITY.md")
+                == "https://github.com/ftchvs/VaultPeek/blob/main/SECURITY.md"
+        )
+    }
+
     @Test("Constants have reasonable values")
     func constantsReasonable() {
         #expect(PlaidBarConstants.backgroundRefreshInterval > 0)

--- a/docs/qa-matrix.md
+++ b/docs/qa-matrix.md
@@ -1,7 +1,7 @@
 # QA Matrix
 
 This matrix defines the minimum 1.0 release candidate checks. It is deliberately
-manual-friendly because PlaidBar crosses macOS UI, local server, Plaid sandbox,
+manual-friendly because VaultPeek crosses macOS UI, local server, Plaid sandbox,
 local storage, notifications, and distribution.
 
 ## Automated Gates


### PR DESCRIPTION
## Summary
Centralized the hard-coded GitHub repo URL into PlaidBarCore. Added `PlaidBarConstants.repositoryURL = "https://github.com/ftchvs/VaultPeek"` plus a `repositoryFileURL(_:)` helper that builds `…/blob/main/<path>` doc URLs (trimming leading/trailing slashes). Rewired all 10 user-clickable link call sites (6 in SettingsView.swift, 3 in SetupView.swift, 1 in ManagedPlanShell.swift) to build their URLs from the constant pointing at the VaultPeek slug, so the rename is now a one-line change. Fixed the stale prose in docs/qa-matrix.md:4 ("PlaidBar crosses" -> "VaultPeek crosses"), leaving the intentional executable/target names on lines 13 and 90 untouched. Did not touch Scripts/release.sh or PLAIDBAR_* env names. Added a Swift Testing test asserting the constant and helper produce the expected VaultPeek URLs (including the leading-slash trim case). New code uses only Foundation/String on a static enum method, so it is Sendable and strict-concurrency clean with no force-unwraps.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift: "Repository URL helper builds VaultPeek doc URLs"

## For the reviewer
None flagged.

## Source
Pre-release audit 2026-06-16 — **AND-468** / #444. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)