### PR TITLE
feat(ui): spend donut + center total (SectorMark) (AND-537)

### DIFF
--- a/Sources/PlaidBar/Views/Charts/SpendDonutChart.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendDonutChart.swift
@@ -1,0 +1,167 @@
+import Charts
+import PlaidBarCore
+import SwiftUI
+
+/// Spend donut + center total (AND-537) — a Swift Charts `SectorMark` ring of this
+/// month's spend by ``CategoryGroup``, with the overall total in the hole.
+///
+/// It is a **thin renderer**: all spend, ordering, shares, and label text come from
+/// the injected ``SpendDonutModel`` (built from the existing override-aware
+/// ``CategoryDashboardPresentation`` — no recompute, spec §3/§4, Option A). The view
+/// owns only geometry, color, and motion.
+///
+/// Accessibility (ACCESSIBILITY.md): color is never the only signal. A glyph+text
+/// legend lists every slice's group, amount, and share, so the breakdown reads
+/// without distinguishing hues; the chart itself is one VoiceOver element whose label
+/// is the model's spoken summary, and each legend row is its own labeled element.
+struct SpendDonutChart: View {
+    let model: SpendDonutModel
+    /// When true (Privacy Mask on), every amount the donut exposes — center total,
+    /// legend amounts, and the VoiceOver figures — is masked. Slice geometry, group
+    /// titles, and shares still render so the chart's shape and structure stay legible.
+    var isPrivacyMasked: Bool = false
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealFraction: CGFloat = 0
+
+    private let ringHeight: CGFloat = 168
+    private let innerRatio: CGFloat = 0.62
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            ring
+            legend
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Ring
+
+    private var ring: some View {
+        Chart(model.slices) { slice in
+            SectorMark(
+                angle: .value("Spend", slice.amount),
+                innerRadius: .ratio(innerRatio),
+                angularInset: 1.5
+            )
+            .cornerRadius(3)
+            // Fill resolved through the foreground-style scale (keyed by group title)
+            // so each sector gets its design-system group accent.
+            .foregroundStyle(by: .value("Group", slice.title))
+            .opacity(revealFraction)
+        }
+        .chartForegroundStyleScale(domain: model.slices.map(\.title), range: sliceColors)
+        .chartLegend(.hidden) // Custom glyph+text legend below carries amounts + shares.
+        .frame(height: ringHeight)
+        .frame(maxWidth: .infinity)
+        .overlay {
+            centerTotal
+                .opacity(revealFraction)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(chartAccessibilityLabel)
+        .onAppear(perform: animateReveal)
+    }
+
+    private var centerTotal: some View {
+        VStack(spacing: Spacing.xxs) {
+            Text(masked(model.totalText))
+                .font(.title2.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(model.centerCaption)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .accessibilityHidden(true) // Spoken via the chart's combined label instead.
+    }
+
+    // MARK: - Legend (glyph + text, color-independent)
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(model.slices) { slice in
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: glyph(for: slice.group))
+                        .font(.caption)
+                        .foregroundStyle(color(for: slice.group))
+                        .frame(width: Sizing.glyphSmall, alignment: .center)
+                        .accessibilityHidden(true)
+                    Text(slice.title)
+                        .font(.caption)
+                        .lineLimit(1)
+                    Spacer(minLength: Spacing.sm)
+                    Text(slice.shareText)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                    Text(masked(slice.amountText))
+                        .font(.caption.weight(.medium))
+                        .monospacedDigit()
+                        .frame(minWidth: 64, alignment: .trailing)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(legendAccessibilityLabel(for: slice))
+            }
+        }
+    }
+
+    // MARK: - Privacy masking
+
+    private func masked(_ value: String) -> String {
+        PrivacyMaskPresentation.value(value, isEnabled: isPrivacyMasked)
+    }
+
+    // MARK: - Accessibility text
+
+    /// Combined VoiceOver label for the ring. When masked, the structure (groups +
+    /// shares) is preserved but every amount is hidden so the donut never speaks
+    /// exact financial values while Privacy Mask is on.
+    private var chartAccessibilityLabel: String {
+        guard isPrivacyMasked else { return model.accessibilityLabel }
+        guard !model.isEmpty else { return model.accessibilityLabel }
+        let hidden = PrivacyMaskPresentation.compactValue
+        let breakdown = model.slices
+            .map { "\($0.title), \(hidden), \($0.shareText)" }
+            .joined(separator: ". ")
+        return "Spending by category. \(hidden) spent this month across \(model.sliceCount) "
+            + "\(model.sliceCount == 1 ? "group" : "groups"). \(breakdown). "
+            + "Amounts hidden while Privacy Mask is on."
+    }
+
+    private func legendAccessibilityLabel(for slice: SpendDonutModel.Slice) -> String {
+        let amount = isPrivacyMasked ? PrivacyMaskPresentation.compactValue : slice.amountText
+        return "\(slice.title), \(amount), \(slice.shareText)"
+    }
+
+    // MARK: - Color + glyph
+
+    private var sliceColors: [Color] {
+        model.slices.map { color(for: $0.group) }
+    }
+
+    /// A group's accent is its first (canonical-order) leaf's design-system chart
+    /// color — `CategoryAccentTokens` already returns appearance-aware SwiftUI colors,
+    /// matching the per-leaf hues used elsewhere (e.g. the income-flow chart).
+    private func color(for group: CategoryGroup) -> Color {
+        guard let representative = group.categories.first else { return .secondary }
+        return CategoryAccentTokens.color(for: representative)
+    }
+
+    private func glyph(for group: CategoryGroup) -> String {
+        group.categories.first?.iconName ?? "circle.fill"
+    }
+
+    // MARK: - Motion
+
+    private func animateReveal() {
+        guard !reduceMotion else { revealFraction = 1; return }
+        revealFraction = 0
+        withAnimation(MotionTokens.chartReveal.delay(0.1)) {
+            revealFraction = 1
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/SpendDonutModel.swift
+++ b/Sources/PlaidBarCore/Models/SpendDonutModel.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Pure, `Sendable` view-model for the **spend donut + center total** (AND-537).
+///
+/// The donut visualizes *where this month's money went* by ``CategoryGroup``,
+/// consuming the already-computed override-aware rollups in
+/// ``CategoryDashboardPresentation`` — it never recomputes spend. Each slice is one
+/// spending group's net total; the ring's center shows the overall spend total.
+///
+/// All display strings (slice/legend labels, share percentages, VoiceOver text, the
+/// center total) are baked here so the SwiftUI view stays a thin renderer and every
+/// label can be unit-tested without a host view. Meaning never rides on color alone:
+/// each slice carries its group title, amount, and share as text (ACCESSIBILITY.md).
+///
+/// Slices are ordered spend-heaviest first (a stable tiebreak on
+/// ``CategoryGroup/sortIndex`` keeps equal-spend ordering deterministic for
+/// screenshots and tests), and shares are computed against the donut's *own* slice
+/// total — which equals ``CategoryDashboardPresentation/totalSpent`` because the
+/// presentation only ever contains spend groups (income / transfers are dropped
+/// before aggregation), so the shares always sum to ~100%.
+public struct SpendDonutModel: Sendable, Hashable {
+    /// One donut slice — a spending ``CategoryGroup`` and its net current-month spend.
+    public struct Slice: Sendable, Hashable, Identifiable {
+        /// Stable identity (`group.rawValue`) — also the Swift Charts plot key.
+        public let id: String
+        public let group: CategoryGroup
+        /// Net current-month spend for this group (already floored at `0`).
+        public let amount: Double
+        /// `amount / total`, in `0...1`; `0` when the donut total is `0`.
+        public let fraction: Double
+        /// Group title, e.g. `"Food & Dining"`.
+        public var title: String { group.title }
+        /// Pre-formatted currency amount, e.g. `"$420.00"`.
+        public let amountText: String
+        /// Pre-formatted share, e.g. `"34%"` (whole-percent, never color-only).
+        public let shareText: String
+        /// Legend / VoiceOver line: `"Food & Dining, $420.00, 34%"`.
+        public let label: String
+
+        public init(group: CategoryGroup, amount: Double, fraction: Double, currencyCode: String) {
+            self.id = group.rawValue
+            self.group = group
+            self.amount = amount
+            self.fraction = fraction
+            let amountText = Formatters.currency(amount, format: .full, currencyCode: currencyCode)
+            self.amountText = amountText
+            let shareText = SpendDonutModel.shareText(fraction)
+            self.shareText = shareText
+            self.label = "\(group.title), \(amountText), \(shareText)"
+        }
+    }
+
+    /// Slices, spend-heaviest first. Empty when there is no spend to show.
+    public let slices: [Slice]
+    /// Sum of every slice's spend — the figure shown in the ring's center.
+    public let total: Double
+    /// Pre-formatted center total, e.g. `"$1,234.00"`.
+    public let totalText: String
+    /// Short label rendered under the center total (`"Spent this month"`).
+    public let centerCaption: String
+    /// Currency code the amounts were formatted with (carried for the view).
+    public let currencyCode: String
+
+    /// Build the donut model from the dashboard rollups.
+    ///
+    /// - Parameters:
+    ///   - presentation: the override-aware rollup the donut renders. Only groups
+    ///     with positive spend become slices; income / transfers never carry spend so
+    ///     they never appear.
+    ///   - currencyCode: ISO code used to format every amount. Defaults to `"USD"`.
+    public init(presentation: CategoryDashboardPresentation, currencyCode: String = "USD") {
+        self.currencyCode = currencyCode
+        self.centerCaption = "Spent this month"
+
+        // Only groups that actually carry spend are slices. Sort spend-heaviest
+        // first, breaking ties on the canonical display order so equal-spend groups
+        // never reorder between builds (stable screenshots / tests).
+        let spendingGroups = presentation.groups
+            .filter { $0.spent > 0 }
+            .sorted { lhs, rhs in
+                if lhs.spent != rhs.spent { return lhs.spent > rhs.spent }
+                return lhs.group.sortIndex < rhs.group.sortIndex
+            }
+
+        let total = spendingGroups.reduce(0) { $0 + $1.spent }
+        self.total = total
+        self.totalText = Formatters.currency(total, format: .full, currencyCode: currencyCode)
+
+        self.slices = spendingGroups.map { rollup in
+            let fraction = total > 0 ? rollup.spent / total : 0
+            return Slice(
+                group: rollup.group,
+                amount: rollup.spent,
+                fraction: fraction,
+                currencyCode: currencyCode
+            )
+        }
+    }
+
+    /// True when there is no spend to chart.
+    public var isEmpty: Bool { slices.isEmpty }
+
+    /// Number of slices.
+    public var sliceCount: Int { slices.count }
+
+    /// One-line VoiceOver summary of the whole donut: total + every slice's group,
+    /// amount, and share, so a screen-reader user gets the same breakdown the
+    /// sighted legend shows — never color alone (ACCESSIBILITY.md).
+    public var accessibilityLabel: String {
+        guard !isEmpty else {
+            return "Spending by category. No spending this month."
+        }
+        let breakdown = slices.map(\.label).joined(separator: ". ")
+        return "Spending by category. \(totalText) spent this month across \(sliceCount) "
+            + "\(sliceCount == 1 ? "group" : "groups"). \(breakdown)."
+    }
+
+    /// Whole-percent share string, e.g. `0.3412 -> "34%"`. A non-zero-but-tiny share
+    /// floors to `"<1%"` rather than `"0%"` so a present slice never reads as absent.
+    static func shareText(_ fraction: Double) -> String {
+        let pct = fraction * 100
+        if pct > 0, pct < 1 { return "<1%" }
+        return Formatters.percent(pct, decimals: 0)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SpendDonutModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SpendDonutModelTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("SpendDonutModel slice + label prep (AND-537)")
+struct SpendDonutModelTests {
+    // MARK: - Fixtures
+
+    /// A group rollup with a single leaf of the given spend (no budget).
+    private func group(_ group: CategoryGroup, leaf category: SpendingCategory, spent: Double) -> CategoryDashboardPresentation.GroupRollup {
+        CategoryDashboardPresentation.GroupRollup(
+            group: group,
+            leaves: [CategoryDashboardPresentation.Leaf(category: category, spent: spent, monthlyLimit: nil)]
+        )
+    }
+
+    private func presentation(_ groups: [CategoryDashboardPresentation.GroupRollup]) -> CategoryDashboardPresentation {
+        CategoryDashboardPresentation(groups: groups)
+    }
+
+    // MARK: - Construction / totals
+
+    @Test("empty presentation yields an empty donut")
+    func emptyIsEmpty() {
+        let model = SpendDonutModel(presentation: .empty)
+        #expect(model.isEmpty)
+        #expect(model.slices.isEmpty)
+        #expect(model.total == 0)
+        #expect(model.sliceCount == 0)
+    }
+
+    @Test("total equals the sum of slice spend and matches the presentation total")
+    func totalSumsSlices() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            group(.shopping, leaf: .shopping, spent: 100),
+            group(.transportation, leaf: .transportation, spent: 100),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        #expect(model.total == 500)
+        #expect(model.total == p.totalSpent)
+        #expect(model.slices.reduce(0) { $0 + $1.amount } == 500)
+    }
+
+    // MARK: - Ordering
+
+    @Test("slices are ordered spend-heaviest first")
+    func sortedBySpendDescending() {
+        let p = presentation([
+            group(.shopping, leaf: .shopping, spent: 100),
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 400),
+            group(.transportation, leaf: .transportation, spent: 250),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        #expect(model.slices.map(\.group) == [.foodAndDining, .transportation, .shopping])
+    }
+
+    @Test("equal-spend groups break ties on canonical display order (deterministic)")
+    func equalSpendTiebreak() {
+        // foodAndDining (sortIndex 2) precedes shopping (sortIndex 4) at equal spend.
+        let p = presentation([
+            group(.shopping, leaf: .shopping, spent: 200),
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 200),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        #expect(model.slices.map(\.group) == [.foodAndDining, .shopping])
+    }
+
+    // MARK: - Shares
+
+    @Test("slice fractions are spend / total and sum to ~1")
+    func fractionsSumToOne() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            group(.shopping, leaf: .shopping, spent: 100),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        let food = try! #require(model.slices.first { $0.group == .foodAndDining })
+        #expect(abs(food.fraction - 0.75) < 1e-9)
+        #expect(abs(model.slices.reduce(0) { $0 + $1.fraction } - 1.0) < 1e-9)
+    }
+
+    @Test("share text is whole-percent")
+    func shareTextWholePercent() {
+        #expect(SpendDonutModel.shareText(0.3412) == "34%")
+        #expect(SpendDonutModel.shareText(0.5) == "50%")
+        #expect(SpendDonutModel.shareText(1.0) == "100%")
+    }
+
+    @Test("a tiny but present share floors to <1%, never 0%")
+    func tinyShareNeverZero() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 1000),
+            group(.shopping, leaf: .shopping, spent: 1), // ~0.0999%
+        ])
+        let model = SpendDonutModel(presentation: p)
+        let shopping = try! #require(model.slices.first { $0.group == .shopping })
+        #expect(shopping.shareText == "<1%")
+        #expect(shopping.shareText != "0%")
+    }
+
+    // MARK: - Labels (color-independent)
+
+    @Test("each slice label carries group title, amount, and share as text")
+    func sliceLabelCarriesTextMeaning() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 420),
+            group(.shopping, leaf: .shopping, spent: 580),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        let food = try! #require(model.slices.first { $0.group == .foodAndDining })
+        #expect(food.title == "Food & Dining")
+        #expect(food.amountText == "$420.00")
+        #expect(food.shareText == "42%")
+        #expect(food.label == "Food & Dining, $420.00, 42%")
+    }
+
+    @Test("center total text is the formatted overall spend")
+    func centerTotalText() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 1200),
+            group(.shopping, leaf: .shopping, spent: 34),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        #expect(model.totalText == "$1,234.00")
+        #expect(model.centerCaption == "Spent this month")
+    }
+
+    @Test("currency code threads through every formatted amount")
+    func currencyCodeThreads() {
+        let p = presentation([group(.foodAndDining, leaf: .foodAndDrink, spent: 100)])
+        let model = SpendDonutModel(presentation: p, currencyCode: "EUR")
+        #expect(model.currencyCode == "EUR")
+        // EUR formatting differs from USD ("$"); just assert it isn't a dollar string.
+        #expect(!model.totalText.contains("$"))
+    }
+
+    // MARK: - Accessibility
+
+    @Test("empty donut has a spoken no-spending summary")
+    func emptyAccessibilityLabel() {
+        let model = SpendDonutModel(presentation: .empty)
+        #expect(model.accessibilityLabel == "Spending by category. No spending this month.")
+    }
+
+    @Test("accessibility label names the total and every slice's breakdown")
+    func accessibilityLabelDescribesEverySlice() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            group(.shopping, leaf: .shopping, spent: 100),
+        ])
+        let model = SpendDonutModel(presentation: p)
+        let label = model.accessibilityLabel
+        #expect(label.contains("$400.00"))
+        #expect(label.contains("2 groups"))
+        #expect(label.contains("Food & Dining, $300.00, 75%"))
+        #expect(label.contains("Shopping, $100.00, 25%"))
+    }
+
+    @Test("single-slice accessibility label uses singular 'group'")
+    func singularGroupGrammar() {
+        let p = presentation([group(.foodAndDining, leaf: .foodAndDrink, spent: 100)])
+        let model = SpendDonutModel(presentation: p)
+        #expect(model.accessibilityLabel.contains("1 group."))
+        #expect(!model.accessibilityLabel.contains("1 groups"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **spend donut + center total** for the Copilot-style category dashboard: a Swift Charts `SectorMark` ring of this month's spend by `CategoryGroup`, with the overall spend total rendered in the ring's hole. Scope is deliberately donut-only — the dashboard card/window that assembles it is AND-539.

The view is a thin renderer. All spend, slice ordering, share math, and label/center text are produced by a new pure, `Sendable` `SpendDonutModel` in `PlaidBarCore`, built from the existing override-aware `CategoryDashboardPresentation` group rollups. **No spend is recomputed; no `AppState` edits.**

- `Sources/PlaidBarCore/Models/SpendDonutModel.swift` — pure slice/label prep (ordering, shares, baked currency + VoiceOver text).
- `Sources/PlaidBar/Views/Charts/SpendDonutChart.swift` — `SectorMark` ring, center total overlay, glyph+text legend.
- `Tests/PlaidBarCoreTests/SpendDonutModelTests.swift` — 13 unit tests for the pure model.

## Linear (AND-537)

Implements **AND-537** (Epic AND-521, Category Dashboard). Consumes the AND-536 `CategoryDashboardBuilder` / `CategoryDashboardPresentation` rollups and the AND-535 `CategoryGroup` map.

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` **§3** (Category Dashboard "where money went" — donut + top groups) and **§4** (Views: `CategoryDonutChart`; Option A display-only rollups, additive, no migration):

- **Consumes, never recomputes** — slices are `CategoryDashboardPresentation.GroupRollup.spent`, the already override-aware/net-signed figure. Income and transfers carry no spend (the planner drops them before aggregation), so they never appear as slices; the model also explicitly filters to groups with positive spend.
- **Center total** = sum of slice spend, which equals `presentation.totalSpent`.
- **Option A** — no schema change, no new `SpendingCategory` raw values, no server work, no `AppState` edits.

## Testing notes

New pure-model tests in `SpendDonutModelTests` (13):
`emptyIsEmpty`, `totalSumsSlices`, `sortedBySpendDescending`, `equalSpendTiebreak`, `fractionsSumToOne`, `shareTextWholePercent`, `tinyShareNeverZero`, `sliceLabelCarriesTextMeaning`, `centerTotalText`, `currencyCodeThreads`, `emptyAccessibilityLabel`, `accessibilityLabelDescribesEverySlice`, `singularGroupGrammar`.

Strict-concurrency build (CI gate):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (196.46s)
```

Full test suite:

```
swift test
✔ Test run with 1203 tests passed after 0.820 seconds.
```

New suite in isolation:

```
swift test --filter SpendDonutModelTests
✔ Suite "SpendDonutModel slice + label prep (AND-537)" passed after 0.004 seconds.
✔ Test run with 13 tests passed after 0.004 seconds.
```

## Architectural decisions

- **Pure logic in `PlaidBarCore`, view stays thin.** SwiftUI views in the app target aren't headlessly unit-testable, so ordering/shares/label/VoiceOver text live in `SpendDonutModel` and are fully covered; the view only owns geometry, color, and motion.
- **Color is never the only signal (ACCESSIBILITY.md).** A glyph+text legend lists every slice's group title, amount, and share; the ring is one VoiceOver element speaking the model's combined breakdown summary, and each legend row is its own labeled element. Slice fills come from the existing `CategoryAccentTokens` design-system hues via `chartForegroundStyleScale`.
- **Group accent** = the group's first canonical-order leaf's `CategoryAccentTokens` color, matching the per-leaf hues used elsewhere (e.g. the income-flow chart).
- **Deterministic ordering** — slices sort spend-heaviest first with a stable tiebreak on `CategoryGroup.sortIndex`, so equal-spend groups never reorder between builds (stable screenshots/QA).
- **Privacy Mask + Reduce Motion** honored: masked amounts (center, legend, VoiceOver) when Privacy Mask is on; the reveal animation is gated by Reduce Motion.
- **Tiny-but-present shares** floor to `<1%` rather than `0%`, so a present slice never reads as absent.

## Migration notes

None — additive. No schema, DTO, `SpendingCategory` raw value, or server change; no `AppState` change. Two new files plus one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)