### PR TITLE
feat: expose the "Lock when it loses focus" App Lock toggle

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -356,6 +356,13 @@ struct PrivacySecuritySettingsView: View {
                 Toggle("Lock on launch", isOn: $state.appLockPreferences.lockOnLaunch)
                     .disabled(!appState.appLockPreferences.appLockEnabled)
 
+                Toggle("Lock when it loses focus", isOn: $state.appLockPreferences.lockWhenBackgrounded)
+                    .disabled(!appState.appLockPreferences.appLockEnabled)
+
+                Text("Re-lock automatically — on launch, and whenever VaultPeek loses focus (you click away or the popover closes). Turn either off to stay unlocked across those transitions.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+
                 Toggle("Pause refresh while locked", isOn: $state.appLockPreferences.pauseRefreshWhileLocked)
                     .disabled(!appState.appLockPreferences.appLockEnabled)
 


### PR DESCRIPTION
## What
Adds the missing Settings toggle for `lockWhenBackgrounded`. The preference was already persisted and consumed (it drives `lockOnResignActiveIfNeeded()`, fired on `NSApplication.didResignActiveNotification`), but there was **no UI** to view or change it — flagged as the residual from #479/AND-479.

## Where
`Settings → App Lock`, directly below **Lock on launch** (the two automatic re-lock triggers grouped together), gated on `appLockEnabled` exactly like its siblings, with a one-line description of when each trigger fires.

```
Require authentication            [on]
Lock on launch                    [ ]
Lock when it loses focus          [on]   ← new
  Re-lock automatically — on launch, and whenever VaultPeek loses
  focus (you click away or the popover closes)…
Pause refresh while locked        [ ]
```

## Notes
- **Label** says "loses focus", not "background": the trigger is the menu-bar app losing focus (clicking away / popover closing), not OS backgrounding — the honest description of `didResignActiveNotification`.
- **Persistence**: mutating `$state.appLockPreferences.lockWhenBackgrounded` flows through `appLockPreferences.didSet → persistAppLockPreferences()`, the same path the working `lockOnLaunch` toggle already uses.
- Default remains `true`, so the toggle reads on for users with App Lock enabled — it now lets them *turn it off* and makes the behavior discoverable.

## Verification (app-target UI isn't @testable-importable; CI billing-blocked)
- `swift build -strict-concurrency=complete -warnings-as-errors` ✅
- `swift test` ✅ **857** — the underlying `shouldLockWhenBackgrounded` policy is already unit-tested in `AppLockPresentationTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)