### PR TITLE
test: add 232 tests across 31 files, push PlaidBarCore to 95.2% coverage

### DIFF
--- a/Tests/PlaidBarCoreTests/AccountActivityEmptyStateTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountActivityEmptyStateTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Account activity empty state")
+struct AccountActivityEmptyStateTests {
+    private func evaluate(
+        transactionCount: Int = 0,
+        isDemoMode: Bool = false,
+        isInitialLoad: Bool = false,
+        serverConnected: Bool = true,
+        connectionLevel: AccountConnectionLevel = .healthy,
+        accountDisplayName: String = "Everyday Checking"
+    ) -> AccountActivityEmptyState? {
+        AccountActivityEmptyState.evaluate(
+            transactionCount: transactionCount,
+            isDemoMode: isDemoMode,
+            isInitialLoad: isInitialLoad,
+            serverConnected: serverConnected,
+            connectionLevel: connectionLevel,
+            accountDisplayName: accountDisplayName
+        )
+    }
+
+    @Test("No empty state when the account has transactions")
+    func nonEmptyReturnsNil() {
+        #expect(evaluate(transactionCount: 3) == nil)
+    }
+
+    @Test("Demo mode outranks every other reason")
+    func demoMode() {
+        let state = evaluate(isDemoMode: true, isInitialLoad: true, serverConnected: false, connectionLevel: .error)
+        #expect(state?.title == "No demo activity")
+        #expect(state?.tone == .secondary)
+        #expect(state?.iconName == "play.circle")
+        #expect(state?.detail.contains("Everyday Checking") == true)
+    }
+
+    @Test("Initial load reads as loading, not a degraded connection")
+    func initialLoadOutranksOffline() {
+        let state = evaluate(isInitialLoad: true, serverConnected: false, connectionLevel: .error)
+        #expect(state?.title == "Loading activity")
+        #expect(state?.tone == .loading)
+        #expect(state?.iconName == "arrow.triangle.2.circlepath")
+    }
+
+    @Test("Offline server is reported before connection-level messaging")
+    func serverOffline() {
+        let state = evaluate(serverConnected: false, connectionLevel: .healthy)
+        #expect(state?.title == "Server offline")
+        #expect(state?.tone == .offline)
+        #expect(state?.iconName == "server.rack")
+    }
+
+    @Test("Login-required connection prompts a reconnect")
+    func loginRequired() {
+        let state = evaluate(connectionLevel: .loginRequired)
+        #expect(state?.title == "Reconnect to sync activity")
+        #expect(state?.tone == .warning)
+    }
+
+    @Test("Item error warns and asks for a reconnect")
+    func itemError() {
+        let state = evaluate(connectionLevel: .error)
+        #expect(state?.title == "Item error blocks activity")
+        #expect(state?.tone == .warning)
+        #expect(state?.iconName == "exclamationmark.triangle.fill")
+    }
+
+    @Test("Stale connection nudges a refresh")
+    func stale() {
+        let state = evaluate(connectionLevel: .stale)
+        #expect(state?.title == "Activity may be stale")
+        #expect(state?.tone == .warning)
+    }
+
+    @Test("Unknown status reads as status-unavailable, not an error")
+    func unknown() {
+        let state = evaluate(connectionLevel: .unknown)
+        #expect(state?.title == "Item status unavailable")
+        #expect(state?.tone == .secondary)
+    }
+
+    @Test("Demo and offline connection levels both read as plain no-activity")
+    func demoAndOfflineLevels() {
+        for level in [AccountConnectionLevel.demo, .offline] {
+            let state = evaluate(connectionLevel: level)
+            #expect(state?.title == "No recent activity")
+            #expect(state?.tone == .secondary)
+            #expect(state?.iconName == "tray")
+        }
+    }
+
+    @Test("Healthy account with no activity stays positive in tone")
+    func healthy() {
+        let state = evaluate(connectionLevel: .healthy)
+        #expect(state?.title == "No recent activity")
+        #expect(state?.tone == .healthy)
+        #expect(state?.detail.contains("linked") == true)
+    }
+
+    @Test("Accessibility label joins title and detail")
+    func accessibilityLabel() {
+        let state = AccountActivityEmptyState(
+            title: "Title", detail: "Detail.", iconName: "tray", tone: .secondary
+        )
+        #expect(state.accessibilityLabel == "Title. Detail.")
+    }
+}

--- a/Tests/PlaidBarCoreTests/AccountConnectionPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountConnectionPresentationTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Account connection presentation")
+struct AccountConnectionPresentationTests {
+    private func evaluate(
+        isDemoMode: Bool = false,
+        serverConnected: Bool = true,
+        isSyncStale: Bool = false,
+        statusSyncText: String = "Updated just now",
+        itemStatus: ItemConnectionStatus?,
+        institutionName: String? = "Acme Bank",
+        itemLastSyncRelative: String? = "2m ago"
+    ) -> AccountConnectionPresentation {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            isSyncStale: isSyncStale,
+            statusSyncText: statusSyncText,
+            itemStatus: itemStatus,
+            institutionName: institutionName,
+            itemLastSyncRelative: itemLastSyncRelative
+        )
+    }
+
+    @Test("Demo mode short-circuits to the demo presentation")
+    func demo() {
+        let presentation = evaluate(isDemoMode: true, itemStatus: .error)
+        #expect(presentation.level == .demo)
+        #expect(!presentation.showsRecoveryActions)
+        // statusFilterSubtitle defaults to detailLabel when not supplied.
+        #expect(presentation.statusFilterSubtitle == "Demo data")
+    }
+
+    @Test("Offline server outranks item status")
+    func offline() {
+        let presentation = evaluate(serverConnected: false, itemStatus: .connected)
+        #expect(presentation.level == .offline)
+        #expect(!presentation.showsRecoveryActions)
+    }
+
+    @Test("Connected and fresh is healthy with no recovery")
+    func healthy() {
+        let presentation = evaluate(itemStatus: .connected)
+        #expect(presentation.level == .healthy)
+        #expect(presentation.signalLabel == "Fresh")
+        #expect(!presentation.showsRecoveryActions)
+        #expect(presentation.statusFilterSubtitle == "Healthy • Last sync 2m ago")
+    }
+
+    @Test("Connected but stale offers a refresh")
+    func stale() {
+        let presentation = evaluate(isSyncStale: true, itemStatus: .connected)
+        #expect(presentation.level == .stale)
+        #expect(presentation.recoveryActionTitle == "Refresh")
+        #expect(presentation.showsRecoveryActions)
+        #expect(presentation.recoveryDetailLabel?.contains("stale") == true)
+    }
+
+    @Test("login_repaired is treated as a healthy sync")
+    func loginRepaired() {
+        #expect(evaluate(itemStatus: .loginRepaired).level == .healthy)
+    }
+
+    @Test("Unknown item status reads as unknown with no recovery")
+    func unknown() {
+        let presentation = evaluate(itemStatus: nil)
+        #expect(presentation.level == .unknown)
+        #expect(!presentation.showsRecoveryActions)
+        #expect(presentation.signalLabel == "Unknown")
+    }
+
+    @Test("Item error surfaces a reconnect naming the institution")
+    func errorNamed() {
+        let presentation = evaluate(itemStatus: .error, institutionName: "Acme Bank")
+        #expect(presentation.level == .error)
+        #expect(presentation.recoveryActionTitle == "Reconnect Acme Bank")
+        #expect(presentation.detailLabel == "Acme Bank item error")
+        #expect(presentation.recoveryDetailLabel?.contains("Acme Bank") == true)
+    }
+
+    @Test("Item error falls back to a generic reconnect when unnamed")
+    func errorUnnamed() {
+        let presentation = evaluate(itemStatus: .error, institutionName: nil)
+        #expect(presentation.recoveryActionTitle == "Reconnect Item")
+        #expect(presentation.detailLabel == "Item error")
+    }
+
+    @Test("Provider outage is advisory and non-actionable")
+    func providerOutage() {
+        let presentation = evaluate(itemStatus: .providerOutage, institutionName: "Acme Bank")
+        #expect(presentation.level == .stale)
+        #expect(!presentation.showsRecoveryActions)
+        #expect(presentation.signalLabel == "Outage")
+        #expect(presentation.recoveryDetailLabel?.contains("retry automatically") == true)
+    }
+
+    @Test("new_accounts_available uses an Update verb; other repairs use Reconnect")
+    func repairVerbs() {
+        #expect(evaluate(itemStatus: .newAccountsAvailable, institutionName: "Acme Bank").recoveryActionTitle == "Update Acme Bank")
+        #expect(evaluate(itemStatus: .newAccountsAvailable, institutionName: nil).recoveryActionTitle == "Update Item")
+        #expect(evaluate(itemStatus: .loginRequired, institutionName: "Acme Bank").recoveryActionTitle == "Reconnect Acme Bank")
+    }
+
+    @Test("Every repair status maps to a distinct recovery presentation")
+    func repairStatuses() {
+        let statuses: [ItemConnectionStatus] = [
+            .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable,
+        ]
+        var signals = Set<String>()
+        var details = Set<String>()
+        for status in statuses {
+            let named = evaluate(itemStatus: status, institutionName: "Acme Bank")
+            #expect(named.level == .loginRequired)
+            #expect(named.showsRecoveryActions)
+            #expect(named.recoveryActionTitle?.isEmpty == false)
+            #expect(named.recoveryDetailLabel?.contains("Acme Bank") == true)
+            signals.insert(named.signalLabel)
+            if let detail = named.recoveryDetailLabel { details.insert(detail) }
+
+            let unnamed = evaluate(itemStatus: status, institutionName: nil)
+            #expect(unnamed.recoveryDetailLabel?.contains("Acme Bank") == false)
+        }
+        #expect(signals.count == statuses.count)
+        #expect(details.count == statuses.count)
+    }
+
+    @Test("A blank institution name is treated as unnamed")
+    func blankInstitutionName() {
+        #expect(evaluate(itemStatus: .error, institutionName: "   ").recoveryActionTitle == "Reconnect Item")
+    }
+
+    @Test("Missing item sync timestamp reads as no sync recorded")
+    func itemSyncLabelFallback() {
+        let withSync = evaluate(itemStatus: .error, itemLastSyncRelative: "5m ago")
+        #expect(withSync.itemSyncLabel == "Last sync 5m ago")
+        #expect(withSync.statusFilterSubtitle.contains("Last sync 5m ago"))
+
+        let noSync = evaluate(itemStatus: .error, itemLastSyncRelative: nil)
+        #expect(noSync.itemSyncLabel == "No sync recorded")
+        #expect(noSync.statusFilterSubtitle.contains("No sync recorded"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/AccountTransactionFeedCoverageTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountTransactionFeedCoverageTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Account transaction feed coverage")
+struct AccountTransactionFeedCoverageTests {
+    private func tx(_ id: String, account: String, pending: Bool, date: String) -> TransactionDTO {
+        TransactionDTO(
+            id: id, accountId: account, amount: 10, date: date,
+            name: id, merchantName: id, category: .foodAndDrink, pending: pending
+        )
+    }
+
+    @Test("Snapshot built from transactions derives counts, pending list, and latest date")
+    func snapshotFromTransactions() {
+        let snapshot = AccountTransactionFeed.AccountActivitySnapshot(transactions: [
+            tx("a", account: "x", pending: false, date: "2026-06-10"),
+            tx("b", account: "x", pending: true, date: "2026-06-12"),
+        ])
+        #expect(snapshot.transactionCount == 2)
+        #expect(snapshot.pendingTransactionCount == 1)
+        #expect(snapshot.pendingTransactions.map(\.id) == ["b"])
+        #expect(snapshot.latestTransactionDate == "2026-06-12")
+    }
+
+    @Test("sortedForFeed returns every transaction in a deterministic order")
+    func sortedForFeed() {
+        let sorted = AccountTransactionFeed.sortedForFeed([
+            tx("a", account: "x", pending: false, date: "2026-06-10"),
+            tx("b", account: "x", pending: false, date: "2026-06-12"),
+        ])
+        #expect(sorted.count == 2)
+        #expect(Set(sorted.map(\.id)) == ["a", "b"])
+    }
+
+    @Test("transactions(forAccountId:) filters to the requested account")
+    func transactionsForAccount() {
+        let txns = [
+            tx("a", account: "x", pending: false, date: "2026-06-10"),
+            tx("c", account: "y", pending: false, date: "2026-06-11"),
+        ]
+        #expect(AccountTransactionFeed.transactions(forAccountId: "x", in: txns).map(\.id) == ["a"])
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -34,6 +34,15 @@ struct AppLockPresentationTests {
         #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: false, isIconOnly: false) == "Private")
     }
 
+    @Test("normal mode passes the menu-bar text through untouched")
+    func normalModePassesTextThrough() {
+        let preferences = AppLockPreferences()
+
+        #expect(preferences.effectiveDisplayMode(isAppLocked: false) == .normal)
+        #expect(preferences.effectiveDisplayMode(isAppLocked: true) == .normal)
+        #expect(preferences.menuBarText(currentText: "$42,000", isAppLocked: false, isIconOnly: false) == "$42,000")
+    }
+
     @Test("private Review Inbox header does not expose queue counts")
     func privateReviewInboxHeaderDoesNotExposeCounts() {
         let presentation = ReviewInboxPrivacyPresentation.make(
@@ -167,5 +176,41 @@ struct AppLockPresentationTests {
         #expect(AppLockPreferences.normalizedInactivityInterval(75) == 60)
         #expect(AppLockPreferences.normalizedInactivityInterval(301) == 300)
         #expect(AppLockPreferences.normalizedInactivityInterval(1_600) == 1_800)
+    }
+
+    @Test("notification privacy modes expose a stable display name")
+    func notificationPrivacyDisplayNames() {
+        #expect(NotificationPrivacyMode.detailed.displayName == "Detailed")
+        #expect(NotificationPrivacyMode.genericWhenPrivate.displayName == "Generic when private")
+        #expect(NotificationPrivacyMode.alwaysGeneric.displayName == "Always generic")
+        #expect(NotificationPrivacyMode.offWhileLocked.displayName == "Off while locked")
+    }
+
+    @Test("only off-while-locked describes suppression; the rest share generic copy")
+    func notificationPrivacyDetailCopy() {
+        let generic = NotificationPrivacyMode.alwaysGeneric.detail
+        #expect(NotificationPrivacyMode.detailed.detail == generic)
+        #expect(NotificationPrivacyMode.genericWhenPrivate.detail == generic)
+        #expect(generic.contains("alerts still arrive while VaultPeek is locked"))
+        #expect(NotificationPrivacyMode.offWhileLocked.detail.contains("suppressed entirely while VaultPeek is locked"))
+        #expect(NotificationPrivacyMode.offWhileLocked.detail != generic)
+    }
+
+    @Test("shouldSend suppresses only off-while-locked while locked")
+    func notificationShouldSend() {
+        #expect(NotificationPrivacyMode.offWhileLocked.shouldSend(isLocked: true) == false)
+        #expect(NotificationPrivacyMode.offWhileLocked.shouldSend(isLocked: false) == true)
+        #expect(NotificationPrivacyMode.alwaysGeneric.shouldSend(isLocked: true) == true)
+        #expect(NotificationPrivacyMode.detailed.shouldSend(isLocked: true) == true)
+    }
+
+    @Test("each authentication outcome has distinct, non-empty locked-surface copy")
+    func authenticationMessageSurfaceCopy() {
+        let messages: [AppLockAuthenticationMessage] = [.failed, .canceled, .unavailable, .lockout]
+        let copies = messages.map(\.lockedSurfaceCopy)
+        #expect(copies.allSatisfy { !$0.isEmpty })
+        #expect(Set(copies).count == messages.count)
+        #expect(AppLockAuthenticationMessage.failed.lockedSurfaceCopy.contains("Try again"))
+        #expect(AppLockAuthenticationMessage.lockout.lockedSurfaceCopy.contains("Touch ID"))
     }
 }

--- a/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockServiceTests.swift
@@ -183,6 +183,32 @@ struct AppLockServiceTests {
         #expect(authenticator.authenticateCallCount == 1)
         #expect(service.state == .unlocked)
     }
+
+    @Test("lock locks an enabled service and stays unlocked when disabled")
+    func lockBehavior() {
+        let enabled = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: true),
+            authenticator: StubAppLockAuthenticator(capability: .available(biometry: .touchID))
+        )
+        enabled.lock()
+        #expect(enabled.state == .locked)
+
+        let disabled = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: false),
+            authenticator: StubAppLockAuthenticator()
+        )
+        disabled.lock()
+        #expect(disabled.state == .unlocked)
+    }
+
+    @Test("authenticationCapability surfaces the authenticator capability")
+    func capabilityPassthrough() {
+        let service = AppLockService(
+            settingsStore: InMemoryAppLockSettingsStore(isLockEnabled: false),
+            authenticator: StubAppLockAuthenticator(capability: .available(biometry: .faceID))
+        )
+        #expect(service.authenticationCapability() == .available(biometry: .faceID))
+    }
 }
 
 @MainActor

