### PR TITLE
refactor: extract pure logic from AppState into PlaidBarCore (5 steps)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -947,12 +947,7 @@ final class AppState {
     }
 
     var statusModeText: String {
-        if isDemoMode { return "Demo" }
-        switch serverEnvironment {
-        case .sandbox: return "Sandbox"
-        case .production: return "Production"
-        case nil: return "Unknown"
-        }
+        StatusPanelText.mode(isDemoMode: isDemoMode, environment: serverEnvironment)
     }
 
     var statusServerText: String {
@@ -1013,19 +1008,23 @@ final class AppState {
     }
 
     var serverCredentialsText: String {
-        if isDemoMode { return "Not required" }
-        guard serverConnected else { return "Unknown" }
-        return serverCredentialsConfigured == true ? "Ready" : "Missing"
+        StatusPanelText.serverCredentials(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            credentialsConfigured: serverCredentialsConfigured
+        )
     }
 
     var serverSyncReadinessText: String {
-        if isDemoMode { return "Demo data" }
-        guard serverConnected else { return "Unknown" }
-        return serverSyncReady == true ? "Ready" : "No items"
+        StatusPanelText.serverSyncReadiness(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            syncReady: serverSyncReady
+        )
     }
 
     var refreshCadenceText: String {
-        "\(Int(refreshInterval / 60)) min"
+        StatusPanelText.refreshCadence(interval: refreshInterval)
     }
 
     var connectedItemCount: Int {
@@ -1065,23 +1064,14 @@ final class AppState {
     }
 
     var diagnosticsSummary: String {
-        if isDemoStatusRecoveryScenario {
-            if erroredItemCount > 0 { return "\(erroredItemCount) demo item\(erroredItemCount == 1 ? "" : "s") need attention" }
-            if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(needsLoginItemCount == 1 ? "" : "s") need update" }
-        }
-        let serverPresentation = serverConnectionPresentation
-        if isDemoMode { return serverPresentation.diagnosticsSummary }
-        switch serverPresentation.issue {
-        case .offline, .localAuthMissing, .localAuthRejected, .serverModeMismatch:
-            return serverPresentation.diagnosticsSummary
-        case .demo, .syncing, .connected, .error:
-            break
-        }
-        if statusItemCount == 0 { return "No Plaid items connected" }
-        if erroredItemCount > 0 { return "\(erroredItemCount) item\(erroredItemCount == 1 ? "" : "s") need attention" }
-        if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(needsLoginItemCount == 1 ? "" : "s") need update" }
-        if serverPresentation.issue == .error { return serverPresentation.diagnosticsSummary }
-        return "Plaid connection healthy"
+        StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: isDemoStatusRecoveryScenario,
+            isDemoMode: isDemoMode,
+            serverConnection: serverConnectionPresentation,
+            statusItemCount: statusItemCount,
+            erroredItemCount: erroredItemCount,
+            needsLoginItemCount: needsLoginItemCount
+        )
     }
 
     private var serverConnectionPresentation: ServerConnectionPresentation {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2483,13 +2483,16 @@ final class AppState {
             .appendingPathComponent(LocalDataStore.serverConfigFilename)
         if let configContents = try? String(contentsOf: configURL, encoding: .utf8) {
             for rawLine in configContents.components(separatedBy: .newlines) {
-                guard let entry = parseServerConfigLine(rawLine) else { continue }
-                environment[entry.key] = entry.value
+                guard let entry = ServerConfigLine.parse(rawLine) else { continue }
+                environment[entry.key] = ServerConfigLine.unquote(entry.value)
             }
         }
 
         let rawEnvironment = trimmedNonEmpty(environment["PLAID_ENV"]) ?? PlaidEnvironment.production.rawValue
-        guard let plaidEnvironment = PlaidEnvironment(rawValue: unquoteConfigValue(rawEnvironment)) else {
+        // Unquoted a second time on purpose: file-sourced values were unquoted in
+        // the loop above, but a PLAID_ENV inherited from the process environment
+        // bypasses it, so this normalizes a quoted value from either source.
+        guard let plaidEnvironment = PlaidEnvironment(rawValue: ServerConfigLine.unquote(rawEnvironment)) else {
             return nil
         }
 
@@ -2509,36 +2512,10 @@ final class AppState {
         )
     }
 
-    private func parseServerConfigLine(_ rawLine: String) -> (key: String, value: String)? {
-        var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
-        if line.hasPrefix("export ") {
-            line.removeFirst("export ".count)
-            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        guard let separator = line.firstIndex(of: "=") else { return nil }
-        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty else { return nil }
-        let value = String(line[line.index(after: separator)...])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (key, unquoteConfigValue(value))
-    }
-
     private func trimmedNonEmpty(_ value: String?) -> String? {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func unquoteConfigValue(_ value: String) -> String {
-        guard value.count >= 2,
-              let first = value.first,
-              let last = value.last,
-              (first == "\"" && last == "\"") || (first == "'" && last == "'")
-        else {
-            return value
-        }
-        return String(value.dropFirst().dropLast())
     }
 
     private func persistedTransactionCacheContext() -> TransactionCacheContext? {
@@ -2991,8 +2968,8 @@ final class AppState {
         let configURL = localStorageDirectoryURL.appendingPathComponent(LocalDataStore.serverConfigFilename)
         if let contents = try? String(contentsOf: configURL, encoding: .utf8) {
             for line in contents.components(separatedBy: .newlines) {
-                guard let entry = Self.parseConfigLine(line) else { continue }
-                values[entry.key] = Self.unquotedConfigValue(entry.value)
+                guard let entry = ServerConfigLine.parse(line) else { continue }
+                values[entry.key] = ServerConfigLine.unquote(entry.value)
             }
         }
 
@@ -3003,34 +2980,6 @@ final class AppState {
             return nil
         }
         return PlaidEnvironment(rawValue: rawValue)
-    }
-
-    private static func parseConfigLine(_ rawLine: String) -> (key: String, value: String)? {
-        var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
-
-        if line.hasPrefix("export ") {
-            line.removeFirst("export ".count)
-            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        guard let separator = line.firstIndex(of: "=") else { return nil }
-        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty else { return nil }
-        let value = String(line[line.index(after: separator)...])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (key, value)
-    }
-
-    private static func unquotedConfigValue(_ value: String) -> String {
-        guard value.count >= 2,
-              let first = value.first,
-              let last = value.last,
-              (first == "\"" && last == "\"") || (first == "'" && last == "'")
-        else {
-            return value
-        }
-        return String(value.dropFirst().dropLast())
     }
 
     @discardableResult

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -918,63 +918,27 @@ final class AppState {
     }
 
     var menuBarHelpText: String {
-        let reviewText = transactionReviewCount > 0
-            ? " \(transactionReviewCount) transaction\(transactionReviewCount == 1 ? "" : "s") need review."
-            : ""
-        let status = "Status: \(diagnosticsSummary)"
-        let review = weeklyReviewPresentation.menuBarPrompt.map { " Weekly review: \($0)." } ?? ""
-        switch menuBarSummaryMode {
-        case .netWorth:
-            return "VaultPeek - Net worth: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .netCash:
-            return "VaultPeek - Net cash: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .totalCash:
-            return "VaultPeek - Total cash: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .creditUtilization:
-            return "VaultPeek - Credit utilization: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .highestUtilization:
-            return "VaultPeek - Highest card utilization: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .recentSpend:
-            return "VaultPeek - Recent spend: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .todaySpend:
-            return "VaultPeek - Today's spend: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .safeToSpend:
-            return "VaultPeek - Safe to spend: \(menuBarText).\(reviewText) \(status)\(review)"
-        case .iconOnly:
-            return "VaultPeek.\(reviewText) \(status)\(review)"
-        }
+        MenuBarAnnouncement.helpText(
+            mode: menuBarSummaryMode,
+            valueText: menuBarText,
+            reviewCount: transactionReviewCount,
+            diagnosticsSummary: diagnosticsSummary,
+            weeklyReviewPrompt: weeklyReviewPresentation.menuBarPrompt
+        )
     }
 
     var menuBarAccessibilityLabel: String {
-        let reviewText = transactionReviewCount > 0
-            ? "\(transactionReviewCount) transaction\(transactionReviewCount == 1 ? "" : "s") need review. "
-            : ""
-        // diagnosticsSummary stays "healthy" for finance warnings, so fold the
-        // visible finance badge (Cash/Credit/Spend) into the spoken status to
-        // keep VoiceOver in sync with the badge sighted users see.
-        let attention = menuBarAttentionText.map { ". Attention \($0)" } ?? ""
-        let status = "Status \(diagnosticsSummary)\(attention)"
-        let review = weeklyReviewPresentation.menuBarPrompt.map { " Weekly review \($0)." } ?? ""
-        switch menuBarSummaryMode {
-        case .netWorth:
-            return "VaultPeek net worth \(menuBarText). \(reviewText)\(status)\(review)"
-        case .netCash:
-            return "VaultPeek net cash \(menuBarText). \(reviewText)\(status)\(review)"
-        case .totalCash:
-            return "VaultPeek total cash \(menuBarText). \(reviewText)\(status)\(review)"
-        case .creditUtilization:
-            return "VaultPeek credit utilization \(menuBarText). \(reviewText)\(status)\(review)"
-        case .highestUtilization:
-            return "VaultPeek highest card utilization \(menuBarText). \(reviewText)\(status)\(review)"
-        case .recentSpend:
-            return "VaultPeek recent spend \(menuBarText). \(reviewText)\(status)\(review)"
-        case .todaySpend:
-            return "VaultPeek today's spend \(menuBarText). \(reviewText)\(status)\(review)"
-        case .safeToSpend:
-            return "VaultPeek safe to spend \(menuBarText). \(reviewText)\(status)\(review)"
-        case .iconOnly:
-            return "VaultPeek. \(reviewText)\(status)\(review)"
-        }
+        // diagnosticsSummary stays "healthy" for finance warnings, so the spoken
+        // label folds the visible finance badge (Cash/Credit/Spend) into the
+        // status to keep VoiceOver in sync with the badge sighted users see.
+        MenuBarAnnouncement.accessibilityLabel(
+            mode: menuBarSummaryMode,
+            valueText: menuBarText,
+            reviewCount: transactionReviewCount,
+            diagnosticsSummary: diagnosticsSummary,
+            attentionText: menuBarAttentionText,
+            weeklyReviewPrompt: weeklyReviewPresentation.menuBarPrompt
+        )
     }
 
     var lastSyncRelative: String? {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1204,71 +1204,13 @@ final class AppState {
 
     var categoryBudgetPresentation: CategoryBudgetPresentation {
         if let cached = _cachedCategoryBudgetPresentation { return cached }
-        let presentation = computeCategoryBudgetPresentation()
+        let presentation = CategoryBudgetPlanner.mergedPresentation(
+            explicitBudgets: categoryBudgets,
+            transactions: transactions,
+            asOf: Date()
+        )
         _cachedCategoryBudgetPresentation = presentation
         return presentation
-    }
-
-    private func computeCategoryBudgetPresentation() -> CategoryBudgetPresentation {
-        let now = Date()
-        let suggestedBudgets = CategoryBudgetPlanner.suggestedBudgets(
-            from: transactions,
-            asOf: now
-        )
-        let suggestedPresentation = CategoryBudgetPlanner.presentation(
-            budgets: suggestedBudgets.filter { categoryBudgets[$0.key] == nil },
-            transactions: transactions,
-            asOf: now,
-            areSuggested: true
-        )
-
-        guard !categoryBudgets.isEmpty else { return suggestedPresentation }
-
-        let serverPresentation = CategoryBudgetPlanner.presentation(
-            budgets: categoryBudgets,
-            transactions: transactions,
-            asOf: now
-        )
-        return Self.mergeCategoryBudgetPresentations(
-            serverPresentation,
-            suggestedPresentation
-        )
-    }
-
-    private static func mergeCategoryBudgetPresentations(
-        _ explicit: CategoryBudgetPresentation,
-        _ suggested: CategoryBudgetPresentation
-    ) -> CategoryBudgetPresentation {
-        let explicitCategoryIds = Set(explicit.items.map(\.id))
-        let items = (explicit.items + suggested.items.filter { !explicitCategoryIds.contains($0.id) })
-            .sorted { lhs, rhs in
-                if lhs.status != rhs.status {
-                    return categoryBudgetStatusRank(lhs.status) < categoryBudgetStatusRank(rhs.status)
-                }
-                if lhs.fractionUsed != rhs.fractionUsed {
-                    return lhs.fractionUsed > rhs.fractionUsed
-                }
-                if lhs.isSuggested != rhs.isSuggested {
-                    return !lhs.isSuggested
-                }
-                return lhs.category.displayName < rhs.category.displayName
-            }
-
-        return CategoryBudgetPresentation(
-            items: items,
-            totalLimit: items.reduce(0) { $0 + $1.monthlyLimit },
-            totalSpent: items.reduce(0) { $0 + $1.spent },
-            overBudgetCount: items.reduce(0) { $0 + ($1.status == .over ? 1 : 0) },
-            nearingCount: items.reduce(0) { $0 + ($1.status == .nearing ? 1 : 0) }
-        )
-    }
-
-    private static func categoryBudgetStatusRank(_ status: CategoryBudgetStatus) -> Int {
-        switch status {
-        case .over: 0
-        case .nearing: 1
-        case .under: 2
-        }
     }
 
     private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {

--- a/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
+++ b/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
@@ -58,18 +58,8 @@ struct AccountSpotlightEntry: Sendable, Equatable {
     /// for the (unindexed) Plaid identifiers.
     var searchableIdentifier: String {
         let material = "\(AccountSpotlightIndexer.domainIdentifier)|\(displayName)|\(mask ?? "")|\(institutionName ?? "")"
-        return "vaultpeek.account.\(stableHash(material))"
-    }
-
-    private func stableHash(_ string: String) -> String {
-        // FNV-1a 64-bit: dependency-free and stable across launches (Swift's
-        // `Hasher` is per-process salted, so it cannot be persisted).
-        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
-        for byte in string.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x100_0000_01B3
-        }
-        return String(hash, radix: 16)
+        // Spotlight identifiers use the minimal-width hex form (historical format).
+        return "vaultpeek.account.\(StableHash.hex(material))"
     }
 }
 

--- a/Sources/PlaidBarCore/Models/CategoryBudgetPresentation.swift
+++ b/Sources/PlaidBarCore/Models/CategoryBudgetPresentation.swift
@@ -124,6 +124,19 @@ public struct CategoryBudgetPresentation: Sendable, Hashable {
         self.nearingCount = nearingCount
     }
 
+    /// Build a presentation from already-ordered `items`, deriving the aggregate
+    /// totals (limit, spent, over/nearing counts) from them so the aggregates can
+    /// never drift from the items they summarize.
+    public init(items: [Item]) {
+        self.init(
+            items: items,
+            totalLimit: items.reduce(0) { $0 + $1.monthlyLimit },
+            totalSpent: items.reduce(0) { $0 + $1.spent },
+            overBudgetCount: items.reduce(0) { $0 + ($1.status == .over ? 1 : 0) },
+            nearingCount: items.reduce(0) { $0 + ($1.status == .nearing ? 1 : 0) }
+        )
+    }
+
     public var isEmpty: Bool { items.isEmpty }
     public var count: Int { items.count }
 

--- a/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
+++ b/Sources/PlaidBarCore/Models/ServerAutoLaunchPlan.swift
@@ -83,7 +83,7 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
 
     public static func containsBlockedManagedConfigKey(in contents: String) -> Bool {
         contents.components(separatedBy: .newlines).contains { rawLine in
-            guard let entry = parseConfigLine(rawLine) else { return false }
+            guard let entry = ServerConfigLine.parse(rawLine) else { return false }
             return blockedManagedConfigKeys.contains(entry.key)
         }
     }
@@ -95,42 +95,12 @@ public struct ServerAutoLaunchPlan: Equatable, Sendable {
     public static func configProvidesCredentials(in contents: String) -> Bool {
         var values: [String: String] = [:]
         for rawLine in contents.components(separatedBy: .newlines) {
-            guard let entry = parseConfigLine(rawLine) else { continue }
+            guard let entry = ServerConfigLine.parse(rawLine) else { continue }
             values[entry.key] = entry.value
         }
         return ["PLAID_CLIENT_ID", "PLAID_SECRET"].allSatisfy { key in
             guard let value = values[key] else { return false }
-            return !unquote(value).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            return !ServerConfigLine.unquote(value).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
-    }
-
-    /// Mirrors the server's `server.conf` line syntax: comments, blank lines,
-    /// an optional `export ` prefix, and `KEY=value` pairs.
-    private static func parseConfigLine(_ rawLine: String) -> (key: String, value: String)? {
-        var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
-
-        if line.hasPrefix("export ") {
-            line.removeFirst("export ".count)
-            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        guard let separator = line.firstIndex(of: "=") else { return nil }
-        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty else { return nil }
-        let value = String(line[line.index(after: separator)...])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (key, value)
-    }
-
-    private static func unquote(_ value: String) -> String {
-        guard value.count >= 2,
-              let first = value.first,
-              let last = value.last,
-              (first == "\"" && last == "\"") || (first == "'" && last == "'")
-        else {
-            return value
-        }
-        return String(value.dropFirst().dropLast())
     }
 }

--- a/Sources/PlaidBarCore/Models/SyncHistoryDiff.swift
+++ b/Sources/PlaidBarCore/Models/SyncHistoryDiff.swift
@@ -93,7 +93,7 @@ public enum SyncHistoryDiff {
             let summary = "\(name): \(stats.changedDays) prior \(dayWord) restated (\(deltaText))"
             let accessibilityText = "\(name) had \(stats.changedDays) prior \(dayWord) restated by your bank, a net change of \(deltaText)."
             return Row(
-                id: stableHash(accountId),
+                id: StableHash.hexPadded(accountId),
                 accountDisplayName: name,
                 changedDayCount: stats.changedDays,
                 netDelta: stats.netDelta,
@@ -132,14 +132,5 @@ public enum SyncHistoryDiff {
         if amount > 0 { return "+\(formatted)" }
         if amount < 0 { return "-\(formatted)" }
         return formatted
-    }
-
-    private static func stableHash(_ value: String) -> String {
-        var hash: UInt64 = 14_695_981_039_346_656_037
-        for byte in value.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 1_099_511_628_211
-        }
-        return String(format: "%016llx", hash)
     }
 }

--- a/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
@@ -139,13 +139,7 @@ public enum CategoryBudgetPlanner {
                 return lhs.category.displayName < rhs.category.displayName
             }
 
-        return CategoryBudgetPresentation(
-            items: items,
-            totalLimit: items.reduce(0) { $0 + $1.monthlyLimit },
-            totalSpent: items.reduce(0) { $0 + $1.spent },
-            overBudgetCount: items.reduce(0) { $0 + ($1.status == .over ? 1 : 0) },
-            nearingCount: items.reduce(0) { $0 + ($1.status == .nearing ? 1 : 0) }
-        )
+        return CategoryBudgetPresentation(items: items)
     }
 
     /// Convenience for the read-only slice: suggest limits from history and score
@@ -171,6 +165,64 @@ public enum CategoryBudgetPlanner {
             calendar: calendar,
             areSuggested: true
         )
+    }
+
+    /// The dashboard's combined view: explicit (user/server) budgets always
+    /// appear, history-derived suggestions fill only the categories the user has
+    /// not explicitly budgeted, and the union is re-ranked together. With no
+    /// explicit budgets the suggestions stand alone.
+    public static func mergedPresentation(
+        explicitBudgets: [SpendingCategory: Double],
+        transactions: [TransactionDTO],
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> CategoryBudgetPresentation {
+        let suggested = presentation(
+            budgets: suggestedBudgets(from: transactions, asOf: date, calendar: calendar)
+                .filter { explicitBudgets[$0.key] == nil },
+            transactions: transactions,
+            asOf: date,
+            calendar: calendar,
+            areSuggested: true
+        )
+
+        guard !explicitBudgets.isEmpty else { return suggested }
+
+        let explicit = presentation(
+            budgets: explicitBudgets,
+            transactions: transactions,
+            asOf: date,
+            calendar: calendar
+        )
+        return merge(explicit: explicit, suggested: suggested)
+    }
+
+    /// Combine an explicit-budget presentation with a suggestion presentation:
+    /// explicit items win on identity, suggestions fill the rest, and the union
+    /// is re-ranked attention-first, then by spend pressure, then explicit-before-
+    /// suggested, then category name. `internal` so the ranking is unit-testable.
+    static func merge(
+        explicit: CategoryBudgetPresentation,
+        suggested: CategoryBudgetPresentation
+    ) -> CategoryBudgetPresentation {
+        let explicitCategoryIds = Set(explicit.items.map(\.id))
+        let items = (explicit.items + suggested.items.filter { !explicitCategoryIds.contains($0.id) })
+            .sorted { lhs, rhs in
+                if lhs.status != rhs.status {
+                    return statusRank(lhs.status) < statusRank(rhs.status)
+                }
+                // Spend pressure: heavier first. The `!=` guard is an exact Double
+                // compare, which is intentional — only items whose fractions are
+                // bit-equal fall through to the explicit-before-suggested tiebreaker.
+                if lhs.fractionUsed != rhs.fractionUsed {
+                    return lhs.fractionUsed > rhs.fractionUsed
+                }
+                if lhs.isSuggested != rhs.isSuggested {
+                    return !lhs.isSuggested
+                }
+                return lhs.category.displayName < rhs.category.displayName
+            }
+        return CategoryBudgetPresentation(items: items)
     }
 
     // MARK: - Internals

--- a/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalDataStore.swift
@@ -759,14 +759,14 @@ public enum LocalDataStore {
         guard let context else { return accountCacheFilename }
 
         let key = "\(context.environment.rawValue)|\(context.storagePath)"
-        return "accounts-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+        return "accounts-\(context.environment.rawValue)-\(StableHash.hexPadded(key)).json"
     }
 
     private static func transactionCacheFilename(for context: TransactionCacheContext?) -> String {
         guard let context else { return transactionCacheFilename }
 
         let key = "\(context.environment.rawValue)|\(context.storagePath)"
-        return "transactions-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+        return "transactions-\(context.environment.rawValue)-\(StableHash.hexPadded(key)).json"
     }
 
     // Review metadata and merchant rules are scoped to the active cache context
@@ -779,14 +779,14 @@ public enum LocalDataStore {
         guard let context else { return transactionReviewMetadataFilename }
 
         let key = "\(context.environment.rawValue)|\(context.storagePath)"
-        return "\(transactionReviewMetadataScopedPrefix)-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+        return "\(transactionReviewMetadataScopedPrefix)-\(context.environment.rawValue)-\(StableHash.hexPadded(key)).json"
     }
 
     private static func transactionRulesFilename(for context: TransactionCacheContext?) -> String {
         guard let context else { return transactionRulesFilename }
 
         let key = "\(context.environment.rawValue)|\(context.storagePath)"
-        return "\(transactionRulesScopedPrefix)-\(context.environment.rawValue)-\(stableHashHex(key)).json"
+        return "\(transactionRulesScopedPrefix)-\(context.environment.rawValue)-\(StableHash.hexPadded(key)).json"
     }
 
     private static func isTransactionReviewMetadataFilename(_ filename: String) -> Bool {
@@ -803,15 +803,6 @@ public enum LocalDataStore {
             legacyFilename: transactionRulesFilename,
             prefix: transactionRulesScopedPrefix
         )
-    }
-
-    private static func stableHashHex(_ value: String) -> String {
-        var hash: UInt64 = 14_695_981_039_346_656_037
-        for byte in value.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 1_099_511_628_211
-        }
-        return String(format: "%016llx", hash)
     }
 
     private static func ensurePrivateDirectory(

--- a/Sources/PlaidBarCore/Utilities/MenuBarAnnouncement.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarAnnouncement.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Pure derivation of the menu-bar item's hover tooltip ("help") text and its
+/// VoiceOver accessibility label.
+///
+/// Extracted from `AppState` so the wording is `Sendable`, unit-tested, and the
+/// per-mode noun comes from a single source of truth (`MenuBarSummaryMode`)
+/// rather than two hand-maintained switch statements. The tooltip uses the
+/// mode's `displayName` ("Net worth", "Today's spend"); the spoken label uses its
+/// lowercased form ("net worth", "today's spend" — the apostrophe is preserved),
+/// matching the previous inline behavior exactly.
+public enum MenuBarAnnouncement {
+
+    /// Tooltip shown when hovering the menu-bar item.
+    ///
+    /// - Parameters:
+    ///   - mode: which summary the menu bar is currently showing.
+    ///   - valueText: the rendered menu-bar value (e.g. `"$1,234"`).
+    ///   - reviewCount: number of transactions awaiting review.
+    ///   - diagnosticsSummary: short health string (e.g. `"All good"`).
+    ///   - weeklyReviewPrompt: optional weekly-review nudge.
+    public static func helpText(
+        mode: MenuBarSummaryMode,
+        valueText: String,
+        reviewCount: Int,
+        diagnosticsSummary: String,
+        weeklyReviewPrompt: String?
+    ) -> String {
+        let review = reviewCount > 0 ? " \(reviewPhrase(reviewCount)) need review." : ""
+        let status = "Status: \(diagnosticsSummary)"
+        let weekly = weeklyReviewPrompt.map { " Weekly review: \($0)." } ?? ""
+        switch mode {
+        case .iconOnly:
+            return "VaultPeek.\(review) \(status)\(weekly)"
+        default:
+            return "VaultPeek - \(mode.displayName): \(valueText).\(review) \(status)\(weekly)"
+        }
+    }
+
+    /// VoiceOver label for the menu-bar item.
+    ///
+    /// Unlike the tooltip, the spoken label folds the visible finance attention
+    /// badge into the status (`diagnosticsSummary` stays "healthy" for finance
+    /// warnings, so the badge sighted users see must be spoken explicitly).
+    ///
+    /// - Parameters:
+    ///   - mode: which summary the menu bar is currently showing.
+    ///   - valueText: the rendered menu-bar value (e.g. `"$1,234"`).
+    ///   - reviewCount: number of transactions awaiting review.
+    ///   - diagnosticsSummary: short health string (e.g. `"All good"`).
+    ///   - attentionText: optional finance attention badge to speak.
+    ///   - weeklyReviewPrompt: optional weekly-review nudge.
+    public static func accessibilityLabel(
+        mode: MenuBarSummaryMode,
+        valueText: String,
+        reviewCount: Int,
+        diagnosticsSummary: String,
+        attentionText: String?,
+        weeklyReviewPrompt: String?
+    ) -> String {
+        let review = reviewCount > 0 ? "\(reviewPhrase(reviewCount)) need review. " : ""
+        let attention = attentionText.map { ". Attention \($0)" } ?? ""
+        let status = "Status \(diagnosticsSummary)\(attention)"
+        let weekly = weeklyReviewPrompt.map { " Weekly review \($0)." } ?? ""
+        switch mode {
+        case .iconOnly:
+            return "VaultPeek. \(review)\(status)\(weekly)"
+        default:
+            return "VaultPeek \(mode.displayName.lowercased()) \(valueText). \(review)\(status)\(weekly)"
+        }
+    }
+
+    /// `"1 transaction"` / `"3 transactions"` — the shared, pluralized count phrase.
+    ///
+    /// Only the count phrase is shared; the surrounding spacing is intentionally
+    /// asymmetric and lives at each call site — the tooltip wraps it with a leading
+    /// space (`" … need review."`) while the spoken label uses a trailing space
+    /// (`"… need review. "`). Keep that split when editing.
+    private static func reviewPhrase(_ count: Int) -> String {
+        "\(count) transaction\(count == 1 ? "" : "s")"
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -11,6 +11,14 @@ public enum MenuBarSummaryMode: String, CaseIterable, Codable, Sendable {
     case safeToSpend
     case iconOnly
 
+    /// Human-readable name for this mode.
+    ///
+    /// - Important: this is a single source of truth used in **two** places — the
+    ///   Settings picker label AND, via `MenuBarAnnouncement`, the menu-bar tooltip
+    ///   and VoiceOver label (the spoken form is `displayName.lowercased()`). A
+    ///   re-word here changes accessibility copy; `MenuBarAnnouncementTests` golden
+    ///   literals will fail if the wording drifts. Split this out if the two uses
+    ///   must diverge.
     public var displayName: String {
         switch self {
         case .netWorth: return "Net worth"

--- a/Sources/PlaidBarCore/Utilities/ServerConfigLine.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerConfigLine.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Pure parsing of a single `server.conf` line.
+///
+/// Mirrors the shell-ish syntax the server file uses: comments (`#`), blank
+/// lines, an optional `export ` prefix, and `KEY=value` pairs whose value may be
+/// wrapped in matching single or double quotes. This is the single source of
+/// truth shared by the app (`AppState` config probes), the server
+/// (`ServerConfig.loadConfigFile`), and `ServerAutoLaunchPlan`, so the syntax can
+/// never silently diverge between the process that writes the file and the ones
+/// that read it.
+public enum ServerConfigLine {
+    /// Outcome of classifying one raw line.
+    public enum ParseResult: Equatable, Sendable {
+        /// A blank line or a `#` comment — skip it.
+        case ignored
+        /// A well-formed `KEY=value` pair (value trimmed, not yet unquoted).
+        case pair(key: String, value: String)
+        /// A line that carries content but is not a valid pair (no `=`, or an
+        /// empty key). Lenient readers skip it; strict readers (the server) treat
+        /// it as a hard error.
+        case malformed
+    }
+
+    /// Classify one raw line into ignored / pair / malformed. Distinguishing the
+    /// last two lets a strict caller reject a malformed line while still skipping
+    /// blanks and comments.
+    public static func classify(_ rawLine: String) -> ParseResult {
+        var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty, !line.hasPrefix("#") else { return .ignored }
+
+        if line.hasPrefix("export ") {
+            line.removeFirst("export ".count)
+            line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        guard let separator = line.firstIndex(of: "=") else { return .malformed }
+        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return .malformed }
+        let value = String(line[line.index(after: separator)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return .pair(key: key, value: value)
+    }
+
+    /// Lenient tokenizer: the `(key, value)` pair, or `nil` for a blank, comment,
+    /// or malformed line. The value is trimmed but NOT unquoted — call
+    /// `unquote(_:)` when you need the bare value.
+    public static func parse(_ rawLine: String) -> (key: String, value: String)? {
+        if case let .pair(key, value) = classify(rawLine) { return (key, value) }
+        return nil
+    }
+
+    /// Strip a single layer of matching single or double quotes, if present.
+    public static func unquote(_ value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              let last = value.last,
+              (first == "\"" && last == "\"") || (first == "'" && last == "'")
+        else {
+            return value
+        }
+        return String(value.dropFirst().dropLast())
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/StableHash.swift
+++ b/Sources/PlaidBarCore/Utilities/StableHash.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// FNV-1a 64-bit hashing — dependency-free and stable across process launches.
+///
+/// Swift's `Hasher` is per-process salted, so it can't be persisted; this is the
+/// shared implementation behind every place that needs a stable string
+/// fingerprint (cache filenames, sync-diff identities, Spotlight identifiers,
+/// logo cache keys). Previously copy-pasted into four files across all three
+/// targets — kept here once so the algorithm can never drift between the writers
+/// and readers of a persisted hash.
+///
+/// Two hex renderings are offered because existing on-disk/identifier formats
+/// depend on them and must not change: `hexPadded` (fixed 16-char width) and
+/// `hex` (minimal width). They wrap the same `fnv1a64` value.
+public enum StableHash {
+    /// Raw FNV-1a 64-bit hash of the string's UTF-8 bytes.
+    public static func fnv1a64(_ value: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV offset basis
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100_0000_01b3 // FNV prime
+        }
+        return hash
+    }
+
+    /// Lowercase hex, zero-padded to a fixed 16 characters.
+    public static func hexPadded(_ value: String) -> String {
+        String(format: "%016llx", fnv1a64(value))
+    }
+
+    /// Lowercase hex with no leading-zero padding (variable width).
+    public static func hex(_ value: String) -> String {
+        String(fnv1a64(value), radix: 16)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/StatusPanelText.swift
+++ b/Sources/PlaidBarCore/Utilities/StatusPanelText.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Pure derivation of the short status strings shown in the Settings / Status
+/// panels (and folded into menu-bar copy via `MenuBarAnnouncement`).
+///
+/// Extracted from `AppState` so the wording — especially the multi-branch
+/// `diagnosticsSummary` health ladder — is `Sendable` and unit-tested. Each
+/// function takes only the values it needs; callers in the app layer pass their
+/// already-derived state.
+public enum StatusPanelText {
+
+    /// Data-mode label: `"Demo"`, `"Sandbox"`, `"Production"`, or `"Unknown"`.
+    public static func mode(isDemoMode: Bool, environment: PlaidEnvironment?) -> String {
+        if isDemoMode { return "Demo" }
+        switch environment {
+        case .sandbox: return "Sandbox"
+        case .production: return "Production"
+        case nil: return "Unknown"
+        }
+    }
+
+    /// Whether the server has Plaid credentials: `"Not required"` (demo),
+    /// `"Unknown"` (server unreachable), `"Ready"`, or `"Missing"`. A `nil`
+    /// `credentialsConfigured` (status not yet known) folds to `"Missing"`.
+    public static func serverCredentials(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        credentialsConfigured: Bool?
+    ) -> String {
+        if isDemoMode { return "Not required" }
+        guard serverConnected else { return "Unknown" }
+        return credentialsConfigured == true ? "Ready" : "Missing"
+    }
+
+    /// Whether the server can sync: `"Demo data"`, `"Unknown"` (unreachable),
+    /// `"Ready"`, or `"No items"`. A `nil` `syncReady` (status not yet known)
+    /// folds to `"No items"`.
+    public static func serverSyncReadiness(
+        isDemoMode: Bool,
+        serverConnected: Bool,
+        syncReady: Bool?
+    ) -> String {
+        if isDemoMode { return "Demo data" }
+        guard serverConnected else { return "Unknown" }
+        return syncReady == true ? "Ready" : "No items"
+    }
+
+    /// Background-refresh cadence rendered in whole minutes, e.g. `"15 min"`.
+    public static func refreshCadence(interval: TimeInterval) -> String {
+        "\(Int(interval / 60)) min"
+    }
+
+    /// One-line Plaid health summary. The branch order is significant: a recovery
+    /// demo scenario and blocking server issues win over per-item attention, which
+    /// in turn wins over the healthy fallback.
+    public static func diagnosticsSummary(
+        isDemoStatusRecoveryScenario: Bool,
+        isDemoMode: Bool,
+        serverConnection: ServerConnectionPresentation,
+        statusItemCount: Int,
+        erroredItemCount: Int,
+        needsLoginItemCount: Int
+    ) -> String {
+        if isDemoStatusRecoveryScenario {
+            if erroredItemCount > 0 { return "\(erroredItemCount) demo item\(plural(erroredItemCount)) need attention" }
+            if needsLoginItemCount > 0 { return "\(needsLoginItemCount) demo item\(plural(needsLoginItemCount)) need update" }
+        }
+        if isDemoMode { return serverConnection.diagnosticsSummary }
+        switch serverConnection.issue {
+        case .offline, .localAuthMissing, .localAuthRejected, .serverModeMismatch:
+            return serverConnection.diagnosticsSummary
+        case .demo, .syncing, .connected, .error:
+            break
+        }
+        if statusItemCount == 0 { return "No Plaid items connected" }
+        if erroredItemCount > 0 { return "\(erroredItemCount) item\(plural(erroredItemCount)) need attention" }
+        if needsLoginItemCount > 0 { return "\(needsLoginItemCount) item\(plural(needsLoginItemCount)) need update" }
+        if serverConnection.issue == .error { return serverConnection.diagnosticsSummary }
+        return "Plaid connection healthy"
+    }
+
+    /// `""` for a count of 1, `"s"` otherwise.
+    private static func plural(_ count: Int) -> String {
+        count == 1 ? "" : "s"
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -493,38 +493,17 @@ struct ServerConfig: Sendable {
         var values: [String: String] = [:]
 
         for (offset, rawLine) in contents.components(separatedBy: .newlines).enumerated() {
-            var line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !line.isEmpty, !line.hasPrefix("#") else { continue }
-
-            if line.hasPrefix("export ") {
-                line.removeFirst("export ".count)
-                line = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-
-            guard let separator = line.firstIndex(of: "=") else {
+            switch ServerConfigLine.classify(rawLine) {
+            case .ignored:
+                continue
+            case .malformed:
                 throw ServerConfigError.invalidConfigLine(path: expandedPath, line: offset + 1)
+            case let .pair(key, value):
+                values[key] = ServerConfigLine.unquote(value)
             }
-
-            let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
-            let rawValue = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else {
-                throw ServerConfigError.invalidConfigLine(path: expandedPath, line: offset + 1)
-            }
-            values[key] = unquote(rawValue)
         }
 
         return values
-    }
-
-    private static func unquote(_ value: String) -> String {
-        guard value.count >= 2,
-              let first = value.first,
-              let last = value.last,
-              (first == "\"" && last == "\"") || (first == "'" && last == "'")
-        else {
-            return value
-        }
-        return String(value.dropFirst().dropLast())
     }
 
     private static func shouldMigrateLegacyDatabase(

--- a/Sources/PlaidBarServer/Routes/MerchantLogoRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/MerchantLogoRoutes.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Hummingbird
 import NIOCore
+import PlaidBarCore
 #if canImport(FoundationNetworking)
     import FoundationNetworking
 #endif
@@ -83,11 +84,6 @@ struct MerchantLogoRoutes: Sendable {
     /// Deterministic, dependency-free FNV-1a hash of the URL for a cache
     /// filename (avoids unsafe characters and stays well under path limits).
     private static func cacheKey(for url: String) -> String {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in url.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x0000_0100_0000_01b3
-        }
-        return String(hash, radix: 16) + ".img"
+        StableHash.hex(url) + ".img"
     }
 }

--- a/Tests/PlaidBarCoreTests/CategoryBudgetMergeTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetMergeTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// Covers the merge/aggregate logic lifted out of AppState in Step 3:
+/// `CategoryBudgetPresentation(items:)`, `CategoryBudgetPlanner.merge`, and the
+/// `mergedPresentation` composition.
+@Suite("Category budget merge")
+struct CategoryBudgetMergeTests {
+    private let now = Formatters.parseTransactionDate("2026-06-13")!
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func tx(_ amount: Double, _ date: String, _ category: SpendingCategory) -> TransactionDTO {
+        TransactionDTO(
+            id: "\(category.rawValue)-\(date)-\(amount)",
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: "Merchant",
+            category: category,
+            pending: false
+        )
+    }
+
+    private func item(
+        _ category: SpendingCategory,
+        limit: Double,
+        spent: Double,
+        suggested: Bool
+    ) -> CategoryBudgetPresentation.Item {
+        CategoryBudgetPresentation.Item(
+            category: category,
+            monthlyLimit: limit,
+            spent: spent,
+            isSuggested: suggested
+        )
+    }
+
+    // MARK: - Convenience init derives aggregates
+
+    @Test("Presentation(items:) derives totals and counts from its items")
+    func convenienceInitTotals() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 150, suggested: false), // over
+            item(.shopping, limit: 100, spent: 90, suggested: false), // nearing
+            item(.travel, limit: 100, spent: 10, suggested: false), // under
+        ])
+        #expect(presentation.totalLimit == 300)
+        #expect(presentation.totalSpent == 250)
+        #expect(presentation.overBudgetCount == 1)
+        #expect(presentation.nearingCount == 1)
+    }
+
+    @Test("Presentation(items:) of no items is empty")
+    func convenienceInitEmpty() {
+        let presentation = CategoryBudgetPresentation(items: [])
+        #expect(presentation.isEmpty)
+        #expect(presentation.totalLimit == 0)
+        #expect(presentation.totalSpent == 0)
+    }
+
+    // MARK: - merge
+
+    @Test("merge: explicit budgets win on identity; suggestions fill the rest")
+    func mergeDedup() {
+        let explicit = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 50, suggested: false),
+        ])
+        let suggested = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 200, spent: 100, suggested: true), // dropped — explicit wins
+            item(.shopping, limit: 100, spent: 10, suggested: true),
+        ])
+        let merged = CategoryBudgetPlanner.merge(explicit: explicit, suggested: suggested)
+        #expect(merged.count == 2)
+        let food = merged.items.first { $0.id == SpendingCategory.foodAndDrink.rawValue }
+        #expect(food?.isSuggested == false)
+        #expect(food?.monthlyLimit == 100) // the explicit limit, not the suggested 200
+        let hasShopping = merged.items.contains { $0.id == SpendingCategory.shopping.rawValue }
+        #expect(hasShopping)
+    }
+
+    @Test("merge: ranks attention-first — over, then nearing, then under")
+    func mergeStatusOrder() {
+        let explicit = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 10, suggested: false), // under
+        ])
+        let suggested = CategoryBudgetPresentation(items: [
+            item(.shopping, limit: 100, spent: 150, suggested: true), // over
+            item(.travel, limit: 100, spent: 90, suggested: true), // nearing
+        ])
+        let merged = CategoryBudgetPlanner.merge(explicit: explicit, suggested: suggested)
+        let order = merged.items.map(\.category)
+        #expect(order == [.shopping, .travel, .foodAndDrink])
+    }
+
+    @Test("merge: explicit precedes suggested on a tie, overriding the name fallback")
+    func mergeSuggestedTiebreaker() {
+        // Same status (under) and fractionUsed (0.5). Names are chosen so the
+        // alphabetical fallback ("Education" < "Travel") would reverse the order —
+        // proving the explicit-before-suggested tiebreaker wins.
+        let explicit = CategoryBudgetPresentation(items: [
+            item(.travel, limit: 100, spent: 50, suggested: false),
+        ])
+        let suggested = CategoryBudgetPresentation(items: [
+            item(.education, limit: 200, spent: 100, suggested: true),
+        ])
+        let merged = CategoryBudgetPlanner.merge(explicit: explicit, suggested: suggested)
+        let order = merged.items.map(\.category)
+        #expect(order == [.travel, .education])
+    }
+
+    // MARK: - mergedPresentation (composition)
+
+    @Test("mergedPresentation: no explicit budgets returns suggestions only")
+    func mergedNoExplicit() {
+        let transactions = [
+            tx(300, "2026-03-15", .foodAndDrink),
+            tx(300, "2026-04-15", .foodAndDrink),
+            tx(300, "2026-05-15", .foodAndDrink),
+        ]
+        let merged = CategoryBudgetPlanner.mergedPresentation(
+            explicitBudgets: [:],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(!merged.isEmpty)
+        let allSuggested = merged.items.allSatisfy(\.isSuggested)
+        #expect(allSuggested)
+    }
+
+    @Test("mergedPresentation: an explicit budget replaces its suggestion and is not flagged suggested")
+    func mergedExplicitOverridesSuggestion() {
+        let transactions = [
+            // Trailing history seeds suggestions for food (~300) and shopping (~200).
+            tx(300, "2026-03-15", .foodAndDrink),
+            tx(300, "2026-04-15", .foodAndDrink),
+            tx(300, "2026-05-15", .foodAndDrink),
+            tx(200, "2026-03-10", .shopping),
+            tx(200, "2026-04-10", .shopping),
+            tx(200, "2026-05-10", .shopping),
+            // Current-month spend on the explicitly-budgeted category.
+            tx(50, "2026-06-05", .foodAndDrink),
+        ]
+        let merged = CategoryBudgetPlanner.mergedPresentation(
+            explicitBudgets: [.foodAndDrink: 400],
+            transactions: transactions,
+            asOf: now,
+            calendar: calendar
+        )
+        let food = merged.items.first { $0.id == SpendingCategory.foodAndDrink.rawValue }
+        #expect(food?.isSuggested == false) // explicit, not the dropped suggestion
+        #expect(food?.monthlyLimit == 400)
+        #expect(food?.spent == 50)
+        // foodAndDrink appears exactly once — its suggestion was de-duped.
+        let foodCount = merged.items.filter { $0.id == SpendingCategory.foodAndDrink.rawValue }.count
+        #expect(foodCount == 1)
+        // Shopping has no explicit budget, so it stays a suggestion.
+        let shopping = merged.items.first { $0.id == SpendingCategory.shopping.rawValue }
+        #expect(shopping?.isSuggested == true)
+    }
+}

--- a/Tests/PlaidBarCoreTests/MenuBarAnnouncementTests.swift
+++ b/Tests/PlaidBarCoreTests/MenuBarAnnouncementTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("MenuBarAnnouncement Tests")
+struct MenuBarAnnouncementTests {
+    // MARK: - Help text (tooltip)
+
+    @Test("Help text: value mode, no review, no weekly prompt")
+    func helpTextBaseline() {
+        let text = MenuBarAnnouncement.helpText(
+            mode: .netWorth,
+            valueText: "$1,234",
+            reviewCount: 0,
+            diagnosticsSummary: "All good",
+            weeklyReviewPrompt: nil
+        )
+        #expect(text == "VaultPeek - Net worth: $1,234. Status: All good")
+    }
+
+    @Test("Help text: review count + weekly prompt are appended")
+    func helpTextWithReviewAndWeekly() {
+        let text = MenuBarAnnouncement.helpText(
+            mode: .netCash,
+            valueText: "$500",
+            reviewCount: 3,
+            diagnosticsSummary: "Sync stale",
+            weeklyReviewPrompt: "ready"
+        )
+        #expect(text == "VaultPeek - Net cash: $500. 3 transactions need review. Status: Sync stale Weekly review: ready.")
+    }
+
+    @Test("Help text: icon-only mode omits the value noun")
+    func helpTextIconOnly() {
+        let text = MenuBarAnnouncement.helpText(
+            mode: .iconOnly,
+            valueText: "(ignored)",
+            reviewCount: 1,
+            diagnosticsSummary: "OK",
+            weeklyReviewPrompt: nil
+        )
+        // Singular "transaction" for a count of 1.
+        #expect(text == "VaultPeek. 1 transaction need review. Status: OK")
+    }
+
+    // MARK: - Accessibility label
+
+    @Test("Accessibility label: value mode, no review, no attention, no weekly")
+    func accessibilityBaseline() {
+        let label = MenuBarAnnouncement.accessibilityLabel(
+            mode: .netWorth,
+            valueText: "$1,234",
+            reviewCount: 0,
+            diagnosticsSummary: "All good",
+            attentionText: nil,
+            weeklyReviewPrompt: nil
+        )
+        #expect(label == "VaultPeek net worth $1,234. Status All good")
+    }
+
+    @Test("Accessibility label: folds attention badge into spoken status")
+    func accessibilityWithAttentionReviewWeekly() {
+        let label = MenuBarAnnouncement.accessibilityLabel(
+            mode: .safeToSpend,
+            valueText: "$200",
+            reviewCount: 2,
+            diagnosticsSummary: "Healthy",
+            attentionText: "Credit high",
+            weeklyReviewPrompt: "due"
+        )
+        #expect(label == "VaultPeek safe to spend $200. 2 transactions need review. Status Healthy. Attention Credit high Weekly review due.")
+    }
+
+    @Test("Accessibility label: icon-only mode omits the value noun")
+    func accessibilityIconOnly() {
+        let label = MenuBarAnnouncement.accessibilityLabel(
+            mode: .iconOnly,
+            valueText: "(ignored)",
+            reviewCount: 0,
+            diagnosticsSummary: "OK",
+            attentionText: nil,
+            weeklyReviewPrompt: nil
+        )
+        #expect(label == "VaultPeek. Status OK")
+    }
+
+    // MARK: - Golden noun literals (catch copy drift, independent of displayName)
+
+    /// Pins the EXACT tooltip/VoiceOver wording for every value mode. Because the
+    /// nouns flow from `MenuBarSummaryMode.displayName` — which also drives the
+    /// Settings picker — a re-word there for UI reasons would otherwise silently
+    /// change accessibility copy. These literals fail loudly if that happens.
+    @Test("Golden noun literals for every value mode")
+    func goldenNounLiterals() {
+        let cases: [(mode: MenuBarSummaryMode, help: String, spoken: String)] = [
+            (.netWorth, "Net worth", "net worth"),
+            (.netCash, "Net cash", "net cash"),
+            (.totalCash, "Total cash", "total cash"),
+            (.creditUtilization, "Credit utilization", "credit utilization"),
+            (.highestUtilization, "Highest card utilization", "highest card utilization"),
+            (.recentSpend, "Recent spend", "recent spend"),
+            (.todaySpend, "Today's spend", "today's spend"),
+            (.safeToSpend, "Safe to spend", "safe to spend"),
+        ]
+        for (mode, helpNoun, spokenNoun) in cases {
+            #expect(MenuBarAnnouncement.helpText(
+                mode: mode,
+                valueText: "V",
+                reviewCount: 0,
+                diagnosticsSummary: "D",
+                weeklyReviewPrompt: nil
+            ) == "VaultPeek - \(helpNoun): V. Status: D")
+            #expect(MenuBarAnnouncement.accessibilityLabel(
+                mode: mode,
+                valueText: "V",
+                reviewCount: 0,
+                diagnosticsSummary: "D",
+                attentionText: nil,
+                weeklyReviewPrompt: nil
+            ) == "VaultPeek \(spokenNoun) V. Status D")
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/ServerConfigLineTests.swift
+++ b/Tests/PlaidBarCoreTests/ServerConfigLineTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("ServerConfigLine Tests")
+struct ServerConfigLineTests {
+    // MARK: - classify
+
+    @Test("classify: blank and comment lines are ignored")
+    func classifyIgnored() {
+        #expect(ServerConfigLine.classify("") == .ignored)
+        #expect(ServerConfigLine.classify("   \t ") == .ignored)
+        #expect(ServerConfigLine.classify("# a comment") == .ignored)
+        #expect(ServerConfigLine.classify("   # indented comment") == .ignored)
+    }
+
+    @Test("classify: well-formed pairs, with trimming and optional export prefix")
+    func classifyPairs() {
+        #expect(ServerConfigLine.classify("FOO=bar") == .pair(key: "FOO", value: "bar"))
+        #expect(ServerConfigLine.classify("export FOO=bar") == .pair(key: "FOO", value: "bar"))
+        // Surrounding and inner whitespace around key/value is trimmed.
+        #expect(ServerConfigLine.classify("  export   FOO = bar  ") == .pair(key: "FOO", value: "bar"))
+        // An empty value is still a valid pair.
+        #expect(ServerConfigLine.classify("FOO=") == .pair(key: "FOO", value: ""))
+        // Only the FIRST '=' splits; later ones belong to the value.
+        #expect(ServerConfigLine.classify("FOO=a=b") == .pair(key: "FOO", value: "a=b"))
+        // Inner spaces in the value are preserved; quotes are NOT stripped here.
+        #expect(ServerConfigLine.classify("FOO=\"a b\"") == .pair(key: "FOO", value: "\"a b\""))
+    }
+
+    @Test("classify: content without a valid key=value is malformed")
+    func classifyMalformed() {
+        #expect(ServerConfigLine.classify("FOO") == .malformed) // no '='
+        #expect(ServerConfigLine.classify("=bar") == .malformed) // empty key
+        #expect(ServerConfigLine.classify("   =bar") == .malformed)
+        #expect(ServerConfigLine.classify("export ") == .malformed) // export prefix, nothing after
+        #expect(ServerConfigLine.classify("export") == .malformed) // bare word, no '='
+    }
+
+    // MARK: - parse (lenient convenience)
+
+    @Test("parse: returns the pair, or nil for ignored/malformed")
+    func parseLenient() {
+        let pair = ServerConfigLine.parse("export KEY=value")
+        #expect(pair?.key == "KEY")
+        #expect(pair?.value == "value")
+        #expect(ServerConfigLine.parse("# comment") == nil)
+        #expect(ServerConfigLine.parse("") == nil)
+        #expect(ServerConfigLine.parse("NOEQUALS") == nil)
+        #expect(ServerConfigLine.parse("=novalue") == nil)
+    }
+
+    // MARK: - unquote
+
+    @Test("unquote: strips one layer of matching quotes only")
+    func unquote() {
+        #expect(ServerConfigLine.unquote("\"hello\"") == "hello")
+        #expect(ServerConfigLine.unquote("'hello'") == "hello")
+        #expect(ServerConfigLine.unquote("bare") == "bare")
+        #expect(ServerConfigLine.unquote("\"\"") == "") // empty quoted value
+        // Mismatched / single / unbalanced quotes are left untouched.
+        #expect(ServerConfigLine.unquote("\"oops'") == "\"oops'")
+        #expect(ServerConfigLine.unquote("\"") == "\"")
+        #expect(ServerConfigLine.unquote("") == "")
+        // Only the outermost layer is removed.
+        #expect(ServerConfigLine.unquote("\"'nested'\"") == "'nested'")
+    }
+}

--- a/Tests/PlaidBarCoreTests/StableHashTests.swift
+++ b/Tests/PlaidBarCoreTests/StableHashTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("StableHash Tests")
+struct StableHashTests {
+    @Test("fnv1a64: canonical FNV-1a 64-bit vectors")
+    func canonicalVectors() {
+        // Empty string hashes to the FNV-1a 64-bit offset basis.
+        #expect(StableHash.fnv1a64("") == 0xcbf2_9ce4_8422_2325)
+        // "a" is a published FNV-1a-64 reference vector.
+        #expect(StableHash.fnv1a64("a") == 0xaf63_dc4c_8601_ec8c)
+    }
+
+    @Test("hexPadded: lowercase, fixed 16-character width")
+    func hexPaddedFormat() {
+        #expect(StableHash.hexPadded("") == "cbf29ce484222325")
+        #expect(StableHash.hexPadded("a") == "af63dc4c8601ec8c")
+        #expect(StableHash.hexPadded("account-1") == "de637fc248681e56")
+        // A hash with a leading-zero nibble keeps the zero (always 16 chars).
+        #expect(StableHash.hexPadded("k0") == "08be0e07b562230e")
+        #expect(StableHash.hexPadded("k0").count == 16)
+    }
+
+    @Test("hex: lowercase, minimal width (leading zeros dropped)")
+    func hexFormat() {
+        #expect(StableHash.hex("") == "cbf29ce484222325")
+        #expect(StableHash.hex("account-1") == "de637fc248681e56")
+        // Same underlying value as hexPadded("k0") but with the leading zero gone.
+        #expect(StableHash.hex("k0") == "8be0e07b562230e")
+    }
+
+    @Test("hex and hexPadded encode the same value, differing only in padding")
+    func paddedVsUnpadded() {
+        for input in ["", "a", "k0", "account-1", "https://example.com/logo.png"] {
+            let value = StableHash.fnv1a64(input)
+            #expect(StableHash.hexPadded(input).count == 16)
+            #expect(UInt64(StableHash.hexPadded(input), radix: 16) == value)
+            #expect(UInt64(StableHash.hex(input), radix: 16) == value)
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/StatusPanelTextTests.swift
+++ b/Tests/PlaidBarCoreTests/StatusPanelTextTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("StatusPanelText Tests")
+struct StatusPanelTextTests {
+    private static func presentation(
+        _ issue: ServerConnectionIssue,
+        diag: String = "DIAG"
+    ) -> ServerConnectionPresentation {
+        ServerConnectionPresentation(issue: issue, statusText: "S", diagnosticsSummary: diag)
+    }
+
+    // MARK: - mode
+
+    @Test("mode: demo wins over environment")
+    func modeDemo() {
+        #expect(StatusPanelText.mode(isDemoMode: true, environment: .production) == "Demo")
+    }
+
+    @Test("mode: environment label when not demo")
+    func modeEnvironment() {
+        #expect(StatusPanelText.mode(isDemoMode: false, environment: .sandbox) == "Sandbox")
+        #expect(StatusPanelText.mode(isDemoMode: false, environment: .production) == "Production")
+        #expect(StatusPanelText.mode(isDemoMode: false, environment: nil) == "Unknown")
+    }
+
+    // MARK: - serverCredentials
+
+    @Test("serverCredentials: demo / unreachable / ready / missing")
+    func serverCredentials() {
+        #expect(StatusPanelText.serverCredentials(isDemoMode: true, serverConnected: false, credentialsConfigured: nil) == "Not required")
+        #expect(StatusPanelText.serverCredentials(isDemoMode: false, serverConnected: false, credentialsConfigured: true) == "Unknown")
+        #expect(StatusPanelText.serverCredentials(isDemoMode: false, serverConnected: true, credentialsConfigured: true) == "Ready")
+        #expect(StatusPanelText.serverCredentials(isDemoMode: false, serverConnected: true, credentialsConfigured: false) == "Missing")
+        // nil is not `== true`, so it reads as Missing.
+        #expect(StatusPanelText.serverCredentials(isDemoMode: false, serverConnected: true, credentialsConfigured: nil) == "Missing")
+    }
+
+    // MARK: - serverSyncReadiness
+
+    @Test("serverSyncReadiness: demo / unreachable / ready / no items")
+    func serverSyncReadiness() {
+        #expect(StatusPanelText.serverSyncReadiness(isDemoMode: true, serverConnected: false, syncReady: nil) == "Demo data")
+        #expect(StatusPanelText.serverSyncReadiness(isDemoMode: false, serverConnected: false, syncReady: true) == "Unknown")
+        #expect(StatusPanelText.serverSyncReadiness(isDemoMode: false, serverConnected: true, syncReady: true) == "Ready")
+        #expect(StatusPanelText.serverSyncReadiness(isDemoMode: false, serverConnected: true, syncReady: false) == "No items")
+        #expect(StatusPanelText.serverSyncReadiness(isDemoMode: false, serverConnected: true, syncReady: nil) == "No items")
+    }
+
+    // MARK: - refreshCadence
+
+    @Test("refreshCadence: whole minutes")
+    func refreshCadence() {
+        #expect(StatusPanelText.refreshCadence(interval: 900) == "15 min")
+        #expect(StatusPanelText.refreshCadence(interval: 60) == "1 min")
+        #expect(StatusPanelText.refreshCadence(interval: 0) == "0 min")
+        // Truncates toward zero like the original Int(_:) conversion.
+        #expect(StatusPanelText.refreshCadence(interval: 119) == "1 min")
+    }
+
+    // MARK: - diagnosticsSummary ladder
+
+    @Test("diagnostics: recovery demo errors win first (with pluralization)")
+    func diagnosticsRecoveryErrored() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: true, isDemoMode: true,
+            serverConnection: Self.presentation(.demo), statusItemCount: 0,
+            erroredItemCount: 1, needsLoginItemCount: 5
+        ) == "1 demo item need attention")
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: true, isDemoMode: true,
+            serverConnection: Self.presentation(.demo), statusItemCount: 0,
+            erroredItemCount: 2, needsLoginItemCount: 0
+        ) == "2 demo items need attention")
+    }
+
+    @Test("diagnostics: recovery demo needs-update when no errors")
+    func diagnosticsRecoveryNeedsUpdate() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: true, isDemoMode: true,
+            serverConnection: Self.presentation(.demo), statusItemCount: 0,
+            erroredItemCount: 0, needsLoginItemCount: 3
+        ) == "3 demo items need update")
+    }
+
+    @Test("diagnostics: recovery scenario with no flagged items falls through to the ladder")
+    func diagnosticsRecoveryFallThrough() {
+        // recovery == true but errored == 0 && needsLogin == 0 -> the demo block
+        // returns nothing and execution proceeds into the isDemoMode/switch ladder.
+        // Here: non-demo + connected + items > 0 with no problems -> healthy.
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: true, isDemoMode: false,
+            serverConnection: Self.presentation(.connected), statusItemCount: 3,
+            erroredItemCount: 0, needsLoginItemCount: 0
+        ) == "Plaid connection healthy")
+    }
+
+    @Test("diagnostics: demo mode defers to the server presentation summary")
+    func diagnosticsDemoDefers() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: true,
+            serverConnection: Self.presentation(.demo, diag: "DEMO-DIAG"),
+            statusItemCount: 9, erroredItemCount: 9, needsLoginItemCount: 9
+        ) == "DEMO-DIAG")
+    }
+
+    @Test("diagnostics: blocking server issues defer to the presentation summary")
+    func diagnosticsBlockingDefers() {
+        for issue in [ServerConnectionIssue.offline, .localAuthMissing, .localAuthRejected, .serverModeMismatch] {
+            #expect(StatusPanelText.diagnosticsSummary(
+                isDemoStatusRecoveryScenario: false, isDemoMode: false,
+                serverConnection: Self.presentation(issue, diag: "BLOCK"),
+                statusItemCount: 9, erroredItemCount: 9, needsLoginItemCount: 9
+            ) == "BLOCK")
+        }
+    }
+
+    @Test("diagnostics: no items connected")
+    func diagnosticsNoItems() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: false,
+            serverConnection: Self.presentation(.connected), statusItemCount: 0,
+            erroredItemCount: 0, needsLoginItemCount: 0
+        ) == "No Plaid items connected")
+    }
+
+    @Test("diagnostics: per-item attention then update, with pluralization")
+    func diagnosticsPerItem() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: false,
+            serverConnection: Self.presentation(.connected), statusItemCount: 5,
+            erroredItemCount: 1, needsLoginItemCount: 4
+        ) == "1 item need attention")
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: false,
+            serverConnection: Self.presentation(.connected), statusItemCount: 5,
+            erroredItemCount: 0, needsLoginItemCount: 2
+        ) == "2 items need update")
+    }
+
+    @Test("diagnostics: .error issue with no per-item counts defers to the summary")
+    func diagnosticsErrorIssueDefers() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: false,
+            serverConnection: Self.presentation(.error, diag: "ERR"), statusItemCount: 3,
+            erroredItemCount: 0, needsLoginItemCount: 0
+        ) == "ERR")
+    }
+
+    @Test("diagnostics: healthy fallback")
+    func diagnosticsHealthy() {
+        #expect(StatusPanelText.diagnosticsSummary(
+            isDemoStatusRecoveryScenario: false, isDemoMode: false,
+            serverConnection: Self.presentation(.connected), statusItemCount: 3,
+            erroredItemCount: 0, needsLoginItemCount: 0
+        ) == "Plaid connection healthy")
+    }
+}

