### PR TITLE
feat(ui): BudgetEditorSheet wiring set/removeCategoryBudget (AND-540)

### DIFF
--- a/Sources/PlaidBar/Views/BudgetEditorSheet.swift
+++ b/Sources/PlaidBar/Views/BudgetEditorSheet.swift
@@ -1,0 +1,202 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Set, edit, or clear a single category's current-month budget (AND-540).
+///
+/// This is the live half of category-budget editing — the first caller of the
+/// previously-dead `AppState.setCategoryBudget` / `removeCategoryBudget`. Scope is
+/// deliberately Option-A: one monthly limit per category, no per-month series and
+/// no rollover (those are the deferred v2 epic, AND-524).
+///
+/// The sheet owns only its local text/validation state; persistence (server CRUD +
+/// local cache + dashboard invalidation) lives in `AppState`. Validation is the
+/// pure `BudgetEditorInput`, so the same rules are unit-tested without a view.
+///
+/// Accessibility: the validation verdict is always carried by text + an SF Symbol,
+/// never color alone (ACCESSIBILITY.md); the field has an explicit value label.
+struct BudgetEditorSheet: View {
+    let category: SpendingCategory
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    /// Raw text the user is editing. Seeded from the existing saved limit.
+    @State private var amountText: String
+    /// True while a save/clear network round-trip is in flight.
+    @State private var isSaving = false
+
+    init(category: SpendingCategory) {
+        self.category = category
+        // The field is seeded from the live saved limit in `onAppear`, once the
+        // AppState environment is available; it starts empty.
+        _amountText = State(initialValue: "")
+    }
+
+    /// Outcome of parsing the current field text, recomputed every render.
+    private var outcome: BudgetEditorInput.Outcome {
+        BudgetEditorInput.parse(amountText, category: category)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                categoryHeader
+            }
+
+            if BudgetEditorInput.isBudgetable(category) {
+                Section {
+                    amountField
+                } header: {
+                    Text("Monthly limit")
+                } footer: {
+                    validationFooter
+                }
+            } else {
+                Section {
+                    Label(
+                        "Income and transfer categories can't have a budget.",
+                        systemImage: "info.circle"
+                    )
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 360, minHeight: 240)
+        .navigationTitle("Edit Budget")
+        .onAppear(perform: seedFromCurrentLimit)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+                    .disabled(isSaving)
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button(saveButtonTitle) { Task { await commit() } }
+                    .disabled(!outcome.isCommittable || isSaving)
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var categoryHeader: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: category.iconName)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(category.displayName)
+                    .font(.headline)
+                if let currentLimit, currentLimit > 0 {
+                    Text("Current limit \(Formatters.currency(currentLimit))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("No budget set")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var amountField: some View {
+        HStack(spacing: Spacing.xs) {
+            Text("$")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            TextField("0", text: $amountText)
+                .textFieldStyle(.plain)
+                .disabled(isSaving)
+                .accessibilityLabel("Monthly budget limit for \(category.displayName)")
+                .accessibilityValue(amountText.isEmpty ? "No amount entered" : amountText)
+        }
+    }
+
+    @ViewBuilder
+    private var validationFooter: some View {
+        switch outcome {
+        case .invalid:
+            Label("Enter a positive dollar amount.", systemImage: "exclamationmark.circle")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .clear:
+            Label("Saving 0 removes this budget.", systemImage: "trash")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .save(let amount):
+            Label(
+                "Sets the monthly limit to \(Formatters.currency(amount)).",
+                systemImage: "checkmark.circle"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        case .empty, .categoryNotBudgetable:
+            // Offer the remove affordance when a budget already exists.
+            if (currentLimit ?? 0) > 0 {
+                Button(role: .destructive) {
+                    Task { await remove() }
+                } label: {
+                    Label("Remove budget", systemImage: "trash")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .disabled(isSaving)
+            } else {
+                Text("Enter a monthly limit, or leave blank to keep none.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Derived state
+
+    /// The category's currently-saved (explicit, non-suggested) limit, if any.
+    private var currentLimit: Double? {
+        appState.categoryBudgets[category]
+    }
+
+    private var saveButtonTitle: String {
+        outcome == .clear ? "Clear" : "Save"
+    }
+
+    // MARK: - Actions
+
+    private func seedFromCurrentLimit() {
+        guard amountText.isEmpty, let currentLimit, currentLimit > 0 else { return }
+        // Whole-dollar limits read cleaner without trailing ".0".
+        if currentLimit == currentLimit.rounded() {
+            amountText = String(Int(currentLimit))
+        } else {
+            amountText = String(format: "%.2f", currentLimit)
+        }
+    }
+
+    private func commit() async {
+        guard !isSaving else { return }
+        switch outcome {
+        case .save(let amount):
+            isSaving = true
+            await appState.setCategoryBudget(category, amount: amount)
+            isSaving = false
+            if appState.error == nil { dismiss() }
+        case .clear:
+            await remove()
+        case .empty, .invalid, .categoryNotBudgetable:
+            break
+        }
+    }
+
+    private func remove() async {
+        guard !isSaving else { return }
+        isSaving = true
+        await appState.removeCategoryBudget(category)
+        isSaving = false
+        if appState.error == nil { dismiss() }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/BudgetEditorInput.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetEditorInput.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Pure parsing + validation for the per-category budget editor (AND-540).
+///
+/// The `BudgetEditorSheet` lets a user type a monthly limit for one category and
+/// either save it or clear it. All of the "is this a legal edit, and what does it
+/// resolve to" logic lives here as a stateless `enum` so it is `Sendable`,
+/// testable, and identical wherever a budget is edited — the view only renders the
+/// result and dispatches the resulting `AppState.setCategoryBudget` /
+/// `removeCategoryBudget` call.
+///
+/// Mirrors `CategoryBudgetPlanner` excluded-category rules: income and transfer
+/// categories are never spend, so they can never carry a budget.
+public enum BudgetEditorInput {
+    /// Outcome of interpreting the editor's raw text for a category.
+    public enum Outcome: Sendable, Hashable {
+        /// The category itself cannot be budgeted (income / transfer).
+        case categoryNotBudgetable
+        /// Field is blank — nothing to do (Save is disabled).
+        case empty
+        /// Text is not a parseable, non-negative amount.
+        case invalid
+        /// A positive amount the user wants to save as the monthly limit.
+        case save(amount: Double)
+        /// A zero amount — interpreted as "clear this budget".
+        case clear
+
+        /// True when this outcome is something the user can commit with Save.
+        public var isCommittable: Bool {
+            switch self {
+            case .save, .clear: true
+            case .categoryNotBudgetable, .empty, .invalid: false
+            }
+        }
+    }
+
+    /// Categories that can never carry a budget (income + both transfer
+    /// directions). Kept in lock-step with `CategoryBudgetPlanner.excludedCategories`.
+    public static func isBudgetable(_ category: SpendingCategory) -> Bool {
+        !CategoryBudgetPlanner.excludedCategories.contains(category)
+    }
+
+    /// Interpret the editor's raw text for `category`.
+    ///
+    /// - Trims whitespace; strips a single leading currency symbol and any grouping
+    ///   separators so "$1,200" parses; accepts both `.` and `,` decimal forms.
+    /// - A blank field is `.empty`; an unparseable / negative value is `.invalid`.
+    /// - Exactly `0` resolves to `.clear` (remove the saved budget); any positive
+    ///   amount resolves to `.save`.
+    /// - A non-budgetable category short-circuits to `.categoryNotBudgetable`
+    ///   regardless of the text.
+    public static func parse(
+        _ rawText: String,
+        category: SpendingCategory
+    ) -> Outcome {
+        guard isBudgetable(category) else { return .categoryNotBudgetable }
+
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .empty }
+
+        guard let amount = normalizedAmount(trimmed) else { return .invalid }
+        guard amount >= 0, amount.isFinite else { return .invalid }
+
+        return amount == 0 ? .clear : .save(amount: amount)
+    }
+
+    /// Parse a user-typed amount tolerant of a currency symbol, grouping
+    /// separators, and either decimal convention. Returns `nil` when the residue
+    /// is not a single non-negative number.
+    private static func normalizedAmount(_ text: String) -> Double? {
+        var cleaned = text
+        // Drop a leading currency symbol (e.g. "$", "€", "£") and any spaces.
+        cleaned.removeAll { $0 == "$" || $0 == "€" || $0 == "£" || $0 == " " }
+        guard !cleaned.isEmpty else { return nil }
+
+        // Reject anything that isn't digits plus at most the separators we handle,
+        // so "12.3.4", "1e9", or "abc" never sneak through as a Double.
+        let allowed = Set("0123456789.,")
+        guard cleaned.allSatisfy({ allowed.contains($0) }) else { return nil }
+
+        // Normalize to a `.`-decimal form. If both separators appear, the last one
+        // is the decimal point and the other is grouping; if only commas appear,
+        // treat a single trailing-group comma as decimal only when it looks like
+        // cents (",dd"), otherwise as grouping.
+        let normalized = normalizeSeparators(cleaned)
+        guard let value = Double(normalized) else { return nil }
+        return value
+    }
+
+    private static func normalizeSeparators(_ text: String) -> String {
+        let hasDot = text.contains(".")
+        let hasComma = text.contains(",")
+
+        if hasDot && hasComma {
+            // The right-most separator is the decimal point; strip the other.
+            if let lastDot = text.lastIndex(of: "."),
+               let lastComma = text.lastIndex(of: ",") {
+                if lastDot > lastComma {
+                    // "1,200.50" — comma groups, dot decimals.
+                    return text.replacingOccurrences(of: ",", with: "")
+                } else {
+                    // "1.200,50" — dot groups, comma decimals.
+                    return text
+                        .replacingOccurrences(of: ".", with: "")
+                        .replacingOccurrences(of: ",", with: ".")
+                }
+            }
+        }
+
+        if hasComma && !hasDot {
+            // Only commas: a single comma followed by exactly two digits is a
+            // decimal (e.g. "12,50"); anything else is grouping ("1,200").
+            let parts = text.split(separator: ",", omittingEmptySubsequences: false)
+            if parts.count == 2, parts[1].count == 2 {
+                return parts[0] + "." + parts[1]
+            }
+            return text.replacingOccurrences(of: ",", with: "")
+        }
+
+        return text
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetEditorInputTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetEditorInputTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Budget editor input parsing (AND-540)")
+struct BudgetEditorInputTests {
+    // MARK: - Budgetable categories
+
+    @Test("Income and transfer categories are never budgetable")
+    func excludedCategoriesNotBudgetable() {
+        for excluded in CategoryBudgetPlanner.excludedCategories {
+            #expect(!BudgetEditorInput.isBudgetable(excluded))
+            #expect(
+                BudgetEditorInput.parse("200", category: excluded)
+                    == .categoryNotBudgetable
+            )
+        }
+    }
+
+    @Test("A spend category is budgetable")
+    func spendCategoryBudgetable() {
+        #expect(BudgetEditorInput.isBudgetable(.foodAndDrink))
+        #expect(BudgetEditorInput.isBudgetable(.shopping))
+    }
+
+    // MARK: - Empty / invalid
+
+    @Test("Blank text is empty (not committable)")
+    func blankIsEmpty() {
+        #expect(BudgetEditorInput.parse("", category: .foodAndDrink) == .empty)
+        #expect(BudgetEditorInput.parse("   ", category: .foodAndDrink) == .empty)
+        #expect(!BudgetEditorInput.parse("", category: .foodAndDrink).isCommittable)
+    }
+
+    @Test("Non-numeric or negative text is invalid")
+    func invalidText() {
+        #expect(BudgetEditorInput.parse("abc", category: .foodAndDrink) == .invalid)
+        #expect(BudgetEditorInput.parse("-50", category: .foodAndDrink) == .invalid)
+        #expect(BudgetEditorInput.parse("12.3.4", category: .foodAndDrink) == .invalid)
+        #expect(BudgetEditorInput.parse("1e9", category: .foodAndDrink) == .invalid)
+        #expect(!BudgetEditorInput.parse("abc", category: .foodAndDrink).isCommittable)
+    }
+
+    // MARK: - Save
+
+    @Test("A positive amount resolves to .save")
+    func positiveSaves() {
+        #expect(
+            BudgetEditorInput.parse("500", category: .foodAndDrink)
+                == .save(amount: 500)
+        )
+        #expect(
+            BudgetEditorInput.parse("499.99", category: .shopping)
+                == .save(amount: 499.99)
+        )
+        #expect(BudgetEditorInput.parse("500", category: .foodAndDrink).isCommittable)
+    }
+
+    @Test("Currency symbol and grouping separators are tolerated")
+    func toleratesFormatting() {
+        #expect(
+            BudgetEditorInput.parse("$1,200", category: .travel)
+                == .save(amount: 1200)
+        )
+        #expect(
+            BudgetEditorInput.parse("$1,200.50", category: .travel)
+                == .save(amount: 1200.50)
+        )
+        #expect(
+            BudgetEditorInput.parse(" 750 ", category: .travel)
+                == .save(amount: 750)
+        )
+    }
+
+    @Test("Comma-as-decimal (European) parses as cents")
+    func commaDecimal() {
+        #expect(
+            BudgetEditorInput.parse("12,50", category: .foodAndDrink)
+                == .save(amount: 12.50)
+        )
+        #expect(
+            BudgetEditorInput.parse("1.200,50", category: .foodAndDrink)
+                == .save(amount: 1200.50)
+        )
+    }
+
+    // MARK: - Clear
+
+    @Test("Zero resolves to .clear (committable)")
+    func zeroClears() {
+        #expect(BudgetEditorInput.parse("0", category: .foodAndDrink) == .clear)
+        #expect(BudgetEditorInput.parse("0.00", category: .foodAndDrink) == .clear)
+        #expect(BudgetEditorInput.parse("0", category: .foodAndDrink).isCommittable)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a native SwiftUI `BudgetEditorSheet` (`Sources/PlaidBar/Views/BudgetEditorSheet.swift`) — the **first caller** of the previously-dead `AppState.setCategoryBudget` / `removeCategoryBudget`. A user can now set, edit, or clear a per-category current-month budget limit:

- Native `Form` + `TextField` with a `$` affordance, seeded from any existing saved limit.
- Live validation via a new pure helper; Save/Clear is disabled until the input is committable.
- Save persists through the existing server budget CRUD (`ServerClient.saveCategoryBudget` / `deleteCategoryBudget`) and updates local `categoryBudgets`, which already invalidates the dashboard presentation cache on `categoryBudgets.didSet`.
- Zero or an explicit "Remove budget" action clears the saved limit.

Pure parsing/validation is extracted to `Sources/PlaidBarCore/Utilities/BudgetEditorInput.swift` (`BudgetEditorInput`): tolerant amount parsing (currency symbol, grouping separators, comma- or dot-decimal), the non-budgetable income/transfer guard (kept in lock-step with `CategoryBudgetPlanner.excludedCategories`), and `0 → clear`.

## Linear (AND-540)

Implements **AND-540** (Epic AND-522, Budget editing) — wires the live half of category-budget editing that the design doc flagged as having **zero callers**. Phase 3 of the delivery plan: `AND-540 (needs 526)`. The override-aware planner + presentation cache invalidation (AND-526/554) already landed on `main`, so this PR is purely the editor surface + its persistence call path.

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §1 ("a budget editor UI with **zero callers** — `AppState.setCategoryBudget`/`removeCategoryBudget` are dead") and §4 ("`BudgetEditorSheet`"):

- **Option A, no migration.** Single current-month limit per category. No per-month series, no rollover, no rebalance — those are the deferred v2 epic (AND-524). No schema, DTO, or `SpendingCategory` rawValue changes.
- No new server work — budget CRUD already exists via `BudgetRoutes` + `BudgetStore`.

## Testing notes

New pure-helper suite `BudgetEditorInputTests` (`Tests/PlaidBarCoreTests/BudgetEditorInputTests.swift`, 8 tests):
- `excludedCategoriesNotBudgetable`, `spendCategoryBudgetable`
- `blankIsEmpty`, `invalidText`
- `positiveSaves`, `toleratesFormatting`, `commaDecimal`
- `zeroClears`

Strict-concurrency build (CI gate) — green:

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
...
Build complete! (14.96s)
```

Full suite — green:

```
swift test
...
✔ Test run with 1153 tests passed after 0.682 seconds.
```

(The `✘ skipped` entries are the pre-existing Keychain-environment skips, not failures.)

## Architectural decisions

- **Pure logic in PlaidBarCore.** All "is this a legal edit and what does it resolve to" logic lives in `BudgetEditorInput` (`Sendable`, no view), so the rules are unit-tested headlessly and the view only renders the outcome and dispatches the AppState call. Matches the repo convention of keeping shared/testable logic out of views.
- **No edits to AppState's existing budget methods.** `setCategoryBudget` / `removeCategoryBudget` were already correct (optimistic local update → server round-trip → rollback on error); they were "dead" only in the sense of having no caller. This PR adds the caller and leaves `categoryBudgetPresentation` / cache invalidation untouched (owned by AND-526/554).
- **Accessibility.** Every validation verdict is carried by text + an SF Symbol, never color alone (ACCESSIBILITY.md); the amount field has an explicit `accessibilityLabel` and `accessibilityValue`.

## Migration notes

None. Zero schema/DTO/rawValue changes; review and budget state paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)