### PR TITLE
feat(app): add DemoFixtures providers for budgets/review/rules + wire demo mode (AND-543)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3313,9 +3313,17 @@ final class AppState {
         accounts = DemoFixtures.accounts
         liabilities = DemoFixtures.liabilities()
         transactions = DemoFixtures.transactions()
-        transactionReviewMetadata = []
-        transactionRules = []
-        categoryBudgets = [:]
+        // Seed review metadata, categorization rules, and category budgets so
+        // --demo actually surfaces the Review Inbox + budget/category state
+        // (AND-543) instead of empty placeholders. Held in-memory only: these
+        // assignments invalidate the inbox/budget caches via `didSet` but never
+        // persist, so a demo session never overwrites the user's real saved data.
+        transactionReviewMetadata = DemoFixtures.demoReviewMetadata()
+        transactionRules = DemoFixtures.demoTransactionRules()
+        categoryBudgets = Dictionary(
+            DemoFixtures.demoBudgets().map { ($0.category, $0.monthlyLimit) },
+            uniquingKeysWith: { first, _ in first }
+        )
         balanceHistory = DemoFixtures.balanceHistory()
         // Seed demo watchlist nudges (AND-501) so the Settings Watchlists section
         // is populated and the evaluator fires against the demo transactions.

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1204,9 +1204,19 @@ final class AppState {
 
     var categoryBudgetPresentation: CategoryBudgetPresentation {
         if let cached = _cachedCategoryBudgetPresentation { return cached }
+        // The budget scorer counts only current-calendar-month transactions. The
+        // demo set anchors dates relative to `now`, so on the 1st/2nd of a month
+        // the high-spend rows roll into the previous month and the dashboard
+        // collapses to all-under. Score demo budgets against the dedicated
+        // current-month-anchored rows so the under/near/over spread is stable
+        // regardless of launch day (AND-543 review). Suggestions are suppressed in
+        // demo mode (empty `transactions`) so only the seeded budgets show.
+        let scoringTransactions = isDemoMode
+            ? DemoFixtures.demoBudgetScoringTransactions()
+            : transactions
         let presentation = CategoryBudgetPlanner.mergedPresentation(
             explicitBudgets: categoryBudgets,
-            transactions: transactions,
+            transactions: scoringTransactions,
             asOf: Date()
         )
         _cachedCategoryBudgetPresentation = presentation
@@ -1216,14 +1226,14 @@ final class AppState {
     private var weeklyReviewTransactionState: WeeklyReviewTransactionState? {
         // Production weekly reviews require loaded transaction-review metadata.
         // Raw Plaid transactions alone are not treated as reviewed; demo mode
-        // keeps using pending flags so the checklist surface remains locally
-        // exercisable.
+        // keeps trusting non-pending rows so the checklist surface remains
+        // locally exercisable without seeding metadata for every fixture, while
+        // still honoring explicitly seeded `.needsReview` rows so the Review
+        // Inbox and the Weekly Review agree. See `demoDerived` for the contract.
         guard !isDemoMode else {
-            let unreviewed = Set(transactions.filter(\.pending).map(\.id))
-            let trusted = Set(transactions.map(\.id)).subtracting(unreviewed)
-            return WeeklyReviewTransactionState(
-                trustedTransactionIds: trusted,
-                unreviewedTransactionIds: unreviewed
+            return WeeklyReviewTransactionState.demoDerived(
+                from: transactions,
+                metadata: transactionReviewMetadata
             )
         }
 
@@ -3513,6 +3523,13 @@ final class AppState {
     }
 
     private func persistReviewStorage() {
+        // Demo mode seeds synthetic review metadata and rules into the real
+        // AppState (see `loadDemoData`). Acting on a demo inbox item must never
+        // write those fixtures to disk: `activeStorageDirectoryURL` is the
+        // sandbox-scoped real cache, and a later real connection on the same
+        // storage path would reload the synthetic `tx*`/Starbucks/Venmo records.
+        // The decision is a pure, tested predicate in PlaidBarCore.
+        guard ReviewStoragePersistencePolicy.shouldPersist(isDemoMode: isDemoMode) else { return }
         let metadata = transactionReviewMetadata
         let rules = transactionRules
         let cacheDirectory = activeStorageDirectoryURL

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -589,3 +589,20 @@ public enum TransactionReviewInbox {
         return trimmed.isEmpty ? nil : trimmed
     }
 }
+
+/// Decides whether review-inbox metadata and categorization rules may be written
+/// to the on-disk cache.
+///
+/// In `--demo`, synthetic fixtures are seeded into the live AppState, so a review
+/// action there must NOT persist: `activeStorageDirectoryURL` is the
+/// sandbox-scoped real cache, and a later real connection on the same storage
+/// path would reload the synthetic `tx*`/Starbucks/Venmo records. This is a pure,
+/// testable predicate so the security-relevant guard does not live only in the
+/// (untestable, `@main`) app target.
+public enum ReviewStoragePersistencePolicy {
+    /// `true` only when the current review/rule state may be saved to disk.
+    /// Demo mode is never persisted.
+    public static func shouldPersist(isDemoMode: Bool) -> Bool {
+        !isDemoMode
+    }
+}

--- a/Sources/PlaidBarCore/Models/WeeklyReview.swift
+++ b/Sources/PlaidBarCore/Models/WeeklyReview.swift
@@ -75,6 +75,36 @@ public struct WeeklyReviewTransactionState: Sendable, Equatable {
             unreviewedTransactionIds: unreviewedTransactionIds
         )
     }
+
+    /// Demo-mode trust model. Unlike production (`derived`), demo mode does not
+    /// seed review metadata for every fixture, so a transaction with no metadata
+    /// is trusted as long as it is not pending — keeping the weekly-review
+    /// checklist locally exercisable without a full metadata seed. It must still
+    /// honor *explicitly* seeded `.needsReview` metadata, though, so a demo
+    /// Review Inbox row (e.g. an uncategorized fixture) is counted as unreviewed
+    /// here and the Weekly Review agrees with the inbox instead of reading clear.
+    public static func demoDerived(
+        from transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]
+    ) -> WeeklyReviewTransactionState {
+        let metadataById = Dictionary(metadata.map { ($0.id, $0) }) { _, latest in latest }
+        var trustedTransactionIds = Set<String>()
+        var unreviewedTransactionIds = Set<String>()
+
+        for transaction in transactions {
+            let seededNeedsReview = metadataById[transaction.id]?.status == .needsReview
+            if transaction.pending || seededNeedsReview {
+                unreviewedTransactionIds.insert(transaction.id)
+            } else {
+                trustedTransactionIds.insert(transaction.id)
+            }
+        }
+
+        return WeeklyReviewTransactionState(
+            trustedTransactionIds: trustedTransactionIds,
+            unreviewedTransactionIds: unreviewedTransactionIds
+        )
+    }
 }
 
 public enum WeeklyReviewOutcome: String, Sendable, Equatable {

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -111,6 +111,102 @@ public enum DemoFixtures {
         ]
     }
 
+    // MARK: - Budgets / review / rules (AND-543)
+
+    /// Synthetic category budgets so `--demo` shows a populated Category
+    /// Dashboard with a spread of status bands (under / near / over) instead of
+    /// an empty budgets section. Limits are hand-tuned against the demo spend so
+    /// the high-traffic categories (Food & Drink, Shopping) read as at-or-over
+    /// plan while the lighter ones stay comfortably under — making every status
+    /// bar demoable without Plaid. Matches the persisted `CategoryBudgetDTO`
+    /// shape used by the server budget store and `CategoryBudgetPlanner`.
+    ///
+    /// Never budgets income/transfer pseudo-categories. All amounts invented.
+    public static func demoBudgets() -> [CategoryBudgetDTO] {
+        [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 400),
+            CategoryBudgetDTO(category: .shopping, monthlyLimit: 500),
+            CategoryBudgetDTO(category: .transportation, monthlyLimit: 150),
+            CategoryBudgetDTO(category: .entertainment, monthlyLimit: 120),
+            CategoryBudgetDTO(category: .billsAndUtilities, monthlyLimit: 2_400),
+            CategoryBudgetDTO(category: .travel, monthlyLimit: 600),
+            CategoryBudgetDTO(category: .healthAndFitness, monthlyLimit: 200),
+        ]
+    }
+
+    /// Seeded transaction-review metadata so the Review Inbox is populated in
+    /// `--demo` and a user override visibly flows into budget/category math.
+    /// Every id references an explicit demo transaction (see `explicitTransactions`):
+    ///
+    /// - `tx55` (SQ *KMNT LLC) — left `.needsReview`: deliberately unresolvable
+    ///   by the NL tier, so the genuinely-uncategorized inbox row is always
+    ///   present.
+    /// - `tx52` (Blue Bottle Coffee) — `.reviewed` with a `foodAndDrink`
+    ///   override, demonstrating an NL suggestion the user approved; its spend
+    ///   now counts under Food & Drink downstream.
+    /// - `tx14` (Venmo payment, an inflow) — `.reviewed`, marked a transfer and
+    ///   excluded from budgets, so the transfer-override path is demoable.
+    ///
+    /// Fixed (no `reviewedAt: Date()`) timestamps are derived from `now` so the
+    /// records stay deterministic across launches and screenshots.
+    public static func demoReviewMetadata(now: Date = Date(), calendar: Calendar = .current) -> [TransactionReviewMetadata] {
+        let reviewedAt = calendar.date(byAdding: .hour, value: -3, to: now) ?? now
+        return [
+            // Genuinely uncategorized — stays in the inbox.
+            TransactionReviewMetadata(
+                id: "tx55",
+                status: .needsReview,
+                reviewReasonCodes: [.uncategorized, .newMerchant]
+            ),
+            // Approved NL suggestion — persisted as a user category override.
+            TransactionReviewMetadata(
+                id: "tx52",
+                status: .reviewed,
+                userCategory: .foodAndDrink,
+                reviewedAt: reviewedAt,
+                lastSeenAmount: 6.75,
+                lastSeenName: "BLUE BOTTLE COFFEE"
+            ),
+            // User-confirmed transfer, excluded from spend/budget totals.
+            TransactionReviewMetadata(
+                id: "tx14",
+                status: .reviewed,
+                isTransferOverride: true,
+                excludedFromBudgets: true,
+                reviewedAt: reviewedAt,
+                lastSeenAmount: -1_500.00,
+                lastSeenName: "VENMO PAYMENT"
+            ),
+        ]
+    }
+
+    /// A couple of synthetic categorization rules so `--demo` shows the rules
+    /// surface working and rule-driven recategorization flowing into totals.
+    ///
+    /// - Starbucks → Food & Drink (matches `tx11`, `tx42`).
+    /// - Venmo → transfer, excluded from budgets (matches `tx14`), mirroring the
+    ///   transfer override above as a reusable rule.
+    ///
+    /// Fixed UUIDs keep order and identity deterministic for screenshots.
+    public static func demoTransactionRules(now: Date = Date(), calendar: Calendar = .current) -> [TransactionRule] {
+        let createdAt = calendar.date(byAdding: .day, value: -10, to: now) ?? now
+        return [
+            TransactionRule(
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!,
+                matchMerchantContains: "Starbucks",
+                category: .foodAndDrink,
+                createdAt: createdAt
+            ),
+            TransactionRule(
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000B2")!,
+                matchMerchantContains: "Venmo",
+                isTransfer: true,
+                excludedFromBudgets: true,
+                createdAt: createdAt
+            ),
+        ]
+    }
+
     /// Deterministic 60-day net-worth history with a gentle upward drift so the
     /// header trend reads the same on every demo launch and screenshots
     /// reproduce.

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -134,6 +134,67 @@ public enum DemoFixtures {
         ]
     }
 
+    /// Current-month-anchored spend rows used **only** to score `demoBudgets`
+    /// against `CategoryBudgetPlanner` in `--demo`.
+    ///
+    /// The Category Dashboard scorer counts only transactions dated in the
+    /// current calendar month. The main demo set anchors dates relative to
+    /// `now` (`daysAgo`), so when `--demo` opens on the 1st/2nd the high-spend
+    /// rows that produce the intended under/near/over spread roll into the
+    /// previous month and the dashboard renders mostly under budget. These rows
+    /// are instead anchored to the **start of the current month** (day-of-month
+    /// 1...5), so the status mix survives every month boundary:
+    ///
+    /// - Shopping over budget (≈ 933 of 500)
+    /// - Food & Drink / Bills / Travel near their limits (≈ 89% / 88% / 90%)
+    /// - Transportation / Entertainment / Health comfortably under
+    ///
+    /// Kept separate from the main transaction list so the heatmap/recurring
+    /// continuity contract (which depends on the `daysAgo` cadence) is untouched.
+    /// All amounts invented.
+    public static func demoBudgetScoringTransactions(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [TransactionDTO] {
+        let monthStart = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: now)
+        ) ?? now
+        func dayOfMonth(_ offset: Int) -> String {
+            let date = calendar.date(byAdding: .day, value: offset, to: monthStart) ?? monthStart
+            return Formatters.transactionDateString(date)
+        }
+        // (category, amount, day-of-month offset). Offsets stay within 0...4 so
+        // every row lands in the current month regardless of launch day.
+        let rows: [(SpendingCategory, Double, Int)] = [
+            // Shopping → over budget (500): West Elm + Costco + Nordstrom + Target.
+            (.shopping, 650.00, 0), (.shopping, 142.80, 1),
+            (.shopping, 85.00, 2), (.shopping, 55.00, 3),
+            // Food & Drink → near (400): ≈ 355.
+            (.foodAndDrink, 142.80, 0), (.foodAndDrink, 134.62, 2), (.foodAndDrink, 78.00, 4),
+            // Bills & Utilities → near (2400): rent + utilities ≈ 2100.
+            (.billsAndUtilities, 1_850.00, 1), (.billsAndUtilities, 250.00, 3),
+            // Travel → near (600): ≈ 540.
+            (.travel, 320.00, 1), (.travel, 220.00, 3),
+            // Transportation → under (150): ≈ 68.
+            (.transportation, 23.50, 0), (.transportation, 45.00, 2),
+            // Entertainment → under (120): ≈ 50.
+            (.entertainment, 15.99, 1), (.entertainment, 34.50, 3),
+            // Health & Fitness → under (200): ≈ 75.
+            (.healthAndFitness, 75.00, 2),
+        ]
+        return rows.enumerated().map { index, row in
+            let (category, amount, offset) = row
+            return TransactionDTO(
+                id: "demo_budget_\(index)",
+                accountId: "demo_checking",
+                amount: amount,
+                date: dayOfMonth(offset),
+                name: "DEMO BUDGET \(category.rawValue.uppercased())",
+                category: category
+            )
+        }
+    }
+
     /// Seeded transaction-review metadata so the Review Inbox is populated in
     /// `--demo` and a user override visibly flows into budget/category math.
     /// Every id references an explicit demo transaction (see `explicitTransactions`):

