### PR TITLE
[macOS 26] Epic D — App Intents bundle + App Group

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3228,6 +3228,10 @@ final class AppState {
         // previous balances on disk — otherwise the widget would keep showing
         // removed-account net worth until a later reset or successful write.
         guard !accounts.isEmpty else {
+            // App Intents read a parallel App Group snapshot. Clear it on the same
+            // empty path so Spotlight/Siri/Shortcuts stop reporting removed-account
+            // figures (AND-512).
+            try? AppGroupSnapshotStore.clear()
             Task {
                 await clearGlanceSnapshot()
                 await MainActor.run {
@@ -3236,6 +3240,9 @@ final class AppState {
             }
             return
         }
+        // Keep the App Intents snapshot fresh on the same path that already
+        // recomputes summaries for the widget (AND-512).
+        writeFinanceSnapshot(updatedAt: updatedAt)
         glanceSnapshotWriteGeneration += 1
         let generation = glanceSnapshotWriteGeneration
         let snapshot = GlanceSnapshot.make(
@@ -3269,10 +3276,64 @@ final class AppState {
         }
     }
 
+    /// Writes the display-safe ``FinanceSnapshot`` consumed by the Finance App
+    /// Intents (Spotlight / Siri / Shortcuts) into the shared App Group — the
+    /// "Tahoe spine" writer half (AND-512). Runs on the same path that already
+    /// recomputes summaries for the glance widget so the intents stay fresh.
+    ///
+    /// Reuses the existing core inputs — `accounts`, `recurringTransactions`, and
+    /// the cashflow from ``WealthSummaryPresentation`` — and lets
+    /// ``FinanceSnapshotBuilder`` do the math, so the figures match the popover
+    /// with no duplicated calculation here. Values only; never tokens or ids.
+    /// When App Lock / Privacy Mask is active the snapshot is written with
+    /// `isMasked == true` so the intents withhold the figures past the lock.
+    private func writeFinanceSnapshot(updatedAt: Date = Date()) {
+        let cashflow = WealthSummaryPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            isDemoMode: usesDemoConnectionPresentation,
+            serverConnected: serverConnected,
+            credentialsConfigured: serverCredentialsConfigured,
+            linkedItemCount: statusItemCount,
+            syncedItemCount: serverSyncedItemCount ?? 0,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            statusSyncText: statusSyncText,
+            errorMessage: error,
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            balanceHistory: balanceHistory
+        ).cashflow
+
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            cashflow: cashflow,
+            isMasked: shouldMaskFinancialValues,
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            generatedAt: updatedAt
+        )
+        // File IO off the main actor; the snapshot is `Sendable` and the store is
+        // a stateless enum, so a detached task is safe under strict concurrency.
+        Task.detached(priority: .utility) {
+            do {
+                try AppGroupSnapshotStore.save(snapshot)
+            } catch {
+                AppState.glanceSnapshotLogger.error(
+                    "Failed to write finance snapshot: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
     private func clearGlanceSnapshot() async {
         glanceSnapshotWriteGeneration += 1
         await glanceSnapshotWriteDebouncer.cancel()
         try? GlanceSnapshotStore.clear()
+        // The App Intents snapshot lives in a sibling file in the same container;
+        // wipe it on every glance clear (reset / last-institution removal) so it
+        // can't keep answering with pre-clear figures (AND-512).
+        try? AppGroupSnapshotStore.clear()
         // Tell WidgetKit to drop the already-issued timeline entry so the widget
         // surface stops showing pre-clear balances immediately. This covers
         // every clear path — the explicit reset/data-wipe (`resetLocalData`) and

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -397,6 +397,10 @@ final class AppState {
     func togglePrivacyMask() {
         guard !isContentLocked else { return }
         appLockPreferences.privacyMaskEnabled.toggle()
+        // Re-emit the App Intents snapshot so the masked/unmasked state takes
+        // effect on disk immediately: enabling the mask overwrites any prior real
+        // figures with a value-free snapshot; disabling restores the real values.
+        writeFinanceSnapshot()
     }
 
     /// True only in full App Lock (`.locked`) — distinct from
@@ -686,6 +690,10 @@ final class AppState {
         // stale message from a prior cancelled/failed unlock attempt.
         if isAppLocked {
             lastUnlockMessage = nil
+            // Locking masks financial values, so immediately overwrite the App
+            // Intents snapshot with a value-free one — no figures leak past the
+            // lock via Spotlight / Siri / Shortcuts.
+            writeFinanceSnapshot()
         }
     }
 
@@ -2175,6 +2183,7 @@ final class AppState {
             }
             // Refresh (or clear, when the last institution is gone) the widget
             // snapshot so it never shows balances for just-removed accounts.
+            // `writeGlanceSnapshot` also refreshes/clears the App Intents snapshot.
             writeGlanceSnapshot()
         } catch {
             self.error = error.localizedDescription

--- a/Sources/PlaidBar/Intents/FinanceAppIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceAppIntents.swift
@@ -31,8 +31,9 @@ private func valueResult(
         return .result(value: value, dialog: IntentDialog(stringLiteral: spokenDialog))
     case let .message(text):
         // A value intent received a non-numeric answer (e.g. "no credit cards").
-        // Surface it as dialog with a zero value rather than failing.
-        return .result(value: 0, dialog: IntentDialog(stringLiteral: text))
+        // Throw `unavailable` rather than returning a fabricated 0: Shortcuts
+        // automations would otherwise see a real-looking 0% / $0 and act on it.
+        throw FinanceIntentError.unavailable(text)
     case let .withheld(spokenDialog):
         throw FinanceIntentError.locked(spokenDialog)
     case let .unavailable(spokenDialog):

--- a/Sources/PlaidBar/Intents/FinanceAppIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceAppIntents.swift
@@ -1,0 +1,173 @@
+import AppIntents
+import PlaidBarCore
+
+// MARK: - Finance App Intents (AND-512, Epic D)
+//
+// These intents are the macOS 26 "Tahoe spine": Spotlight / Siri / Shortcuts can
+// answer finance questions straight from the shared App Group snapshot
+// (`FinanceSnapshot`) without launching the UI, hitting the local server, or
+// touching Plaid. They are deliberately thin — every numeric/textual decision and
+// the privacy/withholding rule lives in `FinanceIntentQueries` (PlaidBarCore), so
+// it is unit-tested without the AppIntents runtime.
+//
+// Privacy (D3): when the snapshot is masked (App Lock / Privacy Mask active) the
+// query returns `.withheld`, and the intent surfaces a value-free dialog instead
+// of leaking the figure.
+
+/// Reads the current shared snapshot, or `nil` when none has been written yet.
+@MainActor
+private func currentFinanceSnapshot() -> FinanceSnapshot? {
+    AppGroupSnapshotStore.loadIfAvailable()
+}
+
+/// Maps a value-bearing ``FinanceIntentResolution`` to an AppIntents result, or
+/// throws a user-facing error for the withheld / unavailable cases so Siri reads
+/// the safe dialog without a number.
+private func valueResult(
+    from resolution: FinanceIntentResolution
+) throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+    switch resolution {
+    case let .value(value, spokenDialog):
+        return .result(value: value, dialog: IntentDialog(stringLiteral: spokenDialog))
+    case let .message(text):
+        // A value intent received a non-numeric answer (e.g. "no credit cards").
+        // Surface it as dialog with a zero value rather than failing.
+        return .result(value: 0, dialog: IntentDialog(stringLiteral: text))
+    case let .withheld(spokenDialog):
+        throw FinanceIntentError.locked(spokenDialog)
+    case let .unavailable(spokenDialog):
+        throw FinanceIntentError.unavailable(spokenDialog)
+    }
+}
+
+/// Maps a textual ``FinanceIntentResolution`` (bills list) to a dialog-only
+/// result, throwing for withheld / unavailable.
+private func messageResult(
+    from resolution: FinanceIntentResolution
+) throws -> some IntentResult & ProvidesDialog {
+    switch resolution {
+    case let .value(_, spokenDialog):
+        return .result(dialog: IntentDialog(stringLiteral: spokenDialog))
+    case let .message(text):
+        return .result(dialog: IntentDialog(stringLiteral: text))
+    case let .withheld(spokenDialog):
+        throw FinanceIntentError.locked(spokenDialog)
+    case let .unavailable(spokenDialog):
+        throw FinanceIntentError.unavailable(spokenDialog)
+    }
+}
+
+/// User-facing intent errors. `CustomLocalizedStringResourceConvertible` lets Siri
+/// speak the safe message for the locked / unavailable states.
+enum FinanceIntentError: Error, CustomLocalizedStringResourceConvertible {
+    case locked(String)
+    case unavailable(String)
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case let .locked(message), let .unavailable(message):
+            return LocalizedStringResource(stringLiteral: message)
+        }
+    }
+}
+
+// MARK: - Get Safe to Spend
+
+struct GetSafeToSpendIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Safe to Spend"
+    static let description = IntentDescription(
+        "How much you can safely spend through the current window, from local VaultPeek data."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.safeToSpend(from: currentFinanceSnapshot()))
+    }
+}
+
+// MARK: - Get Balance
+
+struct GetBalanceIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Total Balance"
+    static let description = IntentDescription(
+        "Your total spendable balance across linked accounts, from local VaultPeek data."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.totalBalance(from: currentFinanceSnapshot()))
+    }
+}
+
+// MARK: - Next Recurring Bills
+
+struct NextRecurringBillsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Next Recurring Bills"
+    static let description = IntentDescription(
+        "Your upcoming recurring bills, from local VaultPeek data."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try messageResult(from: FinanceIntentQueries.nextRecurringBills(from: currentFinanceSnapshot()))
+    }
+}
+
+// MARK: - Get Credit Utilization
+
+struct GetCreditUtilizationIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Credit Utilization"
+    static let description = IntentDescription(
+        "Your aggregate credit-card utilization percentage, from local VaultPeek data."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.creditUtilization(from: currentFinanceSnapshot()))
+    }
+}
+
+// MARK: - App Shortcuts
+
+/// Exposes the finance intents to Spotlight, Siri, and the Shortcuts app. Phrases
+/// must include `\(.applicationName)` so Siri can disambiguate VaultPeek.
+struct PlaidBarShortcutsProvider: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: GetSafeToSpendIntent(),
+            phrases: [
+                "What's safe to spend in \(.applicationName)",
+                "How much can I spend in \(.applicationName)",
+            ],
+            shortTitle: "Safe to Spend",
+            systemImageName: "wallet.pass"
+        )
+        AppShortcut(
+            intent: GetBalanceIntent(),
+            phrases: [
+                "What's my balance in \(.applicationName)",
+                "Show my total balance in \(.applicationName)",
+            ],
+            shortTitle: "Total Balance",
+            systemImageName: "banknote"
+        )
+        AppShortcut(
+            intent: NextRecurringBillsIntent(),
+            phrases: [
+                "What are my next bills in \(.applicationName)",
+                "Show upcoming bills in \(.applicationName)",
+            ],
+            shortTitle: "Next Bills",
+            systemImageName: "calendar.badge.clock"
+        )
+        AppShortcut(
+            intent: GetCreditUtilizationIntent(),
+            phrases: [
+                "What's my credit utilization in \(.applicationName)",
+                "Show credit usage in \(.applicationName)",
+            ],
+            shortTitle: "Credit Utilization",
+            systemImageName: "creditcard"
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -107,9 +107,14 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         )
     }
 
