### PR TITLE
fix: stop deleted accounts resurrecting from stale cache

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1702,9 +1702,12 @@ final class AppState {
             let fetchedAccounts = try await (live ? serverClient.getBalances() : serverClient.getAccounts())
             let refreshedAccounts = live ? balancesPreservingCachedCurrent(fetchedAccounts) : fetchedAccounts
             let itemStatusesAvailable = await refreshItemStatuses()
-            accounts = itemStatusesAvailable
-                ? accountsPreservingUnavailableItems(refreshedAccounts)
-                : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
+            accounts = AccountReconciliation.accountsAfterRefresh(
+                refreshedAccounts: refreshedAccounts,
+                currentAccounts: accounts,
+                itemStatusesAvailable: itemStatusesAvailable,
+                itemStatuses: itemStatuses
+            )
             let cacheAccounts = accounts
             let cacheDirectory = activeStorageDirectoryURL
             let cacheContext = transactionCacheContext
@@ -1736,9 +1739,12 @@ final class AppState {
         do {
             let refreshedAccounts = try await serverClient.getBalances()
             let itemStatusesAvailable = await refreshItemStatuses()
-            accounts = itemStatusesAvailable
-                ? accountsPreservingUnavailableItems(refreshedAccounts)
-                : accountsPreservingCachedAccountsMissingFromRefresh(refreshedAccounts)
+            accounts = AccountReconciliation.accountsAfterRefresh(
+                refreshedAccounts: refreshedAccounts,
+                currentAccounts: accounts,
+                itemStatusesAvailable: itemStatusesAvailable,
+                itemStatuses: itemStatuses
+            )
             let cacheAccounts = accounts
             let cacheDirectory = activeStorageDirectoryURL
             let cacheContext = transactionCacheContext
@@ -2145,7 +2151,14 @@ final class AppState {
                 let cacheTransactions = transactions
                 let cacheDirectory = activeStorageDirectoryURL
                 let cacheContext = transactionCacheContext
-                try await saveAccountsToCacheWithPerformance(cacheAccounts, to: cacheDirectory, context: cacheContext)
+                // The account cache write is load-bearing: if the post-delete save
+                // is lost, the next launch reloads stale JSON and the removed
+                // account reappears (GH #508). Retry once before giving up.
+                try await persistAccountCacheWithRetry(
+                    cacheAccounts,
+                    to: cacheDirectory,
+                    context: cacheContext
+                )
                 try await saveTransactionsToCacheWithPerformance(
                     cacheTransactions,
                     to: cacheDirectory,
@@ -2153,7 +2166,12 @@ final class AppState {
                 )
                 persistReviewStorage()
             } catch {
-                self.error = "Local cache failed to save: \(error.localizedDescription)"
+                // Server delete already succeeded and in-memory state is correct, so
+                // the account is gone for this session. The on-disk cache is stale,
+                // but boot-time reconciliation against the server item list drops it
+                // on the next launch, so it cannot resurrect (GH #508).
+                self.error = "Removed the account, but couldn't update the local cache: "
+                    + "\(error.localizedDescription)"
             }
             // Refresh (or clear, when the last institution is gone) the widget
             // snapshot so it never shows balances for just-removed accounts.
@@ -2673,13 +2691,40 @@ final class AppState {
 
     private func loadCachedAccounts() async {
         do {
-            accounts = try await loadAccountsFromCacheWithPerformance(
+            let cachedAccounts = try await loadAccountsFromCacheWithPerformance(
                 from: activeStorageDirectoryURL,
                 context: transactionCacheContext
             )
+            accounts = reconcileCachedAccountsAgainstServer(cachedAccounts)
+            // If a prior removal's cache write failed (GH #508), the stale account
+            // was just dropped from `accounts` above. Heal the on-disk cache so it
+            // no longer lists a deleted account on the next launch.
+            if accounts.count != cachedAccounts.count {
+                let healedAccounts = accounts
+                let cacheDirectory = activeStorageDirectoryURL
+                let cacheContext = transactionCacheContext
+                try? await saveAccountsToCacheWithPerformance(
+                    healedAccounts,
+                    to: cacheDirectory,
+                    context: cacheContext
+                )
+            }
         } catch {
             self.error = "Account cache failed to load: \(error.localizedDescription)"
         }
+    }
+
+    /// Drops cached accounts whose item the server no longer reports, using the
+    /// authoritative item list already fetched by `checkServerConnection` before
+    /// boot loads the cache. Guarded so a transient empty item-status list (e.g. a
+    /// failed `/api/items` fetch) never blanks the dashboard — only a known,
+    /// non-empty server item list prunes the cache (GH #508).
+    private func reconcileCachedAccountsAgainstServer(_ cachedAccounts: [AccountDTO]) -> [AccountDTO] {
+        guard !itemStatuses.isEmpty else { return cachedAccounts }
+        return AccountReconciliation.cachedAccountsReconciledAgainstServerItems(
+            cachedAccounts: cachedAccounts,
+            serverItemIds: itemStatuses.map(\.id)
+        )
     }
 
     private func clearCachedAccounts() async {
@@ -2831,6 +2876,21 @@ final class AppState {
         }
     }
 
+    /// Persists the account cache, retrying once on failure. Used after a
+    /// server-side account removal where a lost write would otherwise let the
+    /// deleted account resurrect from stale JSON on the next launch (GH #508).
+    private func persistAccountCacheWithRetry(
+        _ accounts: [AccountDTO],
+        to directory: URL,
+        context: TransactionCacheContext?
+    ) async throws {
+        do {
+            try await saveAccountsToCacheWithPerformance(accounts, to: directory, context: context)
+        } catch {
+            try await saveAccountsToCacheWithPerformance(accounts, to: directory, context: context)
+        }
+    }
+
     private func loadTransactionsFromCacheWithPerformance(
         from directory: URL,
         context: TransactionCacheContext?
@@ -2947,33 +3007,6 @@ final class AppState {
         serverItemCount = itemCount ?? statuses.count
         serverSyncReady = syncReady ?? !statuses.isEmpty
         updateSetupCompletion()
-    }
-
-    private func accountsPreservingUnavailableItems(_ refreshedAccounts: [AccountDTO]) -> [AccountDTO] {
-        guard !accounts.isEmpty, !itemStatuses.isEmpty else { return refreshedAccounts }
-
-        let refreshedAccountIds = Set(refreshedAccounts.map(\.id))
-        let refreshedItemIds = Set(refreshedAccounts.map(\.itemId))
-        let unavailableItemIds = Set(itemStatuses.compactMap { item -> String? in
-            guard item.status != .connected, !refreshedItemIds.contains(item.id) else { return nil }
-            return item.id
-        })
-        guard !unavailableItemIds.isEmpty else { return refreshedAccounts }
-
-        let preservedAccounts = accounts.filter { account in
-            unavailableItemIds.contains(account.itemId) && !refreshedAccountIds.contains(account.id)
-        }
-        return refreshedAccounts + preservedAccounts
-    }
-
-    private func accountsPreservingCachedAccountsMissingFromRefresh(_ refreshedAccounts: [AccountDTO]) -> [AccountDTO] {
-        guard !accounts.isEmpty else { return refreshedAccounts }
-
-        let refreshedAccountIds = Set(refreshedAccounts.map(\.id))
-        let preservedAccounts = accounts.filter { account in
-            !refreshedAccountIds.contains(account.id)
-        }
-        return refreshedAccounts + preservedAccounts
     }
 
     private func updateSetupCompletion() {
@@ -3152,8 +3185,9 @@ final class AppState {
     private func recordAccountBalanceLedger() {
         // Only ledger accounts the bank actually reported on THIS refresh. When a
         // partial refresh omits a degraded item (login-required / provider
-        // outage), `accountsPreservingUnavailableItems` keeps that item's cached
-        // accounts in `accounts`; stamping them with today's date would make Time
+        // outage), `AccountReconciliation.accountsPreservingDegradedItems` keeps
+        // that item's cached accounts in `accounts`; stamping them with today's
+        // date would make Time
         // Machine show a stale cached balance as "what the bank said" today and
         // undermine the ledger's data-integrity purpose (Codex P2).
         let reportedAccounts = bankReportedAccountsForLedger()

--- a/Sources/PlaidBarCore/Utilities/AccountReconciliation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountReconciliation.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Pure reconciliation rules deciding which accounts survive a refresh or a boot
+/// cache load. Extracted from `AppState` so the "deleted accounts must not
+/// resurrect" decisions are `Sendable` and unit-testable (GH #507, #508).
+///
+/// The problem both rules guard against: a server-side `removeItem` deletes the
+/// item authoritatively, but its accounts can still sit in memory or in the
+/// on-disk JSON cache. Naively re-attaching every cached account "missing from
+/// the latest server response" resurrects exactly those just-deleted accounts.
+public enum AccountReconciliation {
+    /// Resolves the account list after a balances/accounts refresh.
+    ///
+    /// - When `itemStatusesAvailable` is `true`, the server's item list is known,
+    ///   so only accounts belonging to a *known-degraded* item that the partial
+    ///   refresh omitted are preserved from cache (a degraded item — e.g.
+    ///   login-required or a provider outage — legitimately drops out of the
+    ///   balances response without being deleted).
+    /// - When `itemStatusesAvailable` is `false`, the item list could not be
+    ///   fetched, so the app cannot tell "intentionally deleted" from
+    ///   "temporarily degraded". In that case the refreshed (server) account list
+    ///   is treated as the source of truth and stale cache is **not** merged back
+    ///   in — otherwise a successfully-deleted account reappears (GH #507).
+    ///
+    /// - Parameters:
+    ///   - refreshedAccounts: accounts returned by the latest server refresh.
+    ///   - currentAccounts: accounts currently held in memory / loaded from cache.
+    ///   - itemStatusesAvailable: whether the `/api/items` fetch succeeded.
+    ///   - itemStatuses: the (possibly empty) item statuses backing the refresh.
+    /// - Returns: the reconciled account list to render and persist.
+    public static func accountsAfterRefresh(
+        refreshedAccounts: [AccountDTO],
+        currentAccounts: [AccountDTO],
+        itemStatusesAvailable: Bool,
+        itemStatuses: [ItemStatus]
+    ) -> [AccountDTO] {
+        // Item statuses unavailable: cannot distinguish a deleted item from a
+        // degraded one, so trust the server response. Merging cached accounts here
+        // is what resurrected server-deleted accounts (GH #507).
+        guard itemStatusesAvailable else { return refreshedAccounts }
+
+        return accountsPreservingDegradedItems(
+            refreshedAccounts: refreshedAccounts,
+            currentAccounts: currentAccounts,
+            itemStatuses: itemStatuses
+        )
+    }
+
+    /// Preserves cached accounts only for items the server reports as degraded but
+    /// that the partial refresh omitted. Mirrors the prior
+    /// `accountsPreservingUnavailableItems` behavior, now pure and testable.
+    public static func accountsPreservingDegradedItems(
+        refreshedAccounts: [AccountDTO],
+        currentAccounts: [AccountDTO],
+        itemStatuses: [ItemStatus]
+    ) -> [AccountDTO] {
+        guard !currentAccounts.isEmpty, !itemStatuses.isEmpty else { return refreshedAccounts }
+
+        let refreshedAccountIds = Set(refreshedAccounts.map(\.id))
+        let refreshedItemIds = Set(refreshedAccounts.map(\.itemId))
+        let unavailableItemIds = Set(itemStatuses.compactMap { item -> String? in
+            guard item.status != .connected, !refreshedItemIds.contains(item.id) else { return nil }
+            return item.id
+        })
+        guard !unavailableItemIds.isEmpty else { return refreshedAccounts }
+
+        let preservedAccounts = currentAccounts.filter { account in
+            unavailableItemIds.contains(account.itemId) && !refreshedAccountIds.contains(account.id)
+        }
+        return refreshedAccounts + preservedAccounts
+    }
+
+    /// Reconciles cached accounts against the authoritative set of server item ids
+    /// (from `/api/items`) at boot, before rendering.
+    ///
+    /// Accounts whose item is no longer present server-side are dropped, even when
+    /// a time-based auto-refresh is not due. This closes the window where a
+    /// removal's cache write failed (so the stale JSON still lists the account)
+    /// and manual-only / recently-synced state skips `refreshAccounts`, leaving a
+    /// deleted account visible after the next launch (GH #508).
+    ///
+    /// - Parameters:
+    ///   - cachedAccounts: accounts just loaded from the on-disk cache.
+    ///   - serverItemIds: item ids the server currently reports as connected.
+    /// - Returns: cached accounts filtered to items the server still knows about.
+    public static func cachedAccountsReconciledAgainstServerItems(
+        cachedAccounts: [AccountDTO],
+        serverItemIds: [String]
+    ) -> [AccountDTO] {
+        guard !cachedAccounts.isEmpty else { return cachedAccounts }
+        let liveItemIds = Set(serverItemIds)
+        return cachedAccounts.filter { liveItemIds.contains($0.itemId) }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AccountReconciliationTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountReconciliationTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+@Suite("Account reconciliation against server item authority")
+struct AccountReconciliationTests {
+    // MARK: Fixtures
+
+    private func account(_ id: String, item: String) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: item,
+            name: "Account \(id)",
+            type: .depository,
+            balances: BalanceDTO(available: 100, current: 100, isoCurrencyCode: "USD")
+        )
+    }
+
+    private func status(_ id: String, _ connection: ItemConnectionStatus) -> ItemStatus {
+        ItemStatus(id: id, status: connection)
+    }
+
+    // MARK: GH #507 — item statuses unavailable must not resurrect deleted accounts
+
+    @Test("Item-statuses-unavailable refresh trusts the server list and does NOT resurrect a deleted account")
+    func unavailableStatusesDoNotResurrect() {
+        // chase_item was deleted server-side; its account is intentionally absent
+        // from the refresh but still lingers in the in-memory / cached list.
+        let cached = [account("a_chase", item: "chase_item"), account("a_amex", item: "amex_item")]
+        let serverResponse = [account("a_amex", item: "amex_item")]
+
+        let result = AccountReconciliation.accountsAfterRefresh(
+            refreshedAccounts: serverResponse,
+            currentAccounts: cached,
+            itemStatusesAvailable: false,
+            itemStatuses: []
+        )
+
+        #expect(result.map(\.id) == ["a_amex"])
+        #expect(!result.contains { $0.itemId == "chase_item" })
+    }
+
+    @Test("Item-statuses-unavailable refresh still returns the full server list when nothing was deleted")
+    func unavailableStatusesPreserveServerTruth() {
+        let cached = [account("a_amex", item: "amex_item")]
+        let serverResponse = [
+            account("a_amex", item: "amex_item"),
+            account("a_chase", item: "chase_item"),
+        ]
+
+        let result = AccountReconciliation.accountsAfterRefresh(
+            refreshedAccounts: serverResponse,
+            currentAccounts: cached,
+            itemStatusesAvailable: false,
+            itemStatuses: []
+        )
+
+        #expect(Set(result.map(\.id)) == ["a_amex", "a_chase"])
+    }
+
+    // MARK: Item statuses available — degraded items preserved, deleted ones dropped
+
+    @Test("Item statuses available preserves cached accounts only for known-degraded omitted items")
+    func availableStatusesPreserveDegradedItem() {
+        // amex is degraded (login_required) and dropped from the partial refresh —
+        // its cached account must survive. chase is connected and present.
+        let cached = [
+            account("a_chase", item: "chase_item"),
+            account("a_amex", item: "amex_item"),
+        ]
+        let serverResponse = [account("a_chase", item: "chase_item")]
+        let statuses = [
+            status("chase_item", .connected),
+            status("amex_item", .loginRequired),
+        ]
+
+        let result = AccountReconciliation.accountsAfterRefresh(
+            refreshedAccounts: serverResponse,
+            currentAccounts: cached,
+            itemStatusesAvailable: true,
+            itemStatuses: statuses
+        )
+
+        #expect(Set(result.map(\.id)) == ["a_chase", "a_amex"])
+    }
+
+    @Test("Item statuses available does NOT preserve a cached account whose item is simply gone (deleted)")
+    func availableStatusesDropDeletedItem() {
+        // amex_item is no longer in the server item list at all (deleted). It is
+        // not in itemStatuses, so it is neither connected nor degraded — drop it.
+        let cached = [
+            account("a_chase", item: "chase_item"),
+            account("a_amex", item: "amex_item"),
+        ]
+        let serverResponse = [account("a_chase", item: "chase_item")]
+        let statuses = [status("chase_item", .connected)]
+
+        let result = AccountReconciliation.accountsAfterRefresh(
+            refreshedAccounts: serverResponse,
+            currentAccounts: cached,
+            itemStatusesAvailable: true,
+            itemStatuses: statuses
+        )
+
+        #expect(result.map(\.id) == ["a_chase"])
+        #expect(!result.contains { $0.itemId == "amex_item" })
+    }
+
+    // MARK: GH #508 — boot reconciliation against authoritative /api/items
+
+    @Test("Boot reconciliation drops cached accounts whose item the server no longer reports (failed post-delete save)")
+    func bootReconciliationDropsStaleRemovedAccount() {
+        // removeAccount deleted chase_item server-side but the cache write failed,
+        // so the stale JSON still lists its account. On boot the server item list
+        // is authoritative and the stale account must not render.
+        let cached = [
+            account("a_chase", item: "chase_item"),
+            account("a_amex", item: "amex_item"),
+        ]
+        let serverItemIds = ["amex_item"]
+
+        let result = AccountReconciliation.cachedAccountsReconciledAgainstServerItems(
+            cachedAccounts: cached,
+            serverItemIds: serverItemIds
+        )
+
+        #expect(result.map(\.id) == ["a_amex"])
+        #expect(!result.contains { $0.itemId == "chase_item" })
+    }
+
+    @Test("Boot reconciliation keeps every cached account when all items are still present server-side")
+    func bootReconciliationKeepsLiveAccounts() {
+        let cached = [
+            account("a_chase", item: "chase_item"),
+            account("a_amex", item: "amex_item"),
+        ]
+        let serverItemIds = ["chase_item", "amex_item"]
+
+        let result = AccountReconciliation.cachedAccountsReconciledAgainstServerItems(
+            cachedAccounts: cached,
+            serverItemIds: serverItemIds
+        )
+
+        #expect(Set(result.map(\.id)) == ["a_chase", "a_amex"])
+    }
+
+    @Test("Boot reconciliation on empty cache returns empty without consulting server ids")
+    func bootReconciliationEmptyCache() {
+        let result = AccountReconciliation.cachedAccountsReconciledAgainstServerItems(
+            cachedAccounts: [],
+            serverItemIds: ["chase_item"]
+        )
+        #expect(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two paths in `AppState` where a successfully-deleted Plaid account could reappear because stale cached accounts were re-attached after a server-side removal. Both bugs live in the same file and the same bug class, so they are fixed together.

The reconciliation decisions are extracted into a pure, `Sendable` `AccountReconciliation` helper in `PlaidBarCore` (per CLAUDE.md: put testable logic in Core, not in `@MainActor @Observable` views/state), then wired into `AppState`.

### #507 — Deleted accounts resurrect when item-status fetch fails during account refresh
When `refreshItemStatuses()` failed (item statuses unavailable), `refreshAccounts`/`refreshBalances` used `accountsPreservingCachedAccountsMissingFromRefresh`, which re-attached **every** cached account not present in the server response — including ones intentionally deleted server-side.
**Fix:** when item statuses are unavailable, the server account list is the source of truth (no stale-cache merge). When statuses **are** available, cached accounts are preserved only for **known-degraded** items (login-required / provider-outage), via `AccountReconciliation.accountsAfterRefresh` / `accountsPreservingDegradedItems`.

### #508 — Removed accounts can reappear from stale cache after a failed post-delete save
`removeAccount` deletes the item server-side and updates in-memory state, but if the local cache write failed it only set an error banner. On next launch `preloadCachedDataBeforeFirstConnect` reloaded the stale JSON; with manual-only refresh (or a recent sync timestamp) `shouldAutoRefreshNow` could skip `refreshAccounts`, so removed accounts stayed visible.
**Fix (defense in depth):**
- `removeAccount` retries the load-bearing account-cache write once (`persistAccountCacheWithRetry`) and surfaces a clearer error on persistent failure.
- Boot's `loadCachedAccounts` reconciles cached accounts against the authoritative server item list (already fetched by `checkServerConnection`) via `AccountReconciliation.cachedAccountsReconciledAgainstServerItems`, dropping accounts for items the server no longer reports **even when auto-refresh is not due**, and heals the on-disk cache. Guarded so a transient empty item-status list never blanks the dashboard.

## Tests
New `Tests/PlaidBarCoreTests/AccountReconciliationTests.swift` covers both scenarios (TDD: confirmed failing against a buggy stub first, then green):
- #507: item-statuses-unavailable refresh must NOT resurrect a server-deleted account (and still returns full server truth when nothing was deleted).
- statuses-available: preserve degraded omitted items, but DROP an item that is simply gone (deleted).
- #508: boot reconciliation drops a cached account whose item the server no longer reports; keeps live accounts; no-ops on empty cache.

Commands run (all relevant suites green; the one unrelated failure below is a pre-existing flaky wall-clock timing test):

```bash
swift test --filter AccountReconciliationTests   # 7/7 passed
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # clean
swift test                                       # full suite
```

Full-suite note: the only non-skipped failure is `LocalInsightModelRuntimeTests › "Runtime timeout returns without waiting for cancellation-ignoring models"`, a wall-clock `elapsed < 0.15` assertion that flakes under parallel CPU load (passes when its suite runs in isolation). It is in the AI-insights runtime — untouched by this change. Keychain-write server tests skip as expected.

## Privacy / security
Local data-consistency only. No Plaid `client_secret`/`access_token` path, no credential boundary, and no `/api/*` auth surface is touched — the change only decides which already-local accounts render and persist.

Closes #507
Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)