### PR TITLE
perf: cache menu-bar presentations and remove O(n^2) inbox scan (AND-463)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -50,11 +50,17 @@ final class AppState {
         didSet {
             _cachedTransactionDerivedIndex = nil
             _cachedRecurringTransactions = nil
+            _cachedCategoryBudgetPresentation = nil
+            _cachedTransactionReviewInboxSnapshot = nil
             invalidateLocalAIActivitySummaries()
         }
     }
-    var transactionReviewMetadata: [TransactionReviewMetadata] = []
-    var transactionRules: [TransactionRule] = []
+    var transactionReviewMetadata: [TransactionReviewMetadata] = [] {
+        didSet { _cachedTransactionReviewInboxSnapshot = nil }
+    }
+    var transactionRules: [TransactionRule] = [] {
+        didSet { _cachedTransactionReviewInboxSnapshot = nil }
+    }
     var hasLoadedTransactionReviewStorage = false
     var isLoading = false
     /// True from launch until the first `loadInitialData()` pass completes.
@@ -115,7 +121,9 @@ final class AppState {
     /// User-set category budget limits hydrated from `/api/budgets`.
     /// Suggestions remain a local fallback/complement, but this cache wins for
     /// categories the user explicitly saved on the server.
-    var categoryBudgets: [SpendingCategory: Double] = [:]
+    var categoryBudgets: [SpendingCategory: Double] = [:] {
+        didSet { _cachedCategoryBudgetPresentation = nil }
+    }
     var isDemoMode = false
     var isDemoStatusRecoveryScenario = false
     var lastSyncDate: Date?
@@ -888,7 +896,20 @@ final class AppState {
         )
     }
 
