### PR TITLE
fix: Approve/Ignore clears the spend from the Review Inbox (+ fluid animate-out)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -54,37 +54,40 @@ struct ReviewInboxView: View {
                             onSelect: { selectedIndex = index },
                             onApprove: {
                                 recordAction(.approved, for: item)
-                                appState.approveReviewItem(item.id)
+                                animatingResolution { appState.approveReviewItem(item.id) }
                             },
-                            onCategory: {
-                                recordAction(.categorized($0), for: item)
-                                appState.updateReviewCategory(item.id, category: $0)
+                            onCategory: { category in
+                                recordAction(.categorized(category), for: item)
+                                animatingResolution { appState.updateReviewCategory(item.id, category: category) }
                             },
                             onRename: {
                                 recordAction(.renamed, for: item)
-                                appState.renameReviewMerchant(item.id, merchantName: merchantDraft(for: item))
+                                animatingResolution { appState.renameReviewMerchant(item.id, merchantName: merchantDraft(for: item)) }
                             },
                             onTransfer: {
                                 recordAction(.markedTransfer, for: item)
-                                appState.markReviewItemTransfer(item.id)
+                                animatingResolution { appState.markReviewItemTransfer(item.id) }
                             },
                             onNotTransfer: {
                                 recordAction(.markedSpend, for: item)
-                                appState.markReviewItemTransfer(item.id, isTransfer: false)
+                                animatingResolution { appState.markReviewItemTransfer(item.id, isTransfer: false) }
                             },
-                            onCategoryRule: {
+                            onCategoryRule: { category in
                                 recordAction(.ruleCreated, for: item)
-                                appState.createRule(from: item, category: $0)
+                                animatingResolution { appState.createRule(from: item, category: category) }
                             },
                             onTransferRule: {
                                 recordAction(.ruleCreated, for: item)
-                                appState.createRule(from: item, markTransfer: true)
+                                animatingResolution { appState.createRule(from: item, markTransfer: true) }
                             },
                             onIgnore: {
                                 recordAction(.ignored, for: item)
-                                appState.ignoreReviewItem(item.id)
+                                animatingResolution { appState.ignoreReviewItem(item.id) }
                             }
                         )
+                        // Resolved rows animate out (and the rest slide up) when
+                        // the action removes them from the snapshot.
+                        .transition(reduceMotion ? .opacity : .move(edge: .trailing).combined(with: .opacity))
                     }
                     }
                 }
@@ -206,6 +209,15 @@ struct ReviewInboxView: View {
 
     private func clampSelection() {
         selectedIndex = min(max(selectedIndex, 0), max(items.count - 1, 0))
+    }
+
+    // Runs a review mutation inside an animation so the resulting snapshot
+    // change (a resolved row leaving the inbox, the rest sliding up) animates
+    // fluidly instead of snapping. Gated by Reduce Motion.
+    private func animatingResolution(_ change: () -> Void) {
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            change()
+        }
     }
 
     private func recordAction(_ action: ReviewActionConfirmation.Action, for item: TransactionReviewItem) {

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -586,6 +586,7 @@ private struct ReviewInboxRow: View {
         case .possibleTransfer: "arrow.left.arrow.right"
         case .recurringChanged: "calendar.badge.exclamationmark"
         case .pendingChanged: "clock.badge.exclamationmark"
+        case .changedSinceReview: "arrow.triangle.2.circlepath"
         }
     }
 

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -251,19 +251,39 @@ public enum TransactionReviewInbox {
             }
             guard !orderedReasons.isEmpty else { return nil }
 
