### PR TITLE
fix: stop ad-hoc DMG signing with sandbox entitlements (unlaunchable installer)

### DIFF
--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -69,13 +69,23 @@ if ! otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"; then
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_BINARY"
 fi
 
+# Ad-hoc sign the whole bundle WITHOUT entitlements. App Sandbox,
+# app-groups, and keychain-access-groups require a Team ID + provisioning
+# profile that an ad-hoc signature lacks; applying them to an ad-hoc build
+# makes launchd refuse to spawn the app ("Launchd job spawn failed", RBS
+# error 163). The drag-install DMG intentionally runs unsandboxed
+# (docs/distribution.md); the entitlements below are applied only for a real
+# Developer ID signing identity, where they are honored and notarization adds
+# the hardened runtime.
 codesign --force --deep --sign - "$APP_DIR" >/dev/null
-codesign --force --sign - \
-    --entitlements "$WIDGET_RESOURCES_DIR/PlaidBarWidgetExtension.entitlements" \
-    "$WIDGET_EXTENSION_DIR" >/dev/null
-codesign --force --sign - \
-    --entitlements "$RESOURCES_DIR/PlaidBar.entitlements" \
-    "$APP_DIR" >/dev/null
+if [ -n "${PLAIDBAR_CODESIGN_IDENTITY:-}" ]; then
+    codesign --force --options runtime --sign "$PLAIDBAR_CODESIGN_IDENTITY" \
+        --entitlements "$WIDGET_RESOURCES_DIR/PlaidBarWidgetExtension.entitlements" \
+        "$WIDGET_EXTENSION_DIR" >/dev/null
+    codesign --force --options runtime --sign "$PLAIDBAR_CODESIGN_IDENTITY" \
+        --entitlements "$RESOURCES_DIR/PlaidBar.entitlements" \
+        "$APP_DIR" >/dev/null
+fi
 
 "$SCRIPT_DIR/validate-app-bundle.sh" "$APP_DIR"
 


### PR DESCRIPTION
## Severity: launch-blocking
Every drag-installed VaultPeek DMG **fails to launch** — "The application "VaultPeek" can't be opened" (`RBSRequestErrorDomain Code=5` → POSIX 163, *Launchd job spawn failed*).

## Root cause
`Scripts/package-app.sh` deep ad-hoc signs the bundle (no entitlements — launches fine), then **re-signs the app + widget with `PlaidBar.entitlements`** (`com.apple.security.app-sandbox` + `application-groups` + `keychain-access-groups`, the last with an unresolved `$(AppIdentifierPrefix)` literal). App Sandbox / app-groups / keychain-groups require a Team ID + provisioning profile an **ad-hoc** signature can't provide, so launchd refuses to spawn. This contradicts `docs/distribution.md`, which states the ad-hoc bundle ships **unsandboxed**.

It shipped uncaught because the packaging launch-smoke (`PLAIDBAR_PACKAGE_SMOKE_LAUNCH`) is **off by default** and the release-checklist "drag-install + launch on a second machine" step (AND-395/AND-460) hasn't been run.

## Fix
Ad-hoc sign without entitlements (the documented unsandboxed drag-install state); apply entitlements + hardened runtime only when `PLAIDBAR_CODESIGN_IDENTITY` is set (Developer ID path, handled with notarization).

## Verification (local; CI/Codex billing-blocked)
- Rebuilt with `PLAIDBAR_PACKAGE_SMOKE_LAUNCH=1` → app **survives** the launch smoke-test.
- Rebuilt bundle carries **no entitlements**; `codesign --verify --deep --strict` passes; DMG checksum valid.
- Installed `/Applications/VaultPeek.app` (re-signed) launches and appears in the menu bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)