### PR TITLE
fix: prefer an instruct model for Local AI insights (fixes "Local Error")

### DIFF
--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -138,7 +138,21 @@ struct LocalAIInsightsService: Sendable {
         }
 
         do {
-            _ = try await boundedProbe(model: model)
+            let probeOutput = try await boundedProbe(model: model)
+            // A model that responds but emits nothing usable (e.g. a reasoning
+            // model that spends a short token budget on chain-of-thought and
+            // returns an empty `response`) must NOT be reported as available —
+            // the real summary call would hit the same empty output and be
+            // rejected. Surface it as invalid output with an actionable hint
+            // instead of falsely claiming the runtime is healthy.
+            guard !probeOutput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return LocalAIRuntimeResolution.resolved(
+                    base: currentAvailability,
+                    usedModelOutput: false,
+                    fallbackReason: .invalidOutput,
+                    fallbackDiagnostic: "Local runtime returned an empty response. This usually means a reasoning model is configured; set an instruct model such as llama3.2."
+                )
+            }
             return LocalAIRuntimeResolution.resolved(
                 base: currentAvailability,
                 usedModelOutput: true,

--- a/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
+++ b/Sources/PlaidBar/Services/OllamaLocalInsightModel.swift
@@ -114,18 +114,25 @@ struct OllamaLocalInsightModel: LocalInsightModel {
         }
     }
 
+    // Auto-discovery prefers small/medium INSTRUCT models. A local insight is a
+    // single short summary, so a direct instruct model is the right fit. Reasoning
+    // models (e.g. gpt-oss) are intentionally NOT preferred: for a short prompt
+    // they spend their token budget on chain-of-thought and return an empty
+    // `response`, which VaultPeek then rejects as invalid output. If a user has
+    // only a reasoning model installed, discovery may still fall through to it,
+    // but the empty-output probe guard surfaces an accurate error rather than
+    // silently degrading.
     private static let preferredModelPrefixes = [
-        "gpt-oss",
         "llama3.2",
         "llama3.1",
-        "gemma4",
+        "qwen2.5",
         "gemma3",
         "gemma2",
-        "qwen3.5",
-        "qwen3",
         "mistral",
-        "qwen2.5",
         "phi3",
+        "qwen3",
+        "gemma4",
+        "qwen3.5",
     ]
 
     private func requestDiagnostic(_ request: URLRequest) -> String {


### PR DESCRIPTION
## The report
"Local Error" on the Local Insight Receipt — even with Ollama running and models installed.

## Diagnosis (not a broken integration)
Ollama is healthy. Model auto-discovery preferred **`gpt-oss`** first (it was #1 in `preferredModelPrefixes`), so it picked **`gpt-oss:20b`** — a **reasoning model**. For the short summary prompt it spends its small token budget on chain-of-thought and returns an **empty `response`** (reproduced: `RESPONSE: ''`). VaultPeek correctly rejects empty/unusable output → deterministic fallback → "Local Error / returned invalid or unsafe output." A small instruct model (`llama3.2:1b`) returns clean usable output to the same prompts.

## Fix
- **Prefer instruct models:** reorder `preferredModelPrefixes` to llama3.2 / llama3.1 / qwen2.5 / gemma / mistral / phi first; drop the gpt-oss reasoning family from the preferred set.
- **Accurate probe:** a model that responds but returns empty/blank output is reported as `.invalidOutput` with an actionable hint, instead of being marked "available" and then failing on the real summary call.

## Verification (CI/Codex billing-blocked; app-target code isn't @testable-importable)
- `swift build -strict-concurrency=complete -warnings-as-errors` ✅ · `swift test` ✅ **853**.
- **Live Ollama:** simulated the new discovery order against the installed models → now selects **`llama3.2:1b`** (usable output) instead of `gpt-oss:20b` (empty). The Local Insight Receipt will render a real on-device summary.

Tip: users can still pin a specific model via `PLAIDBAR_LOCAL_AI_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)