### PR TITLE
[macOS 26] Epic B — Remove macOS 15 fallback code & availability guards

### DIFF
--- a/Sources/PlaidBar/Views/GlassGroup.swift
+++ b/Sources/PlaidBar/Views/GlassGroup.swift
@@ -13,12 +13,9 @@ import SwiftUI
 /// genuinely-adjacent glass merges; distant glass islands in a tall scroll column
 /// stay visually distinct, which is why wrapping a whole scroll body is safe.
 ///
-/// macOS-26 / SwiftUI-7 only; on macOS 15 (and the Swift <6.3 CI toolchain where
-/// the glass APIs aren't compiled at all) this is a transparent passthrough — the
-/// wrapped content renders byte-for-byte as it does today, so the fallback look
-/// never regresses. Glass is chrome only: wrap regions that *contain* glass
-/// surfaces; `GlassEffectContainer` only samples/merges its `glassEffect`
-/// descendants, so non-glass content/text inside is unaffected.
+/// Glass is chrome only: wrap regions that *contain* glass surfaces;
+/// `GlassEffectContainer` only samples/merges its `glassEffect` descendants, so
+/// non-glass content/text inside is unaffected.
 struct GlassGroup<Content: View>: View {
     var spacing: CGFloat
     @ViewBuilder var content: () -> Content
@@ -29,26 +26,17 @@ struct GlassGroup<Content: View>: View {
     }
 
     var body: some View {
-        #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
-            if #available(macOS 26.0, *) {
-                GlassEffectContainer(spacing: spacing) {
-                    content()
-                }
-            } else {
-                content()
-            }
-        #else
+        GlassEffectContainer(spacing: spacing) {
             content()
-        #endif
+        }
     }
 }
 
 extension View {
     /// Group this region's descendant `glassSurface(...)` shapes into one
-    /// `GlassEffectContainer` sampling region on macOS 26 (passthrough on macOS 15
-    /// / pre-6.3 CI). `spacing` is the glass merge radius, default
-    /// `SurfaceTokens.glassMergeRadius` — apply at the smallest ancestor that
-    /// contains the coexisting glass shapes.
+    /// `GlassEffectContainer` sampling region. `spacing` is the glass merge
+    /// radius, default `SurfaceTokens.glassMergeRadius` — apply at the smallest
+    /// ancestor that contains the coexisting glass shapes.
     func glassGroup(spacing: CGFloat = SurfaceTokens.glassMergeRadius) -> some View {
         GlassGroup(spacing: spacing) { self }
     }

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -86,23 +86,14 @@ private struct GlassSurface: ViewModifier {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
         let multiplier = PopoverTransparencySetting(value: popoverTransparency).surfaceDepthMultiplier
 
-        // Liquid Glass is a macOS 26+ progressive enhancement. Raised/inset
-        // ranks carry no underlay fill so the material reads clean, but the
-        // emphasized rank keeps its tinted wash — attention states must
-        // survive the glass path.
-        #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
-            if #available(macOS 26.0, *) {
-                content
-                    .background(liquidGlassFill, in: shape)
-                    .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
-                    .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
-                    .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
-            } else {
-                fallback(content: content, shape: shape, multiplier: multiplier)
-            }
-        #else
-            fallback(content: content, shape: shape, multiplier: multiplier)
-        #endif
+        // Raised/inset ranks carry no underlay fill so the Liquid Glass material
+        // reads clean, but the emphasized rank keeps its tinted wash — attention
+        // states must survive the glass path.
+        content
+            .background(liquidGlassFill, in: shape)
+            .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+            .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
+            .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
     }
 
     private var liquidGlassFill: AnyShapeStyle {
@@ -112,13 +103,6 @@ private struct GlassSurface: ViewModifier {
         case .leftPanel, .hero, .emphasized:
             rank.fill
         }
-    }
-
-    private func fallback(content: Content, shape: RoundedRectangle, multiplier: Double) -> some View {
-        content
-            .background(rank.fill, in: shape)
-            .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
-            .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
     }
 
     private func surfaceStroke(shape: RoundedRectangle, multiplier: Double) -> some View {
@@ -184,34 +168,19 @@ struct NativePanelSurface: ViewModifier {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         if useLiquidGlass {
-            // Keep every reference to Liquid Glass APIs inside this compile-time
-            // gate. PlaidBar supports macOS 15, where the fallback fill/material
-            // surface below must remain the active type-checked path.
-            #if compiler(>=6.3) && canImport(SwiftUI, _version: 7.0)
-                if #available(macOS 26.0, *) {
-                    content
-                        .background(fill, in: shape)
-                        .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
-                        .overlay {
-                            shape.stroke(stroke, lineWidth: 1)
-                        }
-                } else {
-                    fallback(content: content, shape: shape)
+            content
+                .background(fill, in: shape)
+                .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+                .overlay {
+                    shape.stroke(stroke, lineWidth: 1)
                 }
-            #else
-                fallback(content: content, shape: shape)
-            #endif
         } else {
-            fallback(content: content, shape: shape)
+            content
+                .background(fill, in: shape)
+                .overlay {
+                    shape.stroke(stroke, lineWidth: 1)
+                }
         }
-    }
-
-    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
-        content
-            .background(fill, in: shape)
-            .overlay {
-                shape.stroke(stroke, lineWidth: 1)
-            }
     }
 }
 

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -175,7 +175,6 @@ private struct SparklineView: View {
     }
 }
 
