### PR TITLE
fix: prevent state-keyed forgery from vetoing hosted-link completion

### DIFF
--- a/Sources/PlaidBarServer/Auth/HostedLinkCompletionStore.swift
+++ b/Sources/PlaidBarServer/Auth/HostedLinkCompletionStore.swift
@@ -9,7 +9,7 @@ actor HostedLinkCompletionStore {
     @discardableResult
     func record(_ record: HostedLinkCompletionRecord) -> HostedLinkCompletionRecord {
         purgeEmptyIndexes()
-        if let existing = existingRecord(for: record) {
+        if let existing = existingRecord(for: record), !record.canOverride(existing) {
             return existing
         }
 
@@ -64,6 +64,13 @@ struct HostedLinkCompletionRecord: Equatable, Sendable {
     let linkToken: String?
     let linkSessionId: String?
     let status: HostedLinkCompletionStatus
+    /// Whether this record arrived over a trusted, `state`-bound channel — the
+    /// Plaid OAuth redirect validated against the single-use pending session —
+    /// rather than the unauthenticated `/webhooks/plaid/hosted-link` receiver.
+    /// Webhook records are advisory: a local same-user process can POST them, so
+    /// they default to `authoritative == false` and can never override a record
+    /// from the trusted redirect channel.
+    let authoritative: Bool
     let receivedAt: Date
 
     init(
@@ -71,13 +78,25 @@ struct HostedLinkCompletionRecord: Equatable, Sendable {
         linkToken: String?,
         linkSessionId: String?,
         status: HostedLinkCompletionStatus,
+        authoritative: Bool = false,
         receivedAt: Date = Date()
     ) {
         self.state = state?.trimmedCompletionIdentifier
         self.linkToken = linkToken?.trimmedCompletionIdentifier
         self.linkSessionId = linkSessionId?.trimmedCompletionIdentifier
         self.status = status
+        self.authoritative = authoritative
         self.receivedAt = receivedAt
+    }
+
+    /// A new record may overwrite an existing one only when it carries strictly
+    /// more trust. An authoritative (redirect-bound) record overrides a prior
+    /// unauthenticated (webhook) one — so a forged failure can never lock in
+    /// first and veto a genuine completion. Two unauthenticated records keep
+    /// first-write-wins (no thrashing between competing local POSTs), and an
+    /// authoritative record is never overridden by an unauthenticated one.
+    func canOverride(_ existing: HostedLinkCompletionRecord) -> Bool {
+        authoritative && !existing.authoritative
     }
 
     var identity: String {

--- a/Sources/PlaidBarServer/Routes/LinkRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/LinkRoutes.swift
@@ -327,11 +327,17 @@ struct OAuthCallbackRoute: Sendable {
             )
         }
         if let redirectStatus = Self.completionStatus(from: request) {
+            // This status rides Plaid's OAuth redirect, which only reaches here
+            // after `beginCompletion` validated the unguessable, single-use
+            // `state`. It is therefore authoritative and overrides any failure a
+            // local process may have pre-seeded via the unauthenticated webhook
+            // for the same `state` (see `HostedLinkCompletionRecord.canOverride`).
             await hostedLinkCompletions.record(HostedLinkCompletionRecord(
                 state: state,
                 linkToken: nil,
                 linkSessionId: request.uri.queryParameters.get("link_session_id").map { String($0) },
-                status: redirectStatus
+                status: redirectStatus,
+                authoritative: true
             ))
         }
 
@@ -505,17 +511,24 @@ struct OAuthCallbackRoute: Sendable {
         }
 
         // Plaid returned no public token. Only then consult completion metadata to
-        // surface a precise failure message — and ONLY when it is bound to the
-        // unguessable, single-use `state`. The `link_token`/`link_session_id` keys
-        // are handed to the client and surfaced by Plaid's UI, so trusting them
-        // here would let any local caller poison the shared completion store to
-        // grief a known link session.
+        // surface a precise failure message — and ONLY a record that is both bound
+        // to the unguessable, single-use `state` AND authoritative (captured from
+        // this very OAuth redirect, not the unauthenticated webhook). A stored
+        // record that is merely advisory (an unauthenticated `/webhooks/plaid/
+        // hosted-link` POST) must never drive a terminal failure: a local
+        // same-user process could pre-seed a `state`-keyed failure to grief a
+        // genuine session. The `link_token`/`link_session_id` keys are likewise
+        // untrusted here — they are handed to the client and surfaced by Plaid's
+        // UI, so any local caller could poison the shared completion store with
+        // them. Only the redirect-bound, authoritative status — written above
+        // after the `state` was validated against the pending session — may veto.
         if let state = request.uri.queryParameters.get("state").map({ String($0) }),
            let completion = await hostedLinkCompletions.completion(
                state: state,
                linkToken: nil,
                linkSessionId: nil
            ),
+           completion.authoritative,
            completion.status != HostedLinkCompletionStatus.success {
             throw HostedLinkCompletionError.status(completion.status)
         }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -2622,6 +2622,100 @@ struct PlaidBarServerTests {
         }
     }
 
+    @Test("Forged state-keyed failure cannot veto a genuine hosted-link completion")
+    func forgedStateKeyedFailureCannotVetoHostedLinkCompletion() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-hosted-link-state-poison-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Genuine update-mode reconnection: Plaid's authoritative session lookup
+        // returns NO public token (the legitimate empty-token success path), so
+        // the callback should mark the item connected. This is the exact branch
+        // that, on a non-success completion record keyed by `state`, used to throw
+        // a forged failure instead of reporting the honest reconnection.
+        let itemId = "synthetic_state_poison_item_\(UUID().uuidString)"
+        let accessToken = "synthetic-state-poison-access-token-\(UUID().uuidString)"
+        let linkToken = "state-poison-link-token"
+        let plaidClient = HostedLinkStubPlaidClient(
+            linkTokenGetResponse: PlaidLinkTokenGetResponse(
+                linkToken: linkToken,
+                linkSessions: nil,
+                onSuccess: nil,
+                results: nil
+            ),
+            exchangeResponse: PlaidTokenExchangeResponse(
+                accessToken: accessToken,
+                itemId: itemId,
+                requestId: nil
+            ),
+            accountsResponse: PlaidAccountsResponse(
+                accounts: [],
+                item: PlaidItem(
+                    itemId: itemId,
+                    institutionId: "ins_state_poison",
+                    availableProducts: nil,
+                    billedProducts: nil
+                ),
+                requestId: nil
+            )
+        )
+        let pendingLinkSessions = PendingLinkSessionStore(
+            storageURL: directory.appendingPathComponent("pending-link-sessions.json")
+        )
+        let hostedLinkCompletions = HostedLinkCompletionStore()
+        let state = await pendingLinkSessions.issueState()
+        await pendingLinkSessions.save(state: state, linkToken: linkToken, updateItemId: itemId)
+
+        // Attacker pre-seeds a non-success completion keyed by the *genuine*
+        // single-use `state`, exactly as an unauthenticated POST to
+        // /webhooks/plaid/hosted-link could race ahead of the real redirect.
+        // The store is first-write-wins, so this is the record the empty-token
+        // path used to consult and throw on.
+        await hostedLinkCompletions.record(HostedLinkCompletionRecord(
+            state: state,
+            linkToken: nil,
+            linkSessionId: nil,
+            status: .providerFailure
+        ))
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.hosted-link-state-poison")
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await ItemModel(
+                id: itemId,
+                accessToken: accessToken,
+                institutionId: "ins_state_poison",
+                institutionName: "Example Bank"
+            ).save(on: fluent.db())
+            try await store.updateItemStatus(id: itemId, status: ItemConnectionStatus.loginRequired.rawValue)
+
+            let route = OAuthCallbackRoute(
+                plaidClient: plaidClient,
+                tokenStore: store,
+                pendingLinkSessions: pendingLinkSessions,
+                hostedLinkCompletions: hostedLinkCompletions
+            )
+            // The genuine redirect carries Plaid's own authoritative success
+            // signal bound to the validated `state`; that must override an
+            // unauthenticated stored failure for the same `state`.
+            let response = try await route.handleCallback(
+                request: Self.makeRequest(path: "/oauth/callback?state=\(state)&status=success"),
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+            let calls = await plaidClient.recordedCalls()
+
+            // The forged state-keyed failure must NOT veto the genuine
+            // reconnection: the item is marked connected and the success page is
+            // returned, not a "temporary problem"/user-exit failure.
+            #expect(response.status == .ok)
+            #expect(try await store.getItem(id: itemId)?.status == ItemConnectionStatus.connected.rawValue)
+            #expect(calls.linkTokens == [linkToken])
+            #expect(calls.publicTokens.isEmpty)
+        }
+    }
+
     @Test func hostedLinkCompletionStoreIsIdempotentByAnyIdentifier() async {
         let store = HostedLinkCompletionStore()
         let first = HostedLinkCompletionRecord(
@@ -2650,6 +2744,51 @@ struct PlaidBarServerTests {
         #expect(byState == first)
         #expect(byLinkToken == first)
         #expect(bySession == first)
+    }
+
+    @Test func hostedLinkCompletionStoreAuthoritativeRecordOverridesUnauthenticatedFailure() async {
+        let store = HostedLinkCompletionStore()
+
+        // An unauthenticated webhook pre-seeds a failure for a known state.
+        let forgedFailure = HostedLinkCompletionRecord(
+            state: "state-x",
+            linkToken: nil,
+            linkSessionId: nil,
+            status: .providerFailure,
+            authoritative: false,
+            receivedAt: Date(timeIntervalSince1970: 1)
+        )
+        // The genuine OAuth redirect, validated against the pending session,
+        // records an authoritative success for the same state.
+        let authoritativeSuccess = HostedLinkCompletionRecord(
+            state: "state-x",
+            linkToken: nil,
+            linkSessionId: nil,
+            status: .success,
+            authoritative: true,
+            receivedAt: Date(timeIntervalSince1970: 2)
+        )
+        // A later unauthenticated failure must NOT clobber the authoritative one.
+        let lateForgedFailure = HostedLinkCompletionRecord(
+            state: "state-x",
+            linkToken: nil,
+            linkSessionId: nil,
+            status: .providerFailure,
+            authoritative: false,
+            receivedAt: Date(timeIntervalSince1970: 3)
+        )
+
+        await store.record(forgedFailure)
+        let afterAuthoritative = await store.record(authoritativeSuccess)
+        let afterLateForgery = await store.record(lateForgedFailure)
+        let current = await store.completion(state: "state-x", linkToken: nil)
+
+        // The authoritative success wins and the later forgery cannot demote it.
+        #expect(afterAuthoritative == authoritativeSuccess)
+        #expect(afterLateForgery == authoritativeSuccess)
+        #expect(current == authoritativeSuccess)
+        #expect(current?.authoritative == true)
+        #expect(current?.status == .success)
     }
 
     @Test func oauthCallbackDistinguishesUserExitExpiredAndRetryableProviderFailure() async throws {


### PR DESCRIPTION
## Summary

`POST /webhooks/plaid/hosted-link` is unauthenticated, so any local same-user process can pre-seed the shared `HostedLinkCompletionStore`. On the empty-public-token OAuth callback path, the store was consulted keyed by the single-use `state`, and a stored non-success record threw a terminal failure. Because the store was strict **first-write-wins**, a forged FAILURE pre-seeded for a genuine session's `state` could grief an otherwise-successful Hosted Link completion ("temporary problem"/user-exit) — including a legitimate update-mode reconnection.

PR #510 already hardened the **real-token** path (authoritative Plaid session lookup before success). This closes the remaining **state-keyed empty-token** gap.

## Fix (defense in depth)

- **Advisory metadata.** The empty-token path now only lets a completion record drive a TERMINAL failure when that record is `authoritative` — captured from this very OAuth redirect *after* the unguessable single-use `state` was validated against the pending session — never an unauthenticated `/webhooks/plaid/hosted-link` POST.
- **Authoritative success overrides forged failure.** Dropped strict first-write-wins for unauthenticated records: an authoritative (redirect-bound) record now overrides a prior unauthenticated one via `HostedLinkCompletionRecord.canOverride`. Two unauthenticated records still keep first-write-wins (no thrashing between competing local POSTs); an authoritative record is never demoted by a later unauthenticated one.

## Tests (Swift Testing)

- `forgedStateKeyedFailureCannotVetoHostedLinkCompletion` — route-level regression mirroring `forgedHostedLinkCompletionCannotVetoRealSuccess` for the state-keyed empty-token path. Confirmed RED before the fix (500 + item stuck in `loginRequired`), green after.
- `hostedLinkCompletionStoreAuthoritativeRecordOverridesUnauthenticatedFailure` — store-level invariant.

Commands run (all pass):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test --filter PlaidBarServerTests                                          # 167 tests passed
```

## Privacy / security note

Local-first completion-integrity fix. No Plaid secrets, access tokens, public tokens, item/account IDs, or balances are logged or surfaced — the change only governs whether an unauthenticated, locally-injected completion record may veto a genuine Hosted Link session. Server remains localhost-only; all types stay `Sendable` under Swift 6 strict concurrency.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)