### PR TITLE
feat(widgets): add Safe-to-Spend + Utilization Control Center controls (AND-503)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/ControlValuePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ControlValuePresentation.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// Pure presentation logic for the macOS 26 Control Center *value* controls
+/// (AND-503): Safe-to-Spend and Credit Utilization. A Control Widget runs in the
+/// widget extension, never the app, and cannot be unit-tested headlessly — so the
+/// masked-vs-real value-string decision lives here, in ``PlaidBarCore``, where it
+/// is `Sendable` and fully testable.
+///
+/// Each control reads the shared ``FinanceSnapshot`` from the App Group and asks
+/// for a ``ControlValueDisplay``: the figure rendered to a short string, plus an
+/// accessibility label and the SF Symbol the control should show. The figure is
+/// **withheld** (replaced with ``PrivacyMaskPresentation/compactValue``) whenever
+/// the snapshot is masked (App Lock / Privacy Mask), missing, or carries no usable
+/// value — mirroring ``FinanceIntentQueries`` so the control never leaks a figure
+/// the intents would refuse to speak.
+///
+/// State is never conveyed by color alone: the symbol SHAPE changes between the
+/// data, masked, and unavailable states, and the value/label text is explicit.
+public enum ControlValuePresentation {
+    /// The short string a control shows when the value is withheld because the
+    /// snapshot is masked, missing, or has no usable figure. Reuses the shared
+    /// Privacy-Mask dot placeholder so masked controls match masked popover/widget
+    /// surfaces exactly.
+    public static let withheldValue = PrivacyMaskPresentation.compactValue
+
+    /// One rendered Control Center value, ready to drop into a `Label`.
+    public struct ControlValueDisplay: Sendable, Equatable {
+        /// The figure rendered to a short display string, or ``withheldValue``
+        /// when withheld.
+        public let value: String
+        /// A self-contained accessibility sentence (state conveyed in words, never
+        /// color alone).
+        public let accessibilityLabel: String
+        /// SF Symbol name whose SHAPE conveys the state (value / masked / setup).
+        public let systemImage: String
+        /// True when no real figure is shown — the control is masked, the snapshot
+        /// is missing, or there is no usable value.
+        public let isWithheld: Bool
+
+        public init(
+            value: String,
+            accessibilityLabel: String,
+            systemImage: String,
+            isWithheld: Bool
+        ) {
+            self.value = value
+            self.accessibilityLabel = accessibilityLabel
+            self.systemImage = systemImage
+            self.isWithheld = isWithheld
+        }
+    }
+
+    // MARK: - Reasons a value is withheld
+
+    /// Why a value is not shown, so the control can pick the right symbol + copy.
+    private enum WithheldReason {
+        /// App Lock / Privacy Mask is on.
+        case masked
+        /// No snapshot yet (first run / post-reset) or snapshot has no usable data.
+        case unavailable
+    }
+
+    /// Shared gate: returns the reason a value must be withheld, or `nil` to show
+    /// the real figure. Mirrors ``FinanceIntentQueries`` (missing → unavailable,
+    /// masked → masked, empty → unavailable).
+    private static func withheldReason(for snapshot: FinanceSnapshot?) -> WithheldReason? {
+        guard let snapshot else { return .unavailable }
+        if snapshot.isMasked { return .masked }
+        if snapshot.isEmpty { return .unavailable }
+        return nil
+    }
+
+    // MARK: - Safe to spend
+
+    /// Display for the Safe-to-Spend control. Shows the conservative discretionary
+    /// balance as a compact currency string; withholds it when masked/unavailable.
+    public static func safeToSpend(from snapshot: FinanceSnapshot?) -> ControlValueDisplay {
+        if let reason = withheldReason(for: snapshot) {
+            return withheld(reason, metric: "Safe to spend")
+        }
+        // `withheldReason` already proved the snapshot is present, unmasked, and
+        // non-empty; bind it for the figure.
+        guard let snapshot else {
+            return withheld(.unavailable, metric: "Safe to spend")
+        }
+        let amount = snapshot.safeToSpend
+        let formatted = Formatters.currency(
+            amount,
+            format: .compact,
+            currencyCode: snapshot.isoCurrencyCode
+        )
+        let descriptor = amount < 0 ? "over budget" : "safe to spend"
+        return ControlValueDisplay(
+            value: formatted,
+            accessibilityLabel: "Safe to spend \(formatted), \(descriptor)",
+            systemImage: "dollarsign.circle",
+            isWithheld: false
+        )
+    }
+
+    // MARK: - Credit utilization
+
+    /// Display for the Credit-Utilization control. Shows the aggregate utilization
+    /// percent; withholds it when masked/unavailable. A snapshot with no known
+    /// credit limit (`creditUtilization == nil`) is reported as "no credit" rather
+    /// than a misleading 0%.
+    public static func creditUtilization(from snapshot: FinanceSnapshot?) -> ControlValueDisplay {
+        if let reason = withheldReason(for: snapshot) {
+            return withheld(reason, metric: "Credit utilization")
+        }
+        guard let snapshot else {
+            return withheld(.unavailable, metric: "Credit utilization")
+        }
+        guard let percent = snapshot.creditUtilization else {
+            // Non-withheld, but no figure to show — a credit-limit-free user.
+            return ControlValueDisplay(
+                value: "—",
+                accessibilityLabel: "Credit utilization unavailable, no credit card with a known limit is linked",
+                systemImage: "creditcard",
+                isWithheld: false
+            )
+        }
+        let formatted = Formatters.percent(percent, decimals: 0)
+        return ControlValueDisplay(
+            value: formatted,
+            accessibilityLabel: "Credit utilization \(formatted)",
+            systemImage: "creditcard",
+            isWithheld: false
+        )
+    }
+
+    // MARK: - Withheld rendering
+
+    private static func withheld(_ reason: WithheldReason, metric: String) -> ControlValueDisplay {
+        switch reason {
+        case .masked:
+            return ControlValueDisplay(
+                value: withheldValue,
+                accessibilityLabel: "\(metric) hidden while Privacy Mask is on",
+                systemImage: "eye.slash",
+                isWithheld: true
+            )
+        case .unavailable:
+            return ControlValueDisplay(
+                value: withheldValue,
+                accessibilityLabel: "\(metric) unavailable, open VaultPeek to get started",
+                systemImage: "lock.shield",
+                isWithheld: true
+            )
+        }
+    }
+}

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -331,11 +331,95 @@ private struct PlaidBarPrivacyMaskControl: ControlWidget {
     }
 }
 
