### PR TITLE
[macOS 26] Epic C — Full Liquid Glass adoption

### DIFF
--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -359,6 +359,19 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
         // fills it edge-to-edge; while detached, `MainPopover` renders a clear
         // root background so this backdrop *is* the translucent surface rather
         // than an opaque material painted over an opaque window.
+        //
+        // AND-511 SPIKE — evaluated replacing this NSVisualEffectView with a
+        // SwiftUI `.glassEffect(.regular)` (or `.backgroundExtensionEffect`) root
+        // painted directly onto the transparent NSWindow. Decision: KEEP the
+        // behind-window NSVisualEffectView. SwiftUI glass on a borderless/clear
+        // NSWindow does NOT reliably sample what is *behind the window* — it
+        // samples within the window's own (clear) backing, so it renders flat
+        // instead of frosting the desktop. Behind-window translucency on a hosted
+        // NSWindow has regressed in this project before; NSVisualEffectView with
+        // `.behindWindow` is the one path confirmed to yield real desktop
+        // read-through here, so it stays. The in-content glass chrome
+        // (PopoverMaterialBackground / glassSurface) handles the popover host,
+        // where there is no window-level vibrancy to sample.
         let backdrop = NSVisualEffectView()
         backdrop.material = .underWindowBackground
         backdrop.blendingMode = .behindWindow

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -215,17 +215,19 @@ struct AppearanceSettingsView: View {
 
     @ViewBuilder
     private func presetButton(_ preset: PopoverTransparencySetting.Preset) -> some View {
-        // The active preset is filled (prominent) and inactive ones are bordered,
-        // so the current quick-pick reads as selected without relying on tint
-        // alone; VoiceOver also gets the selected trait.
+        // The active preset is filled (prominent glass) and inactive ones are
+        // plain glass, so the current quick-pick reads as selected without
+        // relying on tint alone; VoiceOver also gets the selected trait. The
+        // transparency presets adjust the glass surface, so glass-styled buttons
+        // keep the control consistent with what they tune (AND-511).
         if transparencySetting.matchingPreset == preset {
             Button(preset.title) { popoverTransparency = preset.value }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.glassProminent)
                 .controlSize(.small)
                 .accessibilityAddTraits(.isSelected)
         } else {
             Button(preset.title) { popoverTransparency = preset.value }
-                .buttonStyle(.bordered)
+                .buttonStyle(.glass)
                 .controlSize(.small)
         }
     }

--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -237,9 +237,11 @@ enum SurfaceTokens {
 
     static let heroGlowOpacity = 0.10
 
-    /// Liquid Glass is a progressive enhancement on macOS 26+.
-    /// macOS 15 users keep the same layout with SwiftUI material/fill fallback.
-    static let liquidGlassAvailability = "macOS 26+ progressive enhancement; macOS 15 uses material fallback"
+    // AND-511: the `liquidGlassAvailability` descriptor was removed. The macOS-26
+    // floor (AND-509/510) makes Liquid Glass the only, unconditional path, so the
+    // "macOS 15 material fallback" note it carried no longer describes any code.
+    // Shadow depths and the spacing grid are intentionally retained — system
+    // glass supplies the material, not the depth/elevation language above.
 
     static func panelFill(emphasisTint: Color? = nil) -> Color {
         if let emphasisTint {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -417,21 +417,37 @@ struct MainPopover: View {
             }
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: columnMaxHeight)
-            .leftPanelSurface()
-            // Liquid Glass morph (AND-511): a stable id in the columns'
-            // GlassEffectContainer lets the inspector's glass surface fluidly
-            // morph in/out when a drill-in opens or closes, rather than just
-            // sliding a hard-edged panel. Pairs with the existing slide/opacity
-            // transition for the non-glass content.
-            .glassEffectID("account-inspector-column", in: glassNamespace)
-            // The column is stable now, so this transition only plays when it
-            // first appears as setup completes — not on every selection (AND-405).
+            // Liquid Glass morph (AND-511): the surface treatment and the
+            // morph id are applied by ONE modifier so `.glassEffectID` lands
+            // immediately after the `.glassEffect` on the SAME view, inside the
+            // columns' shared GlassEffectContainer (`.glassGroup()`). Applying
+            // `.glassEffectID` to the composed result of `leftPanelSurface()`
+            // (as before) bound it to a wrapper view, not to the glass-bearing
+            // view buried in the modifier, so the show/hide morph silently
+            // no-op'd. A stable id across content swaps lets the inspector's
+            // glass fluidly morph as drill-ins open/close instead of hard-cutting.
+            .modifier(InspectorGlassMorphSurface(
+                morphID: Self.inspectorMorphID,
+                namespace: glassNamespace
+            ))
+            // The column is stable once setup completes, so this transition only
+            // plays when the whole column first appears at setup completion — not
+            // on every selection. Content swaps inside the column animate via the
+            // glass morph above plus the `MotionTokens.content` animation keyed on
+            // the selection, so there is no competing trailing-slide on drill-ins
+            // (AND-405/511). On removal (setup re-entered) it slides out.
             .transition(.asymmetric(
                 insertion: inspectorInsertionTransition,
                 removal: .move(edge: .trailing).combined(with: .opacity)
             ))
         }
     }