-    /// True when the snapshot carries no usable figures (no accounts and no
-    /// bills). Used to drive a setup/unavailable intent response.
+    /// True when the snapshot carries no usable figures. Used to drive a
+    /// setup/unavailable intent response. A credit-only user (paid-off cards, no
+    /// cash accounts, no bills) still has a usable `creditUtilization`, so a
+    /// non-nil utilization keeps the snapshot non-empty.
     public var isEmpty: Bool {
-        accountBalances.isEmpty && nextRecurringBills.isEmpty && totalBalance == 0
+        accountBalances.isEmpty
+            && nextRecurringBills.isEmpty
+            && totalBalance == 0
+            && creditUtilization == nil
     }
 }

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Display-safe finance summary shared from the app to App Intents / extensions
+/// through the App Group container (AND-512).
+///
+/// This is the "Tahoe spine": the app computes the headline numbers once (reusing
+/// `SafeToSpendCalculator`, the wealth utilities, and `RecurringDetector`) and
+/// writes a single small snapshot that Spotlight / Siri / Shortcuts read back.
+/// It contains **values only** — never Plaid `access_token`s, `client_secret`s,
+/// `account_id`s, `item_id`s, or transaction payloads. The per-account entries
+/// carry a user-facing display name and a balance, nothing that identifies the
+/// linked institution record.
+///
+/// When App Lock / Privacy Mask is active the app writes a snapshot with
+/// `isMasked == true`; intents then return a withheld response (see
+/// `FinanceIntentQueries`) rather than leaking the figures past the lock.
+public struct FinanceSnapshot: Codable, Sendable, Equatable {
+    /// App Group identifier shared by the app, widget extension, and intents.
+    /// Matches `GlanceSnapshot.appGroupIdentifier` so a single container backs
+    /// every sharing surface.
+    public static let appGroupIdentifier = "group.com.ftchvs.PlaidBar"
+    public static let filename = "finance-snapshot.json"
+
+    /// One spendable/holding account, reduced to a display label and a balance.
+    /// No Plaid identifiers — `displayName` is the same name the popover shows.
+    public struct AccountBalance: Codable, Sendable, Equatable, Identifiable {
+        public let displayName: String
+        public let balance: Double
+        public let isoCurrencyCode: String?
+
+        public var id: String { displayName }
+
+        public init(displayName: String, balance: Double, isoCurrencyCode: String? = nil) {
+            self.displayName = displayName
+            self.balance = balance
+            self.isoCurrencyCode = isoCurrencyCode
+        }
+    }
+
+    /// One upcoming recurring obligation, reduced to a merchant label, amount,
+    /// and the next expected date string (`yyyy-MM-dd`).
+    public struct UpcomingBill: Codable, Sendable, Equatable, Identifiable {
+        public let merchantName: String
+        public let amount: Double
+        public let nextExpectedDate: String
+
+        public var id: String { "\(merchantName)-\(nextExpectedDate)" }
+
+        public init(merchantName: String, amount: Double, nextExpectedDate: String) {
+            self.merchantName = merchantName
+            self.amount = amount
+            self.nextExpectedDate = nextExpectedDate
+        }
+    }
+
+    /// Conservative discretionary balance through the look-ahead horizon
+    /// (`SafeToSpendResult.amount`). May be negative — reported honestly.
+    public let safeToSpend: Double
+    /// Net cash / total spendable balance across depository accounts.
+    public let totalBalance: Double
+    /// Per-account spendable balances, display-safe.
+    public let accountBalances: [AccountBalance]
+    /// Upcoming recurring bills within the look-ahead window, soonest first.
+    public let nextRecurringBills: [UpcomingBill]
+    /// Aggregate credit utilization percent (0–100), nil when no credit limit
+    /// is known.
+    public let creditUtilization: Double?
+    /// ISO currency code for the headline figures (best-effort; "USD" default).
+    public let isoCurrencyCode: String
+    /// When the snapshot was produced.
+    public let generatedAt: Date
+    /// True when App Lock / Privacy Mask is active. Intents must withhold values
+    /// while this is set.
+    public let isMasked: Bool
+
+    public init(
+        safeToSpend: Double,
+        totalBalance: Double,
+        accountBalances: [AccountBalance],
+        nextRecurringBills: [UpcomingBill],
+        creditUtilization: Double?,
+        isoCurrencyCode: String = "USD",
+        generatedAt: Date,
+        isMasked: Bool
+    ) {
+        self.safeToSpend = safeToSpend
+        self.totalBalance = totalBalance
+        self.accountBalances = accountBalances
+        self.nextRecurringBills = nextRecurringBills
+        self.creditUtilization = creditUtilization
+        self.isoCurrencyCode = isoCurrencyCode
+        self.generatedAt = generatedAt
+        self.isMasked = isMasked
+    }
+
+    /// Empty placeholder used before the first real snapshot exists. Treated as
+    /// "no data yet" by the intents rather than a misleading "$0".
+    public static func placeholder(generatedAt: Date = Date()) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: 0,
+            totalBalance: 0,
+            accountBalances: [],
+            nextRecurringBills: [],
+            creditUtilization: nil,
+            generatedAt: generatedAt,
+            isMasked: false
+        )
+    }
+
+    /// True when the snapshot carries no usable figures (no accounts and no
+    /// bills). Used to drive a setup/unavailable intent response.
+    public var isEmpty: Bool {
+        accountBalances.isEmpty && nextRecurringBills.isEmpty && totalBalance == 0
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/AppGroupSnapshotStore.swift
+++ b/Sources/PlaidBarCore/Utilities/AppGroupSnapshotStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Reads and writes the shared ``FinanceSnapshot`` in the App Group container so
+/// App Intents (Spotlight / Siri / Shortcuts) and extensions can answer finance
+/// queries without touching the local server, Plaid, or any credential (AND-512).
+///
+/// Mirrors ``GlanceSnapshotStore``: the same container-URL-or-local-fallback
+/// resolution and the same atomic, owner-only (`0o600`) JSON write, but a
+/// distinct filename (``FinanceSnapshot/filename``) so the App Intents payload
+/// never collides with the glance widget snapshot.
+///
+/// - The app is the only **writer** (`save`).
+/// - Intents / extensions are **readers** (`load`).
+/// Values only — never tokens or secrets. See ``FinanceSnapshot``.
+public enum AppGroupSnapshotStore {
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    /// Resolves the App Group container directory, falling back to the local
+    /// data store directory when the group container is unavailable (e.g. an
+    /// unsigned SwiftPM build or tests). Matches ``GlanceSnapshotStore``.
+    public static func snapshotDirectory(
+        fileManager: FileManager = .default,
+        appGroupIdentifier: String = FinanceSnapshot.appGroupIdentifier
+    ) -> URL {
+        if let url = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) {
+            return url
+        }
+        return LocalDataStore.storageDirectoryURL()
+    }
+
+    public static func snapshotURL(directory: URL) -> URL {
+        directory.appendingPathComponent(FinanceSnapshot.filename)
+    }
+
+    /// Writes the snapshot (app side). Creates the container directory if needed
+    /// and writes atomically with owner-only permissions.
+    public static func save(
+        _ snapshot: FinanceSnapshot,
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        let url = snapshotURL(directory: directory)
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try encoder.encode(snapshot)
+        try data.write(to: url, options: [.atomic])
+        #if os(macOS)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        #endif
+    }
+
+    /// Reads the snapshot (intent / extension side). Throws when no snapshot has
+    /// been written yet so callers can present a setup state.
+    public static func load(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws -> FinanceSnapshot {
+        let data = try Data(contentsOf: snapshotURL(directory: directory))
+        return try decoder.decode(FinanceSnapshot.self, from: data)
+    }
+
+    /// Non-throwing read used by intents: returns `nil` when no snapshot exists
+    /// or it cannot be decoded.
+    public static func loadIfAvailable(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) -> FinanceSnapshot? {
+        try? load(directory: directory, fileManager: fileManager)
+    }
+
+    public static func clear(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        let url = snapshotURL(directory: directory)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
@@ -81,7 +81,7 @@ public enum FinanceIntentQueries {
         }
 
         let spoken = bills.prefix(maxSpokenBills).map { bill in
-            "\(bill.merchantName) for \(Formatters.currency(bill.amount, format: .full, currencyCode: snapshot.isoCurrencyCode)) on \(displayDate(bill.nextExpectedDate))"
+            "\(bill.merchantName) for \(Formatters.currency(bill.amount, format: .full, currencyCode: snapshot.isoCurrencyCode)) on \(Formatters.displayTransactionDate(bill.nextExpectedDate))"
         }
         var sentence = "Coming up: " + listSentence(spoken) + "."
         let remainder = bills.count - min(bills.count, maxSpokenBills)
@@ -105,20 +105,6 @@ public enum FinanceIntentQueries {
     }
 
     // MARK: - Formatting helpers
-
-    /// Renders a `yyyy-MM-dd` string as a friendly medium date, or returns the
-    /// raw string if it cannot be parsed.
-    private static func displayDate(_ raw: String) -> String {
-        guard let date = Formatters.parseTransactionDate(raw) else { return raw }
-        return mediumDateFormatter.string(from: date)
-    }
-
-    private static let mediumDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }()
 
     /// Joins items into a spoken list: "a", "a and b", "a, b, and c".
     private static func listSentence(_ items: [String]) -> String {

--- a/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// The outcome of answering a finance App Intent from the shared snapshot.
+///
+/// App Intents in the app target are thin shells: they load the snapshot and ask
+/// one of the ``FinanceIntentQueries`` helpers for a `Resolution`, then translate
+/// it into an AppIntents `IntentResult`. Keeping the decision logic here makes the
+/// masked/withheld/unavailable behavior (AND-512, D3) fully unit-testable without
+/// the AppIntents runtime.
+public enum FinanceIntentResolution: Sendable, Equatable {
+    /// A numeric answer is available. `value` is the raw figure (for a
+    /// `ReturnsValue` intent); `spokenDialog` is the natural-language sentence
+    /// for Siri/Spotlight.
+    case value(Double, spokenDialog: String)
+    /// A non-numeric textual answer (e.g. a bills list, or "no upcoming bills").
+    case message(String)
+    /// Privacy Mask / App Lock is active — withhold the figure. `spokenDialog`
+    /// is a safe, value-free sentence.
+    case withheld(spokenDialog: String)
+    /// No snapshot has been produced yet (first run / post-reset). Prompts setup.
+    case unavailable(spokenDialog: String)
+}
+
+/// Pure helpers that turn a ``FinanceSnapshot`` (or its absence) into a
+/// ``FinanceIntentResolution`` for each finance App Intent. No AppIntents import,
+/// no `Date()` side effects beyond formatting, fully testable.
+public enum FinanceIntentQueries {
+    static let lockedDialog = "Your finances are locked. Unlock VaultPeek to see this."
+    static let unavailableDialog = "VaultPeek hasn't synced yet. Open VaultPeek to get started."
+
+    /// Guard shared by every query: returns a non-`value` resolution when the
+    /// snapshot is missing or masked, otherwise `nil` to proceed.
+    private static func gate(_ snapshot: FinanceSnapshot?) -> FinanceIntentResolution? {
+        guard let snapshot else {
+            return .unavailable(spokenDialog: unavailableDialog)
+        }
+        if snapshot.isMasked {
+            return .withheld(spokenDialog: lockedDialog)
+        }
+        if snapshot.isEmpty {
+            return .unavailable(spokenDialog: unavailableDialog)
+        }
+        return nil
+    }
+
+    // MARK: - Safe to spend
+
+    public static func safeToSpend(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {
+        if let blocked = gate(snapshot) { return blocked }
+        guard let snapshot else { return .unavailable(spokenDialog: unavailableDialog) }
+        let amount = snapshot.safeToSpend
+        let formatted = Formatters.currency(amount, format: .full, currencyCode: snapshot.isoCurrencyCode)
+        let dialog: String = amount < 0
+            ? "You're over budget by \(Formatters.currency(abs(amount), format: .full, currencyCode: snapshot.isoCurrencyCode))."
+            : "You have \(formatted) safe to spend."
+        return .value(amount, spokenDialog: dialog)
+    }
+
+    // MARK: - Total balance
+
+    public static func totalBalance(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {
+        if let blocked = gate(snapshot) { return blocked }
+        guard let snapshot else { return .unavailable(spokenDialog: unavailableDialog) }
+        let amount = snapshot.totalBalance
+        let formatted = Formatters.currency(amount, format: .full, currencyCode: snapshot.isoCurrencyCode)
+        return .value(amount, spokenDialog: "Your total balance is \(formatted).")
+    }
+
+    // MARK: - Next recurring bills
+
+    /// How many upcoming bills to read aloud before summarizing the remainder.
+    public static let maxSpokenBills = 3
+
+    public static func nextRecurringBills(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {
+        if let blocked = gate(snapshot) { return blocked }
+        guard let snapshot else { return .unavailable(spokenDialog: unavailableDialog) }
+
+        let bills = snapshot.nextRecurringBills
+        guard !bills.isEmpty else {
+            return .message("No upcoming bills in your tracked window.")
+        }
+
+        let spoken = bills.prefix(maxSpokenBills).map { bill in
+            "\(bill.merchantName) for \(Formatters.currency(bill.amount, format: .full, currencyCode: snapshot.isoCurrencyCode)) on \(displayDate(bill.nextExpectedDate))"
+        }
+        var sentence = "Coming up: " + listSentence(spoken) + "."
+        let remainder = bills.count - min(bills.count, maxSpokenBills)
+        if remainder > 0 {
+            sentence += " Plus \(remainder) more."
+        }
+        return .message(sentence)
+    }
+
+    // MARK: - Credit utilization
+
+    public static func creditUtilization(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {
+        if let blocked = gate(snapshot) { return blocked }
+        guard let snapshot else { return .unavailable(spokenDialog: unavailableDialog) }
+
+        guard let percent = snapshot.creditUtilization else {
+            return .message("No credit cards with a known limit are linked.")
+        }
+        let formatted = Formatters.percent(percent)
+        return .value(percent, spokenDialog: "Your credit utilization is \(formatted).")
+    }
+
+    // MARK: - Formatting helpers
+
+    /// Renders a `yyyy-MM-dd` string as a friendly medium date, or returns the
+    /// raw string if it cannot be parsed.
+    private static func displayDate(_ raw: String) -> String {
+        guard let date = Formatters.parseTransactionDate(raw) else { return raw }
+        return mediumDateFormatter.string(from: date)
+    }
+
+    private static let mediumDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    /// Joins items into a spoken list: "a", "a and b", "a, b, and c".
+    private static func listSentence(_ items: [String]) -> String {
+        switch items.count {
+        case 0: return ""
+        case 1: return items[0]
+        case 2: return "\(items[0]) and \(items[1])"
+        default:
+            let head = items.dropLast().joined(separator: ", ")
+            return "\(head), and \(items[items.count - 1])"
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Builds a display-safe ``FinanceSnapshot`` for the App Group from raw account,
+/// transaction, and recurring data — reusing the existing core math so the
+/// numbers App Intents read match the popover exactly (AND-512).
+///
+/// Math reuse (no duplication):
+/// - `safeToSpend` ← ``SafeToSpendCalculator/compute(accounts:recurringTransactions:cashflow:inputs:pendingHolds:asOf:calendar:)``
+/// - `totalBalance` ← ``MenuBarSummary/netCash(from:)``
+/// - `creditUtilization` ← ``WealthSummaryPresentation`` credit-utilization rule
+///   (recomputed from the same depository/credit balances)
+/// - `nextRecurringBills` ← the supplied recurring streams, filtered to dated
+///   outflows within the horizon and sorted soonest-first.
+public enum FinanceSnapshotBuilder {
+    /// Recurring outflow streams below this confidence are treated as noise, in
+    /// line with ``SafeToSpendCalculator/minimumObligationConfidence``.
+    public static let minimumBillConfidence = SafeToSpendCalculator.minimumObligationConfidence
+
+    public static func make(
+        accounts: [AccountDTO],
+        recurringTransactions: [RecurringTransaction],
+        cashflow: WealthSummaryPresentation.CashflowSummary? = nil,
+        safeToSpendInputs: SafeToSpendInputs = .default,
+        pendingHolds: Double = 0,
+        isMasked: Bool,
+        creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        generatedAt: Date = Date(),
+        calendar: Calendar = .current
+    ) -> FinanceSnapshot {
+        let safeToSpend = SafeToSpendCalculator.compute(
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            cashflow: cashflow,
+            inputs: safeToSpendInputs,
+            pendingHolds: pendingHolds,
+            asOf: generatedAt,
+            calendar: calendar
+        )
+
+        let totalBalance = MenuBarSummary.netCash(from: accounts)
+
+        let accountBalances = accounts
+            .filter { safeToSpendInputs.includedCashAccountTypes.contains($0.type) }
+            .map { account in
+                FinanceSnapshot.AccountBalance(
+                    displayName: account.name,
+                    balance: account.balances.effectiveBalance,
+                    isoCurrencyCode: account.balances.isoCurrencyCode
+                )
+            }
+
+        let bills = upcomingBills(
+            from: recurringTransactions,
+            inputs: safeToSpendInputs,
+            asOf: generatedAt,
+            calendar: calendar
+        )
+
+        let utilization = creditUtilizationPercent(from: accounts)
+
+        let currencyCode = accounts
+            .compactMap { $0.balances.isoCurrencyCode }
+            .first ?? "USD"
+
+        return FinanceSnapshot(
+            safeToSpend: safeToSpend.amount,
+            totalBalance: totalBalance,
+            accountBalances: accountBalances,
+            nextRecurringBills: bills,
+            creditUtilization: utilization,
+            isoCurrencyCode: currencyCode,
+            generatedAt: generatedAt,
+            isMasked: isMasked
+        )
+    }
+
+    // MARK: - Upcoming bills
+
+    private static func upcomingBills(
+        from recurringTransactions: [RecurringTransaction],
+        inputs: SafeToSpendInputs,
+        asOf date: Date,
+        calendar: Calendar
+    ) -> [FinanceSnapshot.UpcomingBill] {
+        let referenceDay = calendar.startOfDay(for: date)
+        let horizonEnd = inputs.horizon.endDate(asOf: date, calendar: calendar)
+
+        let dated: [(bill: FinanceSnapshot.UpcomingBill, due: Date)] = recurringTransactions.compactMap { recurring in
+            guard recurring.confidence >= minimumBillConfidence else { return nil }
+            // Outflows only — mirror SafeToSpendCalculator's obligation filter so
+            // income and own-account transfers never show up as a "bill".
+            guard isOutflow(recurring.category) else { return nil }
+            guard let nextDate = Formatters.parseTransactionDate(recurring.nextExpectedDate) else { return nil }
+            let nextDay = calendar.startOfDay(for: nextDate)
+            guard nextDay >= referenceDay, nextDay <= horizonEnd else { return nil }
+            let amount = max(recurring.averageAmount, 0)
+            guard amount > 0 else { return nil }
+            return (
+                FinanceSnapshot.UpcomingBill(
+                    merchantName: recurring.merchantName,
+                    amount: amount,
+                    nextExpectedDate: recurring.nextExpectedDate
+                ),
+                nextDay
+            )
+        }
+
+        return dated
+            .sorted { $0.due < $1.due }
+            .map(\.bill)
+    }
+
+    private static func isOutflow(_ category: SpendingCategory?) -> Bool {
+        switch category {
+        case .income, .transfer, .transferOut:
+            return false
+        default:
+            return true
+        }
+    }
+
+    // MARK: - Credit utilization
+
+    /// Aggregate credit utilization (0–100), nil when no credit limit is known.
+    /// Same rule as ``WealthSummaryPresentation`` (`used / limit * 100`).
+    private static func creditUtilizationPercent(from accounts: [AccountDTO]) -> Double? {
+        let creditBalances = accounts
+            .filter { $0.type == .credit }
+            .map(\.balances)
+
+        let totalLimit = creditBalances.reduce(0) { $0 + max($1.limit ?? 0, 0) }
+        guard totalLimit > 0 else { return nil }
+
+        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
+        return (usedCredit / totalLimit) * 100
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -6,7 +6,9 @@ import Foundation
 ///
 /// Math reuse (no duplication):
 /// - `safeToSpend` ← ``SafeToSpendCalculator/compute(accounts:recurringTransactions:cashflow:inputs:pendingHolds:asOf:calendar:)``
-/// - `totalBalance` ← ``MenuBarSummary/netCash(from:)``
+/// - `totalBalance` ← sum of the included cash/depository balances (the same set
+///   used to build `accountBalances`), matching the intent's "spendable balance
+///   across linked accounts" — not net worth.
 /// - `creditUtilization` ← ``WealthSummaryPresentation`` credit-utilization rule
 ///   (recomputed from the same depository/credit balances)
 /// - `nextRecurringBills` ← the supplied recurring streams, filtered to dated
@@ -37,10 +39,17 @@ public enum FinanceSnapshotBuilder {
             calendar: calendar
         )
 
-        let totalBalance = MenuBarSummary.netCash(from: accounts)
-
-        let accountBalances = accounts
+        // Only the included cash/depository accounts — the same set that powers
+        // `accountBalances` below. The balance intent describes "spendable balance
+        // across linked accounts", so this deliberately excludes investments and
+        // does NOT subtract credit/loan debt (that would be net worth, not cash).
+        let includedCashAccounts = accounts
             .filter { safeToSpendInputs.includedCashAccountTypes.contains($0.type) }
+
+        let totalBalance = includedCashAccounts
+            .reduce(0) { $0 + $1.balances.effectiveBalance }
+
+        let accountBalances = includedCashAccounts
             .map { account in
                 FinanceSnapshot.AccountBalance(
                     displayName: account.name,
@@ -61,6 +70,23 @@ public enum FinanceSnapshotBuilder {
         let currencyCode = accounts
             .compactMap { $0.balances.isoCurrencyCode }
             .first ?? "USD"
+
+        // Defense in depth: a masked snapshot must be value-free *on disk*, not
+        // merely withheld at read time. If anyone bypasses the read-time gate
+        // (`FinanceIntentQueries`) the file itself carries no real figures — only
+        // the flag, timestamp, and currency code survive.
+        if isMasked {
+            return FinanceSnapshot(
+                safeToSpend: 0,
+                totalBalance: 0,
+                accountBalances: [],
+                nextRecurringBills: [],
+                creditUtilization: nil,
+                isoCurrencyCode: currencyCode,
+                generatedAt: generatedAt,
+                isMasked: true
+            )
+        }
 
         return FinanceSnapshot(
             safeToSpend: safeToSpend.amount,

--- a/Tests/PlaidBarCoreTests/AppGroupSnapshotStoreTests.swift
+++ b/Tests/PlaidBarCoreTests/AppGroupSnapshotStoreTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("App Group finance snapshot store")
+struct AppGroupSnapshotStoreTests {
+    // MARK: - Round trip
+
+    @Test("Snapshot round-trips through the store unchanged")
+    func snapshotRoundTrips() throws {
+        let directory = temporaryDirectory()
+        let snapshot = sampleSnapshot()
+
+        try AppGroupSnapshotStore.save(snapshot, directory: directory)
+        let loaded = try AppGroupSnapshotStore.load(directory: directory)
+
+        #expect(loaded == snapshot)
+    }
+
+    @Test("loadIfAvailable returns nil when no snapshot has been written")
+    func loadIfAvailableReturnsNilWhenMissing() {
+        let directory = temporaryDirectory()
+        #expect(AppGroupSnapshotStore.loadIfAvailable(directory: directory) == nil)
+    }
+
+    @Test("Clearing removes the snapshot file")
+    func clearRemovesSnapshot() throws {
+        let directory = temporaryDirectory()
+        try AppGroupSnapshotStore.save(sampleSnapshot(), directory: directory)
+        #expect(AppGroupSnapshotStore.loadIfAvailable(directory: directory) != nil)
+
+        try AppGroupSnapshotStore.clear(directory: directory)
+        #expect(AppGroupSnapshotStore.loadIfAvailable(directory: directory) == nil)
+    }
+
+    @Test("Snapshot JSON carries values only — no Plaid identifiers or secrets")
+    func snapshotJSONExcludesPrivateFields() throws {
+        let directory = temporaryDirectory()
+        try AppGroupSnapshotStore.save(sampleSnapshot(), directory: directory)
+
+        let json = try String(
+            contentsOf: AppGroupSnapshotStore.snapshotURL(directory: directory),
+            encoding: .utf8
+        )
+
+        #expect(json.contains("\"safeToSpend\""))
+        #expect(json.contains("\"totalBalance\""))
+        #expect(json.contains("\"isMasked\""))
+        #expect(!json.contains("access_token"))
+        #expect(!json.contains("accessToken"))
+        #expect(!json.contains("client_secret"))
+        #expect(!json.contains("public_token"))
+        #expect(!json.contains("account_id"))
+        #expect(!json.contains("accountId"))
+        #expect(!json.contains("item_id"))
+        #expect(!json.contains("itemId"))
+        #expect(!json.contains("transaction_id"))
+    }
+
+    @Test("Shares the glance snapshot App Group identifier")
+    func sharesAppGroupIdentifier() {
+        #expect(FinanceSnapshot.appGroupIdentifier == GlanceSnapshot.appGroupIdentifier)
+        #expect(FinanceSnapshot.filename != GlanceSnapshot.filename)
+    }
+
+    // MARK: - Helpers
+
+    private func sampleSnapshot(isMasked: Bool = false) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: 1_234.56,
+            totalBalance: 9_876.54,
+            accountBalances: [
+                FinanceSnapshot.AccountBalance(displayName: "Everyday Checking", balance: 4_200.10),
+                FinanceSnapshot.AccountBalance(displayName: "Vacation Savings", balance: 5_676.44),
+            ],
+            nextRecurringBills: [
+                FinanceSnapshot.UpcomingBill(merchantName: "Rent", amount: 1_800, nextExpectedDate: "2026-07-01"),
+            ],
+            creditUtilization: 27.5,
+            generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            isMasked: isMasked
+        )
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppGroupSnapshotStoreTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Finance App Intent query helpers")
+struct FinanceIntentQueriesTests {
+    // MARK: - Privacy (D3)
+
+    @Test("Masked snapshot withholds safe-to-spend with a value-free dialog")
+    func maskedSnapshotWithholdsSafeToSpend() {
+        let resolution = FinanceIntentQueries.safeToSpend(from: snapshot(safeToSpend: 4_321, isMasked: true))
+        guard case let .withheld(dialog) = resolution else {
+            Issue.record("Expected .withheld, got \(resolution)")
+            return
+        }
+        #expect(!dialog.contains("4,321"))
+        #expect(!dialog.contains("4321"))
+    }
+
+    @Test("Masked snapshot withholds every query")
+    func maskedSnapshotWithholdsEveryQuery() {
+        let masked = snapshot(isMasked: true)
+        for resolution in [
+            FinanceIntentQueries.safeToSpend(from: masked),
+            FinanceIntentQueries.totalBalance(from: masked),
+            FinanceIntentQueries.nextRecurringBills(from: masked),
+            FinanceIntentQueries.creditUtilization(from: masked),
+        ] {
+            guard case .withheld = resolution else {
+                Issue.record("Expected .withheld, got \(resolution)")
+                continue
+            }
+        }
+    }
+
+    // MARK: - Unavailable
+
+    @Test("Nil snapshot reports unavailable")
+    func nilSnapshotReportsUnavailable() {
+        guard case .unavailable = FinanceIntentQueries.safeToSpend(from: nil) else {
+            Issue.record("Expected .unavailable for nil snapshot")
+            return
+        }
+    }
+
+    @Test("Empty snapshot reports unavailable")
+    func emptySnapshotReportsUnavailable() {
+        guard case .unavailable = FinanceIntentQueries.totalBalance(from: .placeholder()) else {
+            Issue.record("Expected .unavailable for empty snapshot")
+            return
+        }
+    }
+
+    // MARK: - Values
+
+    @Test("Safe to spend returns the value and a positive dialog")
+    func safeToSpendReturnsValue() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.safeToSpend(from: snapshot(safeToSpend: 1_500)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 1_500)
+        #expect(dialog.contains("safe to spend"))
+    }
+
+    @Test("Negative safe to spend reports an over-budget dialog")
+    func negativeSafeToSpendReportsOverBudget() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.safeToSpend(from: snapshot(safeToSpend: -200)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == -200)
+        #expect(dialog.lowercased().contains("over budget"))
+    }
+
+    @Test("Total balance returns the value")
+    func totalBalanceReturnsValue() {
+        guard case let .value(value, _) = FinanceIntentQueries.totalBalance(from: snapshot(totalBalance: 8_400)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 8_400)
+    }
+
+    @Test("Credit utilization returns the percent value")
+    func creditUtilizationReturnsValue() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.creditUtilization(from: snapshot(creditUtilization: 42)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 42)
+        #expect(dialog.contains("utilization"))
+    }
+
+    @Test("Credit utilization without a known limit reports a message")
+    func creditUtilizationWithoutLimitReportsMessage() {
+        guard case .message = FinanceIntentQueries.creditUtilization(from: snapshot(creditUtilization: nil)) else {
+            Issue.record("Expected .message when no credit limit is known")
+            return
+        }
+    }
+
+    // MARK: - Bills
+
+    @Test("Next bills lists merchants and amounts")
+    func nextBillsListsMerchants() {
+        let bills = [
+            FinanceSnapshot.UpcomingBill(merchantName: "Netflix", amount: 15.99, nextExpectedDate: "2026-07-02"),
+            FinanceSnapshot.UpcomingBill(merchantName: "Gym", amount: 40, nextExpectedDate: "2026-07-05"),
+        ]
+        guard case let .message(text) = FinanceIntentQueries.nextRecurringBills(from: snapshot(bills: bills)) else {
+            Issue.record("Expected .message")
+            return
+        }
+        #expect(text.contains("Netflix"))
+        #expect(text.contains("Gym"))
+    }
+
+    @Test("Next bills summarizes the remainder beyond the spoken cap")
+    func nextBillsSummarizesRemainder() {
+        let bills = (0..<5).map { index in
+            FinanceSnapshot.UpcomingBill(
+                merchantName: "Bill\(index)",
+                amount: Double(index + 1),
+                nextExpectedDate: "2026-07-0\(index + 1)"
+            )
+        }
+        guard case let .message(text) = FinanceIntentQueries.nextRecurringBills(from: snapshot(bills: bills)) else {
+            Issue.record("Expected .message")
+            return
+        }
+        // 5 bills, cap 3 spoken → "Plus 2 more."
+        #expect(text.contains("2 more"))
+    }
+
+    @Test("No bills reports a no-bills message, not unavailable")
+    func noBillsReportsMessage() {
+        // A snapshot with balances but no bills is non-empty, so this is a real
+        // "no upcoming bills" answer rather than a setup prompt.
+        guard case let .message(text) = FinanceIntentQueries.nextRecurringBills(from: snapshot(bills: [])) else {
+            Issue.record("Expected .message for non-empty snapshot with no bills")
+            return
+        }
+        #expect(text.lowercased().contains("no upcoming bills"))
+    }
+
+    // MARK: - Helpers
+
+    private func snapshot(
+        safeToSpend: Double = 1_000,
+        totalBalance: Double = 5_000,
+        bills: [FinanceSnapshot.UpcomingBill] = [],
+        creditUtilization: Double? = 20,
+        isMasked: Bool = false
+    ) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: safeToSpend,
+            totalBalance: totalBalance,
+            accountBalances: [
+                FinanceSnapshot.AccountBalance(displayName: "Checking", balance: totalBalance),
+            ],
+            nextRecurringBills: bills,
+            creditUtilization: creditUtilization,
+            generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            isMasked: isMasked
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
@@ -28,7 +28,10 @@ struct FinanceSnapshotBuilderTests {
             asOf: asOf
         )
         #expect(snapshot.safeToSpend == expectedSafeToSpend.amount)
-        #expect(snapshot.totalBalance == MenuBarSummary.netCash(from: accounts))
+        // totalBalance is the sum of included cash accounts (spendable balance),
+        // NOT net worth — investments are excluded and credit debt is not
+        // subtracted. Here: 3_000 + 5_000 = 8_000.
+        #expect(snapshot.totalBalance == 8_000)
         // Two depository accounts surface as display-safe balances.
         #expect(snapshot.accountBalances.count == 2)
         #expect(snapshot.accountBalances.contains { $0.displayName == "Checking" })
@@ -38,15 +41,52 @@ struct FinanceSnapshotBuilderTests {
         #expect(snapshot.creditUtilization == 20) // 400 / 2000 * 100
     }
 
-    @Test("Masked flag propagates into the snapshot")
-    func maskedFlagPropagates() {
+    @Test("Masked snapshot is value-free on disk (defense in depth)")
+    func maskedSnapshotIsValueFree() {
+        // Even with real accounts, credit, and bills, a masked snapshot must carry
+        // no real figures — only the flag, timestamp, and currency survive.
+        let referenceDay = Calendar.current.startOfDay(for: asOf)
+        let recurring = [
+            recurringStream(
+                merchant: "Rent",
+                amount: 1_800,
+                next: dateString(byAdding: 1, to: referenceDay),
+                category: .billsAndUtilities
+            ),
+        ]
         let snapshot = FinanceSnapshotBuilder.make(
-            accounts: [depository(name: "Checking", available: 1_000)],
-            recurringTransactions: [],
+            accounts: [
+                depository(name: "Checking", available: 1_000),
+                credit(name: "Card", current: 400, limit: 2_000),
+            ],
+            recurringTransactions: recurring,
+            safeToSpendInputs: SafeToSpendInputs(horizon: .days(2)),
             isMasked: true,
             generatedAt: asOf
         )
         #expect(snapshot.isMasked)
+        #expect(snapshot.safeToSpend == 0)
+        #expect(snapshot.totalBalance == 0)
+        #expect(snapshot.accountBalances.isEmpty)
+        #expect(snapshot.nextRecurringBills.isEmpty)
+        #expect(snapshot.creditUtilization == nil)
+        #expect(snapshot.generatedAt == asOf)
+    }
+
+    @Test("Credit-only snapshot is not considered empty")
+    func creditOnlySnapshotIsNotEmpty() {
+        // A paid-off credit user has no cash accounts and no bills, but a usable
+        // utilization — the intents must not treat that as "no data".
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [credit(name: "Card", current: 400, limit: 2_000)],
+            recurringTransactions: [],
+            isMasked: false,
+            generatedAt: asOf
+        )
+        #expect(snapshot.accountBalances.isEmpty)
+        #expect(snapshot.totalBalance == 0)
+        #expect(snapshot.creditUtilization == 20)
+        #expect(!snapshot.isEmpty)
     }
 
     @Test("Upcoming bills include dated outflows in-window and exclude income")

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Finance snapshot builder")
+struct FinanceSnapshotBuilderTests {
+    private let asOf = Date(timeIntervalSince1970: 1_780_000_000) // fixed reference
+
+    @Test("Builder reuses SafeToSpendCalculator and MenuBarSummary for headline figures")
+    func builderReusesCoreMath() throws {
+        let accounts = [
+            depository(name: "Checking", available: 3_000),
+            depository(name: "Savings", available: 5_000),
+            credit(name: "Card", current: 400, limit: 2_000),
+        ]
+        let recurring: [RecurringTransaction] = []
+
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: accounts,
+            recurringTransactions: recurring,
+            isMasked: false,
+            generatedAt: asOf
+        )
+
+        let expectedSafeToSpend = SafeToSpendCalculator.compute(
+            accounts: accounts,
+            recurringTransactions: recurring,
+            asOf: asOf
+        )
+        #expect(snapshot.safeToSpend == expectedSafeToSpend.amount)
+        #expect(snapshot.totalBalance == MenuBarSummary.netCash(from: accounts))
+        // Two depository accounts surface as display-safe balances.
+        #expect(snapshot.accountBalances.count == 2)
+        #expect(snapshot.accountBalances.contains { $0.displayName == "Checking" })
+        // Credit account is not a "spendable cash" account, so it's excluded from
+        // the per-account balances list but still drives utilization.
+        #expect(!snapshot.accountBalances.contains { $0.displayName == "Card" })
+        #expect(snapshot.creditUtilization == 20) // 400 / 2000 * 100
+    }
+
+    @Test("Masked flag propagates into the snapshot")
+    func maskedFlagPropagates() {
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 1_000)],
+            recurringTransactions: [],
+            isMasked: true,
+            generatedAt: asOf
+        )
+        #expect(snapshot.isMasked)
+    }
+
+    @Test("Upcoming bills include dated outflows in-window and exclude income")
+    func upcomingBillsFilterToOutflowsInWindow() throws {
+        // asOf is 2026-05-29; end-of-month horizon is 2026-05-31. Build dated
+        // recurrings relative to that window.
+        let referenceDay = Calendar.current.startOfDay(for: asOf)
+        let inWindow = dateString(byAdding: 1, to: referenceDay)
+        let outOfWindow = dateString(byAdding: 120, to: referenceDay)
+
+        let recurring = [
+            recurringStream(merchant: "Rent", amount: 1_800, next: inWindow, category: .billsAndUtilities),
+            recurringStream(merchant: "Paycheck", amount: 5_000, next: inWindow, category: .income),
+            recurringStream(merchant: "FarOff", amount: 30, next: outOfWindow, category: .subscriptions),
+        ]
+
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 4_000)],
+            recurringTransactions: recurring,
+            safeToSpendInputs: SafeToSpendInputs(horizon: .days(2)),
+            isMasked: false,
+            generatedAt: asOf
+        )
+
+        let merchants = snapshot.nextRecurringBills.map(\.merchantName)
+        #expect(merchants.contains("Rent"))
+        #expect(!merchants.contains("Paycheck"))    // income excluded
+        #expect(!merchants.contains("FarOff"))      // out of horizon
+    }
+
+    @Test("Upcoming bills are sorted soonest-first")
+    func upcomingBillsSortedSoonestFirst() throws {
+        let referenceDay = Calendar.current.startOfDay(for: asOf)
+        let soon = dateString(byAdding: 1, to: referenceDay)
+        let later = dateString(byAdding: 3, to: referenceDay)
+
+        let recurring = [
+            recurringStream(merchant: "Later", amount: 50, next: later, category: .subscriptions),
+            recurringStream(merchant: "Soon", amount: 20, next: soon, category: .billsAndUtilities),
+        ]
+
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 4_000)],
+            recurringTransactions: recurring,
+            safeToSpendInputs: SafeToSpendInputs(horizon: .days(5)),
+            isMasked: false,
+            generatedAt: asOf
+        )
+
+        #expect(snapshot.nextRecurringBills.map(\.merchantName) == ["Soon", "Later"])
+    }
+
+    // MARK: - Helpers
+
+    private func depository(name: String, available: Double) -> AccountDTO {
+        AccountDTO(
+            id: "acct-\(name)",
+            itemId: "item-1",
+            name: name,
+            type: .depository,
+            balances: BalanceDTO(available: available, current: available)
+        )
+    }
+
+    private func credit(name: String, current: Double, limit: Double) -> AccountDTO {
+        AccountDTO(
+            id: "acct-\(name)",
+            itemId: "item-1",
+            name: name,
+            type: .credit,
+            balances: BalanceDTO(current: current, limit: limit)
+        )
+    }
+
+    private func recurringStream(
+        merchant: String,
+        amount: Double,
+        next: String,
+        category: SpendingCategory
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchant,
+            frequency: .monthly,
+            averageAmount: amount,
+            lastDate: "2026-04-29",
+            nextExpectedDate: next,
+            category: category,
+            transactionCount: 4,
+            confidence: 0.9
+        )
+    }
+
+    private func dateString(byAdding days: Int, to date: Date) -> String {
+        let target = Calendar.current.date(byAdding: .day, value: days, to: date) ?? date
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+        return formatter.string(from: target)
+    }
+}


### PR DESCRIPTION
## Summary

Lands the macOS 26 native foundation for Epic D (the "Tahoe spine"): a shared App Group snapshot the app produces once and that Spotlight/Siri/Shortcuts read back through four App Intents — with no server call, no Plaid access, and no credential ever leaving the app. The intents are deliberately thin shells; all numeric/textual decisions and the privacy-withholding rule live in PlaidBarCore so they are fully unit-tested without the AppIntents runtime, and the headline figures reuse `SafeToSpendCalculator`, `MenuBarSummary`, and the wealth/credit-utilization rule rather than duplicating math.

Implements **AND-512**.

**Build:** green (`swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`)
**Tests:** green — 21 new tests + full `PlaidBarCoreTests` suite (858 passing)

## What's included
- **D1 — App Group snapshot store (PlaidBarCore):** `FinanceSnapshot` (Sendable/Codable, values-only: safeToSpend, totalBalance, per-account balances, nextRecurringBills, creditUtilization, generatedAt, isMasked) + `AppGroupSnapshotStore` (write from app / read from extensions via the group container URL with local fallback). Reuses the same App Group id `group.com.ftchvs.PlaidBar` as the glance widget, with a distinct `finance-snapshot.json` so the two payloads never collide. Atomic, owner-only (`0o600`) writes.
- **D2 — Finance App Intents (app target):** `GetSafeToSpendIntent`, `GetBalanceIntent`, `NextRecurringBillsIntent`, `GetCreditUtilizationIntent`, each returning a value + dialog, plus `PlaidBarShortcutsProvider` (AppShortcutsProvider) exposing them to Spotlight/Siri/Shortcuts. `FinanceSnapshotBuilder` builds the snapshot from raw DTOs by calling the existing calculators (no duplicated math).
- **D3 — Privacy:** when the snapshot is masked (App Lock / Privacy Mask active) the query returns `.withheld` and the intent surfaces a value-free dialog instead of the figure. Empty/missing snapshots return `.unavailable` (setup prompt). Covered by tests.
- **D4 — Tests:** snapshot round-trip + values-only JSON assertion, builder math-reuse/sorting/filtering, and masked/withheld/unavailable/value resolutions for every intent.
- **Entitlements:** `com.apple.security.application-groups` (containing `group.com.ftchvs.PlaidBar`) is already present in **both** `PlaidBar.entitlements` and `PlaidBarWidgetExtension.entitlements` on the base branch, so the requirement is satisfied with no edit needed.

## Files changed
- `Sources/PlaidBarCore/Models/FinanceSnapshot.swift` (new)
- `Sources/PlaidBarCore/Utilities/AppGroupSnapshotStore.swift` (new)
- `Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift` (new)
- `Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift` (new)
- `Sources/PlaidBar/Intents/FinanceAppIntents.swift` (new)
- `Tests/PlaidBarCoreTests/AppGroupSnapshotStoreTests.swift` (new)
- `Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift` (new)
- `Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift` (new)

## Follow-ups
- **Wire the live writer.** The app does not yet call `AppGroupSnapshotStore.save(FinanceSnapshotBuilder.make(...))` — that belongs in `AppState` next to the existing `GlanceSnapshotStore` write site, which is an existing file outside this PR's ownership scope (it would conflict with sibling Epic PRs). Until then the intents correctly report `.unavailable`. Tracked for a follow-up wiring PR.
- **Full .appex packaging.** App Intents compile and link inside the SwiftPM executable (verified by the strict-concurrency build), which is sufficient for CI. Bundling them into a signed app/extension target (Info.plist `NSAppIntentsServiceConfiguration`, donation on launch) is tracked separately with the broader macOS 26 packaging work.