### PR TITLE
feat(intents): SetFocusFilterIntent auto privacy mask (AND-506)

### DIFF
--- a/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
+++ b/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
@@ -37,6 +37,13 @@ enum PrivacyMaskControlCommandReader {
         return decoder
     }
 
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
     /// Resolves the shared command directory, reusing the glance store's
     /// container-or-local-fallback logic so the reader and the control agree on a
     /// single App Group location.
@@ -59,6 +66,30 @@ enum PrivacyMaskControlCommandReader {
         let data = try Data(contentsOf: url)
         try fileManager.removeItem(at: url)
         return try decoder.decode(PrivacyMaskControlCommand.self, from: data)
+    }
+
+    /// Writes a pending privacy command into the shared container so it is applied
+    /// on the next `applyPendingPrivacyMaskControlCommand()` activation — the same
+    /// channel the Control Center toggle uses (`WidgetControlCommandStore`), but
+    /// from the **app** side. The Focus filter intent (AND-506) uses this so it
+    /// drives the existing apply path instead of new state machinery. Writes
+    /// atomically with owner-only permissions, byte-identical to the extension's
+    /// writer so the contract stays in sync.
+    static func write(
+        _ command: PrivacyMaskControlCommand,
+        directory: URL = directory(),
+        fileManager: FileManager = .default
+    ) throws {
+        let url = commandURL(directory: directory)
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try encoder.encode(command)
+        try data.write(to: url, options: [.atomic])
+        #if os(macOS)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        #endif
     }
 }
 

