### PR TITLE
fix: hide Review Inbox counts while private

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -27,6 +27,14 @@ struct ReviewInboxView: View {
         Array(snapshot.items.prefix(embedded ? 20 : 6))
     }
 
+    private var headerPresentation: ReviewInboxPrivacyPresentation {
+        ReviewInboxPrivacyPresentation.make(
+            totalCount: snapshot.totalCount,
+            highPriorityCount: snapshot.highPriorityCount,
+            isPrivate: appState.shouldMaskFinancialValues
+        )
+    }
+
     var body: some View {
         if embedded || snapshot.totalCount > 0 || actionConfirmation != nil {
             VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -116,7 +124,7 @@ struct ReviewInboxView: View {
             }
             .onMoveCommand(perform: moveSelection)
             .accessibilityElement(children: .contain)
-            .accessibilityLabel("Review inbox. \(snapshot.totalCount) transaction\(snapshot.totalCount == 1 ? "" : "s") need attention.")
+            .accessibilityLabel(headerPresentation.accessibilityLabel)
         }
     }
 
@@ -126,19 +134,19 @@ struct ReviewInboxView: View {
                 Text("Review Inbox")
                     .sectionTitle()
 
-                Text("\(snapshot.totalCount) item\(snapshot.totalCount == 1 ? "" : "s") need attention")
+                Text(headerPresentation.subtitle)
                     .microText()
                     .foregroundStyle(.secondary)
             }
 
             Spacer()
 
-            if snapshot.highPriorityCount > 0 {
-                Label("\(snapshot.highPriorityCount) high priority", systemImage: "exclamationmark.triangle.fill")
+            if let highPriorityBadge = headerPresentation.highPriorityBadge {
+                Label(highPriorityBadge, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(SemanticColors.warning)
                     .labelStyle(.titleAndIcon)
-                    .accessibilityLabel("\(snapshot.highPriorityCount) high priority review item\(snapshot.highPriorityCount == 1 ? "" : "s")")
+                    .accessibilityLabel(headerPresentation.highPriorityAccessibilityLabel ?? highPriorityBadge)
             }
 
             Button {

--- a/Sources/PlaidBarCore/Models/AppLockPresentation.swift
+++ b/Sources/PlaidBarCore/Models/AppLockPresentation.swift
@@ -182,3 +182,37 @@ public enum AppLockAuthenticationMessage: Sendable, Equatable {
         }
     }
 }
+
+public struct ReviewInboxPrivacyPresentation: Sendable, Equatable {
+    public let subtitle: String
+    public let highPriorityBadge: String?
+    public let highPriorityAccessibilityLabel: String?
+    public let accessibilityLabel: String
+
+    public static func make(
+        totalCount: Int,
+        highPriorityCount: Int,
+        isPrivate: Bool
+    ) -> ReviewInboxPrivacyPresentation {
+        if isPrivate {
+            return ReviewInboxPrivacyPresentation(
+                subtitle: "Items need attention",
+                highPriorityBadge: nil,
+                highPriorityAccessibilityLabel: nil,
+                accessibilityLabel: "Review inbox. Items are hidden while VaultPeek is private."
+            )
+        }
+
+        let itemSuffix = totalCount == 1 ? "item" : "items"
+        let transactionSuffix = totalCount == 1 ? "transaction" : "transactions"
+        let highPrioritySuffix = highPriorityCount == 1 ? "item" : "items"
+        return ReviewInboxPrivacyPresentation(
+            subtitle: "\(totalCount) \(itemSuffix) need attention",
+            highPriorityBadge: highPriorityCount > 0 ? "\(highPriorityCount) high priority" : nil,
+            highPriorityAccessibilityLabel: highPriorityCount > 0
+                ? "\(highPriorityCount) high priority review \(highPrioritySuffix)"
+                : nil,
+            accessibilityLabel: "Review inbox. \(totalCount) \(transactionSuffix) need attention."
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -34,6 +34,37 @@ struct AppLockPresentationTests {
         #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: false, isIconOnly: false) == "Private")
     }
 
+    @Test("private Review Inbox header does not expose queue counts")
+    func privateReviewInboxHeaderDoesNotExposeCounts() {
+        let presentation = ReviewInboxPrivacyPresentation.make(
+            totalCount: 7,
+            highPriorityCount: 3,
+            isPrivate: true
+        )
+
+        #expect(presentation.subtitle == "Items need attention")
+        #expect(presentation.highPriorityBadge == nil)
+        #expect(presentation.highPriorityAccessibilityLabel == nil)
+        #expect(presentation.accessibilityLabel == "Review inbox. Items are hidden while VaultPeek is private.")
+        #expect(!presentation.subtitle.contains("7"))
+        #expect(!presentation.accessibilityLabel.contains("7"))
+        #expect(!presentation.accessibilityLabel.contains("3"))
+    }
+
+    @Test("normal Review Inbox header keeps actionable queue counts")
+    func normalReviewInboxHeaderKeepsCounts() {
+        let presentation = ReviewInboxPrivacyPresentation.make(
+            totalCount: 2,
+            highPriorityCount: 1,
+            isPrivate: false
+        )
+
+        #expect(presentation.subtitle == "2 items need attention")
+        #expect(presentation.highPriorityBadge == "1 high priority")
+        #expect(presentation.highPriorityAccessibilityLabel == "1 high priority review item")
+        #expect(presentation.accessibilityLabel == "Review inbox. 2 transactions need attention.")
+    }
+
     @Test("locked pause settings fail closed for refresh and notifications")
     func lockedPauseSettingsFailClosed() {
         let paused = AppLockPreferences(appLockEnabled: true, notificationPrivacyMode: .offWhileLocked, pauseRefreshWhileLocked: true)


### PR DESCRIPTION
## Summary
- hides exact Review Inbox queue/high-priority counts while Privacy Mask or App Lock is active
- moves the header/accessibility copy decision into a testable `ReviewInboxPrivacyPresentation` policy
- preserves actionable exact counts in normal mode

Fixes #484
Linear: AND-483
Kanban: t_64efa904

## Verification
- `swift test --filter AppLockPresentationTests` — 13 tests passed
- `git diff --check` — passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

Note: `swift test --filter ReviewInboxPrivacyPresentation` built successfully but matched 0 tests; treated as invalid verification and reran the suite-level `AppLockPresentationTests` filter.

## Privacy/security
Local UI privacy disclosure fix only. No raw credentials, Plaid tokens, account IDs, transaction IDs, balances, SQLite data, prompts, or response bodies are moved or printed. The app target continues to use existing local presentation state only.