### PR TITLE
fix: reconcile pending->posted transactions by pending_transaction_id (AND-465)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/TransactionSyncReducer.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionSyncReducer.swift
@@ -15,14 +15,25 @@ public enum TransactionSyncReducer {
             transactionsById[transaction.id] = transaction
         }
 
-        for transaction in response.added + response.modified {
+        let incoming = response.added + response.modified
+        for transaction in incoming {
             if transactionsById[transaction.id] == nil {
                 orderedIds.append(transaction.id)
             }
             transactionsById[transaction.id] = transaction
         }
 
-        let removedIds = Set(response.removed)
+        var removedIds = Set(response.removed)
+
+        // Reconcile pending -> posted: when a posted transaction carries the id of the
+        // pending transaction it supersedes, drop that pending row even if Plaid omits
+        // the explicit `removed` entry. Otherwise the pending and posted rows double-count.
+        for transaction in incoming where !transaction.pending {
+            if let pendingId = transaction.pendingTransactionId, pendingId != transaction.id {
+                removedIds.insert(pendingId)
+            }
+        }
+
         if !removedIds.isEmpty {
             orderedIds.removeAll { removedIds.contains($0) }
             for id in removedIds {

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1292,6 +1292,36 @@ struct PlaidBarCoreTests {
         #expect(transactions.first { $0.id == "new" }?.amount == 50)
     }
 
+    @Test("Transaction sync reducer collapses pending into posted via pendingTransactionId")
+    func transactionSyncReducerReconcilesPendingToPosted() {
+        let existing = [
+            TransactionDTO(id: "pending-1", accountId: "a", amount: 42, date: "2026-01-05", name: "Coffee", pending: true)
+        ]
+        // Plaid posts the transaction under a new id but omits the explicit `removed` entry.
+        let response = SyncResponse(
+            added: [
+                TransactionDTO(
+                    id: "posted-1",
+                    accountId: "a",
+                    amount: 42,
+                    date: "2026-01-05",
+                    name: "Coffee",
+                    pending: false,
+                    pendingTransactionId: "pending-1"
+                )
+            ],
+            modified: [],
+            removed: [],
+            hasMore: false
+        )
+
+        let transactions = TransactionSyncReducer.applying(response, to: existing)
+
+        #expect(transactions.map(\.id) == ["posted-1"])
+        #expect(transactions.first?.pending == false)
+        #expect(transactions.contains { $0.id == "pending-1" } == false)
+    }
+
     @Test("Transaction sync batch applies multi-page changes without duplicates or lost updates")
     func transactionSyncBatchAppliesMultiPageChanges() {
         let existing = [

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1195,6 +1195,7 @@ struct PlaidBarServerTests {
                     name: transactionId,
                     merchantName: nil,
                     pending: false,
+                    pendingTransactionId: nil,
                     isoCurrencyCode: "USD",
                     personalFinanceCategory: nil
                 ),


### PR DESCRIPTION
## Summary
Fixed pending->posted transaction double-counting when Plaid omits the explicit 'removed' entry. Added a pendingTransactionId field threaded from Plaid's pending_transaction_id: PlaidTransaction (server, auto-decoded via the client's .convertFromSnakeCase strategy) -> TransactionRoutes.toDTO -> TransactionDTO (PlaidBarCore). In TransactionSyncReducer.applying, after upserting added+modified rows, any incoming posted (pending==false) row that carries a pendingTransactionId now causes the superseded pending row to be dropped (added to the removed set), so pending and posted collapse to one row even without an explicit removed entry. A guard (pendingId != transaction.id) avoids removing the posted row itself. The new TransactionDTO field is optional and defaults to nil, keeping the public init and Codable backward-compatible (legacy cached JSON decodes to nil).

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: PlaidBarCoreTests: added "Transaction sync reducer collapses pending into posted via pendingTransactionId" (transactionSyncReducerReconcilesPendingToPosted) - a pending row plus a posted row carrying that pendingTransactionId with an empty removed array must collapse to one row; PlaidBarServerTests: updated the PlaidTransaction memberwise-init fixture (~line 1100) to pass pendingTransactionId: nil so the synthesized init keeps compiling

## For the reviewer
None flagged.

## Source
Pre-release audit 2026-06-16 — **AND-465** / #441. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)