### PR TITLE
feat: Trust & Data Integrity cluster (AND-488/489/490/491/492)

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ Deferred product candidates:
 - [ ] Budget alerts per category
 - [ ] Multi-currency support
 - [ ] Investment account tracking (Plaid Investments)
-- [ ] CSV/JSON export for tax/accounting
+- [x] CSV/JSON export for tax/accounting (Settings → Local data → Export & Backup)
 - [ ] Webhook support for real-time updates
 - [ ] Dark/light theme customization
 - [ ] [Teller](https://teller.io/) as alternative provider

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -25,6 +25,7 @@ final class AppState {
         static let refreshInterval = "refreshInterval"
         static let automaticRefreshPolicy = AutomaticRefreshPolicy.storageKey
         static let balanceHistory = "balanceHistory"
+        static let accountBalanceLedger = "accountBalanceLedger"
         static let notificationsEnabled = "notificationsEnabled"
         static let largeTransactionThreshold = "largeTransactionThreshold"
         static let lowBalanceThreshold = "lowBalanceThreshold"
@@ -143,6 +144,12 @@ final class AppState {
     var isDemoStatusRecoveryScenario = false
     var lastSyncDate: Date?
     var balanceHistory: [BalanceSnapshot] = []
+    /// Per-account "what the bank said" ledger (AND-490). Each refresh appends one
+    /// dated row per account; the Time Machine surface reads from it.
+    var accountBalanceLedger = AccountBalanceLedger()
+    /// Display-safe rows describing prior-day balances Plaid restated on the most
+    /// recent sync (AND-490). Empty when no history was rewritten.
+    var syncHistoryDiffRows: [SyncHistoryDiff.Row] = []
     var notificationPermissionState: NotificationPermissionState = .notDetermined
     var weeklyReviewState: WeeklyReviewState = .empty {
         didSet {
@@ -2954,6 +2961,13 @@ final class AppState {
         } else {
             balanceHistory = []
         }
+
+        if let data = UserDefaults.standard.data(forKey: Keys.accountBalanceLedger),
+           let ledger = try? JSONDecoder().decode(AccountBalanceLedger.self, from: data) {
+            accountBalanceLedger = ledger
+        } else {
+            accountBalanceLedger = AccountBalanceLedger()
+        }
     }
 
     private func recordBalanceSnapshot() {
@@ -2965,7 +2979,29 @@ final class AppState {
         if let data = try? JSONEncoder().encode(balanceHistory) {
             UserDefaults.standard.set(data, forKey: Keys.balanceHistory)
         }
+        recordAccountBalanceLedger()
         writeGlanceSnapshot()
+    }
+
+    /// Appends today's per-account bank-reported balances to the ledger and
+    /// recomputes the sync-history diff against the prior ledger (AND-490).
+    private func recordAccountBalanceLedger() {
+        guard !accounts.isEmpty else { return }
+        let previous = accountBalanceLedger
+        let next = previous.appending(accounts: accounts)
+        let nameByAccountId = Dictionary(
+            accounts.map { ($0.id, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        syncHistoryDiffRows = SyncHistoryDiff.evaluate(
+            previousLedger: previous,
+            nextLedger: next,
+            displayName: { nameByAccountId[$0] }
+        )
+        accountBalanceLedger = next
+        if let data = try? JSONEncoder().encode(next) {
+            UserDefaults.standard.set(data, forKey: Keys.accountBalanceLedger)
+        }
     }
 
     private func writeGlanceSnapshot(updatedAt: Date = Date()) {
@@ -3132,6 +3168,22 @@ final class AppState {
         transactionRules = []
         categoryBudgets = [:]
         balanceHistory = DemoFixtures.balanceHistory()
+
+        // Balance Time Machine (AND-490): seed a multi-day per-account ledger and
+        // a post-sync diff so the Time Machine list and the "history changed"
+        // badge are both visible without Plaid.
+        let demoLedger = DemoFixtures.accountBalanceLedger()
+        let demoPostSyncLedger = DemoFixtures.postSyncAccountBalanceLedger()
+        accountBalanceLedger = demoPostSyncLedger
+        let demoNameByAccountId = Dictionary(
+            DemoFixtures.accounts.map { ($0.id, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        syncHistoryDiffRows = SyncHistoryDiff.evaluate(
+            previousLedger: demoLedger,
+            nextLedger: demoPostSyncLedger,
+            displayName: { demoNameByAccountId[$0] }
+        )
 
         isSetupComplete = true
         serverConnected = true

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -925,6 +925,22 @@ final class AppState {
         itemStatuses.filter { $0.status == .error }.count
     }
 
+    /// Per-number completeness badge (AND-489): nil when data is complete and
+    /// fresh, otherwise a `.stale` or `.partial` verdict mounted under derived
+    /// numbers (net worth, utilization, cashflow, safe-to-spend).
+    var dataIntegrityBadge: DataIntegrityBadge.Result? {
+        DataIntegrityBadge.evaluate(
+            isSyncStale: isSyncStale,
+            isBootLoadInFlight: isBootLoadInFlight,
+            itemCount: statusItemCount,
+            syncedItemCount: serverSyncedItemCount ?? statusItemCount,
+            degradedItemCount: itemStatuses.filter { $0.status.isDegraded }.count,
+            needsSyncItemCount: itemStatuses.filter(\.needsSync).count,
+            lastSync: lastSyncDate,
+            lastSyncRelative: lastSyncRelative
+        )
+    }
+
     var degradedItemIds: Set<String> {
         Set(
             itemStatuses
@@ -3126,16 +3142,15 @@ final class AppState {
         serverStoragePath = LocalDataStore.displayPath
         serverSyncReady = true
         serverSyncedItemCount = isDemoStatusRecoveryScenario ? 1 : serverItemCount
-        let recoveredSync = Calendar.current.date(byAdding: .minute, value: -18, to: Date()) ?? Date()
-        let needsLoginSync = Calendar.current.date(byAdding: .day, value: -3, to: Date()) ?? Date()
-        itemStatuses = isDemoStatusRecoveryScenario ? [
-            ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: recoveredSync),
-            ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .loginRequired, lastSync: needsLoginSync),
-        ] : [
+        // Partial-sync statuses (one connected + one degraded) come from
+        // DemoFixtures so the AND-489 data-integrity badge renders `.partial`
+        // in the recovery scenario; the happy path stays all-connected.
+        let recoveryStatuses = DemoFixtures.partialSyncItemStatuses()
+        itemStatuses = isDemoStatusRecoveryScenario ? recoveryStatuses : [
             ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: Date()),
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .connected, lastSync: Date()),
         ]
-        lastSyncDate = isDemoStatusRecoveryScenario ? recoveredSync : Date()
+        lastSyncDate = isDemoStatusRecoveryScenario ? recoveryStatuses.first?.lastSync ?? Date() : Date()
         writeGlanceSnapshot(updatedAt: lastSyncDate ?? Date())
     }
 

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -595,6 +595,10 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.secondary)
                 }
             }
+
+            Section("Where your data lives") {
+                LocalTrustReceiptView(receipt: whereYourDataLivesReceipt)
+            }
         }
         .formStyle(.grouped)
         .toggleStyle(.switch)
@@ -655,6 +659,10 @@ struct GeneralSettingsView: View {
 
     private var localTrustReceipt: LocalTrustReceipt {
         LocalTrustReceipt.settingsReceipt(storagePath: appState.activeStorageDirectoryDisplayText)
+    }
+
+    private var whereYourDataLivesReceipt: LocalTrustReceipt {
+        LocalTrustReceipt.whereYourDataLives(storagePath: appState.activeStorageDirectoryDisplayText)
     }
 
     private var localAIAvailabilityTint: Color {
@@ -824,6 +832,15 @@ private struct LocalTrustReceiptView: View {
             Text(receipt.footer)
                 .detailText()
                 .fixedSize(horizontal: false, vertical: true)
+
+            if let deepLink = receipt.deepLink, let url = URL(string: deepLink.urlString) {
+                Link(destination: url) {
+                    Label(deepLink.title, systemImage: deepLink.systemImage)
+                        .font(.caption.weight(.semibold))
+                }
+                .controlSize(.small)
+                .accessibilityLabel(deepLink.title)
+            }
         }
     }
 }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -596,6 +596,42 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            Section("Export & Backup") {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    Text("Export a portable copy of your accounts, transactions, and balance history. Files are written wherever you choose and never leave this Mac.")
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(alignment: .center, spacing: Spacing.sm) {
+                        Menu {
+                            Button("Export CSV…") { exportCSV() }
+                            Button("Export JSON…") { exportJSON() }
+                        } label: {
+                            Label("Export…", systemImage: "square.and.arrow.up")
+                        }
+                        .menuStyle(.borderlessButton)
+                        .fixedSize()
+                        .disabled(isExportDisabled)
+                    }
+
+                    if appState.appLockPreferences.privacyMaskEnabled {
+                        Label(
+                            "Export is disabled while Privacy Mask is on, so real balances are never written to disk. Turn off Privacy Mask to export.",
+                            systemImage: "eye.slash"
+                        )
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    LabeledContent("Backup file") {
+                        Text(documentedBackupPathText)
+                            .font(.system(.caption, design: .monospaced))
+                            .multilineTextAlignment(.trailing)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+
             Section("Where your data lives") {
                 LocalTrustReceiptView(receipt: whereYourDataLivesReceipt)
             }
@@ -634,6 +670,66 @@ struct GeneralSettingsView: View {
         let url = appState.activeStorageDirectoryURL
         try? LocalDataStore.prepareStorageDirectory(at: url)
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    // MARK: - Export & Backup (AND-492)
+
+    private var isExportDisabled: Bool {
+        appState.appLockPreferences.privacyMaskEnabled
+    }
+
+    /// Documented backup file path, e.g. `~/.vaultpeek/plaidbar-sandbox.sqlite`.
+    /// The SQLite store is per-environment; fall back to the generic filename
+    /// when no environment is connected (demo mode).
+    private var documentedBackupPathText: String {
+        let directory = appState.activeStorageDirectoryDisplayText
+        let filename: String
+        if let environment = appState.serverEnvironment {
+            filename = LocalDataStore.sqliteFilename(for: environment)
+        } else {
+            filename = "plaidbar.sqlite"
+        }
+        let trimmed = directory.hasSuffix("/") ? directory : directory + "/"
+        return trimmed + filename
+    }
+
+    private func exportCSV() {
+        guard !isExportDisabled else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Export"
+        panel.message = "Choose a folder for the exported CSV files."
+        guard panel.runModal() == .OK, let directory = panel.url else { return }
+
+        let documents: [(name: String, contents: String)] = [
+            ("accounts.csv", DataExportBuilder.accountsCSV(appState.accounts)),
+            ("transactions.csv", DataExportBuilder.transactionsCSV(appState.transactions)),
+            ("balance-history.csv", DataExportBuilder.balanceHistoryCSV(appState.balanceHistory)),
+        ]
+        for document in documents {
+            let url = directory.appendingPathComponent(document.name)
+            try? Data(document.contents.utf8).write(to: url, options: [.atomic])
+        }
+    }
+
+    private func exportJSON() {
+        guard !isExportDisabled else { return }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "vaultpeek-export.json"
+        panel.prompt = "Export"
+        panel.message = "Choose where to save the combined JSON backup."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        guard let data = try? DataExportBuilder.combinedJSON(
+            accounts: appState.accounts,
+            transactions: appState.transactions,
+            balanceHistory: appState.balanceHistory,
+            exportedAt: Date(),
+            environment: appState.serverEnvironment?.rawValue
+        ) else { return }
+        try? data.write(to: url, options: [.atomic])
     }
 
     private func copyStoragePath() {

--- a/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
+++ b/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
@@ -1,0 +1,76 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Balance Time Machine (AND-490): a compact "what the bank said" list of the
+/// latest per-account bank-reported balances, plus a "history changed" badge when
+/// a sync restated prior-day numbers. Presentation-only — the ledger and diff
+/// logic live in `AccountBalanceLedger` / `SyncHistoryDiff` (Core). User-facing
+/// text shows account display names only, never accountId / itemId.
+struct BalanceTimeMachineView: View {
+    @Environment(AppState.self) private var appState
+
+    private var latestEntries: [AccountBalanceLedger.LedgerEntry] {
+        appState.accountBalanceLedger.latestEntriesByAccount()
+    }
+
+    private var diffRows: [SyncHistoryDiff.Row] {
+        appState.syncHistoryDiffRows
+    }
+
+    private func displayName(for accountId: String) -> String {
+        appState.accounts.first { $0.id == accountId }?.name ?? "Account"
+    }
+
+    var body: some View {
+        let entries = latestEntries
+        if !entries.isEmpty {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                HStack(spacing: 6) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text("What the bank said")
+                        .sectionTitle()
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(entries) { entry in
+                    HStack(spacing: 6) {
+                        Text(displayName(for: entry.accountId))
+                            .microText()
+                            .lineLimit(1)
+                        Spacer(minLength: 4)
+                        Text(Formatters.currency(entry.current ?? entry.available ?? 0))
+                            .microText()
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                        Text(Formatters.displayDate(entry.date))
+                            .microText()
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(
+                        "\(displayName(for: entry.accountId)) reported \(Formatters.currency(entry.current ?? entry.available ?? 0)) as of \(Formatters.displayDate(entry.date))."
+                    )
+                }
+
+                ForEach(diffRows) { row in
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(row.summary)
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .help(row.accessibilityText)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(row.accessibilityText)
+                }
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.inset)
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
+++ b/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
@@ -1,0 +1,40 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Per-item connection health strip (AND-488): Connected / Reconnect-needed /
+/// Provider-outage buckets. Presentation-only — all classification lives in the
+/// `ConnectionHealthStrip` Core presenter. Each bucket pairs an SF Symbol with
+/// text so meaning is never carried by color alone. Self-hides when there are no
+/// linked items to report on.
+struct ConnectionHealthStripView: View {
+    @Environment(AppState.self) private var appState
+
+    private var result: ConnectionHealthStrip.Result {
+        ConnectionHealthStrip.evaluate(appState.itemStatuses)
+    }
+
+    var body: some View {
+        let result = result
+        if !result.buckets.isEmpty {
+            HStack(spacing: Spacing.sm) {
+                ForEach(result.buckets) { bucket in
+                    HStack(spacing: 5) {
+                        Image(systemName: bucket.iconName)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(bucket.label)
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .help(bucket.detail)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(bucket.label). \(bucket.detail)")
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(Spacing.sm)
+            .glassSurface(.inset)
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/DataIntegrityBadgeView.swift
+++ b/Sources/PlaidBar/Views/DataIntegrityBadgeView.swift
@@ -1,0 +1,24 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Lightweight presentation-only badge for the stale/partial data verdict
+/// (AND-489). Pairs an SF Symbol with text so meaning is never carried by color
+/// alone. All decision logic lives in `DataIntegrityBadge` (Core).
+struct DataIntegrityBadgeView: View {
+    let result: DataIntegrityBadge.Result
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 5) {
+            Image(systemName: result.iconName)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(result.title)
+                .microText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .help(result.detail)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(result.accessibilityLabel)
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1171,6 +1171,21 @@ private struct LocalInsightsCard: View {
                     .microText()
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 4)
+
+                Button {
+                    openSettings()
+                } label: {
+                    Label("Where your data lives", systemImage: "externaldrive.badge.questionmark")
+                        .labelStyle(.titleAndIcon)
+                        .microText()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Open Settings to see where VaultPeek stores your data on this Mac.")
+                .accessibilityLabel("Where your data lives")
+                .accessibilityHint("Opens Settings to the local data section")
             }
         }
         .padding(Spacing.sm)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -444,6 +444,9 @@ struct MainPopover: View {
                         DashboardChangeReceiptStrip()
                             .environment(appState)
 
+                        BalanceTimeMachineView()
+                            .environment(appState)
+
                         WeeklyReviewCard()
                             .environment(appState)
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -460,6 +460,9 @@ struct MainPopover: View {
 
                         if shouldElevateStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                                ConnectionHealthStripView()
+                                    .environment(appState)
+
                                 AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
                                     .environment(appState)
 
@@ -502,6 +505,9 @@ struct MainPopover: View {
 
                         if shouldShowLowerStatusReadinessPanel {
                             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                                ConnectionHealthStripView()
+                                    .environment(appState)
+
                                 AttentionQueueView(title: "Attention", onAddAccount: openAccountSetup)
                                     .environment(appState)
 

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -117,8 +117,40 @@ struct SetupView: View {
                 }
             }
 
+            whereYourDataLivesDisclosure
+
             SetupSupportLinks()
         }
+    }
+
+    /// Onboarding transparency disclosure (AND-491). Reachable before any mode
+    /// choice — including the credential-less "View Demo" path — so users can see
+    /// where VaultPeek stores data before connecting anything.
+    private var whereYourDataLivesDisclosure: some View {
+        let receipt = LocalTrustReceipt.whereYourDataLives(
+            storagePath: appState.activeStorageDirectoryDisplayText
+        )
+        return DisclosureGroup {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                ForEach(receipt.rows) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                        Image(systemName: row.systemImage)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18)
+                        Text(row.detail)
+                            .detailText()
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(row.title). \(row.detail)")
+                }
+            }
+            .padding(.top, Spacing.xs)
+        } label: {
+            Label(receipt.title, systemImage: "lock.shield")
+                .font(.caption.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Link preparation

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -150,6 +150,10 @@ struct WealthSummaryFlyout: View {
                 if !privacyMaskEnabled {
                     WealthNetWorthTrendBlock(trend: presentation.netWorthTrend)
                 }
+
+                if let badge = appState.dataIntegrityBadge {
+                    DataIntegrityBadgeView(result: badge)
+                }
             }
             .padding(Spacing.sm)
             .heroAccentSurface()
@@ -169,7 +173,8 @@ struct WealthSummaryFlyout: View {
         let netCashflow = privacyMaskEnabled
             ? PrivacyMaskPresentation.compactValue
             : cashflowText(presentation.cashflow.net, format: .full)
-        return "Wealth summary. Net worth \(netWorth). 30 day net cashflow \(netCashflow). \(presentation.syncHealth.title). \(presentation.attention.detail)"
+        let integrity = appState.dataIntegrityBadge.map { " \($0.accessibilityLabel)" } ?? ""
+        return "Wealth summary. Net worth \(netWorth). 30 day net cashflow \(netCashflow). \(presentation.syncHealth.title). \(presentation.attention.detail)\(integrity)"
     }
 }
 

--- a/Sources/PlaidBarCore/Models/AccountBalanceLedger.swift
+++ b/Sources/PlaidBarCore/Models/AccountBalanceLedger.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Per-account "what the bank said" ledger (AND-490). Each refresh appends one
+/// dated row per account capturing exactly the bank-reported numbers (current /
+/// available / limit). Mirrors `BalanceHistoryReducer`: one entry per account
+/// per day with same-day replacement and a retention window. Pure, Sendable,
+/// app-side JSON persistence (no SQLite, no extra Plaid calls).
+public struct AccountBalanceLedger: Codable, Sendable, Equatable {
+    public struct LedgerEntry: Codable, Sendable, Equatable, Identifiable {
+        public let accountId: String
+        public let date: Date
+        public let current: Double?
+        public let available: Double?
+        public let limit: Double?
+        public let recordedAt: Date
+
+        /// Stable per-account-per-day identity for deduplication and diffing.
+        public var id: String { "\(accountId)|\(AccountBalanceLedger.dayKey(date))" }
+
+        public init(
+            accountId: String,
+            date: Date,
+            current: Double?,
+            available: Double?,
+            limit: Double?,
+            recordedAt: Date
+        ) {
+            self.accountId = accountId
+            self.date = date
+            self.current = current
+            self.available = available
+            self.limit = limit
+            self.recordedAt = recordedAt
+        }
+    }
+
+    public let entries: [LedgerEntry]
+
+    public init(entries: [LedgerEntry] = []) {
+        self.entries = entries
+    }
+
+    /// Canonical day key (YYYY-MM-DD) used for same-day replacement and ids.
+    static func dayKey(_ date: Date) -> String {
+        Formatters.transactionDateString(date)
+    }
+
+    /// Appends one entry per account for `accounts` at `now`, replacing any
+    /// existing same-account/same-day entry, pruning entries older than the
+    /// retention window, and returning a stably-sorted ledger (by date, then
+    /// accountId). Reuses the BalanceHistoryReducer pattern.
+    public func appending(
+        accounts: [AccountDTO],
+        now: Date = Date(),
+        retentionDays: Int = 90,
+        calendar: Calendar = .current
+    ) -> AccountBalanceLedger {
+        var updated = entries
+
+        for account in accounts {
+            // Drop any prior entry for this account on the same day.
+            updated.removeAll {
+                $0.accountId == account.id && calendar.isDate($0.date, inSameDayAs: now)
+            }
+            updated.append(
+                LedgerEntry(
+                    accountId: account.id,
+                    date: now,
+                    current: account.balances.current,
+                    available: account.balances.available,
+                    limit: account.balances.limit,
+                    recordedAt: now
+                )
+            )
+        }
+
+        let cutoff = calendar.date(byAdding: .day, value: -retentionDays, to: now) ?? now
+        updated.removeAll { $0.date < cutoff }
+
+        updated.sort {
+            if $0.date != $1.date { return $0.date < $1.date }
+            return $0.accountId < $1.accountId
+        }
+        return AccountBalanceLedger(entries: updated)
+    }
+
+    /// Most recent entry per account (one row per account), sorted by accountId.
+    public func latestEntriesByAccount() -> [LedgerEntry] {
+        var latest: [String: LedgerEntry] = [:]
+        for entry in entries {
+            if let existing = latest[entry.accountId] {
+                if entry.date > existing.date { latest[entry.accountId] = entry }
+            } else {
+                latest[entry.accountId] = entry
+            }
+        }
+        return latest.values.sorted { $0.accountId < $1.accountId }
+    }
+}

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -306,6 +306,19 @@ public struct AttentionQueue: Equatable, Sendable {
                     targetItemId: item.id,
                     accessibilityHint: "Reconnects this institution through Plaid Link."
                 )
+            case .providerOutage:
+                // Transient Plaid-side outage: advisory only (.warning, no
+                // reconnect action) — VaultPeek retries automatically, so the
+                // user is told no action is needed rather than offered an Update.
+                return AttentionQueueRow(
+                    id: "item-outage-\(index)",
+                    severity: .warning,
+                    title: itemTitle(item, fallback: "Bank temporarily unavailable"),
+                    detail: itemDetail(item, fallback: "Your bank or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed."),
+                    action: nil,
+                    actionTitle: nil,
+                    targetItemId: item.id
+                )
             }
         }
     }
@@ -411,6 +424,8 @@ public struct AttentionQueue: Equatable, Sendable {
             return "\(institutionName) permission revoked"
         case .newAccountsAvailable:
             return "\(institutionName) has new accounts"
+        case .providerOutage:
+            return "\(institutionName) temporarily unavailable"
         case .error:
             return "\(institutionName) needs attention"
         }
@@ -431,6 +446,8 @@ public struct AttentionQueue: Equatable, Sendable {
             return "Plaid says \(institutionName) permission was revoked. Update this item to restore access."
         case .newAccountsAvailable:
             return "\(institutionName) has newly available accounts. Update this item to choose what VaultPeek can access."
+        case .providerOutage:
+            return "Your bank or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed."
         case .error:
             return "Plaid reported an item error for \(institutionName). Reconnect, then refresh."
         }

--- a/Sources/PlaidBarCore/Models/LinkResponse.swift
+++ b/Sources/PlaidBarCore/Models/LinkResponse.swift
@@ -71,13 +71,17 @@ public enum ItemConnectionStatus: String, Codable, Sendable {
     case permissionRevoked = "permission_revoked"
     case newAccountsAvailable = "new_accounts_available"
     case loginRepaired = "login_repaired"
+    /// A transient Plaid-side outage (institution down, planned maintenance, or
+    /// an internal Plaid error). Degraded but NOT a user-actionable reconnect —
+    /// VaultPeek retries automatically rather than prompting an update flow.
+    case providerOutage = "provider_outage"
     case error
 
     public var needsUpdateMode: Bool {
         switch self {
         case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable:
             true
-        case .connected, .loginRepaired, .error:
+        case .connected, .loginRepaired, .providerOutage, .error:
             false
         }
     }
@@ -86,16 +90,22 @@ public enum ItemConnectionStatus: String, Codable, Sendable {
         switch self {
         case .connected, .loginRepaired:
             false
-        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable, .error:
+        case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable, .providerOutage, .error:
             true
         }
+    }
+
+    /// A non-actionable transient outage: degraded, but the user cannot fix it —
+    /// the connection recovers on its own once Plaid/the institution is back.
+    public var isProviderOutage: Bool {
+        self == .providerOutage
     }
 
     public func applyingLoginRepaired() -> ItemConnectionStatus {
         switch self {
         case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked:
             .loginRepaired
-        case .connected, .newAccountsAvailable, .loginRepaired, .error:
+        case .connected, .newAccountsAvailable, .loginRepaired, .providerOutage, .error:
             self
         }
     }

--- a/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
+++ b/Sources/PlaidBarCore/Models/LocalTrustReceipt.swift
@@ -15,21 +15,39 @@ public struct LocalTrustReceipt: Equatable, Sendable {
         }
     }
 
+    /// Optional trailing call-to-action rendered as a `Link` under the rows
+    /// (e.g. a Plaid scope/deletion deep link). Kept as data, not view-embedded,
+    /// so the URL stays Sendable and unit-testable.
+    public struct DeepLink: Equatable, Sendable {
+        public let title: String
+        public let urlString: String
+        public let systemImage: String
+
+        public init(title: String, urlString: String, systemImage: String) {
+            self.title = title
+            self.urlString = urlString
+            self.systemImage = systemImage
+        }
+    }
+
     public let title: String
     public let subtitle: String
     public let rows: [Row]
     public let footer: String
+    public let deepLink: DeepLink?
 
     public init(
         title: String,
         subtitle: String,
         rows: [Row],
-        footer: String
+        footer: String,
+        deepLink: DeepLink? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
         self.rows = rows
         self.footer = footer
+        self.deepLink = deepLink
     }
 
     public static func settingsReceipt(storagePath: String) -> LocalTrustReceipt {
@@ -66,6 +84,51 @@ public struct LocalTrustReceipt: Equatable, Sendable {
                 ),
             ],
             footer: "Reset does not revoke bank permissions or remove items from Plaid Dashboard; review those accounts separately when you want full revocation."
+        )
+    }
+
+    /// "Where Your Data Lives" trust/transparency panel (AND-491). Names the
+    /// SQLite store and Keychain explicitly, calls out the 127.0.0.1 loopback
+    /// boundary as a dedicated row, and exposes a Plaid scope/deletion deep link.
+    public static func whereYourDataLives(storagePath: String) -> LocalTrustReceipt {
+        let trimmedStoragePath = storagePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayStoragePath = trimmedStoragePath.isEmpty ? LocalDataStore.displayPath : trimmedStoragePath
+
+        return LocalTrustReceipt(
+            title: "Where Your Data Lives",
+            subtitle: "Every byte VaultPeek stores stays on this Mac.",
+            rows: [
+                Row(
+                    id: "sqlite",
+                    title: "Local SQLite store",
+                    detail: "Accounts, transactions, and sync cursors live in a local SQLite database at \(displayStoragePath).",
+                    systemImage: "externaldrive"
+                ),
+                Row(
+                    id: "keychain",
+                    title: "macOS Keychain",
+                    detail: "Plaid access tokens are stored as bytes in the macOS Keychain; SQLite holds only keychain:<item_id> references.",
+                    systemImage: "key.fill"
+                ),
+                Row(
+                    id: "loopback",
+                    title: "Loopback boundary",
+                    detail: "Network reaches only 127.0.0.1 — no VaultPeek backend, analytics, telemetry, or cloud sync. The local VaultPeek server is the only thing that talks to Plaid over HTTPS.",
+                    systemImage: "network.slash"
+                ),
+                Row(
+                    id: "plaid-scope",
+                    title: "Plaid scope & deletion",
+                    detail: "Bank connections are managed in your Plaid account; revoke or delete them there to fully cut off access.",
+                    systemImage: "building.columns"
+                ),
+            ],
+            footer: "VaultPeek never sends your financial data off this machine. Removing items from Plaid is a separate step you control.",
+            deepLink: DeepLink(
+                title: "Manage or delete data at Plaid",
+                urlString: PlaidBarConstants.plaidDataDeletionURL,
+                systemImage: "arrow.up.forward.square"
+            )
         )
     }
 }

--- a/Sources/PlaidBarCore/Models/SyncHistoryDiff.swift
+++ b/Sources/PlaidBarCore/Models/SyncHistoryDiff.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Deterministic diff over two `AccountBalanceLedger` snapshots (AND-490). When
+/// a sync changes an already-recorded prior-day balance for an account (Plaid
+/// modified/removed rewriting history), it emits display-safe rows describing how
+/// many prior days changed and the net signed delta. User-facing strings carry
+/// only the account display name — never accountId / itemId — matching
+/// DashboardChangeReceipt's privacy contract. Pure and Sendable.
+public enum SyncHistoryDiff {
+    public struct Row: Sendable, Equatable, Identifiable {
+        /// Stable, non-PII identity for SwiftUI. Derived from a hash of the
+        /// account id, but never surfaced in user-facing text.
+        public let id: String
+        public let accountDisplayName: String
+        public let changedDayCount: Int
+        public let netDelta: Double
+        public let summary: String
+        public let accessibilityText: String
+
+        public init(
+            id: String,
+            accountDisplayName: String,
+            changedDayCount: Int,
+            netDelta: Double,
+            summary: String,
+            accessibilityText: String
+        ) {
+            self.id = id
+            self.accountDisplayName = accountDisplayName
+            self.changedDayCount = changedDayCount
+            self.netDelta = netDelta
+            self.summary = summary
+            self.accessibilityText = accessibilityText
+        }
+    }
+
+    /// Compares `previousLedger` against `nextLedger`. Only prior-day rewrites
+    /// count: a purely-additive newer day (a new date not present in the prior
+    /// ledger) is not "history changed" and produces no row. `displayName`
+    /// resolves an accountId to a privacy-safe display name; when it returns nil,
+    /// a neutral "An account" label is used (never the id).
+    public static func evaluate(
+        previousLedger: AccountBalanceLedger,
+        nextLedger: AccountBalanceLedger,
+        displayName: (String) -> String?
+    ) -> [Row] {
+        // Index prior entries by (accountId, dayKey) -> current balance.
+        var priorByKey: [String: Double?] = [:]
+        for entry in previousLedger.entries {
+            priorByKey[key(entry.accountId, entry.date)] = entry.current
+        }
+
+        // Accumulate per-account rewrite stats.
+        struct Accumulator {
+            var changedDays = 0
+            var netDelta = 0.0
+        }
+        var perAccount: [String: Accumulator] = [:]
+        var accountOrder: [String] = []
+
+        for entry in nextLedger.entries {
+            let entryKey = key(entry.accountId, entry.date)
+            // Only a day that already existed in the prior ledger can be a
+            // "history changed" rewrite; a brand-new day is additive, not a diff.
+            guard let priorCurrent = priorByKey[entryKey] else { continue }
+            guard priorCurrent != entry.current else { continue }
+
+            let delta = (entry.current ?? 0) - (priorCurrent ?? 0)
+            if perAccount[entry.accountId] == nil {
+                perAccount[entry.accountId] = Accumulator()
+                accountOrder.append(entry.accountId)
+            }
+            perAccount[entry.accountId]?.changedDays += 1
+            perAccount[entry.accountId]?.netDelta += delta
+        }
+
+        return accountOrder.sorted().compactMap { accountId in
+            guard let stats = perAccount[accountId], stats.changedDays > 0 else { return nil }
+            let name = displayName(accountId) ?? "An account"
+            let deltaText = signedCurrency(stats.netDelta)
+            let dayWord = stats.changedDays == 1 ? "day" : "days"
+            let summary = "\(name): \(stats.changedDays) prior \(dayWord) restated (\(deltaText))"
+            let accessibilityText = "\(name) had \(stats.changedDays) prior \(dayWord) restated by your bank, a net change of \(deltaText)."
+            return Row(
+                id: stableHash(accountId),
+                accountDisplayName: name,
+                changedDayCount: stats.changedDays,
+                netDelta: stats.netDelta,
+                summary: summary,
+                accessibilityText: accessibilityText
+            )
+        }
+    }
+
+    private static func key(_ accountId: String, _ date: Date) -> String {
+        "\(accountId)|\(AccountBalanceLedger.dayKey(date))"
+    }
+
+    private static func signedCurrency(_ amount: Double) -> String {
+        let formatted = Formatters.currency(abs(amount))
+        if amount > 0 { return "+\(formatted)" }
+        if amount < 0 { return "-\(formatted)" }
+        return formatted
+    }
+
+    private static func stableHash(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -130,6 +130,28 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 statusFilterSubtitle: "Item error • \(itemSyncLabel)",
                 recoveryDetailLabel: errorRecoveryDetailLabel(institutionName: institutionName)
             )
+        case .providerOutage:
+            // Transient Plaid-side outage: advisory, NOT a user reconnect. No
+            // recovery actions — VaultPeek retries automatically. Rendered at the
+            // .stale (degraded-but-not-your-fault) level.
+            let itemSyncLabel = itemSyncLabel(itemLastSyncRelative)
+            let outageLabel = itemDetailLabel(
+                institutionName: institutionName,
+                fallback: "Bank temporarily unavailable",
+                suffix: "is temporarily unavailable"
+            )
+            return AccountConnectionPresentation(
+                level: .stale,
+                rowLabel: outageLabel,
+                detailLabel: outageLabel,
+                signalLabel: "Outage",
+                iconName: "wifi.exclamationmark",
+                showsRecoveryActions: false,
+                recoveryActionTitle: nil,
+                itemSyncLabel: itemSyncLabel,
+                statusFilterSubtitle: "Provider outage • \(itemSyncLabel)",
+                recoveryDetailLabel: "Your bank or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed."
+            )
         case nil:
             return AccountConnectionPresentation.synced(
                 isSyncStale: isSyncStale,
@@ -217,7 +239,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             return itemDetailLabel(institutionName: institutionName, fallback: "Permission revoked", suffix: "permission revoked")
         case .newAccountsAvailable:
             return itemDetailLabel(institutionName: institutionName, fallback: "New accounts available", suffix: "new accounts available")
-        case .connected, .loginRepaired, .loginRequired, .error, nil:
+        case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
             return itemDetailLabel(institutionName: institutionName, fallback: "Login required", suffix: "login required")
         }
     }
@@ -232,7 +254,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             "Revoked"
         case .newAccountsAvailable:
             "New"
-        case .connected, .loginRepaired, .loginRequired, .error, nil:
+        case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
             "Login"
         }
     }
@@ -247,7 +269,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             "Permission revoked"
         case .newAccountsAvailable:
             "New accounts available"
-        case .connected, .loginRepaired, .loginRequired, .error, nil:
+        case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
             "Login required"
         }
     }
@@ -260,7 +282,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             "hand.raised.fill"
         case .newAccountsAvailable:
             "plus.circle.fill"
-        case .connected, .loginRepaired, .loginRequired, .error, nil:
+        case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
             "person.crop.circle.badge.exclamationmark.fill"
         }
     }
@@ -294,7 +316,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 return "Plaid says permission was revoked. Reconnect this item to restore access."
             case .newAccountsAvailable:
                 return "New accounts are available. Update this item to choose what VaultPeek can access."
-            case .connected, .loginRepaired, .loginRequired, .error, nil:
+            case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
                 return loginRecoveryDetailLabel(institutionName: nil)
             }
         }
@@ -308,7 +330,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
             return "Plaid says \(institutionName) permission was revoked. Reconnect this item to restore access."
         case .newAccountsAvailable:
             return "\(institutionName) has newly available accounts. Update this item to choose what VaultPeek can access."
-        case .connected, .loginRepaired, .loginRequired, .error, nil:
+        case .connected, .loginRepaired, .loginRequired, .providerOutage, .error, nil:
             return loginRecoveryDetailLabel(institutionName: institutionName)
         }
     }

--- a/Sources/PlaidBarCore/Utilities/ConnectionHealthStrip.swift
+++ b/Sources/PlaidBarCore/Utilities/ConnectionHealthStrip.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Pure, Sendable presenter that groups per-item connection statuses into three
+/// buckets — Connected / Reconnect-needed / Provider-outage (AND-488). Each
+/// bucket carries an SF Symbol + text label so meaning is never color-alone, and
+/// whether a reconnect action applies (outage rows are non-actionable).
+public enum ConnectionHealthStrip {
+    public enum State: String, Sendable, Equatable {
+        case connected
+        case reconnectNeeded
+        case providerOutage
+    }
+
+    public struct Bucket: Sendable, Equatable, Identifiable {
+        public let state: State
+        public let count: Int
+        public let label: String
+        public let detail: String
+        public let iconName: String
+        public let isActionable: Bool
+
+        public var id: String { state.rawValue }
+
+        public init(
+            state: State,
+            count: Int,
+            label: String,
+            detail: String,
+            iconName: String,
+            isActionable: Bool
+        ) {
+            self.state = state
+            self.count = count
+            self.label = label
+            self.detail = detail
+            self.iconName = iconName
+            self.isActionable = isActionable
+        }
+    }
+
+    public struct Result: Sendable, Equatable {
+        public let buckets: [Bucket]
+
+        public init(buckets: [Bucket]) {
+            self.buckets = buckets
+        }
+
+        /// True when any non-outage degraded item exists (a real reconnect target).
+        public var hasActionableWork: Bool {
+            buckets.contains { $0.state == .reconnectNeeded && $0.count > 0 }
+        }
+
+        public var hasProviderOutage: Bool {
+            buckets.contains { $0.state == .providerOutage && $0.count > 0 }
+        }
+    }
+
+    /// Classifies a single status into one of the three buckets.
+    private static func bucketState(for status: ItemConnectionStatus) -> State {
+        if status.isProviderOutage { return .providerOutage }
+        if status.isDegraded { return .reconnectNeeded }
+        return .connected
+    }
+
+    /// Groups statuses into the three buckets, omitting empty buckets. The result
+    /// preserves a stable Connected → Reconnect-needed → Provider-outage order.
+    public static func evaluate(_ statuses: [ItemStatus]) -> Result {
+        let counts = statuses.reduce(into: [State: Int]()) { partial, item in
+            partial[bucketState(for: item.status), default: 0] += 1
+        }
+
+        var buckets: [Bucket] = []
+        if let connected = counts[.connected], connected > 0 {
+            buckets.append(
+                Bucket(
+                    state: .connected,
+                    count: connected,
+                    label: "\(connected) connected",
+                    detail: "Syncing normally.",
+                    iconName: "checkmark.circle",
+                    isActionable: false
+                )
+            )
+        }
+        if let reconnect = counts[.reconnectNeeded], reconnect > 0 {
+            buckets.append(
+                Bucket(
+                    state: .reconnectNeeded,
+                    count: reconnect,
+                    label: "\(reconnect) need\(reconnect == 1 ? "s" : "") attention",
+                    detail: "Reconnect to keep these accounts in sync.",
+                    iconName: "exclamationmark.triangle",
+                    isActionable: true
+                )
+            )
+        }
+        if let outage = counts[.providerOutage], outage > 0 {
+            buckets.append(
+                Bucket(
+                    state: .providerOutage,
+                    count: outage,
+                    label: "\(outage) temporarily unavailable",
+                    detail: "Your bank or Plaid is down. We'll retry automatically — no action needed.",
+                    iconName: "wifi.exclamationmark",
+                    isActionable: false
+                )
+            )
+        }
+        return Result(buckets: buckets)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -68,6 +68,14 @@ public enum PlaidBarConstants {
     public static var plaidSandboxRedirectUri: String {
         "http://localhost:\(serverPort)/oauth/callback"
     }
+
+    /// Plaid's consumer-facing privacy portal, where users review what data a
+    /// connected app can access.
+    public static let plaidPrivacyURL: String = "https://my.plaid.com/"
+
+    /// Plaid's data deletion / connection-management portal, where users revoke
+    /// or delete the bank connections VaultPeek created.
+    public static let plaidDataDeletionURL: String = "https://my.plaid.com/"
 }
 
 private extension String {

--- a/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Pure, Sendable serializer that turns the app's locally-held DTO arrays into
+/// portable CSV documents and a combined JSON backup envelope (AND-492). No
+/// AppKit, no I/O — string/Data math over Sendable DTOs, fully unit-testable.
+public enum DataExportBuilder {
+    /// Bumped whenever the JSON envelope shape changes so importers can branch.
+    public static let schemaVersion = 1
+
+    // MARK: - CSV
+
+    /// Escapes a single CSV field per RFC 4180: wrap in double quotes and double
+    /// any interior double quote when the value contains a comma, quote, CR, or LF.
+    public static func csvField(_ value: String) -> String {
+        let needsQuoting = value.contains(",")
+            || value.contains("\"")
+            || value.contains("\n")
+            || value.contains("\r")
+        guard needsQuoting else { return value }
+        let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+    }
+
+    private static func row(_ fields: [String]) -> String {
+        fields.map(csvField).joined(separator: ",")
+    }
+
+    private static func decimalString(_ value: Double?) -> String {
+        guard let value else { return "" }
+        return String(format: "%.2f", value)
+    }
+
+    public static func accountsCSV(_ accounts: [AccountDTO]) -> String {
+        let header = row([
+            "account_id", "item_id", "name", "official_name", "type", "subtype",
+            "mask", "institution_name", "available", "current", "limit", "currency",
+        ])
+        let rows = accounts.map { account in
+            row([
+                account.id,
+                account.itemId,
+                account.name,
+                account.officialName ?? "",
+                account.type.rawValue,
+                account.subtype ?? "",
+                account.mask ?? "",
+                account.institutionName ?? "",
+                decimalString(account.balances.available),
+                decimalString(account.balances.current),
+                decimalString(account.balances.limit),
+                account.balances.isoCurrencyCode ?? "",
+            ])
+        }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
+    public static func transactionsCSV(_ transactions: [TransactionDTO]) -> String {
+        let header = row([
+            "transaction_id", "account_id", "date", "name", "merchant_name",
+            "amount", "currency", "category", "pending",
+        ])
+        let rows = transactions.map { transaction in
+            row([
+                transaction.id,
+                transaction.accountId,
+                transaction.date,
+                transaction.name,
+                transaction.merchantName ?? "",
+                decimalString(transaction.amount),
+                transaction.isoCurrencyCode ?? "",
+                transaction.category?.rawValue ?? "",
+                transaction.pending ? "true" : "false",
+            ])
+        }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
+    public static func balanceHistoryCSV(_ history: [BalanceSnapshot]) -> String {
+        let header = row(["date", "balance"])
+        let rows = history.map { snapshot in
+            row([
+                Formatters.transactionDateString(snapshot.date),
+                decimalString(snapshot.balance),
+            ])
+        }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - JSON
+
+    /// Versioned, stable backup envelope: schemaVersion, exportedAt, environment,
+    /// per-array counts, then the three DTO arrays (reusing their Codable
+    /// conformances). Round-trips back into the original DTO arrays.
+    public struct Envelope: Codable, Sendable, Equatable {
+        public struct Counts: Codable, Sendable, Equatable {
+            public let accounts: Int
+            public let transactions: Int
+            public let balanceHistory: Int
+
+            public init(accounts: Int, transactions: Int, balanceHistory: Int) {
+                self.accounts = accounts
+                self.transactions = transactions
+                self.balanceHistory = balanceHistory
+            }
+        }
+
+        public let schemaVersion: Int
+        public let exportedAt: Date
+        public let environment: String?
+        public let counts: Counts
+        public let accounts: [AccountDTO]
+        public let transactions: [TransactionDTO]
+        public let balanceHistory: [BalanceSnapshot]
+
+        public init(
+            schemaVersion: Int,
+            exportedAt: Date,
+            environment: String?,
+            counts: Counts,
+            accounts: [AccountDTO],
+            transactions: [TransactionDTO],
+            balanceHistory: [BalanceSnapshot]
+        ) {
+            self.schemaVersion = schemaVersion
+            self.exportedAt = exportedAt
+            self.environment = environment
+            self.counts = counts
+            self.accounts = accounts
+            self.transactions = transactions
+            self.balanceHistory = balanceHistory
+        }
+    }
+
+    public static func envelope(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        balanceHistory: [BalanceSnapshot],
+        exportedAt: Date,
+        environment: String? = nil
+    ) -> Envelope {
+        Envelope(
+            schemaVersion: schemaVersion,
+            exportedAt: exportedAt,
+            environment: environment,
+            counts: Envelope.Counts(
+                accounts: accounts.count,
+                transactions: transactions.count,
+                balanceHistory: balanceHistory.count
+            ),
+            accounts: accounts,
+            transactions: transactions,
+            balanceHistory: balanceHistory
+        )
+    }
+
+    public static func combinedJSON(
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        balanceHistory: [BalanceSnapshot],
+        exportedAt: Date,
+        environment: String? = nil
+    ) throws -> Data {
+        let envelope = envelope(
+            accounts: accounts,
+            transactions: transactions,
+            balanceHistory: balanceHistory,
+            exportedAt: exportedAt,
+            environment: environment
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(envelope)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/DataIntegrityBadge.swift
+++ b/Sources/PlaidBarCore/Utilities/DataIntegrityBadge.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Pure, Sendable decider for the per-number "data may be incomplete / stale"
+/// badge (AND-489). Maps completeness inputs to an optional badge whose verdict
+/// is carried by text + an SF Symbol — never color alone. Distinguishes "stale"
+/// (last sync too old, all items) from "partial/incomplete" (some items not yet
+/// synced, or a degraded item omitted from the totals).
+public enum DataIntegrityBadge {
+    public enum Severity: String, Sendable, Equatable {
+        case stale
+        case partial
+    }
+
+    public struct Result: Sendable, Equatable {
+        public let severity: Severity
+        public let title: String
+        public let detail: String
+        public let iconName: String
+        public let accessibilityLabel: String
+
+        public init(
+            severity: Severity,
+            title: String,
+            detail: String,
+            iconName: String,
+            accessibilityLabel: String
+        ) {
+            self.severity = severity
+            self.title = title
+            self.detail = detail
+            self.iconName = iconName
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    /// Returns nil when data is complete and fresh.
+    ///
+    /// Precedence:
+    /// 1. boot-in-flight -> nil (first sync still running, no verdict yet)
+    /// 2. stale -> `.stale` ("since <relative>", or "Never" when never synced)
+    /// 3. some items unsynced OR degraded/needs-sync items exist -> `.partial`
+    /// 4. otherwise -> nil
+    public static func evaluate(
+        isSyncStale: Bool,
+        isBootLoadInFlight: Bool,
+        itemCount: Int,
+        syncedItemCount: Int,
+        degradedItemCount: Int,
+        needsSyncItemCount: Int,
+        lastSync: Date?,
+        lastSyncRelative: String?,
+        now: Date = Date()
+    ) -> Result? {
+        if isBootLoadInFlight {
+            return nil
+        }
+
+        if isSyncStale {
+            let token = lastSync == nil ? "Never" : (lastSyncRelative ?? "recently")
+            let title = lastSync == nil ? "Never synced" : "As of \(token) — sync stale"
+            let detail = lastSync == nil
+                ? "These numbers have not synced yet."
+                : "These numbers may be out of date. Last synced \(token)."
+            return Result(
+                severity: .stale,
+                title: title,
+                detail: detail,
+                iconName: "clock.badge.exclamationmark",
+                accessibilityLabel: "\(title). \(detail)"
+            )
+        }
+
+        let hasUnsyncedItems = syncedItemCount < itemCount
+        let hasIncompleteItems = degradedItemCount > 0 || needsSyncItemCount > 0
+        if hasUnsyncedItems || hasIncompleteItems {
+            let token = lastSyncRelative ?? "the last sync"
+            let title = "Data may be incomplete since \(token)"
+            let detail: String
+            if hasUnsyncedItems {
+                detail = "\(syncedItemCount) of \(itemCount) connections are included; the rest are still catching up."
+            } else {
+                detail = "Some connections need attention, so these totals may be missing accounts."
+            }
+            return Result(
+                severity: .partial,
+                title: title,
+                detail: detail,
+                iconName: "exclamationmark.triangle",
+                accessibilityLabel: "\(title). \(detail)"
+            )
+        }
+
+        return nil
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -126,6 +126,8 @@ public enum DemoFixtures {
             TransactionDTO(id: "tx2", accountId: "demo_checking", amount: 23.50, date: today, name: "UBER TRIP", merchantName: "Uber", category: .transportation),
             TransactionDTO(id: "tx3", accountId: "demo_checking", amount: -3_200.00, date: today, name: "STRIPE TRANSFER", merchantName: "Stripe", category: .income),
             TransactionDTO(id: "tx4", accountId: "demo_amex", amount: 142.80, date: today, name: "AMAZON.COM", merchantName: "Amazon", category: .shopping),
+            // Merchant name with a comma exercises CSV quoting/escaping in exports (AND-492).
+            TransactionDTO(id: "tx4b", accountId: "demo_amex", amount: 58.10, date: today, name: "DINING PURCHASE", merchantName: "Joe's Bar, Grill & Co.", category: .foodAndDrink),
             // Yesterday
             TransactionDTO(id: "tx5", accountId: "demo_checking", amount: 15.99, date: yesterday, name: "NETFLIX.COM", merchantName: "Netflix", category: .entertainment),
             TransactionDTO(id: "tx6", accountId: "demo_checking", amount: 45.00, date: yesterday, name: "SHELL OIL 57422", merchantName: "Shell", category: .transportation),

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -81,16 +81,19 @@ public enum DemoFixtures {
         }
     }
 
-    /// Partial-sync demo statuses (AND-489): one connected item plus one
-    /// degraded (`loginRequired`) item, so `syncedItemCount < itemCount` and the
-    /// data-integrity badge renders `.partial`. Used by the demo status-recovery
-    /// scenario so the badge is visible without Plaid.
+    /// Partial-sync demo statuses (AND-489 / AND-488): one connected item, one
+    /// degraded (`loginRequired`) reconnect target, and one `.providerOutage`
+    /// item. This makes `syncedItemCount < itemCount` (so the data-integrity
+    /// badge renders `.partial`) and exercises all three Connection Health Strip
+    /// buckets (Connected / Reconnect-needed / Provider-outage) without Plaid.
     public static func partialSyncItemStatuses(now: Date = Date(), calendar: Calendar = .current) -> [ItemStatus] {
         let recoveredSync = calendar.date(byAdding: .minute, value: -18, to: now) ?? now
         let needsLoginSync = calendar.date(byAdding: .day, value: -3, to: now) ?? now
+        let outageSync = calendar.date(byAdding: .hour, value: -2, to: now) ?? now
         return [
             ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: recoveredSync),
             ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .loginRequired, lastSync: needsLoginSync),
+            ItemStatus(id: "demo_wells_fargo", institutionName: "Wells Fargo", status: .providerOutage, lastSync: outageSync),
         ]
     }
 

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -120,6 +120,62 @@ public enum DemoFixtures {
         }
     }
 
+    /// Deterministic multi-day per-account ledger for the Balance Time Machine
+    /// (AND-490), built from the existing `accountBalanceHistory` drift/wobble
+    /// generator so demo and tests share one source of truth. Covers the last
+    /// `dayCount` days for every demo account.
+    public static func accountBalanceLedger(
+        dayCount: Int = 14,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> AccountBalanceLedger {
+        var entries: [AccountBalanceLedger.LedgerEntry] = []
+        for account in accounts {
+            let history = accountBalanceHistory(forAccountId: account.id, now: now, calendar: calendar)
+            // Take the most recent `dayCount` days from the generated history.
+            for snapshot in history.suffix(dayCount) {
+                entries.append(
+                    AccountBalanceLedger.LedgerEntry(
+                        accountId: account.id,
+                        date: snapshot.date,
+                        current: snapshot.balance,
+                        available: account.balances.available,
+                        limit: account.balances.limit,
+                        recordedAt: snapshot.date
+                    )
+                )
+            }
+        }
+        return AccountBalanceLedger(entries: entries)
+    }
+
+    /// A "post-sync" variant of `accountBalanceLedger` that rewrites one prior-day
+    /// `current` balance for the first account, so `SyncHistoryDiff` renders a
+    /// non-empty "history changed" row in --demo (AND-490).
+    public static func postSyncAccountBalanceLedger(
+        dayCount: Int = 14,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> AccountBalanceLedger {
+        let base = accountBalanceLedger(dayCount: dayCount, now: now, calendar: calendar)
+        guard let firstAccountId = accounts.first?.id else { return base }
+        // Rewrite the entry from ~3 days ago for the first account.
+        let targetDay = calendar.date(byAdding: .day, value: -3, to: now) ?? now
+        let rewritten = base.entries.map { entry -> AccountBalanceLedger.LedgerEntry in
+            guard entry.accountId == firstAccountId,
+                  calendar.isDate(entry.date, inSameDayAs: targetDay) else { return entry }
+            return AccountBalanceLedger.LedgerEntry(
+                accountId: entry.accountId,
+                date: entry.date,
+                current: (entry.current ?? 0) + 125.50,
+                available: entry.available,
+                limit: entry.limit,
+                recordedAt: now
+            )
+        }
+        return AccountBalanceLedger(entries: rewritten)
+    }
+
     // MARK: - Explicit recent window
 
     private static func explicitTransactions(now: Date, calendar: Calendar) -> [TransactionDTO] {

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -81,6 +81,19 @@ public enum DemoFixtures {
         }
     }
 
+    /// Partial-sync demo statuses (AND-489): one connected item plus one
+    /// degraded (`loginRequired`) item, so `syncedItemCount < itemCount` and the
+    /// data-integrity badge renders `.partial`. Used by the demo status-recovery
+    /// scenario so the badge is visible without Plaid.
+    public static func partialSyncItemStatuses(now: Date = Date(), calendar: Calendar = .current) -> [ItemStatus] {
+        let recoveredSync = calendar.date(byAdding: .minute, value: -18, to: now) ?? now
+        let needsLoginSync = calendar.date(byAdding: .day, value: -3, to: now) ?? now
+        return [
+            ItemStatus(id: "demo_chase", institutionName: "Chase", status: .connected, lastSync: recoveredSync),
+            ItemStatus(id: "demo_amex_item", institutionName: "American Express", status: .loginRequired, lastSync: needsLoginSync),
+        ]
+    }
+
     public static func accountBalanceHistory(
         forAccountId accountId: String,
         now: Date = Date(),

--- a/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
+++ b/Sources/PlaidBarCore/Utilities/ItemRecoveryTarget.swift
@@ -52,7 +52,10 @@ public enum ItemRecoveryTarget {
                 return "Plaid reported an item error for \(institutionName). Reconnect it, then refresh balances."
             }
             return "Plaid reported an item error. Reconnect the item, then refresh balances."
-        case .connected, .loginRepaired:
+        case .connected, .loginRepaired, .providerOutage:
+            // .providerOutage is a non-actionable transient outage and is never
+            // selected as a recovery target by item(from:), so it carries no
+            // reconnect detail here.
             return nil
         }
     }
@@ -61,7 +64,7 @@ public enum ItemRecoveryTarget {
         switch status {
         case .newAccountsAvailable:
             "Update"
-        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .error:
+        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .providerOutage, .error:
             "Reconnect"
         }
     }
@@ -70,7 +73,7 @@ public enum ItemRecoveryTarget {
         switch status {
         case .newAccountsAvailable:
             "Update Item"
-        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .error:
+        case .connected, .loginRepaired, .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .providerOutage, .error:
             "Reconnect Item"
         }
     }

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -93,6 +93,14 @@ public enum LocalDataStore {
     private static let directoryPermissions = 0o700
     private static let cacheFilePermissions = 0o600
 
+    /// Filename of the per-environment SQLite store the server writes
+    /// (`plaidbar-<env>.sqlite`). Exposed so the app can render the documented
+    /// backup path without importing the server module. Mirrors
+    /// `ServerConfig.databaseFilename(for:)`.
+    public static func sqliteFilename(for environment: PlaidEnvironment) -> String {
+        "plaidbar-\(environment.rawValue).sqlite"
+    }
+
     public static func accountHomeDirectoryURL() -> URL {
         #if os(macOS)
         if let user = getpwuid(getuid()),

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -49,6 +49,7 @@ public struct NotificationTriggers: Sendable {
 
 public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
     case itemError = "item-error"
+    case providerOutage = "provider-outage"
     case loginRequired = "login-required"
     case syncStale = "sync-stale"
     case highUtilization = "high-utilization"
@@ -60,7 +61,7 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
 
     public var clearsWhenResolved: Bool {
         switch self {
-        case .itemError, .loginRequired, .syncStale, .highUtilization, .lowBalance,
+        case .itemError, .providerOutage, .loginRequired, .syncStale, .highUtilization, .lowBalance,
              .recurringChargeChanged, .recurringChargeDueSoon:
             true
         case .largeTransaction, .recurringChargeDetected:
@@ -138,6 +139,12 @@ public enum NotificationTriggerSelection {
         if config.itemError {
             for item in itemStatuses where item.status == .error {
                 append(itemErrorDecision(for: item))
+            }
+            // Provider outages are connection-health signals but emit a distinct,
+            // non-actionable advisory kind (not itemError) — VaultPeek retries
+            // automatically, so no reconnect is prompted.
+            for item in itemStatuses where item.status == .providerOutage {
+                append(providerOutageDecision(for: item))
             }
         }
 
@@ -294,6 +301,16 @@ public enum NotificationTriggerSelection {
             title: "Institution needs attention",
             body: "A linked institution reported a sync error. Reconnect, then refresh.",
             severity: .blocking
+        )
+    }
+
+    private static func providerOutageDecision(for item: ItemStatus) -> NotificationTriggerDecision {
+        NotificationTriggerDecision(
+            kind: .providerOutage,
+            dedupKey: dedupKey(kind: .providerOutage, sourceID: item.id),
+            title: "Bank temporarily unavailable",
+            body: "A linked institution or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed.",
+            severity: .informational
         )
     }
 

--- a/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
+++ b/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
@@ -44,6 +44,11 @@ enum ItemStatusMapping {
             return .permissionRevoked
         case "NEW_ACCOUNTS_AVAILABLE":
             return .newAccountsAvailable
+        // Transient Plaid-side outages: degraded but NOT a user-actionable
+        // reconnect (mirrors LinkRoutes.retryableProviderCodes). VaultPeek shows
+        // a "we'll retry automatically" advisory instead of an Update flow.
+        case "INSTITUTION_DOWN", "INSTITUTION_NOT_RESPONDING", "PLANNED_MAINTENANCE", "INTERNAL_SERVER_ERROR":
+            return .providerOutage
         default:
             return nil
         }

--- a/Tests/PlaidBarCoreTests/AccountBalanceLedgerTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountBalanceLedgerTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Account Balance Ledger Tests")
+struct AccountBalanceLedgerTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func account(_ id: String, current: Double, available: Double? = nil, limit: Double? = nil) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item-\(id)",
+            name: id.capitalized,
+            type: .depository,
+            balances: BalanceDTO(available: available, current: current, limit: limit, isoCurrencyCode: "USD")
+        )
+    }
+
+    @Test("Appending the same account twice on the same day replaces (no duplicate per account/day)")
+    func sameDayReplaces() {
+        let first = AccountBalanceLedger().appending(
+            accounts: [account("a", current: 100)], now: now, calendar: calendar
+        )
+        let second = first.appending(
+            accounts: [account("a", current: 150)], now: now, calendar: calendar
+        )
+        let aEntries = second.entries.filter { $0.accountId == "a" }
+        #expect(aEntries.count == 1)
+        #expect(aEntries.first?.current == 150)
+    }
+
+    @Test("Entries older than the retention window are pruned")
+    func retentionPrune() {
+        let oldDate = calendar.date(byAdding: .day, value: -120, to: now)!
+        let seeded = AccountBalanceLedger(entries: [
+            AccountBalanceLedger.LedgerEntry(accountId: "a", date: oldDate, current: 50, available: nil, limit: nil, recordedAt: oldDate),
+        ])
+        let updated = seeded.appending(
+            accounts: [account("a", current: 100)], now: now, retentionDays: 90, calendar: calendar
+        )
+        #expect(updated.entries.allSatisfy { $0.date >= calendar.date(byAdding: .day, value: -90, to: now)! })
+        #expect(updated.entries.contains { $0.current == 100 })
+        #expect(!updated.entries.contains { $0.current == 50 })
+    }
+
+    @Test("Output is stably sorted by (date, accountId)")
+    func stableSort() {
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
+        let ledger = AccountBalanceLedger()
+            .appending(accounts: [account("b", current: 1), account("a", current: 2)], now: yesterday, calendar: calendar)
+            .appending(accounts: [account("b", current: 3), account("a", current: 4)], now: now, calendar: calendar)
+        // Same-day entries sorted by accountId; earlier date first.
+        let keys = ledger.entries.map { "\(AccountBalanceLedger.dayKey($0.date))|\($0.accountId)" }
+        #expect(keys == keys.sorted())
+    }
+
+    @Test("Multi-account days keep one row per account")
+    func multiAccountOneRowEach() {
+        let ledger = AccountBalanceLedger().appending(
+            accounts: [account("a", current: 1), account("b", current: 2), account("c", current: 3)],
+            now: now, calendar: calendar
+        )
+        #expect(ledger.entries.count == 3)
+        #expect(Set(ledger.entries.map(\.accountId)) == ["a", "b", "c"])
+    }
+
+    @Test("latestEntriesByAccount returns the most recent entry per account")
+    func latestPerAccount() {
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: now)!
+        let ledger = AccountBalanceLedger()
+            .appending(accounts: [account("a", current: 10)], now: yesterday, calendar: calendar)
+            .appending(accounts: [account("a", current: 20)], now: now, calendar: calendar)
+        let latest = ledger.latestEntriesByAccount()
+        #expect(latest.count == 1)
+        #expect(latest.first?.current == 20)
+    }
+}

--- a/Tests/PlaidBarCoreTests/ConnectionHealthStripTests.swift
+++ b/Tests/PlaidBarCoreTests/ConnectionHealthStripTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Connection Health Strip Tests")
+struct ConnectionHealthStripTests {
+    private func status(_ id: String, _ state: ItemConnectionStatus) -> ItemStatus {
+        ItemStatus(id: id, institutionName: id, status: state)
+    }
+
+    @Test("evaluate buckets a mixed list into Connected / Reconnect-needed / Provider-outage with correct counts")
+    func bucketsMixedList() {
+        let result = ConnectionHealthStrip.evaluate([
+            status("a", .connected),
+            status("b", .connected),
+            status("c", .loginRequired),
+            status("d", .error),
+            status("e", .providerOutage),
+        ])
+        let byState = Dictionary(uniqueKeysWithValues: result.buckets.map { ($0.state, $0) })
+        #expect(byState[.connected]?.count == 2)
+        #expect(byState[.reconnectNeeded]?.count == 2) // loginRequired + error
+        #expect(byState[.providerOutage]?.count == 1)
+    }
+
+    @Test("A provider-outage bucket is non-actionable with a distinct symbol and non-empty label")
+    func outageBucketNonActionable() {
+        let result = ConnectionHealthStrip.evaluate([status("a", .providerOutage)])
+        let outage = result.buckets.first { $0.state == .providerOutage }
+        #expect(outage?.isActionable == false)
+        #expect(outage?.iconName.isEmpty == false)
+        #expect(outage?.label.isEmpty == false)
+        // Distinct from the reconnect-needed symbol.
+        let reconnect = ConnectionHealthStrip.evaluate([status("b", .error)]).buckets.first
+        #expect(outage?.iconName != reconnect?.iconName)
+    }
+
+    @Test("Reconnect-needed bucket is actionable, provider-outage is not")
+    func actionableFlags() {
+        let result = ConnectionHealthStrip.evaluate([
+            status("a", .error),
+            status("b", .providerOutage),
+        ])
+        #expect(result.hasActionableWork == true)
+        #expect(result.hasProviderOutage == true)
+    }
+
+    @Test("providerOutage semantics: degraded but not update-mode")
+    func providerOutageSemantics() {
+        #expect(ItemConnectionStatus.providerOutage.isDegraded == true)
+        #expect(ItemConnectionStatus.providerOutage.needsUpdateMode == false)
+        #expect(ItemConnectionStatus.providerOutage.isProviderOutage == true)
+    }
+
+    @Test("ItemRecoveryTarget never selects an outage-only item as a reconnect target")
+    func recoveryTargetIgnoresOutage() {
+        let outageOnly = ConnectionHealthStrip.evaluate([status("a", .providerOutage)])
+        #expect(outageOnly.hasActionableWork == false)
+        // Direct recovery-target check: an outage-only list yields no target.
+        let target = ItemRecoveryTarget.item(from: [
+            status("a", .connected),
+            status("b", .providerOutage),
+        ])
+        #expect(target == nil)
+        // But a list with a real error still selects the error item.
+        let withError = ItemRecoveryTarget.item(from: [
+            status("a", .providerOutage),
+            status("b", .error),
+        ])
+        #expect(withError?.id == "b")
+    }
+
+    @Test("AttentionQueue produces a .warning advisory (no reconnect) for an outage item")
+    func attentionQueueOutageAdvisory() {
+        let rows = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 0,
+            itemStatuses: [status("a", .providerOutage)],
+            isSyncStale: false,
+            lastSyncRelative: "just now",
+            errorMessage: nil
+        ).rows
+        let outageRow = rows.first { $0.id.hasPrefix("item-outage") }
+        #expect(outageRow != nil)
+        #expect(outageRow?.severity == .warning)
+        #expect(outageRow?.action == nil) // no reconnect action
+    }
+
+    @Test("NotificationTriggerSelection emits a distinct providerOutage kind (not itemError) for outage")
+    func notificationDistinctKind() {
+        let evaluation = NotificationTriggerSelection.evaluate(
+            itemStatuses: [status("a", .providerOutage)],
+            isSyncStale: false,
+            config: NotificationTriggers()
+        )
+        let kinds = Set(evaluation.decisions.map(\.kind))
+        #expect(kinds.contains(.providerOutage))
+        #expect(!kinds.contains(.itemError))
+    }
+
+    @Test("ItemStatus round-trips .providerOutage through Codable")
+    func codableRoundTrip() throws {
+        let original = ItemStatus(id: "a", institutionName: "Wells Fargo", status: .providerOutage, needsSync: true)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ItemStatus.self, from: data)
+        #expect(decoded.status == .providerOutage)
+        #expect(decoded.id == "a")
+        #expect(decoded.status.rawValue == "provider_outage")
+    }
+}

--- a/Tests/PlaidBarCoreTests/DataExportBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/DataExportBuilderTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Data Export Builder Tests")
+struct DataExportBuilderTests {
+    private func sampleAccount(
+        id: String = "acc1",
+        officialName: String? = "Chase Total Checking",
+        mask: String? = "0000",
+        limit: Double? = 500
+    ) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: "item1",
+            name: "Checking",
+            officialName: officialName,
+            type: .depository,
+            subtype: "checking",
+            mask: mask,
+            balances: BalanceDTO(available: 100.5, current: 120.25, limit: limit, isoCurrencyCode: "USD"),
+            institutionName: "Chase"
+        )
+    }
+
+    private func sampleTransaction(
+        id: String = "tx1",
+        name: String = "WHOLEFDS",
+        merchantName: String? = "Whole Foods"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acc1",
+            amount: 12.34,
+            date: "2026-06-15",
+            name: name,
+            merchantName: merchantName,
+            category: .foodAndDrink,
+            pending: false,
+            isoCurrencyCode: "USD"
+        )
+    }
+
+    @Test("transactionsCSV produces a header plus one row per transaction in declared field order")
+    func transactionsCSVHeaderAndRows() {
+        let csv = DataExportBuilder.transactionsCSV([
+            sampleTransaction(id: "tx1"),
+            sampleTransaction(id: "tx2"),
+        ])
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        #expect(lines.count == 3) // header + 2 rows
+        #expect(lines[0] == "transaction_id,account_id,date,name,merchant_name,amount,currency,category,pending")
+        #expect(lines[1].hasPrefix("tx1,acc1,2026-06-15,WHOLEFDS,Whole Foods,12.34,USD,FOOD_AND_DRINK,false"))
+    }
+
+    @Test("csvField quotes and escapes commas, quotes, and newlines; leaves plain values unquoted")
+    func csvFieldEscaping() {
+        #expect(DataExportBuilder.csvField("plain") == "plain")
+        #expect(DataExportBuilder.csvField("a,b") == "\"a,b\"")
+        #expect(DataExportBuilder.csvField("say \"hi\"") == "\"say \"\"hi\"\"\"")
+        #expect(DataExportBuilder.csvField("line1\nline2") == "\"line1\nline2\"")
+    }
+
+    @Test("accountsCSV renders nil officialName/mask/limit as empty fields and formats balances with fixed decimals")
+    func accountsCSVNilFields() {
+        let csv = DataExportBuilder.accountsCSV([
+            sampleAccount(officialName: nil, mask: nil, limit: nil),
+        ])
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        #expect(lines.count == 2)
+        let fields = lines[1].components(separatedBy: ",")
+        // account_id,item_id,name,official_name,type,subtype,mask,institution_name,available,current,limit,currency
+        #expect(fields[3] == "") // official_name nil -> empty, not "nil"
+        #expect(fields[6] == "") // mask nil -> empty
+        #expect(fields[8] == "100.50") // available, fixed 2 decimals
+        #expect(fields[9] == "120.25") // current
+        #expect(fields[10] == "") // limit nil -> empty
+        #expect(!lines[1].contains("nil"))
+    }
+
+    @Test("balanceHistoryCSV emits canonical YYYY-MM-DD dates")
+    func balanceHistoryCSVCanonicalDates() {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 6
+        components.day = 9
+        let date = Calendar(identifier: .gregorian).date(from: components)!
+        let csv = DataExportBuilder.balanceHistoryCSV([BalanceSnapshot(date: date, balance: 1234.5)])
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        #expect(lines[0] == "date,balance")
+        #expect(lines[1] == "2026-06-09,1234.50")
+        #expect(lines[1].hasPrefix(Formatters.transactionDateString(date)))
+    }
+
+    @Test("combinedJSON round-trips and carries schemaVersion + counts")
+    func combinedJSONRoundTrips() throws {
+        let accounts = [sampleAccount()]
+        let transactions = [sampleTransaction()]
+        let history = [BalanceSnapshot(date: Date(timeIntervalSince1970: 1_700_000_000), balance: 500)]
+        let data = try DataExportBuilder.combinedJSON(
+            accounts: accounts,
+            transactions: transactions,
+            balanceHistory: history,
+            exportedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            environment: "sandbox"
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
+        #expect(envelope.schemaVersion == DataExportBuilder.schemaVersion)
+        #expect(envelope.counts.accounts == 1)
+        #expect(envelope.counts.transactions == 1)
+        #expect(envelope.counts.balanceHistory == 1)
+        #expect(envelope.environment == "sandbox")
+        #expect(envelope.accounts == accounts)
+        #expect(envelope.transactions == transactions)
+        #expect(envelope.balanceHistory == history)
+    }
+
+    @Test("Empty input yields header-only CSV and a zero-count envelope without crashing")
+    func emptyInput() throws {
+        let accountsCSV = DataExportBuilder.accountsCSV([])
+        let transactionsCSV = DataExportBuilder.transactionsCSV([])
+        let historyCSV = DataExportBuilder.balanceHistoryCSV([])
+        #expect(accountsCSV.split(separator: "\n", omittingEmptySubsequences: true).count == 1)
+        #expect(transactionsCSV.split(separator: "\n", omittingEmptySubsequences: true).count == 1)
+        #expect(historyCSV.split(separator: "\n", omittingEmptySubsequences: true).count == 1)
+
+        let data = try DataExportBuilder.combinedJSON(
+            accounts: [],
+            transactions: [],
+            balanceHistory: [],
+            exportedAt: Date()
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
+        #expect(envelope.counts.accounts == 0)
+        #expect(envelope.counts.transactions == 0)
+        #expect(envelope.counts.balanceHistory == 0)
+    }
+
+    @Test("sqliteFilename composes the documented per-environment backup path")
+    func sqliteFilename() {
+        #expect(LocalDataStore.sqliteFilename(for: .sandbox) == "plaidbar-sandbox.sqlite")
+        #expect(LocalDataStore.sqliteFilename(for: .production) == "plaidbar-production.sqlite")
+        let path = LocalDataStore.displayPath + LocalDataStore.sqliteFilename(for: .sandbox)
+        #expect(path == "~/.vaultpeek/plaidbar-sandbox.sqlite")
+    }
+}

--- a/Tests/PlaidBarCoreTests/DataIntegrityBadgeTests.swift
+++ b/Tests/PlaidBarCoreTests/DataIntegrityBadgeTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Data Integrity Badge Tests")
+struct DataIntegrityBadgeTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("Fresh and all items synced -> nil")
+    func freshAllSyncedIsNil() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: false,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 2,
+            degradedItemCount: 0,
+            needsSyncItemCount: 0,
+            lastSync: now,
+            lastSyncRelative: "2 minutes ago",
+            now: now
+        )
+        #expect(result == nil)
+    }
+
+    @Test("Boot load in flight -> nil even if counts look partial")
+    func bootLoadIsNil() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: true,
+            isBootLoadInFlight: true,
+            itemCount: 2,
+            syncedItemCount: 1,
+            degradedItemCount: 1,
+            needsSyncItemCount: 1,
+            lastSync: nil,
+            lastSyncRelative: nil,
+            now: now
+        )
+        #expect(result == nil)
+    }
+
+    @Test("Sync stale -> .stale with relative token and non-empty icon")
+    func staleVerdict() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: true,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 2,
+            degradedItemCount: 0,
+            needsSyncItemCount: 0,
+            lastSync: now,
+            lastSyncRelative: "3 days ago",
+            now: now
+        )
+        #expect(result?.severity == .stale)
+        #expect(result?.title.contains("3 days ago") == true)
+        #expect(result?.iconName.isEmpty == false)
+    }
+
+    @Test("syncedItemCount < itemCount, not stale -> .partial 'may be incomplete'")
+    func partialFromUnsyncedItems() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: false,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 1,
+            degradedItemCount: 0,
+            needsSyncItemCount: 0,
+            lastSync: now,
+            lastSyncRelative: "5 minutes ago",
+            now: now
+        )
+        #expect(result?.severity == .partial)
+        #expect(result?.title.contains("may be incomplete since") == true)
+    }
+
+    @Test("degradedItemCount > 0 while counts equal -> .partial")
+    func partialFromDegradedItems() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: false,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 2,
+            degradedItemCount: 1,
+            needsSyncItemCount: 0,
+            lastSync: now,
+            lastSyncRelative: "5 minutes ago",
+            now: now
+        )
+        #expect(result?.severity == .partial)
+    }
+
+    @Test("needsSyncItemCount > 0 -> .partial")
+    func partialFromNeedsSync() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: false,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 2,
+            degradedItemCount: 0,
+            needsSyncItemCount: 1,
+            lastSync: now,
+            lastSyncRelative: "5 minutes ago",
+            now: now
+        )
+        #expect(result?.severity == .partial)
+    }
+
+    @Test("lastSync nil and not boot -> .stale Never")
+    func neverSyncedIsStale() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: true,
+            isBootLoadInFlight: false,
+            itemCount: 1,
+            syncedItemCount: 0,
+            degradedItemCount: 0,
+            needsSyncItemCount: 0,
+            lastSync: nil,
+            lastSyncRelative: nil,
+            now: now
+        )
+        #expect(result?.severity == .stale)
+        #expect(result?.title.contains("Never") == true)
+    }
+
+    @Test("Stale takes precedence over partial when both true")
+    func stalePrecedence() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: true,
+            isBootLoadInFlight: false,
+            itemCount: 2,
+            syncedItemCount: 1,
+            degradedItemCount: 1,
+            needsSyncItemCount: 1,
+            lastSync: now,
+            lastSyncRelative: "4 days ago",
+            now: now
+        )
+        #expect(result?.severity == .stale)
+    }
+
+    @Test("accessibilityLabel carries the date/relative token, not color")
+    func accessibilityLabelCarriesToken() {
+        let result = DataIntegrityBadge.evaluate(
+            isSyncStale: true,
+            isBootLoadInFlight: false,
+            itemCount: 1,
+            syncedItemCount: 1,
+            degradedItemCount: 0,
+            needsSyncItemCount: 0,
+            lastSync: now,
+            lastSyncRelative: "3 days ago",
+            now: now
+        )
+        #expect(result?.accessibilityLabel.isEmpty == false)
+        #expect(result?.accessibilityLabel.contains("3 days ago") == true)
+    }
+
+    @Test("Result is Equatable for clean @Observable reads")
+    func resultIsEquatable() {
+        let a = DataIntegrityBadge.Result(
+            severity: .partial, title: "t", detail: "d", iconName: "i", accessibilityLabel: "a"
+        )
+        let b = DataIntegrityBadge.Result(
+            severity: .partial, title: "t", detail: "d", iconName: "i", accessibilityLabel: "a"
+        )
+        #expect(a == b)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SyncHistoryDiffTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncHistoryDiffTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Sync History Diff Tests")
+struct SyncHistoryDiffTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func entry(_ accountId: String, daysAgo: Int, current: Double) -> AccountBalanceLedger.LedgerEntry {
+        let date = calendar.date(byAdding: .day, value: -daysAgo, to: now)!
+        return AccountBalanceLedger.LedgerEntry(
+            accountId: accountId, date: date, current: current, available: nil, limit: nil, recordedAt: date
+        )
+    }
+
+    private let names: [String: String] = ["a": "Chase Checking", "b": "Amex Platinum"]
+    private func displayName(_ id: String) -> String? { names[id] }
+
+    @Test("Identical previous/next ledgers yield no diff rows")
+    func identicalYieldsNoRows() {
+        let ledger = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 1, current: 100),
+            entry("a", daysAgo: 0, current: 110),
+        ])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: ledger, nextLedger: ledger, displayName: displayName)
+        #expect(rows.isEmpty)
+    }
+
+    @Test("A rewrite of a prior-day current balance yields one row with correct signed delta and accessibility text")
+    func rewriteYieldsRow() {
+        let previous = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 2, current: 100),
+            entry("a", daysAgo: 1, current: 105),
+        ])
+        let next = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 2, current: 130), // restated +30
+            entry("a", daysAgo: 1, current: 105),
+        ])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: previous, nextLedger: next, displayName: displayName)
+        #expect(rows.count == 1)
+        #expect(rows.first?.changedDayCount == 1)
+        #expect(rows.first?.netDelta == 30)
+        #expect(rows.first?.summary.contains("+") == true)
+        #expect(rows.first?.accessibilityText.isEmpty == false)
+    }
+
+    @Test("A purely-additive newer day (no prior-day rewrite) yields no history-changed rows")
+    func additiveDayYieldsNoRows() {
+        let previous = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 1, current: 100),
+        ])
+        let next = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 1, current: 100), // unchanged
+            entry("a", daysAgo: 0, current: 120), // brand-new day, additive
+        ])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: previous, nextLedger: next, displayName: displayName)
+        #expect(rows.isEmpty)
+    }
+
+    @Test("User-facing strings carry the account display name and never the accountId")
+    func stringsUseDisplayNameNotId() {
+        let previous = AccountBalanceLedger(entries: [entry("a", daysAgo: 2, current: 100)])
+        let next = AccountBalanceLedger(entries: [entry("a", daysAgo: 2, current: 80)])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: previous, nextLedger: next, displayName: displayName)
+        #expect(rows.first?.summary.contains("Chase Checking") == true)
+        #expect(rows.first?.summary.contains("\"a\"") == false)
+        #expect(rows.first?.accessibilityText.contains("Chase Checking") == true)
+        // accountId never appears in user text.
+        #expect(rows.first?.summary.contains("a|") == false)
+        #expect(rows.first?.accessibilityText.lowercased().contains("accountid") == false)
+    }
+
+    @Test("Multiple rewritten days for one account accumulate into a single row")
+    func multipleDaysAccumulate() {
+        let previous = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 3, current: 100),
+            entry("a", daysAgo: 2, current: 100),
+        ])
+        let next = AccountBalanceLedger(entries: [
+            entry("a", daysAgo: 3, current: 110), // +10
+            entry("a", daysAgo: 2, current: 95),  // -5
+        ])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: previous, nextLedger: next, displayName: displayName)
+        #expect(rows.count == 1)
+        #expect(rows.first?.changedDayCount == 2)
+        #expect(rows.first?.netDelta == 5) // +10 - 5
+    }
+}