--- a/Tests/PlaidBarCoreTests/DemoReviewBudgetFixturesTests.swift
+++ b/Tests/PlaidBarCoreTests/DemoReviewBudgetFixturesTests.swift
@@ -66,6 +66,71 @@ struct DemoReviewBudgetFixturesTests {
         #expect(Set(budgets.map(\.monthlyLimit)).count >= 2)
     }
 
+    /// The Category Dashboard scorer only counts current-calendar-month
+    /// transactions. The dedicated `demoBudgetScoringTransactions` rows are
+    /// anchored to the start of the current month so the intended
+    /// under/near/over spread survives `--demo` opening on any day — including
+    /// the 1st/2nd, where the relative-dated main set would roll the high-spend
+    /// rows into the previous month and collapse every band to "under".
+    @Test("Demo budget status mix is stable across every day of the month")
+    func budgetStatusMixSurvivesMonthBoundaries() {
+        let budgets = Dictionary(
+            DemoFixtures.demoBudgets().map { ($0.category, $0.monthlyLimit) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let calendar = Calendar.current
+
+        // Walk a representative month day-by-day (a 31-day month covers every
+        // start-of-month edge). The status set must include all three bands and
+        // never change, regardless of the launch day-of-month.
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 1
+        components.hour = 12
+
+        var observedStatusSets: Set<Set<CategoryBudgetStatus>> = []
+        for day in 1...31 {
+            components.day = day
+            let asOf = calendar.date(from: components)!
+            let presentation = CategoryBudgetPlanner.presentation(
+                budgets: budgets,
+                transactions: DemoFixtures.demoBudgetScoringTransactions(
+                    now: asOf,
+                    calendar: calendar
+                ),
+                asOf: asOf,
+                calendar: calendar
+            )
+            let statuses = Set(presentation.items.map(\.status))
+            observedStatusSets.insert(statuses)
+
+            #expect(
+                statuses == [.over, .nearing, .under],
+                "day \(day) produced \(statuses.map(\.rawValue).sorted()) instead of the full band mix"
+            )
+        }
+
+        // Every day produced exactly the same band mix — no month-boundary drift.
+        #expect(
+            observedStatusSets.count == 1,
+            "budget status mix drifted across the month: \(observedStatusSets)"
+        )
+    }
+
+    @Test("Demo budget scoring rows only reference budgeted spending categories")
+    func budgetScoringRowsAreWellFormed() {
+        let budgetedCategories = Set(DemoFixtures.demoBudgets().map(\.category))
+        let rows = DemoFixtures.demoBudgetScoringTransactions()
+        #expect(!rows.isEmpty)
+        for row in rows {
+            #expect(row.amount > 0, "scoring row \(row.id) is not an outflow")
+            #expect(
+                row.category.map(budgetedCategories.contains) == true,
+                "scoring row \(row.id) targets an unbudgeted category"
+            )
+        }
+    }
+
     // MARK: - Review metadata
 
     @Test("demoReviewMetadata is non-empty and references real demo transactions")
