### PR TITLE
feat(core): add CategoryGroup map + SpendingCategory.group (AND-535)

### DIFF
--- a/Sources/PlaidBarCore/Models/CategoryGroup.swift
+++ b/Sources/PlaidBarCore/Models/CategoryGroup.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// A fixed, 2-level grouping over the closed 16-case ``SpendingCategory`` taxonomy.
+///
+/// `CategoryGroup` is the *parent* level of the category tree the Copilot-style
+/// dashboard renders (AND-521 / AND-536…AND-538). It is **purely additive**: it does
+/// not change any ``SpendingCategory`` `rawValue`, DTO, or persisted format. Aggregation
+/// always rolls leaf ``SpendingCategory`` totals up into one of these groups via
+/// ``SpendingCategory/group``.
+///
+/// The grouping is exhaustive — every one of the 16 leaf categories maps to exactly one
+/// group — and the group set is closed, so `switch` statements over it stay exhaustive.
+public enum CategoryGroup: String, Codable, Sendable, CaseIterable, Hashable {
+    case income = "INCOME"
+    case housing = "HOUSING"
+    case foodAndDining = "FOOD_AND_DINING"
+    case transportation = "TRANSPORTATION"
+    case shopping = "SHOPPING"
+    case billsAndUtilities = "BILLS_AND_UTILITIES"
+    case healthAndWellness = "HEALTH_AND_WELLNESS"
+    case entertainment = "ENTERTAINMENT"
+    case transfers = "TRANSFERS"
+    case other = "OTHER"
+
+    /// Stable, human-readable group title for dashboard headers and rollup rows.
+    ///
+    /// Titles are part of the group's stable contract — the dashboard and design spec
+    /// reference them by name — so they must not drift with display tweaks.
+    public var title: String {
+        switch self {
+        case .income: "Income"
+        case .housing: "Housing"
+        case .foodAndDining: "Food & Dining"
+        case .transportation: "Transportation"
+        case .shopping: "Shopping"
+        case .billsAndUtilities: "Bills & Utilities"
+        case .healthAndWellness: "Health & Wellness"
+        case .entertainment: "Entertainment"
+        case .transfers: "Transfers"
+        case .other: "Other"
+        }
+    }
+
+    /// Canonical top-to-bottom display order for the group tree.
+    ///
+    /// Income leads (money in), `Other` trails (catch-all), and spend groups sit between
+    /// in a stable, intuitive order. The dashboard renders groups in exactly this order;
+    /// keep it stable so screenshots and the QA matrix don't churn.
+    public static let displayOrder: [CategoryGroup] = [
+        .income,
+        .housing,
+        .foodAndDining,
+        .transportation,
+        .shopping,
+        .billsAndUtilities,
+        .healthAndWellness,
+        .entertainment,
+        .transfers,
+        .other,
+    ]
+
+    /// Position of this group within ``displayOrder`` (0-based, contiguous).
+    ///
+    /// Useful as a `Comparable`/sort key when building ordered rollups without threading
+    /// ``displayOrder`` through call sites. `Other` is intentionally the largest index.
+    public var sortIndex: Int {
+        // `displayOrder` is exhaustive over `allCases`, so this lookup never fails;
+        // the fallback keeps the property total without a force-unwrap.
+        CategoryGroup.displayOrder.firstIndex(of: self) ?? CategoryGroup.displayOrder.count
+    }
+
+    /// The leaf ``SpendingCategory`` cases that roll up into this group.
+    ///
+    /// Derived from ``SpendingCategory/group`` so the mapping has a single source of
+    /// truth: changing a leaf's group automatically updates this membership list.
+    public var categories: [SpendingCategory] {
+        SpendingCategory.allCases.filter { $0.group == self }
+    }
+}
+
+public extension SpendingCategory {
+    /// The fixed parent ``CategoryGroup`` this leaf category rolls up into.
+    ///
+    /// Total over all 16 cases — the closed `switch` is the single source of truth for
+    /// the leaf→group mapping. Pure and `Sendable`; no I/O, no migration.
+    var group: CategoryGroup {
+        switch self {
+        case .income:
+            .income
+        case .homeImprovement:
+            .housing
+        case .foodAndDrink:
+            .foodAndDining
+        case .transportation:
+            .transportation
+        case .shopping:
+            .shopping
+        case .billsAndUtilities, .subscriptions:
+            // `subscriptions` is Plaid `LOAN_PAYMENTS` (recurring obligations), which sit
+            // with bills/utilities as fixed monthly outflows rather than discretionary spend.
+            .billsAndUtilities
+        case .healthAndFitness, .personalCare:
+            .healthAndWellness
+        case .entertainment, .travel, .education:
+            // Travel and education are discretionary/lifestyle spend; they fold into the
+            // Entertainment group rather than spawning low-volume singleton groups.
+            .entertainment
+        case .transfer, .transferOut:
+            .transfers
+        case .bankFees, .government, .other:
+            .other
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryGroupTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryGroupTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("CategoryGroup map + SpendingCategory.group (AND-535)")
+struct CategoryGroupTests {
+    @Test("every SpendingCategory case maps to a group (exhaustive)")
+    func everyCategoryMapsToAGroup() {
+        // Iterating CaseIterable guarantees the assertion stays exhaustive as cases
+        // are added: a new SpendingCategory case is automatically covered here, and
+        // the non-optional `group` property forces the mapping to be total.
+        for category in SpendingCategory.allCases {
+            let group = category.group
+            #expect(CategoryGroup.allCases.contains(group))
+        }
+    }
+
+    @Test("every CategoryGroup is reachable from at least one SpendingCategory")
+    func everyGroupIsReachable() {
+        let reached = Set(SpendingCategory.allCases.map(\.group))
+        for group in CategoryGroup.allCases {
+            #expect(reached.contains(group), "Group \(group) has no SpendingCategory mapped to it")
+        }
+    }
+
+    @Test("group ordering is stable, total, and duplicate-free")
+    func orderingIsStable() {
+        let ordered = CategoryGroup.displayOrder
+        // Ordering covers every group exactly once.
+        #expect(ordered.count == CategoryGroup.allCases.count)
+        #expect(Set(ordered).count == ordered.count)
+        #expect(Set(ordered) == Set(CategoryGroup.allCases))
+        // sortIndex is consistent with the ordering and contiguous from 0.
+        for (index, group) in ordered.enumerated() {
+            #expect(group.sortIndex == index)
+        }
+        // Pinned anchors the dashboard relies on: Income first, Other last.
+        #expect(ordered.first == .income)
+        #expect(ordered.last == .other)
+    }
+
+    @Test("group titles are stable, non-empty, and unique")
+    func titlesAreStableAndUnique() {
+        let titles = CategoryGroup.allCases.map(\.title)
+        #expect(titles.allSatisfy { !$0.isEmpty })
+        #expect(Set(titles).count == titles.count)
+        // A few stable, load-bearing titles the dashboard/spec reference by name.
+        #expect(CategoryGroup.income.title == "Income")
+        #expect(CategoryGroup.foodAndDining.title == "Food & Dining")
+        #expect(CategoryGroup.billsAndUtilities.title == "Bills & Utilities")
+        #expect(CategoryGroup.healthAndWellness.title == "Health & Wellness")
+        #expect(CategoryGroup.transfers.title == "Transfers")
+        #expect(CategoryGroup.other.title == "Other")
+    }
+
+    @Test("representative SpendingCategory cases land in the expected group")
+    func representativeMappings() {
+        #expect(SpendingCategory.income.group == .income)
+        #expect(SpendingCategory.foodAndDrink.group == .foodAndDining)
+        #expect(SpendingCategory.transportation.group == .transportation)
+        #expect(SpendingCategory.shopping.group == .shopping)
+        #expect(SpendingCategory.billsAndUtilities.group == .billsAndUtilities)
+        #expect(SpendingCategory.subscriptions.group == .billsAndUtilities)
+        #expect(SpendingCategory.healthAndFitness.group == .healthAndWellness)
+        #expect(SpendingCategory.personalCare.group == .healthAndWellness)
+        #expect(SpendingCategory.entertainment.group == .entertainment)
+        #expect(SpendingCategory.homeImprovement.group == .housing)
+        #expect(SpendingCategory.transfer.group == .transfers)
+        #expect(SpendingCategory.transferOut.group == .transfers)
+        #expect(SpendingCategory.bankFees.group == .other)
+        #expect(SpendingCategory.government.group == .other)
+        #expect(SpendingCategory.other.group == .other)
+    }
+
+    @Test("group exposes its member categories and membership round-trips")
+    func membershipRoundTrips() {
+        // Every category listed by a group's `categories` actually maps back to it,
+        // and the union of all members covers the full SpendingCategory set.
+        var union: Set<SpendingCategory> = []
+        for group in CategoryGroup.allCases {
+            for category in group.categories {
+                #expect(category.group == group)
+                union.insert(category)
+            }
+        }
+        #expect(union == Set(SpendingCategory.allCases))
+    }
+}


### PR DESCRIPTION
## Summary

Adds the parent level of the Copilot-style category tree as a pure, additive model in `PlaidBarCore`:

- **`CategoryGroup`** — a new `Sendable`, `CaseIterable`, `Codable`, `Hashable` enum with **10 groups** (`income`, `housing`, `foodAndDining`, `transportation`, `shopping`, `billsAndUtilities`, `healthAndWellness`, `entertainment`, `transfers`, `other`) that **exhaustively** cover all 16 `SpendingCategory` cases. It carries the display metadata the dashboard (AND-536/537/538) needs: a stable `title`, a canonical `displayOrder`, a contiguous `sortIndex`, and a derived `categories` membership list.
- **`SpendingCategory.group`** — a computed property whose total, closed `switch` is the single source of truth for the leaf→group mapping (every one of the 16 cases is mapped).

Leaf→group mapping:

| Group | SpendingCategory cases |
|---|---|
| Income | income |
| Housing | homeImprovement |
| Food & Dining | foodAndDrink |
| Transportation | transportation |
| Shopping | shopping |
| Bills & Utilities | billsAndUtilities, subscriptions (Plaid `LOAN_PAYMENTS`) |
| Health & Wellness | healthAndFitness, personalCare |
| Entertainment | entertainment, travel, education |
| Transfers | transfer, transferOut |
| Other | bankFees, government, other |

## Linear

AND-535 "CategoryGroup map + SpendingCategory.group" (Epic AND-521 Category Dashboard).

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`:

- §2 / §4 ratify **Option A** — display-only rollups over the existing closed 16-case taxonomy. **No migration.**
- §4 cites the new `CategoryGroup` enum + `SpendingCategory.group` as the first PlaidBarCore addition feeding `CategoryDashboardBuilder` (AND-536).
- §6 lists AND-535 as a Phase-0 task runnable in parallel with the override-aware planner work — this PR delivers exactly that model + mapping and nothing else.

This change is **additive only**: it does not touch `SpendingCategory` rawValues, `TransactionDTO`, `CategoryBudgetDTO`, the server schema, `CategoryBudgetPlanner`, or any view. The `switch` over `SpendingCategory` stays exhaustive, preserving the §7 risk guard against breaking exhaustiveness.

## Testing notes

New test file `Tests/PlaidBarCoreTests/CategoryGroupTests.swift` (Swift Testing):

- `every SpendingCategory case maps to a group (exhaustive)` — iterates `CaseIterable`.
- `every CategoryGroup is reachable from at least one SpendingCategory`.
- `group ordering is stable, total, and duplicate-free` — `displayOrder` totality, uniqueness, `sortIndex` contiguity, Income-first/Other-last anchors.
- `group titles are stable, non-empty, and unique`.
- `representative SpendingCategory cases land in the expected group`.
- `group exposes its member categories and membership round-trips`.

Final local gate (sandbox off):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
  → Build complete! (108.23s)

swift test
  → Test run with 1105 tests passed after 0.993 seconds.
```

Both gates fully green; all pre-existing tests stay green.

## Architectural decisions

- **Closed `switch` as the single source of truth.** `SpendingCategory.group` uses a total `switch` (no `default`), so adding a future leaf category forces a compile error until it is grouped. `CategoryGroup.categories` derives membership from this mapping rather than duplicating it.
- **10 groups, not the example's ~10 with singletons.** Travel and education fold into Entertainment (discretionary/lifestyle) and `subscriptions`/`LOAN_PAYMENTS` folds into Bills & Utilities (fixed monthly obligations) to avoid low-volume singleton groups while keeping coverage exhaustive and intuitive.
- **Stable presentation metadata.** `title` and `displayOrder` are part of the group's contract (referenced by the dashboard and QA screenshots), separated from any future display tweaks. `Income` is pinned first, `Other` last.
- **Pure + Sendable, in `PlaidBarCore`.** No I/O, no concurrency surface; compiles clean under `-strict-concurrency=complete -warnings-as-errors`.

## Migration notes

None — additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
