### PR TITLE
test: stabilize local insight timeout race

### DIFF
--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -180,24 +180,29 @@ struct LocalInsightModelRuntimeTests {
 
     @Test("Runtime timeout returns without waiting for cancellation-ignoring models")
     func runtimeTimeoutDoesNotWaitForCancellationIgnoringModel() async {
-        let model = CancellationIgnoringLocalInsightModel(
+        let state = BlockingCancellationIgnoringLocalInsightModel.State()
+        let model = BlockingCancellationIgnoringLocalInsightModel(
             output: "Food spending was the largest driver this month.",
-            delaySeconds: 0.2
+            state: state
         )
-        let startedAt = Date()
 
-        let result = await LocalInsightModelRuntime.generateSummary(
-            input: input(),
-            model: model,
-            fallbackSummary: { _ in "deterministic fallback" },
-            configuration: LocalInsightModelGenerationConfiguration(timeoutNanoseconds: 1_000_000)
-        )
-        let elapsed = Date().timeIntervalSince(startedAt)
+        let runtimeTask = Task {
+            await LocalInsightModelRuntime.generateSummary(
+                input: input(),
+                model: model,
+                fallbackSummary: { _ in "deterministic fallback" },
+                configuration: LocalInsightModelGenerationConfiguration(timeoutNanoseconds: 1_000_000)
+            )
+        }
+
+        await state.waitUntilStarted()
+        let result = await runtimeTask.value
+        #expect(!state.wasReleased)
+        state.release()
 
         #expect(result.summary == "deterministic fallback")
         #expect(result.usedModelOutput == false)
         #expect(result.fallbackReason == .timeout)
-        #expect(elapsed < 0.15)
     }
 
     private func input() -> LocalAIActivitySummaryInput {
@@ -272,15 +277,76 @@ private struct DelayedLocalInsightModel: LocalInsightModel {
     }
 }
 
-private struct CancellationIgnoringLocalInsightModel: LocalInsightModel {
+private struct BlockingCancellationIgnoringLocalInsightModel: LocalInsightModel {
+    final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private let semaphore = DispatchSemaphore(value: 0)
+        private var startedContinuation: CheckedContinuation<Void, Never>?
+        private var hasStarted = false
+        private var isReleased = false
+
+        var wasReleased: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return isReleased
+        }
+
+        func waitUntilStarted() async {
+            if hasStartedSnapshot() { return }
+
+            await withCheckedContinuation { continuation in
+                if installStartedContinuation(continuation) {
+                    continuation.resume()
+                }
+            }
+        }
+
+        private func hasStartedSnapshot() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return hasStarted
+        }
+
+        private func installStartedContinuation(_ continuation: CheckedContinuation<Void, Never>) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if hasStarted { return true }
+            startedContinuation = continuation
+            return false
+        }
+
+        func markStarted() {
+            let continuation: CheckedContinuation<Void, Never>?
+            lock.lock()
+            hasStarted = true
+            continuation = startedContinuation
+            startedContinuation = nil
+            lock.unlock()
+            continuation?.resume()
+        }
+
+        func release() {
+            lock.lock()
+            guard !isReleased else {
+                lock.unlock()
+                return
+            }
+            isReleased = true
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        func waitUntilReleased() {
+            semaphore.wait()
+        }
+    }
+
     let output: String
-    let delaySeconds: TimeInterval
+    let state: State
 
     func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
-        let deadline = Date().addingTimeInterval(delaySeconds)
-        while Date() < deadline {
-            _ = 1 + 1
-        }
+        state.markStarted()
+        state.waitUntilReleased()
         return output
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #513 by replacing the `LocalInsightModelRuntimeTests` timeout wall-clock assertion with a deterministic blocked-model probe.
- The test now proves `generateSummary` returns the timeout fallback while the fake cancellation-ignoring model is still blocked, then releases the fake model for cleanup.
- Test-only change; no production code or private finance data flow changed.

Linear: AND-516
Kanban: t_c60fae54

## Verification

- `swift test --filter LocalInsightModelRuntimeTests` — 13 tests passed
- `git diff --check` — passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

## Note

A stricter `swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --filter LocalInsightModelRuntimeTests` still compiles the broader test target and fails on pre-existing unrelated warnings in `WatchlistEvaluatorTests.swift` and `BalanceProjectorTests.swift`; the touched file emitted no warnings in the focused test run.