--- a/Tests/PlaidBarCoreTests/WhereYourDataLivesReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/WhereYourDataLivesReceiptTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Where Your Data Lives Receipt Tests")
+struct WhereYourDataLivesReceiptTests {
+    @Test("Receipt names the 127.0.0.1 loopback boundary as a dedicated row")
+    func receiptIncludesLoopbackRow() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        let loopback = receipt.rows.first { $0.id == "loopback" }
+        #expect(loopback != nil)
+        #expect(loopback?.detail.contains("127.0.0.1") == true)
+    }
+
+    @Test("Receipt names both SQLite and Keychain")
+    func receiptNamesSQLiteAndKeychain() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        let joined = receipt.rows.map(\.detail).joined(separator: " ")
+        #expect(joined.contains("SQLite"))
+        #expect(joined.contains("Keychain"))
+    }
+
+    @Test("Loopback row asserts no telemetry, analytics, or cloud sync")
+    func loopbackRowAssertsNoTelemetry() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        let loopbackDetail = receipt.rows.first { $0.id == "loopback" }?.detail ?? ""
+        #expect(loopbackDetail.contains("telemetry"))
+        #expect(loopbackDetail.contains("analytics"))
+        #expect(loopbackDetail.contains("cloud sync"))
+    }
+
+    @Test("Blank storage path falls back to LocalDataStore.displayPath")
+    func blankStoragePathFallsBack() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "   ")
+        let sqliteRow = receipt.rows.first { $0.id == "sqlite" }
+        #expect(sqliteRow?.detail.contains(LocalDataStore.displayPath) == true)
+    }
+
+    @Test("Storage path renders in the SQLite row")
+    func storagePathRendersInSQLiteRow() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        let sqliteRow = receipt.rows.first { $0.id == "sqlite" }
+        #expect(sqliteRow?.detail.contains("~/.vaultpeek/") == true)
+    }
+
+    @Test("Plaid deletion deep link is non-nil and matches the constant")
+    func plaidDeletionDeepLinkPresent() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        #expect(receipt.deepLink != nil)
+        #expect(receipt.deepLink?.urlString == PlaidBarConstants.plaidDataDeletionURL)
+    }
+
+    @Test("Rows preserve a stable id order for snapshot stability")
+    func rowsPreserveStableOrder() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        #expect(receipt.rows.map(\.id) == ["sqlite", "keychain", "loopback", "plaid-scope"])
+    }
+
+    @Test("Every row pairs an SF Symbol with text (never color-alone)")
+    func everyRowPairsSymbolWithText() {
+        let receipt = LocalTrustReceipt.whereYourDataLives(storagePath: "~/.vaultpeek/")
+        for row in receipt.rows {
+            #expect(!row.systemImage.isEmpty)
+            #expect(!row.title.isEmpty)
+            #expect(!row.detail.isEmpty)
+        }
+    }
+
+    @Test("Plaid privacy and deletion URLs are well-formed https URLs")
+    func plaidURLsAreWellFormed() {
+        for raw in [PlaidBarConstants.plaidPrivacyURL, PlaidBarConstants.plaidDataDeletionURL] {
+            let url = URL(string: raw)
+            #expect(url != nil)
+            #expect(url?.scheme == "https")
+        }
+    }
+}

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1668,6 +1668,18 @@ struct PlaidBarServerTests {
         #expect(ItemStatusMapping.status(forWebhookCode: "LOGIN_REPAIRED", currentStatus: .error) == .error)
     }
 
