### PR TITLE
fix(privacy): redact glance-snapshot.json under Privacy Mask / App Lock (AND-517)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -397,10 +397,14 @@ final class AppState {
     func togglePrivacyMask() {
         guard !isContentLocked else { return }
         appLockPreferences.privacyMaskEnabled.toggle()
-        // Re-emit the App Intents snapshot so the masked/unmasked state takes
+        // Re-emit both App Group snapshots so the masked/unmasked state takes
         // effect on disk immediately: enabling the mask overwrites any prior real
-        // figures with a value-free snapshot; disabling restores the real values.
-        writeFinanceSnapshot()
+        // figures with value-free snapshots; disabling restores the real values.
+        // `writeGlanceSnapshot` also rewrites the App Intents `FinanceSnapshot`
+        // (via `writeFinanceSnapshot`), so the widget glance snapshot and the
+        // intents snapshot are redacted together — no stale real glance file is
+        // left on disk while the app is masked (AND-517).
+        writeGlanceSnapshot()
     }
 
     /// True only in full App Lock (`.locked`) — distinct from
@@ -690,10 +694,13 @@ final class AppState {
         // stale message from a prior cancelled/failed unlock attempt.
         if isAppLocked {
             lastUnlockMessage = nil
-            // Locking masks financial values, so immediately overwrite the App
-            // Intents snapshot with a value-free one — no figures leak past the
-            // lock via Spotlight / Siri / Shortcuts.
-            writeFinanceSnapshot()
+            // Locking masks financial values, so immediately overwrite both App
+            // Group snapshots with value-free ones — no figures leak past the lock
+            // via the widget / Control Center (glance snapshot) or Spotlight / Siri
+            // / Shortcuts (App Intents snapshot). `writeGlanceSnapshot` redacts the
+            // glance file and also re-emits the redacted `FinanceSnapshot` through
+            // `writeFinanceSnapshot` (AND-517).
+            writeGlanceSnapshot()
         }
     }
 
@@ -726,6 +733,14 @@ final class AppState {
             reason: "Unlock VaultPeek to view your balances."
         )
         isAppLocked = appLockService.isLocked
+        // A successful unlock that fully clears the masked state must restore the
+        // real figures on disk immediately, rather than leaving the value-free
+        // snapshots written at lock time until the next data refresh. Mirrors the
+        // disable path in `togglePrivacyMask`; guarded on `shouldMaskFinancialValues`
+        // so a still-active Privacy Mask keeps the snapshots redacted (AND-517).
+        if !shouldMaskFinancialValues {
+            writeGlanceSnapshot()
+        }
         // Surface the outcome on the locked gate: `nil` on success (the gate is
         // about to be dismissed), otherwise the cancelled / failed / unavailable
         // message so the user sees why it stayed locked.
@@ -3104,11 +3119,17 @@ final class AppState {
         writeFinanceSnapshot(updatedAt: updatedAt)
         glanceSnapshotWriteGeneration += 1
         let generation = glanceSnapshotWriteGeneration
+        // When Privacy Mask / App Lock is active, build a value-free snapshot so
+        // the on-disk glance-snapshot.json carries no balances, today's change, or
+        // sparkline for a widget / Control Center surface to leak (AND-517). The
+        // widget view already dots figures at read time via the FinanceSnapshot
+        // mask flag; this is defense in depth at the file level.
         let snapshot = GlanceSnapshot.make(
             netWorth: netBalance,
             balanceHistory: balanceHistory,
             updatedAt: updatedAt,
-            isDemo: isDemoMode
+            isDemo: isDemoMode,
+            isMasked: shouldMaskFinancialValues
         )
         let debouncer = glanceSnapshotWriteDebouncer
         Task { [snapshot, debouncer, generation] in

--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -31,6 +31,13 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
     public let updatedAt: Date
     public let sparkline: [Double]
     public let isDemo: Bool
+    /// True when App Lock / Privacy Mask was active at build time, so the figures
+    /// above were zeroed/cleared before they ever reached disk. Mirrors
+    /// ``FinanceSnapshot/isMasked``: defense in depth so a masked snapshot is
+    /// value-free *in the file*, not merely dotted at read time. The widget reads
+    /// this so it can self-mask even if the sibling ``FinanceSnapshot`` is missing
+    /// or stale (AND-517).
+    public let isRedacted: Bool
 
     public var changeDirection: ChangeDirection {
         ChangeDirection.evaluate(todayChange)
@@ -53,7 +60,8 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
             todayChange == other.todayChange &&
             updatedAt == other.updatedAt &&
             sparkline == other.sparkline &&
-            isDemo == other.isDemo
+            isDemo == other.isDemo &&
+            isRedacted == other.isRedacted
     }
 
     public init(
@@ -61,13 +69,32 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
         todayChange: Double,
         updatedAt: Date,
         sparkline: [Double],
-        isDemo: Bool
+        isDemo: Bool,
+        isRedacted: Bool = false
     ) {
         self.netWorth = netWorth
         self.todayChange = todayChange
         self.updatedAt = updatedAt
         self.sparkline = sparkline
         self.isDemo = isDemo
+        self.isRedacted = isRedacted
+    }
+
+    // Decode `isRedacted` defensively: a snapshot written by an older build (no
+    // `isRedacted` key) decodes as `false`, so upgrades never spuriously treat a
+    // real snapshot as redacted.
+    private enum CodingKeys: String, CodingKey {
+        case netWorth, todayChange, updatedAt, sparkline, isDemo, isRedacted
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        netWorth = try container.decode(Double.self, forKey: .netWorth)
+        todayChange = try container.decode(Double.self, forKey: .todayChange)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        sparkline = try container.decode([Double].self, forKey: .sparkline)
+        isDemo = try container.decode(Bool.self, forKey: .isDemo)
+        isRedacted = try container.decodeIfPresent(Bool.self, forKey: .isRedacted) ?? false
     }
 
     public static func make(
@@ -75,14 +102,32 @@ public struct GlanceSnapshot: Codable, Sendable, Equatable {
         balanceHistory: [BalanceSnapshot],
         updatedAt: Date,
         isDemo: Bool,
+        isMasked: Bool = false,
         calendar: Calendar = .current
     ) -> GlanceSnapshot {
-        GlanceSnapshot(
+        let snapshot = GlanceSnapshot(
             netWorth: netWorth,
             todayChange: todayChange(from: balanceHistory, currentNetWorth: netWorth, now: updatedAt, calendar: calendar),
             updatedAt: updatedAt,
             sparkline: normalizedSparkline(from: balanceHistory, currentNetWorth: netWorth),
             isDemo: isDemo
+        )
+        return isMasked ? snapshot.redacted() : snapshot
+    }
+
+    /// Returns a copy with every real financial value cleared — net worth, today's
+    /// change, and the sparkline are zeroed/emptied and `isRedacted` is set — while
+    /// preserving the non-sensitive `updatedAt`/`isDemo` metadata. Used when App
+    /// Lock or Privacy Mask is active so the on-disk `glance-snapshot.json` carries
+    /// no balances for a widget or Control Center surface to leak (AND-517).
+    public func redacted() -> GlanceSnapshot {
+        GlanceSnapshot(
+            netWorth: 0,
+            todayChange: 0,
+            updatedAt: updatedAt,
+            sparkline: [],
+            isDemo: isDemo,
+            isRedacted: true
         )
     }
 

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -50,8 +50,13 @@ private struct GlanceTimelineProvider: TimelineProvider {
         // The richer FinanceSnapshot (Epic D) carries the live privacy-mask flag
         // toggled by the Control Center control; honor it so the widget hides
         // figures the moment the user masks the app, without waiting for a glance
-        // snapshot rewrite.
-        let isMasked = AppGroupSnapshotStore.loadIfAvailable()?.isMasked ?? false
+        // snapshot rewrite. The glance snapshot also carries its own `isRedacted`
+        // flag (set when the app wrote it while masked/locked); honoring either
+        // means the widget stays masked even if the sibling FinanceSnapshot is
+        // missing or stale — and a redacted glance file already holds no figures
+        // (AND-517).
+        let financeMasked = AppGroupSnapshotStore.loadIfAvailable()?.isMasked ?? false
+        let isMasked = financeMasked || snapshot.isRedacted
         return GlanceEntry(date: snapshot.updatedAt, snapshot: snapshot, isMasked: isMasked)
     }
 }

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -59,6 +59,183 @@ struct GlanceSnapshotTests {
         #expect(!json.contains("accounts"))
     }
 
+    // MARK: - Privacy Mask / App Lock redaction (AND-517)
+
+    @Test("Masked build zeroes every financial value")
+    func maskedBuildZeroesEveryFinancialValue() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let previous = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let history = [
+            BalanceSnapshot(date: previous, balance: 1_000),
+            BalanceSnapshot(date: now, balance: 1_250),
+        ]
+
+        let masked = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: history,
+            updatedAt: now,
+            isDemo: false,
+            isMasked: true
+        )
+
+        #expect(masked.isRedacted)
+        #expect(masked.netWorth == 0)
+        #expect(masked.todayChange == 0)
+        #expect(masked.changeDirection == .flat)
+        #expect(masked.sparkline.isEmpty)
+        // Non-sensitive metadata is preserved so the widget can still render an
+        // "updated"/demo state without exposing balances.
+        #expect(masked.updatedAt == now)
+        #expect(!masked.isDemo)
+    }
+
+    @Test("Unmasked build is unchanged and carries real values")
+    func unmaskedBuildIsUnchanged() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let previous = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let history = [
+            BalanceSnapshot(date: previous, balance: 1_000),
+            BalanceSnapshot(date: now, balance: 1_250),
+        ]
+
+        let masked = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: history,
+            updatedAt: now,
+            isDemo: false,
+            isMasked: false
+        )
+        // Default (no `isMasked` argument) must match the explicit-unmasked build,
+        // so existing callers keep their behavior.
+        let defaulted = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: history,
+            updatedAt: now,
+            isDemo: false
+        )
+
+        #expect(!masked.isRedacted)
+        #expect(masked.netWorth == 1_250)
+        #expect(masked.todayChange == 250)
+        #expect(masked.changeDirection == .up)
+        #expect(masked.sparkline.count >= 2)
+        #expect(masked == defaulted)
+    }
+
+    @Test("redacted() clears figures but keeps metadata")
+    func redactedClearsFiguresButKeepsMetadata() throws {
+        let updatedAt = Date(timeIntervalSince1970: 1_780_000_000)
+        let real = GlanceSnapshot(
+            netWorth: 17_604.24,
+            todayChange: -42,
+            updatedAt: updatedAt,
+            sparkline: [0, 0.5, 1],
+            isDemo: true
+        )
+
+        let redacted = real.redacted()
+
+        #expect(redacted.isRedacted)
+        #expect(redacted.netWorth == 0)
+        #expect(redacted.todayChange == 0)
+        #expect(redacted.sparkline.isEmpty)
+        #expect(redacted.updatedAt == updatedAt)
+        #expect(redacted.isDemo)
+    }
+
+    @Test("Redacted snapshot JSON on disk carries no real figures")
+    func redactedSnapshotJSONOnDiskCarriesNoRealFigures() throws {
+        let directory = temporaryDirectory()
+        let masked = GlanceSnapshot(
+            netWorth: 17_604.24,
+            todayChange: -421.55,
+            updatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            sparkline: [0.12, 0.48, 0.97],
+            isDemo: false
+        ).redacted()
+
+        try GlanceSnapshotStore.save(masked, directory: directory)
+        let json = try String(
+            contentsOf: GlanceSnapshotStore.snapshotURL(directory: directory),
+            encoding: .utf8
+        )
+
+        // The redaction flag is recorded and the on-disk figures are zeroed —
+        // not the real values written before masking.
+        #expect(json.contains("\"isRedacted\":true"))
+        #expect(!json.contains("17604"))
+        #expect(!json.contains("421.55"))
+        #expect(!json.contains("0.48"))
+        #expect(json.contains("\"netWorth\":0"))
+        #expect(json.contains("\"todayChange\":0"))
+        #expect(json.contains("\"sparkline\":[]"))
+
+        // Round-trips back as a redacted, value-free snapshot.
+        let reloaded = try GlanceSnapshotStore.load(directory: directory)
+        #expect(reloaded.isRedacted)
+        #expect(reloaded.netWorth == 0)
+        #expect(reloaded.sparkline.isEmpty)
+    }
+
+    @Test("Enabling mask redacts the persisted snapshot (transition)")
+    func enablingMaskRedactsPersistedSnapshot() throws {
+        let directory = temporaryDirectory()
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let previous = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let history = [
+            BalanceSnapshot(date: previous, balance: 1_000),
+            BalanceSnapshot(date: now, balance: 1_250),
+        ]
+
+        // 1. Unmasked: the real snapshot lands on disk with live figures.
+        let real = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: history,
+            updatedAt: now,
+            isDemo: false,
+            isMasked: false
+        )
+        #expect(try GlanceSnapshotStore.saveIfChanged(real, directory: directory))
+        #expect(try GlanceSnapshotStore.load(directory: directory).netWorth == 1_250)
+
+        // 2. Mask turns on — the writer rebuilds and the persisted file is
+        // rewritten value-free (the change in `isRedacted`/figures defeats the
+        // saveIfChanged short-circuit).
+        let masked = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: history,
+            updatedAt: now,
+            isDemo: false,
+            isMasked: true
+        )
+        #expect(try GlanceSnapshotStore.saveIfChanged(masked, directory: directory))
+
+        let onDisk = try GlanceSnapshotStore.load(directory: directory)
+        #expect(onDisk.isRedacted)
+        #expect(onDisk.netWorth == 0)
+        #expect(onDisk.todayChange == 0)
+        #expect(onDisk.sparkline.isEmpty)
+    }
+
+    @Test("Legacy snapshot without isRedacted decodes as not redacted")
+    func legacySnapshotWithoutIsRedactedDecodesAsNotRedacted() throws {
+        // A glance-snapshot.json written by a pre-AND-517 build has no
+        // `isRedacted` key. It must decode as a normal, non-redacted snapshot so
+        // upgrades never treat a real snapshot as masked.
+        let legacyJSON = """
+        {"isDemo":false,"netWorth":17604.24,"sparkline":[0,0.5,1],\
+        "todayChange":-42,"updatedAt":"2026-06-14T00:00:00Z"}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(GlanceSnapshot.self, from: Data(legacyJSON.utf8))
+
+        #expect(!snapshot.isRedacted)
+        #expect(snapshot.netWorth == 17_604.24)
+        #expect(snapshot.todayChange == -42)
+        #expect(snapshot.sparkline == [0, 0.5, 1])
+    }
+
     @Test("Timestamp display changes rewrite the file")
     func timestampDisplayChangesRewriteFile() throws {
         let directory = temporaryDirectory()


### PR DESCRIPTION
## Summary

When **Privacy Mask** or **App Lock** is active, the App-Group `glance-snapshot.json` — the file that feeds WidgetKit widgets and the Control Center glance — was still written with the user's real `netWorth`, `todayChange`, and `sparkline`. Those figures leaked on surfaces *outside* the gated popover (Home Screen / Notification Center widget, Control Center), even while the in-app dashboard was masked or locked.

This PR makes the on-disk glance snapshot **value-free whenever the app is masked or locked**, and rewrites the existing file on the mask/lock state transition so no stale real snapshot is left behind. The redaction is a pure, `Sendable`, unit-tested transform in `PlaidBarCore`.

Three cases covered:
- **(a) Build while masked/locked** — `AppState.writeGlanceSnapshot` builds the snapshot with `isMasked: shouldMaskFinancialValues`, so every periodic/refresh write during a masked/locked session is redacted.
- **(b) On-state-change rewrite** — `togglePrivacyMask` and `lockApp` now call `writeGlanceSnapshot` (which also re-emits the sibling App Intents `FinanceSnapshot`), so *enabling* mask/lock immediately overwrites any prior real file; a successful `unlockApp` that clears the mask restores the real figures.
- **(c) Unmasked path unchanged** — the default `make(...)` argument (`isMasked: false`) leaves existing callers and real snapshots byte-for-byte identical.

## Linear

- **AND-517** (P0) — Redact glance-snapshot.json on Privacy Mask / App Lock.

## Architectural decisions

- **Redaction as a pure transform in `PlaidBarCore`.** `GlanceSnapshot` gains an `isRedacted` flag and a `redacted()` method that zeroes `netWorth`/`todayChange`, empties `sparkline`, sets the flag, and preserves only the non-sensitive `updatedAt`/`isDemo` metadata. `make(..., isMasked:)` applies it. Keeping it in Core makes it `Sendable`, reusable, and unit-testable at the file level — defense in depth beyond the widget's read-time dotting.
- **Single mask predicate.** Both the glance snapshot and the existing `FinanceSnapshot` are driven by `AppState.shouldMaskFinancialValues` (true for both `.masked` Privacy Mask and `.locked` App Lock), so the two App-Group files redact in lockstep with the Spotlight index.
- **State-change rewrite via `writeGlanceSnapshot`.** The previous code re-emitted only the `FinanceSnapshot` on toggle/lock. Routing through `writeGlanceSnapshot` redacts *both* files together — closing the gap where a real glance file lingered while masked.
- **Widget self-masks on either flag.** `GlanceTimelineProvider` now masks on `FinanceSnapshot.isMasked || GlanceSnapshot.isRedacted`, so it stays masked even if the sibling `FinanceSnapshot` is missing or stale; a redacted glance file already holds no figures regardless.

## Migration notes

- **Backward-compatible decode.** `isRedacted` is decoded with `decodeIfPresent(...) ?? false` via an explicit `init(from:)`, so a `glance-snapshot.json` written by a pre-AND-517 build (no `isRedacted` key) decodes as a normal, non-redacted snapshot. Upgrades never mistake a real snapshot for a masked one. New field defaults to `false` in the memberwise init, so all existing call sites are unaffected.
- No schema migration, no data-dir changes, no server changes.

## Testing notes

New tests in `Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift`:
- `Masked build zeroes every financial value`
- `Unmasked build is unchanged and carries real values`
- `redacted() clears figures but keeps metadata`
- `Redacted snapshot JSON on disk carries no real figures`
- `Enabling mask redacts the persisted snapshot (transition)`
- `Legacy snapshot without isRedacted decodes as not redacted`

CI gate (strict concurrency) + full suite, sandbox off:

```
$ swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (46.41s)

$ swift test
✔ Test run with 1135 tests passed after 0.713 seconds.
```

GlanceSnapshot suite in isolation:

```
$ swift test --filter "GlanceSnapshotTests"
✔ Test "redacted() clears figures but keeps metadata" passed
✔ Test "Legacy snapshot without isRedacted decodes as not redacted" passed
✔ Test "Redacted snapshot JSON on disk carries no real figures" passed
✔ Test "Unmasked build is unchanged and carries real values" passed
✔ Test "Masked build zeroes every financial value" passed
✔ Test "Enabling mask redacts the persisted snapshot (transition)" passed
✔ Suite "Glance snapshot" passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)