--- a/Tests/PlaidBarCoreTests/AppearancePreferencesTests.swift
+++ b/Tests/PlaidBarCoreTests/AppearancePreferencesTests.swift
@@ -81,4 +81,67 @@ struct AppearancePreferencesTests {
         #expect(DecorativeEffectsPreference.defaultValue == .followSystem)
         #expect(AppDensityPreference.defaultValue == .comfortable)
     }
+
+    // MARK: Human-readable titles
+
+    @Test("Each preference exposes a stable human-readable title")
+    func titles() {
+        #expect(AppAppearanceMode.followSystem.title == "Follow System")
+        #expect(AppAppearanceMode.light.title == "Light")
+        #expect(AppAppearanceMode.dark.title == "Dark")
+
+        #expect(AppContrastPreference.followSystem.title == "Follow System")
+        #expect(AppContrastPreference.standard.title == "Standard")
+        #expect(AppContrastPreference.increased.title == "Increased")
+
+        #expect(DecorativeEffectsPreference.followSystem.title == "Follow System")
+        #expect(DecorativeEffectsPreference.on.title == "On")
+        #expect(DecorativeEffectsPreference.reduced.title == "Reduced")
+
+        #expect(AppDensityPreference.comfortable.title == "Comfortable")
+        #expect(AppDensityPreference.compact.title == "Compact")
+    }
+
+    // MARK: Identifiable + storage keys
+
+    @Test("Identifiable id mirrors the persisted raw value for every case")
+    func identifiersMatchRawValues() {
+        for mode in AppAppearanceMode.allCases { #expect(mode.id == mode.rawValue) }
+        for contrast in AppContrastPreference.allCases { #expect(contrast.id == contrast.rawValue) }
+        for effects in DecorativeEffectsPreference.allCases { #expect(effects.id == effects.rawValue) }
+        for density in AppDensityPreference.allCases { #expect(density.id == density.rawValue) }
+    }
+
+    @Test("Storage keys are namespaced under appearance.* and are distinct")
+    func storageKeys() {
+        #expect(AppAppearanceMode.storageKey == "appearance.appColorScheme")
+        #expect(AppContrastPreference.storageKey == "appearance.contrast")
+        #expect(DecorativeEffectsPreference.storageKey == "appearance.decorativeEffects")
+        #expect(AppDensityPreference.storageKey == "appearance.density")
+
+        let keys = Set([
+            AppAppearanceMode.storageKey,
+            AppContrastPreference.storageKey,
+            DecorativeEffectsPreference.storageKey,
+            AppDensityPreference.storageKey,
+        ])
+        #expect(keys.count == 4)
+    }
+
+    @Test("CaseIterable exposes every option")
+    func caseCounts() {
+        #expect(AppAppearanceMode.allCases.count == 3)
+        #expect(AppContrastPreference.allCases.count == 3)
+        #expect(DecorativeEffectsPreference.allCases.count == 3)
+        #expect(AppDensityPreference.allCases.count == 2)
+    }
+
+    @Test("Raw values round-trip through the persisted string representation")
+    func rawValueRoundTrip() {
+        #expect(AppAppearanceMode(rawValue: "dark") == .dark)
+        #expect(AppContrastPreference(rawValue: "increased") == .increased)
+        #expect(DecorativeEffectsPreference(rawValue: "reduced") == .reduced)
+        #expect(AppDensityPreference(rawValue: "compact") == .compact)
+        #expect(ForcedColorScheme(rawValue: "light") == .light)
+    }
 }

--- a/Tests/PlaidBarCoreTests/BalanceProjectionTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceProjectionTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Balance projection value type (AND-498)")
+struct BalanceProjectionTests {
+    private func snap(_ day: Int, _ balance: Double) -> BalanceSnapshot {
+        BalanceSnapshot(date: Date(timeIntervalSince1970: TimeInterval(day) * 86_400), balance: balance)
+    }
+
+    @Test("anchorBalance is the first snapshot; endBalance is the last")
+    func anchorAndEndFromSeries() {
+        let projection = BalanceProjection(
+            series: [snap(0, 1_000), snap(1, 800), snap(2, 600)],
+            projectedLow: snap(2, 600),
+            confidence: .lowConfidence,
+            accessibilitySummary: "summary"
+        )
+        #expect(projection.anchorBalance == 1_000)
+        #expect(projection.endBalance == 600)
+    }
+
+    @Test("Empty series falls back to the projected low for both anchor and end")
+    func emptySeriesFallsBackToLow() {
+        let low = snap(5, 42)
+        let projection = BalanceProjection(
+            series: [],
+            projectedLow: low,
+            confidence: .insufficientData,
+            accessibilitySummary: "summary"
+        )
+        #expect(projection.anchorBalance == 42)
+        #expect(projection.endBalance == 42)
+    }
+
+    @Test("Single-element series uses it for both anchor and end")
+    func singleElementSeries() {
+        let only = snap(0, 250)
+        let projection = BalanceProjection(
+            series: [only],
+            projectedLow: only,
+            confidence: .ok,
+            accessibilitySummary: "summary"
+        )
+        #expect(projection.anchorBalance == 250)
+        #expect(projection.endBalance == 250)
+    }
+}

--- a/Tests/PlaidBarCoreTests/BalanceTrendTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceTrendTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Balance trend display values")
+struct BalanceTrendTests {
+    private func snap(_ balance: Double) -> BalanceSnapshot {
+        BalanceSnapshot(date: Date(timeIntervalSince1970: 0), balance: balance)
+    }
+
+    @Test("Chart baseline is the minimum point balance, or zero when empty")
+    func chartBaseline() {
+        let trend = BalanceTrend(direction: .up, delta: 50, spanDays: 5, points: [snap(100), snap(50), snap(120)])
+        #expect(trend.chartBaseline == 50)
+        #expect(BalanceTrend(direction: .flat, delta: 0, spanDays: 1, points: []).chartBaseline == 0)
+    }
+
+    @Test("Delta text signs the magnitude by direction")
+    func deltaText() {
+        #expect(BalanceTrend(direction: .up, delta: 1_200, spanDays: 5, points: []).deltaText.hasPrefix("+"))
+        #expect(BalanceTrend(direction: .down, delta: -300, spanDays: 5, points: []).deltaText.hasPrefix("-"))
+        let flat = BalanceTrend(direction: .flat, delta: 0, spanDays: 5, points: []).deltaText
+        #expect(!flat.hasPrefix("+"))
+        #expect(!flat.hasPrefix("-"))
+    }
+
+    @Test("Span text is a compact day count")
+    func spanText() {
+        #expect(BalanceTrend(direction: .up, delta: 1, spanDays: 30, points: []).spanText == "30D")
+    }
+
+    @Test("Accessibility summary states direction and pluralizes the span")
+    func accessibilitySummary() {
+        #expect(BalanceTrend(direction: .up, delta: 100, spanDays: 5, points: []).accessibilitySummary.contains("up"))
+        #expect(BalanceTrend(direction: .down, delta: -100, spanDays: 5, points: []).accessibilitySummary.contains("down"))
+        let flat = BalanceTrend(direction: .flat, delta: 0, spanDays: 5, points: [])
+        #expect(flat.accessibilitySummary.contains("unchanged"))
+        #expect(flat.accessibilitySummary.contains("5 days"))
+        #expect(BalanceTrend(direction: .up, delta: 100, spanDays: 1, points: []).accessibilitySummary.contains("1 day."))
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryBudgetDTOTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetDTOTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Category budget DTO")
+struct CategoryBudgetDTOTests {
+    @Test("Identity is the category raw value")
+    func identity() {
+        let dto = CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 300)
+        #expect(dto.id == "FOOD_AND_DRINK")
+        #expect(dto.monthlyLimit == 300)
+    }
+
+    @Test("Response byCategory maps each budget to its limit")
+    func byCategory() {
+        let response = CategoryBudgetsResponse(budgets: [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 300),
+            CategoryBudgetDTO(category: .shopping, monthlyLimit: 150),
+        ])
+        #expect(response.byCategory[.foodAndDrink] == 300)
+        #expect(response.byCategory[.shopping] == 150)
+        #expect(response.byCategory.count == 2)
+    }
+
+    @Test("Save request carries the monthly limit")
+    func saveRequest() {
+        #expect(SaveCategoryBudgetRequest(monthlyLimit: 99).monthlyLimit == 99)
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryBudgetPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetPresentationTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Category budget presentation")
+struct CategoryBudgetPresentationTests {
+    // MARK: Status bands
+
+    @Test("Status bands follow the consumed fraction with an 80% nearing threshold")
+    func statusBands() {
+        #expect(CategoryBudgetStatus(fractionUsed: 0.5) == .under)
+        #expect(CategoryBudgetStatus(fractionUsed: 0.79) == .under)
+        #expect(CategoryBudgetStatus(fractionUsed: 0.8) == .nearing)
+        #expect(CategoryBudgetStatus(fractionUsed: 1.0) == .nearing)
+        #expect(CategoryBudgetStatus(fractionUsed: 1.01) == .over)
+        #expect(CategoryBudgetStatus.nearingThreshold == 0.8)
+    }
+
+    @Test("Each status band has a non-empty label and distinct icon")
+    func statusLabelsAndIcons() {
+        for status in CategoryBudgetStatus.allCases {
+            #expect(!status.label.isEmpty)
+            #expect(!status.iconName.isEmpty)
+        }
+        let icons = CategoryBudgetStatus.allCases.map(\.iconName)
+        #expect(Set(icons).count == icons.count)
+    }
+
+    // MARK: Item derivations
+
+    @Test("Item derives remaining, fraction, status, and identity from limit and spend")
+    func itemDerivations() {
+        let item = CategoryBudgetPresentation.Item(
+            category: .foodAndDrink, monthlyLimit: 200, spent: 250, isSuggested: true
+        )
+        #expect(item.id == "FOOD_AND_DRINK")
+        #expect(item.spent == 250)
+        #expect(item.remaining == -50)
+        #expect(item.fractionUsed == 1.25)
+        #expect(item.status == .over)
+        #expect(item.isOverBudget)
+        #expect(item.needsAttention)
+        #expect(item.isSuggested)
+    }
+
+    @Test("Negative spend floors at zero")
+    func negativeSpendFloors() {
+        let item = CategoryBudgetPresentation.Item(
+            category: .shopping, monthlyLimit: 100, spent: -30, isSuggested: false
+        )
+        #expect(item.spent == 0)
+        #expect(item.remaining == 100)
+        #expect(item.fractionUsed == 0)
+        #expect(item.status == .under)
+        #expect(!item.needsAttention)
+    }
+
+    @Test("A non-positive limit yields a zero fraction rather than dividing by zero")
+    func nonPositiveLimit() {
+        let item = CategoryBudgetPresentation.Item(
+            category: .travel, monthlyLimit: 0, spent: 40, isSuggested: false
+        )
+        #expect(item.fractionUsed == 0)
+        #expect(item.status == .under)
+    }
+
+    // MARK: Aggregates
+
+    @Test("Aggregate initializer derives totals and pressure counts from items")
+    func aggregateInit() {
+        let items = [
+            CategoryBudgetPresentation.Item(category: .foodAndDrink, monthlyLimit: 100, spent: 130, isSuggested: false),
+            CategoryBudgetPresentation.Item(category: .shopping, monthlyLimit: 100, spent: 85, isSuggested: false),
+            CategoryBudgetPresentation.Item(category: .travel, monthlyLimit: 100, spent: 10, isSuggested: false),
+        ]
+        let presentation = CategoryBudgetPresentation(items: items)
+        #expect(presentation.totalLimit == 300)
+        #expect(presentation.totalSpent == 225)
+        #expect(presentation.overBudgetCount == 1)
+        #expect(presentation.nearingCount == 1)
+        #expect(presentation.count == 3)
+        #expect(!presentation.isEmpty)
+    }
+
+    @Test("Empty presentation is empty with zeroed aggregates")
+    func emptyPresentation() {
+        #expect(CategoryBudgetPresentation.empty.isEmpty)
+        #expect(CategoryBudgetPresentation.empty.count == 0)
+        #expect(CategoryBudgetPresentation.empty.totalLimit == 0)
+        #expect(CategoryBudgetPresentation.empty.overBudgetCount == 0)
+    }
+
+    @Test("The explicit initializer preserves supplied aggregates verbatim")
+    func explicitInit() {
+        let presentation = CategoryBudgetPresentation(
+            items: [], totalLimit: 99, totalSpent: 50, overBudgetCount: 2, nearingCount: 3
+        )
+        #expect(presentation.totalLimit == 99)
+        #expect(presentation.totalSpent == 50)
+        #expect(presentation.overBudgetCount == 2)
+        #expect(presentation.nearingCount == 3)
+    }
+}

--- a/Tests/PlaidBarCoreTests/DashboardCardKindTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardCardKindTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Dashboard card kind")
+struct DashboardCardKindTests {
+    @Test("Each kind exposes a stable id matching its raw value")
+    func identifiers() {
+        for kind in DashboardCardKind.allCases {
+            #expect(kind.id == kind.rawValue)
+        }
+    }
+
+    @Test("Each kind has a distinct, human-readable display name")
+    func displayNames() {
+        #expect(DashboardCardKind.changeReceipt.displayName == "Latest changes")
+        #expect(DashboardCardKind.weeklyReview.displayName == "Weekly review")
+        #expect(DashboardCardKind.overview.displayName == "Accounts overview")
+        #expect(DashboardCardKind.recentSpend.displayName == "Recent spend")
+        #expect(DashboardCardKind.insights.displayName == "Insights")
+
+        let names = DashboardCardKind.allCases.map(\.displayName)
+        #expect(Set(names).count == names.count)
+        #expect(DashboardCardKind.allCases.count == 5)
+    }
+}

--- a/Tests/PlaidBarCoreTests/DashboardDrillInSurfaceTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardDrillInSurfaceTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Dashboard drill-in surfaces and actions")
+struct DashboardDrillInSurfaceTests {
+    private func account(type: AccountType) -> AccountDTO {
+        AccountDTO(id: "a", itemId: "i", name: "Acct", type: type, balances: BalanceDTO(current: 0))
+    }
+
+    // MARK: Surfaces
+
+    @Test("Every surface exposes title, icon, and accessibility summary")
+    func surfaceCopy() {
+        for surface in DashboardDrillInSurface.allCases {
+            #expect(!surface.title.isEmpty)
+            #expect(!surface.iconName.isEmpty)
+            #expect(!surface.accessibilitySummary.isEmpty)
+        }
+    }
+
+    @Test("Credit surface is relevant only for credit and loan accounts")
+    func creditRelevance() {
+        #expect(DashboardDrillInSurface.credit.isRelevant(for: account(type: .credit)))
+        #expect(DashboardDrillInSurface.credit.isRelevant(for: account(type: .loan)))
+        #expect(!DashboardDrillInSurface.credit.isRelevant(for: account(type: .depository)))
+        #expect(DashboardDrillInSurface.account.isRelevant(for: account(type: .depository)))
+        #expect(DashboardDrillInSurface.activity.isRelevant(for: account(type: .investment)))
+        #expect(DashboardDrillInSurface.status.isRelevant(for: account(type: .other)))
+    }
+
+    @Test("surfaces(for:) drops the credit surface for non-credit accounts")
+    func surfacesFilter() {
+        #expect(DashboardDrillInSurface.surfaces(for: account(type: .depository)) == [.account, .activity, .status])
+        #expect(DashboardDrillInSurface.surfaces(for: account(type: .credit)) == [.account, .activity, .credit, .status])
+    }
+
+    // MARK: Actions
+
+    @Test("Every action exposes title, icon, and hint")
+    func actionCopy() {
+        for action in DashboardDrillInAction.allCases {
+            #expect(!action.title.isEmpty)
+            #expect(!action.iconName.isEmpty)
+            #expect(!action.accessibilityHint.isEmpty)
+        }
+    }
+
+    @Test("Action accessibility labels name the account")
+    func actionLabels() {
+        #expect(DashboardDrillInAction.reconnect.accessibilityLabel(accountDisplayName: "Chase") == "Reconnect Chase")
+        #expect(DashboardDrillInAction.remove.accessibilityLabel(accountDisplayName: "Chase") == "Remove institution for Chase")
+        #expect(DashboardDrillInAction.settings.accessibilityLabel(accountDisplayName: "Chase") == "Open VaultPeek settings from Chase")
+    }
+
+    @Test("Demo mode keeps only Settings; real mode keeps all three actions")
+    func demoModeActions() {
+        #expect(DashboardDrillInAction.accountDrillInActions(isDemoMode: true) == [.settings])
+        #expect(DashboardDrillInAction.accountDrillInActions(isDemoMode: false) == [.reconnect, .remove, .settings])
+        #expect(DashboardDrillInAction.accountDrillInActions == [.reconnect, .remove, .settings])
+    }
+
+    // MARK: Drill-in path
+
+    @Test("Drill-in path copy differs by selection state")
+    func drillInPath() {
+        let selected = DashboardAccountDrillInPath.presentation(for: account(type: .depository), isSelected: true)
+        let unselected = DashboardAccountDrillInPath.presentation(for: account(type: .depository), isSelected: false)
+        #expect(selected.accessibilityActionName == "Close account details")
+        #expect(unselected.accessibilityActionName == "Open account details")
+        #expect(selected.pointerHelp.contains("Close"))
+        #expect(unselected.pointerHelp.contains("Open"))
+    }
+
+    // MARK: Summary accessibility label
+
+    private func summary(
+        utilizationPercent: Double?,
+        transactionCount: Int,
+        pendingTransactionCount: Int,
+        latestTransactionDate: String?
+    ) -> DashboardAccountDrillInSummary {
+        DashboardAccountDrillInSummary(
+            displayName: "Checking",
+            subtitle: "Bank • Checking",
+            availableTitle: "Available",
+            availableBalance: 1_000,
+            currentTitle: "Current",
+            currentBalance: 1_050,
+            utilizationPercent: utilizationPercent,
+            limit: utilizationPercent == nil ? nil : 2_000,
+            transactionCount: transactionCount,
+            pendingTransactionCount: pendingTransactionCount,
+            latestTransactionDate: latestTransactionDate,
+            syncState: .connected,
+            freshnessLabel: "just now"
+        )
+    }
+
+    @Test("Public label includes counts, plural suffixes, and latest date")
+    func summaryLabelPublic() {
+        let label = summary(
+            utilizationPercent: nil, transactionCount: 3, pendingTransactionCount: 2,
+            latestTransactionDate: "2026-06-13"
+        ).accessibilityLabel
+        #expect(label.contains("Selected account drill-in"))
+        #expect(label.contains("Checking"))
+        #expect(label.contains("3 synced transactions"))
+        #expect(label.contains("2 pending transactions"))
+        #expect(label.contains("Latest transaction"))
+        #expect(!label.contains("Utilization"))
+    }
+
+    @Test("Private label hides counts and latest date but keeps utilization")
+    func summaryLabelPrivate() {
+        let label = summary(
+            utilizationPercent: 30, transactionCount: 1, pendingTransactionCount: 1,
+            latestTransactionDate: "2026-06-13"
+        ).accessibilityLabel(privacyMaskEnabled: true)
+        #expect(label.contains("Checking"))
+        #expect(!label.contains("synced transaction"))
+        #expect(!label.contains("Latest transaction"))
+        #expect(label.contains("Utilization"))
+    }
+
+    @Test("Public label uses singular suffixes for single transactions")
+    func summaryLabelSingular() {
+        let label = summary(
+            utilizationPercent: nil, transactionCount: 1, pendingTransactionCount: 1,
+            latestTransactionDate: nil
+        ).accessibilityLabel
+        #expect(label.contains("1 synced transaction"))
+        #expect(label.contains("1 pending transaction"))
+        #expect(!label.contains("Latest transaction"))
+    }
+
+    @Test("Summary presentation derives counts and sync state from inputs")
+    func summaryPresentation() {
+        let acct = AccountDTO(
+            id: "a1", itemId: "i1", name: "Checking", type: .depository,
+            balances: BalanceDTO(available: 500, current: 520)
+        )
+        let txns = [
+            TransactionDTO(id: "t1", accountId: "a1", amount: 10, date: "2026-06-10", name: "A", merchantName: "A", category: .foodAndDrink, pending: false),
+            TransactionDTO(id: "t2", accountId: "a1", amount: 20, date: "2026-06-12", name: "B", merchantName: "B", category: .shopping, pending: true),
+            TransactionDTO(id: "t3", accountId: "other", amount: 5, date: "2026-06-12", name: "C", merchantName: "C", category: .foodAndDrink, pending: false),
+        ]
+        let status = ItemStatus(id: "i1", status: .connected, lastSync: nil)
+        let result = DashboardAccountDrillInSummary.presentation(
+            for: acct, transactions: txns, itemStatus: status, fallbackFreshnessLabel: "never"
+        )
+        #expect(!result.displayName.isEmpty)
+        #expect(result.transactionCount == 2)
+        #expect(result.pendingTransactionCount == 1)
+        #expect(result.syncState == .connected)
+        #expect(result.freshnessLabel == "never")
+    }
+}

--- a/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Dashboard status readiness")
+struct DashboardStatusReadinessTests {
+    private func evaluate(
+        isDemoMode: Bool = false,
+        isInitialLoad: Bool = false,
+        serverConnected: Bool = true,
+        credentialsConfigured: Bool? = true,
+        linkedItemCount: Int = 2,
+        accountCount: Int = 3,
+        syncedItemCount: Int = 2,
+        needsLoginItemCount: Int = 0,
+        erroredItemCount: Int = 0,
+        isSyncStale: Bool = false,
+        lastSyncRelative: String? = "2m ago",
+        errorMessage: String? = nil,
+        notificationsEnabled: Bool = false,
+        notificationPermission: NotificationPermissionPresentation? = nil
+    ) -> DashboardStatusReadiness {
+        DashboardStatusReadiness.evaluate(
+            isDemoMode: isDemoMode,
+            isInitialLoad: isInitialLoad,
+            serverConnected: serverConnected,
+            credentialsConfigured: credentialsConfigured,
+            linkedItemCount: linkedItemCount,
+            accountCount: accountCount,
+            syncedItemCount: syncedItemCount,
+            needsLoginItemCount: needsLoginItemCount,
+            erroredItemCount: erroredItemCount,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            errorMessage: errorMessage,
+            notificationsEnabled: notificationsEnabled,
+            notificationPermission: notificationPermission
+        )
+    }
+
+    @Test("Demo mode is healthy with a connect prompt")
+    func demo() {
+        let readiness = evaluate(isDemoMode: true)
+        #expect(readiness.level == .healthy)
+        #expect(readiness.title == "Demo data ready")
+        #expect(readiness.primaryAction == .addAccount)
+        #expect(readiness.secondaryActions == [.openSettings])
+    }
+
+    @Test("Initial load is a passive loading level")
+    func loading() {
+        #expect(evaluate(isInitialLoad: true).level == .loading)
+    }
+
+    @Test("Missing local auth token blocks toward settings")
+    func authMissing() {
+        let readiness = evaluate(errorMessage: "Auth token is unavailable")
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Local server auth missing")
+        #expect(readiness.primaryAction == .openSettings)
+    }
+
+    @Test("Rejected local auth (401/403) blocks")
+    func authRejected() {
+        #expect(evaluate(errorMessage: "PlaidBar server returned 401").title == "Local server auth rejected")
+        #expect(evaluate(errorMessage: "VaultPeek companion server returned 403").title == "Local server auth rejected")
+    }
+
+    @Test("Offline server blocks toward a connection check")
+    func offline() {
+        let readiness = evaluate(serverConnected: false)
+        #expect(readiness.level == .blocked)
+        #expect(readiness.primaryAction == .checkServer)
+    }
+
+    @Test("Missing Plaid credentials block")
+    func credentialsMissing() {
+        #expect(evaluate(credentialsConfigured: false).title == "Plaid credentials missing")
+    }
+
+    @Test("Server mode mismatch blocks before item guidance")
+    func modeMismatch() {
+        let readiness = evaluate(erroredItemCount: 1, errorMessage: "Server is running in production, not sandbox")
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "Server mode mismatch")
+        #expect(readiness.primaryAction == .checkServer)
+    }
+
+    @Test("Errored items block with reconnect (pluralized)")
+    func erroredItems() {
+        let readiness = evaluate(erroredItemCount: 2)
+        #expect(readiness.level == .blocked)
+        #expect(readiness.title == "2 items need attention")
+        #expect(readiness.primaryAction == .reconnect)
+    }
+
+    @Test("Login-needed items warn with reconnect (singular)")
+    func needsLogin() {
+        let readiness = evaluate(needsLoginItemCount: 1)
+        #expect(readiness.level == .warning)
+        #expect(readiness.title == "1 item needs update")
+        #expect(readiness.primaryAction == .reconnect)
+    }
+
+    @Test("A recent action failure warns with the sanitized detail")
+    func recentError() {
+        let readiness = evaluate(errorMessage: "Something failed")
+        #expect(readiness.level == .warning)
+        #expect(readiness.title == "Recent action failed")
+    }
+
+    @Test("No linked institution warns toward connect")
+    func noLink() {
+        #expect(evaluate(linkedItemCount: 0).title == "No institution linked")
+    }
+
+    @Test("No accounts loaded warns toward load")
+    func noAccounts() {
+        #expect(evaluate(accountCount: 0).title == "Balances not loaded")
+    }
+
+    @Test("First sync needed when nothing has synced")
+    func firstSync() {
+        #expect(evaluate(syncedItemCount: 0).title == "First sync needed")
+    }
+
+    @Test("Partial sync warns to finish")
+    func partialSync() {
+        #expect(evaluate(linkedItemCount: 3, accountCount: 3, syncedItemCount: 1).title == "First sync incomplete")
+    }
+
+    @Test("Stale sync warns to refresh, echoing the last sync time")
+    func staleSync() {
+        let readiness = evaluate(isSyncStale: true)
+        #expect(readiness.title == "Sync is stale")
+        #expect(readiness.detail.contains("2m ago"))
+    }
+
+    @Test("Stale sync with no timestamp says never")
+    func staleNoTimestamp() {
+        #expect(evaluate(isSyncStale: true, lastSyncRelative: nil).detail.contains("never"))
+    }
+
+    @Test("Fully healthy state offers refresh and add account")
+    func healthy() {
+        let readiness = evaluate()
+        #expect(readiness.level == .healthy)
+        #expect(readiness.title == "Plaid sync healthy")
+        #expect(readiness.secondaryActions == [.addAccount])
+    }
+
+    @Test("Healthy with no last sync says just now")
+    func healthyNoTimestamp() {
+        #expect(evaluate(lastSyncRelative: nil).detail.contains("just now"))
+    }
+
+    @Test("Notification recovery surfaces for each permission action")
+    func notificationRecovery() {
+        func recovery(kind: NotificationPermissionKind) -> DashboardStatusReadiness {
+            evaluate(notificationsEnabled: true, notificationPermission: .evaluate(kind: kind))
+        }
+        #expect(recovery(kind: .notDetermined).title == "Notification permission not requested")
+        #expect(recovery(kind: .denied).title == "Notifications blocked")
+        #expect(recovery(kind: .unknown).title == "Notification permission unknown")
+        #expect(recovery(kind: .unsupported).title == "Notification identity unavailable")
+    }
+
+    @Test("Notification recovery with no action falls back to settings")
+    func notificationRecoveryNilAction() {
+        let permission = NotificationPermissionPresentation(
+            label: "x", detail: "y", iconName: "i", tone: .secondary,
+            recoveryAction: nil, isNotificationToggleDisabled: true, shouldDisableNotifications: true
+        )
+        let readiness = evaluate(notificationsEnabled: true, notificationPermission: permission)
+        #expect(readiness.title == "Notifications unavailable")
+        #expect(readiness.primaryAction == .openSettings)
+    }
+
+    @Test("Notifications disabled skips recovery and stays healthy")
+    func notificationsDisabledNoRecovery() {
+        #expect(evaluate(notificationsEnabled: false, notificationPermission: .evaluate(kind: .denied)).level == .healthy)
+    }
+
+    @Test("Every action exposes a default title and icon")
+    func actionDefaults() {
+        let actions: [DashboardStatusReadinessAction] = [
+            .checkServer, .addAccount, .refresh, .reconnect, .openSettings,
+            .requestNotificationPermission, .openNotificationSettings,
+        ]
+        for action in actions {
+            #expect(!action.defaultTitle.isEmpty)
+            #expect(!action.defaultIconName.isEmpty)
+        }
+    }
+
+    @Test("Error severity tracks the readiness level")
+    func errorSeverity() {
+        #expect(evaluate().errorSeverity == nil)
+        #expect(evaluate(isInitialLoad: true).errorSeverity == nil)
+        #expect(evaluate(needsLoginItemCount: 1).errorSeverity == .advisory)
+        #expect(evaluate(erroredItemCount: 1).errorSeverity == .blocking)
+    }
+}

--- a/Tests/PlaidBarCoreTests/FirstRunCompletionTests.swift
+++ b/Tests/PlaidBarCoreTests/FirstRunCompletionTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("First run completion state")
+struct FirstRunCompletionTests {
+    private func evaluate(
+        isDemoMode: Bool = false,
+        serverConnected: Bool = true,
+        linkedItemCount: Int = 1,
+        accountCount: Int = 1,
+        transactionCount: Int = 5,
+        syncedItemCount: Int = 1,
+        errorMessage: String? = nil
+    ) -> FirstRunCompletionState {
+        FirstRunCompletionState.evaluate(
+            isDemoMode: isDemoMode,
+            serverConnected: serverConnected,
+            linkedItemCount: linkedItemCount,
+            accountCount: accountCount,
+            transactionCount: transactionCount,
+            syncedItemCount: syncedItemCount,
+            errorMessage: errorMessage
+        )
+    }
+
+    @Test("Demo mode is immediately ready")
+    func demo() {
+        let state = evaluate(isDemoMode: true, serverConnected: false, linkedItemCount: 0)
+        #expect(state.step == .ready)
+        #expect(state.title == "Demo ready")
+        #expect(state.isReady)
+        #expect(!state.canRetry)
+    }
+
+    @Test("An error message blocks with a retry")
+    func errorBlocks() {
+        let state = evaluate(errorMessage: "Plaid Link failed")
+        #expect(state.step == .blocked)
+        #expect(state.title == "Connection needs attention")
+        #expect(state.canRetry)
+        #expect(!state.isReady)
+    }
+
+    @Test("Offline server blocks")
+    func offline() {
+        let state = evaluate(serverConnected: false)
+        #expect(state.step == .blocked)
+        #expect(state.title == "Server offline")
+    }
+
+    @Test("No linked item routes back to Plaid Link")
+    func noLinkedItem() {
+        #expect(evaluate(linkedItemCount: 0).step == .openPlaidLink)
+    }
+
+    @Test("No accounts routes to load accounts")
+    func noAccounts() {
+        #expect(evaluate(accountCount: 0).step == .loadAccounts)
+    }
+
+    @Test("Partial sync stays on the sync step with progress detail")
+    func partialSync() {
+        let state = evaluate(linkedItemCount: 2, accountCount: 2, transactionCount: 10, syncedItemCount: 1)
+        #expect(state.step == .syncTransactions)
+        #expect(state.title == "First sync incomplete")
+        #expect(state.detail.contains("1 of 2 linked items synced"))
+    }
+
+    @Test("Accounts loaded but unsynced explains the pending first sync")
+    func accountsLoadedNoSync() {
+        let withTransactions = evaluate(linkedItemCount: 1, accountCount: 1, transactionCount: 3, syncedItemCount: 0)
+        #expect(withTransactions.step == .syncTransactions)
+        #expect(withTransactions.title == "Accounts loaded")
+        #expect(withTransactions.detail.contains("Transactions are present"))
+
+        let noTransactions = evaluate(linkedItemCount: 1, accountCount: 1, transactionCount: 0, syncedItemCount: 0)
+        #expect(noTransactions.detail.contains("Run the first transaction sync check"))
+    }
+
+    @Test("Fully synced is ready, with singular and plural transaction copy")
+    func ready() {
+        let plural = evaluate(transactionCount: 5, syncedItemCount: 1)
+        #expect(plural.step == .ready)
+        #expect(plural.title == "Dashboard ready")
+        #expect(plural.detail.contains("5 transactions synced"))
+
+        let singular = evaluate(transactionCount: 1, syncedItemCount: 1)
+        #expect(singular.detail.contains("1 transaction synced"))
+        #expect(!singular.detail.contains("1 transactions"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/FormattersTests.swift
+++ b/Tests/PlaidBarCoreTests/FormattersTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Formatters")
+struct FormattersTests {
+    @Test("USD currency renders each format")
+    func usdCurrency() {
+        #expect(Formatters.currency(12_450.32, format: .full).contains("12,450"))
+        #expect(Formatters.currency(12_450, format: .compact).contains("12,450"))
+        #expect(Formatters.currency(12_400, format: .abbreviated) == "$12.4K")
+        #expect(Formatters.currency(1_500_000, format: .abbreviated) == "$1.5M")
+        #expect(Formatters.currency(500, format: .abbreviated) == "$500")
+        #expect(Formatters.currency(-2_000, format: .abbreviated) == "-$2.0K")
+    }
+
+    @Test("Non-USD currency uses the supplied currency code")
+    func nonUsdCurrency() {
+        #expect(!Formatters.currency(1_000, format: .full, currencyCode: "EUR").isEmpty)
+        #expect(!Formatters.currency(1_000, format: .compact, currencyCode: "EUR").isEmpty)
+        #expect(Formatters.currency(1_500, format: .abbreviated, currencyCode: "EUR") == "EUR1.5K")
+    }
+
+    @Test("Percent formats with the requested precision")
+    func percent() {
+        #expect(Formatters.percent(42.5, decimals: 1) == "42.5%")
+        #expect(Formatters.percent(42, decimals: 0) == "42%")
+    }
+
+    @Test("Display date special-cases today and yesterday")
+    func displayDate() throws {
+        #expect(Formatters.displayDate(Date()) == "Today")
+        let yesterday = try #require(Calendar.current.date(byAdding: .day, value: -1, to: Date()))
+        #expect(Formatters.displayDate(yesterday) == "Yesterday")
+        let old = try #require(Formatters.parseTransactionDate("2020-01-15"))
+        #expect(Formatters.displayDate(old) != "Today")
+        #expect(Formatters.displayDate(old) != "Yesterday")
+    }
+
+    @Test("Canonical transaction date keys are validated structurally")
+    func canonicalKey() {
+        #expect(Formatters.isCanonicalTransactionDateKey("2026-06-14"))
+        #expect(!Formatters.isCanonicalTransactionDateKey("2026/06/14"))
+        #expect(!Formatters.isCanonicalTransactionDateKey("2026-6-4"))
+        #expect(!Formatters.isCanonicalTransactionDateKey("not-a-date"))
+        #expect(!Formatters.isCanonicalTransactionDateKey("2026-06-1x"))
+    }
+
+    @Test("Transaction dates round-trip through parse and format")
+    func transactionDateRoundTrip() throws {
+        let date = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        #expect(Formatters.transactionDateString(date) == "2026-06-14")
+        #expect(Formatters.parseTransactionDate("garbage") == nil)
+    }
+
+    @Test("displayTransactionDate falls back to the raw string when unparseable")
+    func displayTransactionDate() {
+        #expect(Formatters.displayTransactionDate("not-a-date") == "not-a-date")
+    }
+
+    @Test("relativeDate produces a non-empty relative string")
+    func relativeDate() {
+        #expect(!Formatters.relativeDate(Date().addingTimeInterval(-3_600)).isEmpty)
+    }
+}

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -331,6 +331,132 @@ struct GlanceSnapshotTests {
         #expect(try GlanceSnapshotStore.consumeCommand(directory: directory) == nil)
     }
 
+    @Test("Change direction maps sign to glyph for up, down, and flat")
+    func changeDirectionGlyphs() {
+        #expect(GlanceSnapshot.ChangeDirection.evaluate(5) == .up)
+        #expect(GlanceSnapshot.ChangeDirection.evaluate(-5) == .down)
+        #expect(GlanceSnapshot.ChangeDirection.evaluate(0) == .flat)
+        #expect(GlanceSnapshot.ChangeDirection.up.glyph == "▲")
+        #expect(GlanceSnapshot.ChangeDirection.down.glyph == "▼")
+        #expect(GlanceSnapshot.ChangeDirection.flat.glyph == "■")
+    }
+
+    @Test("Signed change text prefixes a plus only for positive changes")
+    func signedChangeText() {
+        func snapshot(todayChange: Double) -> GlanceSnapshot {
+            GlanceSnapshot(netWorth: 1_000, todayChange: todayChange, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [], isDemo: false)
+        }
+        #expect(snapshot(todayChange: 250).signedChangeText.hasPrefix("+"))
+        #expect(!snapshot(todayChange: -250).signedChangeText.hasPrefix("+"))
+        #expect(!snapshot(todayChange: 0).signedChangeText.hasPrefix("+"))
+        #expect(snapshot(todayChange: -250).changeDirection == .down)
+        #expect(snapshot(todayChange: 0).changeDirection == .flat)
+    }
+
+    @Test("Accessibility summary prefixes a demo notice only in demo mode")
+    func accessibilitySummaryDemoPrefix() {
+        let demo = GlanceSnapshot(netWorth: 1_000, todayChange: 10, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [], isDemo: true)
+        let live = GlanceSnapshot(netWorth: 1_000, todayChange: 10, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [], isDemo: false)
+        #expect(demo.accessibilitySummary.hasPrefix("Demo data. "))
+        #expect(!live.accessibilitySummary.hasPrefix("Demo data. "))
+        #expect(live.accessibilitySummary.contains("Net worth"))
+    }
+
+    @Test("Today change is zero when no prior-day balance exists")
+    func todayChangeNoPriorDay() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let snapshot = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: [BalanceSnapshot(date: now, balance: 1_000)],
+            updatedAt: now,
+            isDemo: false
+        )
+        #expect(snapshot.todayChange == 0)
+    }
+
+    @Test("Sparkline does not duplicate the current net worth when history already ends on it")
+    func sparklineNoDuplicate() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let prior = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let snapshot = GlanceSnapshot.make(
+            netWorth: 1_250,
+            balanceHistory: [BalanceSnapshot(date: prior, balance: 1_000), BalanceSnapshot(date: now, balance: 1_250)],
+            updatedAt: now,
+            isDemo: false
+        )
+        #expect(snapshot.sparkline.count == 2)
+    }
+
+    @Test("Sparkline appends the current net worth when history ends on a different value")
+    func sparklineAppendsCurrent() throws {
+        let now = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let prior = try #require(Calendar.current.date(byAdding: .day, value: -1, to: now))
+        let snapshot = GlanceSnapshot.make(
+            netWorth: 1_300,
+            balanceHistory: [BalanceSnapshot(date: prior, balance: 1_000), BalanceSnapshot(date: now, balance: 1_250)],
+            updatedAt: now,
+            isDemo: false
+        )
+        #expect(snapshot.sparkline.count == 3)
+    }
+
+    @Test("Placeholder is a zeroed, non-demo snapshot")
+    func placeholder() {
+        let placeholder = GlanceSnapshot.placeholder(updatedAt: Date(timeIntervalSince1970: 0))
+        #expect(placeholder.netWorth == 0)
+        #expect(placeholder.todayChange == 0)
+        #expect(placeholder.sparkline.isEmpty)
+        #expect(!placeholder.isDemo)
+    }
+
+    @Test("hasSameDisplayContent compares every display field")
+    func hasSameDisplayContent() {
+        let base = GlanceSnapshot(netWorth: 100, todayChange: 1, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [0, 1], isDemo: false)
+        let same = base
+        let differentBalance = GlanceSnapshot(netWorth: 200, todayChange: 1, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [0, 1], isDemo: false)
+        #expect(base.hasSameDisplayContent(as: same))
+        #expect(!base.hasSameDisplayContent(as: differentBalance))
+    }
+
+    @Test("saveIfChanged is a no-op when display content is identical")
+    func saveIfChangedNoOp() throws {
+        let directory = temporaryDirectory()
+        let snapshot = GlanceSnapshot(netWorth: 100, todayChange: 1, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [0, 1], isDemo: false)
+        #expect(try GlanceSnapshotStore.saveIfChanged(snapshot, directory: directory))
+        #expect(try GlanceSnapshotStore.saveIfChanged(snapshot, directory: directory) == false)
+    }
+
+    @Test("clear removes a saved snapshot and is safe to call when absent")
+    func clearRemovesSnapshot() throws {
+        let directory = temporaryDirectory()
+        let snapshot = GlanceSnapshot(netWorth: 100, todayChange: 1, updatedAt: Date(timeIntervalSince1970: 0), sparkline: [0, 1], isDemo: false)
+        try GlanceSnapshotStore.save(snapshot, directory: directory)
+        try GlanceSnapshotStore.clear(directory: directory)
+        #expect(throws: (any Error).self) {
+            try GlanceSnapshotStore.load(directory: directory)
+        }
+        // Clearing again with nothing present must not throw.
+        try GlanceSnapshotStore.clear(directory: directory)
+    }
+
+    @Test("System debounce scheduler sleeps for the requested duration")
+    func systemDebounceSchedulerSleeps() async throws {
+        let scheduler = SystemDebounceScheduler()
+        try await scheduler.sleep(for: .milliseconds(1))
+    }
+
+    @Test("Debouncer cancel clears pending work without writing")
+    func debouncerCancelClearsPendingWork() async {
+        let debouncer = GlanceSnapshotWriteDebouncer(delay: .milliseconds(1), scheduler: ManualDebounceScheduler())
+        await debouncer.schedule(firstSnapshot(netWorth: 1)) { _ in }
+        await debouncer.cancel()
+    }
+
+    @Test("Snapshot directory resolves to a usable URL")
+    func snapshotDirectoryResolves() {
+        #expect(!GlanceSnapshotStore.snapshotDirectory().path.isEmpty)
+    }
+
     private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("GlanceSnapshotTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/PlaidBarCoreTests/ItemRecoveryTargetTests.swift
+++ b/Tests/PlaidBarCoreTests/ItemRecoveryTargetTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Item recovery target selection")
+struct ItemRecoveryTargetTests {
+    private func status(
+        _ id: String,
+        _ connection: ItemConnectionStatus,
+        institution: String? = "Acme Bank"
+    ) -> ItemStatus {
+        ItemStatus(id: id, institutionName: institution, status: connection)
+    }
+
+    // MARK: Selection
+
+    @Test("Error items outrank update-mode items as the recovery target")
+    func errorOutranksUpdateMode() {
+        let statuses = [
+            status("a", .loginRequired),
+            status("b", .error),
+        ]
+        #expect(ItemRecoveryTarget.item(from: statuses)?.id == "b")
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "b")
+    }
+
+    @Test("First update-mode item is chosen when nothing is in error")
+    func firstUpdateModeChosen() {
+        let statuses = [
+            status("a", .connected),
+            status("b", .pendingExpiration),
+            status("c", .permissionRevoked),
+        ]
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == "b")
+    }
+
+    @Test("Healthy / transient-only items expose no recovery target")
+    func noTargetForHealthyOrTransient() {
+        let statuses = [
+            status("a", .connected),
+            status("b", .loginRepaired),
+            status("c", .providerOutage),
+        ]
+        #expect(ItemRecoveryTarget.item(from: statuses) == nil)
+        #expect(ItemRecoveryTarget.itemId(from: statuses) == nil)
+        #expect(ItemRecoveryTarget.actionTitle(from: statuses) == nil)
+        #expect(ItemRecoveryTarget.recoveryDetail(from: statuses) == nil)
+    }
+
+    @Test("Empty input has no target")
+    func emptyInput() {
+        #expect(ItemRecoveryTarget.itemId(from: []) == nil)
+        #expect(ItemRecoveryTarget.actionTitle(from: []) == nil)
+        #expect(ItemRecoveryTarget.recoveryDetail(from: []) == nil)
+    }
+
+    // MARK: Action titles
+
+    @Test("Action title reconnects a named institution on error")
+    func actionTitleReconnectNamed() {
+        #expect(ItemRecoveryTarget.actionTitle(from: [status("a", .error)]) == "Reconnect Acme Bank")
+    }
+
+    @Test("Action title updates a named institution for new accounts")
+    func actionTitleUpdateNamed() {
+        #expect(
+            ItemRecoveryTarget.actionTitle(from: [status("a", .newAccountsAvailable)]) == "Update Acme Bank"
+        )
+    }
+
+    @Test("Action title falls back to a generic verb when the institution is unnamed")
+    func actionTitleFallback() {
+        #expect(ItemRecoveryTarget.actionTitle(from: [status("a", .error, institution: nil)]) == "Reconnect Item")
+        #expect(
+            ItemRecoveryTarget.actionTitle(from: [status("a", .newAccountsAvailable, institution: nil)]) == "Update Item"
+        )
+    }
+
+    @Test("Blank institution names are treated as unnamed (trimmed)")
+    func blankInstitutionTreatedAsUnnamed() {
+        #expect(ItemRecoveryTarget.actionTitle(from: [status("a", .error, institution: "   ")]) == "Reconnect Item")
+    }
+
+    // MARK: Recovery detail
+
+    @Test("Each actionable status has distinct named recovery copy")
+    func recoveryDetailNamedPerStatus() {
+        let actionable: [ItemConnectionStatus] = [
+            .loginRequired, .pendingExpiration, .pendingDisconnect,
+            .permissionRevoked, .newAccountsAvailable, .error,
+        ]
+        var seen = Set<String>()
+        for connection in actionable {
+            let detail = ItemRecoveryTarget.recoveryDetail(from: [status("a", connection)])
+            #expect(detail?.isEmpty == false)
+            #expect(detail?.contains("Acme Bank") == true)
+            if let detail { seen.insert(detail) }
+        }
+        #expect(seen.count == actionable.count)
+    }
+
+    @Test("Recovery detail has an unnamed fallback for each actionable status")
+    func recoveryDetailUnnamedPerStatus() {
+        let actionable: [ItemConnectionStatus] = [
+            .loginRequired, .pendingExpiration, .pendingDisconnect,
+            .permissionRevoked, .newAccountsAvailable, .error,
+        ]
+        for connection in actionable {
+            let detail = ItemRecoveryTarget.recoveryDetail(from: [status("a", connection, institution: nil)])
+            #expect(detail?.isEmpty == false)
+            #expect(detail?.contains("Acme Bank") == false)
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Local AI insights model accessors")
+struct LocalAIInsightsModelTests {
+    @Test("Insight window ids mirror their raw values")
+    func windowIds() {
+        for window in LocalAIInsightWindow.allCases {
+            #expect(window.id == window.rawValue)
+        }
+    }
+
+    @Test("Category resolution source has a distinct display name per case")
+    func resolutionSourceDisplayNames() {
+        #expect(LocalAICategoryResolutionSource.localAISuggestion.displayName == "Local AI")
+        #expect(LocalAICategoryResolutionSource.appleNaturalLanguage.displayName == "Suggested")
+        #expect(LocalAICategoryResolutionSource.plaidCategory.displayName == "Plaid")
+        #expect(LocalAICategoryResolutionSource.fallbackOther.displayName == "Other")
+    }
+
+    @Test("DTO identities derive from their key fields")
+    func dtoIdentities() {
+        let total = LocalAICategoryTotal(
+            category: .foodAndDrink, totalAmount: 100, transactionCount: 3,
+            transactionIds: ["t1"], evidence: []
+        )
+        #expect(total.id == "FOOD_AND_DRINK")
+
+        let item = LocalAITransactionInsightItem(
+            transactionId: "t1", accountId: "a1", date: "2026-06-14", displayName: "Coffee",
+            amount: 5, effectiveCategory: .foodAndDrink, plaidCategory: nil,
+            categorySource: .appleNaturalLanguage, pending: false, evidence: []
+        )
+        #expect(item.id == "t1")
+
+        let suggestion = LocalAICategorySuggestion(
+            transactionId: "t1", suggestedCategory: .shopping, confidence: 0.9, evidence: []
+        )
+        #expect(suggestion.id == "t1-GENERAL_MERCHANDISE")
+    }
+}

--- a/Tests/PlaidBarCoreTests/NetWorthTrendPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/NetWorthTrendPresentationTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Net worth trend presentation (AND-498)")
+struct NetWorthTrendPresentationTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func snap(daysAgo: Int, balance: Double) -> BalanceSnapshot {
+        BalanceSnapshot(date: now.addingTimeInterval(TimeInterval(-daysAgo) * 86_400), balance: balance)
+    }
+
+    @Test("Available when enough in-window points exist, mirroring BalanceTrend")
+    func availableWithHistory() {
+        let history = [snap(daysAgo: 30, balance: 1_000), snap(daysAgo: 1, balance: 1_500)]
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: history, now: now, windowDays: 90, calendar: calendar
+        )
+        guard case let .available(trend) = presentation else {
+            Issue.record("expected .available, got \(presentation)")
+            return
+        }
+        #expect(trend.direction == .up)
+        #expect(trend.delta == 500)
+    }
+
+    @Test("Insufficient history reports in-window point count and required count")
+    func insufficientHistory() {
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: [snap(daysAgo: 5, balance: 1_000)], now: now, windowDays: 90, calendar: calendar
+        )
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation else {
+            Issue.record("expected .insufficientHistory, got \(presentation)")
+            return
+        }
+        #expect(pointCount == 1)
+        #expect(requiredPointCount == BalanceTrend.requiredPointCount)
+    }
+
+    @Test("Accessibility summary mirrors the trend when available")
+    func accessibilityAvailable() {
+        let history = [snap(daysAgo: 30, balance: 1_000), snap(daysAgo: 1, balance: 1_500)]
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: history, now: now, windowDays: 90, calendar: calendar
+        )
+        guard case let .available(trend) = presentation else {
+            Issue.record("expected .available")
+            return
+        }
+        #expect(presentation.accessibilitySummary == trend.accessibilitySummary)
+    }
+
+    @Test("Accessibility summary pluralizes when two more snapshots are needed")
+    func accessibilityInsufficientPlural() {
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: [], now: now, windowDays: 90, calendar: calendar
+        )
+        #expect(presentation.accessibilitySummary.contains("Needs 2 more local balance snapshots."))
+    }
+
+    @Test("Accessibility summary is singular when exactly one snapshot is needed")
+    func accessibilityInsufficientSingular() {
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: [snap(daysAgo: 5, balance: 1_000)], now: now, windowDays: 90, calendar: calendar
+        )
+        #expect(presentation.accessibilitySummary.contains("Needs 1 more local balance snapshot."))
+        #expect(!presentation.accessibilitySummary.contains("snapshots"))
+    }
+
+    @Test("Non-positive window yields insufficient history with zero points")
+    func nonPositiveWindow() {
+        let history = [snap(daysAgo: 1, balance: 1), snap(daysAgo: 2, balance: 2)]
+        let presentation = NetWorthTrendPresentation.evaluate(
+            history: history, now: now, windowDays: 0, calendar: calendar
+        )
+        guard case let .insufficientHistory(pointCount, _) = presentation else {
+            Issue.record("expected .insufficientHistory")
+            return
+        }
+        #expect(pointCount == 0)
+    }
+}

