### PR TITLE
test: stabilize glance snapshot debounce assertion

### DIFF
--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -124,8 +124,7 @@ struct GlanceSnapshotTests {
             await recorder.record(snapshot)
         }
 
-        try await Task.sleep(for: .milliseconds(80))
-        let snapshots = await recorder.snapshots
+        let snapshots = try await recorder.waitForSnapshotCount(1, timeout: .milliseconds(500))
         #expect(snapshots.map(\.netWorth) == [300])
     }
 
@@ -165,5 +164,18 @@ private actor SnapshotWriteRecorder {
 
     func record(_ snapshot: GlanceSnapshot) {
         snapshots.append(snapshot)
+    }
+
+    func waitForSnapshotCount(
+        _ expectedCount: Int,
+        timeout: Duration,
+        pollInterval: Duration = .milliseconds(10)
+    ) async throws -> [GlanceSnapshot] {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while snapshots.count < expectedCount, clock.now < deadline {
+            try await Task.sleep(for: pollInterval)
+        }
+        return snapshots
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the fixed 80 ms assertion delay in the GlanceSnapshot debouncer test with a bounded wait for the async write to be observed.
- Keeps the production debouncer unchanged; this is a test reliability fix for full-suite scheduler load.

## Verification
- `git diff --check`
- `swift test --filter debouncerCoalescesBurstWritesToLatestSnapshot`
- `swift test --filter PlaidBarCoreTests`

Fixes #468
Linear: AND-477
Kanban: t_550b0fc6
