### PR TITLE
feat(ui): colored icon+text category pill on review rows (AND-530)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -599,10 +599,12 @@ private struct ReviewInboxRow: View {
                 }
 
                 HStack(spacing: Spacing.xs) {
-                    Text(item.effectiveCategory?.displayName ?? "Uncategorized")
-                        .microText()
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                    // Colored icon+text category pill (AND-530). Color is a
+                    // redundant layer only: the pill always shows the category
+                    // name as text + a glyph, so meaning never rides on color
+                    // (ACCESSIBILITY.md). The pure CategoryPillModel owns the
+                    // category→{title, glyph, accent} mapping.
+                    CategoryPill(model: CategoryPillModel.make(category: item.effectiveCategory))
 
                     if item.isNLSuggestedCategory {
                         suggestedBadge
@@ -828,5 +830,42 @@ private struct ReviewInboxRow: View {
 
     private func tint(for reason: TransactionReviewReason) -> Color {
         reason.isHighPriority ? SemanticColors.warning : .secondary
+    }
+}
+
+/// A colored icon+text category pill for a review row (AND-530).
+///
+/// Renders the category glyph + name in a tinted capsule. The accent is a
+/// **redundant** layer only — the title text and the glyph always carry the
+/// meaning, so the pill never conveys the category by color alone
+/// (ACCESSIBILITY.md). The category→{title, glyph, accent} mapping lives in the
+/// pure, unit-tested `CategoryPillModel` in PlaidBarCore; this view is a thin
+/// renderer that resolves the accent through the app's `CategoryAccentTokens`
+/// (falling back to a neutral secondary tint for the uncategorized case).
+///
+/// Privacy: the pill carries only a category label and glyph — never a merchant,
+/// amount, or other sensitive figure — and the inbox never renders rows at all
+/// while masked (it shows `privateInboxPlaceholder` instead), so nothing leaks.
+private struct CategoryPill: View {
+    let model: CategoryPillModel
+
+    private var accent: Color {
+        model.category.map(CategoryAccentTokens.color(for:)) ?? .secondary
+    }
+
+    var body: some View {
+        Label(model.title, systemImage: model.glyph)
+            .font(.caption2.weight(.semibold))
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(accent)
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(accent.opacity(0.10), in: Capsule())
+            .overlay {
+                Capsule().stroke(accent.opacity(0.18), lineWidth: 1)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Category: \(model.title)")
     }
 }

--- a/Sources/PlaidBarCore/Models/CategoryPillModel.swift
+++ b/Sources/PlaidBarCore/Models/CategoryPillModel.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The display contract for a colored icon+text category pill (AND-530).
+///
+/// A review-inbox row tags each transaction with its effective ``SpendingCategory``
+/// (or "Uncategorized" when none resolves yet). The pill renders that tag as a glyph
+/// plus the category name plus an accent — the accent is a *redundant* layer only:
+/// the title text and the glyph always carry the meaning, so the pill never conveys
+/// the category by color alone (ACCESSIBILITY.md).
+///
+/// This is the pure, `Sendable`, testable half: it owns the title / glyph / accent-hex
+/// mapping so the view stays a thin renderer. The view maps `accentColorHex` to a
+/// SwiftUI `Color` through the app's `CategoryAccentTokens`; the hex carried here is the
+/// canonical chart hex the rest of the app already keys off, so the pill's accent never
+/// drifts from the donut / status bars for the same category.
+public struct CategoryPillModel: Sendable, Hashable {
+    /// The category this pill represents, or `nil` for an unresolved/uncategorized row.
+    public let category: SpendingCategory?
+    /// The user-facing label — always shown, so meaning never rides on color.
+    public let title: String
+    /// SF Symbol name shown alongside the title (the redundant glyph layer).
+    public let glyph: String
+    /// Canonical accent hex (light appearance) the view resolves to a `Color`. Kept in
+    /// sync with ``SpendingCategory/colorHex`` so the pill matches the dashboard accents.
+    public let accentColorHex: String
+
+    public init(category: SpendingCategory?, title: String, glyph: String, accentColorHex: String) {
+        self.category = category
+        self.title = title
+        self.glyph = glyph
+        self.accentColorHex = accentColorHex
+    }
+
+    /// The placeholder title shown when a row has no resolved category.
+    public static let uncategorizedTitle = "Uncategorized"
+    /// The placeholder glyph for an uncategorized row — a neutral tag outline that reads
+    /// as "no category yet" rather than borrowing any real category's symbol.
+    public static let uncategorizedGlyph = "tag"
+    /// Neutral grey accent hex for the uncategorized pill (mirrors `SpendingCategory.other`).
+    public static let uncategorizedAccentHex = "#BDC3C7"
+
+    /// Builds the pill model for an effective category. Passing `nil` yields the neutral
+    /// "Uncategorized" pill, so a review row that has not been categorized still shows a
+    /// labelled, glyphed pill instead of nothing.
+    public static func make(category: SpendingCategory?) -> CategoryPillModel {
+        guard let category else {
+            return CategoryPillModel(
+                category: nil,
+                title: uncategorizedTitle,
+                glyph: uncategorizedGlyph,
+                accentColorHex: uncategorizedAccentHex
+            )
+        }
+        return CategoryPillModel(
+            category: category,
+            title: category.displayName,
+            glyph: category.iconName,
+            accentColorHex: category.colorHex
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryPillModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryPillModelTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("CategoryPillModel — colored icon+text pill (AND-530)")
+struct CategoryPillModelTests {
+    @Test("a real category yields its name, glyph, and accent")
+    func realCategoryMapping() {
+        let pill = CategoryPillModel.make(category: .foodAndDrink)
+        #expect(pill.category == .foodAndDrink)
+        #expect(pill.title == SpendingCategory.foodAndDrink.displayName)
+        #expect(pill.glyph == SpendingCategory.foodAndDrink.iconName)
+        #expect(pill.accentColorHex == SpendingCategory.foodAndDrink.colorHex)
+    }
+
+    @Test("nil category yields the neutral uncategorized pill")
+    func uncategorizedMapping() {
+        let pill = CategoryPillModel.make(category: nil)
+        #expect(pill.category == nil)
+        #expect(pill.title == CategoryPillModel.uncategorizedTitle)
+        #expect(pill.title == "Uncategorized")
+        #expect(pill.glyph == CategoryPillModel.uncategorizedGlyph)
+        #expect(pill.accentColorHex == CategoryPillModel.uncategorizedAccentHex)
+    }
+
+    @Test("every category produces a non-empty title and glyph (no color-only meaning)")
+    func everyCategoryHasTextAndGlyph() {
+        // The pill must always carry its meaning in text + glyph so it never relies on
+        // color alone (ACCESSIBILITY.md). Assert that for the uncategorized case too.
+        let pills = SpendingCategory.allCases.map { CategoryPillModel.make(category: $0) }
+            + [CategoryPillModel.make(category: nil)]
+        for pill in pills {
+            #expect(!pill.title.isEmpty)
+            #expect(!pill.glyph.isEmpty)
+            #expect(!pill.accentColorHex.isEmpty)
+        }
+    }
+
+    @Test("title and glyph match the source SpendingCategory for every case")
+    func mappingStaysInSyncWithCategory() {
+        // Pin the pill to the canonical category contract so a future rename of a
+        // category's display name / icon flows through without the pill drifting.
+        for category in SpendingCategory.allCases {
+            let pill = CategoryPillModel.make(category: category)
+            #expect(pill.title == category.displayName)
+            #expect(pill.glyph == category.iconName)
+            #expect(pill.accentColorHex == category.colorHex)
+        }
+    }
+
+    @Test("distinct categories produce distinct pill models")
+    func categoriesProduceDistinctPills() {
+        let foodPill = CategoryPillModel.make(category: .foodAndDrink)
+        let travelPill = CategoryPillModel.make(category: .travel)
+        #expect(foodPill != travelPill)
+        // Hashable conformance keeps the model usable as a dictionary key / set member.
+        #expect(Set([foodPill, travelPill, foodPill]).count == 2)
+    }
+}


### PR DESCRIPTION
## Summary

Each review-inbox row now shows its category as a **colored icon+text pill** instead of bare secondary-grey text. The pill pairs the category glyph, the category name, and a tinted capsule accent — bringing the inbox to Copilot parity (spec §3, AND-519/AND-530) and matching the accent system already used by the Category Dashboard donut, status bars, and tree.

The category→`{title, glyph, accent}` mapping is extracted into a pure, `Sendable` `CategoryPillModel` in `PlaidBarCore` and unit-tested; the SwiftUI `CategoryPill` is a thin renderer.

## Linear (AND-530)

Implements **AND-530** ("Review Inbox parity → colored pill") under epic **AND-519**, per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §3.

## Spec alignment

- §3 Review Inbox: "colored icon+text category pill" on each row — delivered.
- §4 Views: adds the `CategoryPill` view called out in the architecture's view list.
- Accent reuses `CategoryAccentTokens` + `SpendingCategory` glyphs/`colorHex`, so the pill never drifts from the dashboard accents for the same category.

## Testing notes

- New `CategoryPillModelTests` (5 tests): real-category mapping, neutral uncategorized pill, every-case non-empty title/glyph/accent (the color-redundancy guarantee), title/glyph/accent stay in sync with `SpendingCategory`, and distinct categories → distinct (Hashable) pills.
- Strict-concurrency CI gate green: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.
- Full suite green: **1525 tests passed**.

## Architectural decisions

- **Pure logic in Core, thin view in app.** SwiftUI views in the `PlaidBar` target aren't headlessly unit-testable, so the category→display mapping lives in `CategoryPillModel` (PlaidBarCore) and is fully tested there; `CategoryPill` only resolves the accent hex to a SwiftUI `Color` via `CategoryAccentTokens` (neutral `.secondary` fallback for the uncategorized/nil case).
- **Color is a redundant layer only (ACCESSIBILITY.md).** The pill always renders the category name as text plus a glyph; the accent never carries meaning alone. The Core test asserts every case (including uncategorized) has a non-empty title and glyph.
- **Privacy Mask safe.** The inbox already renders no rows while masked (it shows `privateInboxPlaceholder`), and the pill carries only a category label/glyph — never a merchant, amount, or other sensitive figure — so nothing leaks.
- **No `AppState` changes; no migration.** Purely additive: a new Core model + a private view + one row substitution.

## Migration notes

None. No schema, DTO, `SpendingCategory` rawValue, or persisted-format change. Additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)