--- a/Tests/PlaidBarCoreTests/NotificationPermissionPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationPermissionPresentationTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Notification permission presentation")
+struct NotificationPermissionPresentationTests {
+    @Test("Authorized is positive with notifications enabled and no recovery")
+    func authorized() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .authorized)
+        #expect(presentation.label == "Allowed")
+        #expect(presentation.tone == .positive)
+        #expect(presentation.recoveryAction == nil)
+        #expect(presentation.isNotificationToggleDisabled == false)
+        #expect(presentation.shouldDisableNotifications == false)
+    }
+
+    @Test("Denied warns and routes to System Settings")
+    func denied() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .denied)
+        #expect(presentation.tone == .warning)
+        #expect(presentation.recoveryAction == .openSystemSettings)
+        #expect(presentation.recoveryActionTitle == "Open System Settings")
+        #expect(presentation.recoveryActionIconName == "gearshape")
+        #expect(presentation.isNotificationToggleDisabled)
+        #expect(presentation.shouldDisableNotifications)
+    }
+
+    @Test("Not-determined offers a permission request and keeps the toggle live")
+    func notDetermined() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .notDetermined)
+        #expect(presentation.recoveryAction == .requestPermission)
+        #expect(presentation.recoveryActionTitle == "Request Permission")
+        #expect(presentation.recoveryActionIconName == "bell.badge")
+        #expect(presentation.isNotificationToggleDisabled == false)
+        // Still gated until the user actually grants permission.
+        #expect(presentation.shouldDisableNotifications)
+    }
+
+    @Test("Unsupported launch points at the app bundle and is non-interactive")
+    func unsupported() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .unsupported)
+        #expect(presentation.tone == .secondary)
+        #expect(presentation.recoveryAction == .runBundledApp)
+        #expect(presentation.recoveryActionTitle == "Run App Bundle")
+        #expect(presentation.recoveryActionIconName == "app.badge")
+        #expect(presentation.isRecoveryActionInteractive == false)
+        #expect(presentation.isNotificationToggleDisabled)
+    }
+
+    @Test("Unknown asks the user to check again")
+    func unknown() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .unknown)
+        #expect(presentation.recoveryAction == .checkAgain)
+        #expect(presentation.recoveryActionTitle == "Check Again")
+        #expect(presentation.recoveryActionIconName == "arrow.clockwise")
+    }
+
+    @Test("Provisional and ephemeral are positive with no recovery needed")
+    func provisionalAndEphemeral() {
+        for kind in [NotificationPermissionKind.provisional, .ephemeral] {
+            let presentation = NotificationPermissionPresentation.evaluate(kind: kind)
+            #expect(presentation.tone == .positive)
+            #expect(presentation.recoveryAction == nil)
+            #expect(presentation.shouldDisableNotifications == false)
+        }
+    }
+
+    @Test("Explicit recovery title and icon override the action defaults")
+    func explicitOverrides() {
+        let presentation = NotificationPermissionPresentation(
+            label: "Custom",
+            detail: "Detail",
+            iconName: "icon",
+            tone: .secondary,
+            recoveryAction: .checkAgain,
+            recoveryActionTitle: "Custom Title",
+            recoveryActionIconName: "custom.icon",
+            isNotificationToggleDisabled: false,
+            shouldDisableNotifications: false
+        )
+        #expect(presentation.recoveryActionTitle == "Custom Title")
+        #expect(presentation.recoveryActionIconName == "custom.icon")
+    }
+
+    @Test("No recovery action means no derived title or icon")
+    func noRecoveryNoTitle() {
+        let presentation = NotificationPermissionPresentation.evaluate(kind: .authorized)
+        #expect(presentation.recoveryActionTitle == nil)
+        #expect(presentation.recoveryActionIconName == nil)
+    }
+}

