### PR TITLE
fix(privacy): hide review confirmation details while private

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -41,7 +41,10 @@ struct ReviewInboxView: View {
                 header
 
                 if let actionConfirmation {
-                    ReviewActionConfirmationBanner(confirmation: actionConfirmation)
+                    ReviewActionConfirmationBanner(
+                        confirmation: actionConfirmation,
+                        isPrivate: appState.shouldMaskFinancialValues
+                    )
                         .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
                 }
 
@@ -296,18 +299,23 @@ private struct ReviewActionConfirmation: Equatable {
 
     let action: Action
     let merchantName: String
-
-    var accessibilityLabel: String {
-        "Review action completed: \(action.message) for \(merchantName)"
-    }
 }
 
 private struct ReviewActionConfirmationBanner: View {
     let confirmation: ReviewActionConfirmation
+    let isPrivate: Bool
+
+    private var presentation: ReviewActionConfirmationPrivacyPresentation {
+        ReviewActionConfirmationPrivacyPresentation.make(
+            actionMessage: confirmation.action.message,
+            merchantName: confirmation.merchantName,
+            isPrivate: isPrivate
+        )
+    }
 
     var body: some View {
         Label {
-            Text("\(confirmation.action.message): \(confirmation.merchantName)")
+            Text(presentation.message)
                 .font(.caption.weight(.semibold))
                 .lineLimit(2)
         } icon: {
@@ -322,7 +330,7 @@ private struct ReviewActionConfirmationBanner: View {
             RoundedRectangle(cornerRadius: 10).stroke(SemanticColors.positive.opacity(0.20), lineWidth: 1)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(confirmation.accessibilityLabel)
+        .accessibilityLabel(presentation.accessibilityLabel)
     }
 }
 

--- a/Sources/PlaidBarCore/Models/AppLockPresentation.swift
+++ b/Sources/PlaidBarCore/Models/AppLockPresentation.swift
@@ -216,3 +216,26 @@ public struct ReviewInboxPrivacyPresentation: Sendable, Equatable {
         )
     }
 }
+
+public struct ReviewActionConfirmationPrivacyPresentation: Sendable, Equatable {
+    public let message: String
+    public let accessibilityLabel: String
+
+    public static func make(
+        actionMessage: String,
+        merchantName: String,
+        isPrivate: Bool
+    ) -> ReviewActionConfirmationPrivacyPresentation {
+        if isPrivate {
+            return ReviewActionConfirmationPrivacyPresentation(
+                message: "Review action completed",
+                accessibilityLabel: "Review action completed. Details are hidden while VaultPeek is private."
+            )
+        }
+
+        return ReviewActionConfirmationPrivacyPresentation(
+            message: "\(actionMessage): \(merchantName)",
+            accessibilityLabel: "Review action completed: \(actionMessage) for \(merchantName)"
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -65,6 +65,33 @@ struct AppLockPresentationTests {
         #expect(presentation.accessibilityLabel == "Review inbox. 2 transactions need attention.")
     }
 
+    @Test("private Review Inbox confirmation hides merchant details")
+    func privateReviewInboxConfirmationHidesMerchantDetails() {
+        let presentation = ReviewActionConfirmationPrivacyPresentation.make(
+            actionMessage: "Approved",
+            merchantName: "Sensitive Merchant",
+            isPrivate: true
+        )
+
+        #expect(presentation.message == "Review action completed")
+        #expect(presentation.accessibilityLabel == "Review action completed. Details are hidden while VaultPeek is private.")
+        #expect(!presentation.message.contains("Approved"))
+        #expect(!presentation.message.contains("Sensitive Merchant"))
+        #expect(!presentation.accessibilityLabel.contains("Sensitive Merchant"))
+    }
+
+    @Test("normal Review Inbox confirmation keeps merchant details")
+    func normalReviewInboxConfirmationKeepsMerchantDetails() {
+        let presentation = ReviewActionConfirmationPrivacyPresentation.make(
+            actionMessage: "Ignored",
+            merchantName: "Local Grocer",
+            isPrivate: false
+        )
+
+        #expect(presentation.message == "Ignored: Local Grocer")
+        #expect(presentation.accessibilityLabel == "Review action completed: Ignored for Local Grocer")
+    }
+
     @Test("locked pause settings fail closed for refresh and notifications")
     func lockedPauseSettingsFailClosed() {
         let paused = AppLockPreferences(appLockEnabled: true, notificationPrivacyMode: .offWhileLocked, pauseRefreshWhileLocked: true)


### PR DESCRIPTION
## Summary

Fixes #535. Linear: AND-573.

- adds a Core presentation policy for Review Inbox action confirmations
- keeps merchant-specific confirmation copy in normal mode
- replaces confirmation copy with generic private text while Privacy Mask/App Lock is active
- wires `ReviewInboxView` to pass `appState.shouldMaskFinancialValues` into the banner

## Verification

- `git diff --check`
- `swift test --filter AppLockPresentation` — 15 tests passed
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

## Privacy/security

No raw credentials, Plaid secrets, access/public tokens, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies were added to fixtures or logs. The fix only changes local presentation copy.