### PR TITLE
fix: honor manual-only automatic refresh policy

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -205,16 +205,16 @@ final class AppState {
     /// Whether an automatic (non-user-triggered) refresh is due now, per the
     /// refresh policy and the last successful sync. Manual refreshes bypass this.
     var shouldAutoRefreshNow: Bool {
-        // Some conditions must refresh regardless of the throttle (even "manual
-        // only") because waiting would leave the UI blank/stale-wrong:
-        if needsImmediateRefresh { return true }
-        return automaticRefreshPolicy.shouldAutoRefresh(lastSync: lastSyncDate, now: Date())
+        automaticRefreshPolicy.shouldAutoRefresh(
+            lastSync: lastSyncDate,
+            now: Date(),
+            hasImmediateNeed: needsImmediateRefresh
+        )
     }
 
-    /// Refresh-now conditions the time-based throttle must not suppress:
-    /// linked items with nothing cached (blank dashboard), a freshly linked item
-    /// the server hasn't synced yet, or a Plaid webhook that flagged an item as
-    /// needing sync. Without these the throttle would hide real, fetchable data.
+    /// Refresh-now conditions the time-based throttle must not suppress. These
+    /// bypass the twice-daily floor, but AutomaticRefreshPolicy still honors
+    /// Manual only before any automatic Plaid-backed fetch is allowed.
     private var needsImmediateRefresh: Bool {
         if statusItemCount > 0, accounts.isEmpty { return true }
         if itemStatuses.contains(where: \.needsSync) { return true }

--- a/Sources/PlaidBarCore/Models/AutomaticRefreshPolicy.swift
+++ b/Sources/PlaidBarCore/Models/AutomaticRefreshPolicy.swift
@@ -42,4 +42,15 @@ public enum AutomaticRefreshPolicy: String, Codable, Sendable, CaseIterable, Equ
         guard let lastSync else { return true }
         return now.timeIntervalSince(lastSync) >= minimumInterval
     }
+
+    /// Whether an automatic refresh should run when the app has detected a
+    /// correctness-critical immediate need, such as linked items with no cached
+    /// accounts yet or an item explicitly marked as needing sync. Immediate needs
+    /// bypass the time floor for time-based policies, but they must not override
+    /// the user's explicit Manual only choice.
+    public func shouldAutoRefresh(lastSync: Date?, now: Date, hasImmediateNeed: Bool) -> Bool {
+        guard minimumInterval != nil else { return false }
+        if hasImmediateNeed { return true }
+        return shouldAutoRefresh(lastSync: lastSync, now: now)
+    }
 }

--- a/Tests/PlaidBarCoreTests/AutomaticRefreshPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/AutomaticRefreshPolicyTests.swift
@@ -39,6 +39,22 @@ struct AutomaticRefreshPolicyTests {
         #expect(AutomaticRefreshPolicy.manualOnly.shouldAutoRefresh(lastSync: longAgo, now: now) == false)
     }
 
+    @Test("Immediate refresh needs do not override manual-only policy")
+    func immediateRefreshNeedsRespectManualOnlyPolicy() {
+        let recentSync = now.addingTimeInterval(-60 * 60)
+
+        #expect(AutomaticRefreshPolicy.manualOnly.shouldAutoRefresh(
+            lastSync: recentSync,
+            now: now,
+            hasImmediateNeed: true
+        ) == false)
+        #expect(AutomaticRefreshPolicy.twiceDaily.shouldAutoRefresh(
+            lastSync: recentSync,
+            now: now,
+            hasImmediateNeed: true
+        ) == true)
+    }
+
     @Test("Display names and raw values round-trip for persistence")
     func metadataIsStable() {
         #expect(AutomaticRefreshPolicy.twiceDaily.displayName == "Twice a day")


### PR DESCRIPTION
## Summary

- Fixes the automatic refresh decision so `Manual only` cannot be overridden by immediate refresh needs.
- Keeps immediate refresh needs as a bypass for the twice-daily time floor.
- Adds regression coverage for manual-only vs timed-policy immediate refresh behavior.

## Verification

- `swift test --filter AutomaticRefreshPolicyTests`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `git diff --check`

## Tracking

Fixes #494

Linear issue creation was attempted for the matching VaultPeek bug but Linear returned: workspace free issue limit exceeded.
Kanban: `t_eb0ac136`