+// MARK: - Value controls (AND-503, Epic E)
+//
+// Two read-only Control Center value displays: Safe-to-Spend and Credit
+// Utilization. Unlike the Refresh button and Privacy-Mask toggle, these render a
+// *number* pinned to Control Center / the menu bar. Each reads the shared
+// `FinanceSnapshot` (the same App-Group payload the App Intents use) and renders
+// it through `ControlValuePresentation` — the pure PlaidBarCore helper that owns
+// the masked-vs-real decision so the figure is withheld the instant App Lock /
+// Privacy Mask is on, mirroring `FinanceSnapshotBuilder`'s value-free behavior.
+//
+// Tapping a value control opens the app to the dashboard via an `OpenURLIntent`
+// pointed at `vaultpeek://dashboard` (handled by the app's `.onOpenURL`), the same
+// deep link the glance widget uses. State is never conveyed by color alone — the
+// SF Symbol shape changes between the value, masked, and unavailable states.
+
+/// Supplies the rendered Safe-to-Spend display string for the value control.
+struct SafeToSpendValueProvider: ControlValueProvider {
+    var previewValue: ControlValuePresentation.ControlValueDisplay {
+        ControlValuePresentation.safeToSpend(from: nil)
+    }
+
+    func currentValue() async throws -> ControlValuePresentation.ControlValueDisplay {
+        ControlValuePresentation.safeToSpend(from: AppGroupSnapshotStore.loadIfAvailable())
+    }
+}
+
+private struct PlaidBarSafeToSpendControl: ControlWidget {
+    let kind = "PlaidBarSafeToSpendControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: kind,
+            provider: SafeToSpendValueProvider()
+        ) { display in
+            ControlWidgetButton(action: openDashboardIntent()) {
+                Label(display.value, systemImage: display.systemImage)
+                    .accessibilityLabel(display.accessibilityLabel)
+            }
+        }
+        .displayName("Safe to Spend")
+        .description("Show your VaultPeek safe-to-spend amount in Control Center.")
+    }
+}
+
+/// Supplies the rendered Credit-Utilization display string for the value control.
+struct CreditUtilizationValueProvider: ControlValueProvider {
+    var previewValue: ControlValuePresentation.ControlValueDisplay {
+        ControlValuePresentation.creditUtilization(from: nil)
+    }
+
+    func currentValue() async throws -> ControlValuePresentation.ControlValueDisplay {
+        ControlValuePresentation.creditUtilization(from: AppGroupSnapshotStore.loadIfAvailable())
+    }
+}
+
+private struct PlaidBarCreditUtilizationControl: ControlWidget {
+    let kind = "PlaidBarCreditUtilizationControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: kind,
+            provider: CreditUtilizationValueProvider()
+        ) { display in
+            ControlWidgetButton(action: openDashboardIntent()) {
+                Label(display.value, systemImage: display.systemImage)
+                    .accessibilityLabel(display.accessibilityLabel)
+            }
+        }
+        .displayName("Credit Utilization")
+        .description("Show your VaultPeek credit utilization in Control Center.")
+    }
+}
+
+/// The deep-link action shared by both value controls: opens VaultPeek to the
+/// dashboard via the system `OpenURLIntent` pointed at `vaultpeek://dashboard`
+/// (handled by the app's `.onOpenURL`), the same link the glance widget uses.
+/// `GlanceSnapshot.deepLinkURL` is a compile-time constant, so the fallback URL
+/// is unreachable in practice — it only satisfies the non-optional initializer.
+private func openDashboardIntent() -> OpenURLIntent {
+    OpenURLIntent(URL(string: GlanceSnapshot.deepLinkURL) ?? URL(fileURLWithPath: "/"))
+}
+
 @main
 struct PlaidBarWidgetBundle: WidgetBundle {
     var body: some Widget {
         PlaidBarGlanceWidget()
         PlaidBarRefreshControl()
         PlaidBarPrivacyMaskControl()
+        PlaidBarSafeToSpendControl()
+        PlaidBarCreditUtilizationControl()
     }
 }