--- a/Tests/PlaidBarCoreTests/PrivacyMaskPresentationHelpersTests.swift
+++ b/Tests/PlaidBarCoreTests/PrivacyMaskPresentationHelpersTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Privacy mask presentation helpers")
+struct PrivacyMaskPresentationHelpersTests {
+    @Test("value applies the style-specific mask token when enabled")
+    func valueStyles() {
+        #expect(PrivacyMaskPresentation.value("$42", isEnabled: true, style: .compact) == PrivacyMaskPresentation.compactValue)
+        #expect(PrivacyMaskPresentation.value("$42", isEnabled: true, style: .hero) == PrivacyMaskPresentation.heroValue)
+        #expect(PrivacyMaskPresentation.value("$42", isEnabled: true, style: .detail) == PrivacyMaskPresentation.detailValue)
+    }
+
+    @Test("value passes through unmasked text when disabled")
+    func valueDisabled() {
+        #expect(PrivacyMaskPresentation.value("$42", isEnabled: false, style: .hero) == "$42")
+    }
+
+    @Test("Masked help text is present only while masking is enabled")
+    func maskedHelpText() {
+        #expect(PrivacyMaskPresentation.maskedHelpText(isEnabled: true) == PrivacyMaskPresentation.detailValue)
+        #expect(PrivacyMaskPresentation.maskedHelpText(isEnabled: false) == nil)
+    }
+
+    @Test("Currency and percent helpers mask through the shared value path")
+    func currencyAndPercent() {
+        #expect(PrivacyMaskPresentation.currency(1_000, isEnabled: true) == PrivacyMaskPresentation.compactValue)
+        #expect(PrivacyMaskPresentation.percent(50, isEnabled: true) == PrivacyMaskPresentation.compactValue)
+        // Disabled passes through a real formatted value.
+        #expect(PrivacyMaskPresentation.currency(1_000, isEnabled: false) != PrivacyMaskPresentation.compactValue)
+    }
+
+    @Test("Toggle affordance carries state through glyph shape and verb, not color")
+    func toggleAffordance() {
+        #expect(PrivacyMaskPresentation.toggleSymbolName(isMasked: true) == "eye.slash")
+        #expect(PrivacyMaskPresentation.toggleSymbolName(isMasked: false) == "eye")
+        #expect(PrivacyMaskPresentation.toggleActionLabel(isMasked: true) == "Show amounts")
+        #expect(PrivacyMaskPresentation.toggleActionLabel(isMasked: false) == "Hide amounts")
+    }
+
+    @Test("Currency tokens in free text are masked only when enabled")
+    func maskCurrencyTokens() {
+        let text = "Spent $4,545 and refunded -$1,707.50 across 12 charges."
+        let masked = PrivacyMaskPresentation.maskCurrencyTokens(in: text, isEnabled: true)
+        #expect(!masked.contains("$4,545"))
+        #expect(!masked.contains("$1,707.50"))
+        #expect(masked.contains("12 charges"))
+        #expect(masked.contains(PrivacyMaskPresentation.compactValue))
+        // Disabled leaves the text untouched.
+        #expect(PrivacyMaskPresentation.maskCurrencyTokens(in: text, isEnabled: false) == text)
+    }
+}

