### PR TITLE
fix: require authoritative OAuth callback success

### DIFF
--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -317,15 +317,6 @@ struct OAuthCallbackRoute: Sendable {
             )
         }
         let state = String(stateParam)
-        if let redirectStatus = Self.completionStatus(from: request) {
-            await hostedLinkCompletions.record(HostedLinkCompletionRecord(
-                state: state,
-                linkToken: nil,
-                linkSessionId: request.uri.queryParameters.get("link_session_id").map { String($0) },
-                status: redirectStatus
-            ))
-            return Self.completionResponse(for: redirectStatus)
-        }
         guard let pendingSession = await pendingLinkSessions.beginCompletion(state: state) else {
             return Response(
                 status: .badRequest,
@@ -334,6 +325,14 @@ struct OAuthCallbackRoute: Sendable {
                     string: Self.expiredPage()
                 ))
             )
+        }
+        if let redirectStatus = Self.completionStatus(from: request) {
+            await hostedLinkCompletions.record(HostedLinkCompletionRecord(
+                state: state,
+                linkToken: nil,
+                linkSessionId: request.uri.queryParameters.get("link_session_id").map { String($0) },
+                status: redirectStatus
+            ))
         }
 
         do {
@@ -431,6 +430,9 @@ struct OAuthCallbackRoute: Sendable {
                 headers: [.contentType: "text/html"],
                 body: .init(byteBuffer: ByteBuffer(string: Self.successPage()))
             )
+        } catch let completionError as HostedLinkCompletionError {
+            await pendingLinkSessions.releaseCompletion(state: state)
+            return Self.completionResponse(for: completionError.status)
         } catch {
             // A failure outside the per-result loop (e.g. /link/token/get) leaves
             // nothing consumed, so the session stays retryable. Keep the HTML
@@ -692,6 +694,12 @@ struct OAuthCallbackRoute: Sendable {
 
 private enum HostedLinkCompletionError: LocalizedError {
     case status(HostedLinkCompletionStatus)
+
+    var status: HostedLinkCompletionStatus {
+        switch self {
+        case let .status(status): status
+        }
+    }
 
     var errorDescription: String? {
         switch self {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -2309,6 +2309,66 @@ struct PlaidBarServerTests {
         }
     }
 
+    @Test("OAuth callback ignores query-only success until Plaid confirms completion")
+    func oauthCallbackDoesNotTrustQueryOnlySuccess() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-oauth-query-success-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let linkToken = "query-success-link-token"
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                linkToken: linkToken,
+                linkSessions: nil,
+                onSuccess: nil,
+                results: nil
+            ),
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: "unused-access-token",
+                itemId: "unused-item",
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: nil,
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken)
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-query-success")
+        let recorder = HostedLinkCompletionResultRecorder()
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions,
+                storePublicTokenResult: { result in
+                    await recorder.store(result)
+                }
+            )
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)&error_code=SUCCESS"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let body = try await Self.responseString(response)
+            let calls = await plaidClient.recordedCalls()
+            let storedPublicTokens = await recorder.recordedPublicTokens()
+
+            #expect(response.status == .badRequest)
+            #expect(body.contains("completed without a public token"))
+            #expect(calls.linkTokens == [linkToken])
+            #expect(calls.publicTokens.isEmpty)
+            #expect(storedPublicTokens.isEmpty)
+        }
+    }
+
     @Test("Hosted Link webhook success allows callback to fetch public token from session lookup")
     func hostedLinkWebhookSuccessAllowsSessionLookup() async throws {
         let directory = FileManager.default.temporaryDirectory
@@ -2602,6 +2662,14 @@ struct PlaidBarServerTests {
         let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.oauth-outcome-copy")
 
         try await withTokenStore(databasePath: databasePath, logger: logger) { store in
+            let pendingLinkSessions = PendingLinkSessionStore()
+            let exitState = await pendingLinkSessions.issueState()
+            let expiredState = await pendingLinkSessions.issueState()
+            let retryState = await pendingLinkSessions.issueState()
+            await pendingLinkSessions.save(state: exitState, linkToken: "unused")
+            await pendingLinkSessions.save(state: expiredState, linkToken: "unused")
+            await pendingLinkSessions.save(state: retryState, linkToken: "unused")
+
             let route = OAuthCallbackRoute(
                 plaidClient: HostedLinkStubPlaidClient(
                     linkTokenGetResponse: PlaidLinkTokenGetResponse(
@@ -2618,20 +2686,20 @@ struct PlaidBarServerTests {
                     accountsResponse: PlaidAccountsResponse(accounts: [], item: nil, requestId: nil)
                 ),
                 tokenStore: store,
-                pendingLinkSessions: PendingLinkSessionStore()
+                pendingLinkSessions: pendingLinkSessions
             )
             let context = TestRequestContext(source: TestRequestContextSource())
 
             let userExit = try await route.handleCallback(
-                request: Self.makeRequest(path: "/oauth/callback?state=exit-state&error_code=USER_EXIT"),
+                request: Self.makeRequest(path: "/oauth/callback?state=\(exitState)&error_code=USER_EXIT"),
                 context: context
             )
             let expired = try await route.handleCallback(
-                request: Self.makeRequest(path: "/oauth/callback?state=expired-state&error_code=LINK_TOKEN_EXPIRED"),
+                request: Self.makeRequest(path: "/oauth/callback?state=\(expiredState)&error_code=LINK_TOKEN_EXPIRED"),
                 context: context
             )
             let retryable = try await route.handleCallback(
-                request: Self.makeRequest(path: "/oauth/callback?state=retry-state&error_code=INSTITUTION_DOWN"),
+                request: Self.makeRequest(path: "/oauth/callback?state=\(retryState)&error_code=INSTITUTION_DOWN"),
                 context: context
             )
 


### PR DESCRIPTION
## Summary
- fixes #509 by validating the pending OAuth `state` before treating redirect status parameters as completion hints
- keeps redirect status copy for validated pending sessions, but no longer lets query-only `SUCCESS` render the connected page before Plaid/public-token confirmation
- adds a regression test for query-only success with no Plaid-confirmed public token

## Tests
- `swift test --filter oauthCallbackDoesNotTrustQueryOnlySuccess` (failed before fix: returned 200 Account Connected with no Plaid lookup; passed after fix)
- `swift test --filter 'oauthCallbackDoesNotTrustQueryOnlySuccess|oauthCallbackDistinguishesUserExitExpiredAndRetryableProviderFailure|hostedLinkWebhookSuccessAllowsSessionLookup|oauthCallbackUsesRedirectPublicTokenWithoutSessionLookup'`
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift test --filter PlaidBarServerTests` (165 tests passed, 9 skipped for unavailable macOS Keychain test writes)
- `git diff --check`

## Privacy/security
Local Hosted Link UX integrity fix only. No Plaid credentials, access tokens, public tokens, account IDs, transaction IDs, balances, or local SQLite data are moved into the app/docs/tests.

## Linear / Kanban
- Linear child creation was blocked by the workspace free issue limit, so GitHub issue #509 remains canonical; parent AND-447 was commented with evidence.