+    @Test("Provider-outage codes map to .providerOutage, login-required stays actionable")
+    func itemStatusMappingRoutesProviderOutageCodes() {
+        // Transient Plaid-side outages map to the non-actionable .providerOutage
+        // state (AND-488), not to .error / .loginRequired.
+        #expect(ItemStatusMapping.status(forWebhookCode: "INSTITUTION_DOWN", currentStatus: .connected) == .providerOutage)
+        #expect(ItemStatusMapping.status(forWebhookCode: "INSTITUTION_NOT_RESPONDING", currentStatus: .connected) == .providerOutage)
+        #expect(ItemStatusMapping.status(forWebhookCode: "PLANNED_MAINTENANCE", currentStatus: .connected) == .providerOutage)
+        #expect(ItemStatusMapping.status(forWebhookCode: "INTERNAL_SERVER_ERROR", currentStatus: .connected) == .providerOutage)
+        // ITEM_LOGIN_REQUIRED still maps to the actionable reconnect state.
+        #expect(ItemStatusMapping.status(forWebhookCode: "ITEM_LOGIN_REQUIRED", currentStatus: .connected) == .loginRequired)
+    }
+
     @Test("Webhook ERROR and repaired-with-new-accounts codes map correctly and preserve hard errors")
     func webhookItemStatusMappingHandlesErrorAndRepairedWithNewAccounts() {
         // A bare ITEM `ERROR` keeps the item degraded (login needed) rather than


### PR DESCRIPTION
Trust & Data Integrity cluster — all 5 done (5 commits, gate-green).

- **AND-491** Where Your Data Lives — trust/transparency panel (Settings + onboarding + popover footer).
- **AND-492** Portable Export & Backup — CSV/JSON (`DataExportBuilder`) + documented local SQLite path.
- **AND-489** Stale-Data Integrity Badges — `DataIntegrityBadge` decider; text+icon, not color-alone.
- **AND-488** Connection Health Strip — per-item status incl. provider-outage vs reconnect.
- **AND-490** Balance Time Machine — `AccountBalanceLedger` local snapshot ledger + sync diff.

Closes AND-491, AND-492, AND-489, AND-488, AND-490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)