### PR TITLE
feat(ui): one-tap accept for suggested budgets (AND-542)

### DIFF
--- a/Sources/PlaidBar/Views/BudgetEditorSheet.swift
+++ b/Sources/PlaidBar/Views/BudgetEditorSheet.swift
@@ -51,6 +51,14 @@ struct BudgetEditorSheet: View {
                 } footer: {
                     validationFooter
                 }
+
+                if let suggestedItem {
+                    Section {
+                        suggestedRow(suggestedItem)
+                    } header: {
+                        Text("Suggested")
+                    }
+                }
             } else {
                 Section {
                     Label(
@@ -117,6 +125,29 @@ struct BudgetEditorSheet: View {
         }
     }
 
+    /// "Ghost guardrail" row: shows the history-derived suggested limit (and its
+    /// current-month spend, carried by text) with a one-tap accept that promotes it
+    /// to a saved budget. Tapping also seeds the field so the value is visible.
+    private func suggestedRow(_ item: CategoryBudgetPresentation.Item) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Based on recent spending")
+                    .font(.callout)
+                Text(
+                    "\(Formatters.currency(item.spent)) spent so far this month"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: Spacing.sm)
+            SuggestedBudgetAcceptButton(
+                item: item,
+                existingBudgets: appState.categoryBudgets
+            )
+        }
+        .accessibilityElement(children: .contain)
+    }
+
     @ViewBuilder
     private var validationFooter: some View {
         switch outcome {
@@ -159,6 +190,21 @@ struct BudgetEditorSheet: View {
     /// The category's currently-saved (explicit, non-suggested) limit, if any.
     private var currentLimit: Double? {
         appState.categoryBudgets[category]
+    }
+
+    /// The history-derived suggested guardrail for this category, if the dashboard
+    /// is offering one and the user has not already saved a limit. Read from the
+    /// live merged budget presentation (suggestions are flagged `isSuggested`); the
+    /// pure `SuggestedBudgetAcceptance` decides whether a one-tap accept is legal.
+    private var suggestedItem: CategoryBudgetPresentation.Item? {
+        guard (currentLimit ?? 0) <= 0 else { return nil }
+        return appState.categoryBudgetPresentation.items.first { item in
+            item.category == category
+                && SuggestedBudgetAcceptance.evaluate(
+                    item: item,
+                    existingBudgets: appState.categoryBudgets
+                ).isAcceptable
+        }
     }
 
     private var saveButtonTitle: String {

--- a/Sources/PlaidBar/Views/SuggestedBudgetAcceptButton.swift
+++ b/Sources/PlaidBar/Views/SuggestedBudgetAcceptButton.swift
@@ -1,0 +1,65 @@
+import PlaidBarCore
+import SwiftUI
+
+/// One-tap "accept suggested limit" affordance — the "ghost guardrails" UX
+/// (AND-542, spec §3/§4).
+///
+/// Given a `CategoryBudgetPresentation.Item` that is a history-derived *suggestion*
+/// for a budgetable category the user has not yet budgeted, this renders a single
+/// button that promotes the suggestion into a saved budget via
+/// `AppState.setCategoryBudget(category, amount:)` — no sheet, no typing.
+///
+/// The decision of whether the affordance is offered, and what it would persist,
+/// is the pure `SuggestedBudgetAcceptance` (income / transfer rejected, positive
+/// finite limit required, an already-saved budget wins). This view only renders the
+/// outcome and dispatches the call, so it stays trivially correct and the rules are
+/// unit-tested without a view. When the item is not acceptable the view renders
+/// nothing.
+///
+/// Accessibility: the suggested amount is carried by text (not color), the button
+/// has an explicit descriptive label, and the in-flight state is announced.
+struct SuggestedBudgetAcceptButton: View {
+    /// The suggested presentation item to (maybe) offer for one-tap accept.
+    let item: CategoryBudgetPresentation.Item
+    /// The user's current explicit budgets, so an already-saved category is never
+    /// re-accepted. Defaults to empty for callers that pre-filter suggestions.
+    var existingBudgets: [SpendingCategory: Double] = [:]
+
+    @Environment(AppState.self) private var appState
+
+    /// True while the accept network round-trip is in flight.
+    @State private var isAccepting = false
+
+    /// The pure accept decision for this item, recomputed every render.
+    private var outcome: SuggestedBudgetAcceptance.Outcome {
+        SuggestedBudgetAcceptance.evaluate(item: item, existingBudgets: existingBudgets)
+    }
+
+    var body: some View {
+        if case let .accept(category, amount) = outcome {
+            Button {
+                Task { await accept(category: category, amount: amount) }
+            } label: {
+                Label(
+                    "Set \(Formatters.currency(amount)) limit",
+                    systemImage: "wand.and.stars"
+                )
+                .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .disabled(isAccepting)
+            .accessibilityLabel(
+                "Accept suggested \(Formatters.currency(amount)) monthly budget for \(category.displayName)"
+            )
+            .accessibilityHint("Saves this as the monthly limit")
+            .accessibilityValue(isAccepting ? "Saving" : "")
+        }
+    }
+
+    private func accept(category: SpendingCategory, amount: Double) async {
+        guard !isAccepting else { return }
+        isAccepting = true
+        await appState.setCategoryBudget(category, amount: amount)
+        isAccepting = false
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/SuggestedBudgetAcceptance.swift
+++ b/Sources/PlaidBarCore/Utilities/SuggestedBudgetAcceptance.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Pure decision logic for the one-tap "accept suggested limit" affordance —
+/// the "ghost guardrails" UX (AND-542, spec §3/§4).
+///
+/// The dashboard renders history-derived suggestions (`CategoryBudgetPresentation`
+/// items flagged `isSuggested`) as faint guardrails for categories the user has
+/// not yet budgeted. A single tap should promote that suggestion into a saved
+/// budget by calling `AppState.setCategoryBudget(category, amount:)` — no sheet, no
+/// typing.
+///
+/// All of the "is this a legal one-tap accept, and what would it persist" logic
+/// lives here as a stateless `enum` so it is `Sendable`, testable without a view,
+/// and identical wherever the affordance appears. The view only renders the
+/// outcome and dispatches the resulting `setCategoryBudget` call.
+///
+/// The rules mirror the rest of the budget surface so an accept can never write a
+/// budget the editor would reject:
+/// - the item must be a *suggestion* (`isSuggested`) — an explicit, already-saved
+///   limit has nothing to accept;
+/// - the category must be budgetable — income / transfer categories are never
+///   spend (mirrors `BudgetEditorInput.isBudgetable` /
+///   `CategoryBudgetPlanner.excludedCategories` / the server's `budgetableCategory`);
+/// - the suggested limit must be a positive, finite amount;
+/// - the category must not already carry an explicit saved budget (a saved limit
+///   wins — `mergedPresentation` already filters these out, but making the rule
+///   explicit keeps the accept safe even if a caller passes a stale presentation).
+public enum SuggestedBudgetAcceptance {
+    /// Outcome of evaluating whether a suggested item can be accepted in one tap,
+    /// and what it would persist.
+    public enum Outcome: Sendable, Hashable {
+        /// The suggestion is acceptable: persist `amount` as `category`'s monthly
+        /// limit via `AppState.setCategoryBudget`.
+        case accept(category: SpendingCategory, amount: Double)
+        /// The item is an explicit (already-saved) budget, not a suggestion — there
+        /// is nothing to accept.
+        case notSuggested
+        /// The category cannot carry a budget (income / transfer).
+        case categoryNotBudgetable
+        /// The suggested limit is not a positive, finite amount.
+        case invalidLimit
+        /// The category already has an explicit saved budget; the saved limit wins.
+        case alreadyBudgeted
+
+        /// True when this outcome is something the user can accept with one tap.
+        public var isAcceptable: Bool {
+            if case .accept = self { return true }
+            return false
+        }
+
+        /// The amount a one-tap accept would persist, or `nil` when not acceptable.
+        public var acceptedAmount: Double? {
+            if case let .accept(_, amount) = self { return amount }
+            return nil
+        }
+
+        /// The category a one-tap accept would budget, or `nil` when not acceptable.
+        public var acceptedCategory: SpendingCategory? {
+            if case let .accept(category, _) = self { return category }
+            return nil
+        }
+    }
+
+    /// Decide whether `item` can be accepted in one tap given the user's current
+    /// `existingBudgets` (the explicit, saved limits — `AppState.categoryBudgets`).
+    ///
+    /// `existingBudgets` defaults to empty for callers that have already filtered
+    /// suggestions against saved budgets; passing the live map makes the
+    /// "saved limit wins" guard authoritative. A non-positive existing limit is
+    /// treated as unset (no saved budget), matching `setCategoryBudget`, which
+    /// removes a budget on a non-positive amount.
+    public static func evaluate(
+        item: CategoryBudgetPresentation.Item,
+        existingBudgets: [SpendingCategory: Double] = [:]
+    ) -> Outcome {
+        guard item.isSuggested else { return .notSuggested }
+        guard isBudgetable(item.category) else { return .categoryNotBudgetable }
+        guard item.monthlyLimit > 0, item.monthlyLimit.isFinite else { return .invalidLimit }
+        if let existing = existingBudgets[item.category], existing > 0 {
+            return .alreadyBudgeted
+        }
+        return .accept(category: item.category, amount: item.monthlyLimit)
+    }
+
+    /// Whether a category can carry a budget. Kept in lock-step with
+    /// `BudgetEditorInput.isBudgetable` / `CategoryBudgetPlanner.excludedCategories`
+    /// so the accept affordance and the editor agree on which categories are spend.
+    public static func isBudgetable(_ category: SpendingCategory) -> Bool {
+        BudgetEditorInput.isBudgetable(category)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SuggestedBudgetAcceptanceTests.swift
+++ b/Tests/PlaidBarCoreTests/SuggestedBudgetAcceptanceTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Suggested budget acceptance (AND-542)")
+struct SuggestedBudgetAcceptanceTests {
+    private func item(
+        _ category: SpendingCategory,
+        limit: Double,
+        spent: Double = 0,
+        isSuggested: Bool
+    ) -> CategoryBudgetPresentation.Item {
+        CategoryBudgetPresentation.Item(
+            category: category,
+            monthlyLimit: limit,
+            spent: spent,
+            isSuggested: isSuggested
+        )
+    }
+
+    // MARK: - Accept
+
+    @Test("A suggested, budgetable, positive-limit item with no saved budget is acceptable")
+    func acceptsGhostGuardrail() {
+        let outcome = SuggestedBudgetAcceptance.evaluate(
+            item: item(.foodAndDrink, limit: 500, isSuggested: true),
+            existingBudgets: [:]
+        )
+        #expect(outcome == .accept(category: .foodAndDrink, amount: 500))
+        #expect(outcome.acceptedAmount == 500)
+        #expect(outcome.isAcceptable)
+    }
+
+    @Test("The accepted amount is exactly the suggested monthly limit")
+    func acceptsSuggestedLimitVerbatim() {
+        let outcome = SuggestedBudgetAcceptance.evaluate(
+            item: item(.shopping, limit: 225, spent: 180, isSuggested: true),
+            existingBudgets: [:]
+        )
+        #expect(outcome == .accept(category: .shopping, amount: 225))
+    }
+
+    // MARK: - Reject: not a suggestion
+
+    @Test("An explicit (already-saved) item is not acceptable — nothing to accept")
+    func rejectsExplicitItem() {
+        let outcome = SuggestedBudgetAcceptance.evaluate(
+            item: item(.foodAndDrink, limit: 500, isSuggested: false),
+            existingBudgets: [:]
+        )
+        #expect(outcome == .notSuggested)
+        #expect(!outcome.isAcceptable)
+        #expect(outcome.acceptedAmount == nil)
+    }
+
+    // MARK: - Reject: income / transfer (mirror budgetableCategory)
+
+    @Test("Income and transfer categories are never acceptable, even if flagged suggested")
+    func rejectsExcludedCategories() {
+        for excluded in CategoryBudgetPlanner.excludedCategories {
+            let outcome = SuggestedBudgetAcceptance.evaluate(
+                item: item(excluded, limit: 500, isSuggested: true),
+                existingBudgets: [:]
+            )
+            #expect(outcome == .categoryNotBudgetable)
+            #expect(!outcome.isAcceptable)
+        }
+    }
+
+    @Test("Acceptance budgetability matches BudgetEditorInput.isBudgetable")
+    func budgetabilityMatchesEditor() {
+        for category in SpendingCategory.allCases {
+            let outcome = SuggestedBudgetAcceptance.evaluate(
+                item: item(category, limit: 300, isSuggested: true),
+                existingBudgets: [:]
+            )
+            if BudgetEditorInput.isBudgetable(category) {
+                #expect(outcome != .categoryNotBudgetable)
+            } else {
+                #expect(outcome == .categoryNotBudgetable)
+            }
+        }
+    }
+
+    // MARK: - Reject: non-positive / non-finite limit
+
+    @Test("A non-positive suggested limit is not acceptable")
+    func rejectsNonPositiveLimit() {
+        #expect(
+            SuggestedBudgetAcceptance.evaluate(
+                item: item(.foodAndDrink, limit: 0, isSuggested: true),
+                existingBudgets: [:]
+            ) == .invalidLimit
+        )
+        #expect(
+            SuggestedBudgetAcceptance.evaluate(
+                item: item(.foodAndDrink, limit: -10, isSuggested: true),
+                existingBudgets: [:]
+            ) == .invalidLimit
+        )
+    }
+
+    @Test("A non-finite suggested limit is not acceptable")
+    func rejectsNonFiniteLimit() {
+        #expect(
+            SuggestedBudgetAcceptance.evaluate(
+                item: item(.foodAndDrink, limit: .infinity, isSuggested: true),
+                existingBudgets: [:]
+            ) == .invalidLimit
+        )
+        #expect(
+            SuggestedBudgetAcceptance.evaluate(
+                item: item(.foodAndDrink, limit: .nan, isSuggested: true),
+                existingBudgets: [:]
+            ) == .invalidLimit
+        )
+    }
+
+    // MARK: - Reject: already has an explicit budget
+
+    @Test("A category that already has a saved budget is not re-accepted")
+    func rejectsAlreadyBudgeted() {
+        let outcome = SuggestedBudgetAcceptance.evaluate(
+            item: item(.foodAndDrink, limit: 500, isSuggested: true),
+            existingBudgets: [.foodAndDrink: 400]
+        )
+        #expect(outcome == .alreadyBudgeted)
+        #expect(!outcome.isAcceptable)
+    }
+
+    @Test("A zero/negative existing limit does not block acceptance (treated as unset)")
+    func zeroExistingDoesNotBlock() {
+        let outcome = SuggestedBudgetAcceptance.evaluate(
+            item: item(.foodAndDrink, limit: 500, isSuggested: true),
+            existingBudgets: [.foodAndDrink: 0]
+        )
+        #expect(outcome == .accept(category: .foodAndDrink, amount: 500))
+    }
+
+    // MARK: - Convenience flag
+
+    @Test("isAcceptable agrees with the accept case across outcomes")
+    func isAcceptableFlag() {
+        let accept = SuggestedBudgetAcceptance.evaluate(
+            item: item(.shopping, limit: 100, isSuggested: true),
+            existingBudgets: [:]
+        )
+        #expect(accept.isAcceptable)
+        #expect(accept.acceptedAmount == 100)
+
+        let reject = SuggestedBudgetAcceptance.evaluate(
+            item: item(.shopping, limit: 100, isSuggested: false),
+            existingBudgets: [:]
+        )
+        #expect(!reject.isAcceptable)
+        #expect(reject.acceptedAmount == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces the planner's history-derived suggested category limits as **"ghost guardrails"** — for any budgetable category the user has not yet budgeted, a single tap promotes the suggestion into a saved budget via the existing `AppState.setCategoryBudget(_:amount:)`. No sheet round-trip, no typing.

The suggestion math is untouched: this reuses `CategoryBudgetPlanner.suggestedBudgets` (already surfaced as `isSuggested` items in the merged budget presentation) and only adds the accept affordance + the pure decision logic guarding it.

## Linear (AND-542)

Implements **AND-542** (Epic AND-522 *Budget editing*): "surface suggested budgets as one-tap accept." Depends on AND-540 (`BudgetEditorSheet`), which is present in this branch's base.

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` — **Option A** (display-only rollups, no schema migration):

- **§3** Target experience: the Category Dashboard's suggestions are "ghost guardrails"; this delivers the one-tap promotion of a suggested limit to a saved budget.
- **§4** Architecture: pure suggestion-acceptance logic extracted to PlaidBarCore; the affordance only persists through the existing `setCategoryBudget` path; income/transfer rejected (mirrors the server's `budgetableCategory` and `BudgetEditorInput.isBudgetable` / `CategoryBudgetPlanner.excludedCategories`). Additive — `TransactionDTO`, `SpendingCategory` rawValues, `CategoryBudgetDTO` PK, and the server schema are all unchanged.

## Testing notes

New pure tests — `Tests/PlaidBarCoreTests/SuggestedBudgetAcceptanceTests.swift` (`@Suite "Suggested budget acceptance (AND-542)"`), 10 tests:

- `acceptsGhostGuardrail`, `acceptsSuggestedLimitVerbatim`
- `rejectsExplicitItem`
- `rejectsExcludedCategories`, `budgetabilityMatchesEditor`
- `rejectsNonPositiveLimit`, `rejectsNonFiniteLimit`
- `rejectsAlreadyBudgeted`, `zeroExistingDoesNotBlock`
- `isAcceptableFlag`

Strict-concurrency CI gate:

```
$ swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (58.64s)
```

Full suite:

```
$ swift test
✔ Test run with 1200 tests passed after 1.375 seconds.
```

(Keychain-dependent server tests report `skipped` in this environment, not failed — pre-existing. The known LocalInsight timeout flake passed in this run.)

## Architectural decisions

- **Pure logic in PlaidBarCore.** `SuggestedBudgetAcceptance.evaluate(item:existingBudgets:)` owns the entire "is this a legal one-tap accept, and what would it persist" decision as a stateless `Sendable` enum, so it is unit-tested without a view. SwiftUI views in the app target are not headlessly testable, so the views (`SuggestedBudgetAcceptButton`, the new `BudgetEditorSheet` row) stay thin: render the outcome, dispatch the existing call.
- **Reuse, don't reimplement.** No new budget math — the suggested limit comes straight from `CategoryBudgetPlanner.suggestedBudgets` via the merged presentation's `isSuggested` items.
- **"Saved limit wins" guard.** Even though `mergedPresentation` already filters suggestions for explicitly-budgeted categories, `evaluate` re-checks `existingBudgets` so a stale presentation can never overwrite a saved budget; a non-positive existing limit is treated as unset (matching `setCategoryBudget`).
- **Accessibility.** The suggested amount and in-flight state are carried by text + SF Symbol (`wand.and.stars`), never color alone (ACCESSIBILITY.md); the button has an explicit descriptive label and hint.
- **File ownership respected.** No edits to `categoryBudgetPresentation` (read-only consumed), `persistReviewStorage`, `loadDemoData`, `ReviewInboxView`, or the AppState privacy region.

## Migration notes

None — additive. No schema, rawValue, DTO, or server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
