### PR TITLE
fix: filter recent transactions before display limit

### DIFF
--- a/Sources/PlaidBarCore/Utilities/TransactionFilter.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionFilter.swift
@@ -25,12 +25,13 @@ public enum TransactionFilter {
         criteria: TransactionFilterCriteria = TransactionFilterCriteria(),
         maxCount: Int = PlaidBarConstants.maxRecentTransactions
     ) -> [(String, [TransactionDTO])] {
+        let matching = filtered(transactions, criteria: criteria)
         let recent = Array(
-            transactions
+            matching
                 .sorted { $0.date > $1.date }
                 .prefix(maxCount)
         )
-        return grouped(filtered(recent, criteria: criteria))
+        return grouped(recent)
     }
 
     public static func filtered(

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1792,6 +1792,25 @@ struct PlaidBarCoreTests {
         #expect(filtered.map(\.id) == ["1"])
     }
 
+    @Test("Transaction groupedRecent filters before applying recent limit")
+    func transactionGroupedRecentFiltersBeforeApplyingLimit() {
+        let transactions = [
+            TransactionDTO(id: "recent-other-1", accountId: "credit", amount: 20, date: "2026-01-05", name: "Coffee", category: .foodAndDrink),
+            TransactionDTO(id: "recent-other-2", accountId: "savings", amount: 30, date: "2026-01-04", name: "Coffee", category: .foodAndDrink),
+            TransactionDTO(id: "matching-older", accountId: "checking", amount: 40, date: "2026-01-03", name: "Coffee", category: .foodAndDrink),
+            TransactionDTO(id: "matching-oldest", accountId: "checking", amount: 50, date: "2026-01-02", name: "Groceries", category: .foodAndDrink),
+        ]
+
+        let grouped = TransactionFilter.groupedRecent(
+            from: transactions,
+            criteria: TransactionFilterCriteria(accountId: "checking"),
+            maxCount: 2
+        )
+
+        #expect(grouped.map(\.0) == ["2026-01-03", "2026-01-02"])
+        #expect(grouped.flatMap(\.1).map(\.id) == ["matching-older", "matching-oldest"])
+    }
+
     @Test("Transaction filter search matches category display name")
     func transactionFilterSearchMatchesCategoryDisplayName() {
         let transactions = [


### PR DESCRIPTION
## Summary

- fixes `TransactionFilter.groupedRecent` so criteria are applied before `maxCount`
- adds a regression test for account-filtered recent transactions hidden by globally newer rows

Fixes #470
Linear: AND-478
Kanban: t_a452fa05

## Verification

- RED before fix: `swift test --filter transactionGroupedRecentFiltersBeforeApplyingLimit` failed with `grouped.map(\.0) → []`
- GREEN after fix: `swift test --filter 'Transaction filter|transactionGroupedRecentFiltersBeforeApplyingLimit|transactionFilter'` → 4 tests passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → build complete
- `git diff --check` → no output

## Privacy/security

No Plaid credentials, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies were printed or moved. The app remains local-first; this change only updates in-memory local filtering logic.
