### PR TITLE
feat: real popover glass via custom NSStatusItem + NSPopover

### DIFF
--- a/Sources/PlaidBar/App/MenuBarAppDelegate.swift
+++ b/Sources/PlaidBar/App/MenuBarAppDelegate.swift
@@ -1,0 +1,364 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Process-lifetime hand-off from the SwiftUI `App` (which owns init ordering /
+/// appearance-before-paint and the `Settings` scene) to the AppKit
+/// `MenuBarAppDelegate` (which `@NSApplicationDelegateAdaptor` constructs itself,
+/// so it can't be handed dependencies via init). `PlaidBarApp.init` fills this in
+/// on the main thread; the delegate reads it in `applicationDidFinishLaunching`,
+/// which always runs after `App.init`.
+@MainActor
+enum MenuBarAppContext {
+    static var appState: AppState?
+    static var detachedDashboard: DetachedDashboardCoordinator?
+    static var updaterController: SPUUpdaterControlling?
+    static var contextMenuController: StatusItemContextMenuController?
+    static var forcedColorScheme: ColorScheme?
+}
+
+/// Minimal protocol so the context can hold the Sparkle updater controller
+/// without this file importing Sparkle (the App already owns the real one).
+@MainActor
+protocol SPUUpdaterControlling: AnyObject {
+    func checkForUpdatesFromMenu()
+}
+
+/// Owns the menu-bar `NSStatusItem` and the `NSPopover` that hosts `MainPopover`.
+///
+/// Replaces SwiftUI `MenuBarExtra(.window)` (which cannot be made translucent —
+/// Apple exposes no API for its window background). An `NSPopover` renders the
+/// native frosted-glass popover material for free; we only need a clear content
+/// root. Every behavior MenuBarExtra used to provide off the always-mounted
+/// label is re-homed here so none silently break.
+@MainActor
+final class MenuBarAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private var labelHostingView: NSView?
+
+    // Click-away dismissal needs BOTH monitors: global catches clicks in other
+    // apps, local catches clicks in our own other windows (Settings / detached).
+    private var globalClickMonitor: Any?
+    private var localClickMonitor: Any?
+    private var keyDownMonitor: Any?
+    private var observers: [NSObjectProtocol] = []
+    /// Guards the observation bridge against re-entrancy (show/close write the
+    /// same flag they observe).
+    private var isSyncingPresentation = false
+
+    private var appState: AppState? { MenuBarAppContext.appState }
+    private var detachedDashboard: DetachedDashboardCoordinator? { MenuBarAppContext.detachedDashboard }
+    private var reduceMotion: Bool { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard let appState else { return }
+
+        setUpStatusItem(appState: appState)
+        setUpPopover(appState: appState)
+        configureContextMenu(appState: appState)
+        installLifecycleObservers(appState: appState)
+        bridgePresentationFlag(appState: appState)
+
+        // Restore a persisted detached window, then honor the --detach QA flag,
+        // mirroring the old always-mounted-label .task (AND-384).
+        detachedDashboard?.sync(
+            appState: appState,
+            forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+            reduceMotion: reduceMotion
+        )
+        if CommandLine.arguments.contains("--detach") {
+            detachedDashboard?.presentForLaunchOverride(
+                appState: appState,
+                forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+                reduceMotion: reduceMotion
+            )
+        }
+    }
+
+    /// vaultpeek:// deep link (widget / external). Raises the detached window if
+    /// detached, otherwise opens the popover via the presentation flag.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        guard let appState, urls.contains(where: { $0.scheme == "vaultpeek" }) else { return }
+        if detachedDashboard?.handleMenuBarActivation(
+            appState: appState,
+            forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+            reduceMotion: reduceMotion
+        ) == true {
+            return
+        }
+        appState.isPopoverPresented = true
+    }
+
+    // MARK: - Status item
+
+    private func setUpStatusItem(appState: AppState) {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        guard let button = item.button else { return }
+
+        let host = NSHostingView(
+            rootView: MenuBarLabel()
+                .environment(appState)
+                .forcedAppColorScheme(MenuBarAppContext.forcedColorScheme)
+        )
+        host.translatesAutoresizingMaskIntoConstraints = false
+        button.addSubview(host)
+        NSLayoutConstraint.activate([
+            host.leadingAnchor.constraint(equalTo: button.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: button.trailingAnchor),
+            host.topAnchor.constraint(equalTo: button.topAnchor),
+            host.bottomAnchor.constraint(equalTo: button.bottomAnchor),
+        ])
+        labelHostingView = host
+
+        button.target = self
+        button.action = #selector(togglePopover)
+        // Right-click is owned by StatusItemContextMenuController's local
+        // monitor; only route LEFT clicks here to avoid a down/up double-fire.
+        button.sendAction(on: [.leftMouseUp])
+
+        statusItem = item
+    }
+
+    // MARK: - Popover
+
+    private func setUpPopover(appState: AppState) {
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.animates = true
+        popover.delegate = self
+        popover.contentViewController = NSHostingController(
+            rootView: MainPopover()
+                .environment(appState)
+                .environment(\.dashboardPresentation, .popover(detach: { [weak self] in
+                    guard let self, let appState = self.appState else { return }
+                    self.detachedDashboard?.detach(
+                        appState: appState,
+                        forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+                        reduceMotion: self.reduceMotion
+                    )
+                }))
+                .forcedAppColorScheme(MenuBarAppContext.forcedColorScheme)
+        )
+        self.popover = popover
+    }
+
+    private func configureContextMenu(appState: AppState) {
+        guard let statusItem, let controller = MenuBarAppContext.contextMenuController else { return }
+        controller.configure(
+            statusItem: statusItem,
+            actions: StatusItemContextMenuActions(
+                showDashboard: { [weak self] in self?.showDashboardFromMenu() },
+                openInWindow: { [weak self] in
+                    guard let self, let appState = self.appState else { return }
+                    self.detachedDashboard?.detach(
+                        appState: appState,
+                        forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+                        reduceMotion: self.reduceMotion
+                    )
+                },
+                refreshDashboard: { Task { await appState.refreshDashboard() } },
+                openSettings: { SettingsWindowActivationRestorer.shared.open() },
+                checkForUpdates: { MenuBarAppContext.updaterController?.checkForUpdatesFromMenu() },
+                showAbout: {
+                    NSApplication.shared.orderFrontStandardAboutPanel(nil)
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                },
+                dismissPopover: { [weak self] in self?.closePopover() }
+            )
+        )
+    }
+
+    private func showDashboardFromMenu() {
+        guard let appState else { return }
+        // "Open VaultPeek" raises the floating window when detached (AND-384),
+        // otherwise opens the popover. The menu has no SwiftUI observer behind
+        // it, so open the popover explicitly here.
+        if detachedDashboard?.handleMenuBarActivation(
+            appState: appState,
+            forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+            reduceMotion: reduceMotion
+        ) == true {
+            return
+        }
+        showPopover()
+    }
+
+    // MARK: - Toggle / show / close
+
+    @objc private func togglePopover() {
+        guard let appState else { return }
+        // Detach intercept FIRST: a click while detached raises the floating
+        // window instead of the popover (AND-384). handleMenuBarActivation
+        // returns true when it consumed the click.
+        if detachedDashboard?.handleMenuBarActivation(
+            appState: appState,
+            forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+            reduceMotion: reduceMotion
+        ) == true {
+            return
+        }
+        if popover?.isShown == true {
+            closePopover()
+        } else {
+            showPopover()
+        }
+    }
+
+    private func showPopover() {
+        guard let popover, let button = statusItem?.button, !popover.isShown else { return }
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        // A .transient popover doesn't become key under LSUIElement/.accessory,
+        // so TextField focus / Esc would be dead — activate + make key.
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        popover.contentViewController?.view.window?.makeKey()
+        button.isHighlighted = true
+        setPresented(true)
+        // App Lock: opening while locked prompts auth (no-op otherwise). Driven
+        // from popover-open ONLY, never didBecomeActive, so the auth sheet's
+        // app-deactivation can't start a lock/unlock loop (AND-462).
+        if appState?.isAppLocked == true {
+            Task { [weak appState] in await appState?.unlockApp() }
+        }
+        installClickMonitors()
+    }
+
+    private func closePopover() {
+        guard let popover else { return }
+        popover.performClose(nil)
+        statusItem?.button?.isHighlighted = false
+        setPresented(false)
+        removeClickMonitors()
+    }
+
+    /// Writes the canonical flag without re-triggering the observation bridge.
+    private func setPresented(_ value: Bool) {
+        isSyncingPresentation = true
+        appState?.isPopoverPresented = value
+        isSyncingPresentation = false
+    }
+
+    // MARK: - NSPopoverDelegate
+
+    func popoverDidClose(_ notification: Notification) {
+        statusItem?.button?.isHighlighted = false
+        setPresented(false)
+        removeClickMonitors()
+    }
+
+    // MARK: - Click-away + Esc
+
+    private func installClickMonitors() {
+        removeClickMonitors()
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.closePopover() }
+        }
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            // Dismiss when the click lands in another VaultPeek window (Settings,
+            // detached). Clicks inside the popover keep it open.
+            MainActor.assumeIsolated {
+                if let self, event.window !== self.popover?.contentViewController?.view.window {
+                    self.closePopover()
+                }
+            }
+            return event
+        }
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            // Esc closes the popover when nothing inside consumes it first
+            // (MainPopover's inspector handles Esc-to-deselect before this).
+            guard event.keyCode == 53 else { return event }
+            var handled = false
+            MainActor.assumeIsolated {
+                if let self, self.popover?.isShown == true {
+                    self.closePopover()
+                    handled = true
+                }
+            }
+            return handled ? nil : event
+        }
+    }
+
+    private func removeClickMonitors() {
+        for monitor in [globalClickMonitor, localClickMonitor, keyDownMonitor].compactMap({ $0 }) {
+            NSEvent.removeMonitor(monitor)
+        }
+        globalClickMonitor = nil
+        localClickMonitor = nil
+        keyDownMonitor = nil
+    }
+
+    // MARK: - Lifecycle observers (re-homed from the always-mounted label)
+
+    private func installLifecycleObservers(appState: AppState) {
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { _ in
+            Task { @MainActor in _ = await appState.consumePendingGlanceCommand() }
+        })
+        // Lock on focus loss. CRITICALLY does NOT close the popover — closing on
+        // resign would tear down the popover the user is unlocking when the auth
+        // sheet deactivates the app (AND-462). Transient + monitors own dismissal.
+        observers.append(center.addObserver(
+            forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
+        ) { _ in
+            MainActor.assumeIsolated { appState.lockOnResignActiveIfNeeded() }
+        })
+        // Live appearance updater: process-lifetime, so it can't live in the
+        // (lazily mounted) popover content. Re-apply NSApp.appearance whenever
+        // the stored mode changes. Cheap and a no-op under the --appearance flag.
+        observers.append(center.addObserver(
+            forName: UserDefaults.didChangeNotification, object: nil, queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                AppAppearance.applyToNSApp(
+                    modeRaw: UserDefaults.standard.string(forKey: AppAppearanceMode.storageKey)
+                        ?? AppAppearanceMode.defaultValue.rawValue
+                )
+            }
+        })
+    }
+
+    // MARK: - Presentation flag bridge (flag-only callers: --show-popover, deep link, snapshot)
+
+    private func bridgePresentationFlag(appState: AppState) {
+        armPresentationObservation(appState: appState)
+    }
+
+    /// Re-arming `withObservationTracking`: each change fires once, so re-arm on
+    /// the main actor after responding. Uses a method (not a self-capturing local
+    /// func) so the `@Sendable` onChange closure only captures Sendable values.
+    private func armPresentationObservation(appState: AppState) {
+        withObservationTracking {
+            _ = appState.isPopoverPresented
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.respondToPresentationFlag(appState.isPopoverPresented)
+                self.armPresentationObservation(appState: appState)
+            }
+        }
+    }
+
+    private func respondToPresentationFlag(_ isPresented: Bool) {
+        guard !isSyncingPresentation else { return }
+        if isPresented {
+            // A flag-only open while detached must raise the window, not the popover.
+            if let appState, detachedDashboard?.handleMenuBarActivation(
+                appState: appState,
+                forcedColorScheme: MenuBarAppContext.forcedColorScheme,
+                reduceMotion: reduceMotion
+            ) == true {
+                setPresented(false)
+                return
+            }
+            showPopover()
+        } else if popover?.isShown == true {
+            closePopover()
+        }
+    }
+}

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -1,18 +1,19 @@
 import AppKit
 import Combine
