### PR TITLE
feat(ui): Category Dashboard card + detached window (AND-539)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -71,6 +71,7 @@ final class AppState {
             _cachedTransactionDerivedIndex = nil
             _cachedRecurringTransactions = nil
             _cachedCategoryBudgetPresentation = nil
+            _cachedCategoryDashboardPresentation = nil
             _cachedTransactionReviewInboxSnapshot = nil
             invalidateLocalAIActivitySummaries()
         }
@@ -80,16 +81,21 @@ final class AppState {
             _cachedTransactionReviewInboxSnapshot = nil
             // Spend math is now override-aware (AND-526/554): an approve /
             // recategorize / exclude edits this metadata, so the budget
-            // presentation must recompute too — not only the inbox.
+            // presentation must recompute too — not only the inbox. The category
+            // dashboard rollup shares the same override-aware aggregation
+            // (AND-539), so it is invalidated on the same edits.
             _cachedCategoryBudgetPresentation = nil
+            _cachedCategoryDashboardPresentation = nil
         }
     }
     var transactionRules: [TransactionRule] = [] {
         didSet {
             _cachedTransactionReviewInboxSnapshot = nil
             // A new/changed rule recategorizes or excludes spend, so invalidate
-            // the budget presentation alongside the inbox (AND-526/554).
+            // the budget presentation and the category dashboard rollup alongside
+            // the inbox (AND-526/554, AND-539).
             _cachedCategoryBudgetPresentation = nil
+            _cachedCategoryDashboardPresentation = nil
         }
     }
     var hasLoadedTransactionReviewStorage = false
@@ -153,7 +159,10 @@ final class AppState {
     /// Suggestions remain a local fallback/complement, but this cache wins for
     /// categories the user explicitly saved on the server.
     var categoryBudgets: [SpendingCategory: Double] = [:] {
-        didSet { _cachedCategoryBudgetPresentation = nil }
+        didSet {
+            _cachedCategoryBudgetPresentation = nil
+            _cachedCategoryDashboardPresentation = nil
+        }
     }
     var isDemoMode = false
     var isDemoStatusRecoveryScenario = false
@@ -1252,6 +1261,38 @@ final class AppState {
             rules: transactionRules
         )
         _cachedCategoryBudgetPresentation = presentation
+        return presentation
+    }
+
+    /// Cached category dashboard rollup (AND-539) — the override-aware, 2-level
+    /// group/leaf presentation the donut, status-bar tree, and flat table all
+    /// render. Invalidated via the same `didSet`s as
+    /// `categoryBudgetPresentation` (`transactions`, `categoryBudgets`,
+    /// `transactionReviewMetadata`, `transactionRules`), so recategorizing /
+    /// excluding / re-budgeting moves the dashboard immediately — never stale
+    /// until an unrelated refresh.
+    private var _cachedCategoryDashboardPresentation: CategoryDashboardPresentation?
+
+    /// Override-aware current-month category rollup for the Category Dashboard card
+    /// and detached window (AND-539). Built by ``CategoryDashboardBuilder`` from the
+    /// same live inputs the budget presentation uses, so the two surfaces can never
+    /// disagree on a category's spend.
+    var categoryDashboardPresentation: CategoryDashboardPresentation {
+        if let cached = _cachedCategoryDashboardPresentation { return cached }
+        // Mirror `categoryBudgetPresentation`: in demo mode score against the
+        // dedicated current-month-anchored rows so the under/near/over spread is
+        // stable regardless of launch day (AND-543); otherwise use live transactions.
+        let scoringTransactions = isDemoMode
+            ? DemoFixtures.demoBudgetScoringTransactions()
+            : transactions
+        let presentation = CategoryDashboardBuilder.build(
+            transactions: scoringTransactions,
+            budgets: categoryBudgets,
+            asOf: Date(),
+            metadata: transactionReviewMetadata,
+            rules: transactionRules
+        )
+        _cachedCategoryDashboardPresentation = presentation
         return presentation
     }
 