@@ -140,6 +205,54 @@ struct DemoReviewBudgetFixturesTests {
                 "rule \(rule.id) matches no demo transaction"
             )
         }
+    }
+
+    // MARK: - Persistence guard
+
+    /// The demo fixtures are seeded into the live AppState, so a review action in
+    /// `--demo` must never be persisted — `activeStorageDirectoryURL` is the real
+    /// sandbox-scoped cache and would survive into a later real connection.
+    @Test("Review storage persistence is suppressed in demo mode")
+    func persistenceSuppressedInDemoMode() {
+        #expect(ReviewStoragePersistencePolicy.shouldPersist(isDemoMode: true) == false)
+        #expect(ReviewStoragePersistencePolicy.shouldPersist(isDemoMode: false) == true)
+    }
+
+    /// Integration guard: mirrors `AppState.persistReviewStorage` against a
+    /// throwaway directory. With the demo-mode policy honored, acting on a demo
+    /// inbox item writes nothing to the storage dir; a real (non-demo) action
+    /// does write. Proves the synthetic `tx*`/Starbucks/Venmo fixtures never
+    /// reach disk in `--demo`.
+    @Test("Demo-mode review action writes nothing to the storage directory")
+    func demoModeReviewActionDoesNotTouchStorage() throws {
+        let fileManager = FileManager.default
+        let storageDir = fileManager.temporaryDirectory
+            .appendingPathComponent("pb-demo-persist-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: storageDir) }
+
+        let metadata = DemoFixtures.demoReviewMetadata()
+        let rules = DemoFixtures.demoTransactionRules()
+
+        // The exact files AppState's review writer would create.
+        let metadataURL = LocalDataStore.transactionReviewMetadataURL(in: storageDir)
+        let rulesURL = LocalDataStore.transactionRulesURL(in: storageDir)
+
+        // Demo mode: the guard short-circuits, so nothing is written.
+        func simulatePersist(isDemoMode: Bool) throws {
+            guard ReviewStoragePersistencePolicy.shouldPersist(isDemoMode: isDemoMode) else { return }
+            try LocalDataStore.saveTransactionReviewMetadata(metadata, to: storageDir)
+            try LocalDataStore.saveTransactionRules(rules, to: storageDir)
+        }
+
+        try simulatePersist(isDemoMode: true)
+        #expect(fileManager.fileExists(atPath: metadataURL.path) == false, "demo metadata leaked to disk")
+        #expect(fileManager.fileExists(atPath: rulesURL.path) == false, "demo rules leaked to disk")
+
+        // Sanity: a real (non-demo) action *does* persist, so the test exercises a
+        // genuine write path rather than a never-writing stub.
+        try simulatePersist(isDemoMode: false)
+        #expect(fileManager.fileExists(atPath: metadataURL.path), "real metadata was not persisted")
+        #expect(fileManager.fileExists(atPath: rulesURL.path), "real rules were not persisted")
     }
 
     // MARK: - Cross-fixture wiring

--- a/Tests/PlaidBarCoreTests/DemoReviewBudgetFixturesTests.swift
+++ b/Tests/PlaidBarCoreTests/DemoReviewBudgetFixturesTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// Locks in the AND-543 demo providers — category budgets, review metadata, and
+/// categorization rules — so `--demo` actually surfaces the review inbox and
+/// budget state instead of empty placeholders. Every category, amount, and id
+/// here is synthetic; the providers only reference ids that exist in the demo
+/// transaction set so nothing dangles.
+@Suite("Demo Review / Budget Fixtures")
+struct DemoReviewBudgetFixturesTests {
+    /// Fixed midday reference date so the transaction-id assertions never depend
+    /// on the wall clock or DST boundaries.
+    private let referenceDate: Date = {
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 3
+        components.day = 15
+        components.hour = 12
+        return Calendar.current.date(from: components)!
+    }()
+
+    // MARK: - Budgets
+
+    @Test("demoBudgets is non-empty and internally consistent")
+    func demoBudgetsConsistent() {
+        let budgets = DemoFixtures.demoBudgets()
+        #expect(!budgets.isEmpty)
+
+        // Every limit is a positive amount.
+        for budget in budgets {
+            #expect(budget.monthlyLimit > 0, "\(budget.category) had non-positive limit")
+        }
+
+        // At most one budget per category (the DTO's identity contract).
+        let categories = budgets.map(\.category)
+        #expect(Set(categories).count == categories.count, "duplicate category budget")
+
+        // Budgets never target the income / transfer pseudo-categories — those
+        // are not spending categories and would render nonsensically.
+        let nonSpending: Set<SpendingCategory> = [.income, .transfer, .transferOut]
+        #expect(budgets.allSatisfy { !nonSpending.contains($0.category) })
+    }
+
+    @Test("Budgeted categories all appear in the demo spending data")
+    func budgetsReferenceSpentCategories() {
+        let budgets = DemoFixtures.demoBudgets()
+        let spentCategories = Set(
+            DemoFixtures.transactions(now: referenceDate)
+                .filter { !$0.isIncome }
+                .compactMap(\.category)
+        )
+        for budget in budgets {
+            #expect(
+                spentCategories.contains(budget.category),
+                "budget for \(budget.category) has no matching demo spend"
+            )
+        }
+    }
+
+    @Test("demoBudgets produces a mix of under-, near-, and over-budget states")
+    func budgetsExerciseStatusBands() {
+        let budgets = DemoFixtures.demoBudgets()
+        // The fixtures should not be uniformly generous — at least two distinct
+        // limits so the dashboard's status bars are demoable, not all-green.
+        #expect(Set(budgets.map(\.monthlyLimit)).count >= 2)
+    }
+
+    // MARK: - Review metadata
+
+    @Test("demoReviewMetadata is non-empty and references real demo transactions")
+    func reviewMetadataReferencesDemoTransactions() {
+        let metadata = DemoFixtures.demoReviewMetadata()
+        #expect(!metadata.isEmpty)
+
+        let transactionIds = Set(DemoFixtures.transactions(now: referenceDate).map(\.id))
+        for record in metadata {
+            #expect(
+                transactionIds.contains(record.id),
+                "review metadata id \(record.id) is not a demo transaction"
+            )
+        }
+
+        // Ids are unique — the metadata store keys on transaction id.
+        let ids = metadata.map(\.id)
+        #expect(Set(ids).count == ids.count, "duplicate review metadata id")
+    }
+
+    @Test("demoReviewMetadata leaves at least one item needing review")
+    func reviewMetadataHasOpenItems() {
+        let metadata = DemoFixtures.demoReviewMetadata()
+        // The whole point of the fixture is a non-empty review inbox in --demo:
+        // not every seeded record may be reviewed/ignored.
+        #expect(metadata.contains { $0.status == .needsReview })
+    }
+
+    @Test("Reviewed/recategorized metadata carries a user category and timestamp")
+    func reviewedMetadataIsComplete() {
+        let metadata = DemoFixtures.demoReviewMetadata()
+        for record in metadata where record.status == .reviewed {
+            // A reviewed record should have been acted on at a known time.
+            #expect(record.reviewedAt != nil, "reviewed \(record.id) missing reviewedAt")
+        }
+        // At least one record demonstrates a user recategorization so demo mode
+        // shows the override flowing into budget math.
+        #expect(metadata.contains { $0.userCategory != nil })
+    }
+
+    // MARK: - Rules
+
+    @Test("demoTransactionRules is non-empty and each rule has a matcher + effect")
+    func rulesAreWellFormed() {
+        let rules = DemoFixtures.demoTransactionRules()
+        #expect(!rules.isEmpty)
+
+        for rule in rules {
+            // A usable rule needs something to match on...
+            let hasMatcher = rule.matchMerchantContains != nil || rule.matchOriginalNameContains != nil
+            #expect(hasMatcher, "rule \(rule.id) has no matcher")
+            // ...and something to do.
+            let hasEffect = rule.category != nil
+                || rule.merchantName != nil
+                || rule.isTransfer != nil
+                || rule.excludedFromBudgets != nil
+            #expect(hasEffect, "rule \(rule.id) has no effect")
+        }
+
+        // Rule ids are unique.
+        let ids = rules.map(\.id)
+        #expect(Set(ids).count == ids.count, "duplicate rule id")
+    }
+
+    @Test("At least one demo rule matches a demo transaction")
+    func rulesMatchDemoTransactions() {
+        let rules = DemoFixtures.demoTransactionRules()
+        let transactions = DemoFixtures.transactions(now: referenceDate)
+        for rule in rules {
+            #expect(
+                transactions.contains { rule.matches($0) },
+                "rule \(rule.id) matches no demo transaction"
+            )
+        }
+    }
+
+    // MARK: - Cross-fixture wiring
+
+    @Test("Fixtures drive a non-empty review inbox in demo mode")
+    func fixturesProduceNonEmptyInbox() {
+        let transactions = DemoFixtures.transactions(now: referenceDate)
+        let snapshot = TransactionReviewInbox.evaluate(
+            transactions: transactions,
+            metadata: DemoFixtures.demoReviewMetadata(),
+            rules: DemoFixtures.demoTransactionRules(),
+            recurring: [],
+            now: referenceDate
+        )
+        #expect(snapshot.totalCount > 0, "demo review inbox was empty")
+    }
+}