-import MenuBarExtraAccess
 import PlaidBarCore
 import Sparkle
 import SwiftUI
 
 @main
 struct PlaidBarApp: App {
+    // The menu-bar status item + popover are owned by an AppKit delegate so the
+    // popover can be a real NSPopover (native frosted glass — MenuBarExtra(.window)
+    // can't be made translucent). The delegate reads its dependencies from
+    // MenuBarAppContext, filled in below.
+    @NSApplicationDelegateAdaptor(MenuBarAppDelegate.self) private var appDelegate
     @State private var appState: AppState
-    /// Owns the floating desktop-window dashboard (AND-384). `@State` so it
-    /// persists across `body` recomputes for the process lifetime.
-    @State private var detachedDashboard = DetachedDashboardCoordinator()
-    @Environment(\.openSettings) private var openSettings
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Owns the floating desktop-window dashboard (AND-384).
+    private let detachedDashboard = DetachedDashboardCoordinator()
     private let updaterController: SPUStandardUpdaterController
     private let statusItemContextMenuController = StatusItemContextMenuController()
 
@@ -28,6 +29,17 @@ struct PlaidBarApp: App {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        // Hand the process-lifetime dependencies to the AppKit delegate (which
+        // @NSApplicationDelegateAdaptor constructs itself). App.init runs on the
+        // main thread, and the delegate reads these in applicationDidFinishLaunching
+        // (after init), so assumeIsolated is safe and the values are ready in time.
+        MainActor.assumeIsolated {
+            MenuBarAppContext.appState = state
+            MenuBarAppContext.detachedDashboard = detachedDashboard
+            MenuBarAppContext.updaterController = updaterController
+            MenuBarAppContext.contextMenuController = statusItemContextMenuController
+            MenuBarAppContext.forcedColorScheme = Self.forcedColorScheme
+        }
         if CommandLine.arguments.contains("--show-popover") {
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(700))
@@ -62,170 +74,10 @@ struct PlaidBarApp: App {
     }
 
     var body: some Scene {
-        MenuBarExtra {
-            MainPopover()
-                .environment(appState)
-                .environment(\.dashboardPresentation, .popover(detach: {
-                    detachedDashboard.detach(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                }))
-                .forcedAppColorScheme(Self.forcedColorScheme)
-                .appliesAppAppearance()
-        } label: {
-            MenuBarLabel()
-                .environment(appState)
-                .forcedAppColorScheme(Self.forcedColorScheme)
-                // The label is the only scene content mounted for the whole app
-                // lifetime, so it also carries the live appearance updater: with
-                // it here, flipping Light/Dark re-applies NSApp.appearance even
-                // when the popover and Settings are both closed (the popover and
-                // Settings keep their own copies for when they are the only
-                // mounted scene). Without this, a change made while only the label
-                // is up would not take effect until the popover next opened.
-                .appliesAppAppearance()
-                // The menu-bar label is the only scene content that is mounted
-                // for the whole app lifetime — `MainPopover` is mounted lazily,
-                // only while the popover/menu-extra window is presented, and
-                // `Settings` likewise. So the floating-window restore-at-launch,
-                // the persisted/toggled-intent sync, AND the click interceptor
-                // all live here: otherwise a saved `dashboard.detached = true`
-                // would not reopen the window until the user first opened the
-                // popover, a Settings-only toggle would not take effect until
-                // then, and — critically — a status-item click while detached
-                // (before the popover ever mounted) would set
-                // `isPopoverPresented = true` with no observer installed yet, so
-                // SwiftUI would open the popover instead of raising the floating
-                // window (AND-384).
-                .task {
-                    detachedDashboard.sync(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                    // QA/screenshot aid: "--detach" opens the floating window at
-                    // launch (parallel to "--show-popover") WITHOUT persisting the
-                    // detached intent, so a QA run never leaves a durable
-                    // `dashboard.detached` preference behind.
-                    if CommandLine.arguments.contains("--detach") {
-                        detachedDashboard.presentForLaunchOverride(
-                            appState: appState,
-                            forcedColorScheme: Self.forcedColorScheme,
-                            reduceMotion: reduceMotion
-                        )
-                    }
-                }
-                // While detached, a status-item click sets isPopoverPresented
-                // true; intercept it on the always-mounted label, snap it back to
-                // false, and raise the floating window instead of the popover.
-                // A `--detach` launch override also has a visible detached window
-                // but intentionally leaves the persisted detached preference off,
-                // so include window visibility in the intercept.
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isDashboardDetached || detachedDashboard.isWindowVisible else { return }
-                    appState.isPopoverPresented = false
-                    detachedDashboard.handleMenuBarActivation(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                }
-                .onChange(of: appState.isDashboardDetached) { _, _ in
-                    detachedDashboard.sync(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    )
-                }
-                .onOpenURL { url in
-                    guard url.scheme == "vaultpeek" else { return }
-                    if detachedDashboard.handleMenuBarActivation(
-                        appState: appState,
-                        forcedColorScheme: Self.forcedColorScheme,
-                        reduceMotion: reduceMotion
-                    ) {
-                        return
-                    }
-                    appState.isPopoverPresented = true
-                }
-                // The "Refresh balances" widget control opens the app via an
-                // `openAppWhenRun` App Intent that writes a pending command but,
-                // unlike the widget's deep link above, opens neither the popover
-                // nor the detached window — so neither `loadInitialData()` nor a
-                // dashboard refresh runs to consume it, and the control feels
-                // inert. Consume it here on the always-mounted label whenever the
-                // app becomes active (the intent activates it, whether it was
-                // already running or freshly launched). A no-op when no command
-                // is pending, so it is cheap on every activation (AND-385).
-                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-                    Task { await appState.consumePendingGlanceCommand() }
-                }
-                // App Lock trigger: lock when VaultPeek loses focus (the user
-                // clicks away / the popover closes) so balances re-mask behind
-                // the lock. A cheap no-op when App Lock or lock-when-backgrounded
-                // is off. The unlock prompt is driven from the popover-open path
-                // below, not from didBecomeActive, so presenting the system auth
-                // sheet (which deactivates this app) cannot start a lock/unlock
-                // loop (AND-462).
-                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)) { _ in
-                    appState.lockOnResignActiveIfNeeded()
-                }
-                // Opening the popover while locked prompts for authentication to
-                // reveal balances; `unlockApp()` is a no-op when App Lock is off
-                // or already unlocked.
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isAppLocked else { return }
-                    Task { await appState.unlockApp() }
-                }
-        }
-        .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
-            statusItemContextMenuController.configure(
-                statusItem: statusItem,
-                actions: StatusItemContextMenuActions(
-                    showDashboard: {
-                        // "Open VaultPeek" raises the floating window when
-                        // detached; otherwise it opens the popover (AND-384).
-                        if detachedDashboard.handleMenuBarActivation(
-                            appState: appState,
-                            forcedColorScheme: Self.forcedColorScheme,
-                            reduceMotion: reduceMotion
-                        ) {
-                            return
-                        }
-                        appState.isPopoverPresented = true
-                    },
-                    openInWindow: {
-                        // Detach into the floating desktop window directly, so the
-                        // window is reachable without hunting for the footer glyph.
-                        detachedDashboard.detach(
-                            appState: appState,
-                            forcedColorScheme: Self.forcedColorScheme,
-                            reduceMotion: reduceMotion
-                        )
-                    },
-                    refreshDashboard: {
-                        Task { await appState.refreshDashboard() }
-                    },
-                    openSettings: {
-                        SettingsWindowActivationRestorer.shared.open(openSettings: openSettings)
-                    },
-                    checkForUpdates: {
-                        updaterController.updater.checkForUpdates()
-                    },
-                    showAbout: {
-                        NSApplication.shared.orderFrontStandardAboutPanel(nil)
-                        NSApplication.shared.activate(ignoringOtherApps: true)
-                    },
-                    dismissPopover: {
-                        appState.isPopoverPresented = false
-                    }
-                )
-            )
-        }
-        .menuBarExtraStyle(.window)
-
+        // The menu bar status item + NSPopover live in MenuBarAppDelegate; the
+        // only SwiftUI scene is Settings. A Settings-only scene is the canonical
+        // shape for an LSUIElement/.accessory menu-bar app and keeps
+        // @Environment(\.openSettings) + SettingsWindowActivationRestorer working.
         Settings {
             SettingsView(updater: updaterController.updater)
                 .environment(appState)
@@ -366,12 +218,21 @@ enum AppAppearance {
     }
 }
 