--- a/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
@@ -1,0 +1,205 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Hosts the full **Category Dashboard** (`CategoryDashboardWindow`) in a real,
+/// managed desktop window (AND-539) — Copilot's full category tab, pulled off the
+/// popover into its own resizable window.
+///
+/// This deliberately reuses the proven `DetachedDashboardWindowController` pattern
+/// (AND-384): a titled / closable / miniaturizable / resizable `NSWindow` (not an
+/// `NSPanel`) at the normal level so it drags, resizes, minimizes, tiles, and
+/// participates in Mission Control / Spaces / Stage Manager like a first-class app
+/// window; a non-opaque, clear window over a behind-window `NSVisualEffectView`
+/// backdrop for real desktop read-through; frame persisted via `frameAutosaveName`;
+/// and `.regular` activation requested through the shared, refcounted
+/// `AppActivationPolicyCoordinator` so the menu-bar-only app comes to the front
+/// while the window is up and returns to `.accessory` when no surface needs it.
+///
+/// It hosts the *same* `AppState`, so there is no duplicate data, sync timer, or
+/// server client — only a second presentation surface. `isReleasedWhenClosed` is
+/// false so closing hides (not destroys) the window and its SwiftUI state survives.
+///
+/// `@MainActor`-isolated; all AppKit mutation is on the main actor, correct under
+/// `-strict-concurrency=complete`.
+@MainActor
+final class CategoryDashboardWindowController: NSObject, NSWindowDelegate {
+    /// Dedicated window identity — distinct from the full-dashboard window so the
+    /// two persist and restore independently.
+    static let windowTitle = "Spending by Category"
+    static let frameAutosaveName = "VaultPeekCategoryDashboard"
+    static let defaultContentSize = CGSize(width: 640, height: 640)
+    static let minContentSize = CGSize(width: 520, height: 480)
+
+    private let appState: AppState
+    private let forcedColorScheme: ColorScheme?
+    /// Invoked when the window becomes key (focused). The owner uses it to drive
+    /// the App Lock unlock prompt, mirroring the popover-open and detached-dashboard
+    /// triggers so a locked app with this window open is not stuck (AND-462). The
+    /// controller stays unaware of lock policy.
+    private let onWindowBecomeKey: @MainActor () -> Void
+
+    private var window: NSWindow?
+    private var hostingController: NSHostingController<AnyView>?
+    private var becomeKeyObserver: NSObjectProtocol?
+    /// True while this window holds a `.regular` activation request. Tracked so
+    /// show requests exactly once and close releases exactly once.
+    private var holdsRegularRequest = false
+
+    init(
+        appState: AppState,
+        forcedColorScheme: ColorScheme?,
+        onWindowBecomeKey: @escaping @MainActor () -> Void
+    ) {
+        self.appState = appState
+        self.forcedColorScheme = forcedColorScheme
+        self.onWindowBecomeKey = onWindowBecomeKey
+        super.init()
+    }
+
+    /// True while the window exists and is on screen.
+    var isPresented: Bool { window?.isVisible ?? false }
+
+    // MARK: - Lifecycle
+
+    /// Shows the window, creating it on first use. Idempotent: an existing window
+    /// is raised and re-focused rather than recreated, so a second "Open dashboard"
+    /// just brings the window forward (no duplicate windows).
+    func show() {
+        let window = window ?? makeWindow()
+        self.window = window
+        elevateActivationPolicy()
+        if window.isVisible {
+            bringForward(window)
+            return
+        }
+        bringForward(window)
+    }
+
+    /// Hides the window without tearing it down, so the next `show` is instant and
+    /// the hosted SwiftUI state survives.
+    func hide() {
+        guard let window, window.isVisible else { return }
+        window.orderOut(nil)
+        restoreActivationPolicy()
+    }
+
+    // MARK: - Activation policy
+
+    private func elevateActivationPolicy() {
+        guard !holdsRegularRequest else { return }
+        holdsRegularRequest = true
+        AppActivationPolicyCoordinator.shared.requestRegular()
+    }
+
+    private func restoreActivationPolicy() {
+        guard holdsRegularRequest else { return }
+        holdsRegularRequest = false
+        AppActivationPolicyCoordinator.shared.releaseRegular()
+    }
+
+    private func bringForward(_ window: NSWindow) {
+        elevateActivationPolicy()
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    // MARK: - Window construction
+
+    private func makeWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: Self.defaultContentSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.title = Self.windowTitle
+        window.titlebarAppearsTransparent = true
+        window.hidesOnDeactivate = false
+        window.isReleasedWhenClosed = false
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
+        window.contentMinSize = Self.minContentSize
+        window.delegate = self
+
+        // App Lock unlock trigger: focusing the window prompts to unlock, mirroring
+        // the popover-open and detached-dashboard triggers (AND-462). Scoped to this
+        // window via the notification `object` so other windows are ignored. The
+        // owner's callback guards on `isAppLocked`, so this cannot loop.
+        if becomeKeyObserver == nil {
+            becomeKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.onWindowBecomeKey() }
+            }
+        }
+
+        // Pin appearance ONLY for the `--appearance` CLI QA override; otherwise
+        // inherit the live `NSApp.appearance` so Light/Dark flips update the window.
+        if let forcedColorScheme {
+            window.appearance = NSAppearance(named: forcedColorScheme == .dark ? .darkAqua : .aqua)
+        }
+
+        // Behind-window vibrancy backdrop: `.behindWindow` is the one blending mode
+        // confirmed to yield real desktop read-through on a hosted NSWindow in this
+        // project (see DetachedDashboardWindowController's AND-511 spike note).
+        let backdrop = NSVisualEffectView()
+        backdrop.material = .underWindowBackground
+        backdrop.blendingMode = .behindWindow
+        backdrop.state = .active
+
+        let hosting = NSHostingController(rootView: makeRootView())
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        backdrop.addSubview(hosting.view)
+        NSLayoutConstraint.activate([
+            hosting.view.leadingAnchor.constraint(equalTo: backdrop.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: backdrop.trailingAnchor),
+            hosting.view.topAnchor.constraint(equalTo: backdrop.topAnchor),
+            hosting.view.bottomAnchor.constraint(equalTo: backdrop.bottomAnchor),
+        ])
+        window.contentView = backdrop
+        self.hostingController = hosting
+
+        window.setFrameAutosaveName(Self.frameAutosaveName)
+        if !window.setFrameUsingName(Self.frameAutosaveName) {
+            window.setContentSize(Self.defaultContentSize)
+            window.center()
+        }
+        return window
+    }
+
+    private func makeRootView() -> AnyView {
+        AnyView(
+            CategoryDashboardWindow()
+                .environment(appState)
+                .forcedCategoryDashboardColorScheme(forcedColorScheme)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        )
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// Closing the window hides it (state survives) and releases the activation
+    /// request. Returning false keeps AppKit from destroying the hosted SwiftUI.
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        hide()
+        return false
+    }
+}
+
+// MARK: - Forced appearance helper
+
+private extension View {
+    @ViewBuilder
+    func forcedCategoryDashboardColorScheme(_ scheme: ColorScheme?) -> some View {
+        if let scheme {
+            environment(\.colorScheme, scheme)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/PlaidBar/App/CategoryDashboardWindowCoordinator.swift
+++ b/Sources/PlaidBar/App/CategoryDashboardWindowCoordinator.swift
@@ -1,0 +1,40 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Owns the lazily-created ``CategoryDashboardWindowController`` for the detached
+/// full Category Dashboard window (AND-539), bridging the popover card's
+/// declarative "open dashboard" intent to the imperative AppKit window.
+///
+/// Held by the app scene as `@State` so it lives for the process lifetime and
+/// survives `body` recomputes. The controller (and its `NSWindow`) is built only on
+/// first open, so a user who never opens the dashboard never allocates a window.
+/// Mirrors `DetachedDashboardCoordinator` (AND-384), scoped to this one surface.
+///
+/// `@MainActor`/`@Observable`; all window work is main-actor isolated, correct
+/// under `-strict-concurrency=complete`.
+@MainActor
+@Observable
+final class CategoryDashboardWindowCoordinator {
+    private var controller: CategoryDashboardWindowController?
+
+    /// User asked to open the full Category Dashboard window (the card's
+    /// "Open dashboard" affordance). Builds the window on first call, then shows /
+    /// raises it.
+    func open(appState: AppState, forcedColorScheme: ColorScheme?) {
+        let controller = controller ?? CategoryDashboardWindowController(
+            appState: appState,
+            forcedColorScheme: forcedColorScheme,
+            onWindowBecomeKey: {
+                // Focusing the window prompts to unlock when App Lock is engaged,
+                // mirroring the popover-open trigger. `unlockApp()` is a no-op when
+                // App Lock is off or already unlocked, so the guard keeps the system
+                // auth sheet from re-prompting in a loop (AND-462).
+                guard appState.isAppLocked else { return }
+                Task { await appState.unlockApp() }
+            }
+        )
+        self.controller = controller
+        controller.show()
+    }
+}

--- a/Sources/PlaidBar/App/CategoryDashboardWindowEnvironment.swift
+++ b/Sources/PlaidBar/App/CategoryDashboardWindowEnvironment.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Environment hook the popover's ``CategoryDashboardCard`` uses to open the full
+/// detached Category Dashboard window (AND-539), without the view ever touching
+/// AppKit window lifecycle.
+///
+/// The closure is supplied by the app scene (which owns the
+/// ``CategoryDashboardWindowCoordinator``). Previews, the snapshot renderer, and
+/// any host that does not wire the window default to a no-op, so the
+/// "Open dashboard" affordance still renders but does nothing — headless renders
+/// are unaffected. This mirrors the `dashboardPresentation` detach/redock pattern
+/// already used for the full dashboard window (AND-384).
+private struct OpenCategoryDashboardKey: EnvironmentKey {
+    static let defaultValue: @MainActor @Sendable () -> Void = {}
+}
+
+extension EnvironmentValues {
+    /// Opens the detached full Category Dashboard window. No-op by default.
+    var openCategoryDashboard: @MainActor @Sendable () -> Void {
+        get { self[OpenCategoryDashboardKey.self] }
+        set { self[OpenCategoryDashboardKey.self] = newValue }
+    }
+}

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -12,6 +12,9 @@ struct PlaidBarApp: App {
     /// Owns the floating desktop-window dashboard (AND-384). `@State` so it
     /// persists across `body` recomputes for the process lifetime.
     @State private var detachedDashboard = DetachedDashboardCoordinator()
+    /// Owns the detached full Category Dashboard window (AND-539). `@State` so the
+    /// lazily-built window survives `body` recomputes for the process lifetime.
+    @State private var categoryDashboardWindow = CategoryDashboardWindowCoordinator()
     /// Owns the global summon hotkey (⇧⌘V, AND-487). `@State` so the Carbon
     /// registration survives `body` recomputes for the process lifetime.
     @State private var summonHotkeyMonitor = SummonHotkeyMonitor()
@@ -76,6 +79,15 @@ struct PlaidBarApp: App {
                         reduceMotion: reduceMotion
                     )
                 }))
+                // The Category Dashboard card's "Open dashboard" affordance opens
+                // the detached full dashboard window (AND-539). Wired here so the
+                // view never touches AppKit window lifecycle.
+                .environment(\.openCategoryDashboard, {
+                    categoryDashboardWindow.open(
+                        appState: appState,
+                        forcedColorScheme: Self.forcedColorScheme
+                    )
+                })
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
         } label: {

--- a/Sources/PlaidBar/Views/CategoryDashboardCard.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardCard.swift
@@ -1,0 +1,215 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The popover center-column **Category Dashboard card** (AND-539) — the surface
+/// that finally *shows* the Copilot-style category dashboard inline: the spend
+/// donut, the top spending group rollups, and an "Open dashboard" affordance that
+/// launches the full detached window.
+///
+/// It is a thin assembler over already-built pieces (spec §3/§4, Option A):
+/// `SpendDonutChart` (AND-537) and per-group `CategoryStatusBar` rows (AND-538),
+/// all driven by the override-aware ``CategoryDashboardPresentation`` `AppState`
+/// already caches — the card never recomputes spend. Every derived number and the
+/// top-N group selection come from the pure ``CategoryDashboardCardModel`` in
+/// PlaidBarCore, so the view owns only layout, glass, and the open-window intent.
+///
+/// Accessibility (ACCESSIBILITY.md): budget pressure and the headline summary are
+/// carried as glyph + text, never color alone; amounts honor Privacy Mask.
+struct CategoryDashboardCard: View {
+    @Environment(AppState.self) private var appState
+    /// Opens the detached full dashboard window. Injected by the app scene; a
+    /// no-op in previews / headless renders.
+    @Environment(\.openCategoryDashboard) private var openCategoryDashboard
+
+    private var presentation: CategoryDashboardPresentation {
+        appState.categoryDashboardPresentation
+    }
+
+    private var model: CategoryDashboardCardModel {
+        CategoryDashboardCardModel(presentation: presentation)
+    }
+
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        let model = model
+
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            header(model)
+
+            if model.isEmpty {
+                emptyState
+            } else {
+                SpendDonutChart(model: model.donut, isPrivacyMasked: isMasked)
+
+                if !model.topGroups.isEmpty {
+                    topGroups(model)
+                }
+            }
+
+            openDashboardButton(model)
+        }
+        .padding(Spacing.sm)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilitySummary(model))
+    }
+
+    // MARK: - Header
+
+    private func header(_ model: CategoryDashboardCardModel) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label("Spending by Category", systemImage: "chart.pie")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted) {
+                Label(summary, systemImage: attentionIcon(model))
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(attentionTint(model))
+                    .lineLimit(1)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(attentionTint(model).opacity(0.11), in: Capsule())
+                    .accessibilityLabel("Budget status: \(summary)")
+            }
+        }
+    }
+
+    // MARK: - Top group rollups
+
+    private func topGroups(_ model: CategoryDashboardCardModel) -> some View {
+        VStack(spacing: Spacing.xs) {
+            ForEach(model.topGroups) { group in
+                groupRow(group)
+            }
+        }
+    }
+
+    private func groupRow(_ group: CategoryDashboardPresentation.GroupRollup) -> some View {
+        let statusModel = CategoryStatusBarModel(group: group)
+        return VStack(alignment: .leading, spacing: Spacing.xxs) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: groupIcon(group.group))
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(groupAccent(group.group))
+                    .frame(width: Sizing.iconInline)
+                    .accessibilityHidden(true)
+
+                Text(group.title)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: Spacing.sm)
+            }
+
+            CategoryStatusBar(
+                model: statusModel,
+                spentText: currency(group.spent),
+                limitText: group.monthlyLimit.map(currency),
+                accent: groupAccent(group.group)
+            )
+        }
+        .padding(Spacing.sm)
+        .nativeInsetSurface()
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Label("No category spending yet", systemImage: "chart.pie")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text("Spending shows here once this month's transactions arrive.")
+                .microText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.sm)
+        .nativeInsetSurface()
+    }
+
+    // MARK: - Open dashboard
+
+    private func openDashboardButton(_ model: CategoryDashboardCardModel) -> some View {
+        Button {
+            openCategoryDashboard()
+        } label: {
+            HStack(spacing: Spacing.xs) {
+                Label("Open dashboard", systemImage: "rectangle.expand.vertical")
+                    .font(.caption.weight(.semibold))
+                if let overflow = model.overflowText {
+                    Text(overflow)
+                        .microText()
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: Spacing.sm)
+                Image(systemName: "arrow.up.forward")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens the full category dashboard in a window")
+    }
+
+    // MARK: - Helpers
+
+    /// At least one leaf in the rollup tracks a budget — drives whether the header
+    /// summary line shows at all (an unbudgeted month never claims "On track").
+    private var isAnyBudgeted: Bool {
+        presentation.leaves.contains { $0.monthlyLimit != nil }
+    }
+
+    private func currency(_ amount: Double) -> String {
+        PrivacyMaskPresentation.currency(
+            amount,
+            format: .compact,
+            isEnabled: isMasked,
+            style: .compact
+        )
+    }
+
+    private func groupAccent(_ group: CategoryGroup) -> Color {
+        guard let representative = group.categories.first else { return SemanticColors.brand }
+        return CategoryAccentTokens.color(for: representative)
+    }
+
+    private func groupIcon(_ group: CategoryGroup) -> String {
+        group.categories.first?.iconName ?? "circle.fill"
+    }
+
+    /// Attention glyph for the header pill — over outranks nearing; an on-track or
+    /// unbudgeted month uses a neutral check. Never the only signal (text label too).
+    private func attentionIcon(_ model: CategoryDashboardCardModel) -> String {
+        if model.overBudgetCount > 0 { return "exclamationmark.triangle.fill" }
+        if model.nearingCount > 0 { return "exclamationmark.circle" }
+        return "checkmark.circle"
+    }
+
+    /// Redundant color cue layered over the glyph + text (never alone).
+    private func attentionTint(_ model: CategoryDashboardCardModel) -> Color {
+        if model.overBudgetCount > 0 { return SemanticColors.negative }
+        if model.nearingCount > 0 { return SemanticColors.warning }
+        return SemanticColors.positive
+    }
+
+    private func accessibilitySummary(_ model: CategoryDashboardCardModel) -> String {
+        guard !model.isEmpty else {
+            return "Spending by category. No category spending yet this month."
+        }
+        let total = isMasked ? PrivacyMaskPresentation.compactValue : model.totalSpentText
+        var sentence = "Spending by category. \(total) spent this month."
+        if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted) {
+            sentence += " \(summary)."
+        }
+        return sentence
+    }
+}