--- a/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
+++ b/Tests/PlaidBarCoreTests/WeeklyReviewTests.swift
@@ -184,6 +184,62 @@ struct WeeklyReviewTests {
         #expect(state.trustedTransactionIds == ["grocery-0", "grocery-1"])
     }
 
+    /// Demo trust model: a non-pending transaction with no metadata is trusted
+    /// (so the checklist stays exercisable without seeding metadata for every
+    /// fixture), a pending one is unreviewed, and — the AND-543 fix — an
+    /// *explicitly* seeded `.needsReview` row is counted unreviewed so the
+    /// Weekly Review agrees with the Review Inbox.
+    @Test("Demo derived state honors seeded needs-review rows alongside pending")
+    func demoDerivedHonorsSeededNeedsReview() {
+        let transactions = [
+            transaction(id: "trusted-default", date: "2026-06-14"),
+            TransactionDTO(
+                id: "pending-row", accountId: "acct", amount: 10,
+                date: "2026-06-14", name: "Synthetic", pending: true
+            ),
+            transaction(id: "seeded-needs-review", date: "2026-06-14"),
+        ]
+        let state = WeeklyReviewTransactionState.demoDerived(
+            from: transactions,
+            metadata: [
+                // Only the inbox row is seeded; the trusted row has no metadata.
+                TransactionReviewMetadata(id: "seeded-needs-review", status: .needsReview),
+            ]
+        )
+
+        #expect(state.trustedTransactionIds == ["trusted-default"])
+        #expect(state.unreviewedTransactionIds == ["pending-row", "seeded-needs-review"])
+    }
+
+    /// End-to-end regression against the real demo fixtures: the seeded
+    /// uncategorized `tx55` must surface as an unreviewed weekly-review item in
+    /// `--demo`, matching its Review Inbox row, instead of being silently trusted.
+    @Test("Demo fixtures surface the seeded inbox row in the weekly review")
+    func demoFixturesSurfaceSeededInboxRowInWeeklyReview() {
+        let transactions = DemoFixtures.transactions(now: now)
+        let metadata = DemoFixtures.demoReviewMetadata(now: now)
+
+        let state = WeeklyReviewTransactionState.demoDerived(
+            from: transactions,
+            metadata: metadata
+        )
+        #expect(state.unreviewedTransactionIds.contains("tx55"))
+
+        let presentation = WeeklyReviewBuilder.evaluate(
+            state: .empty,
+            transactionState: state,
+            transactions: transactions,
+            recurringTransactions: [],
+            safeToSpend: safeToSpend(amount: 1_000),
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(
+            presentation.items.contains { $0.kind == .transactionReview },
+            "weekly review hid the open demo inbox row"
+        )
+    }
+
     @Test("Reviewed and ignored transaction metadata unblock weekly review")
     func reviewedAndIgnoredTransactionMetadataUnblocksWeeklyReview() {
         let transactions = [


### PR DESCRIPTION
## Summary

Adds three synthetic-data providers to `DemoFixtures` and wires them into demo mode so `swift run PlaidBar --demo` actually surfaces the Review Inbox and Category/budget state instead of empty placeholders.

- **`DemoFixtures.demoBudgets() -> [CategoryBudgetDTO]`** — category budgets (Food & Drink, Shopping, Transportation, Entertainment, Bills & Utilities, Travel, Health & Fitness) tuned against demo spend so the dashboard shows a spread of under/near/over status bands. Never budgets income/transfer pseudo-categories.
- **`DemoFixtures.demoReviewMetadata()`** — review metadata referencing real demo transaction ids:
  - `tx55` (SQ *KMNT LLC) left `.needsReview` (genuinely uncategorized → always an inbox row)
  - `tx52` (Blue Bottle Coffee) `.reviewed` with a `foodAndDrink` `userCategory` override (approved NL suggestion → counts under Food & Drink downstream)
  - `tx14` (Venmo) `.reviewed`, transfer override + excluded from budgets
- **`DemoFixtures.demoTransactionRules()`** — Starbucks → Food & Drink and Venmo → transfer/excluded rules (fixed UUIDs, both match demo transactions).

Wiring: `AppState.loadDemoData` stops zeroing `transactionReviewMetadata` / `transactionRules` / `categoryBudgets` and loads these fixtures. The assignments invalidate the inbox/budget caches via `didSet` but never persist, so a demo session never overwrites the user's real saved data.

## Linear

[AND-543](https://linear.app/andeslab/issue/AND-543) — "DemoFixtures providers for budgets / review metadata / rules" (Epic AND-523).

## Spec alignment

Implements the providers and wiring called out in `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §4:

> Demo: add `DemoFixtures.demoBudgets()/demoReviewMetadata()/demoTransactionRules()`; stop zeroing in `loadDemoData`.

Confirmed **Option A** — display-only over the existing taxonomy, **no schema migration**, fully **additive**. Fixtures match the persisted `CategoryBudgetDTO` / `TransactionReviewMetadata` / `TransactionRule` shapes verbatim; no rawValues or schema touched. The spec cited `loadDemoData:3471-3473` for the "stop zeroing" wiring; post-#524 the zeroing lines are 3316-3318 — wired there.

## Testing notes

New tests in `Tests/PlaidBarCoreTests/DemoReviewBudgetFixturesTests.swift` (suite "Demo Review / Budget Fixtures"):
- `demoBudgets is non-empty and internally consistent`
- `Budgeted categories all appear in the demo spending data`
- `demoBudgets produces a mix of under-, near-, and over-budget states`
- `demoReviewMetadata is non-empty and references real demo transactions`
- `demoReviewMetadata leaves at least one item needing review`
- `Reviewed/recategorized metadata carries a user category and timestamp`
- `demoTransactionRules is non-empty and each rule has a matcher + effect`
- `At least one demo rule matches a demo transaction`
- `Fixtures drive a non-empty review inbox in demo mode`

Final results (sandbox off):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (171.01s)

swift test
Test run with 1108 tests passed after 0.601 seconds.
```

## Architectural decisions

- Fixtures live in `PlaidBarCore` (`DemoFixtures.swift`) alongside the existing demo data, keeping continuity guarantees testable and the providers `Sendable`/pure.
- `demoBudgets()` returns `[CategoryBudgetDTO]` (the persisted shape); `loadDemoData` converts to the `[SpendingCategory: Double]` dictionary `AppState.categoryBudgets` holds.
- Review-metadata ids map only to explicit demo transactions so nothing dangles; deterministic timestamps derived from `now` keep `--demo` and screenshots stable.

## Migration notes

None — additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
