### PR TITLE
feat: zero-setup on-device NL categorization tier (AND-507)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -408,6 +408,10 @@ private struct ReviewInboxRow: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
 
+                    if item.isNLSuggestedCategory {
+                        suggestedBadge
+                    }
+
                     Text(Formatters.displayTransactionDate(item.transaction.date))
                         .microText()
                         .foregroundStyle(.tertiary)
@@ -417,6 +421,24 @@ private struct ReviewInboxRow: View {
                 reasonChips
             }
         }
+    }
+
+    // On-device NL inference badge (AND-507). Pairs a sparkles icon AND the
+    // word "Suggested" with the tint, so meaning is never carried by color
+    // alone (accessibility rule). Shown only when the category was backfilled
+    // by the zero-setup NL tier rather than the user or Plaid.
+    private var suggestedBadge: some View {
+        Label("Suggested", systemImage: "sparkles")
+            .font(.caption2.weight(.semibold))
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(SemanticColors.brand)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(SemanticColors.brand.opacity(0.10), in: Capsule())
+            .overlay {
+                Capsule().stroke(SemanticColors.brand.opacity(0.18), lineWidth: 1)
+            }
+            .accessibilityLabel("Category suggested on device")
     }
 
     private var reasonChips: some View {

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -676,12 +676,18 @@ public struct LocalAICategoryResolution: Codable, Sendable, Hashable {
 
 public enum LocalAICategoryResolutionSource: String, Codable, Sendable, Hashable {
     case localAISuggestion
+    /// Apple NaturalLanguage zero-setup inference tier (AND-507): an always-on,
+    /// on-device categorizer that fills a category when Plaid returned nothing
+    /// usable and the user hasn't overridden. Distinct from `localAISuggestion`,
+    /// which is the heavier (toggle-gated) Ollama insight path.
+    case appleNaturalLanguage
     case plaidCategory
     case fallbackOther
 
     public var displayName: String {
         switch self {
         case .localAISuggestion: "Local AI"
+        case .appleNaturalLanguage: "Suggested"
         case .plaidCategory: "Plaid"
         case .fallbackOther: "Other"
         }

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -132,6 +132,12 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
     public let isTransfer: Bool
     public let excludedFromBudgets: Bool
     public let matchedRuleIds: [UUID]
+    /// Provenance of `effectiveCategory`. `.appleNaturalLanguage` means the
+    /// zero-setup on-device NL tier (AND-507) backfilled the category because
+    /// Plaid returned nothing usable and the user hasn't overridden — the UI
+    /// pairs this with a text+icon "Suggested" badge (never color alone). Nil
+    /// when the category came straight from the user override or Plaid.
+    public let categorySource: LocalAICategoryResolutionSource?
 
     public init(
         transaction: TransactionDTO,
@@ -141,7 +147,8 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
         effectiveMerchantName: String,
         isTransfer: Bool,
         excludedFromBudgets: Bool,
-        matchedRuleIds: [UUID]
+        matchedRuleIds: [UUID],
+        categorySource: LocalAICategoryResolutionSource? = nil
     ) {
         self.id = transaction.id
         self.transaction = transaction
@@ -152,6 +159,13 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
         self.isTransfer = isTransfer
         self.excludedFromBudgets = excludedFromBudgets
         self.matchedRuleIds = matchedRuleIds
+        self.categorySource = categorySource
+    }
+
+    /// Whether `effectiveCategory` was filled by the on-device NL tier rather
+    /// than the user or Plaid — drives the "Suggested" badge.
+    public var isNLSuggestedCategory: Bool {
+        categorySource == .appleNaturalLanguage
     }
 }
 
@@ -175,7 +189,8 @@ public enum TransactionReviewInbox {
         metadata: [TransactionReviewMetadata],
         rules: [TransactionRule],
         recurring: [RecurringTransaction],
-        now: Date
+        now: Date,
+        nlCategorizer: NLMerchantCategorizer = NLMerchantCategorizer()
     ) -> TransactionReviewInboxSnapshot {
         let metadataById = Dictionary(uniqueKeysWithValues: metadata.map { ($0.id, $0) })
         let merchantCounts = Dictionary(grouping: transactions, by: normalizedMerchantKey)
@@ -213,7 +228,18 @@ public enum TransactionReviewInbox {
             let pendingBaseline = ownResolved ? nil : pendingBaseline(own: ownMetadata, prior: priorPendingMetadata)
             let matchedRules = rules.filter { $0.matches(transaction) }
 
-            let effectiveCategory = metadata?.userCategory ?? transaction.category
+            // Category resolution precedence: user override → Plaid → on-device
+            // NL inference (AND-507) → uncategorized. The NL tier only fills in
+            // when the user hasn't overridden AND Plaid returned nothing usable
+            // (nil/.other) or flagged its own category LOW/UNKNOWN — so the
+            // Review Inbox keeps surfacing only genuinely low-confidence items.
+            let resolvedCategory = resolveCategory(
+                transaction: transaction,
+                userCategory: metadata?.userCategory,
+                nlCategorizer: nlCategorizer
+            )
+            let effectiveCategory = resolvedCategory.category
+            let categorySource = resolvedCategory.source
             let effectiveMerchant = trimmedNonEmpty(metadata?.userMerchantName)
                 ?? trimmedNonEmpty(transaction.merchantName)
                 ?? transaction.name
@@ -229,9 +255,16 @@ public enum TransactionReviewInbox {
             // Plaid PFCv2 categorizes most transactions confidently; surface a
             // category as "needs review" when it is missing/uncategorized, or
             // when Plaid itself reports LOW/UNKNOWN confidence — but never once
-            // the user has set their own category.
-            if effectiveCategory == nil || effectiveCategory == .other ||
-                (transaction.isLowConfidenceCategory && metadata?.userCategory == nil) {
+            // the user has set their own category. The on-device NL tier
+            // (AND-507) backfills a trusted category for both the missing and
+            // the LOW/UNKNOWN cases, so when it succeeds the item is no longer
+            // flagged `.uncategorized` (the chip only stays for merchants the
+            // lexicon/NL could not confidently resolve). NL never overrides the
+            // user, so a user category short-circuits this regardless.
+            let nlBackfilled = categorySource == .appleNaturalLanguage
+            if metadata?.userCategory == nil, !nlBackfilled,
+                effectiveCategory == nil || effectiveCategory == .other ||
+                transaction.isLowConfidenceCategory {
                 reasons.insert(.uncategorized)
             }
             if merchantNeedsReview(transaction: transaction, effectiveMerchant: effectiveMerchant) ||
@@ -309,7 +342,8 @@ public enum TransactionReviewInbox {
                 effectiveMerchantName: effectiveMerchant,
                 isTransfer: isTransfer,
                 excludedFromBudgets: metadata?.excludedFromBudgets ?? isTransfer,
-                matchedRuleIds: matchedRules.map(\.id)
+                matchedRuleIds: matchedRules.map(\.id),
+                categorySource: categorySource
             )
         }
         .sorted { lhs, rhs in
@@ -321,6 +355,47 @@ public enum TransactionReviewInbox {
         }
 
         return TransactionReviewInboxSnapshot(items: items)
+    }
+
+    /// Resolved category plus the provenance that produced it.
+    struct ResolvedCategory {
+        let category: SpendingCategory?
+        let source: LocalAICategoryResolutionSource?
+    }
+
+    /// Apply the category precedence chain: user override → Plaid →
+    /// on-device NL inference (AND-507) → uncategorized.
+    ///
+    /// The NL tier is consulted only when the user hasn't overridden AND Plaid
+    /// returned nothing usable: a nil/`.other` category, or a category Plaid
+    /// itself flagged LOW/UNKNOWN (`isLowConfidenceCategory`). Even then, only a
+    /// *trusted* (high/medium) inference fills the category — a `low`-confidence
+    /// inference is discarded so genuinely ambiguous merchants keep flowing to
+    /// the Review Inbox instead of getting a confident wrong guess.
+    static func resolveCategory(
+        transaction: TransactionDTO,
+        userCategory: SpendingCategory?,
+        nlCategorizer: NLMerchantCategorizer
+    ) -> ResolvedCategory {
+        if let userCategory {
+            return ResolvedCategory(category: userCategory, source: nil)
+        }
+
+        let plaidCategory = transaction.category
+        let plaidIsUsable = plaidCategory != nil
+            && plaidCategory != .other
+            && !transaction.isLowConfidenceCategory
+        if plaidIsUsable {
+            return ResolvedCategory(category: plaidCategory, source: .plaidCategory)
+        }
+
+        if let inference = nlCategorizer.infer(for: transaction), inference.isTrusted {
+            return ResolvedCategory(category: inference.category, source: .appleNaturalLanguage)
+        }
+
+        // Nothing usable: keep Plaid's (possibly nil/.other/low-confidence)
+        // category so the `.uncategorized` heuristic still surfaces it.
+        return ResolvedCategory(category: plaidCategory, source: plaidCategory == nil ? nil : .plaidCategory)
     }
 
     private static func normalizedMerchantKey(_ transaction: TransactionDTO) -> String {

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -126,6 +126,19 @@ public enum DemoFixtures {
             TransactionDTO(id: "tx2", accountId: "demo_checking", amount: 23.50, date: today, name: "UBER TRIP", merchantName: "Uber", category: .transportation),
             TransactionDTO(id: "tx3", accountId: "demo_checking", amount: -3_200.00, date: today, name: "STRIPE TRANSFER", merchantName: "Stripe", category: .income),
             TransactionDTO(id: "tx4", accountId: "demo_amex", amount: 142.80, date: today, name: "AMAZON.COM", merchantName: "Amazon", category: .shopping),
+
+            // === AND-507: zero-setup on-device NL categorization tier ===
+            // These arrive with NO Plaid category so the always-on NL tier is
+            // visible in --demo. The first three have recognizable raw names the
+            // lexicon resolves with a "Suggested" badge (foodAndDrink /
+            // transportation / healthAndFitness); the fourth is deliberately
+            // unresolvable so the genuinely-uncategorized → Review Inbox path is
+            // still demonstrable. No merchantName: the raw name carries the
+            // signal, exactly like an un-enriched Plaid transaction.
+            TransactionDTO(id: "tx48", accountId: "demo_checking", amount: 6.75, date: today, name: "BLUE BOTTLE COFFEE", category: nil),
+            TransactionDTO(id: "tx49", accountId: "demo_checking", amount: 52.10, date: today, name: "SHELL OIL 4821", category: nil),
+            TransactionDTO(id: "tx50", accountId: "demo_amex", amount: 18.40, date: today, name: "CVS/PHARMACY #2231", category: nil),
+            TransactionDTO(id: "tx51", accountId: "demo_visa", amount: 27.30, date: today, name: "SQ *KMNT LLC 9921", category: nil),
             // Yesterday
             TransactionDTO(id: "tx5", accountId: "demo_checking", amount: 15.99, date: yesterday, name: "NETFLIX.COM", merchantName: "Netflix", category: .entertainment),
             TransactionDTO(id: "tx6", accountId: "demo_checking", amount: 45.00, date: yesterday, name: "SHELL OIL 57422", merchantName: "Shell", category: .transportation),

--- a/Sources/PlaidBarCore/Utilities/MerchantCategoryLexicon.swift
+++ b/Sources/PlaidBarCore/Utilities/MerchantCategoryLexicon.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Deterministic merchant/keyword → `SpendingCategory` lexicon.
+///
+/// This is the unit-tested *floor* of the zero-setup NL categorization tier
+/// (AND-507). It maps normalized tokens (and a handful of multi-word phrases)
+/// found in a transaction's raw `name`/`merchantName` to a category, with a
+/// confidence band per match kind. The `NLMerchantCategorizer` layers
+/// NaturalLanguage lemmatization on top, but because embedding-model
+/// availability varies by locale, the lexicon stays the deterministic,
+/// reproducible source of truth — it never depends on a model being present.
+///
+/// Pure, `Sendable`, and side-effect-free: every lookup over the same input
+/// yields the same output across repeated calls.
+public enum MerchantCategoryLexicon {
+    /// How a token matched, which determines the confidence band a caller
+    /// should attach to the inference.
+    public enum MatchStrength: Sendable, Equatable {
+        /// A distinctive brand/merchant token (e.g. "netflix", "uber"): the
+        /// strongest signal, trusted enough to fill `effectiveCategory`.
+        case brand
+        /// A descriptive keyword (e.g. "coffee", "pharmacy"): a strong signal,
+        /// still trusted to fill `effectiveCategory`.
+        case keyword
+    }
+
+    public struct Match: Sendable, Equatable {
+        public let category: SpendingCategory
+        public let strength: MatchStrength
+        /// The token/phrase that produced the match (already normalized).
+        public let token: String
+
+        public init(category: SpendingCategory, strength: MatchStrength, token: String) {
+            self.category = category
+            self.strength = strength
+            self.token = token
+        }
+    }
+
+    /// Single-token brand and keyword entries. Tokens are lowercase and
+    /// punctuation-free; they match a transaction token exactly OR as a
+    /// prefix of a longer token (so "wholefds" matches "wholefds" and
+    /// "netflix" matches "netflixcom" after punctuation is stripped).
+    static let tokenTable: [String: Match] = build(entries: [
+        // Food & Drink
+        .keyword("coffee", .foodAndDrink),
+        .keyword("cafe", .foodAndDrink),
+        .keyword("espresso", .foodAndDrink),
+        .keyword("restaurant", .foodAndDrink),
+        .keyword("grocery", .foodAndDrink),
+        .keyword("grocers", .foodAndDrink),
+        .keyword("deli", .foodAndDrink),
+        .keyword("bakery", .foodAndDrink),
+        .keyword("pizza", .foodAndDrink),
+        .keyword("diner", .foodAndDrink),
+        .brand("starbucks", .foodAndDrink),
+        .brand("wholefds", .foodAndDrink),
+        .brand("wholefoods", .foodAndDrink),
+        .brand("sweetgreen", .foodAndDrink),
+        .brand("chipotle", .foodAndDrink),
+        .brand("doordash", .foodAndDrink),
+        .brand("grubhub", .foodAndDrink),
+        .brand("bluebottle", .foodAndDrink),
+        .brand("bluapron", .foodAndDrink),
+        .brand("blueapron", .foodAndDrink),
+        .brand("trader", .foodAndDrink),
+        .brand("safeway", .foodAndDrink),
+        .brand("kroger", .foodAndDrink),
+
+        // Transportation. Generic single words like "gas"/"oil"/"subway" are
+        // deliberately omitted to avoid false positives on synthetic merchant
+        // names; the gas brands below ("shell", "chevron", ...) carry the
+        // signal for fuel purchases instead.
+        .keyword("transit", .transportation),
+        .keyword("parking", .transportation),
+        .keyword("rideshare", .transportation),
+        .keyword("taxi", .transportation),
+        .brand("uber", .transportation),
+        .brand("lyft", .transportation),
+        .brand("shell", .transportation),
+        .brand("chevron", .transportation),
+        .brand("exxon", .transportation),
+        .brand("mobil", .transportation),
+        .brand("bp", .transportation),
+        .brand("texaco", .transportation),
+
+        // Health & Fitness (MEDICAL). "health"/"gym" are too generic to be safe
+        // single-token signals, so the distinctive words and brands carry it.
+        .keyword("pharmacy", .healthAndFitness),
+        .keyword("medical", .healthAndFitness),
+        .keyword("clinic", .healthAndFitness),
+        .keyword("dental", .healthAndFitness),
+        .keyword("dentist", .healthAndFitness),
+        .keyword("hospital", .healthAndFitness),
+        .keyword("fitness", .healthAndFitness),
+        .brand("cvs", .healthAndFitness),
+        .brand("walgreens", .healthAndFitness),
+        .brand("rite", .healthAndFitness), // rite aid
+        .brand("planetfitness", .healthAndFitness),
+        .brand("equinox", .healthAndFitness),
+
+        // Entertainment
+        .keyword("cinema", .entertainment),
+        .keyword("theatre", .entertainment),
+        .keyword("theater", .entertainment),
+        .keyword("movies", .entertainment),
+        .brand("netflix", .entertainment),
+        .brand("spotify", .entertainment),
+        .brand("hulu", .entertainment),
+        .brand("disney", .entertainment),
+        .brand("hbo", .entertainment),
+        .brand("youtube", .entertainment),
+        .brand("steam", .entertainment),
+        .brand("playstation", .entertainment),
+        .brand("xbox", .entertainment),
+
+        // Shopping (GENERAL_MERCHANDISE). "store" is intentionally NOT a
+        // keyword: it appears in too many generic merchant names to be a safe
+        // signal. Distinctive retail brands carry shopping instead.
+        .brand("amazon", .shopping),
+        .brand("target", .shopping),
+        .brand("walmart", .shopping),
+        .brand("costco", .shopping),
+        .brand("nordstrom", .shopping),
+        .brand("ebay", .shopping),
+        .brand("etsy", .shopping),
+        .brand("bestbuy", .shopping),
+
+        // Travel
+        .keyword("airlines", .travel),
+        .keyword("airline", .travel),
+        .keyword("hotel", .travel),
+        .keyword("motel", .travel),
+        .keyword("resort", .travel),
+        .brand("airbnb", .travel),
+        .brand("delta", .travel),
+        .brand("united", .travel),
+        .brand("marriott", .travel),
+        .brand("hilton", .travel),
+        .brand("expedia", .travel),
+
+        // Bills & Utilities (RENT_AND_UTILITIES)
+        .keyword("wireless", .billsAndUtilities),
+        .keyword("electric", .billsAndUtilities),
+        .keyword("utility", .billsAndUtilities),
+        .keyword("utilities", .billsAndUtilities),
+        .keyword("energy", .billsAndUtilities),
+        .brand("verizon", .billsAndUtilities),
+        .brand("comcast", .billsAndUtilities),
+        .brand("xfinity", .billsAndUtilities),
+        .brand("conedison", .billsAndUtilities),
+        .brand("att", .billsAndUtilities),
+    ])
+
+    /// Multi-word phrases (checked against the whole normalized string before
+    /// single-token matching) so e.g. "blue bottle" and "rite aid" resolve as
+    /// brands even when split into separate tokens.
+    static let phraseTable: [(phrase: String, match: Match)] = [
+        ("blue bottle", Match(category: .foodAndDrink, strength: .brand, token: "blue bottle")),
+        ("trader joe", Match(category: .foodAndDrink, strength: .brand, token: "trader joe")),
+        ("whole foods", Match(category: .foodAndDrink, strength: .brand, token: "whole foods")),
+        ("blue apron", Match(category: .foodAndDrink, strength: .brand, token: "blue apron")),
+        ("rite aid", Match(category: .healthAndFitness, strength: .brand, token: "rite aid")),
+        ("planet fitness", Match(category: .healthAndFitness, strength: .brand, token: "planet fitness")),
+        ("con edison", Match(category: .billsAndUtilities, strength: .brand, token: "con edison")),
+        ("best buy", Match(category: .shopping, strength: .brand, token: "best buy")),
+        ("delta air", Match(category: .travel, strength: .brand, token: "delta air")),
+    ]
+
+    /// Look up the best lexicon match for a set of normalized tokens and the
+    /// full normalized string. Phrases win over single tokens; among single
+    /// tokens, brand matches win over keyword matches. Returns nil when nothing
+    /// in the lexicon applies (so the caller can fall back to NL embeddings or
+    /// leave the transaction uncategorized rather than guessing).
+    static func match(normalizedString: String, tokens: [String]) -> Match? {
+        for entry in phraseTable where normalizedString.contains(entry.phrase) {
+            return entry.match
+        }
+
+        var best: Match?
+        for token in tokens {
+            guard let candidate = matchToken(token) else { continue }
+            if candidate.strength == .brand { return candidate }
+            if best == nil { best = candidate }
+        }
+        return best
+    }
+
+    private static func matchToken(_ token: String) -> Match? {
+        if let exact = tokenTable[token] { return exact }
+        // Prefix match handles digit-suffixed merchant codes after the digits
+        // are stripped to a separate token, plus glued names like "netflixcom".
+        for (key, match) in tokenTable where token.hasPrefix(key) && key.count >= 4 {
+            return match
+        }
+        return nil
+    }
+
+    // MARK: - Entry construction
+
+    private struct Entry {
+        let token: String
+        let category: SpendingCategory
+        let strength: MatchStrength
+
+        static func brand(_ token: String, _ category: SpendingCategory) -> Entry {
+            Entry(token: token, category: category, strength: .brand)
+        }
+
+        static func keyword(_ token: String, _ category: SpendingCategory) -> Entry {
+            Entry(token: token, category: category, strength: .keyword)
+        }
+    }
+
+    private static func build(entries: [Entry]) -> [String: Match] {
+        var table: [String: Match] = [:]
+        for entry in entries {
+            table[entry.token] = Match(
+                category: entry.category,
+                strength: entry.strength,
+                token: entry.token
+            )
+        }
+        return table
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/NLMerchantCategorizer.swift
+++ b/Sources/PlaidBarCore/Utilities/NLMerchantCategorizer.swift
@@ -1,0 +1,203 @@
+import Foundation
+import NaturalLanguage
+
+/// Confidence band for a zero-setup NL category inference (AND-507).
+///
+/// `high`/`medium` are *trusted* — strong enough to fill `effectiveCategory`
+/// when the user hasn't overridden and Plaid returned nothing usable. `low`
+/// is surfaced (so the inference source can still be shown) but is NOT trusted
+/// to fill the category, so genuinely uncertain merchants keep flowing to the
+/// Review Inbox instead of getting a confident wrong guess.
+public enum NLCategoryConfidence: String, Sendable, Codable, Hashable, CaseIterable {
+    case high
+    case medium
+    case low
+
+    /// Whether this band is trusted enough to fill `effectiveCategory`.
+    public var isTrusted: Bool {
+        self == .high || self == .medium
+    }
+
+    public var displayName: String {
+        switch self {
+        case .high: "High"
+        case .medium: "Medium"
+        case .low: "Low"
+        }
+    }
+}
+
+/// A single zero-setup NL inference: the suggested category plus its confidence.
+public struct NLCategoryInference: Sendable, Equatable, Hashable {
+    public let category: SpendingCategory
+    public let confidence: NLCategoryConfidence
+
+    public init(category: SpendingCategory, confidence: NLCategoryConfidence) {
+        self.category = category
+        self.confidence = confidence
+    }
+
+    /// Whether this inference is trusted enough to fill `effectiveCategory`.
+    public var isTrusted: Bool {
+        confidence.isTrusted
+    }
+}
+
+/// Zero-setup, on-device merchant categorizer backed by Apple's NaturalLanguage
+/// framework over a deterministic lexicon floor (AND-507).
+///
+/// `NaturalLanguage` is a pure system framework — no entitlement, Info.plist,
+/// App Group, or extension surface — so SwiftPM links it automatically and this
+/// tier is always-on (it does NOT depend on the `localAIEnabled` Ollama toggle).
+///
+/// Strategy, in precedence order:
+/// 1. Normalize the raw Plaid name (lowercase, strip punctuation/digits noise).
+/// 2. Lemmatize tokens with `NLTagger` so "groceries"→"grocery" still hits the
+///    lexicon (widens recall deterministically; falls back to the raw token).
+/// 3. Look the tokens up in `MerchantCategoryLexicon` — the deterministic,
+///    unit-tested floor. Brand hits → `high`, keyword hits → `medium`.
+/// 4. On a lexicon miss, optionally widen recall with `NLEmbedding` nearest-
+///    neighbor over category seed words — but only ever as a `low`-confidence
+///    (untrusted) inference, because embedding-model availability varies by
+///    locale. The trusted band therefore stays fully deterministic and never
+///    flakes across repeated calls.
+///
+/// Pure value type; all calls are non-isolated and side-effect-free.
+public struct NLMerchantCategorizer: Sendable {
+    public init() {}
+
+    /// Infer a category for a transaction, preferring the raw `name` (which
+    /// carries the most signal, e.g. "BLUE BOTTLE COFFEE") and falling back to
+    /// `merchantName`. Returns nil when nothing applies — never a guess.
+    public func infer(for transaction: TransactionDTO) -> NLCategoryInference? {
+        if let inference = infer(rawName: transaction.name) {
+            return inference
+        }
+        if let merchant = transaction.merchantName {
+            return infer(rawName: merchant)
+        }
+        return nil
+    }
+
+    /// Infer a category from a raw merchant string. Deterministic for any input
+    /// whose result comes from the lexicon (the trusted band); the embedding
+    /// fallback only ever yields the untrusted `low` band.
+    public func infer(rawName: String) -> NLCategoryInference? {
+        let normalized = Self.normalize(rawName)
+        guard !normalized.isEmpty else { return nil }
+        let tokens = Self.lemmatizedTokens(from: normalized)
+
+        if let match = MerchantCategoryLexicon.match(normalizedString: normalized, tokens: tokens) {
+            let confidence: NLCategoryConfidence = match.strength == .brand ? .high : .medium
+            return NLCategoryInference(category: match.category, confidence: confidence)
+        }
+
+        // Lexicon miss: optionally widen recall via word embeddings, but cap at
+        // the untrusted `low` band so model-availability differences never leak
+        // into the trusted (deterministic) path.
+        if let embedded = Self.embeddingInference(tokens: tokens) {
+            return NLCategoryInference(category: embedded, confidence: .low)
+        }
+        return nil
+    }
+
+    // MARK: - Normalization & tokenization
+
+    /// Lowercase, replace punctuation with spaces, and drop pure-digit noise
+    /// tokens (Plaid store/terminal codes like "10234") so the lexicon matches
+    /// on the merchant words, not the numbers.
+    static func normalize(_ raw: String) -> String {
+        let lowered = raw.lowercased()
+        var scalars = String.UnicodeScalarView()
+        for scalar in lowered.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                scalars.append(scalar)
+            } else {
+                scalars.append(" ")
+            }
+        }
+        let collapsed = String(scalars)
+        let kept = collapsed
+            .split(separator: " ")
+            .filter { token in
+                // Drop pure-digit tokens; keep alphanumerics like "att".
+                !token.allSatisfy(\.isNumber)
+            }
+        return kept.joined(separator: " ")
+    }
+
+    /// Tokenize a normalized string and lemmatize each token with `NLTagger`
+    /// so morphological variants collapse onto their lemma before lexicon
+    /// lookup. Always returns the raw token too, so a missing lemma never drops
+    /// a token the lexicon could have matched.
+    static func lemmatizedTokens(from normalized: String) -> [String] {
+        let rawTokens = normalized.split(separator: " ").map(String.init)
+        guard !rawTokens.isEmpty else { return [] }
+
+        let tagger = NLTagger(tagSchemes: [.lemma])
+        tagger.string = normalized
+        var lemmas: [String] = []
+        tagger.enumerateTags(
+            in: normalized.startIndex ..< normalized.endIndex,
+            unit: .word,
+            scheme: .lemma,
+            options: [.omitWhitespace, .omitPunctuation]
+        ) { tag, range in
+            if let tag, !tag.rawValue.isEmpty {
+                lemmas.append(tag.rawValue.lowercased())
+            } else {
+                lemmas.append(String(normalized[range]))
+            }
+            return true
+        }
+
+        // Keep both raw and lemma forms, de-duplicated, raw first so ordering
+        // (and thus the deterministic "first keyword wins") is stable.
+        var seen = Set<String>()
+        var combined: [String] = []
+        for token in rawTokens + lemmas where seen.insert(token).inserted {
+            combined.append(token)
+        }
+        return combined
+    }
+
+    // MARK: - Embedding fallback (untrusted, low confidence only)
+
+    /// Seed words per category for the optional embedding nearest-neighbor
+    /// pass. Deliberately small and generic; this only widens recall on lexicon
+    /// misses and never produces a trusted inference.
+    private static let embeddingSeeds: [(category: SpendingCategory, seeds: [String])] = [
+        (.foodAndDrink, ["food", "restaurant", "coffee", "grocery"]),
+        (.transportation, ["transport", "fuel", "transit", "ride"]),
+        (.healthAndFitness, ["pharmacy", "medical", "fitness", "health"]),
+        (.entertainment, ["entertainment", "music", "movie", "streaming"]),
+        (.shopping, ["shopping", "store", "merchandise", "retail"]),
+        (.travel, ["travel", "hotel", "flight", "airline"]),
+        (.billsAndUtilities, ["utility", "electricity", "internet", "phone"]),
+    ]
+
+    /// Nearest-neighbor over category seed words using the English word
+    /// embedding, when the model is available for the current locale. Returns
+    /// nil when the model is unavailable so behavior degrades gracefully to the
+    /// deterministic lexicon-only floor.
+    static func embeddingInference(tokens: [String]) -> SpendingCategory? {
+        guard let embedding = NLEmbedding.wordEmbedding(for: .english) else { return nil }
+
+        var bestCategory: SpendingCategory?
+        var bestDistance = Double.greatestFiniteMagnitude
+        for token in tokens where embedding.contains(token) {
+            for entry in embeddingSeeds {
+                for seed in entry.seeds {
+                    let distance = embedding.distance(between: token, and: seed, distanceType: .cosine)
+                    if distance < bestDistance {
+                        bestDistance = distance
+                        bestCategory = entry.category
+                    }
+                }
+            }
+        }
+        // Only accept a genuinely close neighbor; cosine distance ranges 0...2.
+        guard bestDistance <= 0.55 else { return nil }
+        return bestCategory
+    }
+}

--- a/Tests/PlaidBarCoreTests/NLMerchantCategorizerTests.swift
+++ b/Tests/PlaidBarCoreTests/NLMerchantCategorizerTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("NL Merchant Categorizer Tests")
+struct NLMerchantCategorizerTests {
+    private let categorizer = NLMerchantCategorizer()
+
+    // MARK: - (1) Lexicon hits
+
+    @Test("Recognizable raw merchant names resolve to the right category with a trusted confidence")
+    func lexiconHits() {
+        let cases: [(name: String, category: SpendingCategory)] = [
+            ("WHOLEFDS MKT 10234", .foodAndDrink),
+            ("BLUE BOTTLE COFFEE", .foodAndDrink),
+            ("UBER TRIP", .transportation),
+            ("SHELL OIL 4821", .transportation),
+            ("CVS/PHARMACY #2231", .healthAndFitness),
+            ("NETFLIX.COM", .entertainment),
+        ]
+
+        for testCase in cases {
+            let inference = categorizer.infer(rawName: testCase.name)
+            #expect(inference?.category == testCase.category, "\(testCase.name) should resolve to \(testCase.category)")
+            // High (brand) or medium (keyword) — both are trusted, never low.
+            #expect(inference?.isTrusted == true, "\(testCase.name) should be a trusted inference")
+            #expect(inference?.confidence != .low, "\(testCase.name) should not be low confidence")
+        }
+    }
+
+    @Test("Brand tokens earn high confidence; bare keyword tokens earn medium")
+    func confidenceBands() {
+        // "uber" is a brand token.
+        #expect(categorizer.infer(rawName: "UBER TRIP")?.confidence == .high)
+        // "pharmacy" (no brand present) is a descriptive keyword token.
+        #expect(categorizer.infer(rawName: "NEIGHBORHOOD PHARMACY")?.confidence == .medium)
+    }
+
+    // MARK: - (2) Unknown merchant
+
+    @Test("Unknown/gibberish merchant returns nil or low confidence — never a trusted wrong guess")
+    func unknownMerchantIsNotGuessed() {
+        let unknown = categorizer.infer(rawName: "SQ *KMNT LLC 9921")
+        // Either no inference, or only the untrusted low band from embeddings.
+        if let unknown {
+            #expect(unknown.isTrusted == false, "An unknown merchant must never produce a trusted inference")
+            #expect(unknown.confidence == .low)
+        }
+    }
+
+    @Test("Empty / digit-only names yield no inference")
+    func emptyNamesYieldNothing() {
+        #expect(categorizer.infer(rawName: "") == nil)
+        #expect(categorizer.infer(rawName: "   ") == nil)
+        #expect(categorizer.infer(rawName: "4821 99021 #221") == nil)
+    }
+
+    // MARK: - (3) Determinism
+
+    @Test("Same input yields the same output across repeated calls")
+    func determinism() {
+        let names = ["WHOLEFDS MKT 10234", "UBER TRIP", "SQ *KMNT LLC 9921", "NETFLIX.COM"]
+        for name in names {
+            let first = categorizer.infer(rawName: name)
+            for _ in 0 ..< 8 {
+                #expect(categorizer.infer(rawName: name) == first, "\(name) inference must be stable")
+            }
+        }
+    }
+
+    // MARK: - (5) Case-insensitivity & punctuation normalization
+
+    @Test("Case and punctuation in raw Plaid names do not change the inferred category")
+    func caseAndPunctuationNormalization() {
+        let variants = [
+            "netflix.com",
+            "NETFLIX.COM",
+            "Netflix.Com",
+            "  NETFLIX  .  COM  ",
+        ]
+        let expected = SpendingCategory.entertainment
+        for variant in variants {
+            #expect(categorizer.infer(rawName: variant)?.category == expected, "\(variant) should resolve to entertainment")
+        }
+
+        // Digit/terminal suffixes must not block the merchant match.
+        #expect(categorizer.infer(rawName: "CVS/PHARMACY #2231")?.category == .healthAndFitness)
+        #expect(categorizer.infer(rawName: "SHELL OIL 4821")?.category == .transportation)
+    }
+
+    @Test("Inference falls back to merchantName when the raw name has no signal")
+    func merchantNameFallback() {
+        let transaction = TransactionDTO(
+            id: "t",
+            accountId: "a",
+            amount: 10,
+            date: "2026-06-01",
+            name: "POS PURCHASE 0011",
+            merchantName: "Netflix"
+        )
+        #expect(categorizer.infer(for: transaction)?.category == .entertainment)
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewInboxTests.swift
@@ -610,6 +610,93 @@ struct TransactionReviewInboxTests {
         return fixture
     }
 
+    // MARK: - AND-507 on-device NL categorization precedence
+
+    @Test("A nil-category transaction whose name resolves is NL-backfilled, not flagged uncategorized")
+    func nlBackfillsResolvableMissingCategory() {
+        let transaction = tx(
+            id: "nl-coffee",
+            name: "BLUE BOTTLE COFFEE",
+            category: nil,
+            merchantName: nil
+        )
+
+        let item = evaluate([transaction]).items.first(where: { $0.id == "nl-coffee" })
+
+        #expect(item?.effectiveCategory == .foodAndDrink)
+        #expect(item?.categorySource == .appleNaturalLanguage)
+        #expect(item?.isNLSuggestedCategory == true)
+        #expect(item?.reasonCodes.contains(.uncategorized) == false)
+    }
+
+    @Test("NL never wins over a user category override")
+    func userOverrideBeatsNLInference() {
+        let transaction = tx(
+            id: "nl-user",
+            name: "BLUE BOTTLE COFFEE",
+            category: nil,
+            merchantName: nil
+        )
+        let metadata = TransactionReviewMetadata(id: "nl-user", userCategory: .shopping)
+
+        let item = evaluate([transaction], metadata: [metadata]).items.first(where: { $0.id == "nl-user" })
+
+        // The user's choice stands; the NL tier neither overrides it nor tags
+        // the row as a suggestion.
+        #expect(item?.effectiveCategory == .shopping)
+        #expect(item?.categorySource == nil)
+        #expect(item?.isNLSuggestedCategory == false)
+    }
+
+    @Test("A LOW-confidence Plaid category with no override gets a trusted NL backfill")
+    func nlBackfillsLowConfidencePlaidCategory() {
+        let transaction = tx(
+            id: "nl-low",
+            name: "NETFLIX.COM",
+            category: .other,
+            merchantName: nil,
+            categoryConfidence: "LOW"
+        )
+
+        let item = evaluate([transaction]).items.first(where: { $0.id == "nl-low" })
+
+        #expect(item?.effectiveCategory == .entertainment)
+        #expect(item?.categorySource == .appleNaturalLanguage)
+        #expect(item?.reasonCodes.contains(.uncategorized) == false)
+    }
+
+    @Test("An unresolvable nil-category transaction still lands in the inbox as uncategorized")
+    func unresolvableMissingCategoryStaysInInbox() {
+        let transaction = tx(
+            id: "nl-unknown",
+            name: "SQ *KMNT LLC 9921",
+            category: nil,
+            merchantName: nil
+        )
+
+        let item = evaluate([transaction]).items.first(where: { $0.id == "nl-unknown" })
+
+        #expect(item != nil)
+        #expect(item?.reasonCodes.contains(.uncategorized) == true)
+        #expect(item?.categorySource != .appleNaturalLanguage)
+        #expect(item?.isNLSuggestedCategory == false)
+    }
+
+    @Test("A confident Plaid category is not overridden by the NL tier")
+    func confidentPlaidCategoryWins() {
+        let transaction = tx(
+            id: "nl-plaid",
+            name: "BLUE BOTTLE COFFEE",
+            category: .shopping,
+            merchantName: nil
+        )
+
+        let item = evaluate([transaction]).items.first(where: { $0.id == "nl-plaid" })
+
+        #expect(item?.effectiveCategory == .shopping)
+        #expect(item?.isNLSuggestedCategory == false)
+    }
+
     private func evaluate(
         _ transactions: [TransactionDTO],
         metadata: [TransactionReviewMetadata] = [],


### PR DESCRIPTION
On-device merchant categorization with zero setup (no API key), using Apple NaturalLanguage.

- `NLMerchantCategorizer` + `MerchantCategoryLexicon` (PlaidBarCore, Sendable, pure); precedence wired once in `TransactionReviewInbox`: user override → Plaid (when confident) → trusted NL inference → uncategorized.
- A text+icon **"Suggested"** badge (sparkles + label) — never color-alone. Demo fixtures show resolvable + one deliberately-unresolvable merchant.
- Gate-green; 12 new tests (7 categorizer + 5 precedence).

Closes AND-507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)