### PR TITLE
feat: Menu-Bar Instrument cluster — title picker, summon hotkey, signal glyph (AND-486/487/485)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -21,6 +21,7 @@ final class AppState {
         static let menuBarSummaryMode = "menuBarSummaryMode"
         static let menuBarIconStyle = "menuBarIconStyle"
         static let summonHotkeyEnabled = "summonHotkeyEnabled"
+        static let menuBarShowSignalMeter = "menuBarShowSignalMeter"
         static let balanceFormat = "balanceFormat"
         static let creditUtilizationThreshold = "creditUtilizationThreshold"
         static let refreshInterval = "refreshInterval"
@@ -169,6 +170,16 @@ final class AppState {
         didSet {
             guard menuBarIconStyle != oldValue else { return }
             UserDefaults.standard.set(menuBarIconStyle.rawValue, forKey: Keys.menuBarIconStyle)
+        }
+    }
+    /// Whether the healthy menu-bar glyph is replaced by the live signal meter
+    /// (AND-485). Only the healthy state is affected; the degraded glyph ladder
+    /// (error/login/offline/warning) always wins so a problem is never hidden
+    /// behind a meter. Persisted only; the render branch lives in MenuBarLabel.
+    var menuBarShowSignalMeter: Bool = false {
+        didSet {
+            guard menuBarShowSignalMeter != oldValue else { return }
+            UserDefaults.standard.set(menuBarShowSignalMeter, forKey: Keys.menuBarShowSignalMeter)
         }
     }
     var balanceFormat: CurrencyFormat = .abbreviated {
@@ -448,6 +459,9 @@ final class AppState {
         }
         if defaults.object(forKey: Keys.summonHotkeyEnabled) != nil {
             summonHotkeyEnabled = defaults.bool(forKey: Keys.summonHotkeyEnabled)
+        }
+        if defaults.object(forKey: Keys.menuBarShowSignalMeter) != nil {
+            menuBarShowSignalMeter = defaults.bool(forKey: Keys.menuBarShowSignalMeter)
         }
         if let format = defaults.string(forKey: Keys.balanceFormat),
            let f = CurrencyFormat(rawValue: format) {
@@ -781,6 +795,25 @@ final class AppState {
             financialAttentionText: shouldMaskFinancialValues ? nil : firstMenuBarAttentionText,
             iconStyle: menuBarIconStyle
         )
+    }
+
+    /// The live signal-meter glyph model (AND-485), or `nil` when the meter must
+    /// not draw. The degraded glyph ladder in `menuBarStatusPresentation` always
+    /// wins: the meter renders only when the status is showing the healthy glyph
+    /// (no error/login/offline/warning), so a problem is never hidden behind a
+    /// meter. Also suppressed under the privacy mask and when there is no signal.
+    var menuBarSignalGlyph: SignalGlyphMeter.SignalGlyphRenderModel? {
+        guard menuBarShowSignalMeter else { return nil }
+        guard !shouldMaskFinancialValues else { return nil }
+        // Only override the healthy glyph; defer to the degraded ladder otherwise.
+        let presentation = menuBarStatusPresentation
+        guard presentation.symbolName == menuBarIconStyle.healthySymbolName else { return nil }
+        let model = SignalGlyphMeter.utilization(
+            from: accounts,
+            thresholdPercent: creditUtilizationThreshold,
+            isStale: isSyncStale
+        )
+        return model.isEmpty ? nil : model
     }
 
     /// First attention row that actually carries menu-bar text. A higher-priority

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -20,6 +20,7 @@ final class AppState {
         static let showBalanceInMenuBar = "showBalanceInMenuBar"
         static let menuBarSummaryMode = "menuBarSummaryMode"
         static let menuBarIconStyle = "menuBarIconStyle"
+        static let summonHotkeyEnabled = "summonHotkeyEnabled"
         static let balanceFormat = "balanceFormat"
         static let creditUtilizationThreshold = "creditUtilizationThreshold"
         static let refreshInterval = "refreshInterval"
@@ -369,6 +370,16 @@ final class AppState {
         }
     }
 
+    /// Whether the global summon hotkey (⇧⌘V) is registered (AND-487). The
+    /// register/unregister side effect is owned by the always-mounted label
+    /// scene in `PlaidBarApp`, which observes this flag; here we only persist it.
+    var summonHotkeyEnabled: Bool = true {
+        didSet {
+            guard summonHotkeyEnabled != oldValue else { return }
+            UserDefaults.standard.set(summonHotkeyEnabled, forKey: Keys.summonHotkeyEnabled)
+        }
+    }
+
     // MARK: - Services
     private let serverClient = ServerClient()
     /// Fetches + caches merchant logos via the local server's authed proxy.
@@ -434,6 +445,9 @@ final class AppState {
         if let style = defaults.string(forKey: Keys.menuBarIconStyle),
            let iconStyle = MenuBarIconStyle(rawValue: style) {
             menuBarIconStyle = iconStyle
+        }
+        if defaults.object(forKey: Keys.summonHotkeyEnabled) != nil {
+            summonHotkeyEnabled = defaults.bool(forKey: Keys.summonHotkeyEnabled)
         }
         if let format = defaults.string(forKey: Keys.balanceFormat),
            let f = CurrencyFormat(rawValue: format) {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -731,13 +731,20 @@ final class AppState {
     }
 
     var menuBarText: String {
+        // Safe-to-spend needs recurring + cashflow inputs that the pure Core
+        // text() does not take, so compute it here (only for that mode, to keep
+        // the common render path cheap) and feed the amount in.
+        let safeToSpend: Double? = menuBarSummaryMode == .safeToSpend
+            ? currentSafeToSpendAmount()
+            : nil
         let rawText = MenuBarSummary.text(
             mode: menuBarSummaryMode,
             accounts: accounts,
             transactions: transactions,
             currencyFormat: balanceFormat,
             isInitialLoad: isBootLoadInFlight,
-            privacyMaskEnabled: shouldMaskFinancialValues
+            privacyMaskEnabled: shouldMaskFinancialValues,
+            precomputedSafeToSpend: safeToSpend
         )
         return appLockPreferences.menuBarText(
             currentText: rawText,
@@ -793,8 +800,14 @@ final class AppState {
             return "VaultPeek - Total cash: \(menuBarText).\(reviewText) \(status)\(review)"
         case .creditUtilization:
             return "VaultPeek - Credit utilization: \(menuBarText).\(reviewText) \(status)\(review)"
+        case .highestUtilization:
+            return "VaultPeek - Highest card utilization: \(menuBarText).\(reviewText) \(status)\(review)"
         case .recentSpend:
             return "VaultPeek - Recent spend: \(menuBarText).\(reviewText) \(status)\(review)"
+        case .todaySpend:
+            return "VaultPeek - Today's spend: \(menuBarText).\(reviewText) \(status)\(review)"
+        case .safeToSpend:
+            return "VaultPeek - Safe to spend: \(menuBarText).\(reviewText) \(status)\(review)"
         case .iconOnly:
             return "VaultPeek.\(reviewText) \(status)\(review)"
         }
@@ -819,8 +832,14 @@ final class AppState {
             return "VaultPeek total cash \(menuBarText). \(reviewText)\(status)\(review)"
         case .creditUtilization:
             return "VaultPeek credit utilization \(menuBarText). \(reviewText)\(status)\(review)"
+        case .highestUtilization:
+            return "VaultPeek highest card utilization \(menuBarText). \(reviewText)\(status)\(review)"
         case .recentSpend:
             return "VaultPeek recent spend \(menuBarText). \(reviewText)\(status)\(review)"
+        case .todaySpend:
+            return "VaultPeek today's spend \(menuBarText). \(reviewText)\(status)\(review)"
+        case .safeToSpend:
+            return "VaultPeek safe to spend \(menuBarText). \(reviewText)\(status)\(review)"
         case .iconOnly:
             return "VaultPeek. \(reviewText)\(status)\(review)"
         }

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -11,6 +11,9 @@ struct PlaidBarApp: App {
     /// Owns the floating desktop-window dashboard (AND-384). `@State` so it
     /// persists across `body` recomputes for the process lifetime.
     @State private var detachedDashboard = DetachedDashboardCoordinator()
+    /// Owns the global summon hotkey (⇧⌘V, AND-487). `@State` so the Carbon
+    /// registration survives `body` recomputes for the process lifetime.
+    @State private var summonHotkeyMonitor = SummonHotkeyMonitor()
     @Environment(\.openSettings) private var openSettings
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let updaterController: SPUStandardUpdaterController
@@ -105,6 +108,9 @@ struct PlaidBarApp: App {
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
                     )
+                    // Register the global summon hotkey (⇧⌘V) on first mount when
+                    // enabled; the .onChange below keeps it in sync afterward.
+                    applySummonHotkeyState()
                     // QA/screenshot aid: "--detach" opens the floating window at
                     // launch (parallel to "--show-popover") WITHOUT persisting the
                     // detached intent, so a QA run never leaves a durable
@@ -138,6 +144,11 @@ struct PlaidBarApp: App {
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
                     )
+                }
+                // Register/unregister the global summon hotkey when the user
+                // toggles it in Settings (AND-487).
+                .onChange(of: appState.summonHotkeyEnabled) { _, _ in
+                    applySummonHotkeyState()
                 }
                 .onOpenURL { url in
                     guard url.scheme == "vaultpeek" else { return }
@@ -232,6 +243,33 @@ struct PlaidBarApp: App {
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
         }
+    }
+
+    /// Registers or unregisters the global summon hotkey to match the persisted
+    /// `summonHotkeyEnabled` preference (AND-487). Idempotent.
+    @MainActor
+    private func applySummonHotkeyState() {
+        if appState.summonHotkeyEnabled {
+            summonHotkeyMonitor.start { summonDashboard() }
+        } else {
+            summonHotkeyMonitor.stop()
+        }
+    }
+
+    /// Brings VaultPeek to the front and shows the dashboard — raising the
+    /// floating window when detached, otherwise activating the app and opening
+    /// the popover. Mirrors the `vaultpeek://` deep-link summon path.
+    @MainActor
+    private func summonDashboard() {
+        if detachedDashboard.handleMenuBarActivation(
+            appState: appState,
+            forcedColorScheme: Self.forcedColorScheme,
+            reduceMotion: reduceMotion
+        ) {
+            return
+        }
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        appState.isPopoverPresented = true
     }
 
     /// QA aid: "--appearance light|dark" pins the whole app to one appearance

--- a/Sources/PlaidBar/Services/SummonHotkeyMonitor.swift
+++ b/Sources/PlaidBar/Services/SummonHotkeyMonitor.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Carbon.HIToolbox
+import OSLog
+import PlaidBarCore
+
+/// Registers a single global "summon VaultPeek" hotkey (⇧⌘V, AND-487) via
+/// Carbon's `RegisterEventHotKey`. Carbon global hotkeys need no Accessibility
+/// entitlement and work in this SwiftPM `.accessory` app, unlike `CGEventTap`.
+///
+/// Carbon's event handler is a C function pointer that cannot capture Swift
+/// state, so the fired closure is held on this `@MainActor` monitor and reached
+/// from the trampoline via a process-wide registry keyed by hotkey id. The whole
+/// type is main-actor isolated because it touches AppKit and SwiftUI app state.
+@MainActor
+final class SummonHotkeyMonitor {
+    private static let logger = Logger(subsystem: "com.ftchvs.PlaidBar", category: "SummonHotkey")
+
+    /// Unique signature/id for our one hotkey.
+    private static let hotKeyID = EventHotKeyID(signature: OSType(0x56504B59 /* "VPKY" */), id: 1)
+
+    /// Trampoline registry: the C callback looks the live handler up here.
+    private static var handlers: [UInt32: @MainActor () -> Void] = [:]
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandlerRef: EventHandlerRef?
+    private let configuration: SummonHotkeyConfiguration
+
+    init(configuration: SummonHotkeyConfiguration = .summonDefault) {
+        self.configuration = configuration
+    }
+
+    /// Installs the global hotkey, firing `onSummon` on the main actor when the
+    /// chord is pressed. Idempotent: a second call replaces the prior handler.
+    func start(onSummon: @escaping @MainActor () -> Void) {
+        stop()
+        Self.handlers[Self.hotKeyID.id] = onSummon
+
+        // Install the application-wide event handler once per monitor.
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: OSType(kEventHotKeyPressed)
+        )
+        let installStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            Self.hotKeyEventHandler,
+            1,
+            &eventType,
+            nil,
+            &eventHandlerRef
+        )
+        guard installStatus == noErr else {
+            Self.logger.error("InstallEventHandler failed: \(installStatus)")
+            Self.handlers[Self.hotKeyID.id] = nil
+            return
+        }
+
+        let registerStatus = RegisterEventHotKey(
+            configuration.keyCode,
+            configuration.modifierFlags,
+            Self.hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+        guard registerStatus == noErr else {
+            Self.logger.error("RegisterEventHotKey failed: \(registerStatus)")
+            stop()
+            return
+        }
+        Self.logger.debug("Summon hotkey \(self.configuration.displayString) registered")
+    }
+
+    /// Unregisters the hotkey and tears down the handler. Safe to call repeatedly.
+    func stop() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+        if let eventHandlerRef {
+            RemoveEventHandler(eventHandlerRef)
+            self.eventHandlerRef = nil
+        }
+        Self.handlers[Self.hotKeyID.id] = nil
+    }
+
+    /// Carbon C trampoline: extracts the fired hotkey id and dispatches to the
+    /// registered Swift handler. Carbon delivers hotkey events on the main
+    /// thread, so hopping to the main actor is a no-op safety assertion.
+    private static let hotKeyEventHandler: EventHandlerUPP = { _, event, _ in
+        var firedID = EventHotKeyID()
+        let status = GetEventParameter(
+            event,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &firedID
+        )
+        guard status == noErr else { return status }
+        let id = firedID.id
+        MainActor.assumeIsolated {
+            SummonHotkeyMonitor.handlers[id]?()
+        }
+        return noErr
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -464,6 +464,13 @@ struct GeneralSettingsView: View {
 
                 Toggle("Launch at login", isOn: $state.launchAtLogin)
 
+                // AND-487: a global hotkey that summons VaultPeek from any app.
+                // The chord is fixed for v1; only the on/off switch is exposed.
+                Toggle("Summon with \(SummonHotkeyConfiguration.summonDefault.displayString)", isOn: $state.summonHotkeyEnabled)
+                Text("Press \(SummonHotkeyConfiguration.summonDefault.displayString) from any app to bring VaultPeek to the front.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+
                 // AND-384: pop the dashboard out of the menu bar into a
                 // floating desktop window the user can drag anywhere and that
                 // survives app-switches. Bound to AppState (single source of

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -426,7 +426,11 @@ struct GeneralSettingsView: View {
                     Text("$12.4K").tag(CurrencyFormat.abbreviated)
                     Text("$12,450").tag(CurrencyFormat.compact)
                 }
-                .disabled(appState.menuBarSummaryMode == .creditUtilization || appState.menuBarSummaryMode == .iconOnly)
+                .disabled(
+                    appState.menuBarSummaryMode == .creditUtilization
+                        || appState.menuBarSummaryMode == .highestUtilization
+                        || appState.menuBarSummaryMode == .iconOnly
+                )
 
                 Picker("Refresh", selection: $state.automaticRefreshPolicy) {
                     ForEach(AutomaticRefreshPolicy.allCases, id: \.self) { policy in

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -420,6 +420,16 @@ struct GeneralSettingsView: View {
                         Label(style.displayName, systemImage: style.healthySymbolName).tag(style)
                     }
                 }
+                .disabled(appState.menuBarShowSignalMeter)
+
+                // AND-485: replace the healthy glyph with a live signal meter
+                // (highest credit-card utilization). Only the healthy state is
+                // affected; error/login/offline states keep their distinct glyph,
+                // so a problem is never hidden behind a meter.
+                Toggle("Show live signal meter", isOn: $state.menuBarShowSignalMeter)
+                Text("Replaces the menu bar icon with a small meter of your highest credit-card utilization. Warning and error states still show their own icon.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Picker("Balance format", selection: $state.balanceFormat) {
                     Text("$12,450.32").tag(CurrencyFormat.full)

--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -13,12 +13,23 @@ struct MenuBarLabel: View {
         // down to the warning glyph and never paint attention text here.
         let presentation = appState.menuBarStatusPresentation
         HStack(spacing: Spacing.xs) {
-            Image(systemName: presentation.symbolName)
-                // One-shot Apple-native cross-fade when the status glyph
-                // changes; meaning still lives in the symbol shape + text, so
-                // this is purely calm polish. Disabled under Reduce Motion so
-                // the glyph swaps instantly with no animation (AND-358 helper).
-                .symbolMotion(.replace, reduceMotion: reduceMotion)
+            // When the live signal meter is active AND the status is healthy
+            // (the meter model is non-nil only then), draw the code-rendered
+            // template meter instead of the SF Symbol. The degraded glyph ladder
+            // still wins because the meter model is nil for any non-healthy
+            // state — meaning stays in the symbol/meter SHAPE, never color
+            // (AND-485).
+            if let signalModel = appState.menuBarSignalGlyph,
+               let signalImage = SignalGlyphImage.make(model: signalModel) {
+                Image(nsImage: signalImage)
+            } else {
+                Image(systemName: presentation.symbolName)
+                    // One-shot Apple-native cross-fade when the status glyph
+                    // changes; meaning still lives in the symbol shape + text, so
+                    // this is purely calm polish. Disabled under Reduce Motion so
+                    // the glyph swaps instantly with no animation (AND-358 helper).
+                    .symbolMotion(.replace, reduceMotion: reduceMotion)
+            }
             if let attentionText = presentation.attentionText {
                 Text(attentionText)
                     .font(.caption.weight(.medium))

--- a/Sources/PlaidBar/Views/SignalGlyphImage.swift
+++ b/Sources/PlaidBar/Views/SignalGlyphImage.swift
@@ -1,0 +1,87 @@
+import AppKit
+import PlaidBarCore
+
+/// Draws the AND-485 signal glyph as a monochrome **template** `NSImage`, so the
+/// menu bar tints it natively in light, dark, and increased-contrast modes (the
+/// same `isTemplate = true` path a status-item icon uses). All meaning is in the
+/// SHAPE — fill height for the value, a cap for over-threshold, a dashed/half
+/// treatment for stale — never color, because template images cannot carry tint.
+enum SignalGlyphImage {
+    /// Menu-bar glyph metrics tuned to sit on the ~18pt status-item baseline.
+    private static let size = NSSize(width: 16, height: 14)
+    private static let barWidth: CGFloat = 4.5
+    private static let barSpacing: CGFloat = 3
+    private static let inset: CGFloat = 1.5
+
+    /// Builds the template image for a render model. Returns `nil` for the empty
+    /// model so the caller can fall back to the plain icon.
+    static func make(model: SignalGlyphMeter.SignalGlyphRenderModel) -> NSImage? {
+        guard !model.isEmpty else { return nil }
+
+        let image = NSImage(size: size, flipped: false) { rect in
+            draw(model: model, in: rect)
+            return true
+        }
+        image.isTemplate = true
+        image.accessibilityDescription = accessibilityDescription(for: model)
+        return image
+    }
+
+    /// A two-bar meter: a faint "track" bar and a filled "value" bar. The value
+    /// bar's height encodes the magnitude; an over-threshold model adds a cap
+    /// notch above the fill so severity reads without color.
+    private static func draw(model: SignalGlyphMeter.SignalGlyphRenderModel, in rect: NSRect) {
+        let usableHeight = rect.height - inset * 2
+        let bottom = rect.minY + inset
+        let leftX = rect.minX + inset
+        let rightX = leftX + barWidth + barSpacing
+
+        // Stale signals draw at a reduced alpha + half-height value bar so the
+        // glyph reads as "dimmed/uncertain" — a shape+opacity cue, not a hue.
+        let isStale = model.staleness == .stale
+        let trackAlpha: CGFloat = isStale ? 0.18 : 0.28
+        let valueAlpha: CGFloat = isStale ? 0.55 : 1.0
+        let fill = CGFloat(model.fillFraction) * (isStale ? 0.5 : 1.0)
+
+        // Track bar (left): a constant faint full-height bar for scale reference.
+        NSColor.black.withAlphaComponent(trackAlpha).setFill()
+        roundedBar(x: leftX, bottom: bottom, height: usableHeight).fill()
+
+        // Value bar (right): height = fill fraction.
+        let valueHeight = max(usableHeight * fill, 1)
+        NSColor.black.withAlphaComponent(valueAlpha).setFill()
+        roundedBar(x: rightX, bottom: bottom, height: valueHeight).fill()
+
+        // Over-threshold cap: a short detached segment above the value bar, so
+        // an over-limit signal is legible purely by shape in a monochrome bar.
+        if model.severity == .overThreshold {
+            let capHeight: CGFloat = 2
+            let capBottom = min(bottom + valueHeight + 1.5, rect.maxY - capHeight - inset + capHeight)
+            let capY = min(capBottom, rect.maxY - capHeight)
+            let cap = NSBezierPath(
+                roundedRect: NSRect(x: rightX, y: capY, width: barWidth, height: capHeight),
+                xRadius: 1,
+                yRadius: 1
+            )
+            NSColor.black.withAlphaComponent(valueAlpha).setFill()
+            cap.fill()
+        }
+    }
+
+    private static func roundedBar(x: CGFloat, bottom: CGFloat, height: CGFloat) -> NSBezierPath {
+        NSBezierPath(
+            roundedRect: NSRect(x: x, y: bottom, width: barWidth, height: height),
+            xRadius: 1.5,
+            yRadius: 1.5
+        )
+    }
+
+    /// VoiceOver text for the glyph: conveys the same value+state the shape does,
+    /// so the meter is not color- or sight-only.
+    private static func accessibilityDescription(for model: SignalGlyphMeter.SignalGlyphRenderModel) -> String {
+        let percent = Int((model.fillFraction * 100).rounded())
+        let level = model.severity == .overThreshold ? "over threshold" : "within range"
+        let stale = model.staleness == .stale ? ", data is stale" : ""
+        return "Signal meter \(percent) percent, \(level)\(stale)"
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/DashboardCardOrder.swift
+++ b/Sources/PlaidBarCore/Utilities/DashboardCardOrder.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// The reorderable sections of the dashboard center column (AND-487). Codable
+/// raw values let a saved order survive app updates; `CaseIterable` gives the
+/// canonical default order (declaration order). Adding a future card is a
+/// forward-compatible append — `DashboardCardOrder.resolve` slots new kinds in
+/// at their default position even for users with an older saved order.
+public enum DashboardCardKind: String, CaseIterable, Codable, Sendable, Identifiable {
+    case changeReceipt
+    case weeklyReview
+    case overview
+    case recentSpend
+    case insights
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .changeReceipt: return "Latest changes"
+        case .weeklyReview: return "Weekly review"
+        case .overview: return "Accounts overview"
+        case .recentSpend: return "Recent spend"
+        case .insights: return "Insights"
+        }
+    }
+}
+
+/// Pure resolver that turns a persisted order + pinned set into the concrete
+/// sequence the view renders. Keeping this AppKit-free and Sendable makes the
+/// forward-compat, drop-unknown, and pin-to-front rules unit-testable; the view
+/// just renders `resolve(...)`'s output.
+public enum DashboardCardOrder {
+    /// The canonical default order: declaration order of `DashboardCardKind`.
+    public static let `default`: [DashboardCardKind] = DashboardCardKind.allCases
+
+    /// Resolves the order to render.
+    ///
+    /// - Drops entries in `savedOrder` that are no longer known kinds (handled
+    ///   automatically: `savedOrder` is already `[DashboardCardKind]`, decoded
+    ///   leniently upstream — see `decode(rawOrder:)`).
+    /// - Appends any known kind missing from `savedOrder` at its position in
+    ///   `defaultOrder` (forward-compat when a new card ships).
+    /// - Floats every pinned kind to the front, preserving the relative order
+    ///   the pinned kinds had among themselves in the resolved base order.
+    ///
+    /// - Parameters:
+    ///   - savedOrder: the user's persisted order (may be empty or stale).
+    ///   - pinned: kinds the user pinned to the top.
+    ///   - defaultOrder: the canonical order; defaults to `DashboardCardOrder.default`.
+    public static func resolve(
+        savedOrder: [DashboardCardKind],
+        pinned: Set<DashboardCardKind> = [],
+        defaultOrder: [DashboardCardKind] = DashboardCardOrder.default
+    ) -> [DashboardCardKind] {
+        // 1. Start from the saved order, de-duplicated, keeping only known kinds.
+        var seen = Set<DashboardCardKind>()
+        var base: [DashboardCardKind] = []
+        for kind in savedOrder where !seen.contains(kind) {
+            base.append(kind)
+            seen.insert(kind)
+        }
+
+        // 2. Append any defaultOrder kind not present, at its default position
+        //    relative to the kinds that ARE present (insert in default order).
+        for (index, kind) in defaultOrder.enumerated() where !seen.contains(kind) {
+            // Find the insertion point: after the last already-placed kind that
+            // precedes this one in defaultOrder, so a new middle card lands in
+            // the middle, not at the very end.
+            let precedingDefaults = defaultOrder.prefix(index)
+            let insertAfter = precedingDefaults.last { base.contains($0) }
+            if let insertAfter, let pos = base.firstIndex(of: insertAfter) {
+                base.insert(kind, at: pos + 1)
+            } else {
+                // No earlier kind is placed yet: prepend so default ordering holds.
+                base.insert(kind, at: 0)
+            }
+            seen.insert(kind)
+        }
+
+        // 3. Float pinned kinds to the front, preserving their relative order
+        //    from the resolved base.
+        guard !pinned.isEmpty else { return base }
+        let pinnedInOrder = base.filter { pinned.contains($0) }
+        let rest = base.filter { !pinned.contains($0) }
+        return pinnedInOrder + rest
+    }
+
+    /// Leniently decodes a persisted raw-string order into known kinds, dropping
+    /// any unknown/removed raw values (forward/backward compat).
+    public static func decode(rawOrder: [String]) -> [DashboardCardKind] {
+        rawOrder.compactMap(DashboardCardKind.init(rawValue:))
+    }
+
+    /// Encodes a resolved order back to raw strings for persistence.
+    public static func encode(_ order: [DashboardCardKind]) -> [String] {
+        order.map(\.rawValue)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -5,7 +5,10 @@ public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
     case netCash
     case totalCash
     case creditUtilization
+    case highestUtilization
     case recentSpend
+    case todaySpend
+    case safeToSpend
     case iconOnly
 
     public var displayName: String {
@@ -14,7 +17,10 @@ public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
         case .netCash: return "Net cash"
         case .totalCash: return "Total cash"
         case .creditUtilization: return "Credit utilization"
+        case .highestUtilization: return "Highest card utilization"
         case .recentSpend: return "Recent spend"
+        case .todaySpend: return "Today's spend"
+        case .safeToSpend: return "Safe to spend"
         case .iconOnly: return "Icon only"
         }
     }
@@ -60,6 +66,22 @@ public enum MenuBarSummary {
 
         let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
         return (usedCredit / totalLimit) * 100
+    }
+
+    /// Highest single-card utilization (used/limit) across all credit cards,
+    /// as a percentage. Distinct from `creditUtilization`, which pools every
+    /// card's balance and limit into one aggregate ratio: a single near-maxed
+    /// card can be invisible in the aggregate but is the number a user worried
+    /// about utilization wants in the menu bar. Returns nil when no credit card
+    /// reports a positive limit (cards without a limit are skipped, not zeroed).
+    public static func highestUtilization(from accounts: [AccountDTO]) -> Double? {
+        let ratios = accounts
+            .filter { $0.type == .credit }
+            .compactMap { account -> Double? in
+                guard let limit = account.balances.limit, limit > 0 else { return nil }
+                return (abs(account.balances.current ?? 0) / limit) * 100
+            }
+        return ratios.max()
     }
 
     public static func recentSpend(
@@ -183,7 +205,8 @@ public enum MenuBarSummary {
         transactions: [TransactionDTO],
         currencyFormat: CurrencyFormat,
         isInitialLoad: Bool = false,
-        privacyMaskEnabled: Bool = false
+        privacyMaskEnabled: Bool = false,
+        precomputedSafeToSpend: Double? = nil
     ) -> String {
         switch mode {
         case .netWorth:
@@ -203,6 +226,11 @@ public enum MenuBarSummary {
             guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
             guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.percent(utilization, decimals: 0)
+        case .highestUtilization:
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard let utilization = highestUtilization(from: accounts) else { return "No credit" }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
+            return Formatters.percent(utilization, decimals: 0)
         case .recentSpend:
             // During the boot fetch an empty history is unknown, not zero:
             // show the neutral app name instead of a "No spend" verdict.
@@ -211,6 +239,24 @@ public enum MenuBarSummary {
             }
             guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
             return Formatters.currency(recentSpend(from: transactions), format: currencyFormat)
+        case .todaySpend:
+            // Today is a single-day window of recentSpend; the same boot-empty
+            // guard applies so an in-flight load reads as neutral, not "No spend".
+            guard !transactions.isEmpty else {
+                return isInitialLoad ? PlaidBarConstants.appName : "No spend"
+            }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
+            return Formatters.currency(recentSpend(from: transactions, days: 1), format: currencyFormat)
+        case .safeToSpend:
+            // Safe-to-spend needs recurring + cashflow inputs the pure Core text()
+            // does not take, so AppState computes it via SafeToSpendCalculator and
+            // feeds the amount in. A nil amount means it could not be computed yet.
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard let amount = precomputedSafeToSpend else {
+                return isInitialLoad ? PlaidBarConstants.appName : "No data"
+            }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
+            return Formatters.currency(amount, format: currencyFormat)
         case .iconOnly:
             return ""
         }

--- a/Sources/PlaidBarCore/Utilities/SignalGlyphMeter.swift
+++ b/Sources/PlaidBarCore/Utilities/SignalGlyphMeter.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Pure value→geometry mapping for the menu-bar "signal glyph" — a code-drawn
+/// monochrome template meter that shows a live signal (v1: highest credit-card
+/// utilization) as a fill height, with severity carried by SHAPE (an
+/// over-threshold cap), not color, since template images cannot tint (AND-485).
+///
+/// All clamping, empty-history, and divide-by-zero guards live here so the
+/// drawing layer (`SignalGlyphImage`, app target) is a dumb renderer and the
+/// meter never disagrees with the popover number — both read the same
+/// `MenuBarSummary.creditUtilization` / `AccountSparkline.normalize` source.
+public enum SignalGlyphMeter {
+
+    /// Severity band, expressed as a discrete shape cue (NOT color). The drawing
+    /// layer renders `.overThreshold` with a distinct cap so an over-limit
+    /// signal is legible in a monochrome menu bar.
+    public enum SeverityBand: String, Sendable, Equatable {
+        /// Below the threshold: a plain capless bar.
+        case calm
+        /// At or above the threshold: a capped/notched bar.
+        case overThreshold
+    }
+
+    /// How the model wants the glyph drawn for staleness, again as shape, not
+    /// color: a dashed/half-height treatment reads as "stale" in monochrome.
+    public enum StalenessHint: String, Sendable, Equatable {
+        case fresh
+        case stale
+    }
+
+    /// A render-ready description of the meter geometry. The renderer maps
+    /// `fillFraction` (0...1) onto the glyph height and applies the severity and
+    /// staleness shape cues. `polyline` is populated for the sparkline form.
+    public struct SignalGlyphRenderModel: Sendable, Equatable {
+        /// Bar fill height as a fraction of the glyph height, clamped to 0...1.
+        public let fillFraction: Double
+        /// Severity band (shape cue, not color).
+        public let severity: SeverityBand
+        /// Staleness rendering hint (shape cue, not color).
+        public let staleness: StalenessHint
+        /// `true` when there is no signal to draw (e.g. no credit limit). The
+        /// renderer should fall back to the plain icon rather than an empty bar.
+        public let isEmpty: Bool
+        /// Optional downsampled, normalized polyline (0...1) for the sparkline
+        /// form. Empty for the bar form.
+        public let polyline: [Double]
+
+        public init(
+            fillFraction: Double,
+            severity: SeverityBand,
+            staleness: StalenessHint,
+            isEmpty: Bool,
+            polyline: [Double] = []
+        ) {
+            self.fillFraction = fillFraction
+            self.severity = severity
+            self.staleness = staleness
+            self.isEmpty = isEmpty
+            self.polyline = polyline
+        }
+
+        /// The model the renderer uses when there is no signal: a no-meter
+        /// sentinel that degrades to the plain icon (mirrors `.iconOnly`).
+        public static let empty = SignalGlyphRenderModel(
+            fillFraction: 0,
+            severity: .calm,
+            staleness: .fresh,
+            isEmpty: true
+        )
+    }
+
+    /// Maps a normalized magnitude onto a bar-fill model.
+    ///
+    /// - Parameters:
+    ///   - magnitude: signal magnitude; clamped to 0...1 (values above 1, e.g.
+    ///     an over-limit card, cap at full fill).
+    ///   - threshold: optional 0...1 boundary above which the band is
+    ///     `.overThreshold`. `nil` keeps the band `.calm`.
+    ///   - isStale: when `true`, the staleness hint flips regardless of magnitude.
+    public static func bar(
+        magnitude: Double,
+        threshold: Double? = nil,
+        isStale: Bool = false
+    ) -> SignalGlyphRenderModel {
+        let clamped = clamp01(magnitude)
+        let band: SeverityBand
+        if let threshold, clamped >= clamp01(threshold) {
+            band = .overThreshold
+        } else {
+            band = .calm
+        }
+        return SignalGlyphRenderModel(
+            fillFraction: clamped,
+            severity: band,
+            staleness: isStale ? .stale : .fresh,
+            isEmpty: false
+        )
+    }
+
+    /// Builds the v1 utilization bar model from accounts, reusing
+    /// `MenuBarSummary.creditUtilization` so the meter and the popover number
+    /// agree. Returns the `.empty` model when no credit card reports a limit.
+    ///
+    /// - Parameters:
+    ///   - accounts: all accounts (credit cards are filtered internally).
+    ///   - thresholdPercent: the user's credit-utilization warning threshold,
+    ///     e.g. 30 (percent). Mapped onto 0...1.
+    ///   - isStale: sync-staleness flag from the menu-bar status.
+    public static func utilization(
+        from accounts: [AccountDTO],
+        thresholdPercent: Double,
+        isStale: Bool = false
+    ) -> SignalGlyphRenderModel {
+        guard let utilizationPercent = MenuBarSummary.creditUtilization(from: accounts) else {
+            return .empty
+        }
+        return bar(
+            magnitude: utilizationPercent / 100,
+            threshold: thresholdPercent / 100,
+            isStale: isStale
+        )
+    }
+
+    /// Builds a sparkline model from a balance history, reusing
+    /// `AccountSparkline.normalize`. A flat/empty series collapses to a defined
+    /// mid-line (0.5), never NaN, mirroring the row sparkline's flat guard.
+    ///
+    /// - Parameters:
+    ///   - balances: balance points, oldest first.
+    ///   - maxPoints: downsample cap so the menu-bar glyph stays a few px wide.
+    ///   - isStale: sync-staleness flag.
+    public static func sparkline(
+        balances: [Double],
+        maxPoints: Int = 12,
+        isStale: Bool = false
+    ) -> SignalGlyphRenderModel {
+        guard !balances.isEmpty else { return .empty }
+        let normalized = AccountSparkline.normalize(balances)
+        guard !normalized.isEmpty else {
+            return SignalGlyphRenderModel(
+                fillFraction: 0.5,
+                severity: .calm,
+                staleness: isStale ? .stale : .fresh,
+                isEmpty: false,
+                polyline: [0.5]
+            )
+        }
+        let points = downsample(normalized, to: max(2, maxPoints))
+        // The trailing point doubles as the bar fill so a renderer that only
+        // draws a bar still shows the latest value.
+        return SignalGlyphRenderModel(
+            fillFraction: clamp01(points.last ?? 0.5),
+            severity: .calm,
+            staleness: isStale ? .stale : .fresh,
+            isEmpty: false,
+            polyline: points
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func clamp01(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(max(value, 0), 1)
+    }
+
+    /// Evenly downsamples a series to at most `count` points, always keeping the
+    /// first and last so the trend endpoints survive.
+    private static func downsample(_ values: [Double], to count: Int) -> [Double] {
+        guard values.count > count, count >= 2 else { return values }
+        let step = Double(values.count - 1) / Double(count - 1)
+        return (0 ..< count).map { index in
+            let position = Int((Double(index) * step).rounded())
+            return values[min(position, values.count - 1)]
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/SummonHotkeyConfiguration.swift
+++ b/Sources/PlaidBarCore/Utilities/SummonHotkeyConfiguration.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure, AppKit-free description of the global "summon VaultPeek" hotkey
+/// (AND-487). For v1 the chord is fixed to ⇧⌘V — there is no key recorder, so
+/// this type carries only the Carbon key code, the modifier mask, and a
+/// human-readable label, all unit-testable without AppKit/Carbon.
+///
+/// The actual `RegisterEventHotKey` glue lives in `SummonHotkeyMonitor`
+/// (app target); this stays in Core so the key mapping and the displayed
+/// label never disagree and can be verified in isolation.
+public struct SummonHotkeyConfiguration: Equatable, Sendable {
+    /// Carbon virtual key code (`kVK_*`). `0x09` is the ANSI "V" key.
+    public let keyCode: UInt32
+    /// Carbon modifier mask bits (`cmdKey`/`shiftKey`/`optionKey`/`controlKey`).
+    public let modifierFlags: UInt32
+    /// Human-readable chord, e.g. "⇧⌘V", using the canonical macOS symbol order.
+    public let displayString: String
+
+    public init(keyCode: UInt32, modifierFlags: UInt32, displayString: String) {
+        self.keyCode = keyCode
+        self.modifierFlags = modifierFlags
+        self.displayString = displayString
+    }
+
+    // Carbon modifier mask bit values (from <Carbon/Carbon.h>), restated here so
+    // Core does not import Carbon. The app-side monitor uses the same constants.
+    public static let cmdKeyMask: UInt32 = 1 << 8
+    public static let shiftKeyMask: UInt32 = 1 << 9
+    public static let optionKeyMask: UInt32 = 1 << 11
+    public static let controlKeyMask: UInt32 = 1 << 12
+
+    /// Carbon virtual key code for the ANSI "V" key (`kVK_ANSI_V`).
+    public static let keyCodeV: UInt32 = 0x09
+
+    /// The fixed v1 chord: ⇧⌘V.
+    public static let summonDefault = SummonHotkeyConfiguration(
+        keyCode: keyCodeV,
+        modifierFlags: cmdKeyMask | shiftKeyMask,
+        displayString: "⇧⌘V"
+    )
+}

--- a/Tests/PlaidBarCoreTests/DashboardCardOrderTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardCardOrderTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("DashboardCardOrder (AND-487)")
+struct DashboardCardOrderTests {
+
+    @Test("Empty saved order resolves to the canonical default order")
+    func emptySavedOrderUsesDefault() {
+        let resolved = DashboardCardOrder.resolve(savedOrder: [])
+        #expect(resolved == DashboardCardOrder.default)
+        #expect(resolved == DashboardCardKind.allCases)
+    }
+
+    @Test("A saved order missing a newer kind appends it at its default position")
+    func forwardCompatAppendsNewKind() {
+        // Simulate an old saved order that predates `.insights` shipping.
+        let saved: [DashboardCardKind] = [.changeReceipt, .weeklyReview, .overview, .recentSpend]
+        let resolved = DashboardCardOrder.resolve(savedOrder: saved)
+        // The new kind is present and lands at its default trailing position.
+        #expect(resolved.contains(.insights))
+        #expect(resolved.last == .insights)
+        #expect(resolved.count == DashboardCardKind.allCases.count)
+    }
+
+    @Test("A newer middle kind slots into the middle, not the end")
+    func forwardCompatInsertsMiddleKind() {
+        // Saved order is missing `.overview` (a middle kind in the default).
+        let saved: [DashboardCardKind] = [.changeReceipt, .weeklyReview, .recentSpend, .insights]
+        let resolved = DashboardCardOrder.resolve(savedOrder: saved)
+        let overviewIndex = resolved.firstIndex(of: .overview)
+        let weeklyIndex = resolved.firstIndex(of: .weeklyReview)
+        let recentIndex = resolved.firstIndex(of: .recentSpend)
+        #expect(overviewIndex != nil)
+        // .overview should sit after .weeklyReview and before .recentSpend.
+        #expect((overviewIndex ?? 0) > (weeklyIndex ?? 0))
+        #expect((overviewIndex ?? 0) < (recentIndex ?? 0))
+    }
+
+    @Test("Decode drops unknown/removed raw values")
+    func decodeDropsUnknownKinds() {
+        let raw = ["changeReceipt", "someRemovedCard", "overview", "garbage"]
+        let decoded = DashboardCardOrder.decode(rawOrder: raw)
+        #expect(decoded == [.changeReceipt, .overview])
+    }
+
+    @Test("Pinning a kind floats it to the front, preserving the rest's order")
+    func pinningFloatsToFront() {
+        let resolved = DashboardCardOrder.resolve(
+            savedOrder: DashboardCardKind.allCases,
+            pinned: [.recentSpend]
+        )
+        #expect(resolved.first == .recentSpend)
+        // The non-pinned kinds keep their relative order.
+        let rest = resolved.filter { $0 != .recentSpend }
+        let expectedRest = DashboardCardKind.allCases.filter { $0 != .recentSpend }
+        #expect(rest == expectedRest)
+    }
+
+    @Test("Pinning multiple kinds preserves their relative order")
+    func pinningMultiplePreservesRelativeOrder() {
+        let resolved = DashboardCardOrder.resolve(
+            savedOrder: DashboardCardKind.allCases,
+            pinned: [.insights, .changeReceipt]
+        )
+        // Both float to the front; relative order matches the base (changeReceipt
+        // before insights in the default order).
+        #expect(Array(resolved.prefix(2)) == [.changeReceipt, .insights])
+    }
+
+    @Test("Persisted JSON round-trips stably through encode/decode")
+    func encodeDecodeRoundTrip() {
+        let order = DashboardCardOrder.resolve(savedOrder: [], pinned: [.overview])
+        let raw = DashboardCardOrder.encode(order)
+        let decoded = DashboardCardOrder.decode(rawOrder: raw)
+        #expect(decoded == order)
+
+        // And through a JSON encode/decode of the raw strings.
+        let data = try! JSONEncoder().encode(raw)
+        let restored = try! JSONDecoder().decode([String].self, from: data)
+        #expect(DashboardCardOrder.decode(rawOrder: restored) == order)
+    }
+}

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -516,6 +516,114 @@ struct PlaidBarCoreTests {
         #expect(MenuBarSummary.creditUtilization(from: accounts) == 20)
     }
 
+    // MARK: - AND-486 Menu-Bar Title Picker extensions
+
+    @Test("Menu bar highest utilization returns the worst single card")
+    func menuBarSummaryHighestUtilization() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            // Amex: 1,847.32 / 20,000 = ~9.2%
+            AccountDTO(id: "2", itemId: "i", name: "Amex", type: .credit, balances: BalanceDTO(current: -1_847.32, limit: 20_000)),
+            // Chase Freedom: 4,210 / 5,000 = 84.2% — the worst card
+            AccountDTO(id: "3", itemId: "i", name: "Chase", type: .credit, balances: BalanceDTO(current: -4_210, limit: 5_000)),
+        ]
+        let highest = MenuBarSummary.highestUtilization(from: accounts)
+        #expect(highest != nil)
+        #expect(abs((highest ?? 0) - 84.2) < 0.001)
+        // The aggregate pools both cards, so it is much lower than the worst card.
+        let aggregate = MenuBarSummary.creditUtilization(from: accounts) ?? 0
+        #expect((highest ?? 0) > aggregate)
+    }
+
+    @Test("Menu bar highest utilization is nil when no card has a limit")
+    func menuBarSummaryHighestUtilizationNoLimit() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Charge card", type: .credit, balances: BalanceDTO(current: -500, limit: nil)),
+        ]
+        #expect(MenuBarSummary.highestUtilization(from: accounts) == nil)
+    }
+
+    @Test("Menu bar today spend equals a 1-day recent spend window")
+    func menuBarSummaryTodaySpend() {
+        let now = Formatters.parseTransactionDate("2026-03-10")!
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 10, date: "2026-03-10", name: "Today coffee"),
+            TransactionDTO(id: "2", accountId: "a", amount: 22, date: "2026-03-10", name: "Today lunch"),
+            TransactionDTO(id: "3", accountId: "a", amount: 99, date: "2026-03-09", name: "Yesterday"),
+        ]
+        let oneDay = MenuBarSummary.recentSpend(from: transactions, now: now, days: 1)
+        #expect(oneDay == 32)
+        // The .todaySpend mode renders the same single-day window.
+        let text = MenuBarSummary.text(
+            mode: .todaySpend,
+            accounts: [],
+            transactions: transactions,
+            currencyFormat: .compact
+        )
+        #expect(!text.isEmpty)
+        #expect(text != "No spend")
+    }
+
+    @Test("Menu bar text masks every new mode under privacy mask")
+    func menuBarSummaryNewModesPrivacyMask() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Chase", type: .credit, balances: BalanceDTO(current: -4_210, limit: 5_000)),
+        ]
+        let transactions = [
+            TransactionDTO(id: "1", accountId: "a", amount: 10, date: "2026-03-10", name: "Today"),
+        ]
+        for mode in [MenuBarSummaryMode.highestUtilization, .todaySpend, .safeToSpend] {
+            let text = MenuBarSummary.text(
+                mode: mode,
+                accounts: accounts,
+                transactions: transactions,
+                currencyFormat: .compact,
+                privacyMaskEnabled: true,
+                precomputedSafeToSpend: 1_234
+            )
+            #expect(text == PrivacyMaskPresentation.heroValue)
+        }
+    }
+
+    @Test("Menu bar safe-to-spend renders the precomputed amount and degrades gracefully")
+    func menuBarSummarySafeToSpendText() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+        ]
+        let withAmount = MenuBarSummary.text(
+            mode: .safeToSpend,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact,
+            precomputedSafeToSpend: 1_234
+        )
+        #expect(withAmount.contains("1") && withAmount.contains("2"))
+        #expect(withAmount != "No data")
+        // No precomputed amount once loaded: a defined fallback, never a crash.
+        let withoutAmount = MenuBarSummary.text(
+            mode: .safeToSpend,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact,
+            isInitialLoad: false,
+            precomputedSafeToSpend: nil
+        )
+        #expect(withoutAmount == "No data")
+    }
+
+    @Test("MenuBarSummaryMode exposes the three new cases with display names")
+    func menuBarSummaryModeNewCases() {
+        let allCases = MenuBarSummaryMode.allCases
+        #expect(allCases.contains(.highestUtilization))
+        #expect(allCases.contains(.todaySpend))
+        #expect(allCases.contains(.safeToSpend))
+        for mode in allCases {
+            #expect(!mode.displayName.isEmpty)
+        }
+    }
+
     @Test("Menu bar summary recent spend excludes income and transfers")
     func menuBarSummaryRecentSpend() {
         let now = Formatters.parseTransactionDate("2026-01-15")!

--- a/Tests/PlaidBarCoreTests/SignalGlyphMeterTests.swift
+++ b/Tests/PlaidBarCoreTests/SignalGlyphMeterTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("SignalGlyphMeter (AND-485)")
+struct SignalGlyphMeterTests {
+
+    @Test("Magnitude maps proportionally to fill, clamped at the ends")
+    func magnitudeMapsToFill() {
+        #expect(SignalGlyphMeter.bar(magnitude: 0).fillFraction == 0)
+        #expect(SignalGlyphMeter.bar(magnitude: 1).fillFraction == 1)
+        #expect(abs(SignalGlyphMeter.bar(magnitude: 0.5).fillFraction - 0.5) < 0.0001)
+        // Over-range (e.g. over-limit card) clamps to full fill.
+        #expect(SignalGlyphMeter.bar(magnitude: 1.4).fillFraction == 1)
+        // Negative clamps to empty.
+        #expect(SignalGlyphMeter.bar(magnitude: -0.3).fillFraction == 0)
+    }
+
+    @Test("Severity band changes by value, not color")
+    func severityBandByValue() {
+        let calm = SignalGlyphMeter.bar(magnitude: 0.4, threshold: 0.6)
+        #expect(calm.severity == .calm)
+        let over = SignalGlyphMeter.bar(magnitude: 0.7, threshold: 0.6)
+        #expect(over.severity == .overThreshold)
+        // Exactly at threshold counts as over.
+        let atThreshold = SignalGlyphMeter.bar(magnitude: 0.6, threshold: 0.6)
+        #expect(atThreshold.severity == .overThreshold)
+        // No threshold provided stays calm.
+        #expect(SignalGlyphMeter.bar(magnitude: 0.99).severity == .calm)
+    }
+
+    @Test("isStale flips the staleness hint regardless of magnitude")
+    func staleFlipsHint() {
+        #expect(SignalGlyphMeter.bar(magnitude: 0.1, isStale: true).staleness == .stale)
+        #expect(SignalGlyphMeter.bar(magnitude: 0.9, isStale: true).staleness == .stale)
+        #expect(SignalGlyphMeter.bar(magnitude: 0.5, isStale: false).staleness == .fresh)
+    }
+
+    @Test("Flat or empty balance history yields a defined mid-line, never NaN")
+    func flatSeriesIsDefined() {
+        let flat = SignalGlyphMeter.sparkline(balances: [100, 100, 100, 100])
+        #expect(!flat.isEmpty)
+        #expect(flat.fillFraction.isFinite)
+        // Flat series collapses to the mid-line.
+        #expect(flat.polyline.allSatisfy { $0 == 0.5 })
+
+        let empty = SignalGlyphMeter.sparkline(balances: [])
+        #expect(empty.isEmpty)
+    }
+
+    @Test("Sparkline downsamples while keeping endpoints and stays in 0...1")
+    func sparklineDownsamples() {
+        let rising = (0 ..< 50).map { Double($0) }
+        let model = SignalGlyphMeter.sparkline(balances: rising, maxPoints: 8)
+        #expect(model.polyline.count <= 8)
+        #expect(model.polyline.first == 0) // lowest normalizes to 0
+        #expect(model.polyline.last == 1)  // highest normalizes to 1
+        #expect(model.polyline.allSatisfy { $0 >= 0 && $0 <= 1 })
+        // The trailing point doubles as the bar fill.
+        #expect(model.fillFraction == 1)
+    }
+
+    @Test("Utilization path equals MenuBarSummary.creditUtilization/100, clamped")
+    func utilizationMatchesSummary() {
+        let accounts = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+            AccountDTO(id: "2", itemId: "i", name: "Amex", type: .credit, balances: BalanceDTO(current: -1_000, limit: 10_000)),
+            AccountDTO(id: "3", itemId: "i", name: "Visa", type: .credit, balances: BalanceDTO(current: -2_000, limit: 5_000)),
+        ]
+        let expectedPercent = MenuBarSummary.creditUtilization(from: accounts) ?? 0 // 20%
+        let model = SignalGlyphMeter.utilization(from: accounts, thresholdPercent: 30)
+        #expect(abs(model.fillFraction - expectedPercent / 100) < 0.0001)
+        #expect(model.severity == .calm) // 20% < 30% threshold
+
+        // Over-limit aggregate clamps to a full bar.
+        let overLimit = [
+            AccountDTO(id: "4", itemId: "i", name: "Maxed", type: .credit, balances: BalanceDTO(current: -12_000, limit: 10_000)),
+        ]
+        let overModel = SignalGlyphMeter.utilization(from: overLimit, thresholdPercent: 30)
+        #expect(overModel.fillFraction == 1)
+        #expect(overModel.severity == .overThreshold)
+    }
+
+    @Test("No-credit input degrades to the empty no-meter model, never crashes")
+    func noCreditDegradesToEmpty() {
+        let cashOnly = [
+            AccountDTO(id: "1", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(available: 8_200)),
+        ]
+        let model = SignalGlyphMeter.utilization(from: cashOnly, thresholdPercent: 30)
+        #expect(model.isEmpty)
+        #expect(model == SignalGlyphMeter.SignalGlyphRenderModel.empty)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SummonHotkeyConfigurationTests.swift
+++ b/Tests/PlaidBarCoreTests/SummonHotkeyConfigurationTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("SummonHotkeyConfiguration (AND-487)")
+struct SummonHotkeyConfigurationTests {
+
+    @Test("Default chord maps to the Carbon V key with cmd+shift modifiers")
+    func defaultChordKeyAndModifiers() {
+        let config = SummonHotkeyConfiguration.summonDefault
+        // kVK_ANSI_V == 0x09
+        #expect(config.keyCode == 0x09)
+        #expect(config.keyCode == SummonHotkeyConfiguration.keyCodeV)
+
+        let expectedMask = SummonHotkeyConfiguration.cmdKeyMask | SummonHotkeyConfiguration.shiftKeyMask
+        #expect(config.modifierFlags == expectedMask)
+        // Command and shift bits set, option and control bits clear.
+        #expect(config.modifierFlags & SummonHotkeyConfiguration.cmdKeyMask != 0)
+        #expect(config.modifierFlags & SummonHotkeyConfiguration.shiftKeyMask != 0)
+        #expect(config.modifierFlags & SummonHotkeyConfiguration.optionKeyMask == 0)
+        #expect(config.modifierFlags & SummonHotkeyConfiguration.controlKeyMask == 0)
+    }
+
+    @Test("Default chord renders the human-readable label")
+    func defaultChordDisplayString() {
+        #expect(SummonHotkeyConfiguration.summonDefault.displayString == "⇧⌘V")
+    }
+
+    @Test("Carbon modifier mask bit values match Carbon constants")
+    func modifierMaskBitValues() {
+        // These restate <Carbon/Carbon.h> cmdKey/shiftKey/optionKey/controlKey.
+        #expect(SummonHotkeyConfiguration.cmdKeyMask == 1 << 8)
+        #expect(SummonHotkeyConfiguration.shiftKeyMask == 1 << 9)
+        #expect(SummonHotkeyConfiguration.optionKeyMask == 1 << 11)
+        #expect(SummonHotkeyConfiguration.controlKeyMask == 1 << 12)
+    }
+}


### PR DESCRIPTION
Menu-Bar Instrument cluster (3 commits, gate-green, 23 new tests).

- **AND-486** ✅ Title Picker — extends `MenuBarSummaryMode` with `highestUtilization`, `todaySpend`, `safeToSpend`.
- **AND-485** ✅ Signal Glyph — opt-in live credit-utilization meter (`SignalGlyphMeter` Core + `SignalGlyphImage` template NSImage); severity by shape, staleness by shape/opacity, never color; degraded-status ladder still wins.
- **AND-487** ⚠️ partial — global ⌘⇧V summon hotkey + `DashboardCardOrder` Core model shipped; the MainPopover drag-reorder UI is deferred per the spec's own 'needs-decision' guidance (heterogeneous conditional column).

> Note: reconciles with the glyph PR — live meter → static Vault glyph → SF Symbol (see integration PR).

Closes AND-486, AND-485. Part of AND-487 (drag-reorder UI follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)