### PR TITLE
fix: strip pending transaction ids from local cache

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -576,7 +576,7 @@ public enum LocalDataStore {
 
         let remappedCache = TransactionCache(
             context: remappedContext,
-            transactions: cache.transactions
+            transactions: transactionsForLocalPersistence(cache.transactions)
         )
         return (
             transactionCacheURL(in: currentDirectory, context: remappedContext),
@@ -696,7 +696,10 @@ public enum LocalDataStore {
         try ensurePrivateDirectory(directory, fileManager: fileManager)
 
         let url = transactionCacheURL(in: directory, context: context)
-        let cache = TransactionCache(context: context, transactions: transactions)
+        let cache = TransactionCache(
+            context: context,
+            transactions: transactionsForLocalPersistence(transactions)
+        )
         let data = try JSONEncoder().encode(cache)
         try writePrivateCacheFile(data, to: url, fileManager: fileManager)
         try setPrivateCacheFilePermissions(url, fileManager: fileManager)
@@ -757,6 +760,24 @@ public enum LocalDataStore {
 
         let key = "\(context.environment.rawValue)|\(context.storagePath)"
         return "transactions-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+    }
+
+    private static func transactionsForLocalPersistence(_ transactions: [TransactionDTO]) -> [TransactionDTO] {
+        transactions.map { transaction in
+            TransactionDTO(
+                id: transaction.id,
+                itemId: transaction.itemId,
+                accountId: transaction.accountId,
+                amount: transaction.amount,
+                date: transaction.date,
+                name: transaction.name,
+                merchantName: transaction.merchantName,
+                category: transaction.category,
+                pending: transaction.pending,
+                pendingTransactionId: nil,
+                isoCurrencyCode: transaction.isoCurrencyCode
+            )
+        }
     }
 
     // Review metadata and merchant rules are scoped to the active cache context

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3869,6 +3869,32 @@ struct PlaidBarCoreTests {
         #expect(resolved == directory)
     }
 
+    @Test("Local transaction cache strips pending transaction ids before persistence")
+    func localTransactionCacheStripsPendingTransactionIdsBeforePersistence() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try LocalDataStore.saveTransactions([
+            TransactionDTO(
+                id: "posted-1",
+                accountId: "checking",
+                amount: 12,
+                date: "2026-01-01",
+                name: "Coffee",
+                pendingTransactionId: "pending-sensitive-id"
+            )
+        ], to: directory)
+
+        let payload = try String(
+            contentsOf: LocalDataStore.transactionCacheURL(in: directory),
+            encoding: .utf8
+        )
+        #expect(!payload.contains("pendingTransactionId"))
+        #expect(!payload.contains("pending-sensitive-id"))
+        #expect(try LocalDataStore.loadTransactions(from: directory).first?.pendingTransactionId == nil)
+    }
+
     @Test("Local data store resolves active directory from server database path")
     func localDataStoreResolvesActiveDirectoryFromServerDatabasePath() {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- Strip Plaid `pending_transaction_id` from the local transaction cache before writing `transactions*.json`.
- Apply the same sanitization while remapping legacy scoped transaction caches during migration.
- Add a regression test proving the cache payload and loaded local snapshot do not retain the raw pending id.

Fixes #435
Linear: AND-476

## Verification
- Reproduced before the fix: `swift test --filter localTransactionCacheStripsPendingTransactionIdsBeforePersistence` failed with cache JSON containing `pendingTransactionId` and the pending id value.
- `swift test --filter localTransactionCacheStripsPendingTransactionIdsBeforePersistence` — 1 test passed.
- `swift test --filter transactionSyncReducerReconcilesPendingToPosted` — 1 test passed.
- `git diff --check` — passed (no output).
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed.

## Privacy / security
- Server sync responses can still carry `pendingTransactionId` in memory for one-sync reconciliation.
- Local cache persistence now drops that field so the app does not durable-write the Plaid pending transaction identifier into `transactions*.json`.
- No credentials, balances, raw account ids, raw transaction ids, or payload bodies are included here.