### PR TITLE
test: mark webhook signal helper sendable

### DIFF
--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -260,7 +260,7 @@ struct WebhookReceiverTests {
             // constraint. The store must translate that into `.duplicate`, never
             // surface the throw.
             let hash = "concurrent-\(UUID().uuidString)"
-            func makeSignal() -> WebhookItemSignal {
+            @Sendable func makeSignal() -> WebhookItemSignal {
                 WebhookItemSignal(
                     itemId: "item-webhook",
                     webhookType: "TRANSACTIONS",


### PR DESCRIPTION
## Summary

- Marks the concurrent webhook duplicate test's local signal factory as `@Sendable` so strict-concurrency + warnings-as-errors builds do not warn when the helper is captured by `async let` child tasks.
- Closes #503.

## Autonomous task IDs

- Task ID(s): t_d4e6d3e0
- Backlog slice: AND-447 bug-hunter follow-up
- Scope note: one focused test-only concurrency annotation in `WebhookReceiverTests.swift`

## Agent coordination

- Builder agent: Hermes / Otto
- Builder branch/worktree: `fix/webhook-test-sendable-signal` at `/Users/otto/workspace/VaultPeek-webhook-sendable`
- Reviewer/merge steward: Otto; do not merge without Felipe approval
- Coordination note: no other agent should push to this branch unless explicitly coordinating through the task/PR thread

## Changed files

- `Tests/PlaidBarServerTests/WebhookReceiverTests.swift`

## Local gates

- [x] `git diff --check`
- [x] `swift build --target PlaidBar --skip-update --disable-keychain` not run; test-only change scoped to `WebhookReceiverTests.swift`.
- [x] `swift build --target PlaidBarServer --skip-update --disable-keychain` not run; test-only change scoped to `WebhookReceiverTests.swift`.
- [x] `swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --filter WebhookReceiverTests`
- [x] Secret scan completed for changed diff (`git diff origin/main...HEAD -- Tests/PlaidBarServerTests/WebhookReceiverTests.swift`).

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude/Codex review auth/token/session/setup-only failures are documented as blocking unless Felipe explicitly grants a one-off override.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties.

## Reviewer local-first and secret-exposure checklist

- [x] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [x] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [x] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first: localhost-only companion server, local data directory, no hosted backend, telemetry, tracking, cloud sync, multi-user account system, or cloud AI over transaction data.
- [x] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking when no local model runtime is configured.
- [x] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data and do not imply production readiness, notarization, distribution, or security properties that have not been verified.

## UI and accessibility checks

- [x] I checked keyboard access and visible focus for UI changes, or this PR has no UI changes.
- [x] I spot-checked VoiceOver labels or announcements for UI changes, or this PR has no UI changes.
- [x] I kept balances, risk, utilization, errors, and chart meaning understandable without relying on color alone.
- [x] I updated docs or screenshots if user-facing behavior changed.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [x] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.