--- a/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
@@ -1,0 +1,265 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The full **Category Dashboard** surface hosted in the detached desktop window
+/// (AND-539) — Copilot's "full category tab." It assembles the same override-aware
+/// pieces the popover card previews, at full size (spec §3/§4, Option A):
+///
+/// - the spend donut (`SpendDonutChart`, AND-537) with its center total,
+/// - the two-level status-bar tree (`CategoryTreeView`, AND-538), and
+/// - a flat, sortable **SPENT / BUDGET / LEFT** `Table` of every leaf category.
+///
+/// It reads the finished ``CategoryDashboardPresentation`` from `AppState` and does
+/// no aggregation: the donut/tree drive off the presentation directly, and the
+/// table rows + footer totals come from the pure ``CategoryDashboardTableModel`` in
+/// PlaidBarCore. Amounts honor Privacy Mask; budget pressure rides on glyph + text,
+/// never color alone (ACCESSIBILITY.md).
+///
+/// The monthly-history `BarMark` + dashed budget `RuleMark` (spec §3) is deferred
+/// to a follow-up: there is no current override-aware multi-month spend rollup in
+/// PlaidBarCore to drive it, and building one is beyond assembling existing
+/// components. The card + window ship complete without it.
+struct CategoryDashboardWindow: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openCategoryDashboard) private var openCategoryDashboard
+
+    /// User-selected flat-table ordering. Stored as a small `Sendable` enum (a
+    /// `[KeyPathComparator]` is not `Sendable`, so it cannot live in `@State` under
+    /// strict concurrency); mapped to the pure ``CategoryDashboardTableModel/Order``
+    /// when the rows are built.
+    @State private var tableOrder: CategoryDashboardTableModel.Order = .spendDescending
+
+    private var presentation: CategoryDashboardPresentation {
+        appState.categoryDashboardPresentation
+    }
+
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                header
+
+                if presentation.isEmpty {
+                    emptyState
+                } else {
+                    donutSection
+                    treeSection
+                    tableSection
+                }
+            }
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .frame(minWidth: 520, minHeight: 480)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("Spending by Category")
+                .font(.title2.weight(.bold))
+            Text("Where this month's money went, by category.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Donut
+
+    private var donutSection: some View {
+        let donut = SpendDonutModel(presentation: presentation)
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
+            SpendDonutChart(model: donut, isPrivacyMasked: isMasked)
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    // MARK: - Tree
+
+    private var treeSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label("By group", systemImage: "list.bullet.indent")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+            CategoryTreeView(presentation: presentation, privacyMaskEnabled: isMasked)
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    // MARK: - Flat table
+
+    private var tableSection: some View {
+        let rows = CategoryDashboardTableModel.rows(from: presentation, order: tableOrder)
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Label("All categories", systemImage: "tablecells")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: Spacing.sm)
+
+                Picker("Sort", selection: $tableOrder) {
+                    Text("By spend").tag(CategoryDashboardTableModel.Order.spendDescending)
+                    Text("By group").tag(CategoryDashboardTableModel.Order.groupThenSpend)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+                .accessibilityLabel("Sort categories")
+            }
+
+            Table(rows) {
+                TableColumn("Category") { row in
+                    Label {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(row.categoryName)
+                                .lineLimit(1)
+                            Text(row.groupTitle)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    } icon: {
+                        Image(systemName: row.iconName)
+                            .foregroundStyle(CategoryAccentTokens.color(for: row.category))
+                    }
+                    .accessibilityLabel("\(row.categoryName), \(row.groupTitle)")
+                }
+                .width(min: 160, ideal: 200)
+
+                TableColumn("Spent") { row in
+                    Text(currency(row.spent))
+                        .monospacedDigit()
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .width(min: 80, ideal: 96)
+
+                TableColumn("Budget") { row in
+                    Text(row.budget.map(currency) ?? "—")
+                        .monospacedDigit()
+                        .foregroundStyle(row.isBudgeted ? .primary : .secondary)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .width(min: 80, ideal: 96)
+
+                TableColumn("Left") { row in
+                    leftCell(row)
+                }
+                .width(min: 80, ideal: 96)
+
+                TableColumn("Status") { row in
+                    Label(row.statusText, systemImage: row.statusIconName)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(statusTint(row.status))
+                        .labelStyle(.titleAndIcon)
+                        .lineLimit(1)
+                        .accessibilityLabel(row.statusText)
+                }
+                .width(min: 120, ideal: 140)
+            }
+            .frame(minHeight: 220)
+
+            tableFooter(totals)
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    private func leftCell(_ row: CategoryDashboardTableRow) -> some View {
+        guard let remaining = row.remaining else {
+            return AnyView(
+                Text("—")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            )
+        }
+        // Over-budget rows read negative; the band glyph + text already carry the
+        // verdict, so the tint here is a redundant cue, never the only signal.
+        return AnyView(
+            Text(currency(remaining))
+                .monospacedDigit()
+                .foregroundStyle(remaining < 0 ? SemanticColors.negative : .primary)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .accessibilityLabel(remaining < 0
+                    ? "\(currency(abs(remaining))) over"
+                    : "\(currency(remaining)) left")
+        )
+    }
+
+    private func tableFooter(_ totals: CategoryDashboardTableModel.Totals) -> some View {
+        HStack(spacing: Spacing.md) {
+            footerStat("Total spent", currency(totals.spent))
+            if totals.hasBudget {
+                footerStat("Budgeted", currency(totals.budget))
+                footerStat(
+                    totals.remaining < 0 ? "Over" : "Left",
+                    currency(abs(totals.remaining)),
+                    tint: totals.remaining < 0 ? SemanticColors.negative : .primary
+                )
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.top, Spacing.xs)
+    }
+
+    private func footerStat(_ label: String, _ value: String, tint: Color = .primary) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(tint)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Label("No category spending yet", systemImage: "chart.pie")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("Spending appears here once this month's transactions arrive.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
+        .multilineTextAlignment(.center)
+        .padding(Spacing.lg)
+        .glassSurface(.raised)
+    }
+
+    // MARK: - Helpers
+
+    private func currency(_ amount: Double) -> String {
+        PrivacyMaskPresentation.currency(
+            amount,
+            format: .full,
+            isEnabled: isMasked,
+            style: .compact
+        )
+    }
+
+    /// Redundant color cue for the status column — the glyph + label already carry
+    /// the verdict (ACCESSIBILITY.md).
+    private func statusTint(_ status: CategoryBudgetStatus?) -> Color {
+        switch status {
+        case .over: SemanticColors.negative
+        case .nearing: SemanticColors.warning
+        case .under: .secondary
+        case nil: .secondary
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -516,6 +516,13 @@ struct MainPopover: View {
                         WeeklyReviewCard()
                             .environment(appState)
 
+                        // The Copilot-style Category Dashboard surface (AND-539):
+                        // donut + top group rollups inline, with an "Open dashboard"
+                        // affordance that launches the full detached window. Reads
+                        // the override-aware rollup `AppState` caches — no recompute.
+                        CategoryDashboardCard()
+                            .environment(appState)
+
                         // Review Inbox moved to the right inspector column
                         // (accountInspectorColumn) so the center stays one compact
                         // instrument and the inbox is not shown twice.

--- a/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Pure, `Sendable` view-model for the **Category Dashboard card** (AND-539) — the
+/// compact center-column surface in the popover that previews where this month's
+/// money went and links out to the full detached dashboard window.
+///
+/// The card shows the donut (built from the same override-aware
+/// ``CategoryDashboardPresentation`` the full dashboard uses — never a recompute,
+/// spec §3/§4, Option A) plus the *top N* spending group rollups. This type owns
+/// the "top N groups for the card" selection and every derived headline string so
+/// the SwiftUI card stays a thin renderer and the selection / labels can be
+/// unit-tested without a host view.
+///
+/// Top groups are the spend-heaviest ``CategoryDashboardPresentation/GroupRollup``
+/// values (a stable tiebreak on ``CategoryGroup/sortIndex`` keeps equal-spend
+/// ordering deterministic for screenshots and tests). Only groups that carry
+/// positive spend can be "top groups"; a budgeted-but-unspent group never crowds
+/// out a group the user actually spent in. When more groups exist than the card
+/// shows, ``overflowCount`` reports how many are folded into the "Open dashboard"
+/// affordance so the card can say "+3 more".
+public struct CategoryDashboardCardModel: Sendable, Hashable {
+    /// Default number of group rollups the card previews before overflowing into
+    /// the full-dashboard link.
+    public static let defaultTopGroupLimit = 3
+
+    /// The donut model the card renders (same data as the full dashboard).
+    public let donut: SpendDonutModel
+    /// The top spending group rollups, spend-heaviest first (at most `topGroupLimit`).
+    public let topGroups: [CategoryDashboardPresentation.GroupRollup]
+    /// How many *spending* groups are not shown in ``topGroups`` (>= 0). Drives a
+    /// "+N more" affordance on the open-dashboard link.
+    public let overflowCount: Int
+    /// Count of leaves over their individual budget across the whole month.
+    public let overBudgetCount: Int
+    /// Count of leaves in the nearing band (not yet over).
+    public let nearingCount: Int
+    /// Pre-formatted total spent this month, e.g. `"$1,234.00"` (same figure as the
+    /// donut center). Carried so the card's header reads without a second format.
+    public let totalSpentText: String
+    /// ISO currency code amounts were formatted with (carried for the view).
+    public let currencyCode: String
+
+    /// Build the card model from the finished, override-aware dashboard rollup.
+    ///
+    /// - Parameters:
+    ///   - presentation: the override-aware rollup (built once by
+    ///     `CategoryDashboardBuilder`); the card never recomputes spend.
+    ///   - currencyCode: ISO code used to format every amount. Defaults to `"USD"`.
+    ///   - topGroupLimit: how many spending group rollups to preview. Values `< 1`
+    ///     clamp to `0` (donut only, everything overflows).
+    public init(
+        presentation: CategoryDashboardPresentation,
+        currencyCode: String = "USD",
+        topGroupLimit: Int = CategoryDashboardCardModel.defaultTopGroupLimit
+    ) {
+        self.currencyCode = currencyCode
+        self.donut = SpendDonutModel(presentation: presentation, currencyCode: currencyCode)
+        self.overBudgetCount = presentation.overBudgetCount
+        self.nearingCount = presentation.nearingCount
+        self.totalSpentText = Formatters.currency(
+            presentation.totalSpent,
+            format: .full,
+            currencyCode: currencyCode
+        )
+
+        // Only groups with real spend rank — a budgeted-but-unspent guardrail never
+        // displaces a group the user actually spent in. Heaviest first, stable
+        // tiebreak on canonical order so equal-spend groups never reorder.
+        let spendingGroups = presentation.groups
+            .filter { $0.spent > 0 }
+            .sorted { lhs, rhs in
+                if lhs.spent != rhs.spent { return lhs.spent > rhs.spent }
+                return lhs.group.sortIndex < rhs.group.sortIndex
+            }
+
+        let limit = max(0, topGroupLimit)
+        self.topGroups = Array(spendingGroups.prefix(limit))
+        self.overflowCount = max(0, spendingGroups.count - limit)
+    }
+
+    /// True when there is no spend to preview (empty / first-run dataset).
+    public var isEmpty: Bool { donut.isEmpty }
+
+    /// True when at least one leaf needs attention (over or nearing) this month.
+    public var hasAttention: Bool { overBudgetCount > 0 || nearingCount > 0 }
+
+    /// Short, color-independent summary of budget pressure for the card subtitle,
+    /// e.g. `"2 over budget"`, `"1 over · 3 nearing"`, or `"On track"`. Never relies
+    /// on color (ACCESSIBILITY.md). `nil` when there is nothing to summarize because
+    /// no row is budgeted (so the card omits the line rather than claiming "on
+    /// track" for an unbudgeted month).
+    public func attentionSummary(isBudgeted: Bool) -> String? {
+        guard isBudgeted else { return nil }
+        if overBudgetCount == 0, nearingCount == 0 { return "On track" }
+        var parts: [String] = []
+        if overBudgetCount > 0 { parts.append("\(overBudgetCount) over budget") }
+        if nearingCount > 0 { parts.append("\(nearingCount) nearing") }
+        return parts.joined(separator: " · ")
+    }
+
+    /// `"+N more"` overflow caption for the open-dashboard link, or `nil` when the
+    /// card already shows every spending group.
+    public var overflowText: String? {
+        guard overflowCount > 0 else { return nil }
+        return "+\(overflowCount) more"
+    }
+}

--- a/Sources/PlaidBarCore/Models/CategoryDashboardTableRow.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardTableRow.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// One row of the detached Category Dashboard's flat **SPENT / BUDGET / LEFT**
+/// `Table` (AND-539). A row is a single leaf ``SpendingCategory`` carrying its
+/// group context plus the three money columns, derived purely from the
+/// override-aware ``CategoryDashboardPresentation`` the dashboard already built —
+/// no recompute (spec §3/§4, Option A).
+///
+/// The flat table is the window's analytic counterpart to the two-level status-bar
+/// tree: every leaf in one sortable list, grouped-by visually via the carried
+/// ``groupTitle``. Each money column is exposed both as a raw `Double` (so a
+/// `Table` column can sort numerically) and as a pre-formatted, optionally-masked
+/// string (so the view stays a thin renderer). Budget pressure rides on the
+/// ``CategoryBudgetStatus`` text + symbol, never color alone (ACCESSIBILITY.md).
+///
+/// An unbudgeted leaf has `nil` ``budget`` / ``remaining`` / ``status`` — the table
+/// shows an em dash for those columns rather than a misleading `$0` or a false
+/// "on track" verdict.
+public struct CategoryDashboardTableRow: Sendable, Hashable, Identifiable {
+    /// Stable identity (`category.rawValue`) — also the `Table` row id.
+    public let id: String
+    public let category: SpendingCategory
+    public let group: CategoryGroup
+    /// Parent group title, e.g. `"Food & Dining"` (the table's grouping context).
+    public let groupTitle: String
+    /// Leaf display name, e.g. `"Groceries"`.
+    public let categoryName: String
+    /// SF Symbol for the leaf (the table's leading glyph).
+    public let iconName: String
+
+    /// Net current-month spend (floored at 0 by the builder).
+    public let spent: Double
+    /// Monthly limit when budgeted; `nil` = no budget.
+    public let budget: Double?
+    /// `budget - spent` when budgeted (negative once over); `nil` when unbudgeted.
+    public let remaining: Double?
+    /// `spent / budget`, floored at 0; `nil` when unbudgeted.
+    public let fractionUsed: Double?
+    /// Budget band; `nil` when unbudgeted.
+    public let status: CategoryBudgetStatus?
+
+    /// Build a row from a dashboard leaf and its parent group.
+    public init(leaf: CategoryDashboardPresentation.Leaf, group: CategoryGroup) {
+        self.id = leaf.id
+        self.category = leaf.category
+        self.group = group
+        self.groupTitle = group.title
+        self.categoryName = leaf.category.displayName
+        self.iconName = leaf.category.iconName
+        self.spent = leaf.spent
+        self.budget = leaf.monthlyLimit
+        self.remaining = leaf.remaining
+        self.fractionUsed = leaf.fractionUsed
+        self.status = leaf.status
+    }
+
+    /// True when this row tracks a monthly limit.
+    public var isBudgeted: Bool { budget != nil }
+    /// True when the leaf is over its individual budget.
+    public var isOverBudget: Bool { status == .over }
+
+    /// Short verdict text — the band label when budgeted, else an explicit
+    /// no-budget verdict (never silently "on track").
+    public var statusText: String { status?.label ?? "No budget" }
+    /// SF Symbol carrying the verdict without color.
+    public var statusIconName: String { status?.iconName ?? "minus.circle" }
+}
+
+/// Pure builder for the detached dashboard's flat **SPENT / BUDGET / LEFT** table
+/// (AND-539). Flattens the two-level ``CategoryDashboardPresentation`` into one
+/// sortable list of leaf rows and bakes the column footer totals, so the SwiftUI
+/// `Table` (which is not headlessly unit-testable) does no aggregation itself.
+public enum CategoryDashboardTableModel {
+    /// How the flat table is ordered before the user re-sorts it in the UI.
+    public enum Order: Sendable, Hashable {
+        /// Spend-heaviest leaf first (the default analytic view).
+        case spendDescending
+        /// Canonical group display order, then spend-heaviest leaf within a group
+        /// (mirrors the status-bar tree so the two surfaces read the same).
+        case groupThenSpend
+    }
+
+    /// Flatten the presentation into table rows in the requested order.
+    ///
+    /// - Parameters:
+    ///   - presentation: the override-aware rollup (built once); never recomputed.
+    ///   - order: initial ordering. Defaults to ``Order/spendDescending``.
+    public static func rows(
+        from presentation: CategoryDashboardPresentation,
+        order: Order = .spendDescending
+    ) -> [CategoryDashboardTableRow] {
+        let rows = presentation.groups.flatMap { group in
+            group.leaves.map { CategoryDashboardTableRow(leaf: $0, group: group.group) }
+        }
+        switch order {
+        case .spendDescending:
+            // Heaviest spend first; stable tiebreak on group order then name so equal
+            // spend never reorders between builds (stable screenshots / tests).
+            return rows.sorted { lhs, rhs in
+                if lhs.spent != rhs.spent { return lhs.spent > rhs.spent }
+                if lhs.group.sortIndex != rhs.group.sortIndex {
+                    return lhs.group.sortIndex < rhs.group.sortIndex
+                }
+                return lhs.categoryName < rhs.categoryName
+            }
+        case .groupThenSpend:
+            // `presentation.groups` is already in canonical display order and each
+            // group's leaves are already spend-heaviest first, so flattening preserves
+            // exactly that — the same order the status-bar tree renders.
+            return rows
+        }
+    }
+
+    /// Column footer totals for a flat table: total spent, total budgeted limit, and
+    /// total remaining (budgeted leaves only). Income / transfers / excluded rows are
+    /// already dropped upstream, so these equal the presentation aggregates.
+    public struct Totals: Sendable, Hashable {
+        /// Sum of every row's spend.
+        public let spent: Double
+        /// Sum of every *budgeted* row's limit.
+        public let budget: Double
+        /// `budget - spent over budgeted rows` (negative when collectively over).
+        public let remaining: Double
+        /// True when at least one row is budgeted (so the budget / left footers mean
+        /// something — otherwise the view shows an em dash rather than `$0`).
+        public let hasBudget: Bool
+    }
+
+    /// Compute the footer totals for the given rows.
+    public static func totals(for rows: [CategoryDashboardTableRow]) -> Totals {
+        let spent = rows.reduce(0) { $0 + $1.spent }
+        let budgetedRows = rows.filter(\.isBudgeted)
+        let budget = budgetedRows.reduce(0) { $0 + ($1.budget ?? 0) }
+        return Totals(
+            spent: spent,
+            budget: budget,
+            // Remaining is computed over budgeted rows only: an unbudgeted row has no
+            // limit, so folding its spend into "left" would understate the figure.
+            remaining: budget - budgetedRows.reduce(0) { $0 + $1.spent },
+            hasBudget: !budgetedRows.isEmpty
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("CategoryDashboardCardModel top-N + headline prep (AND-539)")
+struct CategoryDashboardCardModelTests {
+    // MARK: - Fixtures
+
+    /// A group rollup with a single leaf of the given spend and optional limit.
+    private func group(
+        _ group: CategoryGroup,
+        leaf category: SpendingCategory,
+        spent: Double,
+        limit: Double? = nil
+    ) -> CategoryDashboardPresentation.GroupRollup {
+        CategoryDashboardPresentation.GroupRollup(
+            group: group,
+            leaves: [CategoryDashboardPresentation.Leaf(category: category, spent: spent, monthlyLimit: limit)]
+        )
+    }
+
+    private func presentation(_ groups: [CategoryDashboardPresentation.GroupRollup]) -> CategoryDashboardPresentation {
+        CategoryDashboardPresentation(groups: groups)
+    }
+
+    // MARK: - Empty / first run
+
+    @Test("empty presentation yields an empty card with no top groups or overflow")
+    func emptyIsEmpty() {
+        let model = CategoryDashboardCardModel(presentation: .empty)
+        #expect(model.isEmpty)
+        #expect(model.topGroups.isEmpty)
+        #expect(model.overflowCount == 0)
+        #expect(model.overflowText == nil)
+        #expect(!model.hasAttention)
+        // An unbudgeted empty month never claims "on track".
+        #expect(model.attentionSummary(isBudgeted: false) == nil)
+    }
+
+    // MARK: - Top-N selection
+
+    @Test("top groups are the spend-heaviest, capped to the limit")
+    func topGroupsHeaviestFirst() {
+        let p = presentation([
+            group(.shopping, leaf: .shopping, spent: 100),
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 400),
+            group(.transportation, leaf: .transportation, spent: 250),
+            group(.entertainment, leaf: .entertainment, spent: 50),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p, topGroupLimit: 3)
+        #expect(model.topGroups.map(\.group) == [.foodAndDining, .transportation, .shopping])
+        #expect(model.overflowCount == 1)
+        #expect(model.overflowText == "+1 more")
+    }
+
+    @Test("equal-spend groups break ties on canonical order (deterministic)")
+    func equalSpendTiebreak() {
+        // foodAndDining (sortIndex 2) precedes shopping (sortIndex 4) at equal spend.
+        let p = presentation([
+            group(.shopping, leaf: .shopping, spent: 200),
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 200),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p, topGroupLimit: 1)
+        #expect(model.topGroups.map(\.group) == [.foodAndDining])
+        #expect(model.overflowCount == 1)
+    }
+
+    @Test("a budgeted-but-unspent group never displaces a group with real spend")
+    func unspentGroupDoesNotRank() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            // Budgeted guardrail with zero spend — present in the tree, but not a "top
+            // spending group" and never counted in overflow.
+            group(.healthAndWellness, leaf: .healthAndFitness, spent: 0, limit: 200),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p, topGroupLimit: 3)
+        #expect(model.topGroups.map(\.group) == [.foodAndDining])
+        #expect(model.overflowCount == 0)
+        #expect(model.overflowText == nil)
+    }
+
+    @Test("a zero or negative top-group limit shows the donut only, all overflow")
+    func zeroLimitClamps() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            group(.shopping, leaf: .shopping, spent: 100),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p, topGroupLimit: 0)
+        #expect(model.topGroups.isEmpty)
+        #expect(model.overflowCount == 2)
+        let negative = CategoryDashboardCardModel(presentation: p, topGroupLimit: -5)
+        #expect(negative.topGroups.isEmpty)
+        #expect(negative.overflowCount == 2)
+    }
+
+    // MARK: - Headline / attention summary
+
+    @Test("total spent text matches the donut center total")
+    func totalMatchesDonut() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 300),
+            group(.shopping, leaf: .shopping, spent: 200),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p)
+        #expect(model.totalSpentText == model.donut.totalText)
+        #expect(model.donut.total == 500)
+    }
+
+    @Test("attention summary counts over and nearing leaves, never by color")
+    func attentionSummaryText() {
+        let p = presentation([
+            // 250/200 -> over
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 250, limit: 200),
+            // 90/100 -> nearing (>= 80%)
+            group(.shopping, leaf: .shopping, spent: 90, limit: 100),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p)
+        #expect(model.overBudgetCount == 1)
+        #expect(model.nearingCount == 1)
+        #expect(model.hasAttention)
+        #expect(model.attentionSummary(isBudgeted: true) == "1 over budget · 1 nearing")
+    }
+
+    @Test("a fully on-track budgeted month reads 'On track'")
+    func onTrackSummary() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 50, limit: 200),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p)
+        #expect(!model.hasAttention)
+        #expect(model.attentionSummary(isBudgeted: true) == "On track")
+        // Without a budget context the card omits the line entirely.
+        #expect(model.attentionSummary(isBudgeted: false) == nil)
+    }
+
+    @Test("currency code flows into the donut and headline formatting")
+    func currencyCodeFlows() {
+        let p = presentation([group(.foodAndDining, leaf: .foodAndDrink, spent: 300)])
+        let model = CategoryDashboardCardModel(presentation: p, currencyCode: "EUR")
+        #expect(model.currencyCode == "EUR")
+        #expect(model.donut.currencyCode == "EUR")
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryDashboardTableModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardTableModelTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("CategoryDashboardTableModel flat SPENT/BUDGET/LEFT rows (AND-539)")
+struct CategoryDashboardTableModelTests {
+    // MARK: - Fixtures
+
+    private func leaf(_ category: SpendingCategory, spent: Double, limit: Double? = nil) -> CategoryDashboardPresentation.Leaf {
+        CategoryDashboardPresentation.Leaf(category: category, spent: spent, monthlyLimit: limit)
+    }
+
+    private func group(_ group: CategoryGroup, _ leaves: [CategoryDashboardPresentation.Leaf]) -> CategoryDashboardPresentation.GroupRollup {
+        CategoryDashboardPresentation.GroupRollup(group: group, leaves: leaves)
+    }
+
+    private func presentation(_ groups: [CategoryDashboardPresentation.GroupRollup]) -> CategoryDashboardPresentation {
+        CategoryDashboardPresentation(groups: groups)
+    }
+
+    // MARK: - Flatten
+
+    @Test("flatten produces one row per leaf across all groups")
+    func oneRowPerLeaf() {
+        let p = presentation([
+            group(.foodAndDining, [leaf(.foodAndDrink, spent: 300), leaf(.travel, spent: 80)]),
+            group(.shopping, [leaf(.shopping, spent: 120)]),
+        ])
+        // travel maps to entertainment group, not foodAndDining — use real groupings.
+        let rows = CategoryDashboardTableModel.rows(from: p)
+        #expect(rows.count == 3)
+        #expect(Set(rows.map(\.id)).count == 3)
+    }
+
+    @Test("empty presentation yields no rows and zeroed, unbudgeted totals")
+    func emptyTable() {
+        let rows = CategoryDashboardTableModel.rows(from: .empty)
+        #expect(rows.isEmpty)
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+        #expect(totals.spent == 0)
+        #expect(totals.budget == 0)
+        #expect(totals.remaining == 0)
+        #expect(!totals.hasBudget)
+    }
+
+    // MARK: - Ordering
+
+    @Test("spendDescending orders rows heaviest-spend first")
+    func spendDescendingOrder() {
+        let p = presentation([
+            group(.foodAndDining, [leaf(.foodAndDrink, spent: 100)]),
+            group(.shopping, [leaf(.shopping, spent: 400)]),
+            group(.transportation, [leaf(.transportation, spent: 250)]),
+        ])
+        let rows = CategoryDashboardTableModel.rows(from: p, order: .spendDescending)
+        #expect(rows.map(\.category) == [.shopping, .transportation, .foodAndDrink])
+    }
+
+    @Test("groupThenSpend preserves canonical group order then per-group spend order")
+    func groupThenSpendOrder() {
+        // Within a group the builder hands leaves spend-heaviest first; the model
+        // preserves that and keeps groups in canonical display order.
+        let p = presentation([
+            group(.foodAndDining, [leaf(.foodAndDrink, spent: 300), leaf(.foodAndDrink, spent: 50)]),
+            group(.shopping, [leaf(.shopping, spent: 999)]),
+        ])
+        let rows = CategoryDashboardTableModel.rows(from: p, order: .groupThenSpend)
+        // foodAndDining group precedes shopping in canonical order, even though
+        // shopping's single leaf outspends both food leaves.
+        #expect(rows.first?.group == .foodAndDining)
+        #expect(rows.last?.group == .shopping)
+    }
+
+    // MARK: - Row columns
+
+    @Test("an unbudgeted row has nil budget / remaining / status and a no-budget verdict")
+    func unbudgetedRowColumns() {
+        let p = presentation([group(.foodAndDining, [leaf(.foodAndDrink, spent: 120)])])
+        let row = CategoryDashboardTableModel.rows(from: p)[0]
+        #expect(row.spent == 120)
+        #expect(row.budget == nil)
+        #expect(row.remaining == nil)
+        #expect(row.status == nil)
+        #expect(!row.isBudgeted)
+        #expect(row.statusText == "No budget")
+        #expect(row.statusIconName == "minus.circle")
+    }
+
+    @Test("a budgeted row carries budget, remaining, and the correct band")
+    func budgetedRowColumns() {
+        // 250 spent / 200 limit -> over, remaining -50.
+        let p = presentation([group(.foodAndDining, [leaf(.foodAndDrink, spent: 250, limit: 200)])])
+        let row = CategoryDashboardTableModel.rows(from: p)[0]
+        #expect(row.budget == 200)
+        #expect(row.remaining == -50)
+        #expect(row.status == .over)
+        #expect(row.isBudgeted)
+        #expect(row.isOverBudget)
+        #expect(row.statusText == "Over budget")
+    }
+
+    // MARK: - Footer totals
+
+    @Test("totals sum spent across all rows but budget/remaining only over budgeted rows")
+    func totalsBudgetedOnly() {
+        let p = presentation([
+            group(.foodAndDining, [leaf(.foodAndDrink, spent: 150, limit: 200)]),
+            // Unbudgeted: its spend counts toward total spent but NOT toward remaining.
+            group(.shopping, [leaf(.shopping, spent: 90)]),
+        ])
+        let rows = CategoryDashboardTableModel.rows(from: p)
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+        #expect(totals.spent == 240)      // 150 + 90
+        #expect(totals.budget == 200)     // only the budgeted leaf
+        #expect(totals.remaining == 50)   // 200 - 150 (unbudgeted 90 excluded)
+        #expect(totals.hasBudget)
+    }
+
+    @Test("collectively-over budgeted rows yield a negative remaining total")
+    func negativeRemaining() {
+        let p = presentation([
+            group(.foodAndDining, [leaf(.foodAndDrink, spent: 250, limit: 200)]),
+            group(.shopping, [leaf(.shopping, spent: 60, limit: 50)]),
+        ])
+        let rows = CategoryDashboardTableModel.rows(from: p)
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+        #expect(totals.budget == 250)     // 200 + 50
+        #expect(totals.remaining == -60)  // 250 - 310
+        #expect(totals.hasBudget)
+    }
+}


### PR DESCRIPTION
## Summary

Surfaces the Copilot-style **Category Dashboard** that AND-536/537/538 built but never showed. This is the surface that finally renders the dashboard:

- **Center-column popover card** (`CategoryDashboardCard`) — spend donut (`SpendDonutChart`, AND-537) + top spending group rollups (`CategoryStatusBar`, AND-538) + an **Open dashboard** affordance. Mounted in `MainPopover`'s center column next to the Weekly Review card.
- **Detached full window** (`CategoryDashboardWindow` + `CategoryDashboardWindowController` + `CategoryDashboardWindowCoordinator`) — donut + the two-level status-bar tree (`CategoryTreeView`) + a flat, group/spend-sortable **SPENT / BUDGET / LEFT** `Table` with footer totals.

Pure assembly of existing override-aware components — no recompute. New pure logic was extracted to PlaidBarCore and TDD'd.

## Linear (AND-539)

Epic **AND-521** Category Dashboard → **AND-539** dashboard card + window. Builds on AND-536 (builder), AND-537 (donut), AND-538 (status bars + tree). Critical-path node per spec §6 (`526 → 536 → 538 → 539`).

## Spec alignment (`docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §3/§4 — Option A)

- §3 "Category Dashboard": new center-column **card** (donut + top groups) → detached **full window** (donut + tree + flat SPENT/BUDGET/LEFT `Table`). Exactly as specced.
- §4 Architecture: **Option A — additive, no migration.** No schema/DTO/`rawValue` change. The window reuses the documented detached-window pattern (AND-384): a managed `NSWindow` (not `NSPanel`) over a behind-window `NSVisualEffectView`, frame-autosaved, `.regular` activation via the shared `AppActivationPolicyCoordinator`. No new windowing mechanism invented.
- §4 cache invalidation: `AppState.categoryDashboardPresentation` is invalidated on the **same** `didSet`s as `categoryBudgetPresentation` (`transactions`, `categoryBudgets`, `transactionReviewMetadata`, `transactionRules`), so a recategorize / exclude / new-rule / budget edit moves the dashboard immediately — never stale until an unrelated refresh.
- Spend stays override-aware: the rollup comes from `CategoryDashboardBuilder` on live metadata + rules, so the card, window, and budget surfaces can never disagree on a category's spend.
- Accessibility (ACCESSIBILITY.md): budget pressure and the headline summary ride on glyph + text, never color alone; all amounts honor Privacy Mask.

## Testing notes

- **17 new unit tests** (Swift Testing) on the extracted pure logic:
  - `CategoryDashboardCardModelTests` — top-N group selection, equal-spend tiebreak, unspent-budgeted group never ranks, zero/negative limit clamp, attention summary, currency flow.
  - `CategoryDashboardTableModelTests` — flatten, both orderings, row columns (budgeted/unbudgeted), footer totals (budgeted-only remaining, negative remaining).
- Full suite green: **1263 tests passed** (Keychain-env skips are pre-existing and intentional).
- Strict-concurrency CI gate clean: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.

## Architectural decisions

- New pure view-models (`CategoryDashboardCardModel`, `CategoryDashboardTableModel`/`CategoryDashboardTableRow`) live in PlaidBarCore so the SwiftUI surfaces — which are not headlessly unit-testable — stay thin renderers and every derived number is tested.
- The flat `Table` sorts via a small `Sendable` order enum (`CategoryDashboardTableModel.Order`) mapped to the pure builder, rather than a `@State`-stored `[KeyPathComparator]` (a `KeyPath` is not `Sendable` and fails the strict-concurrency gate).
- The card opens the window through an `openCategoryDashboard` environment hook (mirrors the AND-384 `dashboardPresentation` detach/redock pattern), so the view never touches AppKit lifecycle and headless renders default to a no-op.
- The dashboard window is a separate identity from the full-dashboard detach window (own title + `frameAutosaveName`), so the two persist/restore independently.

## Migration notes

**None.** Option A: no schema, DTO, `rawValue`, or server change. Review state stays app-local. The `AppState` edit is strictly additive (one cache field, one accessor, four cache invalidations) — `categoryBudgetPresentation`, `persistReviewStorage`, `loadDemoData`, review, and privacy regions are untouched.

The monthly-history `BarMark` + dashed `RuleMark` budget line (spec §3) is **deferred to a follow-up**: there is no override-aware multi-month spend rollup in PlaidBarCore yet, and building one is beyond assembling existing components. The card + window ship complete without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
