### PR TITLE
fix: surface swallowed errors (server spawn, glance write, webhook dup) (AND-470)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1,12 +1,20 @@
 import SwiftUI
 import PlaidBarCore
 import Combine
+import OSLog
 import WidgetKit
 @preconcurrency import UserNotifications
 
 @Observable
 @MainActor
 final class AppState {
+    /// Used off the main actor inside the glance-snapshot write task; a
+    /// `Logger` is `Sendable`, so it is safe to reference there.
+    nonisolated static let glanceSnapshotLogger = Logger(
+        subsystem: "com.ftchvs.PlaidBar",
+        category: "GlanceSnapshot"
+    )
+
     // MARK: - UserDefaults Keys
     private enum Keys {
         static let showBalanceInMenuBar = "showBalanceInMenuBar"
@@ -2662,7 +2670,20 @@ final class AppState {
         Task { [snapshot, debouncer, generation] in
             guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }
             await debouncer.schedule(snapshot) { snapshot in
-                guard (try? GlanceSnapshotStore.saveIfChanged(snapshot)) == true else { return }
+                let changed: Bool
+                do {
+                    changed = try GlanceSnapshotStore.saveIfChanged(snapshot)
+                } catch {
+                    // A genuine write failure was previously indistinguishable
+                    // from the "no change" skip below. Surface it (no balance
+                    // material is logged) so a stuck widget snapshot is
+                    // diagnosable; otherwise behave as before and skip.
+                    AppState.glanceSnapshotLogger.error(
+                        "Failed to write glance snapshot: \(String(describing: error), privacy: .public)"
+                    )
+                    return
+                }
+                guard changed else { return }
                 await MainActor.run {
                     WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
                 }

--- a/Sources/PlaidBar/Services/ServerProcessService.swift
+++ b/Sources/PlaidBar/Services/ServerProcessService.swift
@@ -74,6 +74,16 @@ final class ServerProcessService {
         do {
             try process.run()
         } catch {
+            // A failed spawn is otherwise indistinguishable from "no server
+            // was started"; record the cause in the already-open server log so
+            // it is diagnosable. The message carries no credentials.
+            if let logHandle {
+                let line = "VaultPeek: failed to launch bundled server at " +
+                    "\(plan.executablePath): \(String(describing: error))\n"
+                if let data = line.data(using: .utf8) {
+                    try? logHandle.write(contentsOf: data)
+                }
+            }
             return false
         }
 

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -128,8 +128,13 @@ actor TokenStore {
         do {
             try PlaidTokenVault.delete(storedToken: item.accessToken, fallbackItemId: id)
         } catch {
+            // Best-effort: the SQLite item/cursor rows are already gone, so a
+            // Keychain-delete failure leaves only an orphaned token entry
+            // (reclaimed later by `pruneOrphanedKeychainTokens`). Log enough to
+            // diagnose — the item id is an opaque identifier, never token
+            // material — without aborting the delete.
             logger.warning(
-                "Failed to delete Plaid access token from Keychain: \(String(describing: error))"
+                "Failed to delete Plaid access token from Keychain for item \(id): \(String(describing: error))"
             )
         }
     }

--- a/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
+++ b/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
@@ -119,7 +119,20 @@ actor WebhookEventStore {
             eventAt: signal.eventAt,
             receivedAt: signal.receivedAt
         )
-        try await model.save(on: fluent.db())
+        do {
+            try await model.save(on: fluent.db())
+        } catch {
+            // The find-then-save above is not atomic: two concurrent deliveries
+            // of the same webhook can both pass the existence check and race to
+            // insert, so one save hits the `idempotency_hash` unique constraint.
+            // Re-check existence — if the row is now present, the other writer
+            // won and this delivery is a duplicate (idempotent). Otherwise the
+            // failure is unrelated and must propagate.
+            if try await WebhookEventModel.find(signal.idempotencyHash, on: fluent.db()) != nil {
+                return WebhookStoreResult(disposition: .duplicate)
+            }
+            throw error
+        }
         return WebhookStoreResult(disposition: isOutOfOrder ? .outOfOrder : .stored)
     }
 

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -252,6 +252,43 @@ struct WebhookReceiverTests {
         }
     }
 
+    @Test("Concurrent duplicate record returns .duplicate instead of throwing a unique-constraint error")
+    func concurrentDuplicateRecordIsIdempotent() async throws {
+        try await Self.withStores { _, eventStore in
+            // Both deliveries share an idempotency hash, so the find-then-save in
+            // `record` races: one save wins, the other hits the unique
+            // constraint. The store must translate that into `.duplicate`, never
+            // surface the throw.
+            let hash = "concurrent-\(UUID().uuidString)"
+            func makeSignal() -> WebhookItemSignal {
+                WebhookItemSignal(
+                    itemId: "item-webhook",
+                    webhookType: "TRANSACTIONS",
+                    webhookCode: "SYNC_UPDATES_AVAILABLE",
+                    requestId: "request-concurrent",
+                    idempotencyHash: hash,
+                    eventAt: Date(timeIntervalSince1970: 1_800_000_000),
+                    receivedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                    needsSync: true
+                )
+            }
+
+            async let first = eventStore.record(makeSignal())
+            async let second = eventStore.record(makeSignal())
+            let results = try await [first, second]
+
+            // Neither call threw; the pair is one persisted write and one
+            // duplicate (order is nondeterministic).
+            #expect(results.contains { $0.disposition == .duplicate })
+            #expect(results.filter { $0.disposition == .stored }.count <= 1)
+            #expect(results.allSatisfy { $0.disposition != .outOfOrder })
+
+            // Exactly one row exists for the shared hash.
+            let stored = try await eventStore.latestEvent(itemId: "item-webhook")
+            #expect(stored?.idempotencyHash == hash)
+        }
+    }
+
     private static func withStores(
         _ body: (TokenStore, WebhookEventStore) async throws -> Void
     ) async throws {


### PR DESCRIPTION
## Summary
Silent-failure hardening: surfaced four swallowed errors without changing happy-path behavior. (#15) ServerProcessService now writes the thrown spawn error to the already-open private server log before returning false, so a failed launch is diagnosable vs merely-absent. (#21) AppState's glance-snapshot write now distinguishes a real write throw (logged via os.Logger, no balance material) from the normal "no change" skip, instead of collapsing both with try?==true. (#22) WebhookEventStore.record catches a save failure and re-checks existence: a concurrent-duplicate unique-constraint loss is translated to .duplicate (idempotent), other failures still propagate; added a Swift Testing test that two concurrent records of the same idempotency hash both return without throwing (one stored, one duplicate). (#20) TokenStore.deleteItem now logs the opaque item id alongside the Keychain-delete failure (no token material), behavior otherwise unchanged. All changes are additive logging/error-mapping.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: concurrentDuplicateRecordIsIdempotent

## For the reviewer
- #16 partial-refresh banner: deferred. The issue gave no file:line and there is no existing partial-failure/banner state in RefreshService/SyncService/AppState to extend. Adding a banner is a UI/product change (presentation, partial-failure state modeling, and the accessibility rule against color-alone signaling) rather than an additive logging fix, so it was left untouched to keep the diff scoped and avoid a happy-path change. Needs a product decision on where/how partial-refresh failure should surface before implementing.
- #22 translation strategy: rather than coupling to a specific SQLite/Fluent error type (the server depends on FluentSQLiteDriver but not SQLiteNIO directly), the fix catches any save error and re-checks existence to confirm the duplicate. This is driver-agnostic and idempotent, but it will also classify a save failure as .duplicate if some unrelated path concurrently inserted the same idempotency hash. Given the hash is a unique fingerprint that is the primary key, that scenario is effectively the duplicate case, so this is intended; flagging in case a stricter SQLiteError-code match is preferred.
- The concurrent-duplicate test relies on actor interleaving at await points to exercise the find-then-save race; if SQLite serializes the two records fully (one completes before the other's find), the test still passes via the early find-based .duplicate path. Either path validates the observable contract (no throw, exactly one stored), so the test is correct but not guaranteed to hit the catch branch on every run/platform.

## Source
Pre-release audit 2026-06-16 — **AND-470** / #446. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)