+    /// Cached category budget presentation — invalidated via transactions.didSet
+    /// and categoryBudgets.didSet. Recomputed full-scan on every read otherwise,
+    /// which `MenuBarLabel.body` triggers repeatedly through the weekly-review
+    /// and menu-bar accessors.
+    private var _cachedCategoryBudgetPresentation: CategoryBudgetPresentation?
+
     var categoryBudgetPresentation: CategoryBudgetPresentation {
+        if let cached = _cachedCategoryBudgetPresentation { return cached }
+        let presentation = computeCategoryBudgetPresentation()
+        _cachedCategoryBudgetPresentation = presentation
+        return presentation
+    }
+
+    private func computeCategoryBudgetPresentation() -> CategoryBudgetPresentation {
         let now = Date()
         let suggestedBudgets = CategoryBudgetPlanner.suggestedBudgets(
             from: transactions,
@@ -986,14 +1007,25 @@ final class AppState {
         return defaults.double(forKey: Keys.weeklyReviewPreviousSafeToSpend)
     }
 
+    /// Cached review inbox snapshot — invalidated via transactions.didSet,
+    /// transactionReviewMetadata.didSet, and transactionRules.didSet. The
+    /// underlying scan is O(n) (peer aggregates are precomputed once in
+    /// `TransactionReviewInbox.evaluate`), but `MenuBarLabel.body` reads
+    /// `transactionReviewCount` from several accessors per render, so memoizing
+    /// avoids re-running the whole scan multiple times for one frame.
+    private var _cachedTransactionReviewInboxSnapshot: TransactionReviewInboxSnapshot?
+
     var transactionReviewInboxSnapshot: TransactionReviewInboxSnapshot {
-        TransactionReviewInbox.evaluate(
+        if let cached = _cachedTransactionReviewInboxSnapshot { return cached }
+        let snapshot = TransactionReviewInbox.evaluate(
             transactions: transactions,
             metadata: transactionReviewMetadata,
             rules: transactionRules,
             recurring: recurringTransactions,
             now: Date()
         )
+        _cachedTransactionReviewInboxSnapshot = snapshot
+        return snapshot
     }
 
     var transactionReviewCount: Int {

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -181,6 +181,11 @@ public enum TransactionReviewInbox {
         let spendTransactions = transactions.filter { !$0.isIncome }
         let recurringByMerchant = Dictionary(grouping: recurring, by: { normalizedKey($0.merchantName) })
 
+        // Precompute per-merchant and per-category spend aggregates once so the
+        // unusual-amount check is O(1) per transaction instead of re-scanning
+        // every spend transaction per row (which made the inbox O(n^2)).
+        let unusualPeerIndex = UnusualSpendPeerIndex(spendTransactions: spendTransactions)
+
         let items = transactions.compactMap { transaction -> TransactionReviewItem? in
             let metadata = metadataById[transaction.id]
             let isAlreadyResolved = metadata?.status == .reviewed || metadata?.status == .ignored
@@ -206,7 +211,7 @@ public enum TransactionReviewInbox {
                 merchantCounts[normalizedMerchantKey(transaction), default: 0] == 1 {
                 reasons.insert(.newMerchant)
             }
-            if isUnusual(transaction, in: spendTransactions, category: effectiveCategory) {
+            if isUnusual(transaction, peers: unusualPeerIndex, category: effectiveCategory) {
                 reasons.insert(.unusualAmount)
             }
             if looksLikeTransfer(transaction), !isTransfer {
@@ -281,24 +286,80 @@ public enum TransactionReviewInbox {
 
     private static func isUnusual(
         _ transaction: TransactionDTO,
-        in transactions: [TransactionDTO],
+        peers index: UnusualSpendPeerIndex,
         category: SpendingCategory?
     ) -> Bool {
         guard transaction.amount > 0 else { return false }
         let merchantKey = normalizedMerchantKey(transaction)
-        var peers = transactions.filter {
-            $0.id != transaction.id &&
-                normalizedMerchantKey($0) == merchantKey &&
-                abs($0.amount) > 0
-        }
+        var peers = index.merchantPeers(excluding: transaction, merchantKey: merchantKey)
         if peers.count < 3, let category {
-            peers = transactions.filter {
-                $0.id != transaction.id && $0.category == category && abs($0.amount) > 0
-            }
+            peers = index.categoryPeers(excluding: transaction, category: category)
         }
         guard peers.count >= 3 else { return false }
-        let average = peers.map { abs($0.amount) }.reduce(0, +) / Double(peers.count)
+        let average = peers.sum / Double(peers.count)
         return transaction.displayAmount >= max(average * 1.75, average + 50)
+    }
+
+    /// Precomputed spend aggregates so `isUnusual` can resolve a transaction's
+    /// peer set in O(1) instead of filtering every spend transaction per row.
+    ///
+    /// Aggregates are built over spend transactions with `abs(amount) > 0`,
+    /// grouped by normalized merchant key and by raw category — matching the
+    /// two filters the original per-row scan used. Because the current
+    /// transaction is itself part of these aggregates when it qualifies, each
+    /// lookup subtracts its own contribution, reproducing the `id != self`
+    /// exclusion exactly.
+    private struct UnusualSpendPeerIndex {
+        struct Peers {
+            let count: Int
+            let sum: Double
+        }
+
+        private struct Aggregate {
+            var count = 0
+            var sum = 0.0
+
+            mutating func add(_ magnitude: Double) {
+                count += 1
+                sum += magnitude
+            }
+
+            /// Peers seen by another transaction, excluding its own contribution
+            /// when it is part of this aggregate.
+            func excluding(magnitude: Double, present: Bool) -> Peers {
+                guard present else { return Peers(count: count, sum: sum) }
+                return Peers(count: count - 1, sum: sum - magnitude)
+            }
+        }
+
+        private var byMerchantKey: [String: Aggregate] = [:]
+        private var byCategory: [SpendingCategory: Aggregate] = [:]
+
+        init(spendTransactions: [TransactionDTO]) {
+            for transaction in spendTransactions where abs(transaction.amount) > 0 {
+                let magnitude = abs(transaction.amount)
+                let merchantKey = TransactionReviewInbox.normalizedMerchantKey(transaction)
+                byMerchantKey[merchantKey, default: Aggregate()].add(magnitude)
+                if let category = transaction.category {
+                    byCategory[category, default: Aggregate()].add(magnitude)
+                }
+            }
+        }
+
+        func merchantPeers(excluding transaction: TransactionDTO, merchantKey: String) -> Peers {
+            let aggregate = byMerchantKey[merchantKey] ?? Aggregate()
+            // The current transaction is in this aggregate when it is a qualifying
+            // spend (amount > 0 implies non-income and abs > 0), so remove itself.
+            return aggregate.excluding(magnitude: abs(transaction.amount), present: transaction.amount > 0)
+        }
+
+        func categoryPeers(excluding transaction: TransactionDTO, category: SpendingCategory) -> Peers {
+            let aggregate = byCategory[category] ?? Aggregate()
+            // Aggregates key on the raw category, so the current transaction is in
+            // this bucket only when its own category equals the lookup category.
+            let isSelfInBucket = transaction.amount > 0 && transaction.category == category
+            return aggregate.excluding(magnitude: abs(transaction.amount), present: isSelfInBucket)
+        }
     }
 
     private static func looksLikeTransfer(_ transaction: TransactionDTO) -> Bool {

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -226,6 +226,102 @@ struct TransactionReviewInboxTests {
         #expect(try LocalDataStore.loadTransactionRules(from: directory).isEmpty)
     }
 
+    @Test("Cached peer aggregates match the per-row scan on a mixed fixture")
+    func unusualAmountMatchesBruteForceScan() {
+        let transactions = unusualFixture()
+
+        let snapshot = evaluate(transactions)
+        let optimized = Set(
+            snapshot.items
+                .filter { $0.reasonCodes.contains(.unusualAmount) }
+                .map(\.id)
+        )
+
+        // `.unusualAmount` is high priority, so any transaction the heuristic
+        // flags surfaces an item carrying that reason — no suppression hides it.
+        // Comparing against a frozen brute-force replica of the original
+        // per-row scan proves the O(1) aggregate lookup is semantics-preserving.
+        let bruteForce = Set(
+            transactions
+                .filter { referenceIsUnusual($0, in: transactions) }
+                .map(\.id)
+        )
+
+        #expect(optimized == bruteForce)
+        // Guard the fixture itself stays meaningful: it must exercise both the
+        // flagged and unflagged paths so the equivalence check is not vacuous.
+        #expect(!bruteForce.isEmpty)
+        #expect(bruteForce.count < transactions.count)
+    }
+
+    /// Frozen replica of the original O(n^2) `isUnusual` decision, used only as
+    /// a test oracle for the cached-aggregate implementation.
+    private func referenceIsUnusual(
+        _ transaction: TransactionDTO,
+        in allTransactions: [TransactionDTO]
+    ) -> Bool {
+        guard transaction.amount > 0 else { return false }
+        let spend = allTransactions.filter { !$0.isIncome }
+        let category = transaction.category
+        let merchantKey = (transaction.merchantName ?? transaction.name)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        var peers = spend.filter {
+            let key = ($0.merchantName ?? $0.name)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            return $0.id != transaction.id && key == merchantKey && abs($0.amount) > 0
+        }
+        if peers.count < 3, let category {
+            peers = spend.filter {
+                $0.id != transaction.id && $0.category == category && abs($0.amount) > 0
+            }
+        }
+        guard peers.count >= 3 else { return false }
+        let average = peers.map { abs($0.amount) }.reduce(0, +) / Double(peers.count)
+        return transaction.displayAmount >= max(average * 1.75, average + 50)
+    }
+
+    private func unusualFixture() -> [TransactionDTO] {
+        var fixture: [TransactionDTO] = []
+
+        // Stable same-merchant cluster plus a spike (merchant-peer path).
+        fixture += [
+            tx(id: "coffee-1", amount: 20, date: "2026-05-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "coffee-2", amount: 22, date: "2026-05-08", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "coffee-3", amount: 21, date: "2026-05-15", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "coffee-spike", amount: 120, date: "2026-06-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+        ]
+
+        // Distinct merchants sharing a category force the category-fallback path
+        // (each merchant has < 3 peers on its own).
+        fixture += [
+            tx(id: "shop-a", amount: 30, date: "2026-05-02", category: .shopping, merchantName: "Store A"),
+            tx(id: "shop-b", amount: 35, date: "2026-05-09", category: .shopping, merchantName: "Store B"),
+            tx(id: "shop-c", amount: 28, date: "2026-05-16", category: .shopping, merchantName: "Store C"),
+            tx(id: "shop-spike", amount: 400, date: "2026-06-02", category: .shopping, merchantName: "Store D"),
+        ]
+
+        // A near-threshold charge that must NOT trip the heuristic.
+        fixture += [
+            tx(id: "gym-1", amount: 50, date: "2026-05-03", category: .entertainment, merchantName: "Gym"),
+            tx(id: "gym-2", amount: 50, date: "2026-05-10", category: .entertainment, merchantName: "Gym"),
+            tx(id: "gym-3", amount: 50, date: "2026-05-17", category: .entertainment, merchantName: "Gym"),
+            tx(id: "gym-normal", amount: 60, date: "2026-06-03", category: .entertainment, merchantName: "Gym"),
+        ]
+
+        // Income rows (negative amount) that the spend filter must drop entirely.
+        fixture += [
+            tx(id: "paycheck-1", amount: -2_000, date: "2026-05-15", category: .other, merchantName: "Employer"),
+            tx(id: "paycheck-2", amount: -2_000, date: "2026-06-15", category: .other, merchantName: "Employer"),
+        ]
+
+        // Lone transaction with no peers — never unusual.
+        fixture.append(tx(id: "solo", amount: 75, date: "2026-06-04", category: .travel, merchantName: "One Off"))
+
+        return fixture
+    }
+
     private func evaluate(
         _ transactions: [TransactionDTO],
         metadata: [TransactionReviewMetadata] = [],


### PR DESCRIPTION
## Summary
Killed the O(n^2) review-inbox scan and the repeated per-render full-transaction recomputes. In TransactionReview.swift, TransactionReviewInbox.evaluate now builds a single UnusualSpendPeerIndex (per-merchant and per-category count+sum aggregates over spend transactions) up front, and isUnusual does O(1) lookups instead of two .filter scans per row. Exact output semantics are preserved by subtracting the current transaction's own contribution to reproduce the original id != self exclusion, including the subtlety that the category fallback keys on the raw category while the lookup uses the effective category. In AppState.swift, categoryBudgetPresentation and transactionReviewInboxSnapshot are now memoized with the existing didSet-invalidation pattern (transactions/categoryBudgets for the budget cache; transactions/transactionReviewMetadata/transactionRules for the inbox cache), so MenuBarLabel.body no longer re-runs those scans multiple times per frame. weeklyReviewPresentation was deliberately left uncached (see open questions) but now benefits indirectly because it already routes through the now-memoized categoryBudgetPresentation and recurringTransactions. Added a Swift Testing test asserting the cached-aggregate unusual-amount decision is byte-for-byte identical to a frozen brute-force replica of the original scan on a mixed fixture exercising both the merchant-peer and category-fallback paths.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: unusualAmountMatchesBruteForceScan

## For the reviewer
- weeklyReviewPresentation was NOT given its own cache. Its inputs span ~15 fields (accounts, transactions, weeklyReviewState, transactionReviewMetadata, hasLoadedTransactionReviewStorage, isDemoMode, categoryBudgets, itemStatuses, serverConnected, serverCredentialsConfigured, serverItemCount, serverSyncedItemCount, lastSyncDate, error, creditUtilizationThreshold, balanceHistory, isBooting, refreshInterval) plus Date()/isSyncStale which is purely time-derived. Most of those have no didSet and are assigned at many scattered sites with no choke point, so a didSet-invalidated cache would be fragile and risk staleness (e.g. a sync going stale by elapsed time would never refresh until some unrelated field mutated). Left uncached per the smallest-correct-change rule; it now reuses the two newly memoized vars so its per-access cost is already much lower. Caching it safely likely needs a small data-version token bumped at the central status-refresh choke point plus an explicit time-bucket key, which is a follow-up.
- Caching transactionReviewInboxSnapshot means the recurringChanged/isStale(asOf: now) signal no longer re-evaluates on elapsed time alone; it refreshes when transactions/metadata/rules change (i.e. on each sync). This matches the pre-existing _cachedRecurringTransactions tradeoff and is consistent with the codebase's memoization philosophy, but confirm it is acceptable that a charge crossing the recurring-stale time boundary between syncs is reflected only after the next data mutation.
- Floating-point note: the aggregate path sums all qualifying spend then subtracts the current row's magnitude, vs the original which summed only the peer subset. Differences are ~1e-13 relative and far below the max(avg*1.75, avg+50) threshold for realistic dollar amounts, so no boundary flip is expected; the equivalence test passes on the fixture, but a pathological near-threshold dataset is theoretically distinguishable.

## Source
Pre-release audit 2026-06-16 — **AND-463** / #439. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)