--- a/Tests/PlaidBarCoreTests/ControlValuePresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/ControlValuePresentationTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Control Center value control presentation (AND-503)")
+struct ControlValuePresentationTests {
+    // MARK: - Safe to spend
+
+    @Test("Unmasked safe-to-spend shows a compact currency value")
+    func unmaskedSafeToSpendShowsValue() {
+        let display = ControlValuePresentation.safeToSpend(from: snapshot(safeToSpend: 1_250))
+        #expect(!display.isWithheld)
+        #expect(display.value == Formatters.currency(1_250, format: .compact))
+        #expect(display.value.contains("1,250"))
+        #expect(display.accessibilityLabel.lowercased().contains("safe to spend"))
+        #expect(display.systemImage == "dollarsign.circle")
+    }
+
+    @Test("Negative safe-to-spend renders the figure and an over-budget label")
+    func negativeSafeToSpendIsOverBudget() {
+        let display = ControlValuePresentation.safeToSpend(from: snapshot(safeToSpend: -340))
+        #expect(!display.isWithheld)
+        #expect(display.accessibilityLabel.lowercased().contains("over budget"))
+    }
+
+    @Test("Masked safe-to-spend withholds the value and never leaks the figure")
+    func maskedSafeToSpendIsWithheld() {
+        let display = ControlValuePresentation.safeToSpend(from: snapshot(safeToSpend: 4_321, isMasked: true))
+        #expect(display.isWithheld)
+        #expect(display.value == ControlValuePresentation.withheldValue)
+        #expect(display.value == PrivacyMaskPresentation.compactValue)
+        #expect(!display.value.contains("4,321"))
+        #expect(!display.accessibilityLabel.contains("4,321"))
+        #expect(!display.accessibilityLabel.contains("4321"))
+        #expect(display.systemImage == "eye.slash")
+        #expect(display.accessibilityLabel.lowercased().contains("privacy mask"))
+    }
+
+    @Test("Nil snapshot withholds safe-to-spend as unavailable")
+    func nilSafeToSpendIsUnavailable() {
+        let display = ControlValuePresentation.safeToSpend(from: nil)
+        #expect(display.isWithheld)
+        #expect(display.value == ControlValuePresentation.withheldValue)
+        #expect(display.systemImage == "lock.shield")
+        #expect(display.accessibilityLabel.lowercased().contains("unavailable"))
+    }
+
+    @Test("Empty placeholder snapshot withholds safe-to-spend as unavailable")
+    func emptySafeToSpendIsUnavailable() {
+        let display = ControlValuePresentation.safeToSpend(from: .placeholder())
+        #expect(display.isWithheld)
+        #expect(display.systemImage == "lock.shield")
+    }
+
+    // MARK: - Credit utilization
+
+    @Test("Unmasked credit utilization shows a whole-percent value")
+    func unmaskedUtilizationShowsValue() {
+        let display = ControlValuePresentation.creditUtilization(from: snapshot(creditUtilization: 42))
+        #expect(!display.isWithheld)
+        #expect(display.value == Formatters.percent(42, decimals: 0))
+        #expect(display.value.contains("42"))
+        #expect(display.value.contains("%"))
+        #expect(display.systemImage == "creditcard")
+    }
+
+    @Test("Masked credit utilization withholds the percent")
+    func maskedUtilizationIsWithheld() {
+        let display = ControlValuePresentation.creditUtilization(from: snapshot(creditUtilization: 73, isMasked: true))
+        #expect(display.isWithheld)
+        #expect(display.value == ControlValuePresentation.withheldValue)
+        #expect(!display.value.contains("73"))
+        #expect(!display.accessibilityLabel.contains("73"))
+        #expect(display.systemImage == "eye.slash")
+    }
+
+    @Test("No-credit-limit snapshot reports a non-withheld dash, not a fake 0%")
+    func noLimitUtilizationShowsDash() {
+        // A snapshot with cash balances but no credit limit is non-empty, so this
+        // is a real "no credit" answer rather than a setup prompt.
+        let display = ControlValuePresentation.creditUtilization(from: snapshot(creditUtilization: nil))
+        #expect(!display.isWithheld)
+        #expect(display.value == "—")
+        #expect(!display.value.contains("0"))
+        #expect(display.accessibilityLabel.lowercased().contains("no credit"))
+    }
+
+    @Test("Nil snapshot withholds credit utilization as unavailable")
+    func nilUtilizationIsUnavailable() {
+        let display = ControlValuePresentation.creditUtilization(from: nil)
+        #expect(display.isWithheld)
+        #expect(display.systemImage == "lock.shield")
+    }
+
+    // MARK: - Helpers
+
+    private func snapshot(
+        safeToSpend: Double = 1_000,
+        totalBalance: Double = 5_000,
+        creditUtilization: Double? = 20,
+        isMasked: Bool = false
+    ) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: safeToSpend,
+            totalBalance: totalBalance,
+            accountBalances: [
+                FinanceSnapshot.AccountBalance(displayName: "Checking", balance: totalBalance),
+            ],
+            nextRecurringBills: [],
+            creditUtilization: creditUtilization,
+            generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+            isMasked: isMasked
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds two read-only macOS 26 Control Center value controls to `PlaidBarWidgetBundle.swift`, completing the AND-503 spec on top of the existing Epic E control infra (Refresh button + Privacy-Mask toggle):

- **Safe to Spend** — shows the conservative discretionary balance as a compact currency string.
- **Credit Utilization** — shows aggregate credit utilization as a whole percent.

Each control reads the shared App-Group `FinanceSnapshot` (the same value-only payload that already backs the App Intents — no tokens, account IDs, or transactions) via `AppGroupSnapshotStore.loadIfAvailable()`, and renders it through a new pure `PlaidBarCore` helper, `ControlValuePresentation`.

Masking is honored end-to-end: when the snapshot `isMasked` (Privacy Mask / App Lock), the figure is withheld and replaced with the shared `••••` placeholder, mirroring `FinanceSnapshotBuilder`'s value-free-on-disk behavior. A missing or empty snapshot (first run / post-reset) renders a setup state instead of a misleading `$0`/`0%`.

Tapping a control opens VaultPeek to the dashboard via `OpenURLIntent` on the shared `vaultpeek://dashboard` deep link (handled by the app's `.onOpenURL`), the same link the glance widget uses. State is conveyed by SF Symbol shape and text — never color alone (`dollarsign.circle`/`creditcard` for values, `eye.slash` when masked, `lock.shield` when unavailable).

## Linear (AND-503)

Implements AND-503: pinnable Control Center controls for Safe-to-Spend and Credit Utilization.

## Testing notes

- New unit suite **`ControlValuePresentationTests`** (9 tests) covers the extracted pure logic:
  - `unmaskedSafeToSpendShowsValue`, `negativeSafeToSpendIsOverBudget`
  - `maskedSafeToSpendIsWithheld` (asserts the figure never appears in value or a11y label), `nilSafeToSpendIsUnavailable`, `emptySafeToSpendIsUnavailable`
  - `unmaskedUtilizationShowsValue`, `maskedUtilizationIsWithheld`, `noLimitUtilizationShowsDash` (no fake 0%), `nilUtilizationIsUnavailable`
- **Strict-concurrency build green:** `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — compiles all targets including `PlaidBarWidgetExtension`.
- **Full test suite green:** `swift test` — **1199 tests passed** (9 new).

## Architectural decisions

- **Pure logic in `PlaidBarCore`.** Control Widgets are not headlessly unit-testable, so the masked-vs-real value-string decision lives in `ControlValuePresentation`, where it is `Sendable` and tested. The controls are thin shells: load snapshot → ask the helper → drop the `ControlValueDisplay` into a `Label`.
- **Reuses existing surfaces, no new App-Group plumbing.** Reads the same `FinanceSnapshot` / `AppGroupSnapshotStore` that AND-502/504 already populate for App Intents; reuses `Formatters` (compact currency, whole percent) and `PrivacyMaskPresentation.compactValue` so masked controls match masked popover/widget surfaces exactly.
- **Withholding mirrors `FinanceIntentQueries`** (missing → unavailable, masked → masked, empty → unavailable) so a control never shows a figure the intents would refuse to speak.
- **Deep-link via `OpenURLIntent`** on the shared `vaultpeek://dashboard` constant rather than a bespoke open-app intent, matching the glance widget.

## Migration notes

None. No schema, snapshot-format, or App-Group container changes — the controls are pure readers of the existing snapshot. New controls appear in the user's Control Center gallery after install; nothing to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)