--- a/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
+++ b/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
@@ -1,0 +1,127 @@
+import AppIntents
+import Foundation
+import PlaidBarCore
+import WidgetKit
+
+// MARK: - Focus-aware Privacy Mask (AND-506)
+//
+// A `SetFocusFilterIntent` lets the user attach VaultPeek to any Focus (Work, a
+// shared Focus, Do Not Disturb…) in System Settings → Focus → Focus Filters.
+// When that Focus turns on, the system calls `perform()` with the configured
+// parameters; when it turns off, the system calls `perform()` again with the
+// default parameters. We translate each callback into a desired Privacy-Mask
+// state and route it through the EXISTING privacy-mask command channel
+// (`PrivacyMaskControlCommandReader.write` →
+// `AppState.applyPendingPrivacyMaskControlCommand`) — the app-side twin of the
+// Control Center toggle's writer (`WidgetControlCommandStore.savePrivacyCommand`,
+// extension target). No new state machinery in `AppState`.
+//
+// All the real logic — "given the Focus turned on/off, what should the mask be,
+// and what prior state must I remember so I can restore it" — lives in
+// `FocusPrivacyMaskDecision` (PlaidBarCore) and is unit-tested there. This file
+// is the thin AppIntents shell: read inputs, call the pure decision, persist the
+// command + the remembered prior state.
+//
+// `openAppWhenRun` is intentionally **false** (inherited default): toggling a
+// Focus should silently mask figures without yanking VaultPeek to the
+// foreground. The app applies the pending command on its next activation, the
+// same way the Control Center toggle is consumed. Values only — never tokens or
+// balances.
+
+struct FocusPrivacyFilterIntent: SetFocusFilterIntent {
+    static let title: LocalizedStringResource = "Privacy Mask while focused"
+    static let description = IntentDescription(
+        "Automatically hide VaultPeek balances while this Focus is on, then restore your previous setting when it ends."
+    )
+
+    /// Whether this Focus should turn Privacy Mask on. Defaulting to `true` means
+    /// adding the filter does the obvious thing (mask while focused); the user can
+    /// uncheck it to make the filter inert without removing it. A non-optional
+    /// `SetFocusFilterIntent` parameter must supply a default.
+    @Parameter(title: "Hide balances", default: true)
+    var hideBalances: Bool
+
+    /// The configuration summary the system shows in the Focus settings UI.
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: hideBalances ? "Hide VaultPeek balances" : "Leave VaultPeek balances visible"
+        )
+    }
+
+    func perform() async throws -> some IntentResult {
+        // The system invokes `perform()` with the configured parameters when a
+        // Focus carrying this filter turns on, and again with the default
+        // parameters when it turns off. `SetFocusFilterIntent.current` resolves to
+        // the active filter instance while a matching Focus is on and throws once
+        // none is — that's our activate/deactivate signal.
+        let focusActive = await Self.isFocusActive()
+        let currentMask = AppGroupSnapshotStore.loadIfAvailable()?.isMasked ?? false
+        let remembered = FocusPrivacyMaskMemory.load()
+
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: focusActive,
+            maskWhileFocused: hideBalances,
+            currentMaskEnabled: currentMask,
+            rememberedMask: remembered
+        )
+
+        // Persist the prior-state bookkeeping first so a crash between the two
+        // writes can't strand a mask the user can't undo via this filter.
+        FocusPrivacyMaskMemory.store(outcome.rememberedMask)
+
+        // Only write a command when the desired state actually differs, so a
+        // no-op callback (inert filter, or restoring to the same value) doesn't
+        // churn the snapshot or fight an in-app toggle.
+        if outcome.desiredMaskEnabled != currentMask {
+            try PrivacyMaskControlCommandReader.write(
+                PrivacyMaskControlCommand(maskEnabled: outcome.desiredMaskEnabled, requestedAt: Date())
+            )
+            // Reload the Control Center toggle + widgets so the "Privacy Mask"
+            // control reflects the new state even before the app applies it.
+            ControlCenter.shared.reloadAllControls()
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+
+        return .result()
+    }
+
+    /// Whether a Focus that includes this filter is currently active.
+    ///
+    /// `SetFocusFilterIntent.current` resolves to the configured filter instance
+    /// while a matching Focus is on and throws when none is, so a successful read
+    /// means "active" and a throw means "deactivating". This is the one place
+    /// that distinguishes the activation call from the deactivation call.
+    private static func isFocusActive() async -> Bool {
+        (try? await current) != nil
+    }
+}
+
+// MARK: - Remembered pre-Focus mask state
+
+/// Persists the user's Privacy-Mask state from *before* a Focus turned masking
+/// on, so deactivation can restore it. Stored in the App Group `UserDefaults`
+/// (shared with the widget/control surfaces); a single bool, never a balance.
+enum FocusPrivacyMaskMemory {
+    private static let key = "focusPrivacyMask.rememberedPriorMask"
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: FinanceSnapshot.appGroupIdentifier) ?? .standard
+    }
+
+    /// The remembered pre-Focus mask, or `nil` when nothing is stored.
+    static func load() -> Bool? {
+        let store = defaults
+        guard store.object(forKey: key) != nil else { return nil }
+        return store.bool(forKey: key)
+    }
+
+    /// Stores the remembered value, or removes it when `value == nil`.
+    static func store(_ value: Bool?) {
+        let store = defaults
+        if let value {
+            store.set(value, forKey: key)
+        } else {
+            store.removeObject(forKey: key)
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FocusPrivacyMaskDecision.swift
+++ b/Sources/PlaidBarCore/Utilities/FocusPrivacyMaskDecision.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - Focus-aware Privacy Mask decision (AND-506)
+//
+// A `SetFocusFilterIntent` (in the app target) fires `perform()` when a Focus
+// the user has configured with VaultPeek's filter turns **on** (with the
+// configured parameters) and again when it turns **off** (with default
+// parameters). The intent itself is a thin shell: it converts that callback into
+// a desired Privacy-Mask state and routes it through the existing privacy-mask
+// command channel (`WidgetControlCommandStore.savePrivacyCommand` →
+// `AppState.applyPendingPrivacyMaskControlCommand`).
+//
+// The only real logic — "given the Focus turned on/off, what should the mask be,
+// and what prior state must I remember so I can restore it" — lives here so it is
+// unit-testable without the AppIntents runtime. The Focus callback is otherwise
+// stateless, so we thread the remembered pre-Focus mask state through the
+// decision rather than reading app state inside the intent.
+
+/// The outcome of reconciling a Focus activation/deactivation with the current
+/// Privacy-Mask state.
+public struct FocusPrivacyMaskOutcome: Sendable, Equatable {
+    /// The Privacy-Mask state the app should apply (`true` hides figures).
+    public let desiredMaskEnabled: Bool
+
+    /// The pre-Focus mask state to persist so it can be restored when the Focus
+    /// later deactivates, or `nil` when nothing should be remembered (the Focus
+    /// is off, or this filter does not drive masking).
+    ///
+    /// `Bool??` would be ambiguous, so this is modeled as: write `rememberedMask`
+    /// when non-`nil`; clear any stored value when `nil`.
+    public let rememberedMask: Bool?
+
+    public init(desiredMaskEnabled: Bool, rememberedMask: Bool?) {
+        self.desiredMaskEnabled = desiredMaskEnabled
+        self.rememberedMask = rememberedMask
+    }
+}
+
+/// Pure decision for the Focus-aware Privacy Mask feature (AND-506).
+///
+/// `SetFocusFilterIntent.perform()` is invoked on both Focus activation and
+/// deactivation; this helper turns each invocation into the desired mask state
+/// plus the prior-state bookkeeping needed to restore the user's choice when the
+/// Focus ends — without the intent touching app state directly.
+public enum FocusPrivacyMaskDecision {
+    /// Reconciles a Focus filter callback with the current mask state.
+    ///
+    /// - Parameters:
+    ///   - focusActive: Whether the configured Focus is currently on. The system
+    ///     passes the configured parameters when on and the defaults (Focus off)
+    ///     when off.
+    ///   - maskWhileFocused: The filter's user choice — whether this Focus should
+    ///     enable Privacy Mask while active. When `false`, the filter is inert and
+    ///     never changes the mask in either direction.
+    ///   - currentMaskEnabled: The mask state at the moment of the callback, used
+    ///     to remember what to restore on deactivation.
+    ///   - rememberedMask: The pre-Focus mask state previously stored by an
+    ///     activation, or `nil` when none is stored.
+    /// - Returns: The mask state to apply and the prior-state value to persist
+    ///   (`rememberedMask == nil` means "clear any stored value").
+    public static func resolve(
+        focusActive: Bool,
+        maskWhileFocused: Bool,
+        currentMaskEnabled: Bool,
+        rememberedMask: Bool?
+    ) -> FocusPrivacyMaskOutcome {
+        // An inert filter (the user did not ask this Focus to mask) must never
+        // move the mask or strand a remembered value — leave everything as-is and
+        // forget any prior bookkeeping so a later toggle starts clean.
+        guard maskWhileFocused else {
+            return FocusPrivacyMaskOutcome(desiredMaskEnabled: currentMaskEnabled, rememberedMask: nil)
+        }
+
+        if focusActive {
+            // Turning the Focus on: force the mask on. Remember the pre-Focus
+            // state so deactivation can restore it — but only capture it the
+            // first time (when nothing is remembered yet), so repeated
+            // activations while already focused don't overwrite the true prior
+            // value with the now-masked `true`.
+            let priorToRemember = rememberedMask ?? currentMaskEnabled
+            return FocusPrivacyMaskOutcome(desiredMaskEnabled: true, rememberedMask: priorToRemember)
+        }
+
+        // Turning the Focus off: restore the remembered pre-Focus state. If we
+        // never recorded one (e.g. the app launched mid-Focus), fall back to
+        // revealing, since the Focus filter is what was holding the mask on.
+        let restored = rememberedMask ?? false
+        return FocusPrivacyMaskOutcome(desiredMaskEnabled: restored, rememberedMask: nil)
+    }
+}

--- a/Tests/PlaidBarCoreTests/FocusPrivacyMaskDecisionTests.swift
+++ b/Tests/PlaidBarCoreTests/FocusPrivacyMaskDecisionTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Focus-aware Privacy Mask decision (AND-506)")
+struct FocusPrivacyMaskDecisionTests {
+    @Test("Focus activates with masking on → mask turns on and the prior visible state is remembered")
+    func activationFromVisibleEnablesMaskAndRemembers() {
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: true,
+            maskWhileFocused: true,
+            currentMaskEnabled: false,
+            rememberedMask: nil
+        )
+        #expect(outcome.desiredMaskEnabled == true)
+        #expect(outcome.rememberedMask == false)
+    }
+
+    @Test("Focus activates while already masked → mask stays on and the prior masked state is remembered")
+    func activationWhileAlreadyMaskedRemembersTrue() {
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: true,
+            maskWhileFocused: true,
+            currentMaskEnabled: true,
+            rememberedMask: nil
+        )
+        #expect(outcome.desiredMaskEnabled == true)
+        // So that deactivation restores the user's pre-Focus masked preference.
+        #expect(outcome.rememberedMask == true)
+    }
+
+    @Test("Repeated activation does not overwrite the originally remembered prior state")
+    func repeatedActivationKeepsOriginalPrior() {
+        // First activation captured `false` (user was visible). A second perform()
+        // call while focused must not clobber it with the now-masked `true`.
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: true,
+            maskWhileFocused: true,
+            currentMaskEnabled: true,
+            rememberedMask: false
+        )
+        #expect(outcome.desiredMaskEnabled == true)
+        #expect(outcome.rememberedMask == false)
+    }
+
+    @Test("Focus deactivates → restores the remembered visible state and clears the bookkeeping")
+    func deactivationRestoresVisible() {
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: false,
+            maskWhileFocused: true,
+            currentMaskEnabled: true,
+            rememberedMask: false
+        )
+        #expect(outcome.desiredMaskEnabled == false)
+        #expect(outcome.rememberedMask == nil)
+    }
+
+    @Test("Focus deactivates → restores a remembered masked preference")
+    func deactivationRestoresMaskedPreference() {
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: false,
+            maskWhileFocused: true,
+            currentMaskEnabled: true,
+            rememberedMask: true
+        )
+        // User had Privacy Mask on before the Focus; keep it on afterwards.
+        #expect(outcome.desiredMaskEnabled == true)
+        #expect(outcome.rememberedMask == nil)
+    }
+
+    @Test("Focus deactivates with no remembered state → reveals (the filter was the only thing masking)")
+    func deactivationWithoutMemoryReveals() {
+        let outcome = FocusPrivacyMaskDecision.resolve(
+            focusActive: false,
+            maskWhileFocused: true,
+            currentMaskEnabled: true,
+            rememberedMask: nil
+        )
+        #expect(outcome.desiredMaskEnabled == false)
+        #expect(outcome.rememberedMask == nil)
+    }
+
+    @Test("An inert filter (masking unchecked) never moves the mask and clears any stray memory")
+    func inertFilterIsNoOp() {
+        // Active focus, but the user did not ask this Focus to mask.
+        let active = FocusPrivacyMaskDecision.resolve(
+            focusActive: true,
+            maskWhileFocused: false,
+            currentMaskEnabled: false,
+            rememberedMask: true
+        )
+        #expect(active.desiredMaskEnabled == false)
+        #expect(active.rememberedMask == nil)
+
+        // Inactive focus, inert filter, currently masked by the user themselves.
+        let inactive = FocusPrivacyMaskDecision.resolve(
+            focusActive: false,
+            maskWhileFocused: false,
+            currentMaskEnabled: true,
+            rememberedMask: nil
+        )
+        #expect(inactive.desiredMaskEnabled == true)
+        #expect(inactive.rememberedMask == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Focus-aware Privacy** (AND-506): attaching VaultPeek to a Focus (Work, a shared Focus, Do Not Disturb…) in **System Settings → Focus → Focus Filters** now automatically enables **Privacy Mask** while that Focus is active, and restores the user's prior mask state when the Focus ends.

The new `FocusPrivacyFilterIntent` is a thin `SetFocusFilterIntent` shell. It does **not** add new `AppState` machinery — it routes the desired mask state through the *existing* privacy-mask command channel that the Control Center "Privacy Mask" toggle already uses:

```
FocusPrivacyFilterIntent.perform()
  → PrivacyMaskControlCommandReader.write(privacy-mask-command.json)
  → AppState.applyPendingPrivacyMaskControlCommand()  (consumed on next activation)
  → appLockPreferences.privacyMaskEnabled
```

`perform()` fires on both Focus activation (configured parameters) and deactivation (default parameters); `SetFocusFilterIntent.current` (resolves while active, throws once inactive) is the activate/deactivate signal. The pre-Focus mask state is remembered in App Group `UserDefaults` (a single bool — never a balance) so deactivation restores exactly what the user had.

The intent's conformance to `SetFocusFilterIntent` in the app target is what surfaces it under Focus Filters — no extra registration glue is required.

### Files
- `Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift` — new `SetFocusFilterIntent` conformer + App-Group-backed `FocusPrivacyMaskMemory`.
- `Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift` — adds an app-side `write(_:)`, the twin of the extension's `WidgetControlCommandStore.savePrivacyCommand`, so the app can feed the command file it already consumes.
- `Sources/PlaidBarCore/Utilities/FocusPrivacyMaskDecision.swift` — pure, testable decision (focus active/inactive → desired mask + prior-state bookkeeping).
- `Tests/PlaidBarCoreTests/FocusPrivacyMaskDecisionTests.swift` — unit tests for the pure decision.

## Linear (AND-506)

Implements **AND-506 — Focus-aware privacy: auto-enable Privacy Mask when a Focus activates.** The mask plumbing already existed (the Control Center command path + `appLockPreferences.privacyMaskEnabled`); this wires a Focus filter into it.

## Testing notes

- New suite `Focus-aware Privacy Mask decision (AND-506)` — 7 tests, all pass:
  - `activationFromVisibleEnablesMaskAndRemembers`
  - `activationWhileAlreadyMaskedRemembersTrue`
  - `repeatedActivationKeepsOriginalPrior`
  - `deactivationRestoresVisible`
  - `deactivationRestoresMaskedPreference`
  - `deactivationWithoutMemoryReveals`
  - `inertFilterIsNoOp`
- Strict-concurrency CI gate **passes**: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → `Build complete!`
- Full suite **passes**: `swift test` → `Test run with 1197 tests passed`. (The `✘` lines in output are pre-existing *skips* — "macOS Keychain accepts test writes" — in the headless env, not failures.)

Widget/Control/Intent types aren't headlessly unit-testable, so the only real logic (the mask decision, incl. respecting + restoring prior user state) lives in `PlaidBarCore` and is tested there.

## Architectural decisions

- **Reuse, not new state.** Drives the same `applyPendingPrivacyMaskControlCommand` apply path as the Control Center toggle, keeping a single privacy-mask source of truth. The app target can't reference the extension's `WidgetControlCommandStore`, so I added the symmetric `write(_:)` to the app's own copy of the command contract (`PrivacyMaskControlCommandReader`), byte-identical to the extension writer.
- **Restore prior state.** Because the Focus callback is stateless, the pre-Focus mask is captured on first activation and restored on deactivation. The decision only captures the prior value when none is remembered yet, so repeated activations don't overwrite it with the now-masked `true`.
- **Inert filter is a true no-op.** If the user unchecks "Hide balances," the filter never moves the mask in either direction and clears any stray remembered value.
- **Silent.** `openAppWhenRun` stays false (inherited default) — masking shouldn't yank the app forward; the app applies the pending command on its next natural activation, mirroring the Control Center toggle. Never conveys state by color alone (figures are dotted out; SF Symbols differ by shape).

## Migration notes

None. No persistence schema, migration, or server change. New bookkeeping is a single bool in the existing App Group `UserDefaults` suite (`group.com.ftchvs.PlaidBar`), absent until a Focus filter first runs and self-clearing on deactivation. The Focus filter appears in System Settings only after the user installs a build whose app metadata includes the new intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