--- a/Tests/PlaidBarCoreTests/SyncHistoryDiffTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncHistoryDiffTests.swift
@@ -45,6 +45,25 @@ struct SyncHistoryDiffTests {
         #expect(rows.first?.accessibilityText.isEmpty == false)
     }
 
+    @Test("Row id uses the zero-padded stable-hash format (call-site regression guard)")
+    func rowIdUsesPaddedStableHash() {
+        // "k0" hashes to a value with a leading-zero nibble, so the padded form
+        // (08be…) differs from the unpadded form (8be…). This pins the row id to
+        // StableHash.hexPadded so a future swap to .hex — which would orphan
+        // existing identifiers — is caught here, at the call site.
+        let previous = AccountBalanceLedger(entries: [
+            entry("k0", daysAgo: 2, current: 100),
+            entry("k0", daysAgo: 1, current: 105),
+        ])
+        let next = AccountBalanceLedger(entries: [
+            entry("k0", daysAgo: 2, current: 130),
+            entry("k0", daysAgo: 1, current: 105),
+        ])
+        let rows = SyncHistoryDiff.evaluate(previousLedger: previous, nextLedger: next, displayName: displayName)
+        #expect(rows.first?.id == "08be0e07b562230e")
+        #expect(rows.first?.id == StableHash.hexPadded("k0"))
+    }
+
     @Test("A purely-additive newer day (no prior-day rewrite) yields no history-changed rows")
     func additiveDayYieldsNoRows() {
         let previous = AccountBalanceLedger(entries: [

--- a/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
+++ b/Tests/PlaidBarServerTests/LinkTokenRequestTests.swift
@@ -148,6 +148,45 @@ struct LinkTokenRequestTests {
         #expect(configured.link.webhookURL == "https://vaultpeek.example/webhooks/plaid/hosted-link")
     }
 
+    @Test("A malformed server.conf line aborts the load with its 1-based line number")
+    func malformedConfigLineThrowsWithLineNumber() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-malformed-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // A line with no '=' is rejected, reporting its 1-based position (line 3).
+        let noEquals = directory.appendingPathComponent("no-equals.conf")
+        try """
+        PLAID_CLIENT_ID=client-id
+        PLAID_SECRET=secret
+        GARBAGE_LINE_WITHOUT_EQUALS
+        """.write(to: noEquals, atomically: true, encoding: .utf8)
+        do {
+            _ = try ServerConfig.load(from: noEquals.path)
+            Issue.record("expected invalidConfigLine to be thrown")
+        } catch let ServerConfigError.invalidConfigLine(_, line) {
+            #expect(line == 3)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        // An empty key is likewise rejected, at its own line (line 2).
+        let emptyKey = directory.appendingPathComponent("empty-key.conf")
+        try """
+        PLAID_CLIENT_ID=client-id
+        =orphaned-value
+        """.write(to: emptyKey, atomically: true, encoding: .utf8)
+        do {
+            _ = try ServerConfig.load(from: emptyKey.path)
+            Issue.record("expected invalidConfigLine to be thrown")
+        } catch let ServerConfigError.invalidConfigLine(_, line) {
+            #expect(line == 2)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test("Link configuration rejects unsupported values before calling Plaid")
     func linkConfigurationValidation() {
         #expect(throws: PlaidLinkConfigurationError.self) {


### PR DESCRIPTION
## Summary

- Five **behavior-preserving** refactors applying the repo convention (pure, `Sendable` logic lives in `PlaidBarCore`; app/server delegate) to logic that had drifted into the `AppState` god-object and into duplicated copies across targets.
- `f1768a8` — `MenuBarAnnouncement`: extract menu-bar tooltip/VoiceOver text; `MenuBarSummaryMode.displayName` becomes the single source of truth for the per-mode noun (guarded by golden-literal tests).
- `78a4db5` — `StatusPanelText`: extract `statusModeText` / credentials / sync-readiness / cadence / the `diagnosticsSummary` health ladder.
- `2736199` — move the category-budget merge into `CategoryBudgetPlanner.mergedPresentation` + internal `merge`; add `CategoryBudgetPresentation(items:)` and route `presentation` through it (removes a triplicated totals reduce and a duplicated `statusRank`/sort).
- `a2435db` — `ServerConfigLine`: consolidate the `server.conf` parser/unquoter (was 5 copies of unquote / 3 of the tokenizer across all three targets) behind `classify` / `parse` / `unquote`.
- `ad16446` — `StableHash`: consolidate the FNV-1a 64-bit hash (4 copies across all three targets) with explicit `hexPadded` / `hex` variants so each call site keeps its original output format.
- Net: ~220 lines of pure logic moved out of `AppState`, 4 duplications eliminated, +36 tests (suite ~1067 → ~1103, all green), zero behavior change.

## Autonomous task IDs

- Task ID(s): None — not from the AND backlog.
- Backlog slice: N/A — opportunistic, behavior-preserving architecture refactor (self-paced `/loop` session).
- Scope note: one focused theme — extract pure logic / eliminate duplication into `PlaidBarCore`. Each of the 5 commits is independent and self-contained. No product behavior changes.

## Agent coordination

- Builder agent: Claude Code (Opus 4.8).
- Builder branch/worktree: `claude/gracious-booth-591671` (worktree `gracious-booth-591671`).
- Reviewer/merge steward: Otto.
- Coordination note: review only — no other agent should push to this branch.

## Changed files

- Core (new): `MenuBarAnnouncement.swift`, `StatusPanelText.swift`, `ServerConfigLine.swift`, `StableHash.swift`
- Core (changed): `MenuBarSummary.swift`, `CategoryBudgetPlanner.swift`, `CategoryBudgetPresentation.swift`, `ServerAutoLaunchPlan.swift`, `SyncHistoryDiff.swift`, `LocalDataStore.swift`
- App: `App/AppState.swift`, `Spotlight/AccountSpotlightIndexer.swift`
- Server: `Config/ServerConfig.swift`, `Routes/MerchantLogoRoutes.swift`
- Tests (new): `MenuBarAnnouncementTests`, `StatusPanelTextTests`, `CategoryBudgetMergeTests`, `ServerConfigLineTests`, `StableHashTests`
- Tests (changed): `SyncHistoryDiffTests` (id-format guard), `LinkTokenRequestTests` (malformed-config-line regression)

## Local gates

- [x] `git diff --check` — clean.
- [x] `swift build --target PlaidBar ...` — ran the stricter CI-equivalent `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (covers all targets); clean, no warnings.
- [x] `swift build --target PlaidBarServer ...` — covered by the same full strict build (server + shared DTO code changed).
- [x] Full `swift test` after every step — green except the pre-existing `LocalInsightModelRuntime` timeout flake, which passes in isolation (confirmed; unrelated to this PR). Latest full run: 1098 tests.
- [x] Secret scan completed over the full diff (source + tests) — no tokens/secrets/credentials.

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.
- [ ] Skipped checks are expected and not required for this PR.
- [ ] Any failing, pending, cancelled, missing, or ambiguous required check blocks merge.
- [ ] Claude/Codex review auth/token/session/setup-only failures are documented as blocking unless Felipe explicitly grants a one-off override.

> CI not yet evaluated at PR-open time; the steward should confirm the above before merge.

## Privacy and safety impact

- [x] I used only sandbox or synthetic financial data in tests, screenshots, examples, and docs.
- [x] I did not include real Plaid credentials, access tokens, account IDs, transaction exports, raw balances, or screenshots with real financial data.
- [x] This change preserves the local-first boundary: no hosted backend, telemetry, cloud sync, multi-user account system, or cloud AI over private transaction data.
- [x] User-facing copy remains honest about local storage, Plaid credentials, production approval, and unsupported security properties (this PR changes no user-facing copy — extracted text output is byte-identical).

## Reviewer local-first and secret-exposure checklist

- [ ] The diff does not introduce, log, display, persist, or document real Plaid secrets, access tokens, public tokens, item IDs, account IDs, transaction exports, raw balances, or real financial screenshots.
- [ ] New status, diagnostics, error, analytics-like, AI, or logging surfaces expose only readiness metadata or synthetic/demo data, never private financial records or identifiers.
- [ ] Any server, storage, setup, or diagnostics change keeps PlaidBar local-first.
- [ ] Any optional AI behavior is local-only, off by default, explainable, reversible, and non-blocking.
- [ ] Any documentation, examples, fixtures, tests, and screenshots use sandbox or synthetic data.

## UI and accessibility checks

- [x] No UI changes — the menu-bar/VoiceOver text refactor produces byte-identical output (verified by adversarial re-derivation), so keyboard access and visible focus are unaffected.
- [x] VoiceOver labels are byte-identical to before (the `MenuBarAnnouncement` extraction is output-preserving across all 9 modes × review/weekly/attention combinations).
- [x] Balances, risk, utilization, errors, and chart meaning remain understandable without relying on color alone (no presentation changes).
- [x] No user-facing behavior changed, so no docs/screenshots needed updating.

## Merge safety

- [x] Final diff reviewed for secrets, private financial data, generated artifacts, scope creep, and unsafe destructive behavior.
- [ ] Merge is within the scoped PlaidBar approval in `docs/autonomous-roadmap.md`, or Felipe explicitly approved this PR.
- [ ] PR head SHA was rechecked immediately before merge.
- [ ] No other agent is actively mutating this branch/worktree.
- [ ] After merge, completed task IDs will be recorded in the roadmap ledger and backlog checklist.

## How this was verified

Each commit passed the same gate before landing: strict-concurrency build, full `swift test`, a demo-app boot smoke test, and an independent adversarial review that re-derived the original output from `git HEAD` and diffed it. That gate preserved real subtleties: the menu-bar help-vs-VoiceOver spacing asymmetry, the `diagnosticsSummary` branch order, the `server.conf` strict-throw-with-line-number vs lenient-skip distinction and the `PLAID_ENV` double-unquote, and — most importantly — the padded-vs-unpadded hash format per call site (a naive `StableHash` merge would have changed persisted cache filenames and Spotlight identifiers; each site stays on its original format, tested with a leading-zero case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
