### PR TITLE
test: make Debouncer coalescing test deterministic

### DIFF
--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -139,12 +139,36 @@ public struct GlanceCommandRequest: Codable, Sendable, Equatable {
     }
 }
 
+/// Abstracts the delay step of ``GlanceSnapshotWriteDebouncer`` so tests can
+/// drive coalescing deterministically instead of racing a real debounce window.
+/// Production uses ``SystemDebounceScheduler``, a thin `Task.sleep` wrapper, so
+/// the live debounce behavior is unchanged.
+public protocol DebounceScheduler: Sendable {
+    /// Suspends for `duration`, throwing `CancellationError` if the surrounding
+    /// task is cancelled while waiting.
+    func sleep(for duration: Duration) async throws
+}
+
+/// The production scheduler: waits on the real clock via `Task.sleep`.
+public struct SystemDebounceScheduler: DebounceScheduler {
+    public init() {}
+
+    public func sleep(for duration: Duration) async throws {
+        try await Task.sleep(for: duration)
+    }
+}
+
 public actor GlanceSnapshotWriteDebouncer {
     private let delay: Duration
+    private let scheduler: any DebounceScheduler
     private var pendingTask: Task<Void, Never>?
 
-    public init(delay: Duration = .milliseconds(400)) {
+    public init(
+        delay: Duration = .milliseconds(400),
+        scheduler: any DebounceScheduler = SystemDebounceScheduler()
+    ) {
         self.delay = delay
+        self.scheduler = scheduler
     }
 
     deinit {
@@ -156,9 +180,9 @@ public actor GlanceSnapshotWriteDebouncer {
         operation: @escaping @Sendable (GlanceSnapshot) async -> Void
     ) {
         pendingTask?.cancel()
-        pendingTask = Task { [delay] in
+        pendingTask = Task { [delay, scheduler] in
             do {
-                try await Task.sleep(for: delay)
+                try await scheduler.sleep(for: delay)
             } catch {
                 return
             }

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -111,7 +111,8 @@ struct GlanceSnapshotTests {
 
     @Test("Debouncer coalesces burst writes to the latest snapshot")
     func debouncerCoalescesBurstWritesToLatestSnapshot() async throws {
-        let debouncer = GlanceSnapshotWriteDebouncer(delay: .milliseconds(25))
+        let scheduler = ManualDebounceScheduler()
+        let debouncer = GlanceSnapshotWriteDebouncer(delay: .milliseconds(25), scheduler: scheduler)
         let recorder = SnapshotWriteRecorder()
 
         await debouncer.schedule(firstSnapshot(netWorth: 100)) { snapshot in
@@ -124,7 +125,16 @@ struct GlanceSnapshotTests {
             await recorder.record(snapshot)
         }
 
-        try await Task.sleep(for: .milliseconds(80))
+        // Each scheduled task parks in the manual scheduler instead of sleeping
+        // on a real clock. Once all three are parked, release them together: the
+        // two superseded tasks bail at their cancellation check and only the
+        // latest snapshot is written — no wall-clock window to race.
+        await scheduler.waitForParkedSleepers(count: 3)
+        await scheduler.releaseAll()
+
+        let firstWrite = await recorder.waitForWrite()
+        #expect(firstWrite.netWorth == 300)
+
         let snapshots = await recorder.snapshots
         #expect(snapshots.map(\.netWorth) == [300])
     }
@@ -162,8 +172,69 @@ struct GlanceSnapshotTests {
 
 private actor SnapshotWriteRecorder {
     private(set) var snapshots: [GlanceSnapshot] = []
+    private var pendingWaiter: CheckedContinuation<GlanceSnapshot, Never>?
 
     func record(_ snapshot: GlanceSnapshot) {
         snapshots.append(snapshot)
+        if let waiter = pendingWaiter {
+            pendingWaiter = nil
+            waiter.resume(returning: snapshot)
+        }
+    }
+
+    /// Suspends until the first write lands (or returns immediately if one
+    /// already has), so the test awaits the real write event instead of a
+    /// fixed wall-clock budget.
+    func waitForWrite() async -> GlanceSnapshot {
+        if let latest = snapshots.last {
+            return latest
+        }
+        return await withCheckedContinuation { continuation in
+            pendingWaiter = continuation
+        }
+    }
+}
+
+/// A `DebounceScheduler` whose `sleep` parks the caller until the test releases
+/// it, making debounce coalescing deterministic with no dependence on a real
+/// debounce window. The requested `duration` is intentionally ignored.
+private actor ManualDebounceScheduler: DebounceScheduler {
+    private var parked: [CheckedContinuation<Void, Never>] = []
+    private var parkWaiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func sleep(for duration: Duration) async {
+        await withCheckedContinuation { continuation in
+            parked.append(continuation)
+            resolveParkWaiters()
+        }
+    }
+
+    /// Suspends until at least `count` callers are parked inside `sleep`.
+    func waitForParkedSleepers(count: Int) async {
+        if parked.count >= count {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            parkWaiters.append((threshold: count, continuation: continuation))
+        }
+    }
+
+    /// Resumes every parked sleeper at once. Superseded debouncer tasks then
+    /// return at their cancellation check; only the latest task runs its
+    /// operation.
+    func releaseAll() {
+        let resumable = parked
+        parked.removeAll()
+        for continuation in resumable {
+            continuation.resume()
+        }
+    }
+
+    private func resolveParkWaiters() {
+        parkWaiters.removeAll { waiter in
+            guard parked.count >= waiter.threshold else { return false }
+            waiter.continuation.resume()
+            return true
+        }
     }
 }


### PR DESCRIPTION
## What

Makes `GlanceSnapshotTests` → **"Debouncer coalesces burst writes to the latest snapshot"** deterministic. It previously raced a fixed `Task.sleep(80ms)` budget against a real `25ms` debounce window, so under load it intermittently observed `[]` instead of `[300]`. Flagged in the 2026-06-16 pre-release audit; it passed on re-run, confirming a flake rather than a regression.

## How

- **Production seam (behavior-preserving):** added a `DebounceScheduler` protocol to `GlanceSnapshotWriteDebouncer`, with the default `SystemDebounceScheduler` being a thin `Task.sleep(for:)` wrapper. The `init` gained a defaulted `scheduler:` parameter, so the live debounce path is byte-identical and the existing `AppState` call site (`GlanceSnapshotWriteDebouncer()`) is unaffected.
- **Deterministic test:** a `ManualDebounceScheduler` parks each scheduled task (ignoring duration) until the test releases them together — the two superseded tasks then bail at the existing `guard !Task.isCancelled` check, so only the latest write runs. The recorder gained `waitForWrite()`, so the test awaits the **actual** write event instead of a fixed wall-clock budget.

This removes wall-clock dependence in both flake directions: the budget expiring before the write fires (the observed `[]`), and a superseded write racing through.

## Verification

Run with the sandbox disabled (the SwiftPM manifest compile requires it):

- Target test: **5/5 consecutive runs pass**, each in `0.001s` (was ~80ms of real sleep).
- Full `GlanceSnapshotTests` suite: **6/6 pass**.
- Strict-concurrency build (`-strict-concurrency=complete -warnings-as-errors`, the CI gate): **clean** (only the pre-existing unused `async-http-client` dependency warning, untouched here).

## Reviewer notes

- Production debounce behavior is intentionally unchanged — the only runtime difference is an indirection through `SystemDebounceScheduler`, which calls `Task.sleep` exactly as before.
- Addresses the audit follow-up for the flaky `GlanceSnapshotTests "Debouncer coalesces burst writes"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)