### PR TITLE
feat: Forward-Looking Cash Flow cluster (AND-497/498/499/500/501)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -37,6 +37,8 @@ final class AppState {
         static let notifyRecurringChargeChanged = "notifyRecurringChargeChanged"
         static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
         static let notifyBrokenConnection = "notifyBrokenConnection"
+        static let notifyWatchlist = "notifyWatchlist"
+        static let watchlistTargets = "watchlistTargets"
         static let privacyMaskEnabled = "privacyMaskEnabled"
         static let appLockEnabled = UserDefaultsAppLockSettingsStore.defaultStorageKey
         static let appLockNotificationPrivacyMode = "appLock.notificationPrivacyMode"
@@ -293,6 +295,42 @@ final class AppState {
             UserDefaults.standard.set(notifyBrokenConnection, forKey: Keys.notifyBrokenConnection)
         }
     }
+    /// Master gate for watchlist spend nudges (AND-501).
+    var notifyWatchlist: Bool = true {
+        didSet {
+            guard notifyWatchlist != oldValue else { return }
+            UserDefaults.standard.set(notifyWatchlist, forKey: Keys.notifyWatchlist)
+        }
+    }
+    /// User-defined per-merchant / per-category spend watches (AND-501).
+    /// Persisted app-side as Codable JSON in UserDefaults — a lightweight nudge
+    /// list, deliberately not server-side envelope budgeting.
+    var watchlistTargets: [WatchlistTarget] = [] {
+        didSet {
+            guard watchlistTargets != oldValue else { return }
+            persistWatchlistTargets()
+        }
+    }
+
+    func addWatchlistTarget(_ target: WatchlistTarget) {
+        watchlistTargets.append(target)
+    }
+
+    func removeWatchlistTarget(id: WatchlistTarget.ID) {
+        watchlistTargets.removeAll { $0.id == id }
+    }
+
+    private func persistWatchlistTargets() {
+        guard let data = try? JSONEncoder().encode(watchlistTargets) else { return }
+        UserDefaults.standard.set(data, forKey: Keys.watchlistTargets)
+    }
+
+    private func loadWatchlistTargets(defaults: UserDefaults) {
+        guard let data = defaults.data(forKey: Keys.watchlistTargets),
+              let decoded = try? JSONDecoder().decode([WatchlistTarget].self, from: data)
+        else { return }
+        watchlistTargets = decoded
+    }
 
     var appLockPreferences = AppLockPreferences() {
         didSet {
@@ -482,6 +520,10 @@ final class AppState {
         if defaults.object(forKey: Keys.notifyBrokenConnection) != nil {
             notifyBrokenConnection = defaults.bool(forKey: Keys.notifyBrokenConnection)
         }
+        if defaults.object(forKey: Keys.notifyWatchlist) != nil {
+            notifyWatchlist = defaults.bool(forKey: Keys.notifyWatchlist)
+        }
+        loadWatchlistTargets(defaults: defaults)
         loadAppLockPreferences(defaults: defaults)
         loadLocalAISettings(defaults: defaults)
         // Balance history
@@ -2081,6 +2123,7 @@ final class AppState {
             staleSync: notifyBrokenConnection,
             loginRequired: notifyBrokenConnection,
             itemError: notifyBrokenConnection,
+            watchlist: notifyWatchlist,
             largeTransactionThreshold: largeTransactionThreshold,
             lowBalanceThreshold: lowBalanceThreshold,
             creditUtilizationThreshold: creditUtilizationThreshold
@@ -2090,6 +2133,7 @@ final class AppState {
             accounts: accounts,
             recurringTransactions: recurringTransactions,
             itemStatuses: itemStatuses,
+            watchlistTargets: watchlistTargets,
             isSyncStale: isSyncStale,
             config: config
         )
@@ -3116,6 +3160,9 @@ final class AppState {
         transactionRules = []
         categoryBudgets = [:]
         balanceHistory = DemoFixtures.balanceHistory()
+        // Seed demo watchlist nudges (AND-501) so the Settings Watchlists section
+        // is populated and the evaluator fires against the demo transactions.
+        watchlistTargets = DemoFixtures.watchlistTargets()
 
         isSetupComplete = true
         serverConnected = true

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -12,6 +12,7 @@ protocol NotificationServiceProtocol {
         accounts: [AccountDTO],
         recurringTransactions: [RecurringTransaction],
         itemStatuses: [ItemStatus],
+        watchlistTargets: [WatchlistTarget],
         isSyncStale: Bool,
         config: NotificationTriggers
     ) async
@@ -121,6 +122,7 @@ final class NotificationService: NotificationServiceProtocol {
         accounts: [AccountDTO],
         recurringTransactions: [RecurringTransaction],
         itemStatuses: [ItemStatus],
+        watchlistTargets: [WatchlistTarget] = [],
         isSyncStale: Bool,
         config: NotificationTriggers
     ) async {
@@ -129,6 +131,7 @@ final class NotificationService: NotificationServiceProtocol {
             accounts: accounts,
             recurringTransactions: recurringTransactions,
             itemStatuses: itemStatuses,
+            watchlistTargets: watchlistTargets,
             isSyncStale: isSyncStale,
             config: config,
             deliveredDedupKeys: deliveredDedupKeySet

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1131,6 +1131,33 @@ private struct PendingAccountRemoval: Identifiable {
 struct NotificationSettingsView: View {
     @Environment(AppState.self) private var appState
 
+    // Draft fields for adding a new watchlist target (AND-501).
+    @State private var newWatchKind: WatchlistTarget.Kind = .merchant
+    @State private var newWatchMerchant: String = ""
+    @State private var newWatchCategory: SpendingCategory = .shopping
+    @State private var newWatchThreshold: Double = 100
+
+    private var canAddWatchTarget: Bool {
+        guard newWatchThreshold > 0 else { return false }
+        if newWatchKind == .merchant {
+            return !newWatchMerchant.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return true
+    }
+
+    private func addWatchTarget() {
+        let target: WatchlistTarget
+        switch newWatchKind {
+        case .merchant:
+            target = .merchant(newWatchMerchant, threshold: newWatchThreshold)
+        case .category:
+            target = .category(newWatchCategory, threshold: newWatchThreshold)
+        }
+        appState.addWatchlistTarget(target)
+        newWatchMerchant = ""
+        newWatchThreshold = 100
+    }
+
     private var permissionPresentation: NotificationPermissionPresentation {
         appState.notificationPermissionPresentation
     }
@@ -1248,6 +1275,8 @@ struct NotificationSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            watchlistsSection(state: state)
+
             Section("Connection alerts") {
                 Toggle("Broken connection or stale sync", isOn: $state.notifyBrokenConnection)
                     .disabled(areNotificationControlsDisabled)
@@ -1261,6 +1290,114 @@ struct NotificationSettingsView: View {
         .toggleStyle(.switch)
         .task {
             await refreshPermissionStatus()
+        }
+    }
+
+    // Watchlists: per-merchant / per-category month-to-date spend nudges (AND-501).
+    @ViewBuilder
+    private func watchlistsSection(state: AppState) -> some View {
+        Section("Watchlists") {
+            Toggle("Spend nudges", isOn: Binding(
+                get: { appState.notifyWatchlist },
+                set: { appState.notifyWatchlist = $0 }
+            ))
+            .disabled(areNotificationControlsDisabled)
+
+            ForEach(appState.watchlistTargets) { target in
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: watchIcon(for: target))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18)
+                    VStack(alignment: .leading, spacing: Spacing.xxs) {
+                        Text(target.label)
+                            .lineLimit(1)
+                        Text("\(target.kind.displayName) · over \(Formatters.currency(target.monthlyThreshold, format: .compact)) this month")
+                            .detailText()
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: Spacing.sm)
+                    Button {
+                        appState.removeWatchlistTarget(id: target.id)
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Remove watchlist nudge")
+                    .accessibilityLabel("Remove \(target.label) watchlist nudge")
+                }
+            }
+
+            if appState.watchlistTargets.isEmpty {
+                Text("Add a merchant or category and a monthly amount to get a nudge when your month-to-date spend crosses it.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Add row.
+            Picker("Watch", selection: $newWatchKind) {
+                ForEach(WatchlistTarget.Kind.allCases, id: \.self) { kind in
+                    Text(kind.displayName).tag(kind)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(areNotificationControlsDisabled)
+
+            if newWatchKind == .merchant {
+                LabeledContent("Merchant") {
+                    TextField("Merchant name", text: $newWatchMerchant)
+                        .labelsHidden()
+                        .frame(width: 160)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Merchant name to watch")
+                }
+            } else {
+                LabeledContent("Category") {
+                    Picker("Category", selection: $newWatchCategory) {
+                        ForEach(SpendingCategory.allCases, id: \.self) { category in
+                            Text(category.displayName).tag(category)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 160)
+                    .accessibilityLabel("Category to watch")
+                }
+            }
+
+            LabeledContent("Monthly threshold") {
+                HStack(spacing: Spacing.xs) {
+                    Text("$")
+                        .foregroundStyle(.secondary)
+                    TextField(
+                        "Monthly threshold",
+                        value: $newWatchThreshold,
+                        format: .number.precision(.fractionLength(0))
+                    )
+                    .labelsHidden()
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 80)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel("Monthly threshold in dollars")
+                }
+            }
+
+            Button {
+                addWatchTarget()
+            } label: {
+                Label("Add watch", systemImage: "plus.circle")
+            }
+            .buttonStyle(.borderless)
+            .disabled(areNotificationControlsDisabled || !canAddWatchTarget)
+
+            Text("You've spent $X at a merchant — or in a category — this month. Glance-only nudges, not budgets.")
+                .detailText()
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func watchIcon(for target: WatchlistTarget) -> String {
+        switch target.kind {
+        case .merchant: "bell.badge"
+        case .category: target.category?.iconName ?? "tag"
         }
     }
 

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -678,6 +678,20 @@ struct TransactionMiniRow: View {
 
             Spacer()
 
+            if transaction.pending {
+                // Pending capsule (AND-499). Color is paired with an SF Symbol +
+                // text so the state never reads via color alone (ACCESSIBILITY.md).
+                Label("Pending", systemImage: "clock")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(SemanticColors.pending)
+                    .padding(.horizontal, Spacing.xs)
+                    .padding(.vertical, Spacing.xxs)
+                    .background(
+                        Capsule().fill(SemanticColors.pending.opacity(0.14))
+                    )
+                    .accessibilityHidden(true)
+            }
+
             Text(amountText)
                 .dataText()
                 .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
@@ -696,7 +710,8 @@ struct TransactionMiniRow: View {
 
     private var accessibilityLabel: String {
         let direction = transaction.isIncome ? "income" : "outflow"
-        return "\(transaction.displayName), \(direction), \(Formatters.currency(transaction.displayAmount, format: .full)), \(Formatters.displayTransactionDate(transaction.date))"
+        let pendingNote = transaction.pending ? ", pending" : ""
+        return "\(transaction.displayName), \(direction)\(pendingNote), \(Formatters.currency(transaction.displayAmount, format: .full)), \(Formatters.displayTransactionDate(transaction.date))"
     }
 }
 

--- a/Sources/PlaidBar/Views/Charts/IncomeCategoryFlowChart.swift
+++ b/Sources/PlaidBar/Views/Charts/IncomeCategoryFlowChart.swift
@@ -1,0 +1,222 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Inspector-column wrapper for the Income → Category flow (AND-500): header +
+/// close control, the flow chart when there is data, and load/empty states —
+/// mirroring `RecurringPaymentsView`'s chrome so the right column stays uniform.
+struct IncomeCategoryFlowInspector: View {
+    let presentation: IncomeCategoryFlowPresentation
+    var loadState: DashboardLoadState?
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+                .opacity(0.4)
+
+            if presentation.isEmpty {
+                switch loadState?.phase {
+                case .loading:
+                    state("Mapping income flow", systemImage: "arrow.left.arrow.right", detail: "VaultPeek is reading synced local transactions.")
+                case .offline:
+                    state("Income flow unavailable", systemImage: "wifi.slash", detail: "VaultPeek can't reach the local server, so the flow isn't available yet. Reconnect to refresh.")
+                case .error:
+                    state("Income flow unavailable", systemImage: "exclamationmark.triangle", detail: "The last refresh didn't finish, so the flow isn't available yet. Refresh to try again.")
+                default:
+                    state(presentation.emptyTitle, systemImage: "arrow.left.arrow.right", detail: presentation.emptyDetail)
+                }
+            } else {
+                ScrollView {
+                    IncomeCategoryFlowChart(presentation: presentation)
+                        .padding(Spacing.md)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Income to category flow. \(presentation.summaryText)")
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Income flow")
+                    .font(.headline.weight(.semibold))
+                    .lineLimit(1)
+                Text(presentation.summaryText)
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+            }
+            .buttonStyle(.borderless)
+            .help("Close income flow")
+            .accessibilityLabel("Close income flow")
+            .keyboardShortcut(.escape, modifiers: [])
+        }
+        .padding(Spacing.md)
+    }
+
+    private func state(_ title: String, systemImage: String, detail: String) -> some View {
+        ContentUnavailableView {
+            Label(title, systemImage: systemImage)
+        } description: {
+            Text(detail)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+    }
+}
+
+/// Income → Category flow ("Sankey") surface (AND-500).
+///
+/// Swift Charts has no native flow mark, so this is hand-rendered: node columns
+/// as rounded rectangles and proportional ribbons as cubic Bézier bands in a
+/// `Canvas`, sized by `GeometryReader`. The geometry is computed by the pure
+/// `FlowLayout` engine in PlaidBarCore (unit-tested there). Every node carries a
+/// text label + amount and the surface a VoiceOver summary, so meaning never
+/// rides on color alone (ACCESSIBILITY.md). Flows are aggregate-proportional —
+/// honestly labeled, since per-transaction income→category data does not exist.
+struct IncomeCategoryFlowChart: View {
+    let presentation: IncomeCategoryFlowPresentation
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealFraction: CGFloat = 0
+
+    private let chartHeight: CGFloat = 180
+    private let nodeWidth: Double = 14
+    private let nodeGap: Double = 8
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(alignment: .firstTextBaseline) {
+                columnHeader("Income", amount: presentation.totalIncomeText)
+                Spacer()
+                columnHeader("Spending", amount: presentation.totalSpendText)
+            }
+
+            GeometryReader { proxy in
+                let layout = FlowLayout.compute(
+                    graph: presentation.graph,
+                    width: Double(proxy.size.width),
+                    height: Double(proxy.size.height),
+                    nodeGap: nodeGap,
+                    nodeWidth: nodeWidth
+                )
+                Canvas { context, _ in
+                    drawRibbons(layout: layout, context: &context)
+                    drawNodes(layout: layout, context: &context)
+                }
+                .mask(alignment: .leading) {
+                    Rectangle().frame(width: proxy.size.width * revealFraction)
+                }
+            }
+            .frame(height: chartHeight)
+
+            // Text legend so each ribbon/node has a readable label off-color.
+            legend
+        }
+        .onAppear {
+            guard !reduceMotion else { revealFraction = 1; return }
+            revealFraction = 0
+            withAnimation(MotionTokens.chartReveal.delay(0.1)) {
+                revealFraction = 1
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(presentation.accessibilityLabel)
+    }
+
+    private func columnHeader(_ title: String, amount: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+            Text(amount)
+                .microText()
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            ForEach(presentation.categories) { category in
+                HStack(spacing: Spacing.xs) {
+                    Circle()
+                        .fill(color(forNodeID: category.id))
+                        .frame(width: 7, height: 7)
+                    Text(category.label)
+                        .font(.caption2)
+                    Spacer(minLength: Spacing.sm)
+                    Text(category.amountText)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    // MARK: - Canvas drawing
+
+    private func drawNodes(layout: FlowLayout, context: inout GraphicsContext) {
+        for rect in layout.sourceRects {
+            fillNode(rect, color: incomeColor, context: &context)
+        }
+        for rect in layout.categoryRects {
+            fillNode(rect, color: color(forNodeID: rect.id), context: &context)
+        }
+    }
+
+    private func fillNode(_ rect: FlowRect, color: Color, context: inout GraphicsContext) {
+        let cgRect = CGRect(x: rect.x, y: rect.y, width: rect.width, height: rect.height)
+        let path = Path(roundedRect: cgRect, cornerRadius: 3)
+        context.fill(path, with: .color(color))
+    }
+
+    private func drawRibbons(layout: FlowLayout, context: inout GraphicsContext) {
+        for ribbon in layout.ribbons {
+            var path = Path()
+            let halfThickness = ribbon.thickness / 2
+            // Top edge of the band (start top → end top), then bottom edge back.
+            path.move(to: CGPoint(x: ribbon.startX, y: ribbon.startY - halfThickness))
+            path.addCurve(
+                to: CGPoint(x: ribbon.endX, y: ribbon.endY - halfThickness),
+                control1: CGPoint(x: ribbon.control1X, y: ribbon.control1Y - halfThickness),
+                control2: CGPoint(x: ribbon.control2X, y: ribbon.control2Y - halfThickness)
+            )
+            path.addLine(to: CGPoint(x: ribbon.endX, y: ribbon.endY + halfThickness))
+            path.addCurve(
+                to: CGPoint(x: ribbon.startX, y: ribbon.startY + halfThickness),
+                control1: CGPoint(x: ribbon.control2X, y: ribbon.control2Y + halfThickness),
+                control2: CGPoint(x: ribbon.control1X, y: ribbon.control1Y + halfThickness)
+            )
+            path.closeSubpath()
+            context.fill(path, with: .color(color(forNodeID: ribbon.categoryID).opacity(0.28)))
+        }
+    }
+
+    // MARK: - Colors
+
+    private var incomeColor: Color { SemanticColors.positive }
+
+    private func color(forNodeID id: String) -> Color {
+        if id.hasPrefix("income:") { return incomeColor }
+        if let category = SpendingCategory(rawValue: id) {
+            return CategoryAccentTokens.color(for: category)
+        }
+        return .secondary
+    }
+}

--- a/Sources/PlaidBar/Views/Charts/ProjectedBalanceChart.swift
+++ b/Sources/PlaidBar/Views/Charts/ProjectedBalanceChart.swift
@@ -1,0 +1,106 @@
+import Charts
+import PlaidBarCore
+import SwiftUI
+
+/// Forward cash-flow forecast (AND-498): the projected balance over the next
+/// 30–90 days drawn as a dashed line (distinct from the solid recorded trend),
+/// with a "today" rule, a projected-low marker, and a confidence cue. Uncertainty
+/// is shown through the dash + text + marker, never color alone (ACCESSIBILITY.md).
+struct ProjectedBalanceChart: View {
+    let projection: BalanceProjection
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealFraction: CGFloat = 0
+
+    private var anchorDate: Date { projection.series.first?.date ?? projection.projectedLow.date }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Chart {
+                ForEach(projection.series, id: \.date) { snapshot in
+                    LineMark(
+                        x: .value("Date", snapshot.date),
+                        y: .value("Projected balance", snapshot.balance),
+                        series: .value("Series", "projected")
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(.secondary)
+                    // Dashed = forecast, distinguishing it from the solid recorded
+                    // trend without relying on color.
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round, dash: [4, 3]))
+                }
+
+                // "Today" anchor rule.
+                RuleMark(x: .value("Today", anchorDate))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [2, 2]))
+                    .foregroundStyle(.tertiary)
+                    .annotation(position: .top, alignment: .leading) {
+                        Text("Today")
+                            .microText()
+                            .foregroundStyle(.secondary)
+                    }
+
+                // Projected-low marker + labeled annotation.
+                PointMark(
+                    x: .value("Low date", projection.projectedLow.date),
+                    y: .value("Low balance", projection.projectedLow.balance)
+                )
+                .symbol(.circle)
+                .symbolSize(40)
+                .foregroundStyle(lowTint)
+                .annotation(position: .bottom, alignment: .center) {
+                    Label(
+                        Formatters.currency(projection.projectedLow.balance, format: .compact),
+                        systemImage: "arrow.down.to.line"
+                    )
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(lowTint)
+                }
+            }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .chartLegend(.hidden)
+            .chartYScale(domain: .automatic(includesZero: false))
+            .frame(height: 88)
+            .mask(alignment: .leading) {
+                GeometryReader { proxy in
+                    Rectangle()
+                        .frame(width: proxy.size.width * revealFraction)
+                }
+            }
+            .onAppear {
+                guard !reduceMotion else {
+                    revealFraction = 1
+                    return
+                }
+                revealFraction = 0
+                withAnimation(MotionTokens.chartReveal.delay(0.1)) {
+                    revealFraction = 1
+                }
+            }
+
+            // Confidence cue: text + icon, never color alone.
+            Label(confidenceText, systemImage: projection.confidence.iconName)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(projection.accessibilitySummary)
+    }
+
+    private var lowTint: Color {
+        // The projected low dipping below the anchor is the cautionary case.
+        projection.projectedLow.balance < projection.anchorBalance
+            ? SemanticColors.warning
+            : .secondary
+    }
+
+    private var confidenceText: String {
+        switch projection.confidence {
+        case .insufficientData: "Indicative only — no recurring signal yet"
+        case .lowConfidence: "Forecast from recurring patterns"
+        case .ok: "Forecast"
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -19,6 +19,9 @@ struct MainPopover: View {
     @State private var dashboardContentHeight: CGFloat = 0
     @State private var activeScreenVisibleWidth: CGFloat?
     @State private var isRecurringInspectorOpen = false
+    /// Income → Category flow drill-in (AND-500), mirroring the recurring
+    /// inspector pattern. Mutually exclusive with account/recurring inspectors.
+    @State private var isFlowInspectorOpen = false
     /// True after the first render. Gates the inspector's trailing slide-in so a
     /// popover opened with a persisted selection appears directly in three-column
     /// geometry (no slide on restore); in-session selections still slide (AND-405).
@@ -69,7 +72,7 @@ struct MainPopover: View {
     }
 
     private var selectedAccount: AccountDTO? {
-        guard !isRecurringInspectorOpen else { return nil }
+        guard !isRecurringInspectorOpen, !isFlowInspectorOpen else { return nil }
         let accounts = filteredAccounts
         // A selection survives only while the account is still visible; a filter
         // change or a removed/synced-away account deselects it (AND-373/375).
@@ -122,11 +125,22 @@ struct MainPopover: View {
 
     private func openRecurringInspector() {
         selectedAccountId = ""
+        isFlowInspectorOpen = false
         isRecurringInspectorOpen = true
     }
 
     private func closeRecurringInspector() {
         isRecurringInspectorOpen = false
+    }
+
+    private func openFlowInspector() {
+        selectedAccountId = ""
+        isRecurringInspectorOpen = false
+        isFlowInspectorOpen = true
+    }
+
+    private func closeFlowInspector() {
+        isFlowInspectorOpen = false
     }
 
     private var filteredAccounts: [AccountDTO] {
@@ -281,6 +295,7 @@ struct MainPopover: View {
     /// view chain as an explicitly-typed value to keep the type-checker fast.
     private var exitCommandHandler: (() -> Void)? {
         guard !isRecurringInspectorOpen else { return { closeRecurringInspector() } }
+        guard !isFlowInspectorOpen else { return { closeFlowInspector() } }
         guard isAccountInspectorOpen else { return nil }
         return { deselectAccount() }
     }
@@ -315,7 +330,8 @@ struct MainPopover: View {
     private var wealthSummaryRail: some View {
         WealthSummaryFlyout(
             onAddAccount: openAccountSetup,
-            onOpenSubscriptions: openRecurringInspector
+            onOpenSubscriptions: openRecurringInspector,
+            onOpenFlow: openFlowInspector
         )
             .environment(appState)
             .id("wealth-summary-rail")
@@ -356,6 +372,14 @@ struct MainPopover: View {
                         ),
                         loadState: appState.loadState(for: .recurring),
                         onClose: closeRecurringInspector
+                    )
+                } else if isFlowInspectorOpen {
+                    IncomeCategoryFlowInspector(
+                        presentation: IncomeCategoryFlowPresentation.make(
+                            from: appState.transactions
+                        ),
+                        loadState: appState.loadState(for: .transactions),
+                        onClose: closeFlowInspector
                     )
                 } else if !selectedAccountId.isEmpty {
                     // A persisted selection is still resolving (accounts not loaded
@@ -479,6 +503,7 @@ struct MainPopover: View {
                             selectedAccountId: selectedAccount?.id,
                             onSelectAccount: {
                                 isRecurringInspectorOpen = false
+                                isFlowInspectorOpen = false
                                 selectedAccountId = $0.id
                             },
                             onDeselectAccount: { selectedAccountId = "" },

--- a/Sources/PlaidBar/Views/RecurringPaymentsView.swift
+++ b/Sources/PlaidBar/Views/RecurringPaymentsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -84,6 +85,13 @@ struct RecurringPaymentsView: View {
                 .detailText()
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+
+            if let forgottenCallout = presentation.forgottenCalloutText {
+                Label(forgottenCallout, systemImage: "questionmark.app.dashed")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(SemanticColors.warning)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             if presentation.attentionCount > 0 {
                 Label("\(presentation.attentionCount) changed or stale", systemImage: "exclamationmark.triangle")
@@ -182,11 +190,25 @@ private struct RecurringPaymentRow: View {
                     }
                 }
             }
+
+            // Cancel-help action (AND-497). Surfaced for every row, leading with
+            // a chevron for known merchant pages so it never reads via color alone.
+            Button {
+                NSWorkspace.shared.open(row.cancelURL)
+            } label: {
+                Label(row.cancelLinkText, systemImage: "xmark.circle")
+                    .font(.caption2.weight(.semibold))
+            }
+            .buttonStyle(.borderless)
+            .help(row.cancelIsSpecific
+                ? "Open \(row.merchantName)'s cancellation page"
+                : "Search how to cancel \(row.merchantName)")
+            .accessibilityLabel("How to cancel \(row.merchantName)")
         }
         .padding(Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
         .glassSurface(row.needsAttention ? .emphasized(SemanticColors.warning) : .raised)
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(row.accessibilityLabel)
     }
 }

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -6,6 +6,8 @@ struct WealthSummaryFlyout: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let onAddAccount: () -> Void
     var onOpenSubscriptions: (() -> Void)?
+    /// Opens the Income → Category flow drill-in (AND-500).
+    var onOpenFlow: (() -> Void)?
 
     private var presentation: WealthSummaryPresentation {
         WealthSummaryPresentation.evaluate(
@@ -49,7 +51,11 @@ struct WealthSummaryFlyout: View {
                         .loadingRedaction(appState.loadState(for: .summaryCards))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
-                    WealthCashflowSection(cashflow: presentation.cashflow, privacyMaskEnabled: privacyMaskEnabled)
+                    WealthCashflowSection(
+                        cashflow: presentation.cashflow,
+                        privacyMaskEnabled: privacyMaskEnabled,
+                        onOpenFlow: onOpenFlow
+                    )
                         .loadingRedaction(appState.loadState(for: .transactions))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
@@ -440,6 +446,7 @@ private struct WealthCashflowSection: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let cashflow: WealthSummaryPresentation.CashflowSummary
     let privacyMaskEnabled: Bool
+    var onOpenFlow: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -455,6 +462,16 @@ private struct WealthCashflowSection: View {
                 WealthCashflowRow(title: "Income", amount: cashflow.income, role: .income, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
                 WealthCashflowRow(title: "Spending", amount: cashflow.spending, role: .spending, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
                 WealthCashflowRow(title: "Net", amount: cashflow.net, role: .net, privacyMaskEnabled: privacyMaskEnabled, reduceMotion: reduceMotion)
+            }
+
+            // Drill into the Income → Category flow (AND-500).
+            if let onOpenFlow {
+                Button(action: onOpenFlow) {
+                    Label("View income flow", systemImage: "arrow.left.arrow.right")
+                        .font(.caption.weight(.medium))
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("View income to category flow")
             }
         }
         .accessibilityElement(children: .contain)

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -66,6 +66,19 @@ struct WealthSummaryFlyout: View {
                     .loadingRedaction(appState.loadState(for: .summaryCards))
                     .scrollEdgeDepth(reduceMotion: reduceMotion)
 
+                    // Forward cash-flow forecast (AND-498). Self-hides until
+                    // there is enough recorded balance history to anchor a line.
+                    ProjectedBalanceSection(
+                        presentation: ProjectedBalancePresentation.evaluate(
+                            history: appState.balanceHistory,
+                            recurring: appState.recurringTransactions,
+                            now: Date()
+                        ),
+                        privacyMaskEnabled: privacyMaskEnabled
+                    )
+                    .loadingRedaction(appState.loadState(for: .summaryCards))
+                    .scrollEdgeDepth(reduceMotion: reduceMotion)
+
                     // Read-only recurring obligations (AND-400). Built inline
                     // from the already-cached detector output, mirroring how the
                     // safe-to-spend card is composed above; self-hides when no
@@ -520,6 +533,43 @@ private struct WealthCashflowRow: View {
             if amount > 0 { return SemanticColors.positive }
             if amount < 0 { return SemanticColors.negative }
             return AppearanceTextColors.secondary
+        }
+    }
+}
+
+/// Forward cash-flow forecast block (AND-498). Self-hides when there isn't
+/// enough recorded balance history to anchor a line; masks the chart (which
+/// shows balance amounts) when privacy mode is on.
+private struct ProjectedBalanceSection: View {
+    let presentation: ProjectedBalancePresentation
+    let privacyMaskEnabled: Bool
+
+    var body: some View {
+        switch presentation {
+        case let .available(projection):
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                HStack {
+                    WealthFlyoutSectionLabel("Projected balance")
+                    Spacer()
+                    Text("\(projection.series.count - 1)D")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+
+                if privacyMaskEnabled {
+                    Label("Forecast hidden while VaultPeek is private", systemImage: "eye.slash")
+                        .detailText()
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+                } else {
+                    ProjectedBalanceChart(projection: projection)
+                }
+            }
+            .accessibilityElement(children: .contain)
+        case .insufficientHistory:
+            // Stay quiet until there is enough history — no empty placeholder.
+            EmptyView()
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/BalanceProjection.swift
+++ b/Sources/PlaidBarCore/Models/BalanceProjection.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// On-device forward cash-flow forecast (AND-498).
+///
+/// A dated forward `[BalanceSnapshot]` series stepping the anchor balance down
+/// (and up, where recurring income exists) across the horizon as detected
+/// recurring obligations come due, plus the projected-low point and a confidence
+/// matching `SafeToSpendConfidence` semantics. Pure value type — produced by
+/// `BalanceProjector`, rendered by `ProjectedBalanceChart`.
+public struct BalanceProjection: Sendable, Equatable {
+    /// Forward daily balance series, oldest (the anchor, today) first. Length is
+    /// `horizonDays + 1` — index 0 is the anchor day, the rest are future days.
+    public let series: [BalanceSnapshot]
+    /// The lowest projected balance over the horizon (the dip to watch).
+    public let projectedLow: BalanceSnapshot
+    /// How much to trust the forecast — same ladder as safe-to-spend.
+    public let confidence: SafeToSpendConfidence
+    /// Pre-rendered VoiceOver summary so meaning never relies on the line's
+    /// dash/color alone (ACCESSIBILITY.md).
+    public let accessibilitySummary: String
+
+    public init(
+        series: [BalanceSnapshot],
+        projectedLow: BalanceSnapshot,
+        confidence: SafeToSpendConfidence,
+        accessibilitySummary: String
+    ) {
+        self.series = series
+        self.projectedLow = projectedLow
+        self.confidence = confidence
+        self.accessibilitySummary = accessibilitySummary
+    }
+
+    /// The anchor (today) balance the projection starts from.
+    public var anchorBalance: Double { series.first?.balance ?? projectedLow.balance }
+    /// The projected balance at the end of the horizon.
+    public var endBalance: Double { series.last?.balance ?? projectedLow.balance }
+}

--- a/Sources/PlaidBarCore/Models/IncomeCategoryFlowPresentation.swift
+++ b/Sources/PlaidBarCore/Models/IncomeCategoryFlowPresentation.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Display-ready model for the Income → Category flow surface (AND-500).
+///
+/// Wraps `IncomeCategoryFlow.Graph` with formatted labels + a VoiceOver summary
+/// so the view stays thin and the wording is testable without rendering.
+public struct IncomeCategoryFlowPresentation: Sendable, Equatable {
+    public struct NodeRow: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let label: String
+        public let amountText: String
+        public let colorHex: String
+        public let colorHexDark: String
+
+        public init(id: String, label: String, amountText: String, colorHex: String, colorHexDark: String) {
+            self.id = id
+            self.label = label
+            self.amountText = amountText
+            self.colorHex = colorHex
+            self.colorHexDark = colorHexDark
+        }
+    }
+
+    public let graph: IncomeCategoryFlow.Graph
+    public let sources: [NodeRow]
+    public let categories: [NodeRow]
+    public let totalIncomeText: String
+    public let totalSpendText: String
+    public let summaryText: String
+    public let accessibilityLabel: String
+    public let isEmpty: Bool
+    public let emptyTitle: String
+    public let emptyDetail: String
+
+    public init(
+        graph: IncomeCategoryFlow.Graph,
+        sources: [NodeRow],
+        categories: [NodeRow],
+        totalIncomeText: String,
+        totalSpendText: String,
+        summaryText: String,
+        accessibilityLabel: String,
+        isEmpty: Bool,
+        emptyTitle: String,
+        emptyDetail: String
+    ) {
+        self.graph = graph
+        self.sources = sources
+        self.categories = categories
+        self.totalIncomeText = totalIncomeText
+        self.totalSpendText = totalSpendText
+        self.summaryText = summaryText
+        self.accessibilityLabel = accessibilityLabel
+        self.isEmpty = isEmpty
+        self.emptyTitle = emptyTitle
+        self.emptyDetail = emptyDetail
+    }
+
+    public static func make(from transactions: [TransactionDTO]) -> IncomeCategoryFlowPresentation {
+        let graph = IncomeCategoryFlow.graph(from: transactions)
+        let sources = graph.sources.map(Self.row(from:))
+        let categories = graph.categories.map(Self.row(from:))
+        let isEmpty = graph.isEmpty
+
+        let totalIncomeText = Formatters.currency(graph.totalIncome, format: .compact)
+        let totalSpendText = Formatters.currency(graph.totalSpend, format: .compact)
+        let summaryText = isEmpty
+            ? "No income-to-spending flow for this period."
+            : "\(graph.sources.count) income source\(graph.sources.count == 1 ? "" : "s") → \(graph.categories.count) categor\(graph.categories.count == 1 ? "y" : "ies")"
+
+        let accessibilityLabel: String
+        if isEmpty {
+            accessibilityLabel = "Income to category flow. No data for this period."
+        } else {
+            let sourceList = graph.sources.map { "\($0.label) \(Formatters.currency($0.amount, format: .compact))" }.joined(separator: ", ")
+            let categoryList = graph.categories.map { "\($0.label) \(Formatters.currency($0.amount, format: .compact))" }.joined(separator: ", ")
+            accessibilityLabel = "Income to category flow. Income: \(sourceList). Spending: \(categoryList). Flows are aggregate-proportional, not per-transaction."
+        }
+
+        return IncomeCategoryFlowPresentation(
+            graph: graph,
+            sources: sources,
+            categories: categories,
+            totalIncomeText: totalIncomeText,
+            totalSpendText: totalSpendText,
+            summaryText: summaryText,
+            accessibilityLabel: accessibilityLabel,
+            isEmpty: isEmpty,
+            emptyTitle: "No flow to show yet",
+            emptyDetail: "VaultPeek maps income sources to spending categories once this period has both income and spending in synced local transactions."
+        )
+    }
+
+    private static func row(from node: IncomeCategoryFlow.Node) -> NodeRow {
+        NodeRow(
+            id: node.id,
+            label: node.label,
+            amountText: Formatters.currency(node.amount, format: .compact),
+            colorHex: node.colorHex,
+            colorHexDark: node.colorHexDark
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/ProjectedBalancePresentation.swift
+++ b/Sources/PlaidBarCore/Models/ProjectedBalancePresentation.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Gates the projected-balance forecast on having enough history + an anchor
+/// (AND-498), mirroring `NetWorthTrendPresentation.available/.insufficientHistory`.
+public enum ProjectedBalancePresentation: Sendable, Equatable {
+    case available(BalanceProjection)
+    case insufficientHistory(pointCount: Int, requiredPointCount: Int)
+
+    /// Build the presentation from balance history + detected recurring streams.
+    ///
+    /// Requires at least `requiredPointCount` snapshots so a forecast is not drawn
+    /// off a single data point. Uses the most recent snapshot as the anchor.
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        recurring: [RecurringTransaction],
+        now: Date = Date(),
+        horizonDays: Int = PlaidBarConstants.projectedBalanceDefaultHorizonDays,
+        requiredPointCount: Int = PlaidBarConstants.projectedBalanceMinimumHistoryPoints,
+        calendar: Calendar = .current
+    ) -> ProjectedBalancePresentation {
+        guard history.count >= requiredPointCount else {
+            return .insufficientHistory(
+                pointCount: history.count,
+                requiredPointCount: requiredPointCount
+            )
+        }
+        // Anchor on the latest snapshot by date.
+        let anchor = history.max { $0.date < $1.date }
+        guard let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: recurring,
+            asOf: now,
+            horizonDays: horizonDays,
+            calendar: calendar
+        ) else {
+            return .insufficientHistory(
+                pointCount: history.count,
+                requiredPointCount: requiredPointCount
+            )
+        }
+        return .available(projection)
+    }
+
+    public var accessibilitySummary: String {
+        switch self {
+        case let .available(projection):
+            return projection.accessibilitySummary
+        case let .insufficientHistory(pointCount, requiredPointCount):
+            let needed = max(requiredPointCount - pointCount, 0)
+            return "Balance forecast unavailable. Needs \(needed) more local balance snapshot\(needed == 1 ? "" : "s")."
+        }
+    }
+
+    public var projection: BalanceProjection? {
+        if case let .available(projection) = self { return projection }
+        return nil
+    }
+}

--- a/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
@@ -58,9 +58,13 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
         public var needsAttention: Bool { !flags.isEmpty }
         public var hasPriceIncrease: Bool { flags.contains(.priceIncrease) }
         public var isStale: Bool { flags.contains(.stale) }
+        /// True for low-cost, long-running subscriptions the user likely forgot
+        /// about (AND-497). These rank to the very top.
+        public var isForgotten: Bool { flags.contains(.forgotten) }
     }
 
-    /// Detected obligations, attention-first then soonest-due (see `make`).
+    /// Detected obligations, forgotten-first then attention then soonest-due
+    /// (see `make`).
     public let items: [Item]
     /// Monthly-equivalent cost of the *active* (non-stale) obligations — matches
     /// `RecurringSummary.estimatedMonthlyTotal(asOf:)` so the section header and
@@ -68,11 +72,19 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
     public let estimatedMonthlyTotal: Double
     /// Count of obligations carrying at least one flag.
     public let attentionCount: Int
+    /// Count of obligations flagged as likely-forgotten subscriptions (AND-497).
+    public let forgottenCount: Int
 
-    public init(items: [Item], estimatedMonthlyTotal: Double, attentionCount: Int) {
+    public init(
+        items: [Item],
+        estimatedMonthlyTotal: Double,
+        attentionCount: Int,
+        forgottenCount: Int = 0
+    ) {
         self.items = items
         self.estimatedMonthlyTotal = estimatedMonthlyTotal
         self.attentionCount = attentionCount
+        self.forgottenCount = forgottenCount
     }
 
     public var isEmpty: Bool { items.isEmpty }
@@ -80,10 +92,12 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
 
     /// Build the presentation from detected recurring series.
     ///
-    /// Ordering: items needing attention first (so price increases / missing
-    /// charges surface at the top), then soonest `nextExpectedDate`, then
-    /// merchant name for a stable tiebreak. ISO `yyyy-MM-dd` strings sort
-    /// lexicographically, so a plain string compare is the date order.
+    /// Ordering: likely-forgotten subscriptions first (so "you may have forgotten
+    /// this" surfaces at the very top — AND-497), then items needing any other
+    /// attention (price increases / missing charges), then soonest
+    /// `nextExpectedDate`, then merchant name for a stable tiebreak. ISO
+    /// `yyyy-MM-dd` strings sort lexicographically, so a plain string compare is
+    /// the date order.
     public static func make(
         from recurring: [RecurringTransaction],
         asOf date: Date,
@@ -105,6 +119,9 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
             )
         }
         .sorted { lhs, rhs in
+            if lhs.isForgotten != rhs.isForgotten {
+                return lhs.isForgotten && !rhs.isForgotten
+            }
             if lhs.needsAttention != rhs.needsAttention {
                 return lhs.needsAttention && !rhs.needsAttention
             }
@@ -121,7 +138,8 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
                 asOf: date,
                 calendar: calendar
             ),
-            attentionCount: items.reduce(0) { $0 + ($1.needsAttention ? 1 : 0) }
+            attentionCount: items.reduce(0) { $0 + ($1.needsAttention ? 1 : 0) },
+            forgottenCount: items.reduce(0) { $0 + ($1.isForgotten ? 1 : 0) }
         )
     }
 }

--- a/Sources/PlaidBarCore/Models/RecurringPaymentsSurfacePresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringPaymentsSurfacePresentation.swift
@@ -19,6 +19,17 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
         public let accessibilityLabel: String
         public let needsAttention: Bool
         public let isLowConfidence: Bool
+        /// True for low-cost, long-running subscriptions the user likely forgot
+        /// about (AND-497). Drives the "You may have forgotten this" callout.
+        public let isForgotten: Bool
+        /// Link text for the cancel-help action, e.g. "How to cancel".
+        public let cancelLinkText: String
+        /// Destination for the cancel-help action: the merchant's own page when
+        /// known, otherwise a generic "how to cancel <merchant>" search.
+        public let cancelURL: URL
+        /// True when `cancelURL` points at the merchant's own cancel page rather
+        /// than a generic web search.
+        public let cancelIsSpecific: Bool
 
         public init(item: RecurringObligationsPresentation.Item) {
             id = item.id
@@ -34,6 +45,12 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
             flagExplanations = Self.flagExplanations(for: item)
             needsAttention = item.needsAttention
             isLowConfidence = item.confidenceLevel == .low
+            isForgotten = item.isForgotten
+
+            let guidance = SubscriptionCancelGuidance.guidance(for: item.merchantName)
+            cancelLinkText = guidance.linkText
+            cancelURL = guidance.url
+            cancelIsSpecific = guidance.isSpecific
 
             var parts = [
                 merchantName,
@@ -50,6 +67,10 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
 
         private static func flagExplanations(for item: RecurringObligationsPresentation.Item) -> [String] {
             var explanations: [String] = []
+            // Forgotten first so it leads the row, matching the surface ordering.
+            if item.isForgotten {
+                explanations.append("You may have forgotten this subscription — it's small and has charged for a while.")
+            }
             if item.hasPriceIncrease {
                 explanations.append("Latest charge is higher than the prior pattern.")
             }
@@ -70,6 +91,12 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
     public let emptyDetail: String
     public let attentionCount: Int
     public let lowConfidenceCount: Int
+    /// Number of rows flagged as likely-forgotten subscriptions (AND-497).
+    public let forgottenCount: Int
+    /// Header callout shown when at least one subscription looks forgotten, or
+    /// nil when none do. Paired with an SF Symbol in the view so it never reads
+    /// via color alone.
+    public let forgottenCalloutText: String?
 
     public init(
         rows: [Row],
@@ -78,7 +105,9 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
         emptyTitle: String,
         emptyDetail: String,
         attentionCount: Int,
-        lowConfidenceCount: Int
+        lowConfidenceCount: Int,
+        forgottenCount: Int = 0,
+        forgottenCalloutText: String? = nil
     ) {
         self.rows = rows
         self.estimatedMonthlyTotalText = estimatedMonthlyTotalText
@@ -87,6 +116,8 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
         self.emptyDetail = emptyDetail
         self.attentionCount = attentionCount
         self.lowConfidenceCount = lowConfidenceCount
+        self.forgottenCount = forgottenCount
+        self.forgottenCalloutText = forgottenCalloutText
     }
 
     public var isEmpty: Bool { rows.isEmpty }
@@ -103,6 +134,7 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
         )
         let rows = obligations.items.map(Row.init(item:))
         let lowConfidenceCount = rows.count(where: \.isLowConfidence)
+        let forgottenCount = obligations.forgottenCount
 
         return RecurringPaymentsSurfacePresentation(
             rows: rows,
@@ -110,19 +142,29 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
             summaryText: Self.summaryText(
                 rowCount: rows.count,
                 attentionCount: obligations.attentionCount,
-                lowConfidenceCount: lowConfidenceCount
+                lowConfidenceCount: lowConfidenceCount,
+                forgottenCount: forgottenCount
             ),
             emptyTitle: "No recurring payments detected",
             emptyDetail: "VaultPeek will list subscriptions here after it sees a repeated merchant pattern in synced local transactions.",
             attentionCount: obligations.attentionCount,
-            lowConfidenceCount: lowConfidenceCount
+            lowConfidenceCount: lowConfidenceCount,
+            forgottenCount: forgottenCount,
+            forgottenCalloutText: Self.forgottenCalloutText(count: forgottenCount)
         )
+    }
+
+    private static func forgottenCalloutText(count: Int) -> String? {
+        guard count > 0 else { return nil }
+        let noun = count == 1 ? "subscription" : "subscriptions"
+        return "You may have forgotten \(count) \(noun) — small charges that have run for a while."
     }
 
     private static func summaryText(
         rowCount: Int,
         attentionCount: Int,
-        lowConfidenceCount: Int
+        lowConfidenceCount: Int,
+        forgottenCount: Int
     ) -> String {
         guard rowCount > 0 else {
             return "No recurring payments detected yet."
@@ -131,6 +173,9 @@ public struct RecurringPaymentsSurfacePresentation: Sendable, Hashable {
         var parts = [
             "\(rowCount) detected \(rowCount == 1 ? "stream" : "streams")",
         ]
+        if forgottenCount > 0 {
+            parts.append("\(forgottenCount) maybe forgotten")
+        }
         if attentionCount > 0 {
             parts.append("\(attentionCount) flagged")
         }

--- a/Sources/PlaidBarCore/Models/RecurringTransaction.swift
+++ b/Sources/PlaidBarCore/Models/RecurringTransaction.swift
@@ -84,6 +84,48 @@ public struct RecurringTransaction: Sendable, Identifiable, Hashable {
         return isStale(asOf: date, calendar: calendar)
     }
 
+    /// True when the stream looks like a subscription the user probably forgot
+    /// about: still charging, low-cost, monthly-or-rarer, and run for enough
+    /// cycles to have slipped into the background (AND-497).
+    ///
+    /// This is the *opposite* of `isStale` — stale means the expected charge has
+    /// stopped, while forgotten means it keeps charging unnoticed. A stale stream
+    /// is never also forgotten, so `isStale` takes precedence here and in
+    /// `flags(asOf:)`.
+    public func isForgotten(asOf date: Date, calendar: Calendar = .current) -> Bool {
+        // A stopped stream is reported as stale, not forgotten.
+        if isStale(asOf: date, calendar: calendar) { return false }
+        // Weekly/biweekly streams are too frequent to "forget" — keep this to
+        // monthly-or-rarer cadences where a single small charge hides easily.
+        switch frequency {
+        case .weekly, .biweekly:
+            return false
+        case .monthly, .quarterly, .annual:
+            break
+        }
+        guard transactionCount >= PlaidBarConstants.forgottenSubscriptionMinimumCycles else {
+            return false
+        }
+        // Easy to forget means small: a large charge gets noticed every cycle.
+        guard averageAmount > 0,
+              averageAmount <= PlaidBarConstants.forgottenSubscriptionMaxAmount else {
+            return false
+        }
+        // Only flag recognizable subscription/entertainment spend; uncategorized
+        // or other-category recurrence is too noisy to call "forgotten".
+        switch category {
+        case .subscriptions, .entertainment:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public func isForgotten(asOf dateString: String, calendar: Calendar = .current) -> Bool {
+        guard let date = Formatters.parseTransactionDate(dateString) else { return false }
+        return isForgotten(asOf: date, calendar: calendar)
+    }
+
     public func flags(asOf date: Date, calendar: Calendar = .current) -> Set<RecurringStreamFlag> {
         var flags: Set<RecurringStreamFlag> = []
         if hasPriceIncrease {
@@ -91,6 +133,9 @@ public struct RecurringTransaction: Sendable, Identifiable, Hashable {
         }
         if isStale(asOf: date, calendar: calendar) {
             flags.insert(.stale)
+        }
+        if isForgotten(asOf: date, calendar: calendar) {
+            flags.insert(.forgotten)
         }
         return flags
     }
@@ -113,6 +158,7 @@ public struct RecurringPriceIncrease: Sendable, Hashable {
 public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
     case priceIncrease
     case stale
+    case forgotten
 
     /// Short badge text. Paired with `iconName` so the flag never reads through
     /// color alone (ACCESSIBILITY.md).
@@ -120,6 +166,7 @@ public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
         switch self {
         case .priceIncrease: "Price up"
         case .stale: "Missing"
+        case .forgotten: "Forgotten?"
         }
     }
 
@@ -127,6 +174,7 @@ public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
         switch self {
         case .priceIncrease: "arrow.up.right"
         case .stale: "calendar.badge.exclamationmark"
+        case .forgotten: "questionmark.app.dashed"
         }
     }
 
@@ -135,6 +183,7 @@ public enum RecurringStreamFlag: String, Sendable, Hashable, CaseIterable {
         switch self {
         case .priceIncrease: "price increased"
         case .stale: "expected charge missing"
+        case .forgotten: "you may have forgotten this subscription"
         }
     }
 }

--- a/Sources/PlaidBarCore/Models/SafeToSpend.swift
+++ b/Sources/PlaidBarCore/Models/SafeToSpend.swift
@@ -84,6 +84,10 @@ public struct SafeToSpendComponent: Sendable, Equatable, Identifiable {
 public enum SafeToSpendComponentKind: String, Sendable, CaseIterable, Hashable {
     case startingCash
     case expectedIncome
+    /// Money already authorized but not yet posted (pending outflow holds).
+    /// Subtracted so it is not double-counted as spendable cash (AND-499).
+    /// Slotted right after income and before upcoming obligations.
+    case pendingHolds
     case upcomingObligations
     case loanPayments
     case budgetReservations
@@ -95,6 +99,7 @@ public enum SafeToSpendComponentKind: String, Sendable, CaseIterable, Hashable {
         switch self {
         case .startingCash: "banknote"
         case .expectedIncome: "arrow.down.circle"
+        case .pendingHolds: "clock.badge"
         case .upcomingObligations: "calendar.badge.clock"
         case .loanPayments: "creditcard"
         case .budgetReservations: "tray.full"

--- a/Sources/PlaidBarCore/Models/WatchlistTarget.swift
+++ b/Sources/PlaidBarCore/Models/WatchlistTarget.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A user-defined spend watch: "nudge me when I cross $X at merchant Y / in
+/// category Z this month" (AND-501).
+///
+/// Deliberately lightweight — this is a glance-line nudge, not envelope
+/// budgeting. Persisted app-side as Codable JSON in UserDefaults. Pure value
+/// type so the evaluator and persistence stay testable without UI or a server.
+public struct WatchlistTarget: Codable, Sendable, Equatable, Hashable, Identifiable {
+    public enum Kind: String, Codable, Sendable, Equatable, Hashable, CaseIterable {
+        case merchant
+        case category
+
+        public var displayName: String {
+            switch self {
+            case .merchant: "Merchant"
+            case .category: "Category"
+            }
+        }
+    }
+
+    public let id: UUID
+    public let kind: Kind
+    /// For `.merchant`: the normalized merchant display name. For `.category`:
+    /// the `SpendingCategory.rawValue`. Stored already-normalized for merchants
+    /// so equality matching is cheap and case/whitespace-insensitive.
+    public let key: String
+    /// Month-to-date spend threshold in the account currency. Crossing it (>=)
+    /// fires one nudge per month/threshold.
+    public let monthlyThreshold: Double
+    /// User-facing label for nudge copy, e.g. "Starbucks" or "Shopping".
+    public let label: String
+
+    public init(
+        id: UUID = UUID(),
+        kind: Kind,
+        key: String,
+        monthlyThreshold: Double,
+        label: String
+    ) {
+        self.id = id
+        self.kind = kind
+        self.key = kind == .merchant ? WatchlistTarget.normalizeMerchant(key) : key
+        self.monthlyThreshold = max(monthlyThreshold, 0)
+        self.label = label
+    }
+
+    /// Build a merchant watch from a raw display name (normalizes the key and
+    /// keeps the original text as the label).
+    public static func merchant(_ name: String, threshold: Double, id: UUID = UUID()) -> WatchlistTarget {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return WatchlistTarget(
+            id: id,
+            kind: .merchant,
+            key: trimmed,
+            monthlyThreshold: threshold,
+            label: trimmed.isEmpty ? "Merchant" : trimmed
+        )
+    }
+
+    /// Build a category watch from a `SpendingCategory`.
+    public static func category(_ category: SpendingCategory, threshold: Double, id: UUID = UUID()) -> WatchlistTarget {
+        WatchlistTarget(
+            id: id,
+            kind: .category,
+            key: category.rawValue,
+            monthlyThreshold: threshold,
+            label: category.displayName
+        )
+    }
+
+    /// The category this target watches, when it is a category target.
+    public var category: SpendingCategory? {
+        guard kind == .category else { return nil }
+        return SpendingCategory(rawValue: key)
+    }
+
+    /// Lowercased, whitespace-trimmed merchant key so " Whole Foods " and
+    /// "whole foods" resolve to the same watch.
+    public static func normalizeMerchant(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
+++ b/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Builds an on-device forward cash-flow forecast (AND-498).
+///
+/// Anchors on the latest net-balance snapshot ("today") and walks each detected
+/// recurring stream forward across the horizon, applying its `averageAmount` on
+/// every occurrence day. Outflow obligations subtract; recurring income (when
+/// any `.income` stream is present) adds — reusing the exact classification gate
+/// proven in `SafeToSpendCalculator` (confidence >= `minimumObligationConfidence`,
+/// `isOutflowObligation`, skip transfers).
+///
+/// Unlike safe-to-spend — which counts only the single next occurrence in one
+/// window — the projector steps each stream by `RecurringFrequency.estimatedDays`
+/// across the whole horizon, building a running daily balance. Pure, Sendable,
+/// deterministic with an injected `asOf` + `Calendar`.
+public enum BalanceProjector {
+    /// Recurring streams below this confidence are ignored, matching
+    /// `SafeToSpendCalculator.minimumObligationConfidence`.
+    public static let minimumConfidence = SafeToSpendCalculator.minimumObligationConfidence
+
+    /// Project the forward balance series.
+    ///
+    /// - Parameters:
+    ///   - anchor: latest net-balance snapshot (today). Its `balance` seeds the line.
+    ///   - recurring: detected recurring streams.
+    ///   - asOf: reference "today". Occurrences are walked from here forward.
+    ///   - horizonDays: forward window length (clamped to >= 1).
+    ///   - calendar: calendar used to step days.
+    /// - Returns: a `BalanceProjection`, or nil when there is no anchor.
+    public static func project(
+        anchor: BalanceSnapshot?,
+        recurring: [RecurringTransaction],
+        asOf date: Date,
+        horizonDays: Int = PlaidBarConstants.projectedBalanceDefaultHorizonDays,
+        calendar: Calendar = .current
+    ) -> BalanceProjection? {
+        guard let anchor else { return nil }
+        let horizon = max(horizonDays, 1)
+        let startDay = calendar.startOfDay(for: date)
+        guard let horizonEnd = calendar.date(byAdding: .day, value: horizon, to: startDay) else {
+            return nil
+        }
+
+        // Per-day net delta across the horizon, keyed by day index 1...horizon.
+        var deltasByDayIndex: [Int: Double] = [:]
+        var hasSignal = false
+
+        for stream in recurring {
+            guard stream.confidence >= minimumConfidence else { continue }
+            guard let kind = classify(stream) else { continue }
+            hasSignal = true
+
+            let signed: Double
+            switch kind {
+            case .outflow: signed = -max(stream.averageAmount, 0)
+            case .income: signed = max(stream.averageAmount, 0)
+            }
+            guard signed != 0 else { continue }
+
+            // Walk occurrences from nextExpectedDate forward by estimatedDays.
+            guard var occurrence = Formatters.parseTransactionDate(stream.nextExpectedDate)
+                .map({ calendar.startOfDay(for: $0) })
+            else { continue }
+            let step = stream.frequency.estimatedDays
+
+            // Skip any occurrence already in the past relative to the anchor.
+            while occurrence < startDay {
+                guard let next = calendar.date(byAdding: .day, value: step, to: occurrence) else { break }
+                occurrence = next
+            }
+
+            while occurrence <= horizonEnd {
+                if let dayIndex = calendar.dateComponents([.day], from: startDay, to: occurrence).day,
+                   dayIndex >= 1, dayIndex <= horizon {
+                    deltasByDayIndex[dayIndex, default: 0] += signed
+                }
+                guard let next = calendar.date(byAdding: .day, value: step, to: occurrence) else { break }
+                occurrence = next
+            }
+        }
+
+        // Build the running daily series: index 0 = anchor, 1...horizon forward.
+        var series: [BalanceSnapshot] = []
+        series.reserveCapacity(horizon + 1)
+        var running = anchor.balance
+        series.append(BalanceSnapshot(date: startDay, balance: running))
+        for dayIndex in 1...horizon {
+            running += deltasByDayIndex[dayIndex] ?? 0
+            let day = calendar.date(byAdding: .day, value: dayIndex, to: startDay) ?? startDay
+            series.append(BalanceSnapshot(date: day, balance: running))
+        }
+
+        // Projected low = the minimum across the whole series (earliest wins on ties).
+        let projectedLow = series.min { lhs, rhs in
+            if lhs.balance != rhs.balance { return lhs.balance < rhs.balance }
+            return lhs.date < rhs.date
+        } ?? series[0]
+
+        let confidence: SafeToSpendConfidence = hasSignal ? .lowConfidence : .insufficientData
+        let summary = accessibilitySummary(
+            anchor: anchor.balance,
+            end: running,
+            low: projectedLow,
+            horizon: horizon,
+            confidence: confidence,
+            calendar: calendar
+        )
+
+        return BalanceProjection(
+            series: series,
+            projectedLow: projectedLow,
+            confidence: confidence,
+            accessibilitySummary: summary
+        )
+    }
+
+    // MARK: - Classification
+
+    private enum StreamKind { case outflow, income }
+
+    private static func classify(_ stream: RecurringTransaction) -> StreamKind? {
+        switch stream.category {
+        case .income:
+            return .income
+        case .transfer, .transferOut:
+            // Own-account transfers net out; skip them.
+            return nil
+        default:
+            return .outflow
+        }
+    }
+
+    private static func accessibilitySummary(
+        anchor: Double,
+        end: Double,
+        low: BalanceSnapshot,
+        horizon: Int,
+        confidence: SafeToSpendConfidence,
+        calendar: Calendar
+    ) -> String {
+        let direction = end < anchor ? "down" : (end > anchor ? "up" : "flat")
+        let lowText = Formatters.currency(low.balance, format: .compact)
+        let lowDate = Formatters.displayTransactionDate(Formatters.transactionDateString(low.date))
+        let confidenceText: String
+        switch confidence {
+        case .insufficientData: confidenceText = "No recurring signal yet, so this is indicative only."
+        case .lowConfidence: confidenceText = "Estimated from recurring patterns."
+        case .ok: confidenceText = ""
+        }
+        let base = "Projected balance over \(horizon) days trends \(direction), reaching a low of \(lowText) on \(lowDate)."
+        return confidenceText.isEmpty ? base : "\(base) \(confidenceText)"
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -42,6 +42,17 @@ public enum PlaidBarConstants {
     // Display
     public static let creditUtilizationWarningThreshold: Double = 30.0
     public static let maxRecentTransactions: Int = 50
+
+    // Forgotten-subscription heuristic (AND-497).
+    // A recurring stream is "easy to forget" when it has run for many cycles
+    // (so it has slipped into the background) yet costs little each cycle (so it
+    // never draws attention on a statement). Tuned for monthly-or-rarer streams.
+    /// Minimum number of observed charges before a stream is old enough to have
+    /// been forgotten.
+    public static let forgottenSubscriptionMinimumCycles: Int = 6
+    /// Maximum per-charge amount for a stream to count as "easy to forget".
+    /// Larger charges are noticed, so they are never flagged as forgotten.
+    public static let forgottenSubscriptionMaxAmount: Double = 20.0
     public static let initialSyncDays: Int = 90
     public static let maxTransactionSyncPages: Int = 100
     public static let maxTransactionSyncMutationRestarts: Int = 2

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -53,6 +53,12 @@ public enum PlaidBarConstants {
     /// Maximum per-charge amount for a stream to count as "easy to forget".
     /// Larger charges are noticed, so they are never flagged as forgotten.
     public static let forgottenSubscriptionMaxAmount: Double = 20.0
+
+    // Projected balance forecast (AND-498).
+    /// Default forward horizon (days) for the projected-balance line.
+    public static let projectedBalanceDefaultHorizonDays: Int = 30
+    /// Minimum balance snapshots required before a forecast is shown.
+    public static let projectedBalanceMinimumHistoryPoints: Int = 2
     public static let initialSyncDays: Int = 90
     public static let maxTransactionSyncPages: Int = 100
     public static let maxTransactionSyncMutationRestarts: Int = 2

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -66,6 +66,29 @@ public enum DemoFixtures {
     public static func transactions(now: Date = Date(), calendar: Calendar = .current) -> [TransactionDTO] {
         explicitTransactions(now: now, calendar: calendar)
             + historicalTransactions(now: now, calendar: calendar)
+            + forgottenSubscriptionTransactions(now: now, calendar: calendar)
+    }
+
+    /// A small, long-running subscription seeded so `--demo` always shows the
+    /// "You may have forgotten this" callout (AND-497). $4.99/mo "Cloud Backup"
+    /// (Netflix is in the cancel-guidance map for a non-generic link; this one is
+    /// deliberately small and obscure so it reads as easy-to-forget). Twelve
+    /// monthly occurrences land well over the forgotten min-cycle threshold, the
+    /// fixed amount keeps the detected average under the cost ceiling, and the
+    /// most recent charge is recent so it is never read as stale.
+    private static func forgottenSubscriptionTransactions(now: Date, calendar: Calendar) -> [TransactionDTO] {
+        (0..<12).map { monthsAgo in
+            let daysAgo = 4 + (monthsAgo * 30)
+            return TransactionDTO(
+                id: "demo_forgotten_cloud_\(monthsAgo)",
+                accountId: "demo_visa",
+                amount: 4.99,
+                date: dateString(daysAgo: daysAgo, now: now, calendar: calendar),
+                name: "CLOUDVAULT BACKUP",
+                merchantName: "CloudVault",
+                category: .subscriptions
+            )
+        }
     }
 
     /// Deterministic 60-day net-worth history with a gentle upward drift so the

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -91,6 +91,26 @@ public enum DemoFixtures {
         }
     }
 
+    /// Seeded watchlist nudges for demo mode (AND-501). Chosen so they cross
+    /// against the demo transactions' month-to-date spend (Starbucks coffees and
+    /// the Shopping category both clear early), populating the Settings
+    /// Watchlists section and firing the evaluator in `--demo`. Fixed UUIDs keep
+    /// the order and identity deterministic for screenshots.
+    public static func watchlistTargets() -> [WatchlistTarget] {
+        [
+            WatchlistTarget.merchant(
+                "Starbucks",
+                threshold: 10,
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000A1")!
+            ),
+            WatchlistTarget.category(
+                .shopping,
+                threshold: 200,
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000A2")!
+            ),
+        ]
+    }
+
     /// Deterministic 60-day net-worth history with a gentle upward drift so the
     /// header trend reads the same on every demo launch and screenshots
     /// reproduce.

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -179,6 +179,10 @@ public enum DemoFixtures {
             TransactionDTO(id: "tx10", accountId: "demo_amex", amount: 320.00, date: twoDaysAgo, name: "DELTA AIR LINES", merchantName: "Delta Airlines", category: .travel),
             TransactionDTO(id: "tx11", accountId: "demo_checking", amount: 12.50, date: twoDaysAgo, name: "STARBUCKS 8823", merchantName: "Starbucks", category: .foodAndDrink),
             TransactionDTO(id: "tx12", accountId: "demo_amex", amount: 650.00, date: twoDaysAgo, name: "FURNITURE STORE", merchantName: "West Elm", category: .shopping, pending: true),
+            // Pending OUTFLOW on a depository (cash) account so the pending-aware
+            // safe-to-spend holds component is non-zero in --demo (AND-499). tx12
+            // is on a credit account and is therefore excluded from cash holds.
+            TransactionDTO(id: "tx48", accountId: "demo_checking", amount: 86.40, date: today, name: "TRADER JOES 442", merchantName: "Trader Joe's", category: .foodAndDrink, pending: true),
             // 3 days ago
             TransactionDTO(id: "tx13", accountId: "demo_visa", amount: 75.00, date: threeDaysAgo, name: "PLANET FITNESS", merchantName: "Planet Fitness", category: .healthAndFitness),
             TransactionDTO(id: "tx14", accountId: "demo_checking", amount: -1_500.00, date: threeDaysAgo, name: "VENMO PAYMENT", merchantName: "Venmo", category: .income),

--- a/Sources/PlaidBarCore/Utilities/IncomeCategoryFlow.swift
+++ b/Sources/PlaidBarCore/Utilities/IncomeCategoryFlow.swift
@@ -1,0 +1,334 @@
+import Foundation
+
+/// Aggregation + layout geometry for the Income → Category flow ("Sankey")
+/// surface (AND-500).
+///
+/// Swift Charts has no native flow/Sankey mark, so the ribbons are hand-rendered
+/// over node rectangles. ALL the geometry here is pure value types
+/// (`FlowRect`/`FlowRibbon` use plain `Double`), unit-testable with zero
+/// SwiftUI. The aggregation honestly models an *aggregate-proportional* flow:
+/// per-transaction income→category attribution does not exist in the data, so
+/// each income source's total is split across spend categories by each
+/// category's share of total spend. This is documented as such, not implied.
+public enum IncomeCategoryFlow {
+    /// One node in either column (an income source or a spend category).
+    public struct Node: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let label: String
+        public let amount: Double
+        /// Color hex for light backgrounds (categories use their own; sources
+        /// share a neutral income tint).
+        public let colorHex: String
+        public let colorHexDark: String
+
+        public init(id: String, label: String, amount: Double, colorHex: String, colorHexDark: String) {
+            self.id = id
+            self.label = label
+            self.amount = amount
+            self.colorHex = colorHex
+            self.colorHexDark = colorHexDark
+        }
+    }
+
+    /// A proportional link from a source to a category.
+    public struct Link: Sendable, Equatable {
+        public let sourceID: String
+        public let categoryID: String
+        public let amount: Double
+
+        public init(sourceID: String, categoryID: String, amount: Double) {
+            self.sourceID = sourceID
+            self.categoryID = categoryID
+            self.amount = amount
+        }
+    }
+
+    /// The aggregated two-column graph for one period.
+    public struct Graph: Sendable, Equatable {
+        public let sources: [Node]
+        public let categories: [Node]
+        public let links: [Link]
+
+        public init(sources: [Node], categories: [Node], links: [Link]) {
+            self.sources = sources
+            self.categories = categories
+            self.links = links
+        }
+
+        public var isEmpty: Bool { sources.isEmpty || categories.isEmpty }
+        public var totalIncome: Double { sources.reduce(0) { $0 + $1.amount } }
+        public var totalSpend: Double { categories.reduce(0) { $0 + $1.amount } }
+    }
+
+    /// Neutral income tints used for source nodes (no per-source semantic color).
+    static let incomeColorHex = "#82E0AA"
+    static let incomeColorHexDark = "#6FCC98"
+
+    /// Build the flow graph for a period's transactions.
+    ///
+    /// - Income sources: inflows grouped by merchant (`merchantName ?? name`),
+    ///   summed via `displayAmount`, sorted descending.
+    /// - Spend categories: delegated to `SpendingSummary.spendingByCategory`
+    ///   (already excludes income + transfers and sorts descending).
+    /// - Links: each source's total split across categories by each category's
+    ///   share of total spend (aggregate-proportional).
+    public static func graph(from transactions: [TransactionDTO]) -> Graph {
+        let sources = incomeSources(from: transactions)
+        let categoryTotals = SpendingSummary.spendingByCategory(from: transactions)
+        let categories = categoryTotals.map { category, amount in
+            Node(
+                id: category.rawValue,
+                label: category.displayName,
+                amount: amount,
+                colorHex: category.colorHex,
+                colorHexDark: category.colorHexDark
+            )
+        }
+
+        let totalSpend = categories.reduce(0) { $0 + $1.amount }
+        var links: [Link] = []
+        if totalSpend > 0 {
+            for source in sources {
+                for category in categories {
+                    let share = category.amount / totalSpend
+                    let amount = source.amount * share
+                    guard amount > 0 else { continue }
+                    links.append(Link(sourceID: source.id, categoryID: category.id, amount: amount))
+                }
+            }
+        }
+
+        return Graph(sources: sources, categories: categories, links: links)
+    }
+
+    /// Income sources grouped by merchant, summed (abs), sorted descending.
+    public static func incomeSources(from transactions: [TransactionDTO]) -> [Node] {
+        let inflows = transactions.filter(\.isIncome)
+        var totals: [String: Double] = [:]
+        var order: [String] = []
+        for transaction in inflows {
+            let label = transaction.displayName
+            if totals[label] == nil { order.append(label) }
+            totals[label, default: 0] += transaction.displayAmount
+        }
+        return order
+            .map { label in
+                Node(
+                    id: "income:\(label)",
+                    label: label,
+                    amount: totals[label] ?? 0,
+                    colorHex: incomeColorHex,
+                    colorHexDark: incomeColorHexDark
+                )
+            }
+            .filter { $0.amount > 0 }
+            .sorted { lhs, rhs in
+                if lhs.amount != rhs.amount { return lhs.amount > rhs.amount }
+                return lhs.label < rhs.label
+            }
+    }
+}
+
+/// A laid-out node rectangle in flow-view coordinates (origin top-left, y down).
+/// Pure `Double` so it is testable without CoreGraphics/SwiftUI.
+public struct FlowRect: Sendable, Equatable {
+    public let id: String
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(id: String, x: Double, y: Double, width: Double, height: Double) {
+        self.id = id
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    public var minY: Double { y }
+    public var maxY: Double { y + height }
+    public var midY: Double { y + height / 2 }
+}
+
+/// A laid-out ribbon connecting a source rect's right edge to a category rect's
+/// left edge, as a cubic Bezier band described by its endpoints + control points.
+public struct FlowRibbon: Sendable, Equatable {
+    public let sourceID: String
+    public let categoryID: String
+    /// Vertical thickness of the band (proportional to the link amount).
+    public let thickness: Double
+    /// Start (source side) and end (category side) anchor points — band centers.
+    public let startX: Double
+    public let startY: Double
+    public let endX: Double
+    public let endY: Double
+    /// Cubic control points (horizontal tangents for an S-curve).
+    public let control1X: Double
+    public let control1Y: Double
+    public let control2X: Double
+    public let control2Y: Double
+
+    public init(
+        sourceID: String,
+        categoryID: String,
+        thickness: Double,
+        startX: Double,
+        startY: Double,
+        endX: Double,
+        endY: Double,
+        control1X: Double,
+        control1Y: Double,
+        control2X: Double,
+        control2Y: Double
+    ) {
+        self.sourceID = sourceID
+        self.categoryID = categoryID
+        self.thickness = thickness
+        self.startX = startX
+        self.startY = startY
+        self.endX = endX
+        self.endY = endY
+        self.control1X = control1X
+        self.control1Y = control1Y
+        self.control2X = control2X
+        self.control2Y = control2Y
+    }
+}
+
+/// The complete laid-out flow geometry for a given draw size.
+public struct FlowLayout: Sendable, Equatable {
+    public let sourceRects: [FlowRect]
+    public let categoryRects: [FlowRect]
+    public let ribbons: [FlowRibbon]
+    /// True when there is nothing to draw (empty/degenerate period).
+    public let isEmpty: Bool
+
+    public init(sourceRects: [FlowRect], categoryRects: [FlowRect], ribbons: [FlowRibbon], isEmpty: Bool) {
+        self.sourceRects = sourceRects
+        self.categoryRects = categoryRects
+        self.ribbons = ribbons
+        self.isEmpty = isEmpty
+    }
+
+    public static let empty = FlowLayout(sourceRects: [], categoryRects: [], ribbons: [], isEmpty: true)
+
+    /// Compute node rectangles + ribbon geometry for a `Graph` in a draw area of
+    /// `width` × `height`, with `nodeGap` vertical spacing between stacked nodes
+    /// and `nodeWidth` column thickness.
+    ///
+    /// Node heights are proportional to value; the stacked heights + gaps exactly
+    /// fill the available height per column. Guards empty/degenerate input.
+    public static func compute(
+        graph: IncomeCategoryFlow.Graph,
+        width: Double,
+        height: Double,
+        nodeGap: Double = 8,
+        nodeWidth: Double = 14
+    ) -> FlowLayout {
+        guard !graph.isEmpty, width > 0, height > 0 else { return .empty }
+
+        let sourceRects = column(
+            nodes: graph.sources,
+            x: 0,
+            columnHeight: height,
+            nodeGap: nodeGap,
+            nodeWidth: nodeWidth
+        )
+        let categoryRects = column(
+            nodes: graph.categories,
+            x: width - nodeWidth,
+            columnHeight: height,
+            nodeGap: nodeGap,
+            nodeWidth: nodeWidth
+        )
+        guard !sourceRects.isEmpty, !categoryRects.isEmpty else { return .empty }
+
+        let sourceByID = Dictionary(uniqueKeysWithValues: sourceRects.map { ($0.id, $0) })
+        let categoryByID = Dictionary(uniqueKeysWithValues: categoryRects.map { ($0.id, $0) })
+        let sourceTotals = Dictionary(uniqueKeysWithValues: graph.sources.map { ($0.id, $0.amount) })
+        let categoryTotals = Dictionary(uniqueKeysWithValues: graph.categories.map { ($0.id, $0.amount) })
+
+        // Running offsets so multiple ribbons stack within each node's height.
+        var sourceOffset: [String: Double] = [:]
+        var categoryOffset: [String: Double] = [:]
+
+        var ribbons: [FlowRibbon] = []
+        for link in graph.links {
+            guard let sourceRect = sourceByID[link.sourceID],
+                  let categoryRect = categoryByID[link.categoryID],
+                  let sourceTotal = sourceTotals[link.sourceID], sourceTotal > 0,
+                  let categoryTotal = categoryTotals[link.categoryID], categoryTotal > 0
+            else { continue }
+
+            // Thickness on each side is proportional to the link's share of that
+            // node; use the source side for the band thickness.
+            let sourceThickness = sourceRect.height * (link.amount / sourceTotal)
+            let categoryThickness = categoryRect.height * (link.amount / categoryTotal)
+
+            let sOff = sourceOffset[link.sourceID, default: 0]
+            let cOff = categoryOffset[link.categoryID, default: 0]
+            let startY = sourceRect.minY + sOff + sourceThickness / 2
+            let endY = categoryRect.minY + cOff + categoryThickness / 2
+            sourceOffset[link.sourceID] = sOff + sourceThickness
+            categoryOffset[link.categoryID] = cOff + categoryThickness
+
+            let startX = sourceRect.maxX
+            let endX = categoryRect.x
+            let midX = (startX + endX) / 2
+
+            ribbons.append(
+                FlowRibbon(
+                    sourceID: link.sourceID,
+                    categoryID: link.categoryID,
+                    thickness: sourceThickness,
+                    startX: startX,
+                    startY: startY,
+                    endX: endX,
+                    endY: endY,
+                    control1X: midX,
+                    control1Y: startY,
+                    control2X: midX,
+                    control2Y: endY
+                )
+            )
+        }
+
+        return FlowLayout(
+            sourceRects: sourceRects,
+            categoryRects: categoryRects,
+            ribbons: ribbons,
+            isEmpty: false
+        )
+    }
+
+    /// Stack nodes vertically, height ∝ value, total stacked height + gaps == columnHeight.
+    private static func column(
+        nodes: [IncomeCategoryFlow.Node],
+        x: Double,
+        columnHeight: Double,
+        nodeGap: Double,
+        nodeWidth: Double
+    ) -> [FlowRect] {
+        guard !nodes.isEmpty else { return [] }
+        let total = nodes.reduce(0) { $0 + $1.amount }
+        guard total > 0 else { return [] }
+
+        let gapCount = max(nodes.count - 1, 0)
+        let totalGap = nodeGap * Double(gapCount)
+        let availableForNodes = max(columnHeight - totalGap, 0)
+
+        var rects: [FlowRect] = []
+        var y = 0.0
+        for node in nodes {
+            let nodeHeight = availableForNodes * (node.amount / total)
+            rects.append(FlowRect(id: node.id, x: x, y: y, width: nodeWidth, height: nodeHeight))
+            y += nodeHeight + nodeGap
+        }
+        return rects
+    }
+}
+
+private extension FlowRect {
+    var maxX: Double { x + width }
+}

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -11,6 +11,8 @@ public struct NotificationTriggers: Sendable {
     public var staleSync: Bool
     public var loginRequired: Bool
     public var itemError: Bool
+    /// Gate for watchlist spend nudges (AND-501).
+    public var watchlist: Bool
     public var largeTransactionThreshold: Double
     public var lowBalanceThreshold: Double
     public var creditUtilizationThreshold: Double
@@ -26,6 +28,7 @@ public struct NotificationTriggers: Sendable {
         staleSync: Bool = true,
         loginRequired: Bool = true,
         itemError: Bool = true,
+        watchlist: Bool = true,
         largeTransactionThreshold: Double = 500,
         lowBalanceThreshold: Double = 100,
         creditUtilizationThreshold: Double = 30,
@@ -40,6 +43,7 @@ public struct NotificationTriggers: Sendable {
         self.staleSync = staleSync
         self.loginRequired = loginRequired
         self.itemError = itemError
+        self.watchlist = watchlist
         self.largeTransactionThreshold = largeTransactionThreshold
         self.lowBalanceThreshold = lowBalanceThreshold
         self.creditUtilizationThreshold = creditUtilizationThreshold
@@ -57,13 +61,18 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
     case recurringChargeDetected = "recurring-charge-detected"
     case recurringChargeChanged = "recurring-charge-changed"
     case recurringChargeDueSoon = "recurring-charge-due-soon"
+    case merchantWatch = "merchant-watch"
+    case categoryWatch = "category-watch"
 
     public var clearsWhenResolved: Bool {
         switch self {
         case .itemError, .loginRequired, .syncStale, .highUtilization, .lowBalance,
              .recurringChargeChanged, .recurringChargeDueSoon:
             true
-        case .largeTransaction, .recurringChargeDetected:
+        // A crossed watchlist threshold is a one-shot like largeTransaction:
+        // the spend already happened, so it should not auto-clear when the
+        // month-to-date sum later changes.
+        case .largeTransaction, .recurringChargeDetected, .merchantWatch, .categoryWatch:
             false
         }
     }
@@ -121,6 +130,7 @@ public enum NotificationTriggerSelection {
         accounts: [AccountDTO] = [],
         recurringTransactions: [RecurringTransaction] = [],
         itemStatuses: [ItemStatus] = [],
+        watchlistTargets: [WatchlistTarget] = [],
         isSyncStale: Bool = false,
         now: Date = Date(),
         calendar: Calendar = .current,
@@ -195,6 +205,17 @@ public enum NotificationTriggerSelection {
                 threshold: config.largeTransactionThreshold
             ) {
                 append(largeTransactionDecision(for: transaction))
+            }
+        }
+
+        if config.watchlist {
+            for match in WatchlistEvaluator.evaluate(
+                transactions: transactions,
+                targets: watchlistTargets,
+                now: now,
+                calendar: calendar
+            ) {
+                append(watchlistDecision(for: match))
             }
         }
 
@@ -393,6 +414,31 @@ public enum NotificationTriggerSelection {
             ),
             title: "Recurring charge due soon",
             body: "An inferred recurring charge is expected soon.",
+            severity: .informational
+        )
+    }
+
+    private static func watchlistDecision(
+        for match: WatchlistEvaluator.Match
+    ) -> NotificationTriggerDecision {
+        let target = match.target
+        let kind: NotificationTriggerKind = target.kind == .merchant ? .merchantWatch : .categoryWatch
+        // Key on target + month + threshold (in cents) so each month re-arms the
+        // nudge and raising the limit re-notifies once the higher bar is crossed.
+        let thresholdCents = Int((target.monthlyThreshold * 100).rounded())
+        let sourceID = "\(target.kind.rawValue):\(target.key)#\(match.monthKey)#\(thresholdCents)"
+        // Lock-screen copy stays generic — no merchant name, category, or amount
+        // (privacy hard rule, see NotificationTriggerEvaluationTests). The exact
+        // "$X at Y this month" framing lives in-app where the device is unlocked.
+        let body: String = switch target.kind {
+        case .merchant: "A merchant you're watching crossed its monthly spend limit. Open VaultPeek for details."
+        case .category: "A spending category you're watching crossed its monthly limit. Open VaultPeek for details."
+        }
+        return NotificationTriggerDecision(
+            kind: kind,
+            dedupKey: dedupKey(kind: kind, sourceID: sourceID),
+            title: "Watchlist nudge",
+            body: body,
             severity: .informational
         )
     }

--- a/Sources/PlaidBarCore/Utilities/PendingHoldsCalculator.swift
+++ b/Sources/PlaidBarCore/Utilities/PendingHoldsCalculator.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Sums pending outflow holds on spendable cash accounts (AND-499).
+///
+/// A "pending hold" is money already authorized but not yet posted — a charge
+/// Plaid reports with `pending == true` and a positive (money-out) amount.
+/// Pure, Sendable, deterministic (no `Date()`).
+///
+/// IMPORTANT — double-subtraction risk: Plaid's `available` balance (used by
+/// `SafeToSpendCalculator.startingCash` via `BalanceDTO.effectiveBalance`)
+/// already nets *some* pending holds. Subtracting this total as a new
+/// safe-to-spend component on top of an `available`-based starting cash would
+/// double-count those holds. The total is only safe to subtract when starting
+/// cash uses `current` (safe-to-spend model B). The calculator therefore takes
+/// `pendingHolds` as an explicit caller-supplied parameter (default 0) rather
+/// than computing it itself, so the headline number does not silently shift.
+public enum PendingHoldsCalculator {
+    /// Total absolute pending outflow hold amount for the included cash accounts.
+    ///
+    /// - Parameters:
+    ///   - transactions: all known transactions.
+    ///   - accounts: all accounts (used to resolve each transaction's account type).
+    ///   - includedCashAccountTypes: account types treated as spendable cash.
+    ///     Defaults to depository only, matching `SafeToSpendInputs`.
+    /// - Returns: the summed absolute amount of pending outflows on those
+    ///   accounts (>= 0). Posted transactions, inflows, own-account transfers,
+    ///   and transactions on excluded accounts contribute nothing.
+    public static func pendingHolds(
+        from transactions: [TransactionDTO],
+        accounts: [AccountDTO],
+        includedCashAccountTypes: Set<AccountType> = [.depository]
+    ) -> Double {
+        // Resolve which account ids are spendable cash.
+        let cashAccountIDs = Set(
+            accounts
+                .filter { includedCashAccountTypes.contains($0.type) }
+                .map(\.id)
+        )
+
+        return transactions.reduce(0) { total, transaction in
+            guard transaction.pending,
+                  cashAccountIDs.contains(transaction.accountId),
+                  isOutflowHold(transaction)
+            else { return total }
+            return total + transaction.displayAmount
+        }
+    }
+
+    /// Whether a pending transaction is a real outflow hold (not an inflow or an
+    /// own-account transfer). Mirrors `SafeToSpendCalculator.isOutflowObligation`.
+    static func isOutflowHold(_ transaction: TransactionDTO) -> Bool {
+        // Plaid: positive amount = money out. A pending credit/refund is an
+        // inflow and must not reduce spendable cash.
+        guard transaction.amount > 0 else { return false }
+        switch transaction.category {
+        case .income, .transfer, .transferOut:
+            return false
+        default:
+            return true
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/SafeToSpendCalculator.swift
+++ b/Sources/PlaidBarCore/Utilities/SafeToSpendCalculator.swift
@@ -23,6 +23,7 @@ public enum SafeToSpendCalculator {
         recurringTransactions: [RecurringTransaction],
         cashflow: WealthSummaryPresentation.CashflowSummary? = nil,
         inputs: SafeToSpendInputs = .default,
+        pendingHolds: Double = 0,
         asOf date: Date,
         calendar: Calendar = .current
     ) -> SafeToSpendResult {
@@ -47,9 +48,20 @@ public enum SafeToSpendCalculator {
             calendar: calendar
         )
 
+        // Pending holds are clamped to non-negative and subtracted. Defaulting to
+        // 0 keeps the result byte-identical to today's behavior unless a caller
+        // explicitly supplies holds (gated on the safe-to-spend model B decision
+        // so `available`-based starting cash never double-subtracts).
+        let pendingHoldsTotal = max(pendingHolds, 0)
+
         var components: [SafeToSpendComponent] = [
             SafeToSpendComponent(kind: .startingCash, label: "Starting cash", amount: startingCash),
             SafeToSpendComponent(kind: .expectedIncome, label: "Expected income", amount: income.amount),
+            SafeToSpendComponent(
+                kind: .pendingHolds,
+                label: "Pending holds",
+                amount: -pendingHoldsTotal
+            ),
             SafeToSpendComponent(
                 kind: .upcomingObligations,
                 label: "Upcoming bills",

--- a/Sources/PlaidBarCore/Utilities/SubscriptionCancelGuidance.swift
+++ b/Sources/PlaidBarCore/Utilities/SubscriptionCancelGuidance.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Where to send a user who wants to cancel a recurring subscription (AND-497).
+///
+/// Pure, Sendable, table-driven resolver: a small hand-curated map from known
+/// merchant names to the merchant's own cancellation/manage-subscription page.
+/// Unknown merchants fall back to a generic web search for "how to cancel
+/// <merchant>". No network, no Date — fully testable in PlaidBarCore.
+public enum SubscriptionCancelGuidance {
+    /// Resolved guidance for one merchant.
+    public struct Result: Sendable, Hashable {
+        /// Destination to open (the merchant's own page, or a generic search).
+        public let url: URL
+        /// Short link text for the UI, e.g. "How to cancel".
+        public let linkText: String
+        /// True when `url` points at the merchant's own cancellation page rather
+        /// than a generic search fallback. Lets the UI phrase it more precisely.
+        public let isSpecific: Bool
+
+        public init(url: URL, linkText: String, isSpecific: Bool) {
+            self.url = url
+            self.linkText = linkText
+            self.isSpecific = isSpecific
+        }
+    }
+
+    /// Curated merchant → cancellation-page map. Keys are normalized (lowercased,
+    /// trimmed) so " Netflix " and "netflix" both match. Values are the
+    /// merchant's public account/cancellation page.
+    private static let knownCancelPages: [String: String] = [
+        "netflix": "https://www.netflix.com/cancelplan",
+        "spotify": "https://support.spotify.com/article/cancel-premium/",
+        "adobe": "https://account.adobe.com/plans",
+        "hulu": "https://help.hulu.com/article/hulu-how-do-i-cancel-my-subscription",
+        "disney+": "https://help.disneyplus.com/article/disneyplus-cancel-subscription",
+        "disney plus": "https://help.disneyplus.com/article/disneyplus-cancel-subscription",
+        "apple": "https://support.apple.com/118428",
+        "amazon prime": "https://www.amazon.com/gp/primecentral",
+        "youtube premium": "https://www.youtube.com/paid_memberships",
+        "planet fitness": "https://www.planetfitness.com/account",
+        "audible": "https://www.audible.com/account/membership",
+        "dropbox": "https://www.dropbox.com/account/plan",
+        "icloud": "https://support.apple.com/118428",
+    ]
+
+    /// Resolve cancellation guidance for a merchant name.
+    ///
+    /// - Parameter merchantName: the displayed merchant name (any casing/whitespace).
+    /// - Returns: a specific merchant page when known, otherwise a generic
+    ///   "how to cancel <merchant>" web search. Always non-nil with a valid URL.
+    public static func guidance(for merchantName: String) -> Result {
+        let normalized = normalize(merchantName)
+
+        if !normalized.isEmpty,
+           let page = knownCancelPages[normalized],
+           let url = URL(string: page) {
+            return Result(url: url, linkText: "How to cancel", isSpecific: true)
+        }
+
+        return Result(url: searchURL(for: merchantName), linkText: "How to cancel", isSpecific: false)
+    }
+
+    /// Lowercased, whitespace-trimmed key used for map lookups.
+    static func normalize(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    /// Generic fallback: a web search for how to cancel the named subscription.
+    static func searchURL(for merchantName: String) -> URL {
+        let trimmed = merchantName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = trimmed.isEmpty ? "how to cancel a subscription" : "how to cancel \(trimmed) subscription"
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            ?? "how%20to%20cancel%20a%20subscription"
+        // DuckDuckGo HTML search — no tracking redirect, stable query format.
+        return URL(string: "https://duckduckgo.com/?q=\(encoded)")
+            ?? URL(string: "https://duckduckgo.com")!
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/WatchlistEvaluator.swift
+++ b/Sources/PlaidBarCore/Utilities/WatchlistEvaluator.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Pure month-to-date spend evaluation for watchlist nudges (AND-501).
+///
+/// Given the current transactions and the user's [WatchlistTarget], computes
+/// month-to-date expense spend per target and reports which targets have crossed
+/// their threshold. Income and own-account transfers are excluded by reusing
+/// `SpendingSummary.expenseTransactions`. Deterministic with an injected `now` +
+/// `Calendar` — no hidden `Date()`.
+public enum WatchlistEvaluator {
+    /// A watchlist target that has crossed its month-to-date threshold.
+    public struct Match: Sendable, Equatable, Identifiable {
+        public let target: WatchlistTarget
+        /// Month-to-date spend at this target (>= the threshold).
+        public let currentSpend: Double
+        /// `yyyy-MM` key for the month the spend is summed over. Feeds the
+        /// dedup key so each month re-arms the nudge.
+        public let monthKey: String
+
+        public var id: String { "\(target.id.uuidString)#\(monthKey)" }
+
+        public init(target: WatchlistTarget, currentSpend: Double, monthKey: String) {
+            self.target = target
+            self.currentSpend = currentSpend
+            self.monthKey = monthKey
+        }
+    }
+
+    /// Evaluate all targets against month-to-date spend.
+    ///
+    /// - Parameters:
+    ///   - transactions: all known transactions (any window).
+    ///   - targets: the user's configured watches.
+    ///   - now: reference "today" defining the current calendar month.
+    ///   - calendar: calendar used to bound the month.
+    /// - Returns: one `Match` per target whose month-to-date spend is >= its
+    ///   threshold (threshold > 0). Order follows `targets`.
+    public static func evaluate(
+        transactions: [TransactionDTO],
+        targets: [WatchlistTarget],
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [Match] {
+        guard !targets.isEmpty else { return [] }
+
+        let monthKey = monthKey(for: now, calendar: calendar)
+        let monthStart = monthStartString(for: now, calendar: calendar)
+
+        // Restrict to current-month expense rows once, then sum per target.
+        let monthExpenses = SpendingSummary.expenseTransactions(
+            from: transactions,
+            startingAt: monthStart
+        )
+
+        return targets.compactMap { target -> Match? in
+            guard target.monthlyThreshold > 0 else { return nil }
+            let spend = monthToDateSpend(for: target, in: monthExpenses)
+            guard spend >= target.monthlyThreshold else { return nil }
+            return Match(target: target, currentSpend: spend, monthKey: monthKey)
+        }
+    }
+
+    /// Month-to-date spend for one target across already-filtered expense rows.
+    static func monthToDateSpend(
+        for target: WatchlistTarget,
+        in monthExpenses: [TransactionDTO]
+    ) -> Double {
+        monthExpenses.reduce(0) { total, transaction in
+            guard matches(target, transaction) else { return total }
+            return total + transaction.displayAmount
+        }
+    }
+
+    /// Whether a transaction belongs to a target.
+    static func matches(_ target: WatchlistTarget, _ transaction: TransactionDTO) -> Bool {
+        switch target.kind {
+        case .merchant:
+            return WatchlistTarget.normalizeMerchant(transaction.displayName) == target.key
+        case .category:
+            return transaction.category == target.category
+        }
+    }
+
+    /// `yyyy-MM` key for the month containing `date`.
+    static func monthKey(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        let year = components.year ?? 0
+        let month = components.month ?? 0
+        return String(format: "%04d-%02d", year, month)
+    }
+
+    /// First-of-month `yyyy-MM-dd` string used to bound month-to-date spend.
+    static func monthStartString(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        let startOfMonth = calendar.date(from: components) ?? calendar.startOfDay(for: date)
+        return Formatters.transactionDateString(startOfMonth)
+    }
+}

--- a/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Balance projector (AND-498)")
+struct BalanceProjectorTests {
+    private static let calendar = Calendar(identifier: .gregorian)
+    private static var asOf: Date { Formatters.parseTransactionDate("2026-06-01")! }
+
+    @Test("Nil anchor yields nil projection")
+    func nilAnchorReturnsNil() {
+        let projection = BalanceProjector.project(
+            anchor: nil,
+            recurring: [],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )
+        #expect(projection == nil)
+    }
+
+    @Test("Empty history via presentation -> insufficientHistory with needed count")
+    func emptyHistoryPresentation() {
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: [],
+            recurring: [],
+            now: Self.asOf,
+            calendar: Self.calendar
+        )
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation else {
+            Issue.record("expected insufficientHistory")
+            return
+        }
+        #expect(pointCount == 0)
+        #expect(requiredPointCount == PlaidBarConstants.projectedBalanceMinimumHistoryPoints)
+    }
+
+    @Test("Anchor + one monthly outflow due in 10 days steps down once on that day")
+    func singleOutflowStepsDownOnce() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let stream = Self.recurring(
+            "Rent", amount: 200, nextExpectedDate: "2026-06-11", category: .billsAndUtilities
+        )
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [stream],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        // Series length = horizon + 1 (anchor + each future day).
+        #expect(projection.series.count == 31)
+        // First projected point equals the anchor.
+        #expect(projection.series.first?.balance == 1_000)
+        // Day 9 (the day before the charge) is still 1000; day 10 drops to 800.
+        #expect(projection.series[9].balance == 1_000)
+        #expect(projection.series[10].balance == 800)
+        // The monthly stream recurs at +30 days = day 40, past the 30-day horizon,
+        // so only one step occurs.
+        #expect(projection.series.last?.balance == 800)
+        // Projected low equals anchor - averageAmount on the due day.
+        #expect(projection.projectedLow.balance == 800)
+        #expect(projection.confidence == .lowConfidence)
+    }
+
+    @Test("Two streams accumulate on the correct days; low is the global minimum")
+    func twoStreamsAccumulate() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let monthly = Self.recurring("Rent", amount: 300, nextExpectedDate: "2026-06-06", category: .billsAndUtilities)
+        let biweekly = Self.recurring(
+            "Bill", amount: 100, frequency: .biweekly, nextExpectedDate: "2026-06-04", category: .billsAndUtilities
+        )
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [monthly, biweekly],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        // Biweekly: day 3 (-100 -> 900), day 17 (-100 -> 800 cumulative after rent).
+        // Monthly rent: day 5 (-300).
+        // Running: d3 900, d5 600, d17 500, d31 (biweekly again at day 31>30? day 3+14+14=31 just past) ...
+        #expect(projection.series[3].balance == 900)
+        #expect(projection.series[5].balance == 600)
+        #expect(projection.series[17].balance == 500)
+        // Global minimum is the lowest running balance.
+        #expect(projection.projectedLow.balance == projection.series.map(\.balance).min())
+    }
+
+    @Test("Below-confidence and income/transfer streams are handled per gating")
+    func gatingExcludesAndIncludes() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let lowConfidence = Self.recurring(
+            "Weak", amount: 500, nextExpectedDate: "2026-06-05", category: .billsAndUtilities, confidence: 0.3
+        )
+        let transfer = Self.recurring(
+            "Move", amount: 500, nextExpectedDate: "2026-06-05", category: .transferOut
+        )
+        let income = Self.recurring(
+            "Paycheck", amount: 400, nextExpectedDate: "2026-06-10", category: .income
+        )
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [lowConfidence, transfer, income],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        // Low-confidence + transfer excluded; income adds on day 10.
+        #expect(projection.series[10].balance == 1_400)
+        // No outflow at all, so the line only ever goes up -> low is the anchor.
+        #expect(projection.projectedLow.balance == 1_000)
+    }
+
+    @Test("Horizon boundary: occurrence on the edge is included, one day past excluded")
+    func horizonBoundary() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let onEdge = Self.recurring(
+            "Edge", amount: 50, frequency: .annual, nextExpectedDate: "2026-07-01", category: .billsAndUtilities
+        )
+        // 2026-06-01 + 30 days = 2026-07-01 (the inclusive horizon edge).
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [onEdge],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        #expect(projection.series.last?.balance == 950)
+
+        let pastEdge = Self.recurring(
+            "Past", amount: 50, frequency: .annual, nextExpectedDate: "2026-07-02", category: .billsAndUtilities
+        )
+        let projection2 = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [pastEdge],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        #expect(projection2.series.last?.balance == 1_000)
+        #expect(projection2.confidence == .lowConfidence) // it is still a signal
+    }
+
+    @Test("Deterministic across two calls with the same inputs")
+    func deterministic() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let stream = Self.recurring("Rent", amount: 200, nextExpectedDate: "2026-06-11", category: .billsAndUtilities)
+        let a = BalanceProjector.project(anchor: anchor, recurring: [stream], asOf: Self.asOf, horizonDays: 30, calendar: Self.calendar)
+        let b = BalanceProjector.project(anchor: anchor, recurring: [stream], asOf: Self.asOf, horizonDays: 30, calendar: Self.calendar)
+        #expect(a == b)
+    }
+
+    @Test("No obligation signal -> insufficientData confidence")
+    func noSignalInsufficient() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        #expect(projection.confidence == .insufficientData)
+        // Flat line: every point equals the anchor.
+        #expect(projection.series.allSatisfy { $0.balance == 1_000 })
+    }
+
+    @Test("Presentation requires the minimum history points")
+    func presentationRequiresHistory() {
+        let oneSnapshot = [BalanceSnapshot(date: Self.asOf, balance: 1_000)]
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: oneSnapshot,
+            recurring: [],
+            now: Self.asOf,
+            requiredPointCount: 2,
+            calendar: Self.calendar
+        )
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation else {
+            Issue.record("expected insufficientHistory")
+            return
+        }
+        #expect(pointCount == 1)
+        #expect(requiredPointCount == 2)
+    }
+
+    @Test("Anchor is the latest snapshot by date")
+    func anchorsOnLatest() {
+        let history = [
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-05-01")!, balance: 500),
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-05-31")!, balance: 1_200),
+        ]
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: history,
+            recurring: [],
+            now: Self.asOf,
+            calendar: Self.calendar
+        )
+        let projection = try? #require(presentation.projection)
+        #expect(projection?.anchorBalance == 1_200)
+    }
+
+    @Test("Demo data produces a non-trivial projection in-window")
+    func demoProducesProjection() {
+        let now = Formatters.parseTransactionDate("2026-06-15")!
+        let history = DemoFixtures.balanceHistory(now: now, calendar: Self.calendar)
+        let recurring = RecurringDetector.detect(from: DemoFixtures.transactions(now: now, calendar: Self.calendar))
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: history,
+            recurring: recurring,
+            now: now,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )
+        let projection = try? #require(presentation.projection)
+        // The forward line should step (not stay perfectly flat) given demo bills.
+        let balances = Set(projection?.series.map(\.balance) ?? [])
+        #expect(balances.count > 1)
+    }
+
+    private static func recurring(
+        _ merchant: String,
+        amount: Double,
+        frequency: RecurringFrequency = .monthly,
+        nextExpectedDate: String,
+        category: SpendingCategory?,
+        confidence: Double = 0.9
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchant,
+            frequency: frequency,
+            averageAmount: amount,
+            lastDate: "2026-05-20",
+            nextExpectedDate: nextExpectedDate,
+            category: category,
+            transactionCount: 4,
+            confidence: confidence
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/ForgottenSubscriptionTests.swift
+++ b/Tests/PlaidBarCoreTests/ForgottenSubscriptionTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Forgotten subscription finder (AND-497)")
+struct ForgottenSubscriptionTests {
+    // A fixed "today" close to the streams' last charge so nothing is stale.
+    private static let asOf = "2026-05-20"
+
+    @Test("Long-lived low-cost monthly stream at the cycle threshold is forgotten")
+    func longLivedLowCostStreamIsForgotten() {
+        let stream = Self.recurring(
+            averageAmount: 4.99,
+            lastDate: "2026-05-10",
+            transactionCount: PlaidBarConstants.forgottenSubscriptionMinimumCycles
+        )
+        #expect(stream.isForgotten(asOf: Self.asOf))
+        #expect(stream.flags(asOf: Self.asOf).contains(.forgotten))
+    }
+
+    @Test("Stream below the cycle threshold is not forgotten")
+    func belowCycleThresholdIsNotForgotten() {
+        let stream = Self.recurring(
+            averageAmount: 4.99,
+            lastDate: "2026-05-10",
+            transactionCount: PlaidBarConstants.forgottenSubscriptionMinimumCycles - 1
+        )
+        #expect(!stream.isForgotten(asOf: Self.asOf))
+    }
+
+    @Test("Stream above the cost ceiling is not forgotten")
+    func aboveCostCeilingIsNotForgotten() {
+        let stream = Self.recurring(
+            averageAmount: PlaidBarConstants.forgottenSubscriptionMaxAmount + 0.01,
+            lastDate: "2026-05-10",
+            transactionCount: 12
+        )
+        #expect(!stream.isForgotten(asOf: Self.asOf))
+    }
+
+    @Test("Weekly/biweekly cadences are too frequent to be forgotten")
+    func frequentCadencesAreNotForgotten() {
+        for frequency in [RecurringFrequency.weekly, .biweekly] {
+            let stream = Self.recurring(
+                frequency: frequency,
+                averageAmount: 4.99,
+                lastDate: "2026-05-18",
+                transactionCount: 20
+            )
+            #expect(!stream.isForgotten(asOf: Self.asOf))
+        }
+    }
+
+    @Test("Non-subscription categories are not forgotten")
+    func unrelatedCategoriesAreNotForgotten() {
+        let stream = Self.recurring(
+            averageAmount: 4.99,
+            lastDate: "2026-05-10",
+            transactionCount: 12,
+            category: .foodAndDrink
+        )
+        #expect(!stream.isForgotten(asOf: Self.asOf))
+    }
+
+    @Test("Stale streams are reported as stale, never forgotten (stale precedence)")
+    func staleStreamsAreNotForgotten() {
+        // Last charge two-plus intervals ago -> stale, so forgotten must be false.
+        let stream = Self.recurring(
+            averageAmount: 4.99,
+            lastDate: "2026-02-01",
+            transactionCount: 12
+        )
+        #expect(stream.isStale(asOf: Self.asOf))
+        #expect(!stream.isForgotten(asOf: Self.asOf))
+        let flags = stream.flags(asOf: Self.asOf)
+        #expect(flags.contains(.stale))
+        #expect(!flags.contains(.forgotten))
+    }
+
+    @Test("flags includes both forgotten and price increase when both hold")
+    func forgottenAndPriceIncreaseCombine() {
+        let stream = Self.recurring(
+            averageAmount: 4.99,
+            latestAmount: 6.99,
+            trailingAverageAmount: 4.99,
+            lastDate: "2026-05-10",
+            transactionCount: 12,
+            confidence: 0.95
+        )
+        #expect(stream.hasPriceIncrease)
+        let flags = stream.flags(asOf: Self.asOf)
+        #expect(flags.contains(.forgotten))
+        #expect(flags.contains(.priceIncrease))
+    }
+
+    @Test("Detected via RecurringDetector: 8 monthly $4.99 charges flag forgotten")
+    func detectorProducesForgottenStream() throws {
+        // Build 8 monthly occurrences ending ~10 days before asOf.
+        var transactions: [TransactionDTO] = []
+        let calendar = Calendar(identifier: .gregorian)
+        let asOfDate = try #require(Formatters.parseTransactionDate("2026-05-20"))
+        for monthsAgo in 0..<8 {
+            let date = calendar.date(byAdding: .day, value: -(10 + monthsAgo * 30), to: asOfDate)!
+            transactions.append(
+                TransactionDTO(
+                    id: "cv-\(monthsAgo)",
+                    accountId: "checking",
+                    amount: 4.99,
+                    date: Formatters.transactionDateString(date),
+                    name: "CLOUDVAULT",
+                    merchantName: "CloudVault",
+                    category: .subscriptions
+                )
+            )
+        }
+        let recurring = try #require(RecurringDetector.detect(from: transactions).first)
+        #expect(recurring.transactionCount >= PlaidBarConstants.forgottenSubscriptionMinimumCycles)
+        #expect(recurring.isForgotten(asOf: asOfDate, calendar: calendar))
+    }
+
+    @Test("Forgotten items sort ahead of plain attention and due-soon items")
+    func forgottenSortsFirst() {
+        let forgotten = Self.recurring(
+            merchantName: "CloudVault",
+            averageAmount: 4.99,
+            lastDate: "2026-05-10",
+            nextExpectedDate: "2026-06-10",
+            transactionCount: 12
+        )
+        // A price-increase (attention) stream that is NOT forgotten.
+        let attention = Self.recurring(
+            merchantName: "BigSaaS",
+            averageAmount: 80,
+            latestAmount: 100,
+            trailingAverageAmount: 80,
+            lastDate: "2026-05-15",
+            nextExpectedDate: "2026-06-01",
+            transactionCount: 5,
+            confidence: 0.95
+        )
+        // A plain due-soon stream with no flags.
+        let plain = Self.recurring(
+            merchantName: "Plain",
+            averageAmount: 40,
+            lastDate: "2026-05-18",
+            nextExpectedDate: "2026-05-25",
+            transactionCount: 4
+        )
+
+        let date = Formatters.parseTransactionDate(Self.asOf)!
+        let presentation = RecurringObligationsPresentation.make(
+            from: [plain, attention, forgotten],
+            asOf: date,
+            calendar: Calendar(identifier: .gregorian)
+        )
+        #expect(presentation.items.first?.merchantName == "CloudVault")
+        #expect(presentation.items.first?.isForgotten == true)
+        #expect(presentation.forgottenCount == 1)
+        // attention (flagged but not forgotten) ranks ahead of the plain stream.
+        let order = presentation.items.map(\.merchantName)
+        #expect(order.firstIndex(of: "BigSaaS")! < order.firstIndex(of: "Plain")!)
+    }
+
+    @Test("Surface presentation builds a forgotten callout and per-row flag")
+    func surfaceBuildsForgottenCallout() {
+        let forgotten = Self.recurring(
+            merchantName: "Netflix",
+            averageAmount: 9.99,
+            lastDate: "2026-05-10",
+            nextExpectedDate: "2026-06-10",
+            transactionCount: 12,
+            category: .entertainment
+        )
+        let date = Formatters.parseTransactionDate(Self.asOf)!
+        let surface = RecurringPaymentsSurfacePresentation.make(
+            from: [forgotten],
+            asOf: date,
+            calendar: Calendar(identifier: .gregorian)
+        )
+        #expect(surface.forgottenCount == 1)
+        #expect(surface.forgottenCalloutText != nil)
+        let row = surface.rows.first
+        #expect(row?.isForgotten == true)
+        // Netflix is in the cancel-guidance map -> a specific (non-generic) link.
+        #expect(row?.cancelIsSpecific == true)
+        #expect(row?.flagExplanations.contains(where: { $0.contains("forgotten") }) == true)
+    }
+
+    @Test("Demo fixtures expose at least one forgotten subscription")
+    func demoFixturesExposeForgotten() {
+        let calendar = Calendar(identifier: .gregorian)
+        let now = Date()
+        let recurring = RecurringDetector.detect(from: DemoFixtures.transactions(now: now, calendar: calendar))
+        let forgotten = recurring.filter { $0.isForgotten(asOf: now, calendar: calendar) }
+        #expect(!forgotten.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private static func recurring(
+        merchantName: String = "StreamCo",
+        frequency: RecurringFrequency = .monthly,
+        averageAmount: Double = 4.99,
+        latestAmount: Double? = nil,
+        trailingAverageAmount: Double? = nil,
+        lastDate: String = "2026-05-10",
+        nextExpectedDate: String = "2026-06-10",
+        transactionCount: Int = 12,
+        confidence: Double = 0.9,
+        category: SpendingCategory? = .subscriptions
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchantName,
+            frequency: frequency,
+            averageAmount: averageAmount,
+            latestAmount: latestAmount,
+            trailingAverageAmount: trailingAverageAmount,
+            lastDate: lastDate,
+            nextExpectedDate: nextExpectedDate,
+            category: category,
+            transactionCount: transactionCount,
+            confidence: confidence
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/IncomeCategoryFlowTests.swift
+++ b/Tests/PlaidBarCoreTests/IncomeCategoryFlowTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Income → category flow (AND-500)")
+struct IncomeCategoryFlowTests {
+    @Test("incomeSources groups same-merchant inflows and excludes outflows/transfers")
+    func incomeSourcesGroupAndExclude() {
+        let transactions = [
+            tx(id: "a", amount: -1_000, merchant: "Employer", category: .income),
+            tx(id: "b", amount: -500, merchant: "Employer", category: .income),
+            tx(id: "c", amount: -300, merchant: "Stripe", category: .income),
+            // Outflow — excluded.
+            tx(id: "d", amount: 80, merchant: "Whole Foods", category: .foodAndDrink),
+            // Transfer-in — isIncome (negative) but should it count? It's an inflow.
+            // Income grouping keys on isIncome, so transfer-in inflows are included
+            // as a "source"; we assert the two real income merchants group correctly.
+        ]
+        let sources = IncomeCategoryFlow.incomeSources(from: transactions)
+        let employer = sources.first { $0.label == "Employer" }
+        #expect(employer?.amount == 1_500)
+        #expect(sources.contains { $0.label == "Stripe" })
+        #expect(!sources.contains { $0.label == "Whole Foods" })
+    }
+
+    @Test("Source amounts use abs(amount) and sort descending")
+    func sourcesUseAbsAndSortDesc() {
+        let transactions = [
+            tx(id: "a", amount: -300, merchant: "Small", category: .income),
+            tx(id: "b", amount: -900, merchant: "Big", category: .income),
+        ]
+        let sources = IncomeCategoryFlow.incomeSources(from: transactions)
+        #expect(sources.map(\.label) == ["Big", "Small"])
+        #expect(sources.first?.amount == 900)
+    }
+
+    @Test("Spend column delegates to SpendingSummary (excludes income + transfers)")
+    func spendColumnDelegates() {
+        let transactions = [
+            tx(id: "a", amount: -1_000, merchant: "Employer", category: .income),
+            tx(id: "b", amount: 100, merchant: "Store", category: .shopping),
+            tx(id: "c", amount: 60, merchant: "Cafe", category: .foodAndDrink),
+            tx(id: "d", amount: 200, merchant: "Move", category: .transferOut),
+        ]
+        let graph = IncomeCategoryFlow.graph(from: transactions)
+        let categoryIDs = Set(graph.categories.map(\.id))
+        #expect(categoryIDs.contains(SpendingCategory.shopping.rawValue))
+        #expect(categoryIDs.contains(SpendingCategory.foodAndDrink.rawValue))
+        #expect(!categoryIDs.contains(SpendingCategory.income.rawValue))
+        #expect(!categoryIDs.contains(SpendingCategory.transferOut.rawValue))
+    }
+
+    @Test("Each source's outgoing ribbons sum to that source's total")
+    func sourceRibbonsSumToTotal() {
+        let graph = sampleGraph()
+        for source in graph.sources {
+            let outgoing = graph.links.filter { $0.sourceID == source.id }.reduce(0) { $0 + $1.amount }
+            #expect(abs(outgoing - source.amount) < 0.001)
+        }
+    }
+
+    @Test("Each category's incoming ribbons sum to that category's spend")
+    func categoryRibbonsSumToSpend() {
+        let graph = sampleGraph()
+        // Incoming per category = sum over sources of (sourceTotal * categoryShare)
+        // = totalIncome * categoryShare. Only equals category spend when income
+        // == spend; otherwise it is proportional. Assert proportional consistency:
+        // each category's incoming share of total-incoming equals its spend share.
+        let totalIncoming = graph.links.reduce(0) { $0 + $1.amount }
+        for category in graph.categories {
+            let incoming = graph.links.filter { $0.categoryID == category.id }.reduce(0) { $0 + $1.amount }
+            let incomingShare = incoming / totalIncoming
+            let spendShare = category.amount / graph.totalSpend
+            #expect(abs(incomingShare - spendShare) < 0.001)
+        }
+    }
+
+    @Test("Layout node heights are proportional and fill available height")
+    func layoutHeightsProportional() {
+        let graph = sampleGraph()
+        let layout = FlowLayout.compute(graph: graph, width: 200, height: 100, nodeGap: 8, nodeWidth: 14)
+        #expect(!layout.isEmpty)
+
+        // Source column: total stacked heights + gaps == available height.
+        let sourceHeights = layout.sourceRects.reduce(0) { $0 + $1.height }
+        let sourceGaps = 8.0 * Double(max(layout.sourceRects.count - 1, 0))
+        #expect(abs((sourceHeights + sourceGaps) - 100) < 0.001)
+
+        // Larger value -> taller node (ordering invariant within a column).
+        let sortedByAmount = graph.sources.sorted { $0.amount > $1.amount }
+        if sortedByAmount.count >= 2 {
+            let tallest = layout.sourceRects.first { $0.id == sortedByAmount[0].id }!
+            let shorter = layout.sourceRects.first { $0.id == sortedByAmount[1].id }!
+            #expect(tallest.height >= shorter.height)
+        }
+    }
+
+    @Test("Empty period yields an empty layout with the empty flag, no NaN")
+    func emptyPeriodEmptyLayout() {
+        let graph = IncomeCategoryFlow.graph(from: [])
+        #expect(graph.isEmpty)
+        let layout = FlowLayout.compute(graph: graph, width: 200, height: 100)
+        #expect(layout.isEmpty)
+        #expect(layout.ribbons.isEmpty)
+    }
+
+    @Test("Income-only or spend-only period is degenerate (empty graph)")
+    func oneSidedIsEmpty() {
+        let incomeOnly = IncomeCategoryFlow.graph(from: [tx(id: "a", amount: -100, merchant: "Job", category: .income)])
+        #expect(incomeOnly.isEmpty)
+        let spendOnly = IncomeCategoryFlow.graph(from: [tx(id: "b", amount: 100, merchant: "Store", category: .shopping)])
+        #expect(spendOnly.isEmpty)
+    }
+
+    @Test("Single source + single category produces one full-height ribbon")
+    func singleSourceSingleCategory() {
+        let transactions = [
+            tx(id: "a", amount: -500, merchant: "Job", category: .income),
+            tx(id: "b", amount: 200, merchant: "Store", category: .shopping),
+        ]
+        let graph = IncomeCategoryFlow.graph(from: transactions)
+        #expect(graph.sources.count == 1)
+        #expect(graph.categories.count == 1)
+        #expect(graph.links.count == 1)
+        let layout = FlowLayout.compute(graph: graph, width: 200, height: 100, nodeGap: 8, nodeWidth: 14)
+        #expect(layout.ribbons.count == 1)
+        // Single nodes fill the whole column height (no gaps with one node).
+        #expect(abs((layout.sourceRects.first?.height ?? 0) - 100) < 0.001)
+        #expect(abs((layout.categoryRects.first?.height ?? 0) - 100) < 0.001)
+    }
+
+    @Test("Determinism: identical inputs yield identical geometry")
+    func deterministicGeometry() {
+        let graph = sampleGraph()
+        let a = FlowLayout.compute(graph: graph, width: 240, height: 120)
+        let b = FlowLayout.compute(graph: graph, width: 240, height: 120)
+        #expect(a == b)
+    }
+
+    @Test("Presentation builds non-empty rows and an accessibility summary for demo data")
+    func presentationFromDemo() {
+        let now = Formatters.parseTransactionDate("2026-06-15")!
+        let calendar = Calendar(identifier: .gregorian)
+        let presentation = IncomeCategoryFlowPresentation.make(
+            from: DemoFixtures.transactions(now: now, calendar: calendar)
+        )
+        #expect(!presentation.isEmpty)
+        #expect(!presentation.sources.isEmpty)
+        #expect(!presentation.categories.isEmpty)
+        #expect(presentation.accessibilityLabel.contains("Income"))
+    }
+
+    @Test("Presentation empty-state for an empty period")
+    func presentationEmpty() {
+        let presentation = IncomeCategoryFlowPresentation.make(from: [])
+        #expect(presentation.isEmpty)
+        #expect(!presentation.emptyTitle.isEmpty)
+        #expect(!presentation.emptyDetail.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func sampleGraph() -> IncomeCategoryFlow.Graph {
+        IncomeCategoryFlow.graph(from: [
+            tx(id: "i1", amount: -2_000, merchant: "Employer", category: .income),
+            tx(id: "i2", amount: -600, merchant: "Stripe", category: .income),
+            tx(id: "i3", amount: -200, merchant: "Venmo", category: .income),
+            tx(id: "s1", amount: 400, merchant: "Store", category: .shopping),
+            tx(id: "s2", amount: 250, merchant: "Cafe", category: .foodAndDrink),
+            tx(id: "s3", amount: 150, merchant: "Gas", category: .transportation),
+        ])
+    }
+
+    private func tx(
+        id: String,
+        amount: Double,
+        merchant: String,
+        category: SpendingCategory
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: amount,
+            date: "2026-06-10",
+            name: merchant,
+            merchantName: merchant,
+            category: category
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
@@ -264,6 +264,11 @@ struct NotificationTriggerEvaluationTests {
             itemStatuses: [
                 ItemStatus(id: rawItemID, institutionName: institutionName, status: .error),
             ],
+            watchlistTargets: [
+                // A watchlist nudge whose label/key is the sensitive merchant —
+                // its lock-screen copy must still avoid that name and the amount.
+                WatchlistTarget.merchant(merchantName, threshold: 10),
+            ],
             isSyncStale: true,
             now: fixedNow,
             config: testConfig

--- a/Tests/PlaidBarCoreTests/PendingHoldsCalculatorTests.swift
+++ b/Tests/PlaidBarCoreTests/PendingHoldsCalculatorTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Pending holds calculator (AND-499)")
+struct PendingHoldsCalculatorTests {
+    private static let checking = AccountDTO(
+        id: "checking", itemId: "item", name: "Checking",
+        type: .depository, balances: BalanceDTO(available: 1_000, current: 1_050)
+    )
+    private static let savings = AccountDTO(
+        id: "savings", itemId: "item", name: "Savings",
+        type: .depository, balances: BalanceDTO(available: 5_000, current: 5_000)
+    )
+    private static let credit = AccountDTO(
+        id: "card", itemId: "item", name: "Card",
+        type: .credit, balances: BalanceDTO(current: -300, limit: 2_000)
+    )
+    private static let loan = AccountDTO(
+        id: "loan", itemId: "item", name: "Loan",
+        type: .loan, balances: BalanceDTO(current: -5_000)
+    )
+
+    @Test("Sums absolute amounts of pending outflows on included cash accounts only")
+    func sumsPendingCashOutflows() {
+        let transactions = [
+            tx(id: "a", account: "checking", amount: 80, pending: true),
+            tx(id: "b", account: "savings", amount: 20, pending: true),
+        ]
+        let total = PendingHoldsCalculator.pendingHolds(
+            from: transactions,
+            accounts: [Self.checking, Self.savings]
+        )
+        #expect(abs(total - 100) < 0.001)
+    }
+
+    @Test("Excludes pending transactions on credit/loan accounts")
+    func excludesNonCashAccounts() {
+        let transactions = [
+            tx(id: "a", account: "card", amount: 650, pending: true),
+            tx(id: "b", account: "loan", amount: 200, pending: true),
+        ]
+        let total = PendingHoldsCalculator.pendingHolds(
+            from: transactions,
+            accounts: [Self.checking, Self.credit, Self.loan]
+        )
+        #expect(total == 0)
+    }
+
+    @Test("Excludes pending income and own-account transfers")
+    func excludesInflowsAndTransfers() {
+        let transactions = [
+            // Income: negative amount AND income category — never a hold.
+            tx(id: "a", account: "checking", amount: -500, pending: true, category: .income),
+            // Positive amount but transfer-out category — own-account move.
+            tx(id: "b", account: "checking", amount: 300, pending: true, category: .transferOut),
+            tx(id: "c", account: "checking", amount: 200, pending: true, category: .transfer),
+        ]
+        let total = PendingHoldsCalculator.pendingHolds(
+            from: transactions,
+            accounts: [Self.checking]
+        )
+        #expect(total == 0)
+    }
+
+    @Test("Posted (non-pending) transactions contribute zero")
+    func postedContributeZero() {
+        let transactions = [
+            tx(id: "a", account: "checking", amount: 80, pending: false),
+            tx(id: "b", account: "checking", amount: 40, pending: true),
+        ]
+        let total = PendingHoldsCalculator.pendingHolds(
+            from: transactions,
+            accounts: [Self.checking]
+        )
+        #expect(abs(total - 40) < 0.001)
+    }
+
+    @Test("Empty input returns zero")
+    func emptyReturnsZero() {
+        #expect(PendingHoldsCalculator.pendingHolds(from: [], accounts: []) == 0)
+        #expect(PendingHoldsCalculator.pendingHolds(from: [], accounts: [Self.checking]) == 0)
+    }
+
+    @Test("Demo fixtures expose a non-zero cash pending hold")
+    func demoHasCashHold() {
+        let now = Date()
+        let calendar = Calendar(identifier: .gregorian)
+        let total = PendingHoldsCalculator.pendingHolds(
+            from: DemoFixtures.transactions(now: now, calendar: calendar),
+            accounts: DemoFixtures.accounts
+        )
+        #expect(total > 0)
+    }
+
+    private func tx(
+        id: String,
+        account: String,
+        amount: Double,
+        pending: Bool,
+        category: SpendingCategory = .foodAndDrink
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: account,
+            amount: amount,
+            date: "2026-06-13",
+            name: "Synthetic",
+            merchantName: "Synthetic",
+            category: category,
+            pending: pending
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/RecurringStreamFlagTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringStreamFlagTests.swift
@@ -65,6 +65,15 @@ struct RecurringStreamFlagTests {
         ])
     }
 
+    @Test("Every flag carries color-independent label, icon, and accessibility text")
+    func everyFlagIsColorIndependent() {
+        for flag in RecurringStreamFlag.allCases {
+            #expect(!flag.label.isEmpty)
+            #expect(!flag.iconName.isEmpty)
+            #expect(!flag.accessibilityDescription.isEmpty)
+        }
+    }
+
     @Test("Estimated monthly total can exclude stale streams")
     func estimatedMonthlyTotalCanExcludeStaleStreams() {
         let active = Self.recurring(

--- a/Tests/PlaidBarCoreTests/SafeToSpendCalculatorTests.swift
+++ b/Tests/PlaidBarCoreTests/SafeToSpendCalculatorTests.swift
@@ -239,6 +239,82 @@ struct SafeToSpendCalculatorTests {
 
     // MARK: - Fixtures
 
+    @Test("Pending holds argument yields a negated pendingHolds component (AND-499)")
+    func pendingHoldsComponentIsNegated() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [],
+            inputs: SafeToSpendInputs(manualExpectedIncome: 0),
+            pendingHolds: 86.40,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(component(result, .pendingHolds) == -86.40)
+        // 1000 + 0 - 86.40 = 913.60
+        #expect(abs(result.amount - 913.60) < 0.001)
+    }
+
+    @Test("Signed components still reconcile to amount with the pending line present")
+    func pendingHoldsReconciles() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [
+                recurring("Rent", amount: 500, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+            ],
+            inputs: SafeToSpendInputs(safetyBuffer: 100, manualExpectedIncome: 200),
+            pendingHolds: 50,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.components.reduce(0) { $0 + $1.amount } == result.amount)
+        #expect(result.components.contains { $0.kind == .pendingHolds })
+    }
+
+    @Test("Default pending argument leaves the result identical to today's behavior")
+    func pendingHoldsDefaultIsSourceCompatible() {
+        let accounts = [checking(900), savings(600)]
+        let recurring = [
+            recurring("Rent", amount: 500, nextExpectedDate: "2026-06-20", category: .billsAndUtilities),
+        ]
+        let inputs = SafeToSpendInputs(safetyBuffer: 200, horizon: .endOfMonth)
+
+        let withDefault = SafeToSpendCalculator.compute(
+            accounts: accounts, recurringTransactions: recurring,
+            inputs: inputs, asOf: now, calendar: calendar
+        )
+        let explicitZero = SafeToSpendCalculator.compute(
+            accounts: accounts, recurringTransactions: recurring,
+            inputs: inputs, pendingHolds: 0, asOf: now, calendar: calendar
+        )
+        #expect(withDefault.amount == explicitZero.amount)
+        // A zero pending line never appears in the visible breakdown.
+        #expect(!withDefault.visibleComponents.contains { $0.kind == .pendingHolds })
+    }
+
+    @Test("Pending holds slot in the fixed display order between income and obligations")
+    func pendingHoldsDisplayOrder() {
+        let order = SafeToSpendComponentKind.allCases
+        let incomeIdx = order.firstIndex(of: .expectedIncome)!
+        let pendingIdx = order.firstIndex(of: .pendingHolds)!
+        let obligationsIdx = order.firstIndex(of: .upcomingObligations)!
+        #expect(incomeIdx < pendingIdx)
+        #expect(pendingIdx < obligationsIdx)
+    }
+
+    @Test("Negative pending holds are clamped to zero")
+    func pendingHoldsClamped() {
+        let result = SafeToSpendCalculator.compute(
+            accounts: [checking(1_000)],
+            recurringTransactions: [],
+            inputs: SafeToSpendInputs(manualExpectedIncome: 0),
+            pendingHolds: -500,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(component(result, .pendingHolds) == 0)
+        #expect(result.amount == 1_000)
+    }
+
     private func component(_ result: SafeToSpendResult, _ kind: SafeToSpendComponentKind) -> Double {
         result.components.first { $0.kind == kind }?.amount ?? 0
     }

--- a/Tests/PlaidBarCoreTests/SubscriptionCancelGuidanceTests.swift
+++ b/Tests/PlaidBarCoreTests/SubscriptionCancelGuidanceTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Subscription cancel guidance (AND-497)")
+struct SubscriptionCancelGuidanceTests {
+    @Test("Known merchant resolves to a specific cancellation page")
+    func knownMerchantResolvesSpecific() {
+        let result = SubscriptionCancelGuidance.guidance(for: "Netflix")
+        #expect(result.isSpecific)
+        #expect(result.url.host?.contains("netflix.com") == true)
+        #expect(!result.linkText.isEmpty)
+    }
+
+    @Test("Merchant match is case- and whitespace-insensitive")
+    func matchIsNormalized() {
+        let spaced = SubscriptionCancelGuidance.guidance(for: "  NETFLIX  ")
+        let lower = SubscriptionCancelGuidance.guidance(for: "netflix")
+        #expect(spaced.isSpecific)
+        #expect(spaced.url == lower.url)
+    }
+
+    @Test("Unknown merchant falls back to a well-formed generic search URL")
+    func unknownMerchantFallsBack() {
+        let result = SubscriptionCancelGuidance.guidance(for: "Obscure Gym XYZ")
+        #expect(!result.isSpecific)
+        #expect(result.url.scheme == "https")
+        let query = result.url.query ?? ""
+        #expect(query.contains("cancel"))
+        // The encoded merchant name should appear in the query.
+        #expect(query.lowercased().contains("obscure"))
+    }
+
+    @Test("Empty merchant name still yields a valid generic URL")
+    func emptyMerchantYieldsValidURL() {
+        let result = SubscriptionCancelGuidance.guidance(for: "   ")
+        #expect(!result.isSpecific)
+        #expect(result.url.scheme == "https")
+        #expect(result.url.host != nil)
+    }
+
+    @Test("All curated cancellation URLs are valid https URLs")
+    func curatedURLsAreValid() {
+        // Probe several known merchants spanning the map.
+        for merchant in ["Netflix", "Spotify", "Adobe", "Hulu", "Planet Fitness", "Audible"] {
+            let result = SubscriptionCancelGuidance.guidance(for: merchant)
+            #expect(result.isSpecific, "Expected \(merchant) to resolve to a specific page")
+            #expect(result.url.scheme == "https")
+            #expect(result.url.host != nil)
+        }
+    }
+
+    @Test("normalize lowercases and trims")
+    func normalizeBehaviour() {
+        #expect(SubscriptionCancelGuidance.normalize("  Whole Foods  ") == "whole foods")
+        #expect(SubscriptionCancelGuidance.normalize("NETFLIX") == "netflix")
+    }
+}

--- a/Tests/PlaidBarCoreTests/WatchlistEvaluatorTests.swift
+++ b/Tests/PlaidBarCoreTests/WatchlistEvaluatorTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Watchlist evaluator (AND-501)")
+struct WatchlistEvaluatorTests {
+    private static let calendar = Calendar(identifier: .gregorian)
+    // Mid-month reference so prior/current-month boundaries are unambiguous.
+    private static var now: Date { Formatters.parseTransactionDate("2026-05-15")! }
+
+    @Test("Merchant target crossing threshold yields one match with summed MTD spend")
+    func merchantCrossingProducesMatch() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 10)
+        let transactions = [
+            Self.tx(id: "a", amount: 6, date: "2026-05-03", merchant: "Starbucks"),
+            Self.tx(id: "b", amount: 5, date: "2026-05-10", merchant: "Starbucks"),
+        ]
+        let matches = WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        )
+        #expect(matches.count == 1)
+        #expect(abs((matches.first?.currentSpend ?? 0) - 11) < 0.001)
+        #expect(matches.first?.monthKey == "2026-05")
+    }
+
+    @Test("Merchant target below threshold yields no match")
+    func merchantBelowThresholdNoMatch() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 50)
+        let transactions = [Self.tx(id: "a", amount: 6, date: "2026-05-03", merchant: "Starbucks")]
+        #expect(WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        ).isEmpty)
+    }
+
+    @Test("Category target sums only its expense rows and ignores income/transfers")
+    func categorySumsExpensesOnly() {
+        let target = WatchlistTarget.category(.shopping, threshold: 100)
+        let transactions = [
+            Self.tx(id: "a", amount: 80, date: "2026-05-02", merchant: "StoreA", category: .shopping),
+            Self.tx(id: "b", amount: 40, date: "2026-05-04", merchant: "StoreB", category: .shopping),
+            // Income (negative) at the same category should be excluded.
+            Self.tx(id: "c", amount: -500, date: "2026-05-05", merchant: "Job", category: .income),
+            // A transfer-in row excluded by expenseTransactions.
+            Self.tx(id: "d", amount: 200, date: "2026-05-06", merchant: "Move", category: .transfer),
+        ]
+        let matches = WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        )
+        #expect(matches.count == 1)
+        #expect(abs((matches.first?.currentSpend ?? 0) - 120) < 0.001)
+    }
+
+    @Test("Merchant matching is normalization-insensitive")
+    func merchantMatchingNormalized() {
+        let target = WatchlistTarget.merchant("Whole Foods", threshold: 10)
+        let transactions = [
+            Self.tx(id: "a", amount: 15, date: "2026-05-02", merchant: " whole foods "),
+        ]
+        let matches = WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        )
+        #expect(matches.count == 1)
+    }
+
+    @Test("Only current-month rows count toward the threshold")
+    func onlyCurrentMonthCounts() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 20)
+        let transactions = [
+            // Prior month — must NOT count.
+            Self.tx(id: "a", amount: 18, date: "2026-04-28", merchant: "Starbucks"),
+            // Current month — alone is below threshold.
+            Self.tx(id: "b", amount: 10, date: "2026-05-02", merchant: "Starbucks"),
+        ]
+        #expect(WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        ).isEmpty)
+    }
+
+    @Test("Zero-threshold targets never match")
+    func zeroThresholdNeverMatches() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 0)
+        let transactions = [Self.tx(id: "a", amount: 5, date: "2026-05-02", merchant: "Starbucks")]
+        #expect(WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: [target],
+            now: Self.now,
+            calendar: Self.calendar
+        ).isEmpty)
+    }
+
+    @Test("Demo watchlist targets cross against demo transactions")
+    func demoTargetsCross() {
+        // Use a fixed mid-month 'now' so the explicit recent Starbucks/shopping
+        // rows fall inside the current month deterministically.
+        let demoNow = Formatters.parseTransactionDate("2026-05-15")!
+        let transactions = DemoFixtures.transactions(now: demoNow, calendar: Self.calendar)
+        let matches = WatchlistEvaluator.evaluate(
+            transactions: transactions,
+            targets: DemoFixtures.watchlistTargets(),
+            now: demoNow,
+            calendar: Self.calendar
+        )
+        // At least the Starbucks merchant watch should fire ($12.50 recent coffee).
+        #expect(matches.contains { $0.target.kind == .merchant })
+    }
+
+    // MARK: - NotificationTriggerSelection integration
+
+    @Test("config.watchlist=false suppresses watchlist decisions")
+    func gateOff() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 10)
+        let transactions = [Self.tx(id: "a", amount: 20, date: "2026-05-02", merchant: "Starbucks")]
+        let evaluation = NotificationTriggerSelection.evaluate(
+            transactions: transactions,
+            watchlistTargets: [target],
+            now: Self.now,
+            calendar: Self.calendar,
+            config: NotificationTriggers(watchlist: false)
+        )
+        #expect(!evaluation.decisions.contains { $0.kind == .merchantWatch })
+    }
+
+    @Test("Crossed target appears in decisions and is suppressed once delivered")
+    func crossedAppearsAndDedupes() {
+        let target = WatchlistTarget.merchant("Starbucks", threshold: 10)
+        let transactions = [Self.tx(id: "a", amount: 20, date: "2026-05-02", merchant: "Starbucks")]
+        let config = NotificationTriggers(watchlist: true)
+
+        let first = NotificationTriggerSelection.evaluate(
+            transactions: transactions,
+            watchlistTargets: [target],
+            now: Self.now,
+            calendar: Self.calendar,
+            config: config
+        )
+        let decision = try? #require(first.decisions.first { $0.kind == .merchantWatch })
+        #expect(decision != nil)
+
+        let second = NotificationTriggerSelection.evaluate(
+            transactions: transactions,
+            watchlistTargets: [target],
+            now: Self.now,
+            calendar: Self.calendar,
+            config: config,
+            deliveredDedupKeys: [decision!.dedupKey]
+        )
+        #expect(!second.decisions.contains { $0.dedupKey == decision!.dedupKey })
+    }
+
+    @Test("dedupKey is stable per target+month+threshold but changes when any of them changes")
+    func dedupKeyStability() {
+        let base = WatchlistTarget.merchant("Starbucks", threshold: 10, id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+        let raised = WatchlistTarget.merchant("Starbucks", threshold: 25, id: base.id)
+        let transactions = [Self.tx(id: "a", amount: 30, date: "2026-05-02", merchant: "Starbucks")]
+        let config = NotificationTriggers(watchlist: true)
+
+        func key(target: WatchlistTarget, now: Date) -> String? {
+            NotificationTriggerSelection.evaluate(
+                transactions: transactions,
+                watchlistTargets: [target],
+                now: now,
+                calendar: Self.calendar,
+                config: config
+            ).decisions.first { $0.kind == .merchantWatch }?.dedupKey
+        }
+
+        let mayKey = key(target: base, now: Self.now)
+        let mayKeyAgain = key(target: base, now: Self.now)
+        let raisedKey = key(target: raised, now: Self.now)
+        let juneKey = key(target: base, now: Formatters.parseTransactionDate("2026-06-15")!)
+
+        #expect(mayKey != nil)
+        #expect(mayKey == mayKeyAgain) // stable for same target+month+threshold
+        #expect(mayKey != raisedKey)   // raising threshold re-arms
+        // June has no current-month Starbucks spend so no key — month change
+        // either re-arms (different key) or yields no decision.
+        #expect(juneKey == nil || juneKey != mayKey)
+    }
+
+    // MARK: - Helpers
+
+    private static func tx(
+        id: String,
+        amount: Double,
+        date: String,
+        merchant: String,
+        category: SpendingCategory = .foodAndDrink
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "checking",
+            amount: amount,
+            date: date,
+            name: merchant,
+            merchantName: merchant,
+            category: category
+        )
+    }
+}


### PR DESCRIPTION
Forward-Looking Cash Flow cluster (5 commits, gate-green).

- **AND-497** ✅ Forgotten Subscription Finder — `.forgotten` recurring flag + ranked view.
- **AND-501** ✅ Watchlists — `WatchlistEvaluator` per-merchant/category nudges via NotificationService.
- **AND-498** ✅ Projected Balance Line — `BalanceProjector` 30–90 day on-device forecast.
- **AND-500** ✅ Income → Category Flow — lean local Swift Charts flow/Sankey.
- **AND-499** ⚠️ partial — pending vs posted UI badges shipped; folding pending into the safe-to-spend calc deferred.

Closes AND-497, AND-501, AND-498, AND-500. Part of AND-499 (calc-fold follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)