--- a/Tests/PlaidBarCoreTests/ProjectedBalancePresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/ProjectedBalancePresentationTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Projected balance presentation (AND-498)")
+struct ProjectedBalancePresentationTests {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func snap(daysAgo: Int, balance: Double) -> BalanceSnapshot {
+        BalanceSnapshot(date: now.addingTimeInterval(TimeInterval(-daysAgo) * 86_400), balance: balance)
+    }
+
+    @Test("Too little history yields insufficient with the raw point count")
+    func insufficientHistory() {
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: [snap(daysAgo: 1, balance: 1_000)],
+            recurring: [],
+            now: now,
+            calendar: calendar
+        )
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation else {
+            Issue.record("expected .insufficientHistory, got \(presentation)")
+            return
+        }
+        #expect(pointCount == 1)
+        #expect(requiredPointCount == PlaidBarConstants.projectedBalanceMinimumHistoryPoints)
+        #expect(presentation.projection == nil)
+    }
+
+    @Test("Enough history with no recurring signal still produces an indicative forecast")
+    func availableWithoutRecurring() {
+        let history = [snap(daysAgo: 2, balance: 900), snap(daysAgo: 0, balance: 1_000)]
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: history,
+            recurring: [],
+            now: now,
+            horizonDays: 30,
+            calendar: calendar
+        )
+        guard case let .available(projection) = presentation else {
+            Issue.record("expected .available, got \(presentation)")
+            return
+        }
+        // No recurring deltas -> a flat line anchored on the latest balance.
+        #expect(projection.anchorBalance == 1_000)
+        #expect(projection.endBalance == 1_000)
+        #expect(projection.confidence == .insufficientData)
+        #expect(presentation.projection == projection)
+    }
+
+    @Test("Accessibility summary mirrors the projection when available")
+    func accessibilityAvailable() {
+        let history = [snap(daysAgo: 2, balance: 900), snap(daysAgo: 0, balance: 1_000)]
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: history, recurring: [], now: now, calendar: calendar
+        )
+        guard case let .available(projection) = presentation else {
+            Issue.record("expected .available")
+            return
+        }
+        #expect(presentation.accessibilitySummary == projection.accessibilitySummary)
+    }
+
+    @Test("Insufficient accessibility summary pluralizes the needed snapshots")
+    func accessibilityInsufficientPlural() {
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: [], recurring: [], now: now, requiredPointCount: 3, calendar: calendar
+        )
+        #expect(presentation.accessibilitySummary.contains("Needs 3 more local balance snapshots."))
+    }
+
+    @Test("Insufficient accessibility summary is singular for one needed snapshot")
+    func accessibilityInsufficientSingular() {
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: [snap(daysAgo: 1, balance: 1)], recurring: [], now: now, requiredPointCount: 2, calendar: calendar
+        )
+        #expect(presentation.accessibilitySummary.contains("Needs 1 more local balance snapshot."))
+        #expect(!presentation.accessibilitySummary.contains("snapshots"))
+    }
+
+    @Test("A zero requirement with empty history still fails for lack of an anchor")
+    func zeroRequirementNoAnchor() {
+        let presentation = ProjectedBalancePresentation.evaluate(
+            history: [], recurring: [], now: now, requiredPointCount: 0, calendar: calendar
+        )
+        guard case let .insufficientHistory(pointCount, requiredPointCount) = presentation else {
+            Issue.record("expected .insufficientHistory, got \(presentation)")
+            return
+        }
+        #expect(pointCount == 0)
+        #expect(requiredPointCount == 0)
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReconnectRecoveryMessageTests.swift
+++ b/Tests/PlaidBarCoreTests/ReconnectRecoveryMessageTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Reconnect recovery message")
+struct ReconnectRecoveryMessageTests {
+    @Test("Invalid update-link copy names the institution when known")
+    func invalidUpdateLinkURL() {
+        let named = ReconnectRecoveryMessage.invalidUpdateLinkURL(institutionName: "Acme Bank")
+        #expect(named.contains("for Acme Bank"))
+        #expect(named.contains("Reconnect Acme Bank"))
+
+        let unnamed = ReconnectRecoveryMessage.invalidUpdateLinkURL(institutionName: nil)
+        #expect(!unnamed.contains("for "))
+        #expect(unnamed.contains("Reconnect Item"))
+    }
+
+    @Test("Browser-open-failed copy names the institution when known")
+    func browserOpenFailed() {
+        #expect(ReconnectRecoveryMessage.browserOpenFailed(institutionName: "Acme Bank").contains("Acme Bank"))
+        #expect(ReconnectRecoveryMessage.browserOpenFailed(institutionName: nil).contains("Reconnect Item"))
+    }
+
+    @Test("Create-failed copy appends a sanitized detail when present")
+    func createFailedWithDetail() {
+        let message = ReconnectRecoveryMessage.createFailed(errorMessage: "The link request timed out.", institutionName: "Acme Bank")
+        #expect(message.contains("Acme Bank"))
+        #expect(message.contains("timed out"))
+        #expect(message.contains("Reconnect Acme Bank"))
+    }
+
+    @Test("Create-failed copy omits the detail when there is no error message")
+    func createFailedWithoutDetail() {
+        let message = ReconnectRecoveryMessage.createFailed(errorMessage: nil, institutionName: nil)
+        #expect(message.contains("could not create a reconnect link"))
+        #expect(message.contains("Reconnect Item"))
+    }
+
+    @Test("Blank institution names are treated as unknown")
+    func blankInstitutionName() {
+        #expect(ReconnectRecoveryMessage.invalidUpdateLinkURL(institutionName: "   ").contains("Reconnect Item"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/RecurringDetectorHelpersTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringDetectorHelpersTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Recurring detector helpers")
+struct RecurringDetectorHelpersTests {
+    private func tx(_ id: String, date: String) -> TransactionDTO {
+        TransactionDTO(
+            id: id, accountId: "x", amount: 10, date: date,
+            name: id, merchantName: id, category: .subscriptions, pending: false
+        )
+    }
+
+    @Test("computeIntervals derives day gaps from a transaction sequence")
+    func computeIntervalsFromTransactions() {
+        let intervals = RecurringDetector.computeIntervals([
+            tx("a", date: "2026-01-01"),
+            tx("b", date: "2026-01-08"),
+            tx("c", date: "2026-01-15"),
+        ])
+        #expect(intervals.count == 2)
+        // Tolerance keeps the assertion robust across DST/timezone boundaries.
+        #expect(intervals.allSatisfy { abs($0 - 7) < 0.1 })
+    }
+
+    @Test("computeNextDate steps forward by the detected frequency")
+    func computeNextDate() {
+        #expect(RecurringDetector.computeNextDate(from: "2026-01-15", frequency: .weekly) == "2026-01-22")
+        #expect(RecurringDetector.computeNextDate(from: "2026-01-15", frequency: .biweekly) == "2026-01-29")
+        #expect(RecurringDetector.computeNextDate(from: "2026-01-15", frequency: .monthly) == "2026-02-15")
+        #expect(RecurringDetector.computeNextDate(from: "2026-01-15", frequency: .quarterly) == "2026-04-15")
+        #expect(RecurringDetector.computeNextDate(from: "2026-01-15", frequency: .annual) == "2027-01-15")
+    }
+
+    @Test("computeNextDate returns the input verbatim when the date is unparseable")
+    func computeNextDateUnparseable() {
+        #expect(RecurringDetector.computeNextDate(from: "not-a-date", frequency: .monthly) == "not-a-date")
+    }
+
+    @Test("classifyFrequency maps median day intervals to a cadence")
+    func classifyFrequency() {
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 7) == .weekly)
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 14) == .biweekly)
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 30) == .monthly)
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 90) == .quarterly)
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 365) == .annual)
+        #expect(RecurringDetector.classifyFrequency(medianInterval: 3) == nil)
+    }
+
+    @Test("median handles odd, even, and empty inputs")
+    func median() {
+        #expect(RecurringDetector.median([3, 1, 2]) == 2)
+        #expect(RecurringDetector.median([1, 2, 3, 4]) == 2.5)
+        #expect(RecurringDetector.median([]) == 0)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SafeToSpendModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SafeToSpendModelTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Safe-to-spend model accessors")
+struct SafeToSpendModelTests {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func component(_ kind: SafeToSpendComponentKind, _ amount: Double) -> SafeToSpendComponent {
+        SafeToSpendComponent(kind: kind, label: kind.rawValue, amount: amount)
+    }
+
+    private func makeDate(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        return calendar.startOfDay(for: calendar.date(from: components) ?? Date(timeIntervalSince1970: 0))
+    }
+
+    // MARK: visibleComponents
+
+    @Test("Visible components always keep cash and income, even at zero")
+    func visibleKeepsCashAndIncomeAtZero() {
+        let result = SafeToSpendResult(
+            amount: 0,
+            components: [component(.startingCash, 0), component(.expectedIncome, 0), component(.safetyBuffer, 0)],
+            confidence: .ok,
+            horizonEnd: Date()
+        )
+        #expect(result.visibleComponents.map(\.kind) == [.startingCash, .expectedIncome])
+    }
+
+    @Test("Visible components drop zero subtractions but keep non-zero ones")
+    func visibleDropsZeroSubtractions() {
+        let result = SafeToSpendResult(
+            amount: -50,
+            components: [component(.startingCash, 100), component(.pendingHolds, 0), component(.upcomingObligations, -150)],
+            confidence: .lowConfidence,
+            horizonEnd: Date()
+        )
+        #expect(result.visibleComponents.map(\.kind) == [.startingCash, .upcomingObligations])
+    }
+
+    // MARK: Component identity + icons
+
+    @Test("Component id mirrors its kind")
+    func componentIdentity() {
+        #expect(component(.loanPayments, -10).id == .loanPayments)
+    }
+
+    @Test("Every component kind has a non-empty, distinct icon")
+    func componentKindIcons() {
+        let icons = SafeToSpendComponentKind.allCases.map(\.iconName)
+        #expect(icons.allSatisfy { !$0.isEmpty })
+        #expect(Set(icons).count == SafeToSpendComponentKind.allCases.count)
+    }
+
+    // MARK: Confidence
+
+    @Test("Confidence is ordered least to most trustworthy")
+    func confidenceOrdering() {
+        #expect(SafeToSpendConfidence.insufficientData < .lowConfidence)
+        #expect(SafeToSpendConfidence.lowConfidence < .ok)
+        #expect(SafeToSpendConfidence.allCases.count == 3)
+    }
+
+    @Test("Confidence exposes a label and icon for every case")
+    func confidenceLabelsAndIcons() {
+        for confidence in SafeToSpendConfidence.allCases {
+            #expect(!confidence.label.isEmpty)
+            #expect(!confidence.iconName.isEmpty)
+        }
+        #expect(SafeToSpendConfidence.ok.label == "On track")
+        #expect(SafeToSpendConfidence.insufficientData.iconName == "questionmark.circle")
+    }
+
+    // MARK: Horizon
+
+    @Test("End-of-month horizon resolves to the month's final day")
+    func endOfMonthHorizon() {
+        let end = SafeToSpendHorizon.endOfMonth.endDate(asOf: makeDate(2026, 6, 15), calendar: calendar)
+        #expect(end == makeDate(2026, 6, 30))
+    }
+
+    @Test("Day horizon adds the count and clamps to at least one day")
+    func dayHorizonClamps() {
+        let start = makeDate(2026, 6, 15)
+        #expect(SafeToSpendHorizon.days(5).endDate(asOf: start, calendar: calendar) == makeDate(2026, 6, 20))
+        #expect(SafeToSpendHorizon.days(0).endDate(asOf: start, calendar: calendar) == makeDate(2026, 6, 16))
+        #expect(SafeToSpendHorizon.days(-4).endDate(asOf: start, calendar: calendar) == makeDate(2026, 6, 16))
+    }
+
+    // MARK: Inputs
+
+    @Test("Inputs clamp negative buffer, reservations, and income to safe values")
+    func inputsClampNegatives() {
+        let inputs = SafeToSpendInputs(safetyBuffer: -100, budgetReservations: -50, manualExpectedIncome: -25)
+        #expect(inputs.safetyBuffer == 0)
+        #expect(inputs.budgetReservations == 0)
+        #expect(inputs.manualExpectedIncome == 0)
+    }
+
+    @Test("Default inputs are depository-only with an end-of-month horizon")
+    func defaultInputs() {
+        #expect(SafeToSpendInputs.default.includedCashAccountTypes == [.depository])
+        #expect(SafeToSpendInputs.default.safetyBuffer == 0)
+        #expect(SafeToSpendInputs.default.manualExpectedIncome == nil)
+        #expect(SafeToSpendInputs.default.horizon == .endOfMonth)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SecondaryContentUnavailableStateTests.swift
+++ b/Tests/PlaidBarCoreTests/SecondaryContentUnavailableStateTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Secondary content unavailable state")
+struct SecondaryContentUnavailableStateTests {
+    // MARK: accounts
+
+    @Test("Accounts: initial load is a passive loading state")
+    func accountsLoading() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false, isInitialLoad: true, serverConnected: false, linkedItemCount: 0
+        )
+        #expect(state.title == "Loading accounts")
+        #expect(state.isLoading)
+        #expect(state.action == .refresh)
+    }
+
+    @Test("Accounts: server offline outranks linked-item checks")
+    func accountsServerOffline() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false, serverConnected: false, linkedItemCount: 0
+        )
+        #expect(state.title == "Server offline")
+        #expect(state.action == .checkServer)
+        #expect(!state.isLoading)
+    }
+
+    @Test("Accounts: no linked bank prompts a link")
+    func accountsNoBank() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false, serverConnected: true, linkedItemCount: 0
+        )
+        #expect(state.title == "No bank linked")
+        #expect(state.action == .addAccount)
+    }
+
+    @Test("Accounts: linked but unloaded prompts a refresh")
+    func accountsRefresh() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: false, serverConnected: true, linkedItemCount: 2
+        )
+        #expect(state.title == "Accounts not loaded")
+        #expect(state.action == .refreshAccounts)
+    }
+
+    @Test("Accounts: demo mode bypasses loading and offline gates")
+    func accountsDemoBypass() {
+        let state = SecondaryContentUnavailableState.accounts(
+            isDemoMode: true, isInitialLoad: true, serverConnected: false, linkedItemCount: 0
+        )
+        #expect(state.title == "No bank linked")
+    }
+
+    // MARK: credit
+
+    @Test("Credit: loading during initial load")
+    func creditLoading() {
+        let state = SecondaryContentUnavailableState.credit(
+            isDemoMode: false, isInitialLoad: true, serverConnected: true, linkedItemCount: 1, accountCount: 1
+        )
+        #expect(state.title == "Loading credit accounts")
+        #expect(state.isLoading)
+    }
+
+    @Test("Credit: server offline")
+    func creditOffline() {
+        let state = SecondaryContentUnavailableState.credit(
+            isDemoMode: false, serverConnected: false, linkedItemCount: 1, accountCount: 1
+        )
+        #expect(state.title == "Server offline")
+    }
+
+    @Test("Credit: no bank linked offers Plaid Link")
+    func creditNoBank() {
+        let state = SecondaryContentUnavailableState.credit(
+            isDemoMode: false, serverConnected: true, linkedItemCount: 0, accountCount: 0
+        )
+        #expect(state.title == "No bank linked")
+        #expect(state.action == .addAccount)
+        #expect(state.actionTitle == "Link Bank")
+    }
+
+    @Test("Credit: accounts not loaded")
+    func creditAccountsNotLoaded() {
+        let state = SecondaryContentUnavailableState.credit(
+            isDemoMode: false, serverConnected: true, linkedItemCount: 1, accountCount: 0
+        )
+        #expect(state.title == "Accounts not loaded")
+        #expect(state.action == .refreshAccounts)
+    }
+
+    @Test("Credit: linked accounts without a card")
+    func creditNoCard() {
+        let state = SecondaryContentUnavailableState.credit(
+            isDemoMode: false, serverConnected: true, linkedItemCount: 1, accountCount: 2
+        )
+        #expect(state.title == "No credit card linked")
+        #expect(state.actionTitle == "Link Credit Card")
+    }
+
+    // MARK: transactions
+
+    private func transactions(
+        isDemoMode: Bool = false,
+        isInitialLoad: Bool = false,
+        serverConnected: Bool = true,
+        linkedItemCount: Int = 1,
+        accountCount: Int = 1,
+        syncedItemCount: Int = 1,
+        transactionCount: Int = 0,
+        hasSearchText: Bool = false,
+        hasActiveFilters: Bool = false,
+        errorMessage: String? = nil
+    ) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.transactions(
+            isDemoMode: isDemoMode, isInitialLoad: isInitialLoad, serverConnected: serverConnected,
+            linkedItemCount: linkedItemCount, accountCount: accountCount, syncedItemCount: syncedItemCount,
+            transactionCount: transactionCount, hasSearchText: hasSearchText, hasActiveFilters: hasActiveFilters,
+            errorMessage: errorMessage
+        )
+    }
+
+    @Test("Transactions: active filters over loaded history offer a clear action")
+    func txFiltered() {
+        let state = transactions(transactionCount: 5, hasSearchText: true)
+        #expect(state.title == "No matching transactions")
+        #expect(state.action == .clearFilters)
+    }
+
+    @Test("Transactions: loading")
+    func txLoading() {
+        let state = transactions(isInitialLoad: true)
+        #expect(state.title == "Loading transactions")
+        #expect(state.isLoading)
+    }
+
+    @Test("Transactions: a recent failure surfaces the sanitized error")
+    func txError() {
+        let state = transactions(errorMessage: "The request timed out.")
+        #expect(state.title == "Recent action failed")
+        #expect(state.detail.contains("timed out"))
+        #expect(state.action == .refresh)
+    }
+
+    @Test("Transactions: server offline")
+    func txOffline() {
+        #expect(transactions(serverConnected: false).title == "Server offline")
+    }
+
+    @Test("Transactions: no bank linked")
+    func txNoBank() {
+        #expect(transactions(linkedItemCount: 0, accountCount: 0, syncedItemCount: 0).title == "No bank linked")
+    }
+
+    @Test("Transactions: accounts not loaded")
+    func txAccountsNotLoaded() {
+        #expect(transactions(accountCount: 0, syncedItemCount: 0).title == "Accounts not loaded")
+    }
+
+    @Test("Transactions: first sync needed")
+    func txFirstSync() {
+        let state = transactions(syncedItemCount: 0)
+        #expect(state.title == "First sync needed")
+        #expect(state.action == .syncTransactions)
+    }
+
+    @Test("Transactions: synced but empty uses the no-history title")
+    func txEmptyHistory() {
+        #expect(transactions(transactionCount: 0).title == "No transaction history")
+    }
+
+    @Test("Transactions: loaded count without filters uses the plain empty title")
+    func txPlainEmpty() {
+        #expect(transactions(transactionCount: 3).title == "No transactions")
+    }
+
+    // MARK: spending activity
+
+    private func spending(
+        isDemoMode: Bool = false,
+        isInitialLoad: Bool = false,
+        serverConnected: Bool = true,
+        linkedItemCount: Int = 1,
+        accountCount: Int = 1,
+        syncedItemCount: Int = 1,
+        transactionCount: Int = 1,
+        errorMessage: String? = nil
+    ) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.spendingActivity(
+            isDemoMode: isDemoMode, isInitialLoad: isInitialLoad, serverConnected: serverConnected,
+            linkedItemCount: linkedItemCount, accountCount: accountCount, syncedItemCount: syncedItemCount,
+            transactionCount: transactionCount, errorMessage: errorMessage
+        )
+    }
+
+    @Test("Spending: loading / error / offline / no-bank / accounts gates")
+    func spendingGates() {
+        #expect(spending(isInitialLoad: true).title == "Loading spending activity")
+        #expect(spending(errorMessage: "Sync failed").title == "Recent action failed")
+        #expect(spending(serverConnected: false).title == "Server offline")
+        #expect(spending(linkedItemCount: 0).title == "No bank linked")
+        #expect(spending(accountCount: 0).title == "Accounts not loaded")
+    }
+
+    @Test("Spending: titles vary on whether anything is synced")
+    func spendingDefaults() {
+        #expect(spending(syncedItemCount: 0).title == "No synced activity")
+        #expect(spending(transactionCount: 0).title == "No synced activity")
+        #expect(spending(syncedItemCount: 1, transactionCount: 2).title == "No spending activity")
+    }
+
+    // MARK: spending period
+
+    @Test("Spending period: wider window available")
+    func periodWider() {
+        let state = SecondaryContentUnavailableState.spendingPeriod(periodLabel: "June", canShowWiderPeriod: true)
+        #expect(state.title == "No activity in June")
+        #expect(state.action == .showWiderPeriod)
+        #expect(state.actionTitle == "Show 90 Days")
+    }
+
+    @Test("Spending period: no wider window offers a refresh")
+    func periodRefresh() {
+        let state = SecondaryContentUnavailableState.spendingPeriod(periodLabel: "June", canShowWiderPeriod: false)
+        #expect(state.action == .refresh)
+        #expect(state.actionTitle == "Refresh")
+    }
+
+    // MARK: recurring
+
+    private func recurring(
+        isDemoMode: Bool = false,
+        isInitialLoad: Bool = false,
+        serverConnected: Bool = true,
+        linkedItemCount: Int = 1,
+        accountCount: Int = 1,
+        syncedItemCount: Int = 1,
+        transactionCount: Int = 1,
+        errorMessage: String? = nil
+    ) -> SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.recurring(
+            isDemoMode: isDemoMode, isInitialLoad: isInitialLoad, serverConnected: serverConnected,
+            linkedItemCount: linkedItemCount, accountCount: accountCount, syncedItemCount: syncedItemCount,
+            transactionCount: transactionCount, errorMessage: errorMessage
+        )
+    }
+
+    @Test("Recurring: loading / error / offline / no-bank / accounts gates")
+    func recurringGates() {
+        #expect(recurring(isInitialLoad: true).title == "Loading recurring charges")
+        #expect(recurring(errorMessage: "Sync failed").title == "Recent action failed")
+        #expect(recurring(serverConnected: false).title == "Server offline")
+        #expect(recurring(linkedItemCount: 0).title == "No bank linked")
+        #expect(recurring(accountCount: 0).title == "Accounts not loaded")
+    }
+
+    @Test("Recurring: needs synced transactions, then reports none found")
+    func recurringDefaults() {
+        #expect(recurring(syncedItemCount: 0).title == "No synced transactions")
+        #expect(recurring(transactionCount: 0).title == "No synced transactions")
+        #expect(recurring(syncedItemCount: 1, transactionCount: 5).title == "No recurring charges found")
+    }
+}