-@available(macOS 15.0, *)
 struct RefreshBalancesIntent: AppIntent {
     static let title: LocalizedStringResource = "Refresh balances"
     static let description = IntentDescription("Ask VaultPeek to refresh local balances.")
@@ -190,7 +189,6 @@ struct RefreshBalancesIntent: AppIntent {
     }
 }
 
-@available(macOS 26.0, *)
 private struct PlaidBarRefreshControl: ControlWidget {
     let kind = "PlaidBarRefreshControl"
 
@@ -209,8 +207,6 @@ private struct PlaidBarRefreshControl: ControlWidget {
 struct PlaidBarWidgetBundle: WidgetBundle {
     var body: some Widget {
         PlaidBarGlanceWidget()
-        if #available(macOS 26.0, *) {
-            PlaidBarRefreshControl()
-        }
+        PlaidBarRefreshControl()
     }
 }


### PR DESCRIPTION
## Summary

This repo's toolchain is Swift 6.3 + SwiftUI 7 targeting `arm64-apple-macosx26.0`, so the macOS-26 code branch is already the only one that compiles. This PR removes the now-dead macOS 15 fallback paths and `#available(macOS 26.0, *)` / `compiler(>=6.3)` / `_version: 7.0` version gates that guarded them. Removing the guards keeps the **same** runtime path (the Liquid Glass path was already the one executing) while deleting net-negative LOC and simplifying the surface system. Platform guards (`#if os(macOS)`, `canImport(Security|Darwin|NaturalLanguage)`) were intentionally left untouched.

Implements **AND-510** (Epic B).

## Build: green
`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — Build complete (the CI gate).

## Tests: green
`swift test` — 1038 tests passed. No test asserted the removed fallback rendering (grep over `Tests/` for the glass/fallback/`useLiquidGlass`/`macOS 15`/`macOS 26` types returned nothing), so no test changes were needed (B5 no-op).

## Files changed
- `Sources/PlaidBar/Views/SharedModifiers.swift` — collapsed `GlassSurface` and `NativePanelSurface` to only the Liquid Glass (`.glassEffect`) path; removed the now-unused material/fill `fallback(...)` helpers. **Kept** the `NativePanelSurface.useLiquidGlass` *runtime* flag and its non-glass branch, since `nativeInsetSurface()` passes `useLiquidGlass: false` — that is a behavioral toggle, not a version gate.
- `Sources/PlaidBar/Views/GlassGroup.swift` — `GlassEffectContainer(spacing:)` is now used unconditionally; doc comment updated to drop the macOS-15 passthrough note.
- `Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift` — removed `@available(macOS 15.0, *)` on `RefreshBalancesIntent`, `@available(macOS 26.0, *)` on `PlaidBarRefreshControl`, and the `if #available(macOS 26.0, *)` gate in the bundle body so the `ControlWidget` is always included.

Net: +27 / -74 LOC.

## Follow-ups
- None. No SPIKEs were required. The `useLiquidGlass` runtime flag in `NativePanelSurface` was deliberately preserved (it is not a macOS-version gate); if a later epic wants to fully unify on glass it can revisit `nativeInsetSurface()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)