-            // A matched rule applies its normalized fields, and an already
-            // reviewed/ignored item is settled — but neither should hide a
-            // high-priority signal (large spike, recurring change, posted-pending
-            // change, possible transfer). Surface those; suppress the rest.
-            if isAlreadyResolved || !matchedRules.isEmpty {
+            // A charge the user already reviewed/ignored is CLEARED from the
+            // inbox once they act — even when it carries a high-priority reason.
+            // (Previously a high-priority reason kept resolved items pinned, so
+            // Approve/Ignore appeared to do nothing on exactly the large/unusual
+            // rows users most want to clear.) It only returns if the charge
+            // materially changed SINCE the review — a different posted amount/name
+            // (`reviewedChargeChanged`) or a pending→posted settle difference —
+            // in which case it reopens as needs-review (reportedStatus below).
+            // Reopen a resolved charge only if it materially changed since review:
+            // a pending→posted settle difference (`didSettleDifferently`), or — when
+            // the user resolved the POSTED charge under its own id — a later
+            // amount/name change vs that own baseline. The carried-forward pending
+            // record is NOT used as a change baseline (its pending-phase name/amount
+            // legitimately differ from the posted charge; that comparison is
+            // `didSettleDifferently`'s job).
+            let changedSinceReview = isAlreadyResolved
+                && (didSettleDifferently
+                    || (ownResolved && reviewedChargeChanged(transaction, ownMetadata)))
+            if isAlreadyResolved, !changedSinceReview {
+                return nil
+            }
+
+            // A matched rule normalizes fields on an item the user has NOT
+            // explicitly resolved; it should not hide a fresh high-priority
+            // signal, but the rule handles the lower-priority ones.
+            if !isAlreadyResolved, !matchedRules.isEmpty {
                 guard orderedReasons.contains(where: \.isHighPriority) else { return nil }
             }
 
-            // A charge that settled with a different amount or name after its
-            // pending phase was already approved/ignored is effectively reopened —
-            // present it as needing review rather than as still resolved.
+            // A reviewed charge that changed after the fact is effectively
+            // reopened — present it as needing review rather than as resolved.
             let reportedStatus: TransactionReviewStatus =
-                (didSettleDifferently && isAlreadyResolved) ? .needsReview : (metadata?.status ?? .needsReview)
+                changedSinceReview ? .needsReview : (metadata?.status ?? .needsReview)
 
             return TransactionReviewItem(
                 transaction: transaction,
@@ -421,6 +441,27 @@ public enum TransactionReviewInbox {
             (recurring.lastDate == transaction.date && recurring.hasPriceIncrease) ||
                 recurring.isStale(asOf: now)
         }
+    }
+
+    /// Whether a charge the user already reviewed has materially changed since,
+    /// relative to the amount/name snapshot captured at review time (`lastSeen*`).
+    /// A changed charge reopens in the inbox as needs-review; an unchanged one
+    /// stays cleared. Missing baselines mean "no change". The pending→posted
+    /// transition itself is NOT a material change — a charge that posts with the
+    /// same amount/name should stay cleared (the pending-vs-posted settle
+    /// difference is detected separately by `pendingSettledDifferently`).
+    private static func reviewedChargeChanged(
+        _ transaction: TransactionDTO,
+        _ metadata: TransactionReviewMetadata?
+    ) -> Bool {
+        guard let metadata else { return false }
+        if let seenAmount = metadata.lastSeenAmount, abs(seenAmount - transaction.amount) > 0.005 {
+            return true
+        }
+        if let seenName = metadata.lastSeenName, seenName != transaction.name {
+            return true
+        }
+        return false
     }
 
     /// The record that captured this charge while it was pending. Prefer the

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -13,6 +13,7 @@ public enum TransactionReviewReason: String, Codable, Sendable, CaseIterable, Eq
     case possibleTransfer
     case recurringChanged
     case pendingChanged
+    case changedSinceReview
 
     public var displayName: String {
         switch self {
@@ -22,12 +23,13 @@ public enum TransactionReviewReason: String, Codable, Sendable, CaseIterable, Eq
         case .possibleTransfer: "Possible transfer"
         case .recurringChanged: "Recurring changed"
         case .pendingChanged: "Pending changed"
+        case .changedSinceReview: "Changed since review"
         }
     }
 
     public var priority: Int {
         switch self {
-        case .possibleTransfer, .pendingChanged, .recurringChanged: 0
+        case .possibleTransfer, .pendingChanged, .recurringChanged, .changedSinceReview: 0
         case .unusualAmount: 1
         case .uncategorized, .newMerchant: 2
         }
@@ -244,6 +246,16 @@ public enum TransactionReviewInbox {
             if didSettleDifferently {
                 reasons.insert(.pendingChanged)
             }
+            // A charge the user already resolved under its own id whose amount or
+            // name drifted afterward must reopen even when the new value trips no
+            // other heuristic (e.g. a known, categorized merchant going $50 -> $60,
+            // below the unusual-amount threshold). Insert the reason BEFORE the
+            // empty-reasons guard below — otherwise that guard drops the row and the
+            // reopen logic never runs, silently swallowing the post-review change.
+            let reviewedChargeChangedSinceReview = ownResolved && reviewedChargeChanged(transaction, ownMetadata)
+            if reviewedChargeChangedSinceReview {
+                reasons.insert(.changedSinceReview)
+            }
 
             let orderedReasons = reasons.sorted {
                 if $0.priority == $1.priority { return $0.rawValue < $1.rawValue }
@@ -267,8 +279,7 @@ public enum TransactionReviewInbox {
             // legitimately differ from the posted charge; that comparison is
             // `didSettleDifferently`'s job).
             let changedSinceReview = isAlreadyResolved
-                && (didSettleDifferently
-                    || (ownResolved && reviewedChargeChanged(transaction, ownMetadata)))
+                && (didSettleDifferently || reviewedChargeChangedSinceReview)
             if isAlreadyResolved, !changedSinceReview {
                 return nil
             }

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -320,6 +320,43 @@ struct TransactionReviewInboxTests {
         #expect(snapshot.totalCount == 0)
     }
 
+    @Test("Approving a high-priority (unusual-amount) charge clears it from the inbox")
+    func approvingHighPriorityChargeClearsIt() {
+        let transactions = [
+            tx(id: "old-1", amount: 20, date: "2026-05-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-2", amount: 22, date: "2026-05-08", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-3", amount: 21, date: "2026-05-15", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "spike", amount: 120, date: "2026-06-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+        ]
+
+        // The spike is high-priority (unusual amount) before review.
+        #expect(evaluate(transactions).items.contains { $0.id == "spike" })
+
+        // Approving it clears it from the inbox even though the reason is
+        // high-priority — the user acted, so it should not stay pinned.
+        let approved = TransactionReviewMetadata(id: "spike", status: .reviewed, lastSeenAmount: 120)
+        let afterApprove = evaluate(transactions, metadata: [approved])
+        #expect(afterApprove.items.contains { $0.id == "spike" } == false)
+    }
+
+    @Test("A reviewed charge reopens if its amount changes afterward")
+    func reviewedChargeReopensWhenAmountChanges() {
+        let transactions = [
+            tx(id: "old-1", amount: 20, date: "2026-05-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-2", amount: 22, date: "2026-05-08", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "old-3", amount: 21, date: "2026-05-15", category: .foodAndDrink, merchantName: "Coffee Shop"),
+            tx(id: "spike", amount: 120, date: "2026-06-01", category: .foodAndDrink, merchantName: "Coffee Shop"),
+        ]
+
+        // Reviewed at $40, but the charge is now $120 — materially changed since
+        // review, so it reopens as needs-review instead of staying cleared.
+        let staleApproval = TransactionReviewMetadata(id: "spike", status: .reviewed, lastSeenAmount: 40)
+        let snapshot = evaluate(transactions, metadata: [staleApproval])
+        let spike = snapshot.items.first { $0.id == "spike" }
+        #expect(spike != nil)
+        #expect(spike?.status == .needsReview)
+    }
+
     @Test("Rule-matched transactions stay out of inbox")
     func ruleMatchedTransactionsAreTrusted() {
         let transaction = tx(id: "rule-match", category: nil, merchantName: "Known Merchant")

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -357,6 +357,38 @@ struct TransactionReviewInboxTests {
         #expect(spike?.status == .needsReview)
     }
 
+    @Test("A reviewed charge reopens when its amount drifts below the unusual threshold (no other signal)")
+    func reviewedChargeReopensOnSubThresholdDrift() {
+        // A known, categorized merchant the inbox would not otherwise flag: several
+        // similar prior charges (so it is not a new merchant), categorized (not
+        // uncategorized), and a new amount close to its peers (not unusual). The
+        // ONLY thing that can surface it is that it changed after review — the case
+        // the empty-reasons guard used to swallow before the reopen logic ran.
+        let transactions = [
+            tx(id: "g-1", amount: 40, date: "2026-05-01", category: .foodAndDrink, merchantName: "Corner Grocer"),
+            tx(id: "g-2", amount: 42, date: "2026-05-08", category: .foodAndDrink, merchantName: "Corner Grocer"),
+            tx(id: "g-3", amount: 41, date: "2026-05-15", category: .foodAndDrink, merchantName: "Corner Grocer"),
+            tx(id: "g-4", amount: 43, date: "2026-05-22", category: .foodAndDrink, merchantName: "Corner Grocer"),
+            tx(id: "drift", amount: 45, date: "2026-06-01", category: .foodAndDrink, merchantName: "Corner Grocer"),
+        ]
+
+        // With no metadata the modest $45 charge trips no heuristic on its own.
+        #expect(evaluate(transactions).items.contains { $0.id == "drift" } == false)
+
+        // Reviewed when it was $41, later posted as $45 — a sub-threshold change no
+        // other heuristic catches. It must still reopen as needs-review.
+        let staleReview = TransactionReviewMetadata(id: "drift", status: .reviewed, lastSeenAmount: 41)
+        let reopened = evaluate(transactions, metadata: [staleReview])
+        let drift = reopened.items.first { $0.id == "drift" }
+        #expect(drift != nil)
+        #expect(drift?.status == .needsReview)
+        #expect(drift?.reasonCodes.contains(.changedSinceReview) == true)
+
+        // An unchanged reviewed charge (seen at the same $45) stays cleared.
+        let cleanReview = TransactionReviewMetadata(id: "drift", status: .reviewed, lastSeenAmount: 45)
+        #expect(evaluate(transactions, metadata: [cleanReview]).items.contains { $0.id == "drift" } == false)
+    }
+
     @Test("Rule-matched transactions stay out of inbox")
     func ruleMatchedTransactionsAreTrusted() {
         let transaction = tx(id: "rule-match", category: nil, merchantName: "Known Merchant")


### PR DESCRIPTION
## The report
"When I click Approve, the spend stays listed — feels weird." Verified, diagnosed, fixed.

## Diagnosis (data pipeline is fine; it's the inbox filter)
- **Backend works:** `approveReviewItem` → `status = .reviewed` + `lastSeen` baseline → persists to the **local cache** (`saveTransactionReviewMetadata`, survives restart) → recomputes the snapshot. Local-only by design, undoable. Nothing lost.
- **Why it stayed listed:** `TransactionReviewInbox.evaluate` kept a resolved item whenever it had a **high-priority** reason — and `unusualAmount` ("Large / unusual") is high-priority, so every flagged row stayed after Approve, looking unchanged.

## Fix (you chose "clear it from the inbox")
- A user-resolved (approved/ignored) charge **leaves the inbox** once acted on, regardless of priority.
- It **reopens** only if it materially changed *since review*: a different posted amount/name, or a pending→posted settle difference (`didSettleDifferently`). The carried-forward pending record is not misused as a change baseline.
- Rule-matched items the user hasn't resolved keep high-priority surfacing.

## Fluidity
The resolving action runs inside `withAnimation` and rows have a removal transition (reduce-motion aware), so the cleared row slides out and the rest move up. The "Approved · Undo" banner + Undo are unchanged.

## Tests / verification
- New: approving a high-priority (unusual-amount) charge clears it; a reviewed charge reopens when its amount changes.
- Existing pending→posted settle + carry-forward suppression tests still pass.
- `swift build -strict-concurrency=complete -warnings-as-errors` ✅ · `swift test` ✅ **855**.

Note: computer-use can't drive the menu-bar app (not in the system's controllable-apps index), so this was verified at the code + test level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)