### PR TITLE
fix: suppress the system focus ring on the embedded Review Inbox

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -96,6 +96,11 @@ struct ReviewInboxView: View {
             .modifier(ConditionalRaisedSurface(embedded: embedded))
             .focusable()
             .focused($isFocused)
+            // Keep the container focusable for arrow-key row navigation, but
+            // suppress the macOS system focus ring. Embedded as the full right
+            // column the ring wraps the whole panel and reads as an accidental
+            // "selected" state; the selected row already shows its own accent.
+            .focusEffectDisabled()
             .onAppear {
                 isFocused = true
                 clampSelection()


### PR DESCRIPTION
## What you saw
A blue rounded outline around the **entire** Review Inbox column — looked like the whole panel was selected.

## Why
It's the macOS **system keyboard-focus ring**. `ReviewInboxView`'s scroll container is `.focusable()` and auto-grabs focus on appear (`onAppear { isFocused = true }`) to enable arrow-key row navigation (`.onMoveCommand`). Embedded as the full right-hand inspector column, the focus ring wraps the whole panel. The actually-selected *row* already has its own accent (leading bar + tinted wash), so the panel-wide ring is redundant and misreads as an error/selected state.

## Fix
Add `.focusEffectDisabled()` to the focusable container — keeps focusability and arrow-key navigation, drops the visual ring. (macOS 14+; the app targets macOS 15.)

## Verification
- `swift build -strict-concurrency=complete -warnings-as-errors` ✅
- App-target SwiftUI (not @testable-importable); no logic change, purely the focus *effect*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)