### PR TITLE
fix(core): apply transaction filter criteria before the display limit (AND-478)

### DIFF
--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1919,6 +1919,28 @@ struct PlaidBarCoreTests {
         #expect(grouped.flatMap(\.1).map(\.id) == ["matching-older", "matching-oldest"])
     }
 
+    @Test("Transaction groupedRecent applies search criteria before the recent limit (AND-478)")
+    func transactionGroupedRecentAppliesSearchBeforeLimit() {
+        // The newest `maxCount` rows do NOT match the search term; an older row does.
+        // The matching older row must still surface, proving the criteria filter runs
+        // before the display prefix/limit rather than after it.
+        let transactions = [
+            TransactionDTO(id: "recent-nonmatch-1", accountId: "checking", amount: 20, date: "2026-01-05", name: "Coffee", category: .foodAndDrink),
+            TransactionDTO(id: "recent-nonmatch-2", accountId: "checking", amount: 30, date: "2026-01-04", name: "Groceries", category: .foodAndDrink),
+            TransactionDTO(id: "matching-older", accountId: "checking", amount: 40, date: "2026-01-03", name: "Uber Ride", category: .transportation),
+            TransactionDTO(id: "matching-oldest", accountId: "checking", amount: 50, date: "2026-01-02", name: "Lyft Ride", category: .transportation),
+        ]
+
+        let grouped = TransactionFilter.groupedRecent(
+            from: transactions,
+            criteria: TransactionFilterCriteria(searchText: "ride"),
+            maxCount: 2
+        )
+
+        #expect(grouped.map(\.0) == ["2026-01-03", "2026-01-02"])
+        #expect(grouped.flatMap(\.1).map(\.id) == ["matching-older", "matching-oldest"])
+    }
+
     @Test("Transaction filter search matches category display name")
     func transactionFilterSearchMatchesCategoryDisplayName() {
         let transactions = [


### PR DESCRIPTION
## Summary

AND-478 reported that `TransactionFilter.groupedRecent` could render an **empty filtered view**: when the newest `maxCount` transactions all belong to a different account / category / search term, applying `.prefix(maxCount)` *before* the criteria filter discards every matching (older) row, so the filtered list looks empty even though matching transactions exist further down.

The production fix already shipped on `main` via PR #471 (commit `3446615`, in HEAD `137f1f8`): `groupedRecent` now runs `filtered(_:criteria:)` **first**, then `.sorted { $0.date > $1.date }.prefix(maxCount)` on the matching set, then groups. Sort order (descending date) and all other behavior are preserved.

This PR therefore makes **no production change** — `Sources/PlaidBarCore/Utilities/TransactionFilter.swift` is byte-for-byte unchanged. It hardens regression coverage with a second criteria-dimension test (search text) that complements the existing account-id test.

## Linear (AND-478)

Fixes AND-478 — "Filtered transaction view renders empty when newest N transactions are non-matching." The defect was already resolved in code by PR #471; this PR closes the verification gap by proving the fix holds across a second criteria dimension.

## Spec alignment

The transaction filtering / recent-list surface is part of the category-dashboard work described in `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`. `groupedRecent` feeds the dashboard's recent-transactions list under active filter chips (Cash/Credit/Savings/Debt/Status and category/search), so filter-before-limit correctness is a prerequisite for the dashboard filter states behaving as specified. No spec-level behavior changes here — purely additive test coverage.

## Testing notes

New test added to `Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift`:
- `transactionGroupedRecentAppliesSearchBeforeLimit` — "Transaction groupedRecent applies search criteria before the recent limit (AND-478)". Newest 2 rows do not match the search term "ride"; two older `transportation` rows do. With `maxCount: 2`, both matching older rows must still surface.

Red-step verification: I temporarily reverted `groupedRecent` to the buggy prefix-before-filter ordering and confirmed BOTH the new test and the pre-existing `transactionGroupedRecentFiltersBeforeApplyingLimit` fail with empty results, then restored the correct ordering.

Final strict-concurrency build:
```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (10.73s)
```

Final full test suite:
```
swift test
✔ Test run with 1129 tests passed after 0.671 seconds.
```

The four TransactionFilter tests (existing + new):
```
✔ Test "Transaction filter groups recent transactions by descending date" passed
✔ Test "Transaction filter applies search category account and date" passed
✔ Test "Transaction groupedRecent filters before applying recent limit" passed
✔ Test "Transaction groupedRecent applies search criteria before the recent limit (AND-478)" passed
✔ Test "Transaction filter search matches category display name" passed
```

## Architectural decisions

- Kept all logic in `PlaidBarCore` (pure, `Sendable`, testable) per the repo convention — no view/route changes.
- Added a complementary search-text test rather than duplicating the existing account-id test, so the two regression tests jointly cover distinct criteria dimensions (account filter and free-text search) that both flow through the same prefix/filter ordering.
- No production diff: opening a code-changing PR for an already-fixed defect would be redundant churn. The honest, minimal contribution is the verification gap closure.

## Migration notes

None. Test-only change; no public API, schema, persistence, or runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)