### PR TITLE
feat(ui): set/edit budget affordances on dashboard rows (AND-541)

### DIFF
--- a/Sources/PlaidBar/Views/BudgetEditorCategory.swift
+++ b/Sources/PlaidBar/Views/BudgetEditorCategory.swift
@@ -1,0 +1,16 @@
+import PlaidBarCore
+import SwiftUI
+
+/// A tiny `Identifiable` wrapper around a `SpendingCategory` so the Category
+/// Dashboard surfaces can drive `BudgetEditorSheet` via `.sheet(item:)` (AND-541)
+/// without making the Core enum `Identifiable` (its identity is presentation glue,
+/// not a model concern). Both the popover card and the detached window present the
+/// editor through this, so the wrapper is shared rather than duplicated per view.
+struct BudgetEditorCategory: Identifiable, Hashable {
+    let category: SpendingCategory
+    var id: String { category.rawValue }
+
+    init(_ category: SpendingCategory) {
+        self.category = category
+    }
+}

--- a/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
@@ -28,6 +28,8 @@ struct CategoryDashboardWindow: View {
     /// strict concurrency); mapped to the pure ``CategoryDashboardTableModel/Order``
     /// when the rows are built.
     @State private var tableOrder: CategoryDashboardTableModel.Order = .spendDescending
+    /// The category whose budget the user is editing (AND-541); drives the sheet.
+    @State private var budgetEditorCategory: BudgetEditorCategory?
 
     private var presentation: CategoryDashboardPresentation {
         appState.categoryDashboardPresentation
@@ -54,6 +56,15 @@ struct CategoryDashboardWindow: View {
         .scrollContentBackground(.hidden)
         .frame(minWidth: 520, minHeight: 480)
         .accessibilityElement(children: .contain)
+        .sheet(item: $budgetEditorCategory) { item in
+            BudgetEditorSheet(category: item.category)
+                .environment(appState)
+        }
+    }
+
+    /// Open the budget editor for `category` (AND-541).
+    private func editBudget(_ category: SpendingCategory) {
+        budgetEditorCategory = BudgetEditorCategory(category)
     }
 
     // MARK: - Header
@@ -86,7 +97,11 @@ struct CategoryDashboardWindow: View {
             Label("By group", systemImage: "list.bullet.indent")
                 .sectionTitle()
                 .foregroundStyle(.secondary)
-            CategoryTreeView(presentation: presentation, privacyMaskEnabled: isMasked)
+            CategoryTreeView(
+                presentation: presentation,
+                privacyMaskEnabled: isMasked,
+                onEditBudget: editBudget
+            )
         }
         .padding(Spacing.md)
         .glassSurface(.raised)
@@ -164,6 +179,11 @@ struct CategoryDashboardWindow: View {
                         .accessibilityLabel(row.statusText)
                 }
                 .width(min: 120, ideal: 140)
+
+                TableColumn("Plan") { row in
+                    budgetActionCell(row)
+                }
+                .width(min: 104, ideal: 120)
             }
             .frame(minHeight: 220)
 
@@ -192,6 +212,30 @@ struct CategoryDashboardWindow: View {
                     ? "\(currency(abs(remaining))) over"
                     : "\(currency(remaining)) left")
         )