-private extension View {
+extension View {
+    // Module-visible: also used by MenuBarAppDelegate's hosted MainPopover/MenuBarLabel.
     func forcedAppColorScheme(_ cliOverride: ColorScheme?) -> some View {
         modifier(ForcedAppColorScheme(cliOverride: cliOverride))
     }
 
     func appliesAppAppearance() -> some View {
         modifier(AppAppearanceApplier())
+    }
+}
+
+/// Lets `MenuBarAppContext` hold the Sparkle updater controller without the
+/// AppKit delegate importing Sparkle.
+extension SPUStandardUpdaterController: SPUUpdaterControlling {
+    public func checkForUpdatesFromMenu() {
+        updater.checkForUpdates()
     }
 }

--- a/Sources/PlaidBar/App/SnapshotRenderer.swift
+++ b/Sources/PlaidBar/App/SnapshotRenderer.swift
@@ -96,6 +96,12 @@ enum SnapshotRenderer {
 
     /// Returns `true` when the PNG was written.
     private static func capturePopoverWindow(to url: URL) -> Bool {
+        // Headless contract: the popover is now a native NSPopover, whose frosted
+        // material lives in a PRIVATE backing view that `cacheDisplay` cannot
+        // rasterize. So `--render-snapshot` captures the SwiftUI content over the
+        // slider's tint wash (legible — cards carry their own fills) but WITHOUT
+        // the desktop frost. On-screen `Scripts/screenshots.sh` (CGWindowList /
+        // screencapture) composites the real frost and remains the asset source.
         guard let window = popoverWindow(),
               let contentView = window.contentView
         else {

--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -209,10 +209,14 @@ enum SurfaceTokens {
 
     static let popoverTextureOpacity = 0.12
 
+    // The persistent columns are transparent regions of one frosted surface,
+    // not raised cards — no stroke, no drop shadow. A shadowed/stroked full-height
+    // rounded rect is exactly what made the columns read as "floating above the
+    // main component". Genuinely raised inner cards use raisedDepth/insetDepth.
     static let leftPanelDepth = SurfaceDepth(
-        strokeOpacity: 0.11,
-        innerStrokeOpacity: 0.045,
-        shadow: SurfaceShadow(opacity: 0.16, radius: 14, x: 0, y: 8)
+        strokeOpacity: 0,
+        innerStrokeOpacity: 0,
+        shadow: nil
     )
     static let raisedDepth = SurfaceDepth(
         strokeOpacity: 0.08,

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -6,6 +6,7 @@ struct MainPopover: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorScheme) private var colorScheme
     /// Whether this dashboard is hosted in the menu-bar popover or a floating
     /// desktop window (AND-384). Detached, the host window owns width/height, so
@@ -216,15 +217,26 @@ struct MainPopover: View {
             .foregroundStyle(AppearanceTextColors.primary)
             .environment(\.colorScheme, effectiveColorScheme)
             .background {
-                // The detached desktop window supplies its own behind-window
-                // vibrancy backdrop (a translucent NSVisualEffectView), so the
-                // dashboard renders a clear root there and lets the desktop show
-                // through. The menu-bar popover keeps the in-content material
-                // backdrop (its host window is not vibrant on its own).
+                // Both surfaces are real glass now: the detached desktop window
+                // has its own behind-window NSVisualEffectView, and the menu-bar
+                // popover is a native NSPopover (frosted material on its own
+                // backing). So both render a clear/overlay-only root and let the
+                // host's frost be the surface.
+                //   • Detached: fully clear (the panel owns the backdrop).
+                //   • Popover + Reduce Transparency: paint the flat in-content
+                //     material for a legible, solid surface.
+                //   • Popover (normal): overlay-only — the slider's tint wash over
+                //     the NSPopover frost — with NO second `.ultraThinMaterial`
+                //     (within-window) that would mute the desktop read-through.
                 if dashboardPresentation.isDetached {
                     Color.clear
-                } else {
+                } else if reduceTransparency {
                     PopoverMaterialBackground(transparencySetting: transparencySetting)
+                } else {
+                    PopoverMaterialBackground(
+                        transparencySetting: transparencySetting,
+                        includesMaterial: false
+                    )
                 }
             }
             // The screen-edge anchor and width reader only apply to the menu-bar
@@ -294,7 +306,7 @@ struct MainPopover: View {
                 wealthSummaryRail
 
                 Divider()
-                    .opacity(0.35)
+                    .opacity(0.5)
             }
 
             // The center flexes: the rail and inspector keep their fixed widths,
@@ -325,7 +337,11 @@ struct MainPopover: View {
             // growing the whole popover past the screen-bounded height. In the
             // detached window the panel owns the height, so the rail fills it.
             .frame(maxHeight: columnMaxHeight)
-            .leftPanelSurface()
+            // No card surface: the rail is a transparent region of the single
+            // frosted popover surface, separated from the center only by the
+            // divider hairline — so the three columns read as one sheet of glass
+            // instead of floating cards (the boxed fill+stroke+shadow was the
+            // "floating above the main component" cause).
             .transition(.move(edge: .leading).combined(with: .opacity))
     }
 
@@ -338,7 +354,7 @@ struct MainPopover: View {
     private var accountInspectorColumn: some View {
         if isInspectorColumnVisible {
             Divider()
-                .opacity(0.35)
+                .opacity(0.5)
 
             Group {
                 if let selectedAccount {
@@ -373,7 +389,8 @@ struct MainPopover: View {
             }
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: columnMaxHeight)
-            .leftPanelSurface()
+            // Transparent region of the shared frosted surface (see wealthSummaryRail);
+            // the divider hairline is the only seam between columns.
             // The column is stable now, so this transition only plays when it
             // first appears as setup completes — not on every selection (AND-405).
             .transition(.asymmetric(
@@ -2304,7 +2321,26 @@ final class SettingsWindowActivationRestorer {
     /// so opening Settings twice does not double-count and closing releases once.
     private var holdsRegularRequest = false
 
+    /// SwiftUI entry point (uses the environment's `OpenSettingsAction`).
     func open(openSettings: OpenSettingsAction) {
+        open(invoke: { openSettings() })
+    }
+
+    /// AppKit entry point (no SwiftUI environment available, e.g. the status-item
+    /// context menu owned by `MenuBarAppDelegate`). Opens the SwiftUI `Settings`
+    /// scene via the standard responder-chain selector.
+    func open() {
+        open(invoke: { Self.sendOpenSettingsAction() })
+    }
+
+    private static func sendOpenSettingsAction() {
+        let app = NSApplication.shared
+        // macOS 14+ uses `showSettingsWindow:`; fall back to the older selector.
+        if app.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil) { return }
+        _ = app.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+    }
+
+    private func open(invoke openAction: () -> Void) {
         let app = NSApplication.shared
         removeDiscoveryObserver()
         // Elevate via the shared, refcounted coordinator (not a private save) so
@@ -2314,7 +2350,7 @@ final class SettingsWindowActivationRestorer {
             AppActivationPolicyCoordinator.shared.requestRegular()
         }
 
-        openSettings()
+        openAction()
         app.activate(ignoringOtherApps: true)
 
         if focusCurrentSettingsWindow() { return }

--- a/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
+++ b/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
@@ -4,6 +4,12 @@ import SwiftUI
 
 struct PopoverMaterialBackground: View {
     let transparencySetting: PopoverTransparencySetting
+    /// Whether to paint the in-content `.ultraThinMaterial` layer. False in the
+    /// live NSPopover, which already provides the native frosted material on its
+    /// own backing — stacking a second within-window material over it would
+    /// double-frost and mute the desktop read-through. The slider's tint wash
+    /// still applies so Solid↔Glass works over the NSPopover frost.
+    var includesMaterial: Bool = true
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -28,8 +34,10 @@ struct PopoverMaterialBackground: View {
                 )
             }
 
-            Rectangle()
-                .fill(.ultraThinMaterial)
+            if includesMaterial {
+                Rectangle()
+                    .fill(.ultraThinMaterial)
+            }
 
             Color(nsColor: .windowBackgroundColor)
                 .opacity(transparencySetting.materialOverlayOpacity)

--- a/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
+++ b/Sources/PlaidBarCore/Models/PopoverTransparencySetting.swift
@@ -28,13 +28,17 @@ public struct PopoverTransparencySetting: Sendable, Equatable {
         return (multiplier * 100).rounded() / 100
     }
 
-    /// Solid fill layered over `.ultraThinMaterial`. Lower values produce a
-    /// more opaque panel; higher values preserve more desktop read-through.
-    /// The floor keeps text and numeric finance values legible at maximum
-    /// transparency.
+    /// Solid `windowBackgroundColor` wash layered over the popover's real frost
+    /// (the NSPopover material). At "Solid" the wash is nearly opaque and hides
+    /// the desktop; at "Glass" it nearly vanishes so the desktop reads through.
+    /// The range spans almost the full 0…1 so the difference is unmistakable —
+    /// the previous 0.06…0.32 band was calibrated to sit over an extra
+    /// within-window `.ultraThinMaterial` (now dropped in the popover), so it
+    /// looked nearly identical end to end. A small floor at maximum transparency
+    /// keeps root-level labels legible on busy desktops.
     public var materialOverlayOpacity: Double {
         let progress = (value - Self.minimumValue) / (Self.maximumValue - Self.minimumValue)
-        let opacity = 0.32 - (progress * 0.26)
+        let opacity = 0.96 - (progress * 0.92)
         return (opacity * 100).rounded() / 100
     }
 

--- a/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
+++ b/Tests/PlaidBarCoreTests/PopoverTransparencyTests.swift
@@ -8,7 +8,7 @@ struct PopoverTransparencyTests {
         let setting = PopoverTransparencySetting(value: PopoverTransparencySetting.defaultValue)
 
         #expect(setting.value == 70)
-        #expect(setting.materialOverlayOpacity == 0.12)
+        #expect(setting.materialOverlayOpacity == 0.25)
         #expect(setting.displayPercent == 70)
     }
 
@@ -24,8 +24,8 @@ struct PopoverTransparencyTests {
         let moreTransparent = PopoverTransparencySetting(value: 85)
 
         #expect(lessTransparent.materialOverlayOpacity > moreTransparent.materialOverlayOpacity)
-        #expect(lessTransparent.materialOverlayOpacity == 0.32)
-        #expect(moreTransparent.materialOverlayOpacity == 0.06)
+        #expect(lessTransparent.materialOverlayOpacity == 0.96)
+        #expect(moreTransparent.materialOverlayOpacity == 0.04)
     }
 
     @Test("Higher transparency slightly strengthens depth separation")


### PR DESCRIPTION
Replaces `MenuBarExtra(.window)` (which Apple exposes **no** API to make translucent) with a custom **`NSStatusItem` + `NSPopover`**. NSPopover renders the native frosted-glass material for free; the content renders a clear root so the desktop shows through. Planned + adversarially verified via workflow.

## Architecture
- **`MenuBarAppDelegate`** (`@NSApplicationDelegateAdaptor`) owns the status item + `NSPopover`; `MenuBarAppContext` bridges App-built deps (appState, detachedDashboard, updater, context-menu controller).
- Scene body is **Settings-only** (canonical LSUIElement shape). `MenuBarLabel` → `statusItem.button` via `NSHostingView`; `MainPopover` → `NSHostingController` (built once).

## Behaviors re-homed + adversarial-review fixes folded in
- Left-click toggle; **right-click** kept on the existing `StatusItemContextMenuController` monitor (`sendAction(on:[.leftMouseUp])` — no double-fire).
- **Detach intercept first** in `togglePopover`.
- **App-Lock:** unlock on popover-open only; `didResignActive` locks but does **not** close the popover (avoids the AND-462 auth-sheet loop).
- **Click-away:** global + local monitors + `isShown` guard; **Esc** via keyDown monitor (inspector Esc takes precedence).
- Presentation flag canonical via `NSPopoverDelegate` + re-arming `withObservationTracking` (so `--show-popover` / deep link / snapshot still work).
- `vaultpeek://` via `application(_:open:)`; live appearance updater + glance-consume + lock observers in the delegate.

## Glass + cohesion
- Clear/overlay-only popover root (drops the within-window `.ultraThinMaterial`); Reduce Transparency keeps the flat material.
- Slider re-tuned to a wide wash over the frost (**Solid ≈0.96 / Glass ≈0.04**).
- Three columns drop `.leftPanelSurface()` → one frosted sheet, hairline seams.

## Verification
- `swift build -strict-concurrency=complete -warnings-as-errors` ✅ · `swift test` ✅ **857**.
- ⚠️ **Build-verified only — needs on-device QA** (see checklist).

## QA checklist (please run on the branch DMG)
- [ ] Left-click opens the popover; **desktop blurs through** (real glass)
- [ ] Right-click → context menu (no double-open); click-away dismisses; **Esc** closes (and Esc-deselects the inspector first)
- [ ] Settings → Appearance → **Solid vs Glass** clearly differ; columns read as one sheet (no floating cards)
- [ ] App Lock: lock-on-focus-loss, **unlock-on-open with no auth loop**
- [ ] Detach → floating window; status-click while detached **raises the window**; redock
- [ ] Settings opens; **Check for Updates** / About / Refresh from the menu
- [ ] `--show-popover`, deep link, glass on macOS 15 **and** 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)