--- a/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/SettingsPresentationTests.swift
@@ -199,4 +199,74 @@ struct SettingsPresentationTests {
 
         #expect(message.contains("Left 1 config or unrelated item untouched."))
     }
+
+    // MARK: Remediation category mapping
+
+    private func availability(
+        _ state: LocalAIAvailabilityState,
+        _ detail: String,
+        probe: String? = nil
+    ) -> LocalAIAvailability {
+        LocalAIAvailability(state: state, runtimeName: "ollama", detail: detail, probeErrorText: probe)
+    }
+
+    @Test("Remediation category is derived from state and detail keywords")
+    func remediationCategoryMapping() {
+        let cases: [(LocalAIAvailability, LocalAIRemediationCategory)] = [
+            (availability(.available, "Producing summaries on-device"), .none),
+            (availability(.disabled, "Local AI is off"), .disabled),
+            (availability(.disabled, "Cloud endpoint not supported"), .unsupportedConfiguration),
+            (availability(.checking, "Verifying local runtime"), .checking),
+            (availability(.unavailable, "No installed local model"), .noInstalledModel),
+            (availability(.unavailable, "Configured with a non-local endpoint"), .unsupportedConfiguration),
+            (availability(.unavailable, "Ollama is not reachable"), .runtimeUnavailable),
+            (availability(.unavailable, "Probe returned an error"), .modelError),
+            (availability(.unavailable, "Some unexpected failure"), .runtimeUnavailable),
+        ]
+        for (item, expected) in cases {
+            #expect(LocalAIAvailabilityPresentation.remediationCategory(for: item) == expected)
+        }
+    }
+
+    @Test("Probe error text participates in the unavailable keyword match")
+    func remediationUsesProbeErrorText() {
+        let item = availability(.unavailable, "On-device summary failed", probe: "connection refused")
+        #expect(LocalAIAvailabilityPresentation.remediationCategory(for: item) == .runtimeUnavailable)
+    }
+
+    @Test("Every remediation category yields non-empty settings, popover, and help copy")
+    func remediationCopyForAllCategories() {
+        let representatives: [LocalAIAvailability] = [
+            availability(.available, "ok"),
+            availability(.disabled, "off"),
+            availability(.disabled, "not supported"),
+            availability(.checking, "verifying"),
+            availability(.unavailable, "no installed local model"),
+            availability(.unavailable, "non-local endpoint"),
+            availability(.unavailable, "not reachable"),
+            availability(.unavailable, "returned an error"),
+        ]
+        for item in representatives {
+            #expect(!LocalAIAvailabilityPresentation.settingsLabel(for: item).isEmpty)
+            #expect(!LocalAIAvailabilityPresentation.popoverLabel(for: item).isEmpty)
+            #expect(!LocalAIAvailabilityPresentation.helpText(for: item).isEmpty)
+        }
+    }
+
+    @Test("Cause label is present only for actionable failure categories")
+    func causeLabelPresence() {
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.available, "ok")) == nil)
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.disabled, "off")) == nil)
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.checking, "verifying")) == nil)
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.unavailable, "no installed local model")) == "No local model installed")
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.unavailable, "non-local endpoint")) == "Unsupported local setup")
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.unavailable, "not reachable")) == "Ollama not reachable")
+        #expect(LocalAIAvailabilityPresentation.causeLabel(for: availability(.unavailable, "returned an error")) == "Probe returned an error")
+    }
+
+    @Test("Help text for failure categories embeds the underlying detail")
+    func helpTextEmbedsDetail() {
+        let missingModel = availability(.unavailable, "no installed local model")
+        #expect(LocalAIAvailabilityPresentation.helpText(for: missingModel).contains("no installed local model"))
+    }
 }

