### PR TITLE
fix: non-color cues + dark-mode chart contrast (AND-473)

### DIFF
--- a/Sources/PlaidBar/Theme/CategoryAccentTokens.swift
+++ b/Sources/PlaidBar/Theme/CategoryAccentTokens.swift
@@ -38,4 +38,10 @@ enum CategoryAccentTokens {
             .secondary
         }
     }
+
+    /// Resolves the category's chart hex color for the active appearance, selecting
+    /// `colorHexDark` in dark mode so low-contrast light-mode hues stay above 3:1.
+    static func chartHex(for category: SpendingCategory, colorScheme: ColorScheme) -> String {
+        colorScheme == .dark ? category.colorHexDark : category.colorHex
+    }
 }

--- a/Sources/PlaidBar/Views/BalanceCompositionBar.swift
+++ b/Sources/PlaidBar/Views/BalanceCompositionBar.swift
@@ -28,6 +28,14 @@ struct AnimatedBalanceCompositionBar: View {
                 ForEach(segments) { segment in
                     RoundedRectangle(cornerRadius: Radius.cell)
                         .fill(segment.fillColor)
+                        .overlay(
+                            // Non-color cue: a hairline outline separates adjacent
+                            // segments so the mix is legible without relying on hue.
+                            // Uses the window background so it reads as a "cut" in
+                            // both light and dark appearances.
+                            RoundedRectangle(cornerRadius: Radius.cell)
+                                .strokeBorder(Color(nsColor: .windowBackgroundColor).opacity(0.7), lineWidth: 0.5)
+                        )
                         .frame(
                             width: segmentWidth(
                                 segment,

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -369,7 +369,7 @@ private struct WealthBalanceMixSection: View {
     private func tint(for id: String) -> Color {
         switch id {
         case "cash":
-            Color.secondary.opacity(0.6)
+            SemanticColors.positive
         case "investments":
             Color.primary.opacity(0.36)
         case "credit":

--- a/Sources/PlaidBarCore/Models/SpendingCategory.swift
+++ b/Sources/PlaidBarCore/Models/SpendingCategory.swift
@@ -88,4 +88,20 @@ public enum SpendingCategory: String, Codable, Sendable, CaseIterable, Hashable 
         case .other: "#BDC3C7"
         }
     }
+
+    /// Color for charts on dark backgrounds (hex string).
+    ///
+    /// Five light-mode `colorHex` values fall below a 3:1 contrast ratio against the
+    /// dark background (`#1E1E1E`); those are overridden here with the darker variants
+    /// recommended in `DESIGN.md`. All other categories reuse `colorHex` unchanged.
+    public var colorHexDark: String {
+        switch self {
+        case .personalCare: "#F0D890"
+        case .homeImprovement: "#E8CD60"
+        case .transferOut: "#B8C0C0"
+        case .income: "#6FCC98"
+        case .other: "#A0A8AC"
+        default: colorHex
+        }
+    }
 }

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1566,6 +1566,40 @@ struct PlaidBarCoreTests {
         }
     }
 
+    @Test("SpendingCategory colorHexDark overrides the five low-contrast categories")
+    func categoryColorHexDarkOverrides() {
+        let expectedDarkVariants: [SpendingCategory: String] = [
+            .personalCare: "#F0D890",
+            .homeImprovement: "#E8CD60",
+            .transferOut: "#B8C0C0",
+            .income: "#6FCC98",
+            .other: "#A0A8AC",
+        ]
+        for (category, darkHex) in expectedDarkVariants {
+            #expect(category.colorHexDark == darkHex)
+            // The dark variant must actually differ from the light-mode hex.
+            #expect(category.colorHexDark != category.colorHex)
+        }
+    }
+
+    @Test("SpendingCategory colorHexDark falls back to colorHex for other categories")
+    func categoryColorHexDarkFallback() {
+        let overridden: Set<SpendingCategory> = [
+            .personalCare, .homeImprovement, .transferOut, .income, .other,
+        ]
+        for category in SpendingCategory.allCases where !overridden.contains(category) {
+            #expect(category.colorHexDark == category.colorHex)
+        }
+    }
+
+    @Test("SpendingCategory colorHexDark format")
+    func categoryColorHexDarkFormat() {
+        for category in SpendingCategory.allCases {
+            #expect(category.colorHexDark.hasPrefix("#"))
+            #expect(category.colorHexDark.count == 7)
+        }
+    }
+
     // MARK: - Formatters Tests
 
     @Test("Currency full format")


### PR DESCRIPTION
## Summary
Accessibility polish for AND-473. (1) WealthSummaryFlyout.tint(for:) no longer maps 'cash' and 'default' to a byte-identical Color.secondary.opacity(0.6): 'cash' now resolves to the distinct SemanticColors.positive, while 'default' keeps the secondary fallback, so cash vs default never collide. (2) Added a non-color cue to the balance-mix bar — each AnimatedBalanceCompositionBar segment now carries a 0.5pt hairline strokeBorder using the window background color, reading as a visible 'cut' between adjacent segments in both appearances without relying on hue. (3) Added a colorHexDark property to SpendingCategory in PlaidBarCore with the exact DESIGN.md-recommended darker variants for the five low-contrast categories (personalCare #F0D890, homeImprovement #E8CD60, transferOut #B8C0C0, income #6FCC98, other #A0A8AC); all other categories fall back to colorHex. Added CategoryAccentTokens.chartHex(for:colorScheme:) in the App layer (where SwiftUI/ColorScheme is available, since Core is Foundation-only) as the @Environment(\.colorScheme)-driven selector mechanism for picking the dark variant at hex-consuming render sites. Issue #41 (net-mode heatmap color-only) was left untouched per the documented-accepted note in ACCESSIBILITY.md:15-16.

## Verification (CI is off — gates run locally)
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test` ✅ all green (823 with new tests)
- Tests added/updated: PlaidBarCoreTests.categoryColorHexDarkOverrides — the 5 low-contrast categories return their exact DESIGN.md dark variant and differ from colorHex; PlaidBarCoreTests.categoryColorHexDarkFallback — all other categories' colorHexDark falls back to colorHex; PlaidBarCoreTests.categoryColorHexDarkFormat — every colorHexDark is a #RRGGBB 7-char hex

## For the reviewer
- No live view currently renders SpendingCategory.colorHex through a hex-to-Color path — category swatches in the UI come from CategoryAccentTokens.color(for:), which already uses dark-mode-adaptive SwiftUI semantic colors. So colorHexDark + the new chartHex(for:colorScheme:) selector are wired and tested at the data layer, but there is no existing chart/legend call site to convert today; whoever first consumes the hex palette in a Swift Charts segment should call CategoryAccentTokens.chartHex(for:colorScheme:) (with @Environment(\.colorScheme)) instead of .colorHex directly. Confirm this matches the intended consumption point, or wire it now if a hex-rendering chart is added.
- Issue #41 (net-mode heatmap color-only cue) intentionally skipped — documented-accepted in ACCESSIBILITY.md:15-16; no change made.
- The balance-mix hairline divider uses Color(nsColor: .windowBackgroundColor).opacity(0.7); on a translucent/NSVisualEffectView popover surface the effective contrast of the 'cut' may differ slightly from a solid window background. Worth a visual check in the detached translucent window, though it degrades gracefully (still a visible seam).

## Source
Pre-release audit 2026-06-16 — **AND-473** / #449. **Draft — do not merge yet** (part of the audit-fix stack; merge per the wave plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)