### PR TITLE
feat: add an Investments account filter (AND-496)

### DIFF
--- a/Sources/PlaidBar/Views/DashboardNavBand.swift
+++ b/Sources/PlaidBar/Views/DashboardNavBand.swift
@@ -5,8 +5,9 @@ import SwiftUI
 
 /// The dashboard account filter is the core `DashboardAccountFilterKind`
 /// reused directly. The persisted `@AppStorage("dashboard.accountFilter")`
-/// raw values ("All", "Cash", "Credit", "Savings", "Debt", "Status") are the
-/// core enum's raw values, so stored selections decode exactly as before.
+/// raw values ("All", "Cash", "Credit", "Savings", "Debt", "Investments",
+/// "Status") are the core enum's raw values, so stored selections decode
+/// exactly as before.
 typealias DashboardAccountFilter = DashboardAccountFilterKind
 
 extension DashboardAccountFilterKind {
@@ -21,7 +22,7 @@ extension DashboardAccountFilterKind {
 
 /// Native segmented control for the dashboard's primary filter. Native
 /// before novel: the system control brings focus rings, vibrancy, light
-/// mode, and RTL for free. ⌘1–6 shortcuts are preserved via hidden
+/// mode, and RTL for free. ⌘1–7 shortcuts are preserved via hidden
 /// equivalents; the per-filter counts live in the rows themselves and in
 /// each segment's help/accessibility text rather than in segment labels.
 struct DashboardFilterBar: View {

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -6,6 +6,7 @@ public enum DashboardAccountFilterKind: String, CaseIterable, Sendable {
     case credit = "Credit"
     case savings = "Savings"
     case debt = "Debt"
+    case investment = "Investments"
     case status = "Status"
 
     public func includes(
@@ -23,6 +24,10 @@ public enum DashboardAccountFilterKind: String, CaseIterable, Sendable {
             return account.subtype?.localizedCaseInsensitiveContains("saving") == true
         case .debt:
             return AccountPresentation.isDebt(account)
+        case .investment:
+            // Brokerage / retirement accounts, surfaced as a balance line only
+            // (no holdings, performance, or allocation — explicit non-goal).
+            return account.type == .investment
         case .status:
             return degradedItemIds.contains(account.itemId)
         }

--- a/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardNavBarModelTests.swift
@@ -56,7 +56,25 @@ struct DashboardNavBarModelTests {
         #expect(Self.count(.credit, in: items) == 1)
         #expect(Self.count(.savings, in: items) == 1)
         #expect(Self.count(.debt, in: items) == 2)
+        #expect(Self.count(.investment, in: items) == 0)
         #expect(Self.count(.status, in: items) == 1)
+    }
+
+    @Test("Investment filter matches investment-type accounts only")
+    func investmentFilterMatchesInvestmentType() {
+        let accounts = [
+            Self.makeAccount(id: "brokerage", type: .investment, subtype: "brokerage"),
+            Self.makeAccount(id: "ira", type: .investment, subtype: "ira"),
+            Self.makeAccount(id: "chk", type: .depository, subtype: "checking"),
+            Self.makeAccount(id: "cc", type: .credit, subtype: "credit card"),
+        ]
+
+        let items = DashboardNavBarModel.items(accounts: accounts)
+        #expect(Self.count(.investment, in: items) == 2)
+        // Investment accounts never fall under the cash/credit/debt filters.
+        #expect(Self.count(.cash, in: items) == 1)
+        #expect(Self.count(.credit, in: items) == 1)
+        #expect(Self.count(.debt, in: items) == 1)
     }
 
     @Test("Savings subtype matches case-insensitively")
@@ -124,12 +142,12 @@ struct DashboardNavBarModelTests {
 
     // MARK: - Shortcut ordinals
 
-    @Test("Shortcut ordinals run 1 through 6 in allCases order")
+    @Test("Shortcut ordinals run 1 through 7 in allCases order")
     func shortcutOrdinalsMatchDisplayOrder() {
         let items = DashboardNavBarModel.items(accounts: Self.mixedAccounts)
 
         #expect(items.map(\.shortcutOrdinal) == Array(1 ... DashboardAccountFilterKind.allCases.count))
-        #expect(items.map(\.shortcutOrdinal) == [1, 2, 3, 4, 5, 6])
+        #expect(items.map(\.shortcutOrdinal) == [1, 2, 3, 4, 5, 6, 7])
         #expect(items.map(\.kind) == DashboardAccountFilterKind.allCases)
     }
 
@@ -189,7 +207,8 @@ struct DashboardNavBarModelTests {
 
         #expect(items.first { $0.kind == .all }?.helpText == "Show All accounts (⌘1)")
         #expect(items.first { $0.kind == .cash }?.helpText == "Show Cash accounts (⌘2)")
-        #expect(items.first { $0.kind == .status }?.helpText == "Show Status accounts (⌘6)")
+        #expect(items.first { $0.kind == .investment }?.helpText == "Show Investments accounts (⌘6)")
+        #expect(items.first { $0.kind == .status }?.helpText == "Show Status accounts (⌘7)")
     }
 
     // MARK: - Status icon
@@ -361,7 +380,7 @@ struct DashboardNavBarModelTests {
         #expect(items.count == DashboardAccountFilterKind.allCases.count)
         #expect(items.allSatisfy { $0.count == 0 })
         #expect(items.allSatisfy { !$0.showsAttentionBadge })
-        #expect(items.map(\.shortcutOrdinal) == [1, 2, 3, 4, 5, 6])
+        #expect(items.map(\.shortcutOrdinal) == [1, 2, 3, 4, 5, 6, 7])
         #expect(DashboardNavBarModel.summary(selected: .all, items: items) == "All: 0 accounts")
         #expect(DashboardNavBarModel.summary(selected: .debt, items: items) == "Debt: 0 of 0 accounts")
     }


### PR DESCRIPTION
## What & why
Investment / brokerage / retirement **balances already counted** toward net worth and the wealth-mix composition, but there was no way to view those accounts in the list — the filters were Cash/Credit/Savings/Debt only. This completes net worth by making investments a first-class filter.

## Change
- New `investment` case in `DashboardAccountFilterKind`, predicate `account.type == .investment`.
- **Balance line only** — no holdings, performance, or allocation (the explicit non-goal; a portfolio dashboard stays out of scope).
- No Plaid `investments` product needed: `/accounts/get` already returns investment-type accounts with their institution-reported value.
- Chip auto-renders from `allCases`, grouped with the balance filters before Status → **Status moves ⌘6 → ⌘7**. Persisted `@AppStorage` selections are unaffected (raw-value based).

## Verification
- Strict-concurrency build clean.
- `swift test --skip PlaidBarServerTests` — 700 app+core tests pass (server keychain suite skipped only because this branch predates AND-481; full suite runs in CI). Added an investment-matching test; updated ordinal/help-text assertions.

## Please review
- Filter **order**: investments before Status (shifts Status's ⌘ shortcut). Acceptable, or prefer investments last to keep ⌘6 = Status?
- 7 segments in the menu-bar segmented control — still legible at popover width?

Closes AND-496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
