### PR TITLE
feat(ui): bulk "Mark N reviewed" with blast radius (AND-528)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3501,6 +3501,29 @@ final class AppState {
         persistReviewStorage()
     }
 
+    /// Marks a batch of inbox rows reviewed in a single, undoable step (AND-528).
+    ///
+    /// The blast radius — exactly which transaction ids resolve — is decided by the
+    /// pure `ReviewBulkActionPlan` (computed in the view and surfaced to the user
+    /// before this is called), so this method just applies the already-vetted ids.
+    /// Each id flows through the SAME per-item approve logic as the single-row
+    /// Approve button (`approveReviewItemWithoutUndo`) so the two paths can never
+    /// diverge in what "reviewed" means. The whole batch shares one undo snapshot
+    /// (a single ⌘Z restores the entire bulk action) and one persistence write.
+    @discardableResult
+    func bulkMarkReviewed(ids: [String]) -> Int {
+        // Resolve against current transactions so a stale id (a row already gone
+        // from the snapshot) is skipped rather than seeding orphan metadata.
+        let resolvableIDs = ids.filter { id in transactions.contains(where: { $0.id == id }) }
+        guard !resolvableIDs.isEmpty else { return 0 }
+        pushReviewUndoState()
+        for id in resolvableIDs {
+            approveReviewItemWithoutUndo(id)
+        }
+        persistReviewStorage()
+        return resolvableIDs.count
+    }
+
     func undoLastReviewAction() {
         guard let previous = reviewUndoStack.popLast() else { return }
         transactionReviewMetadata = previous.metadata

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -14,6 +14,10 @@ struct ReviewInboxView: View {
     @State private var selectedIndex = 0
     @State private var merchantDrafts: [String: String] = [:]
     @State private var actionConfirmation: ReviewActionConfirmation?
+    /// Set when the user taps "Mark N reviewed"; holds the pre-computed blast
+    /// radius so the confirmation dialog can state exactly how many and which
+    /// rows resolve before anything is applied (AND-528).
+    @State private var bulkReviewPlan: ReviewBulkActionPlan?
     /// Monotonic token so a queued auto-dismiss only clears the banner it was
     /// scheduled for — a newer action (which bumps the token) is never wiped by
     /// an older timer.
@@ -25,6 +29,14 @@ struct ReviewInboxView: View {
 
     private var items: [TransactionReviewItem] {
         Array(snapshot.items.prefix(embedded ? 20 : 6))
+    }
+
+    /// The blast radius of a bulk "Mark N reviewed" over the rows currently
+    /// listed. No explicit selection: the radius is every unresolved row the user
+    /// can see in this surface (the list is already truncated to the visible
+    /// rows), so the action never resolves more than is on screen.
+    private var listedBulkPlan: ReviewBulkActionPlan {
+        ReviewBulkActionPlan.markReviewed(items: items)
     }
 
     private var headerPresentation: ReviewInboxPrivacyPresentation {
@@ -125,7 +137,29 @@ struct ReviewInboxView: View {
             .onMoveCommand(perform: moveSelection)
             .accessibilityElement(children: .contain)
             .accessibilityLabel(headerPresentation.accessibilityLabel)
+            .confirmationDialog(
+                bulkReviewPlan.map { "Mark \($0.count) reviewed?" } ?? "Mark reviewed?",
+                isPresented: bulkReviewConfirmationBinding,
+                titleVisibility: .visible,
+                presenting: bulkReviewPlan
+            ) { plan in
+                Button("Mark \(plan.count) Reviewed") { applyBulkReview(plan) }
+                Button("Cancel", role: .cancel) {}
+            } message: { plan in
+                // State the blast radius in full so the user sees how many and
+                // which rows resolve before confirming — never a bare count.
+                Text(plan.blastRadiusDescription())
+            }
         }
+    }
+
+    /// Drives the confirmation dialog: presented while a plan is staged, and
+    /// clearing the plan when dismissed.
+    private var bulkReviewConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { bulkReviewPlan != nil },
+            set: { presented in if !presented { bulkReviewPlan = nil } }
+        )
     }
 
     private var header: some View {
@@ -147,6 +181,25 @@ struct ReviewInboxView: View {
                     .foregroundStyle(SemanticColors.warning)
                     .labelStyle(.titleAndIcon)
                     .accessibilityLabel(headerPresentation.highPriorityAccessibilityLabel ?? highPriorityBadge)
+            }
+
+            // Bulk "Mark N reviewed": staging a plan opens the blast-radius
+            // confirmation. Hidden while masked (rows hidden) or when the inbox
+            // has nothing to resolve. The N rides the label text + icon, never
+            // color alone.
+            if !appState.shouldMaskFinancialValues, !listedBulkPlan.isEmpty {
+                Button {
+                    bulkReviewPlan = listedBulkPlan
+                } label: {
+                    Label("Mark \(listedBulkPlan.count) reviewed", systemImage: "checklist")
+                        .font(.caption2.weight(.semibold))
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .help("Review all \(listedBulkPlan.count) listed transactions at once")
+                .accessibilityLabel("Mark \(listedBulkPlan.count) listed transactions reviewed")
+                .accessibilityHint("Shows which transactions will be marked reviewed before applying.")
             }
 
             Button {
@@ -233,6 +286,34 @@ struct ReviewInboxView: View {
         }
     }
 
+    /// Applies a confirmed bulk review: marks the plan's rows reviewed via the
+    /// shared AppState path, animates the resolved rows out, announces the count
+    /// and result to VoiceOver, and surfaces the same confirmation banner the
+    /// single-row actions use. Clears the staged plan either way.
+    private func applyBulkReview(_ plan: ReviewBulkActionPlan) {
+        bulkReviewPlan = nil
+        guard !plan.isEmpty else { return }
+        recordBulkAction(count: plan.count)
+        animatingResolution { appState.bulkMarkReviewed(ids: plan.affectedIDs) }
+        // Announce the outcome with the count spelled out, so the result is not
+        // conveyed only by rows silently vanishing from the list.
+        let noun = plan.count == 1 ? "transaction" : "transactions"
+        AccessibilityNotification.Announcement("Marked \(plan.count) \(noun) reviewed").post()
+    }
+
+    private func recordBulkAction(count: Int) {
+        confirmationGeneration &+= 1
+        let generation = confirmationGeneration
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            actionConfirmation = ReviewActionConfirmation(action: .bulkReviewed(count), merchantName: nil)
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2.5))
+            guard confirmationGeneration == generation else { return }
+            withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) { actionConfirmation = nil }
+        }
+    }
+
     private func recordAction(_ action: ReviewActionConfirmation.Action, for item: TransactionReviewItem) {
         confirmationGeneration &+= 1
         let generation = confirmationGeneration
@@ -273,6 +354,7 @@ private struct ReviewActionConfirmation: Equatable {
         case markedTransfer
         case markedSpend
         case ruleCreated
+        case bulkReviewed(Int)
 
         var message: String {
             switch self {
@@ -290,15 +372,29 @@ private struct ReviewActionConfirmation: Equatable {
                 "Marked as spend"
             case .ruleCreated:
                 "Rule created"
+            case let .bulkReviewed(count):
+                "Marked \(count) reviewed"
             }
         }
     }
 
     let action: Action
-    let merchantName: String
+    /// The single merchant a row-level action resolved. Nil for batch actions
+    /// (bulk review), where the subject is a count, not one merchant.
+    let merchantName: String?
+
+    var bannerText: String {
+        if let merchantName {
+            return "\(action.message): \(merchantName)"
+        }
+        return action.message
+    }
 
     var accessibilityLabel: String {
-        "Review action completed: \(action.message) for \(merchantName)"
+        if let merchantName {
+            return "Review action completed: \(action.message) for \(merchantName)"
+        }
+        return "Review action completed: \(action.message)"
     }
 }
 
@@ -307,7 +403,7 @@ private struct ReviewActionConfirmationBanner: View {
 
     var body: some View {
         Label {
-            Text("\(confirmation.action.message): \(confirmation.merchantName)")
+            Text(confirmation.bannerText)
                 .font(.caption.weight(.semibold))
                 .lineLimit(2)
         } icon: {

--- a/Sources/PlaidBarCore/Models/ReviewBulkAction.swift
+++ b/Sources/PlaidBarCore/Models/ReviewBulkAction.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Pure description of the *blast radius* of a bulk "Mark N reviewed" action on
+/// the Review Inbox (AND-528).
+///
+/// The Review Inbox lets the user clear individual rows; a bulk action must make
+/// its scope explicit *before* applying — how many rows, and exactly which ones —
+/// so a single click never silently resolves more than the user can see. This
+/// type computes that scope from the inbox items currently on screen plus an
+/// optional explicit selection, with no SwiftUI or AppState dependency so the
+/// "which rows are affected" decision is unit-testable.
+///
+/// Scope rules:
+/// - Only items the resolver still considers *unresolved* (`status != .reviewed`)
+///   are eligible — an already-reviewed row that lingers (e.g. reopened) is not
+///   re-marked, and ignored rows are left as the user set them.
+/// - With no explicit selection (`selectedIDs == nil`) the radius is every
+///   eligible row currently listed — "mark everything I can see".
+/// - With an explicit selection the radius is the intersection of the selection
+///   and the eligible listed rows, so a stale id (a row that already left the
+///   list) can never mark a transaction that is no longer shown.
+public struct ReviewBulkActionPlan: Sendable, Equatable {
+    /// Transaction ids that will be marked reviewed, in the order they appear in
+    /// the inbox list (stable, so the announced "which" matches the visual order).
+    public let affectedIDs: [String]
+
+    /// Merchant names of the affected rows, list order, for an explicit
+    /// "which transactions" preview (deduped is intentionally NOT applied — two
+    /// distinct rows from the same merchant are two distinct resolutions).
+    public let affectedMerchantNames: [String]
+
+    public var count: Int { affectedIDs.count }
+
+    public var isEmpty: Bool { affectedIDs.isEmpty }
+
+    public init(affectedIDs: [String], affectedMerchantNames: [String]) {
+        self.affectedIDs = affectedIDs
+        self.affectedMerchantNames = affectedMerchantNames
+    }
+
+    /// Computes the blast radius for marking inbox rows reviewed.
+    ///
+    /// - Parameters:
+    ///   - items: the inbox rows currently listed (already truncated to what the
+    ///     surface shows — the radius never exceeds the visible list).
+    ///   - selectedIDs: an explicit selection, or `nil` to mean "all listed".
+    public static func markReviewed(
+        items: [TransactionReviewItem],
+        selectedIDs: Set<String>? = nil
+    ) -> ReviewBulkActionPlan {
+        let eligible = items.filter { $0.status != .reviewed }
+        let scoped: [TransactionReviewItem]
+        if let selectedIDs {
+            scoped = eligible.filter { selectedIDs.contains($0.id) }
+        } else {
+            scoped = eligible
+        }
+        return ReviewBulkActionPlan(
+            affectedIDs: scoped.map(\.id),
+            affectedMerchantNames: scoped.map(\.effectiveMerchantName)
+        )
+    }
+
+    /// A short, plain-language description of which rows the action will resolve,
+    /// suitable for a confirmation prompt and a VoiceOver announcement — count
+    /// first, then a bounded list of merchant names so meaning never rides on a
+    /// color or an unlabeled number alone.
+    ///
+    /// - Parameter previewLimit: how many merchant names to spell out before
+    ///   collapsing the rest into "and N more".
+    public func blastRadiusDescription(previewLimit: Int = 3) -> String {
+        guard count > 0 else { return "No transactions to mark reviewed" }
+        let noun = count == 1 ? "transaction" : "transactions"
+        let names = affectedMerchantNames.prefix(max(previewLimit, 0))
+        let remainder = count - names.count
+        guard !names.isEmpty else { return "Mark \(count) \(noun) reviewed" }
+        var preview = names.joined(separator: ", ")
+        if remainder > 0 {
+            preview += ", and \(remainder) more"
+        }
+        return "Mark \(count) \(noun) reviewed: \(preview)"
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReviewBulkActionTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewBulkActionTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Review Bulk Action Plan Tests")
+struct ReviewBulkActionTests {
+    @Test("No selection marks every unresolved listed row")
+    func allListedWhenNoSelection() {
+        let items = [
+            item(id: "a", merchant: "Corner Store"),
+            item(id: "b", merchant: "Coffee Shop"),
+            item(id: "c", merchant: "Gas Station"),
+        ]
+
+        let plan = ReviewBulkActionPlan.markReviewed(items: items)
+
+        #expect(plan.affectedIDs == ["a", "b", "c"])
+        #expect(plan.count == 3)
+        #expect(plan.affectedMerchantNames == ["Corner Store", "Coffee Shop", "Gas Station"])
+    }
+
+    @Test("Explicit selection scopes to listed rows in list order")
+    func explicitSelectionScopes() {
+        let items = [
+            item(id: "a", merchant: "Corner Store"),
+            item(id: "b", merchant: "Coffee Shop"),
+            item(id: "c", merchant: "Gas Station"),
+        ]
+
+        // Selection order should NOT leak through — list order is preserved so
+        // the announced "which" matches what the user sees.
+        let plan = ReviewBulkActionPlan.markReviewed(items: items, selectedIDs: ["c", "a"])
+
+        #expect(plan.affectedIDs == ["a", "c"])
+        #expect(plan.affectedMerchantNames == ["Corner Store", "Gas Station"])
+    }
+
+    @Test("Stale selected id that already left the list never marks anything")
+    func staleSelectionIgnored() {
+        let items = [
+            item(id: "a", merchant: "Corner Store"),
+        ]
+
+        let plan = ReviewBulkActionPlan.markReviewed(items: items, selectedIDs: ["ghost"])
+
+        #expect(plan.isEmpty)
+        #expect(plan.affectedIDs.isEmpty)
+    }
+
+    @Test("Already-reviewed rows are excluded from the blast radius")
+    func reviewedRowsExcluded() {
+        let items = [
+            item(id: "a", merchant: "Corner Store", status: .needsReview),
+            item(id: "b", merchant: "Reopened", status: .reviewed),
+            item(id: "c", merchant: "Gas Station", status: .needsReview),
+        ]
+
+        // No selection: only the two unresolved rows are in scope.
+        let all = ReviewBulkActionPlan.markReviewed(items: items)
+        #expect(all.affectedIDs == ["a", "c"])
+
+        // Explicit selection of the reviewed row resolves to nothing.
+        let selected = ReviewBulkActionPlan.markReviewed(items: items, selectedIDs: ["b"])
+        #expect(selected.isEmpty)
+    }
+
+    @Test("Empty inbox produces an empty plan")
+    func emptyInbox() {
+        let plan = ReviewBulkActionPlan.markReviewed(items: [])
+
+        #expect(plan.isEmpty)
+        #expect(plan.count == 0)
+        #expect(plan.blastRadiusDescription() == "No transactions to mark reviewed")
+    }
+
+    @Test("Blast radius description states the count and which merchants")
+    func descriptionStatesCountAndNames() {
+        let items = [
+            item(id: "a", merchant: "Corner Store"),
+            item(id: "b", merchant: "Coffee Shop"),
+        ]
+
+        let plan = ReviewBulkActionPlan.markReviewed(items: items)
+
+        #expect(plan.blastRadiusDescription() == "Mark 2 transactions reviewed: Corner Store, Coffee Shop")
+    }
+
+    @Test("Singular noun for a single transaction")
+    func singularNoun() {
+        let plan = ReviewBulkActionPlan.markReviewed(items: [item(id: "a", merchant: "Corner Store")])
+
+        #expect(plan.blastRadiusDescription() == "Mark 1 transaction reviewed: Corner Store")
+    }
+
+    @Test("Description collapses overflow into 'and N more'")
+    func descriptionCollapsesOverflow() {
+        let items = (1 ... 5).map { item(id: "id-\($0)", merchant: "Merchant \($0)") }
+
+        let plan = ReviewBulkActionPlan.markReviewed(items: items)
+
+        #expect(
+            plan.blastRadiusDescription(previewLimit: 3)
+                == "Mark 5 transactions reviewed: Merchant 1, Merchant 2, Merchant 3, and 2 more"
+        )
+    }
+
+    private func item(
+        id: String,
+        merchant: String,
+        status: TransactionReviewStatus = .needsReview
+    ) -> TransactionReviewItem {
+        TransactionReviewItem(
+            transaction: TransactionDTO(
+                id: id,
+                accountId: "test-account",
+                amount: 12,
+                date: "2026-06-01",
+                name: merchant.uppercased(),
+                merchantName: merchant,
+                category: nil,
+                pending: false
+            ),
+            status: status,
+            reasonCodes: [.uncategorized],
+            effectiveCategory: nil,
+            effectiveMerchantName: merchant,
+            isTransfer: false,
+            excludedFromBudgets: false,
+            matchedRuleIds: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a bulk **"Mark N reviewed"** affordance to the Review Inbox that makes its **blast radius explicit before applying** — the header button reads `Mark N reviewed`, and tapping it opens a confirmation dialog stating exactly how many rows and which merchants will resolve (`Mark 3 transactions reviewed: Corner Store, Coffee Shop, Gas Station`). Only on confirm are the rows marked reviewed.

- **No explicit selection** → the radius is every *unresolved* row currently listed (the list is already truncated to the visible rows, so the action never resolves more than is on screen).
- Resolving the batch goes through the **same per-item approve logic** as the single-row Approve button, so "reviewed" can never mean two different things across the two paths.
- The whole batch is **one undo step** (single ⌘Z restores it) and **one persistence write**.
- Accessible: the count rides the button label + icon (never color alone), and the result is announced to VoiceOver (`Marked N transactions reviewed`) so it is not conveyed only by rows silently vanishing. The button is hidden while Privacy Mask / App Lock hides the rows.

## Linear

[AND-528](https://linear.app/andeslab/issue/AND-528) — bulk "Mark N reviewed" with explicit blast radius (Epic **AND-519** Review Inbox parity).

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`:
- **§3 (Target experience):** "Review Inbox ('triage to zero'): bulk 'Mark N reviewed' + blast radius" — this PR delivers exactly that affordance for the popover/embedded surface.
- **§4 (Architecture — Option A, additive):** purely additive surfacing. No `TransactionDTO`/`SpendingCategory`/schema change; review state stays app-local. The "which rows are in the blast radius" decision is extracted to a pure `ReviewBulkActionPlan` in `PlaidBarCore` (the spec's "extract pure logic, unit-test it" rule), keeping the SwiftUI view thin and headlessly testable logic in Core.

## Testing notes

New pure-logic suite `ReviewBulkActionTests` (`Tests/PlaidBarCoreTests/ReviewBulkActionTests.swift`), 8 tests:
- `allListedWhenNoSelection`
- `explicitSelectionScopes`
- `staleSelectionIgnored`
- `reviewedRowsExcluded`
- `emptyInbox`
- `descriptionStatesCountAndNames`
- `singularNoun`
- `descriptionCollapsesOverflow`

Strict-concurrency build (the CI gate) — green:
```
$ swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (18.20s)
```

Full suite — green:
```
$ swift test
✔ Test run with 1198 tests passed after 0.705 seconds.
```
(The `✘ … skipped: "macOS Keychain accepts test writes"` lines are environment skips, not failures.)

## Architectural decisions

- **Pure plan in Core, thin view.** `ReviewBulkActionPlan.markReviewed(items:selectedIDs:)` computes the affected ids (list-ordered) + merchant names and a `blastRadiusDescription(previewLimit:)`. It intersects an optional selection with the *unresolved* listed rows and drops stale ids, so the type already supports a future multi-select detached `Table` (AND-532) without UI rework.
- **Single source of truth for "reviewed."** `AppState.bulkMarkReviewed(ids:)` loops the existing `approveReviewItemWithoutUndo` rather than re-implementing the metadata mutation — the two review paths cannot drift. It is the only AppState change; `categoryBudgetPresentation`, demo loading, and the privacy region are untouched. Cache invalidation already flows through the `transactionReviewMetadata` `didSet`.
- **Confirm-before-apply.** A staged `bulkReviewPlan` drives a `confirmationDialog`; nothing mutates until the user confirms, so the blast radius is always seen first.

## Migration notes

None — additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
