### PR TITLE
fix: fail-loud CSPRNG, reject foreign Origin, reconcile status contract (AND-472)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,11 +56,15 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
 - Existing legacy `plaidbar.sqlite` data, SQLite sidecar files, and matching transaction cache are copied into a scoped database only when the legacy environment is explicit (`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from the existing transaction-cache context. Ambiguous legacy databases are left untouched to avoid sandbox/production token crossover. Explicit migration can replace an existing scoped store, backs up the previous scoped SQLite store and transaction cache before copying legacy data, and writes a migration marker so restarts do not reapply stale legacy data.
 - The app/server auth token is generated locally under `~/.vaultpeek/auth-token`
   (or `$PLAIDBAR_DATA_DIR/auth-token`).
-- `/api/status` is authenticated and should expose only readiness metadata:
-  version, environment, credential availability, storage path, linked item
-  count, synced item count, sync readiness, and last sync time. It must not
-  include Plaid secrets, Plaid access tokens, public tokens, auth tokens,
-  account IDs, item IDs, balances, or transaction data.
+- `/api/status` is authenticated and exposes readiness metadata: version,
+  environment, credential availability, storage path, linked item count,
+  synced item count, sync readiness, and last sync time. With the opt-in
+  `?include=items` query parameter it additionally returns the same
+  authenticated item-health snapshot served by `/api/items` — per-item Plaid
+  `item_id`, institution name, connection status, last sync, last webhook, and
+  whether a sync is pending. It must never include Plaid secrets, Plaid access
+  tokens, public tokens, auth tokens, account IDs, balances, or transaction
+  data.
 - Protect your macOS user account, disk encryption, backups, and shell history.
 - App-server communication should preserve local-only assumptions unless a future change explicitly documents otherwise.
 

--- a/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
+++ b/Sources/PlaidBarServer/Auth/APITokenMiddleware.swift
@@ -20,11 +20,65 @@ struct APITokenMiddleware<Context: RequestContext>: RouterMiddleware {
             throw HTTPError(.unauthorized, message: "Missing or invalid authorization token")
         }
 
+        // Defense-in-depth: the native app never sends Origin/Referer, but a
+        // browser always attaches Origin on a cross-origin fetch. Reject any
+        // /api request that carries a non-localhost browser origin so a token
+        // leaked to a web page cannot be replayed from the browser.
+        guard APITokenAuthorization.isAllowedBrowserOrigin(
+            origin: request.headers[.origin],
+            referer: request.headers[.referer]
+        ) else {
+            throw HTTPError(.forbidden, message: "Cross-origin requests are not allowed")
+        }
+
         return try await next(request, context)
     }
 }
 
 enum APITokenAuthorization {
+    /// Loopback hosts a browser may legitimately use to reach the local server.
+    private static let allowedLoopbackHosts: Set<String> = ["127.0.0.1", "localhost", "[::1]"]
+
+    /// Returns `true` when the request carries no browser origin (native app),
+    /// or when both Origin and Referer (when present) resolve to a loopback
+    /// host. Any foreign origin is rejected.
+    static func isAllowedBrowserOrigin(origin: String?, referer: String?) -> Bool {
+        // The native app sends neither header; that is the common, allowed case.
+        if let origin, !isLoopbackOrigin(origin) {
+            return false
+        }
+        if let referer, !isLoopbackOrigin(referer) {
+            return false
+        }
+        return true
+    }
+
+    /// `true` when the header value's host component is a loopback host.
+    /// Parses the host without relying on full URL validation so a malformed
+    /// value fails closed (rejected) rather than slipping through.
+    private static func isLoopbackOrigin(_ value: String) -> Bool {
+        guard let host = host(fromOriginValue: value) else { return false }
+        return allowedLoopbackHosts.contains(host.lowercased())
+    }
+
+    private static func host(fromOriginValue value: String) -> String? {
+        // Strip the scheme (e.g. "http://").
+        guard let schemeRange = value.range(of: "://") else { return nil }
+        let afterScheme = value[schemeRange.upperBound...]
+        // Authority ends at the first path/query/fragment delimiter.
+        let authority = afterScheme.prefix { $0 != "/" && $0 != "?" && $0 != "#" }
+        guard !authority.isEmpty else { return nil }
+        // Drop any userinfo ("user@host").
+        let hostPort = authority.split(separator: "@", maxSplits: 1).last.map(String.init) ?? String(authority)
+        // IPv6 literal: "[::1]" or "[::1]:8484".
+        if hostPort.hasPrefix("[") {
+            guard let closing = hostPort.firstIndex(of: "]") else { return nil }
+            return String(hostPort[...closing])
+        }
+        // Strip the port from "host:port".
+        return hostPort.split(separator: ":", maxSplits: 1).first.map(String.init) ?? hostPort
+    }
+
     static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
         let lhsBytes = Array(lhs.utf8)
         let rhsBytes = Array(rhs.utf8)

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -171,21 +171,24 @@ struct ServerConfig: Sendable {
             .replacingOccurrences(of: "=", with: "")
     }
 
-    private static func generateAuthToken() -> String {
-        authTokenString(randomBytes: secureRandomBytes(count: 32))
+    private static func generateAuthToken() throws -> String {
+        authTokenString(randomBytes: try secureRandomBytes(count: 32))
     }
 
-    private static func secureRandomBytes(count: Int) -> [UInt8] {
+    private static func secureRandomBytes(count: Int) throws -> [UInt8] {
         var bytes = [UInt8](repeating: 0, count: count)
         #if canImport(Security)
-        if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess {
-            return bytes
+        let result = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard result == errSecSuccess else {
+            // Fail loudly rather than silently downgrading to UUID-derived
+            // material: the auth token is the only thing guarding /api, so a
+            // CSPRNG failure must be surfaced, not masked by a weaker fallback.
+            throw ServerConfigError.secureRandomUnavailable(status: result)
         }
+        return bytes
+        #else
+        throw ServerConfigError.secureRandomUnavailable(status: nil)
         #endif
-
-        let fallback = "\(UUID().uuidString)\(UUID().uuidString)"
-            .replacingOccurrences(of: "-", with: "")
-        return Array(fallback.utf8.prefix(count))
     }
 
     private static func loadOrCreateAuthToken(at url: URL) throws -> String {
@@ -200,7 +203,7 @@ struct ServerConfig: Sendable {
             return existing
         }
 
-        let generated = generateAuthToken()
+        let generated = try generateAuthToken()
         try writePrivateTextFile(generated, to: url)
         return generated
     }
@@ -219,7 +222,7 @@ struct ServerConfig: Sendable {
             return existing
         }
 
-        let generated = "vaultpeek-install-\(authTokenString(randomBytes: secureRandomBytes(count: 32)))"
+        let generated = "vaultpeek-install-\(authTokenString(randomBytes: try secureRandomBytes(count: 32)))"
         try writePrivateTextFile(generated, to: url)
         return generated
     }
@@ -892,6 +895,7 @@ enum ServerConfigError: LocalizedError {
     case missingManagedRedirectURI
     case invalidManagedRedirectURI
     case appRedirectRequiresHTTPS
+    case secureRandomUnavailable(status: Int32?)
 
     var errorDescription: String? {
         switch self {
@@ -909,6 +913,12 @@ enum ServerConfigError: LocalizedError {
             "Managed production Hosted Link redirect URI must be configured as HTTPS"
         case .appRedirectRequiresHTTPS:
             "App or Universal Link OAuth redirect mode requires an HTTPS Universal Link callback"
+        case .secureRandomUnavailable(let status):
+            if let status {
+                "Secure random generation failed (OSStatus \(status)); refusing to fall back to weaker auth-token material"
+            } else {
+                "Secure random generation is unavailable on this platform; refusing to fall back to weaker auth-token material"
+            }
         }
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -964,6 +964,85 @@ struct PlaidBarServerTests {
         #expect(response.status == .ok)
     }
 
+    @Test func apiMiddlewareRejectsForeignBrowserOrigin() async throws {
+        let middleware = APITokenMiddleware<TestRequestContext>(authToken: "local-token")
+        let context = TestRequestContext(source: TestRequestContextSource())
+
+        for request in [
+            Self.makeRequest(
+                path: "/api/status",
+                authorization: "Bearer local-token",
+                origin: "https://evil.example.com"
+            ),
+            Self.makeRequest(
+                path: "/api/status",
+                authorization: "Bearer local-token",
+                referer: "https://evil.example.com/page"
+            ),
+            Self.makeRequest(
+                path: "/api/status",
+                authorization: "Bearer local-token",
+                origin: "null"
+            ),
+        ] {
+            do {
+                _ = try await middleware.handle(request, context: context) { _, _ in
+                    Response(status: .ok)
+                }
+                #expect(Bool(false), "Expected cross-origin API request to throw")
+            } catch let error as HTTPError {
+                #expect(error.status == .forbidden)
+                #expect(error.body == "Cross-origin requests are not allowed")
+            } catch {
+                #expect(Bool(false), "Expected HTTPError, got \(error)")
+            }
+        }
+    }
+
+    @Test func apiMiddlewareAllowsNativeAppAndLoopbackOrigins() async throws {
+        let middleware = APITokenMiddleware<TestRequestContext>(authToken: "local-token")
+        let context = TestRequestContext(source: TestRequestContextSource())
+
+        for request in [
+            // Native app: no Origin or Referer header.
+            Self.makeRequest(path: "/api/status", authorization: "Bearer local-token"),
+            // Loopback origins are allowed in case a local tool calls the API.
+            Self.makeRequest(
+                path: "/api/status",
+                authorization: "Bearer local-token",
+                origin: "http://127.0.0.1:8484"
+            ),
+            Self.makeRequest(
+                path: "/api/status",
+                authorization: "Bearer local-token",
+                origin: "http://localhost:8484",
+                referer: "http://localhost:8484/index.html"
+            ),
+        ] {
+            let response = try await middleware.handle(request, context: context) { _, _ in
+                Response(status: .ok)
+            }
+            #expect(response.status == .ok)
+        }
+    }
+
+    @Test func apiOriginAllowlistClassifiesHosts() {
+        // Native app sends neither header.
+        #expect(APITokenAuthorization.isAllowedBrowserOrigin(origin: nil, referer: nil))
+        // Loopback hosts (with and without ports) are allowed.
+        #expect(APITokenAuthorization.isAllowedBrowserOrigin(origin: "http://127.0.0.1:8484", referer: nil))
+        #expect(APITokenAuthorization.isAllowedBrowserOrigin(origin: "http://localhost", referer: nil))
+        #expect(APITokenAuthorization.isAllowedBrowserOrigin(origin: "http://[::1]:8484", referer: nil))
+        // Foreign origins are rejected.
+        #expect(!APITokenAuthorization.isAllowedBrowserOrigin(origin: "https://evil.example.com", referer: nil))
+        #expect(!APITokenAuthorization.isAllowedBrowserOrigin(origin: nil, referer: "https://evil.example.com/p"))
+        // Malformed values fail closed.
+        #expect(!APITokenAuthorization.isAllowedBrowserOrigin(origin: "null", referer: nil))
+        #expect(!APITokenAuthorization.isAllowedBrowserOrigin(origin: "127.0.0.1", referer: nil))
+        // Lookalike hosts that merely contain a loopback substring are rejected.
+        #expect(!APITokenAuthorization.isAllowedBrowserOrigin(origin: "http://localhost.evil.com", referer: nil))
+    }
+
     @Test func oauthCallbackErrorPageEscapesDynamicMessage() {
         let html = OAuthCallbackRoute.errorPage("<script>alert('x')</script> & retry \"soon\"")
 
@@ -972,10 +1051,21 @@ struct PlaidBarServerTests {
         #expect(html.contains("&amp; retry &quot;soon&quot;"))
     }
 
-    private static func makeRequest(path: String, authorization: String? = nil) -> Request {
+    private static func makeRequest(
+        path: String,
+        authorization: String? = nil,
+        origin: String? = nil,
+        referer: String? = nil
+    ) -> Request {
         var headers = HTTPFields()
         if let authorization {
             headers[.authorization] = authorization
+        }
+        if let origin {
+            headers[.origin] = origin
+        }
+        if let referer {
+            headers[.referer] = referer
         }
         return Request(
             head: HTTPRequest(method: .get, scheme: nil, authority: nil, path: path, headerFields: headers),

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -101,11 +101,14 @@ Current local data may include:
 
 Sandbox and production use separate scoped stores.
 
-`/api/status` is authenticated and intentionally limited to readiness metadata:
-server version, Plaid environment, credential availability, storage path, item
-counts, synced item count, sync readiness, and last sync time. It should not
-contain Plaid secrets, Plaid access tokens, public tokens, local auth tokens,
-account IDs, item IDs, balances, or transactions.
+`/api/status` is authenticated and limited to readiness metadata: server
+version, Plaid environment, credential availability, storage path, item counts,
+synced item count, sync readiness, and last sync time. When the caller opts in
+with `?include=items`, it also returns the same authenticated item-health
+snapshot as `/api/items` — per-item Plaid `item_id`, institution name,
+connection status, last sync, last webhook, and whether a sync is pending. It
+should not contain Plaid secrets, Plaid access tokens, public tokens, local
+auth tokens, account IDs, balances, or transactions.
 
 ## Credentials
 


### PR DESCRIPTION
## Summary
Security defense-in-depth plus status-contract doc reconciliation. (#17) ServerConfig secureRandomBytes/generateAuthToken now throw a new ServerConfigError.secureRandomUnavailable on CSPRNG failure instead of silently downgrading to UUID material; both call sites (auth token, link client user id) were already throws and now propagate it, and the happy path is unchanged. (#18) APITokenMiddleware adds a cheap origin check after the constant-time bearer check: any /api request whose Origin or Referer resolves to a non-loopback host gets 403; native app (no headers) and loopback origins pass. (#19) SECURITY.md and docs/privacy.md now document that /api/status?include=items and /api/items expose authenticated, opt-in item-health metadata (item_id, institution name, status, last sync/webhook, pending flag), matching the code and ServerStatus doc-comment, while keeping the no-tokens/no-account-IDs/no-balances/no-transactions guarantees intact.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: PlaidBarServerTests.apiMiddlewareRejectsForeignBrowserOrigin; PlaidBarServerTests.apiMiddlewareAllowsNativeAppAndLoopbackOrigins; PlaidBarServerTests.apiOriginAllowlistClassifiesHosts; PlaidBarServerTests.makeRequest (helper extended with origin/referer params)

## For the reviewer
- #17: No Swift Testing test added for the secureRandomUnavailable throw path. secureRandomBytes is private static and unreachable on the macOS-only build (canImport(Security) is always true on macos-15 CI), so the throw is effectively defensive/dead on the supported platform and cannot be exercised without making the function internal or injecting a failing RNG. Left the API surface unchanged to keep the diff minimal; flagging in case a testability seam is desired.
- #18: The origin allowlist permits any loopback host (127.0.0.1/localhost/[::1]) on any port, not strictly the configured server port. This is intentional so a local dev tool on a different loopback port still works, but if a stricter same-port-only policy is wanted that is a product decision.

## Source
Pre-release audit 2026-06-16 — **AND-472** / #448. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)