+    }
+
+    /// The flat-table "Set a budget" / "Edit" action cell (AND-541). Budgetable
+    /// rows get a labeled button that opens `BudgetEditorSheet`; income / transfer
+    /// rows show an em dash, since they can never carry a budget.
+    @ViewBuilder
+    private func budgetActionCell(_ row: CategoryDashboardTableRow) -> some View {
+        let affordance = BudgetRowAffordance(category: row.category, isBudgeted: row.isBudgeted)
+        if affordance.isAvailable {
+            Button {
+                editBudget(row.category)
+            } label: {
+                Label(affordance.title, systemImage: affordance.systemImage)
+                    .labelStyle(.titleAndIcon)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .accessibilityLabel(affordance.accessibilityLabel)
+        } else {
+            Text("—")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+        }
     }
 
     private func tableFooter(_ totals: CategoryDashboardTableModel.Totals) -> some View {

--- a/Sources/PlaidBar/Views/CategoryTreeView.swift
+++ b/Sources/PlaidBar/Views/CategoryTreeView.swift
@@ -18,15 +18,24 @@ struct CategoryTreeView: View {
     let presentation: CategoryDashboardPresentation
     /// When true, every currency figure is masked (Privacy Mask / App Lock).
     var privacyMaskEnabled: Bool = false
+    /// Opens `BudgetEditorSheet` for a leaf category (AND-541). Supplied by the
+    /// host (popover card / dashboard window); a no-op default keeps previews and
+    /// headless renders inert and means the affordance simply doesn't show.
+    var onEditBudget: ((SpendingCategory) -> Void)?
 
     /// Group IDs currently expanded. Budgeted-or-pressured groups start open so
     /// the rows that need attention are visible without a click.
     @State private var expandedGroupIDs: Set<String>
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    init(presentation: CategoryDashboardPresentation, privacyMaskEnabled: Bool = false) {
+    init(
+        presentation: CategoryDashboardPresentation,
+        privacyMaskEnabled: Bool = false,
+        onEditBudget: ((SpendingCategory) -> Void)? = nil
+    ) {
         self.presentation = presentation
         self.privacyMaskEnabled = privacyMaskEnabled
+        self.onEditBudget = onEditBudget
         // Open groups that are over/nearing so attention rows are visible up front.
         let openByDefault = presentation.groups
             .filter { $0.status != nil && $0.status != .under }
@@ -122,6 +131,7 @@ struct CategoryTreeView: View {
                     .font(.caption.weight(.medium))
                     .foregroundStyle(CategoryAccentTokens.color(for: leaf.category))
                     .frame(width: Sizing.iconInline)
+                    .accessibilityHidden(true)
 
                 Text(leaf.category.displayName)
                     .font(.caption)
@@ -129,6 +139,8 @@ struct CategoryTreeView: View {
                     .lineLimit(1)
 
                 Spacer(minLength: Spacing.sm)
+
+                budgetAffordance(for: leaf)
             }
 
             CategoryStatusBar(
@@ -138,8 +150,32 @@ struct CategoryTreeView: View {
                 accent: CategoryAccentTokens.color(for: leaf.category)
             )
         }
-        .accessibilityElement(children: .ignore)
+        // The status bar describes the row; the affordance is a separate, labeled
+        // control so VoiceOver lands on it as its own actionable element.
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(leaf.category.displayName). \(model.accessibilityDescription(spentText: currency(leaf.spent), limitText: leaf.monthlyLimit.map(currency)))")
+    }
+
+    /// The per-leaf "Set a budget" / "Edit" control (AND-541). Hidden entirely for
+    /// categories that can't carry a budget (income / transfer) or when the host
+    /// supplies no handler. The verb + label come from the pure
+    /// ``BudgetRowAffordance`` so the rules are tested without this view.
+    @ViewBuilder
+    private func budgetAffordance(for leaf: CategoryDashboardPresentation.Leaf) -> some View {
+        let affordance = BudgetRowAffordance(leaf: leaf)
+        if affordance.isAvailable, let onEditBudget {
+            Button {
+                onEditBudget(leaf.category)
+            } label: {
+                Label(affordance.title, systemImage: affordance.systemImage)
+                    .font(.caption2.weight(.semibold))
+                    .labelStyle(.titleAndIcon)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .accessibilityLabel(affordance.accessibilityLabel)
+        }
     }
 
     private var emptyState: some View {

--- a/Sources/PlaidBarCore/Utilities/BudgetRowAffordance.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetRowAffordance.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// The per-row "Set a budget" / "Edit" affordance on the Category Dashboard
+/// (AND-541). Given a category and whether it currently carries a budget, this
+/// pure value decides:
+///
+/// - whether the affordance should appear at all (income / transfer categories
+///   can never be budgeted, so they get none — mirroring `BudgetEditorInput`),
+/// - the call-to-action verb ("Set a budget" when unbudgeted, "Edit" when
+///   budgeted) and its SF Symbol, and
+/// - an accessibility label that always names *both* the category and the action,
+///   so the control is unambiguous to VoiceOver (ACCESSIBILITY.md) even though
+///   many such controls share one screen.
+///
+/// Lives in PlaidBarCore so the labels/visibility rules are `Sendable`, unit
+/// tested without a view, and identical on the popover card and the detached
+/// dashboard window. The view layer renders the result and, when tapped, opens
+/// `BudgetEditorSheet` for `category` — it owns no copy of these rules.
+public struct BudgetRowAffordance: Sendable, Hashable {
+    /// What tapping the affordance does — both verbs open the same
+    /// `BudgetEditorSheet`; only the framing differs.
+    public enum Action: Sendable, Hashable {
+        /// No saved budget yet — invite the user to create one.
+        case setBudget
+        /// A budget already exists — invite the user to change or clear it.
+        case editBudget
+    }
+
+    public let category: SpendingCategory
+
+    /// The resolved action, or `nil` when this category can't be budgeted.
+    public let action: Action?
+
+    /// Construct from an explicit budgeted flag.
+    public init(category: SpendingCategory, isBudgeted: Bool) {
+        self.category = category
+        guard BudgetEditorInput.isBudgetable(category) else {
+            self.action = nil
+            return
+        }
+        self.action = isBudgeted ? .editBudget : .setBudget
+    }
+
+    /// Construct from a dashboard leaf — a budgeted leaf carries a `monthlyLimit`.
+    public init(leaf: CategoryDashboardPresentation.Leaf) {
+        self.init(category: leaf.category, isBudgeted: leaf.isBudgeted)
+    }
+
+    /// True when the affordance should be shown for this row.
+    public var isAvailable: Bool { action != nil }
+
+    /// The button title — empty when no affordance applies.
+    public var title: String {
+        switch action {
+        case .setBudget: "Set a budget"
+        case .editBudget: "Edit"
+        case nil: ""
+        }
+    }
+
+    /// The SF Symbol paired with the title (the verb is never carried by icon
+    /// alone — the text label is always present).
+    public var systemImage: String {
+        switch action {
+        case .setBudget: "plus.circle"
+        case .editBudget: "slider.horizontal.3"
+        case nil: ""
+        }
+    }
+
+    /// A VoiceOver label that disambiguates *which* category this control acts on,
+    /// since a dashboard renders one per row. Empty when no affordance applies.
+    public var accessibilityLabel: String {
+        switch action {
+        case .setBudget: "Set a budget for \(category.displayName)"
+        case .editBudget: "Edit budget for \(category.displayName)"
+        case nil: ""
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetRowAffordanceTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetRowAffordanceTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Budget row affordance (AND-541)")
+struct BudgetRowAffordanceTests {
+    // MARK: - Visibility
+
+    @Test("A budgetable category always offers an affordance")
+    func budgetableCategoryShowsAffordance() {
+        let unbudgeted = BudgetRowAffordance(category: .foodAndDrink, isBudgeted: false)
+        let budgeted = BudgetRowAffordance(category: .shopping, isBudgeted: true)
+        #expect(unbudgeted.isAvailable)
+        #expect(budgeted.isAvailable)
+    }
+
+    @Test("Income and transfer categories never offer an affordance")
+    func excludedCategoriesHaveNoAffordance() {
+        for excluded in CategoryBudgetPlanner.excludedCategories {
+            let affordance = BudgetRowAffordance(category: excluded, isBudgeted: false)
+            #expect(!affordance.isAvailable)
+            // Even if some upstream path mislabels it budgeted, it stays unavailable.
+            #expect(!BudgetRowAffordance(category: excluded, isBudgeted: true).isAvailable)
+        }
+    }
+
+    // MARK: - Action verb
+
+    @Test("An unbudgeted category invites setting a budget")
+    func unbudgetedShowsSet() {
+        let affordance = BudgetRowAffordance(category: .foodAndDrink, isBudgeted: false)
+        #expect(affordance.action == .setBudget)
+        #expect(affordance.title == "Set a budget")
+        #expect(affordance.systemImage == "plus.circle")
+    }
+
+    @Test("A budgeted category invites editing the budget")
+    func budgetedShowsEdit() {
+        let affordance = BudgetRowAffordance(category: .shopping, isBudgeted: true)
+        #expect(affordance.action == .editBudget)
+        #expect(affordance.title == "Edit")
+        #expect(affordance.systemImage == "slider.horizontal.3")
+    }
+
+    // MARK: - Accessibility
+
+    @Test("Accessibility label names the category and the action")
+    func accessibilityLabelCarriesCategoryAndAction() {
+        let set = BudgetRowAffordance(category: .foodAndDrink, isBudgeted: false)
+        #expect(set.accessibilityLabel == "Set a budget for Food & Drink")
+
+        let edit = BudgetRowAffordance(category: .shopping, isBudgeted: true)
+        #expect(edit.accessibilityLabel == "Edit budget for Shopping")
+    }
+
+    @Test("Unavailable categories expose an empty, action-less affordance")
+    func unavailableAffordanceIsInert() {
+        let affordance = BudgetRowAffordance(category: .income, isBudgeted: false)
+        #expect(!affordance.isAvailable)
+        #expect(affordance.action == nil)
+        #expect(affordance.title == "")
+        #expect(affordance.accessibilityLabel == "")
+    }
+
+    // MARK: - Convenience builders mirror the dashboard rows
+
+    @Test("Leaf builder reads the leaf's budget state")
+    func builtFromLeaf() {
+        let budgetedLeaf = CategoryDashboardPresentation.Leaf(
+            category: .foodAndDrink,
+            spent: 120,
+            monthlyLimit: 300
+        )
+        let unbudgetedLeaf = CategoryDashboardPresentation.Leaf(
+            category: .shopping,
+            spent: 80,
+            monthlyLimit: nil
+        )
+        #expect(BudgetRowAffordance(leaf: budgetedLeaf).action == .editBudget)
+        #expect(BudgetRowAffordance(leaf: unbudgetedLeaf).action == .setBudget)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the per-row **Set a budget** / **Edit** affordance to the Category Dashboard (AND-541). Each leaf category row now carries a labeled control:

- a row with **no budget** shows **Set a budget** (`plus.circle`),
- a row **with a budget** shows **Edit** (`slider.horizontal.3`),

and tapping it opens the existing `BudgetEditorSheet` for that category. The affordance is rendered both in the dashboard window's two-level status-bar tree (leaf rows) and in its flat SPENT / BUDGET / LEFT table (a new "Plan" action column). Income / transfer categories — which can never carry a budget — get no affordance.

Persistence reuses the existing `AppState.setCategoryBudget` / `removeCategoryBudget` path through `BudgetEditorSheet`; there is **no new server work** and no `AppState` change.

## Linear (AND-541)

Implements AND-541 ("Set a budget" / "Edit" affordances on Category Dashboard rows) under epic **AND-522** (budget editing), per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §4. AND-540 (`BudgetEditorSheet` + the dead `set/removeCategoryBudget` callers) is the dependency this wires up — the sheet previously had zero callers.

## Spec alignment

- §4 "Views: … `BudgetEditorSheet` … set/edit affordances" — done; the sheet is now reachable from the dashboard rows.
- §3 popover-card / detached-window split — the editable category (leaf) rows live in the **window** (tree + table); the popover **card** keeps showing group rollups + "Open dashboard". Group rows are intentionally *not* given a budget affordance since a group spans multiple categories.
- Option A (display-only rollups, no migration) — unchanged. No schema, DTO, or rawValue changes.
- ACCESSIBILITY.md — each control's verb rides on **text + SF Symbol**, never color alone, and its accessibility label always names the category *and* the action ("Set a budget for Food & Drink" / "Edit budget for Shopping") so VoiceOver disambiguates one-per-row controls.

## Testing notes

- New pure-logic suite `BudgetRowAffordanceTests` (7 tests): visibility (budgetable vs. income/transfer), action verb + symbol, category-naming accessibility label, inert/empty unavailable case, and the leaf-state convenience builder.
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — full suite green (1527 tests; the only `✘` lines are pre-existing environment-gated Keychain *skips*).

## Architectural decisions

- The verb / symbol / visibility / a11y-label rules are extracted to a pure, `Sendable` `BudgetRowAffordance` in **PlaidBarCore** (SwiftUI dashboard views aren't headlessly unit-testable), keeping the rules tested once and identical across the tree and the table.
- `CategoryTreeView` gains an optional `onEditBudget: (SpendingCategory) -> Void`; a `nil` default keeps previews / snapshot / headless hosts inert (the affordance simply doesn't render).
- A small shared `BudgetEditorCategory` `Identifiable` wrapper drives `.sheet(item:)` rather than making the Core `SpendingCategory` enum `Identifiable` (sheet identity is presentation glue, not a model concern).

## Migration notes

None. No schema, DTO, `SpendingCategory` rawValue, or server-API changes; review/budget state and CRUD are unchanged. Purely additive UI + one new pure utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)