+
+    /// Stable Liquid Glass morph identity for the inspector column. A single id
+    /// held across every content swap (account / recurring / flow / inbox / empty)
+    /// is what lets the system fluidly morph the one glass surface rather than
+    /// tearing it down and rebuilding it per selection (AND-511).
+    private static let inspectorMorphID = "account-inspector-column"
 
     private var inspectorInsertionTransition: AnyTransition {
         hasAppeared ? .move(edge: .trailing).combined(with: .opacity) : .identity
@@ -642,6 +658,57 @@ struct MainPopover: View {
 
     private func openAccountSetup() {
         isShowingAccountSetup = true
+    }
+}
+
+/// The inspector column's left-panel glass surface, with the Liquid Glass morph
+/// id bound on the SAME view as the glass effect (AND-511).
+///
+/// This mirrors the visual of `leftPanelSurface()` (the shared `.leftPanel`
+/// `SurfaceRank`: fill + `.glassEffect(.regular)` + stroke + shadow) but applies
+/// `.glassEffectID` *immediately after* the `.glassEffect`, on the same `content`,
+/// so the morph identity actually binds. The previous code applied
+/// `.glassEffectID` to the composed output of `leftPanelSurface()`, which is a
+/// wrapper view — not the glass-bearing view inside the modifier — so the
+/// show/hide morph silently no-op'd. The merge radius of the enclosing
+/// `GlassEffectContainer` (`SurfaceTokens.glassMergeRadius`, small) keeps this
+/// panel's glass from fusing with the rail across the wide center column.
+private struct InspectorGlassMorphSurface: ViewModifier {
+    let morphID: String
+    let namespace: Namespace.ID
+
+    @AppStorage(PopoverTransparencySetting.storageKey)
+    private var popoverTransparency = PopoverTransparencySetting.defaultValue
+
+    private let rank = SurfaceRank.leftPanel
+    private var cornerRadius: CGFloat { SurfaceTokens.panelCornerRadius }
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        let multiplier = PopoverTransparencySetting(value: popoverTransparency).surfaceDepthMultiplier
+
+        content
+            .background(rank.fill, in: shape)
+            // `.glassEffect` and `.glassEffectID` are adjacent on this same view,
+            // inside the columns' GlassEffectContainer — the binding the morph
+            // requires (AND-511).
+            .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+            .glassEffectID(morphID, in: namespace)
+            .overlay {
+                shape
+                    .stroke(rank.stroke(multiplier: multiplier), lineWidth: 1)
+                    .overlay {
+                        shape
+                            .inset(by: 1)
+                            .stroke(rank.innerStroke(multiplier: multiplier), lineWidth: 0.5)
+                    }
+            }
+            .shadow(
+                color: Color.black.opacity((rank.depth.shadow?.opacity ?? 0) * multiplier),
+                radius: rank.depth.shadow?.radius ?? 0,
+                x: rank.depth.shadow?.x ?? 0,
+                y: rank.depth.shadow?.y ?? 0
+            )
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -26,6 +26,11 @@ struct MainPopover: View {
     /// popover opened with a persisted selection appears directly in three-column
     /// geometry (no slide on restore); in-session selections still slide (AND-405).
     @State private var hasAppeared = false
+    /// Namespace for Liquid Glass morphing (AND-511): the trailing inspector
+    /// column carries a stable `glassEffectID` in this namespace so its glass
+    /// surface morphs in/out of the shared `GlassEffectContainer` around the
+    /// columns instead of hard-cutting when an account/drill-in is selected.
+    @Namespace private var glassNamespace
 
     private enum Layout {
         // Column widths and the screen-edge margin are owned by the shared,
@@ -321,6 +326,12 @@ struct MainPopover: View {
 
             accountInspectorColumn
         }
+        // One GlassEffectContainer spans the columns so the trailing inspector's
+        // glass surface morphs (via its glassEffectID) when it shows/hides on a
+        // drill-in, instead of hard-cutting (AND-511). The merge radius is small
+        // (SurfaceTokens.glassMergeRadius), so the rail and inspector glass do
+        // not fuse across the wide center — only the morph is shared.
+        .glassGroup()
     }
 
     // LEFT: the Wealth Summary rail is mounted unconditionally once setup is
@@ -407,6 +418,12 @@ struct MainPopover: View {
             .frame(width: Layout.flyoutWidth)
             .frame(maxHeight: columnMaxHeight)
             .leftPanelSurface()
+            // Liquid Glass morph (AND-511): a stable id in the columns'
+            // GlassEffectContainer lets the inspector's glass surface fluidly
+            // morph in/out when a drill-in opens or closes, rather than just
+            // sliding a hard-edged panel. Pairs with the existing slide/opacity
+            // transition for the non-glass content.
+            .glassEffectID("account-inspector-column", in: glassNamespace)
             // The column is stable now, so this transition only plays when it
             // first appears as setup completes — not on every selection (AND-405).
             .transition(.asymmetric(
@@ -573,6 +590,11 @@ struct MainPopover: View {
                     }
                 }
                 .scrollContentBackground(.hidden)
+                // Glass-aware scroll edge effect (AND-511): the soft edge style
+                // lets content fade under the popover's top/bottom glass chrome as
+                // it scrolls, so the scroll column reads as one continuous glass
+                // surface rather than content abruptly clipping at a hard edge.
+                .scrollEdgeEffectStyle(.soft, for: .vertical)
                 .frame(maxWidth: .infinity)
                 .modifier(DashboardScrollHeightModifier(
                     isDetached: dashboardPresentation.isDetached,
@@ -664,7 +686,10 @@ private struct AppLockedGateView: View {
                     Label("Unlock", systemImage: "lock.open.fill")
                         .frame(minWidth: 120)
                 }
-                .buttonStyle(.borderedProminent)
+                // The primary unlock CTA uses prominent Liquid Glass (AND-511):
+                // it is the highest-signal action on the lock surface and reads
+                // as a tinted glass capsule consistent with the glass chrome.
+                .buttonStyle(.glassProminent)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
             }

--- a/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
+++ b/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
@@ -28,9 +28,21 @@ struct PopoverMaterialBackground: View {
                 )
             }
 
+            // Native Liquid Glass popover chrome (AND-511): a clear rectangle
+            // carrying `.glassEffect(.regular)` replaces the hand-rolled
+            // `.ultraThinMaterial` fill. The system glass samples the desktop
+            // behind the popover and collapses to an opaque surface on its own
+            // when Reduce Transparency is enabled, so legibility is preserved
+            // without a manual material swap.
             Rectangle()
-                .fill(.ultraThinMaterial)
+                .fill(.clear)
+                .glassEffect(.regular, in: .rect)
 
+            // The user transparency slider still drives a solid overlay over the
+            // glass: lower values paint a more opaque panel, higher values
+            // preserve more read-through. This keeps balances and status text
+            // legible on busy desktops at maximum transparency and is the same
+            // value the Appearance slider/presets persist.
             Color(nsColor: .windowBackgroundColor)
                 .opacity(transparencySetting.materialOverlayOpacity)
         }

--- a/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
+++ b/Sources/PlaidBar/Views/PopoverMaterialBackground.swift
@@ -34,6 +34,16 @@ struct PopoverMaterialBackground: View {
             // behind the popover and collapses to an opaque surface on its own
             // when Reduce Transparency is enabled, so legibility is preserved
             // without a manual material swap.
+            //
+            // TODO(AND-511): this root glass and the panel glass inside
+            // `popoverColumns` live in separate `GlassEffectContainer` regions
+            // (this background is a `.background {}` sibling of the columns, not a
+            // descendant of their `.glassGroup()`), so panels sample over root
+            // glass = glass-on-glass double sampling. Unifying them into one
+            // container is not trivial here: it would require hoisting the root
+            // glass into the same view-tree branch as the columns rather than a
+            // detached background layer. Left as a follow-up; the visual cost is
+            // small at the current panel opacity.
             Rectangle()
                 .fill(.clear)
                 .glassEffect(.regular, in: .rect)


### PR DESCRIPTION
## Summary

Epic C of the macOS 26 migration (AND-511). Builds on AND-510's unconditional `.glassEffect` path to fully adopt Liquid Glass across the popover chrome, panels, and controls: the popover backdrop becomes native system glass, primary controls move to `.glass`/`.glassProminent`, the three-column inspector morphs via `glassEffectID`, and the dashboard scroll column gains a glass-aware soft edge. All accessibility honoring (transparency slider, Reduce Transparency, the selected trait on presets) is preserved, and the detached-window translucency is deliberately left on NSVisualEffectView after the C4 spike.

Implements: **AND-511**.

**Build:** green (`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`).
**Tests:** PlaidBarTests 34 passed; PopoverTransparencyTests 4 passed.

## Changes by sub-task

- **C1 — PopoverMaterialBackground.swift:** swapped the hand-rolled `Rectangle().fill(.ultraThinMaterial)` for a clear rectangle carrying `.glassEffect(.regular, in: .rect)`. The transparency slider's solid `windowBackgroundColor` overlay (`materialOverlayOpacity`) and the decorative mesh texture / Reduce Transparency + Reduce Motion gating are unchanged — system glass collapses to opaque under Reduce Transparency on its own.
- **C2 — controls:** the lock-screen **Unlock** CTA is now `.glassProminent`; the Appearance **transparency presets** use `.glassProminent` when active and `.glass` when inactive (selected VoiceOver trait retained). Footer glyph buttons were intentionally left `.borderless` to preserve menu-bar density (north star).
- **C3 — morph:** added a `@Namespace` and `.glassEffectID("account-inspector-column", …)` on the trailing inspector's glass surface, with `popoverColumns` wrapped in one `GlassEffectContainer` (`.glassGroup()`), so the inspector morphs in/out on a drill-in instead of hard-cutting.
- **C4 SPIKE — DetachedDashboardWindowController.swift:** evaluated replacing the behind-window `NSVisualEffectView` with SwiftUI glass on the transparent NSWindow. **Decision: keep NSVisualEffectView.** SwiftUI glass on a clear NSWindow samples its own (clear) backing, not what is behind the window, so it renders flat; behind-window glass has regressed here before. Recorded in code.
- **C5 — DesignTokens.swift:** removed the now-stale `liquidGlassAvailability` descriptor (it documented a macOS 15 material fallback that AND-510 deleted). Shadow depths and the spacing grid retained as instructed.
- **C6 — scroll edge:** added `.scrollEdgeEffectStyle(.soft, for: .vertical)` to the dashboard scroll column so content fades under the top/bottom glass chrome.

## Files changed

- `Sources/PlaidBar/Views/PopoverMaterialBackground.swift`
- `Sources/PlaidBar/Views/MainPopover.swift`
- `Sources/PlaidBar/Settings/SettingsView.swift`
- `Sources/PlaidBar/Theme/DesignTokens.swift`
- `Sources/PlaidBar/App/DetachedDashboardWindowController.swift`

## Follow-ups

- **C3 — filter selection morph (deferred):** the Cash/Credit/Savings/Debt/Status selector is a native `Picker(.segmented)` in `DashboardNavBand.swift`, which is outside this PR's file ownership and already animates its own selection. A custom glass segmented control would replace the native picker — left as a separate change to keep this PR build-safe and within scope.
- **C3 — account-row → inspector drill-in morph (deferred):** account rows live in a separate scroll view, use `.background(...)` rather than `.glassEffect`, and have independent lifetimes from the inspector column, so a cross-container `glassEffectID` morph would need broader restructuring than a surgical change allows. The inspector show/hide morph (shipped here) is the in-ownership, build-safe slice.
- **C4 — detached-window SwiftUI glass:** remains on NSVisualEffectView pending a confirmed behind-window SwiftUI glass path (see in-code spike note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)