### PR TITLE
feat: wire App Lock & Privacy Mask into Settings + lifecycle (AND-462)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -235,7 +235,7 @@ final class AppState {
 
     var appLockPreferences = AppLockPreferences() {
         didSet {
-            guard appLockPreferences != oldValue else { return }
+            guard appLockPreferences != oldValue, !isLoadingAppLockPreferences else { return }
             persistAppLockPreferences()
         }
     }
@@ -303,6 +303,7 @@ final class AppState {
     private var localAIProbeAvailability: LocalAIAvailability?
     private var localAIProbeGeneration = 0
     private var isLoadingLocalAISettings = false
+    private var isLoadingAppLockPreferences = false
     private var isUpgradingManagedServer = false
     private var isStartingBundledServer = false
     private var lastAttemptedCredentialUpgradeConfig: String?
@@ -409,13 +410,17 @@ final class AppState {
     }
 
     private func loadAppLockPreferences(defaults: UserDefaults) {
+        // `appLockService` is the single source of truth for the enabled flag —
+        // it owns `Keys.appLockEnabled` via its settings store. Deriving the
+        // preference from the service (rather than reading the key again here)
+        // keeps the in-memory service state and the persisted flag coherent and
+        // avoids the dual-write desync on the shared UserDefaults key.
+        isLoadingAppLockPreferences = true
         appLockPreferences = AppLockPreferences(
             privacyMaskEnabled: defaults.object(forKey: Keys.privacyMaskEnabled) != nil
                 ? defaults.bool(forKey: Keys.privacyMaskEnabled)
                 : appLockPreferences.privacyMaskEnabled,
-            appLockEnabled: defaults.object(forKey: Keys.appLockEnabled) != nil
-                ? defaults.bool(forKey: Keys.appLockEnabled)
-                : appLockPreferences.appLockEnabled,
+            appLockEnabled: appLockService.isLockEnabled,
             notificationPrivacyMode: defaults.string(forKey: Keys.appLockNotificationPrivacyMode)
                 .flatMap(NotificationPrivacyMode.init(rawValue:))
                 ?? appLockPreferences.notificationPrivacyMode,
@@ -423,14 +428,83 @@ final class AppState {
                 ? defaults.bool(forKey: Keys.appLockPauseRefreshWhileLocked)
                 : appLockPreferences.pauseRefreshWhileLocked
         )
+        isLoadingAppLockPreferences = false
         isAppLocked = appLockService.isLocked
     }
 
     private func persistAppLockPreferences() {
+        // `appLockEnabled` is intentionally NOT written here — `appLockService`
+        // owns `Keys.appLockEnabled` and is the single writer for it (via
+        // `setAppLockEnabled`). Writing it from both paths is what previously
+        // desynced the in-memory service from the persisted flag.
         UserDefaults.standard.set(appLockPreferences.privacyMaskEnabled, forKey: Keys.privacyMaskEnabled)
-        UserDefaults.standard.set(appLockPreferences.appLockEnabled, forKey: Keys.appLockEnabled)
         UserDefaults.standard.set(appLockPreferences.notificationPrivacyMode.rawValue, forKey: Keys.appLockNotificationPrivacyMode)
         UserDefaults.standard.set(appLockPreferences.pauseRefreshWhileLocked, forKey: Keys.appLockPauseRefreshWhileLocked)
+    }
+
+    // MARK: - App Lock
+
+    /// The current biometric / device-authentication capability, surfaced to the
+    /// settings UI so the App Lock toggle can disable and explain itself when no
+    /// authentication is available.
+    func appLockAuthenticationCapability() -> AppLockCapability {
+        appLockService.authenticationCapability()
+    }
+
+    /// Single entry point for enabling/disabling App Lock. Routes through
+    /// `AppLockService` (the source of truth for the enabled flag) so the
+    /// service's `isLockEnabled`, the persisted UserDefaults key, and the
+    /// mirrored `appLockPreferences.appLockEnabled` stay coherent.
+    ///
+    /// Returns the resolved capability so callers can surface why enabling was
+    /// refused (e.g. biometrics unavailable).
+    @discardableResult
+    func setAppLockEnabled(_ isEnabled: Bool) -> AppLockCapability {
+        let capability = appLockService.setLockEnabled(isEnabled)
+        // Mirror the service's authoritative state back onto the observable
+        // preference and lock flag. The setter below persists the non-enabled
+        // keys only; the service already persisted the enabled flag.
+        appLockPreferences.appLockEnabled = appLockService.isLockEnabled
+        isAppLocked = appLockService.isLocked
+        return capability
+    }
+
+    /// Locks VaultPeek immediately when App Lock is enabled (no-op otherwise).
+    /// Used by launch and resign-active lifecycle triggers.
+    func lockApp() {
+        appLockService.lock()
+        isAppLocked = appLockService.isLocked
+    }
+
+    /// Locks on launch when both App Lock and the lock-on-launch preference are
+    /// enabled. Called once after the app finishes loading initial data.
+    func lockOnLaunchIfNeeded() {
+        guard appLockPreferences.appLockEnabled, appLockPreferences.lockOnLaunch else { return }
+        lockApp()
+    }
+
+    /// Locks when VaultPeek loses focus (resign active / popover close), when
+    /// the lock-when-backgrounded preference is enabled. MainActor-safe and
+    /// cheap when App Lock is off.
+    func lockOnResignActiveIfNeeded() {
+        guard appLockPreferences.appLockEnabled, appLockPreferences.lockWhenBackgrounded else { return }
+        lockApp()
+    }
+
+    /// Prompts for biometric / device authentication to unlock VaultPeek. A
+    /// no-op that resolves to `.success` when App Lock is disabled or already
+    /// unlocked. Mirrors the resulting lock state back onto `isAppLocked`.
+    @discardableResult
+    func unlockApp() async -> AppLockAuthenticationResult {
+        guard appLockService.isLockEnabled, appLockService.isLocked else {
+            isAppLocked = appLockService.isLocked
+            return .success
+        }
+        let result = await appLockService.authenticate(
+            reason: "Unlock VaultPeek to view your balances."
+        )
+        isAppLocked = appLockService.isLocked
+        return result
     }
 
     private func loadLocalAISettings(defaults: UserDefaults) {
@@ -1871,6 +1945,12 @@ final class AppState {
         // The boot window ends when this pass returns, on every path: from
         // then on, offline/empty verdicts are real and may render.
         defer { isBooting = false }
+
+        // Engage App Lock on launch (when enabled). Done before any data work
+        // so the dashboard's first paint is already masked if lock-on-launch is
+        // on; views read `shouldMaskFinancialValues`, which the locked state
+        // drives.
+        lockOnLaunchIfNeeded()
 
         // Recheck notification permission at startup (user may have revoked in System Settings)
         if notificationsEnabled {

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -162,6 +162,23 @@ struct PlaidBarApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                     Task { await appState.consumePendingGlanceCommand() }
                 }
+                // App Lock trigger: lock when VaultPeek loses focus (the user
+                // clicks away / the popover closes) so balances re-mask behind
+                // the lock. A cheap no-op when App Lock or lock-when-backgrounded
+                // is off. The unlock prompt is driven from the popover-open path
+                // below, not from didBecomeActive, so presenting the system auth
+                // sheet (which deactivates this app) cannot start a lock/unlock
+                // loop (AND-462).
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
+                    appState.lockOnResignActiveIfNeeded()
+                }
+                // Opening the popover while locked prompts for authentication to
+                // reveal balances; `unlockApp()` is a no-op when App Lock is off
+                // or already unlocked.
+                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                    guard isPresented, appState.isAppLocked else { return }
+                    Task { await appState.unlockApp() }
+                }
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
             statusItemContextMenuController.configure(

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -37,6 +37,13 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.notifications.rawValue)
 
+            PrivacySecuritySettingsView()
+                .environment(appState)
+                .tabItem {
+                    Label("Privacy", systemImage: "lock.shield")
+                }
+                .tag(SettingsTab.privacy.rawValue)
+
             AboutView(updater: updater)
                 .tabItem {
                     Label("About", systemImage: "info.circle")
@@ -59,6 +66,7 @@ private enum SettingsTab: String {
     case accounts
     case appearance
     case notifications
+    case privacy
     case about
 }
 
@@ -302,6 +310,79 @@ private struct AppearancePreviewCard: View {
         .accessibilityLabel(
             "Live preview of the popover at \(setting.displayPercent) percent transparency, with sample data only."
         )
+    }
+}
+
+struct PrivacySecuritySettingsView: View {
+    @Environment(AppState.self) private var appState
+    /// Snapshot of the live authentication capability, refreshed on appear and
+    /// after any App Lock change so the toggle can disable + explain itself when
+    /// biometrics / device authentication are unavailable.
+    @State private var capability: AppLockCapability = .available(biometry: .none)
+
+    private var control: AppLockSettingsControl {
+        AppLockSettingsControl.resolve(
+            capability: capability,
+            isEnabled: appState.appLockPreferences.appLockEnabled
+        )
+    }
+
+    var body: some View {
+        @Bindable var state = appState
+
+        Form {
+            Section("Privacy Mask") {
+                Toggle("Hide balances and amounts", isOn: $state.appLockPreferences.privacyMaskEnabled)
+
+                Text("Masks balances, amounts, and the menu bar value behind dots without requiring authentication. Use it for quick over-the-shoulder privacy; flip it off to reveal again.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("App Lock") {
+                Toggle("Require authentication", isOn: Binding(
+                    get: { appState.appLockPreferences.appLockEnabled },
+                    set: { newValue in
+                        appState.setAppLockEnabled(newValue)
+                        capability = appState.appLockAuthenticationCapability()
+                    }
+                ))
+                .disabled(!control.isToggleEnabled)
+
+                Text(control.explanation)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Toggle("Lock on launch", isOn: $state.appLockPreferences.lockOnLaunch)
+                    .disabled(!appState.appLockPreferences.appLockEnabled)
+
+                Toggle("Pause refresh while locked", isOn: $state.appLockPreferences.pauseRefreshWhileLocked)
+                    .disabled(!appState.appLockPreferences.appLockEnabled)
+
+                Text("When locked, VaultPeek stops fetching new balances and transactions until you authenticate. Leave off to keep cached data current behind the lock.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Notifications while private") {
+                Picker("Notification details", selection: $state.appLockPreferences.notificationPrivacyMode) {
+                    ForEach(NotificationPrivacyMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .accessibilityValue(appState.appLockPreferences.notificationPrivacyMode.displayName)
+
+                Text(appState.appLockPreferences.notificationPrivacyMode.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .formStyle(.grouped)
+        .toggleStyle(.switch)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task {
+            capability = appState.appLockAuthenticationCapability()
+        }
     }
 }
 

--- a/Sources/PlaidBarCore/Models/AppLockSettingsControl.swift
+++ b/Sources/PlaidBarCore/Models/AppLockSettingsControl.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Pure presentation policy for the Privacy & Security settings controls.
+///
+/// Keeps the App Lock toggle's availability, biometry wording, and explanatory
+/// copy out of the SwiftUI view so the rules are `Sendable` and unit-testable.
+/// The view passes in the live `AppLockCapability` (from `AppLockService`) and
+/// renders the returned control state verbatim.
+public struct AppLockSettingsControl: Sendable, Equatable {
+    /// Whether the App Lock toggle should accept user input. When biometric /
+    /// device authentication is unavailable, the toggle is disabled and the
+    /// explanatory caption tells the user why.
+    public let isToggleEnabled: Bool
+    /// Caption shown beneath the App Lock toggle explaining the current state.
+    public let explanation: String
+
+    public init(isToggleEnabled: Bool, explanation: String) {
+        self.isToggleEnabled = isToggleEnabled
+        self.explanation = explanation
+    }
+
+    /// Human-readable name for a biometry type, used in the toggle caption.
+    public static func biometryName(_ biometry: AppLockBiometryType) -> String {
+        switch biometry {
+        case .touchID: return "Touch ID"
+        case .faceID: return "Face ID"
+        case .opticID: return "Optic ID"
+        case .none, .unknown: return "your Mac password"
+        }
+    }
+
+    /// Short reason string for why authentication is unavailable.
+    public static func unavailableReason(_ reason: AppLockUnavailableReason) -> String {
+        switch reason {
+        case .passcodeNotSet:
+            return "Set a login password or Touch ID in System Settings to use App Lock."
+        case .biometryNotAvailable:
+            return "This Mac does not support biometric unlock. Set a login password to use App Lock."
+        case .biometryNotEnrolled:
+            return "No biometric identities are enrolled. Add Touch ID in System Settings to use App Lock."
+        case .biometryLockout:
+            return "Biometric unlock is temporarily locked. Use your Mac password, then try again."
+        case .notInteractive:
+            return "Authentication is not available right now. Try again in a moment."
+        case .unknown(let description):
+            let trimmed = description.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty
+                ? "Authentication is unavailable right now."
+                : trimmed
+        }
+    }
+
+    /// Resolves the toggle's enabled state and caption from the live capability.
+    /// `isEnabled` is the current persisted App Lock preference, which still
+    /// controls the explanatory copy when authentication is available.
+    public static func resolve(
+        capability: AppLockCapability,
+        isEnabled: Bool
+    ) -> AppLockSettingsControl {
+        switch capability {
+        case .available(let biometry):
+            let name = biometryName(biometry)
+            let explanation = isEnabled
+                ? "VaultPeek locks and requires \(name) to reveal balances. Locks on launch and when VaultPeek loses focus."
+                : "Require \(name) to reveal balances. VaultPeek locks on launch and when it loses focus."
+            return AppLockSettingsControl(isToggleEnabled: true, explanation: explanation)
+        case .unavailable(let reason):
+            return AppLockSettingsControl(
+                isToggleEnabled: false,
+                explanation: unavailableReason(reason)
+            )
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
@@ -122,6 +122,50 @@ struct AppLockServiceTests {
         #expect(authenticator.authenticateCallCount == 0)
     }
 
+    @Test("Enabling and disabling through setLockEnabled keeps the persisted flag coherent")
+    func setLockEnabledIsSingleSourceOfTruth() throws {
+        // Mirrors AppState.setAppLockEnabled, which routes all enabled-flag
+        // writes through the service so the in-memory state and the persisted
+        // UserDefaults key never desync (AND-462). A second service constructed
+        // from the same store must read back exactly what the first one wrote.
+        let suiteName = "AppLockServiceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let key = UserDefaultsAppLockSettingsStore.defaultStorageKey
+        let store = UserDefaultsAppLockSettingsStore(defaults: defaults, storageKey: key)
+        let service = AppLockService(
+            settingsStore: store,
+            authenticator: StubAppLockAuthenticator(capability: .available(biometry: .touchID))
+        )
+
+        service.setLockEnabled(true)
+
+        #expect(service.isLockEnabled == true)
+        #expect(service.state == .locked)
+        #expect(store.isLockEnabled == true)
+        #expect(defaults.bool(forKey: key) == true)
+        // A fresh service derived from the same persisted store agrees.
+        let reloadedEnabled = AppLockService(
+            settingsStore: UserDefaultsAppLockSettingsStore(defaults: defaults, storageKey: key),
+            authenticator: StubAppLockAuthenticator(capability: .available(biometry: .touchID))
+        )
+        #expect(reloadedEnabled.isLockEnabled == true)
+        #expect(reloadedEnabled.isLocked == true)
+
+        service.setLockEnabled(false)
+
+        #expect(service.isLockEnabled == false)
+        #expect(service.state == .unlocked)
+        #expect(store.isLockEnabled == false)
+        #expect(defaults.bool(forKey: key) == false)
+        let reloadedDisabled = AppLockService(
+            settingsStore: UserDefaultsAppLockSettingsStore(defaults: defaults, storageKey: key),
+            authenticator: StubAppLockAuthenticator(capability: .available(biometry: .touchID))
+        )
+        #expect(reloadedDisabled.isLockEnabled == false)
+        #expect(reloadedDisabled.isLocked == false)
+    }
+
     @Test("Overlapping authentication attempts share one system prompt")
     func overlappingAuthenticationAttemptsCoalesce() async {
         let authenticator = StubAppLockAuthenticator(result: .success, delayNanoseconds: 50_000_000)

--- a/Tests/PlaidBarCoreTests/AppLockSettingsControlTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockSettingsControlTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("App lock settings control policy")
+struct AppLockSettingsControlTests {
+    @Test("available capability enables the toggle and names the biometry")
+    func availableCapabilityEnablesToggle() {
+        let control = AppLockSettingsControl.resolve(
+            capability: .available(biometry: .touchID),
+            isEnabled: false
+        )
+
+        #expect(control.isToggleEnabled == true)
+        #expect(control.explanation.contains("Touch ID"))
+    }
+
+    @Test("enabled state describes the active lock behavior")
+    func enabledStateDescribesBehavior() {
+        let control = AppLockSettingsControl.resolve(
+            capability: .available(biometry: .faceID),
+            isEnabled: true
+        )
+
+        #expect(control.isToggleEnabled == true)
+        #expect(control.explanation.contains("Face ID"))
+        #expect(control.explanation.contains("launch"))
+    }
+
+    @Test("unavailable capability disables the toggle with a reason")
+    func unavailableCapabilityDisablesToggle() {
+        let control = AppLockSettingsControl.resolve(
+            capability: .unavailable(.biometryNotEnrolled),
+            isEnabled: false
+        )
+
+        #expect(control.isToggleEnabled == false)
+        #expect(control.explanation == AppLockSettingsControl.unavailableReason(.biometryNotEnrolled))
+    }
+
+    @Test("biometry names fall back to the Mac password for non-biometric devices")
+    func biometryNameFallbacks() {
+        #expect(AppLockSettingsControl.biometryName(.touchID) == "Touch ID")
+        #expect(AppLockSettingsControl.biometryName(.faceID) == "Face ID")
+        #expect(AppLockSettingsControl.biometryName(.opticID) == "Optic ID")
+        #expect(AppLockSettingsControl.biometryName(.none) == "your Mac password")
+        #expect(AppLockSettingsControl.biometryName(.unknown) == "your Mac password")
+    }
+
+    @Test("unknown unavailable reason surfaces a trimmed description or a fallback")
+    func unknownReasonHandling() {
+        #expect(AppLockSettingsControl.unavailableReason(.unknown("  Boom  ")) == "Boom")
+        #expect(AppLockSettingsControl.unavailableReason(.unknown("   ")) == "Authentication is unavailable right now.")
+    }
+}


### PR DESCRIPTION
## Summary
Wired the previously-unreachable App Lock & Privacy Mask features end to end. (1) Added a "Privacy" tab (PrivacySecuritySettingsView) to SettingsView with a Privacy Mask toggle, an App Lock toggle that routes through AppState.setAppLockEnabled and disables/explains itself when biometrics are unavailable, Lock-on-launch and Pause-refresh-while-locked toggles, and a NotificationPrivacyMode picker — all native Form(.grouped) matching existing tabs and persisting via the existing persistAppLockPreferences path. (2) Made AppLockService the single source of truth for the enabled flag: AppState now derives appLockPreferences.appLockEnabled from appLockService.isLockEnabled, routes all enable/disable writes through the new setAppLockEnabled (which calls AppLockService.setLockEnabled), and stopped persistAppLockPreferences from writing the service-owned Keys.appLockEnabled key — eliminating the dual-write desync on the shared UserDefaults key. (3) Wired lock triggers: lock-on-launch in loadInitialData via lockOnLaunchIfNeeded; lock on resignActive/popover-close via an NSApplication.didResignActiveNotification observer on the always-mounted menu-bar label; and auto-prompt to unlock when the popover opens while locked (unlockApp). Added a pure, testable AppLockSettingsControl presentation helper in PlaidBarCore for the toggle's enabled state and biometry copy. Locked state masks values through the existing shouldMaskFinancialValues path. All new MainActor/Sendable-clean, no force-unwraps.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: AppLockServiceTests.setLockEnabledIsSingleSourceOfTruth — enabling/disabling via setLockEnabled keeps isLockEnabled, state, the persisted UserDefaults key, and a freshly-reconstructed service coherent (the single-source-of-truth invariant AppState.setAppLockEnabled delegates to); AppLockSettingsControlTests — toggle enabled/disabled state, biometry naming fallbacks, and unavailable-reason copy for the new Privacy & Security control helper

## For the reviewer
- The single-source-of-truth invariant is tested at the AppLockService + UserDefaultsAppLockSettingsStore level in PlaidBarCore (which AppState.setAppLockEnabled fully delegates to). AppState itself can't be unit-tested directly — the PlaidBar app target is an executable that can't be @testable-imported, and appLockService has no DI seam — so the AppState wrapper methods (setAppLockEnabled/lockApp/unlockApp/lifecycle triggers) are covered only by the build, not by a unit test.
- Unlock UX is minimal: there is no dedicated locked-overlay surface in MainPopover. When locked, balances mask via the existing shouldMaskFinancialValues path and authentication is auto-prompted on popover open; if the user cancels, the popover stays masked with no explicit in-popover 'Unlock' button. A richer locked surface (explanatory copy + retry button reading AppLockAuthenticationMessage.lockedSurfaceCopy) was left out of scope to keep the diff focused — worth a follow-up.
- resignActive locking + popover-open unlock were both implemented. The auth prompt deactivates the app, but the unlock is driven only from the popover-open onChange (not didBecomeActive), so a lock/unlock loop is avoided by design. Verify on-device that the macOS auth sheet dismissal does not produce an unexpected resign/become cycle that re-locks immediately after a successful unlock.

## Source
Pre-release audit 2026-06-16 — **AND-462** / #438. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)