### PR TITLE
[macOS 26] Epic F — SF Symbols 7, glyph, window/scene

### DIFF
--- a/Sources/PlaidBar/Views/MenuBarLabel.swift
+++ b/Sources/PlaidBar/Views/MenuBarLabel.swift
@@ -33,6 +33,16 @@ struct MenuBarLabel: View {
                let signalImage = SignalGlyphImage.make(model: signalModel) {
                 Image(nsImage: signalImage)
             } else if presentation.symbolName == MenuBarIconStyle.customGlyphToken {
+                // SF Symbols 7 motion review (AND-514, F3): the new symbol
+                // primitives (`.drawOn`/`.drawOff`, `.breathe`, `.wiggle`,
+                // magic `.replace`) animate genuine SF Symbols via
+                // `symbolEffect`; they do not apply to a custom `NSImage`. The
+                // Vault mark is a static template image, so it gains nothing
+                // here. `.replace` is kept as the SwiftUI-level cross-fade for
+                // the glyph swap; the richer primitives would only ever land on
+                // the SF Symbol ladder below, and broadening the shared
+                // `SymbolMotion` vocabulary belongs in SharedModifiers (Epic C),
+                // so no new motion is added in this epic.
                 Image(nsImage: VaultMenuBarGlyph.image)
                     .symbolMotion(.replace, reduceMotion: reduceMotion)
             } else {

--- a/Sources/PlaidBar/Views/PopoverWindowAnchor.swift
+++ b/Sources/PlaidBar/Views/PopoverWindowAnchor.swift
@@ -15,6 +15,18 @@ import SwiftUI
 /// the screen's visible edge it is shifted back on-screen — the leading edge
 /// wins so the Wealth Summary rail always stays visible (AND-374 primary
 /// fallback).
+///
+/// macOS 26 window-scene review (AND-514, SPIKE F2): SwiftUI 7 still offers no
+/// declarative hook for a `MenuBarExtra(.window)` host window's frame origin —
+/// the framework owns that window and re-centers it on the status item across
+/// width changes. The leading-edge pin therefore still requires reaching the
+/// real `NSWindow` through an `NSViewRepresentable` bridge and calling
+/// `setFrameOrigin` after resize, exactly as below. There is no clean
+/// SwiftUI-only replacement that preserves the unit-tested
+/// `PopoverGeometry.clampedLeadingX` anchoring math (see
+/// `PopoverGeometryTests`), so the AppKit bridge is kept intentionally rather
+/// than rewritten for the sake of newness. Re-evaluate if a future SwiftUI
+/// release exposes a window-anchor / placement API for menu-bar windows.
 struct PopoverLeadingEdgeAnchor: NSViewRepresentable {
     /// True while the trailing account inspector is shown (popover is in its
     /// widened three-column state).

--- a/Sources/PlaidBar/Views/VaultMenuBarGlyph.swift
+++ b/Sources/PlaidBar/Views/VaultMenuBarGlyph.swift
@@ -8,6 +8,18 @@ import PlaidBarCore
 /// Symbol, and bundling an asset would mean an SPM resource bundle + packaging
 /// changes; a code-drawn template avoids both while staying fully accessible.
 ///
+/// SF Symbols 7 review (AND-514, macOS 26 catalog, 8302 symbols audited
+/// 2026-06-18): the catalog still ships no `safe`/`vault`/`strongbox` glyph.
+/// The nearest neighbours — `lock`, `lock.shield`, `shield`,
+/// `building.columns`, `banknote`, `dial.*` — read as a padlock, a bank
+/// building, a banknote, or a dial, none of which depict the vault-dial mark
+/// that ties the menu bar to the app icon. A padlock would also collide with
+/// the degraded login/auth glyph ladder. No strong (or even weak) match
+/// exists, so the custom template is kept deliberately rather than forced onto
+/// an off-brand system symbol. Re-audit when SF Symbols ships a safe/vault
+/// glyph; switching `MenuBarIconStyle.vault` to a system symbol would then let
+/// this type be deprecated and the bespoke drawing deleted.
+///
 /// The shape is a deliberately bolder, simplified vault dial than the app icon:
 /// a thick door ring plus a four-spoke wheel handle, sized to read at the ~16pt
 /// menu-bar glyph size where fine detail (bolts, concentric rings) would


### PR DESCRIPTION
## Summary

Epic F is a **spike-and-keep** for the macOS 26 / SF Symbols 7 migration: after auditing the new symbol catalog and the macOS 26 window-scene surface, the right call in all three sub-tasks is to keep the existing, deliberate implementations and document *why* — so this is a documentation-only PR that preserves the audit findings in the code where future readers will look. The strict-concurrency CI build is green and the load-bearing PopoverGeometry tests are green.

Implements **AND-514**.

**Build:** green
**Tests:** PopoverGeometryTests — 12/12 green (anchoring math unchanged); strict-concurrency build green.

## Sub-task outcomes

- **F1 — SF Symbols 7 vault/safe glyph review:** Audited the macOS 26 catalog (`CoreGlyphs.bundle`, 8302 symbols, SF Symbols 7 generation). There is **no** `safe`/`vault`/`strongbox` glyph; nearest neighbours (`lock`, `lock.shield`, `shield`, `building.columns`, `banknote`, `dial.*`) are off-brand and a padlock would collide with the degraded login/auth glyph ladder. **No strong (or weak) match → custom `VaultMenuBarGlyph` template image kept deliberately.** Documented the audit (date + nearest-neighbour rationale) and the re-evaluation trigger in the type's doc comment. Not deprecated, because deprecating it would require shipping a system-symbol replacement that does not exist.

- **F2 (SPIKE) — window-scene API evaluation:** SwiftUI 7 still exposes no declarative frame-origin / placement hook for a `MenuBarExtra(.window)` host window — the framework owns and re-centers that window on width change. The leading-edge pin therefore still needs the `NSViewRepresentable` + `NSWindow.setFrameOrigin` bridge to preserve the unit-tested `PopoverGeometry.clampedLeadingX` anchoring math. **No clean win → AppKit bridge kept**, evaluation recorded in `PopoverWindowAnchor`'s doc comment.

- **F3 — symbol motion vocabulary:** The new SF Symbols 7 motion primitives (`.drawOn`/`.drawOff`, `.breathe`, `.wiggle`, magic `.replace`) animate genuine SF Symbols via `symbolEffect`; they do **not** apply to the custom `NSImage` Vault mark (a static template image). The only place a richer primitive could land is the SF Symbol degraded ladder, and broadening the shared `SymbolMotion` vocabulary lives in `SharedModifiers.swift`, which **Epic C owns**. So no new motion is added in this epic; the rationale is documented inline in `MenuBarLabel`.

## Files changed

- `Sources/PlaidBar/Views/VaultMenuBarGlyph.swift` — F1 audit evidence + re-evaluation trigger in doc comment.
- `Sources/PlaidBar/Views/PopoverWindowAnchor.swift` — F2 window-scene SPIKE evaluation in doc comment.
- `Sources/PlaidBar/Views/MenuBarLabel.swift` — F3 symbol-motion evaluation inline comment on the custom-glyph branch.

## Follow-ups

- Re-audit SF Symbols when Apple ships a `safe`/`vault` glyph: switching `MenuBarIconStyle.vault` to a system symbol would let `VaultMenuBarGlyph` be deprecated and the bespoke drawing deleted (F1).
- If a future SwiftUI release adds a window-anchor / placement API for menu-bar windows, revisit replacing the AppKit bridge in `PopoverWindowAnchor` (F2).
- If Epic C broadens the shared `SymbolMotion` vocabulary, the SF Symbol degraded-status ladder in `MenuBarLabel` is the candidate site for a richer primitive (F3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)