### PR TITLE
fix: stop weekly-review Inspect Category rendering a fake error (AND-466)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1837,7 +1837,11 @@ final class AppState {
             // to it rather than reporting it as missing.
             weeklyReviewNavigation = .reviewInbox
         case .inspectCategory:
-            error = "Category budget drill-in is not available in this slice yet."
+            // No category-budget surface exists to navigate to yet. The drift
+            // item is an informational flag, not a recoverable failure, so this
+            // is a deliberate no-op rather than the error-banner path — surfacing
+            // a red failure banner here read as a broken action (AND-466).
+            break
         case .reviewRecurring:
             weeklyReviewNavigation = .recurring
         case .inspectSafeToSpend:

--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -360,7 +360,10 @@ public enum WeeklyReviewBuilder {
                 title: title,
                 detail: "Category pressure changed this month.",
                 action: .inspectCategory,
-                accessibilityHint: "Opens the category budget details."
+                // No category-budget surface exists to navigate to yet, so the
+                // hint must not promise navigation it cannot perform. Describe
+                // what the item flags instead of "Opens ...".
+                accessibilityHint: "Flags category budget pressure for this month."
             ))
         }
 

--- a/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
+++ b/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
@@ -292,6 +292,44 @@ struct WeeklyReviewTests {
         #expect(presentation.remainingCount == 1)
     }
 
+    @Test("Category drift hint does not promise navigation that does not happen")
+    func categoryDriftHintDoesNotPromiseNavigation() {
+        // The category-drift item's `.inspectCategory` action has no budget
+        // surface to open (AND-466). Its accessibility hint must therefore not
+        // claim it opens one — that read as a live dead-end.
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: WeeklyReviewTransactionState(
+                trustedTransactionIds: [],
+                unreviewedTransactionIds: []
+            ),
+            transactions: [],
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 500),
+            categoryBudgets: CategoryBudgetPresentation(
+                items: [
+                    CategoryBudgetPresentation.Item(
+                        category: .foodAndDrink,
+                        monthlyLimit: 100,
+                        spent: 125,
+                        isSuggested: false
+                    ),
+                ],
+                totalLimit: 100,
+                totalSpent: 125,
+                overBudgetCount: 1,
+                nearingCount: 0
+            ),
+            asOf: now,
+            calendar: calendar
+        )
+
+        let driftItem = presentation.items.first { $0.kind == .categoryDrift }
+        #expect(driftItem?.action == .inspectCategory)
+        #expect(driftItem?.accessibilityHint == "Flags category budget pressure for this month.")
+        #expect(driftItem?.accessibilityHint.contains("Opens") == false)
+    }
+
     @Test("Notification copy is privacy preserving by default")
     func notificationCopyIsPrivate() {
         let presentation = WeeklyReviewBuilder.evaluate(


### PR DESCRIPTION
## Summary
Fixed the Weekly Review "Inspect Category" live dead-end that rendered a fake error banner. In AppState.performWeeklyReviewAction, the .inspectCategory case no longer sets AppState.error ("Category budget drill-in is not available in this slice yet.") — it is now a deliberate, commented no-op, so an informational drift flag no longer surfaces as a red failure. Corrected the misleading accessibilityHint on the .categoryDrift WeeklyReviewItem (PlaidBarCore/Models/WeeklyReview.swift) from "Opens the category budget details." (promised navigation that never happens) to "Flags category budget pressure for this month." Did not build any new budget view, per scope. The app target is an @main executable and cannot be @testable-imported (per Tests/PlaidBarTests header), so the handler itself is not unit-testable; the testable surface is the Core model, where I added a Weekly review test asserting the category drift item keeps action .inspectCategory and its hint no longer says "Opens ...".

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: categoryDriftHintDoesNotPromiseNavigation

## For the reviewer
- Tapping 'Inspect Category' is now a silent no-op (button does nothing visible). A follow-up could either build a real category-budget surface and route .inspectCategory there, or hide/disable the action button on the categoryDrift item so it does not look interactive. Left as-is per the issue's 'do not build a new budget view' constraint.
- There is no neutral/transient informational message field on AppState (only `error`), so a no-op was used instead of a non-error toast. If an informational message channel is later added, the .inspectCategory case could surface a neutral note.

## Source
Pre-release audit 2026-06-16 — **AND-466** / #442. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)