--- a/Tests/PlaidBarCoreTests/StrongMaskFormatterCoverageTests.swift
+++ b/Tests/PlaidBarCoreTests/StrongMaskFormatterCoverageTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Strong mask formatter coverage")
+struct StrongMaskFormatterCoverageTests {
+    @Test("Text masks present content per slot and is unavailable otherwise")
+    func textSlots() {
+        #expect(StrongMaskFormatter.text("Chase", slot: .primaryLabel) == StrongMaskFormatter.TextSlot.primaryLabel.mask)
+        #expect(StrongMaskFormatter.text(nil, slot: .primaryLabel) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.text("   ", slot: .primaryLabel) == StrongMaskFormatter.unavailable)
+
+        let masks = [
+            StrongMaskFormatter.TextSlot.primaryLabel,
+            .secondaryLabel, .metadata, .longDescription, .identifier,
+        ].map(\.mask)
+        #expect(masks.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test("Named string helpers delegate to a slot mask, unavailable when empty")
+    func namedHelpers() {
+        #expect(StrongMaskFormatter.accountName("Everyday") == StrongMaskFormatter.TextSlot.primaryLabel.mask)
+        #expect(StrongMaskFormatter.officialAccountName("Everyday Checking") == StrongMaskFormatter.TextSlot.secondaryLabel.mask)
+        #expect(StrongMaskFormatter.institutionName("Acme") == StrongMaskFormatter.TextSlot.primaryLabel.mask)
+        #expect(StrongMaskFormatter.merchantName("Starbucks") == StrongMaskFormatter.TextSlot.primaryLabel.mask)
+        #expect(StrongMaskFormatter.transactionDescription("Coffee") == StrongMaskFormatter.TextSlot.longDescription.mask)
+        #expect(StrongMaskFormatter.identifier("abc123") == StrongMaskFormatter.TextSlot.identifier.mask)
+        #expect(StrongMaskFormatter.accountLastFour("1234") == StrongMaskFormatter.TextSlot.metadata.mask)
+        #expect(StrongMaskFormatter.accountName(nil) == StrongMaskFormatter.unavailable)
+    }
+
+    @Test("Transaction display name prefers merchant, then the raw name")
+    func transactionDisplayName() {
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: "Starbucks", name: "SQ *STARBUCKS") == StrongMaskFormatter.TextSlot.primaryLabel.mask)
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: nil, name: "SQ *STARBUCKS") == StrongMaskFormatter.TextSlot.longDescription.mask)
+        #expect(StrongMaskFormatter.transactionDisplayName(merchantName: nil, name: nil) == StrongMaskFormatter.unavailable)
+    }
+
+    @Test("Money masks magnitude while optionally preserving sign (Double)")
+    func moneyDouble() {
+        // Explicit Double typing disambiguates from the Decimal overload.
+        #expect(StrongMaskFormatter.money(Double?.none) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.money(Double.nan) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.money(Double(42)) == StrongMaskFormatter.maskedMoney)
+        #expect(StrongMaskFormatter.money(Double(-42), preservesSign: true) == "-\(StrongMaskFormatter.maskedMoney)")
+        #expect(StrongMaskFormatter.money(Double(42), preservesSign: true) == "+\(StrongMaskFormatter.maskedMoney)")
+        #expect(StrongMaskFormatter.money(Double(0), preservesSign: true) == StrongMaskFormatter.maskedMoney)
+    }
+
+    @Test("Money masks magnitude while optionally preserving sign (Decimal)")
+    func moneyDecimal() {
+        #expect(StrongMaskFormatter.money(Decimal?.none) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.money(Decimal(42)) == StrongMaskFormatter.maskedMoney)
+        #expect(StrongMaskFormatter.money(Decimal(-42), preservesSign: true) == "-\(StrongMaskFormatter.maskedMoney)")
+        #expect(StrongMaskFormatter.money(Decimal(42), preservesSign: true) == "+\(StrongMaskFormatter.maskedMoney)")
+        #expect(StrongMaskFormatter.money(Decimal(0), preservesSign: true) == StrongMaskFormatter.maskedMoney)
+    }
+
+    @Test("Percent, count, date, range, freshness, and generic masking")
+    func miscMasks() {
+        #expect(StrongMaskFormatter.percent(nil) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.percent(30) == StrongMaskFormatter.maskedPercent)
+
+        #expect(StrongMaskFormatter.count(nil, label: "items") == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.count(5, label: "items") == "•• items")
+        #expect(StrongMaskFormatter.count(5, label: "   ") == "••")
+
+        #expect(StrongMaskFormatter.date("2026-06-14") == StrongMaskFormatter.maskedDate)
+        #expect(StrongMaskFormatter.date(nil as String?) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.date(Date()) == StrongMaskFormatter.maskedDate)
+        #expect(StrongMaskFormatter.date(nil as Date?) == StrongMaskFormatter.unavailable)
+
+        #expect(StrongMaskFormatter.dateRange(nil, nil) == StrongMaskFormatter.unavailable)
+        #expect(StrongMaskFormatter.dateRange("2026-06-01", nil) == StrongMaskFormatter.maskedDateRange)
+
+        #expect(StrongMaskFormatter.freshness(prefix: "Updated", value: "2m ago") == "Updated •••")
+        #expect(StrongMaskFormatter.freshness(prefix: "   ", value: "2m ago") == "•••")
+        #expect(StrongMaskFormatter.freshness(prefix: "Updated", value: nil) == StrongMaskFormatter.unavailable)
+
+        #expect(StrongMaskFormatter.generic("Checking") == "Checking")
+        #expect(StrongMaskFormatter.generic(nil) == StrongMaskFormatter.unavailable)
+    }
+
+    @Test("Accessibility labels are present and distinct for every hidden value")
+    func accessibilityLabels() {
+        let kinds: [StrongMaskFormatter.AccessibilityHiddenValue] = [
+            .accountName, .institution, .merchant, .description, .amount,
+            .date, .identifier, .accountMask, .percentage, .count,
+        ]
+        let labels = kinds.map(StrongMaskFormatter.accessibilityLabel(for:))
+        #expect(labels.allSatisfy { !$0.isEmpty })
+        #expect(Set(labels).count == kinds.count)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SyncResponseTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncResponseTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Sync response payloads")
+struct SyncResponseTests {
+    @Test("Sync cursor commit request carries its cursors")
+    func commitRequest() {
+        let request = SyncCursorCommitRequest(cursors: ["item-1": "cursor-1"])
+        #expect(request.cursors["item-1"] == "cursor-1")
+    }
+
+    @Test("Memberwise init defaults pending cursors to empty")
+    func memberwiseInit() {
+        let response = SyncResponse(added: [], modified: [], removed: [], hasMore: true)
+        #expect(response.pendingCursors.isEmpty)
+        #expect(response.hasMore)
+    }
+
+    @Test("Decoding tolerates a missing pendingCursors field")
+    func decodeDefaultsPendingCursors() throws {
+        let json = #"{"added":[],"modified":[],"removed":["t1"],"hasMore":false}"#
+        let response = try JSONDecoder().decode(SyncResponse.self, from: Data(json.utf8))
+        #expect(response.pendingCursors.isEmpty)
+        #expect(response.hasMore == false)
+        #expect(response.removed == ["t1"])
+    }
+
+    @Test("Decoding reads a present pendingCursors field")
+    func decodePendingCursors() throws {
+        let json = #"{"added":[],"modified":[],"removed":[],"hasMore":true,"pendingCursors":{"item-1":"c1"}}"#
+        let response = try JSONDecoder().decode(SyncResponse.self, from: Data(json.utf8))
+        #expect(response.pendingCursors["item-1"] == "c1")
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionDerivedIndexCoverageTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionDerivedIndexCoverageTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Transaction derived index coverage")
+struct TransactionDerivedIndexCoverageTests {
+    private func tx(_ id: String, date: String, account: String = "x") -> TransactionDTO {
+        TransactionDTO(
+            id: id, accountId: account, amount: 10, date: date,
+            name: id, merchantName: id, category: .foodAndDrink, pending: false
+        )
+    }
+
+    @Test("recentEntries filters to the inclusive date window and drops unparseable dates")
+    func recentEntriesWindow() throws {
+        let index = TransactionDerivedIndex(transactions: [
+            tx("a", date: "2026-06-01"),
+            tx("b", date: "2026-06-15"),
+            tx("c", date: "2026-06-30"),
+            tx("bad", date: "not-a-date"),
+        ])
+        let start = try #require(Formatters.parseTransactionDate("2026-06-10"))
+        let end = try #require(Formatters.parseTransactionDate("2026-06-20"))
+        #expect(index.recentEntries(from: start, through: end).map(\.transaction.id) == ["b"])
+    }
+
+    @Test("entries(in:from:through:) filters an arbitrary entry source")
+    func entriesInSource() throws {
+        let index = TransactionDerivedIndex(transactions: [
+            tx("a", date: "2026-06-01"),
+            tx("b", date: "2026-06-15"),
+        ])
+        let start = try #require(Formatters.parseTransactionDate("2026-06-14"))
+        let end = try #require(Formatters.parseTransactionDate("2026-06-16"))
+        #expect(index.entries(in: index.entries, from: start, through: end).map(\.transaction.id) == ["b"])
+    }
+
+    @Test("FinanceDerivedSnapshot builds an account lookup and a transaction index")
+    func financeDerivedSnapshot() {
+        let snapshot = FinanceDerivedSnapshot(
+            accounts: [
+                AccountDTO(id: "x", itemId: "i", name: "Checking", type: .depository, balances: BalanceDTO(current: 100)),
+                AccountDTO(id: "y", itemId: "i", name: "Savings", type: .depository, balances: BalanceDTO(current: 200)),
+            ],
+            transactions: [tx("a", date: "2026-06-01", account: "x")]
+        )
+        #expect(snapshot.accounts.count == 2)
+        #expect(snapshot.accountsById["x"]?.name == "Checking")
+        #expect(snapshot.accountsById["y"]?.name == "Savings")
+        #expect(snapshot.transactionIndex.entries.count == 1)
+    }
+}

--- a/Tests/PlaidBarCoreTests/WatchlistTargetTests.swift
+++ b/Tests/PlaidBarCoreTests/WatchlistTargetTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Watchlist target value type (AND-501)")
+struct WatchlistTargetTests {
+    @Test("Kind exposes a display name for every case")
+    func kindDisplayNames() {
+        #expect(WatchlistTarget.Kind.merchant.displayName == "Merchant")
+        #expect(WatchlistTarget.Kind.category.displayName == "Category")
+        #expect(WatchlistTarget.Kind.allCases.count == 2)
+    }
+
+    @Test("Merchant keys are normalized and negative thresholds clamp to zero")
+    func initNormalizesAndClamps() {
+        let target = WatchlistTarget(kind: .merchant, key: "  Whole Foods  ", monthlyThreshold: -10, label: "Whole Foods")
+        #expect(target.key == "whole foods")
+        #expect(target.monthlyThreshold == 0)
+    }
+
+    @Test("Category keys are stored verbatim")
+    func categoryKeyVerbatim() {
+        let target = WatchlistTarget(kind: .category, key: "FOOD_AND_DRINK", monthlyThreshold: 50, label: "Food & Drink")
+        #expect(target.key == "FOOD_AND_DRINK")
+    }
+
+    @Test("Merchant factory trims the name and falls back to a generic label when blank")
+    func merchantFactory() {
+        let named = WatchlistTarget.merchant("  Starbucks  ", threshold: 25)
+        #expect(named.kind == .merchant)
+        #expect(named.key == "starbucks")
+        #expect(named.label == "Starbucks")
+
+        let blank = WatchlistTarget.merchant("   ", threshold: 25)
+        #expect(blank.label == "Merchant")
+        #expect(blank.key.isEmpty)
+    }
+
+    @Test("Category factory derives key and label from the category")
+    func categoryFactory() {
+        let target = WatchlistTarget.category(.shopping, threshold: 100)
+        #expect(target.kind == .category)
+        #expect(target.key == SpendingCategory.shopping.rawValue)
+        #expect(target.label == SpendingCategory.shopping.displayName)
+    }
+
+    @Test("category resolves only for category targets")
+    func categoryAccessor() {
+        #expect(WatchlistTarget.category(.travel, threshold: 1).category == .travel)
+        #expect(WatchlistTarget.merchant("Acme", threshold: 1).category == nil)
+    }
+
+    @Test("normalizeMerchant lowercases and trims")
+    func normalizeMerchant() {
+        #expect(WatchlistTarget.normalizeMerchant("  Whole Foods ") == "whole foods")
+    }
+}


### PR DESCRIPTION
## Summary

- Added **26 new test suites** and augmented **5 existing test files** in `Tests/PlaidBarCoreTests/`, with zero source changes and zero regressions
- Total test count: **1,099 → 1,331** (+232 tests)
- Line coverage: **86.2% → 89.6%** overall; **PlaidBarCore 88.0% → 95.2%**; PlaidBarServer 71.9%

## What was covered

**New suites (26):** `AccountActivityEmptyState`, `AccountConnectionPresentation`, `AccountTransactionFeed`, `BalanceProjection`, `BalanceTrend`, `CategoryBudgetDTO`, `CategoryBudgetPresentation`, `DashboardCardKind`, `DashboardDrillInSurface`, `DashboardStatusReadiness`, `FirstRunCompletion`, `Formatters`, `ItemRecoveryTarget`, `LocalAIInsightsModel`, `NetWorthTrendPresentation`, `NotificationPermissionPresentation`, `PrivacyMaskPresentationHelpers`, `ProjectedBalancePresentation`, `ReconnectRecoveryMessage`, `RecurringDetectorHelpers`, `SafeToSpendModel`, `SecondaryContentUnavailableState`, `StrongMaskFormatterCoverage`, `SyncResponse`, `TransactionDerivedIndexCoverage`, `WatchlistTarget`

**Augmented suites (5):** `AppearancePreferences` (raw-value round-trips, CaseIterable counts), `AppLockPresentation` (display mode copy, normal pass-through), `AppLockService` (lock() behavior, capability passthrough), `GlanceSnapshot` (change glyphs, signedChangeText, sparkline, SystemDebounceScheduler), `SettingsPresentation` (remediation category mapping, cause labels, help text)

## Coverage ceiling

**True 100% is structurally unreachable** — the SwiftUI `PlaidBar` app target (~40 view/service files) is not in the test binary at all. Remaining untestable code: biometric `LAContext` authenticator, Hummingbird HTTP routes, Keychain/filesystem I/O, and confirmed-dead defensive branches. The remaining ~5% PlaidBarCore gap is `WeeklyReviewBuilder`, `LocalAIInsightBuilder` private receipt helpers, `AttentionQueue`, and `DemoFixtures` — all require elaborate fixture construction with no external dependencies.

## Test plan

- [ ] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — strict concurrency gate passes
- [ ] `swift test` — all 1,331 tests green, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)