### PR TITLE
feat(ui): NSStatusItem menu-bar badge for unreviewed count (AND-534)

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -22,6 +22,11 @@ struct PlaidBarApp: App {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let updaterController: SPUStandardUpdaterController
     private let statusItemContextMenuController = StatusItemContextMenuController()
+    /// Draws the unreviewed review-inbox count badge on the menu-bar status item
+    /// (AND-534). Configured with the live `NSStatusItem` in `menuBarExtraAccess`;
+    /// updated from the always-mounted `MenuBarLabel` whenever the count or
+    /// Privacy Mask changes.
+    private let statusItemBadgeController = StatusItemBadgeController()
 
     init() {
         Self.applyForcedAppearance()
@@ -136,6 +141,27 @@ struct PlaidBarApp: App {
                         )
                     }
                 }
+                // Keep the menu-bar count badge in sync from the always-mounted
+                // label (the only scene content live for the whole app lifetime,
+                // so the badge updates even when the popover has never opened).
+                // The visibility/text rule (hidden at zero, withheld under Privacy
+                // Mask) lives in the pure `MenuBarReviewBadge`; the controller only
+                // renders it. The badge view itself is attached lazily in
+                // `menuBarExtraAccess` once the status item exists, so these only
+                // take visible effect after that callback has fired — the
+                // configure-time `update` covers the first appearance (AND-534).
+                .onChange(of: appState.transactionReviewCount) { _, count in
+                    statusItemBadgeController.update(
+                        unreviewedCount: count,
+                        isMasked: appState.shouldMaskFinancialValues
+                    )
+                }
+                .onChange(of: appState.shouldMaskFinancialValues) { _, isMasked in
+                    statusItemBadgeController.update(
+                        unreviewedCount: appState.transactionReviewCount,
+                        isMasked: isMasked
+                    )
+                }
                 // While detached, a status-item click sets isPopoverPresented
                 // true; intercept it on the always-mounted label, snap it back to
                 // false, and raise the floating window instead of the popover.
@@ -219,6 +245,16 @@ struct PlaidBarApp: App {
                 }
         }
         .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
+            // Attach the unreviewed-count badge to the live status item, then
+            // paint the current count immediately so it is correct on first
+            // appearance (not only after the next count/mask change). The button
+            // can be recreated when the menu-bar item rebuilds, so configure is
+            // idempotent and re-pins the overlay (AND-534).
+            statusItemBadgeController.configure(statusItem: statusItem)
+            statusItemBadgeController.update(
+                unreviewedCount: appState.transactionReviewCount,
+                isMasked: appState.shouldMaskFinancialValues
+            )
             statusItemContextMenuController.configure(
                 statusItem: statusItem,
                 actions: StatusItemContextMenuActions(

--- a/Sources/PlaidBar/App/StatusItemBadgeController.swift
+++ b/Sources/PlaidBar/App/StatusItemBadgeController.swift
@@ -1,0 +1,151 @@
+import AppKit
+import PlaidBarCore
+
+/// Draws a small count badge for the unreviewed review-inbox count onto the
+/// menu-bar status item's button (AND-534).
+///
+/// The app's menu bar is a SwiftUI `MenuBarExtra`, but the underlying
+/// `NSStatusItem` is reachable via `MenuBarExtraAccess` (the same hook
+/// `StatusItemContextMenuController` already uses). Per the delivery design
+/// §4/§7 the badge is rendered through that custom `NSStatusItem` rather than
+/// the SwiftUI label, because a `MenuBarExtra` label can't host the overlapping
+/// pill cleanly under the documented glass constraint.
+///
+/// Rather than fight SwiftUI for ownership of the button's image, the controller
+/// pins a lightweight overlay subview to the button's top-trailing corner and
+/// draws the pill there. The overlay sits above the SwiftUI-rendered glyph and
+/// updates independently whenever the count or Privacy Mask changes.
+///
+/// All visibility/text rules live in the pure, tested `MenuBarReviewBadge`
+/// (PlaidBarCore): the badge is hidden at zero and withheld under Privacy Mask,
+/// and meaning is carried by the number (and the spoken accessibility label),
+/// never by color alone (`ACCESSIBILITY.md`).
+@MainActor
+final class StatusItemBadgeController {
+    private weak var statusItem: NSStatusItem?
+    private weak var badgeView: BadgeOverlayView?
+
+    /// The last applied state, so repeated `update` calls during a single frame
+    /// (the menu-bar label reads review state from several accessors per render)
+    /// are cheap no-ops that don't churn the overlay.
+    private var lastText: String?
+
+    /// Attaches the badge overlay to the status item's button. Idempotent: safe
+    /// to call on every `menuBarExtraAccess` callback (the button can be recreated
+    /// when the menu-bar item is rebuilt). Re-applies the current badge state to a
+    /// freshly attached overlay.
+    func configure(statusItem: NSStatusItem) {
+        self.statusItem = statusItem
+        guard let button = statusItem.button else { return }
+
+        if badgeView?.superview !== button {
+            badgeView?.removeFromSuperview()
+            let view = BadgeOverlayView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            button.addSubview(view)
+            // Pin to the top-trailing corner of the button. The slight outward
+            // nudge lets the pill sit at the icon's shoulder like a typical
+            // notification badge without clipping inside the glyph.
+            NSLayoutConstraint.activate([
+                view.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: 3),
+                view.topAnchor.constraint(equalTo: button.topAnchor, constant: -1)
+            ])
+            badgeView = view
+            // Re-apply current state to the new overlay.
+            let pending = lastText
+            lastText = nil
+            apply(text: pending)
+        }
+    }
+
+    /// Updates the badge from the live unreviewed count and Privacy Mask state.
+    /// The pure rule lives in `MenuBarReviewBadge`; this only renders the result.
+    func update(unreviewedCount: Int, isMasked: Bool) {
+        apply(text: MenuBarReviewBadge.text(unreviewedCount: unreviewedCount, isMasked: isMasked),
+              accessibilityLabel: MenuBarReviewBadge.accessibilityLabel(
+                  unreviewedCount: unreviewedCount, isMasked: isMasked))
+    }
+
+    private func apply(text: String?, accessibilityLabel: String? = nil) {
+        guard text != lastText else {
+            // Text unchanged, but the a11y label might be re-supplied on reattach;
+            // keep it in sync without re-laying-out.
+            badgeView?.setAccessibilityLabel(accessibilityLabel)
+            return
+        }
+        lastText = text
+        guard let badgeView else { return }
+        badgeView.text = text
+        badgeView.setAccessibilityLabel(accessibilityLabel)
+        badgeView.isHidden = (text == nil)
+    }
+}
+
+/// The overlay view that draws the rounded count pill. A plain `NSView` (not a
+/// `NSTextField`) so the pill background and digits render together with full
+/// control over insets and corner radius at menu-bar scale.
+private final class BadgeOverlayView: NSView {
+    var text: String? {
+        didSet {
+            guard text != oldValue else { return }
+            invalidateIntrinsicContentSize()
+            needsDisplay = true
+            // Expose the badge to VoiceOver as a static-text element only when it
+            // carries a count; an empty/hidden badge is not an a11y element. The
+            // spoken label (real count, not the capped "99+") is set by the
+            // controller via `accessibilityLabel`.
+            setAccessibilityElement(text != nil)
+            setAccessibilityRole(text != nil ? .staticText : .unknown)
+        }
+    }
+
+    override var isFlipped: Bool { false }
+
+    /// Whether the overlay should pass mouse events through to the status-item
+    /// button beneath it. The badge is decorative; clicks must still open the
+    /// popover, so it never intercepts hit-testing.
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    private static let font = NSFont.systemFont(ofSize: 9, weight: .semibold)
+    private let horizontalInset: CGFloat = 3.5
+    private let verticalInset: CGFloat = 1
+    private let minimumDiameter: CGFloat = 13
+
+    override var intrinsicContentSize: NSSize {
+        guard let text, !text.isEmpty else { return .zero }
+        let textSize = (text as NSString).size(withAttributes: [.font: Self.font])
+        let width = max(minimumDiameter, ceil(textSize.width) + horizontalInset * 2)
+        let height = max(minimumDiameter, ceil(textSize.height) + verticalInset * 2)
+        return NSSize(width: width, height: height)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let text, !text.isEmpty else { return }
+
+        let rect = bounds.insetBy(dx: 0.5, dy: 0.5)
+        let radius = rect.height / 2
+        let pill = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
+
+        // The pill uses the system accent / alert red as a background. Per the
+        // accessibility rule, color is never the *only* signal: the count digits
+        // inside the pill carry the meaning, and the badge is also exposed to
+        // VoiceOver via `accessibilityLabel`. A thin contrasting stroke keeps the
+        // pill legible on both light and dark menu bars and over wallpapers.
+        NSColor.systemRed.setFill()
+        pill.fill()
+        NSColor.windowBackgroundColor.withAlphaComponent(0.9).setStroke()
+        pill.lineWidth = 1
+        pill.stroke()
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: Self.font,
+            .foregroundColor: NSColor.white
+        ]
+        let textSize = (text as NSString).size(withAttributes: attributes)
+        let origin = NSPoint(
+            x: bounds.midX - textSize.width / 2,
+            y: bounds.midY - textSize.height / 2
+        )
+        (text as NSString).draw(at: origin, withAttributes: attributes)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MenuBarReviewBadge.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarReviewBadge.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Pure derivation of the NSStatusItem menu-bar badge for the unreviewed
+/// review-inbox count (AND-534).
+///
+/// The badge is the small overlay drawn on the menu-bar status item's button
+/// (a custom `NSStatusItem` per the documented `MenuBarExtra`-glass constraint —
+/// see the delivery design §4/§7). Extracting the visibility/text rules here
+/// keeps them `Sendable`, unit-tested, and out of the AppKit drawing code, which
+/// then only renders whatever string this returns (or nothing when `nil`).
+///
+/// Rules (all enforced by tests):
+/// - **Zero or negative count → hidden** (`nil`): a "0" badge is noise.
+/// - **Privacy Mask on → withheld** (`nil`): the unreviewed count is a financial
+///   signal, so it is suppressed under the mask exactly like balances/amounts.
+/// - **Otherwise → the count**, capped at `"99+"` so the badge never grows wide
+///   enough to crowd the menu bar.
+///
+/// Meaning is carried by the number itself (and the spoken accessibility label),
+/// never by color alone (`ACCESSIBILITY.md`).
+public enum MenuBarReviewBadge {
+
+    /// Counts at or above this threshold render as the capped overflow string
+    /// rather than their literal value, keeping the badge a stable width.
+    public static let overflowThreshold = 100
+
+    /// The capped overflow string shown for counts at/above `overflowThreshold`.
+    public static let overflowText = "99+"
+
+    /// The badge text to draw on the status item, or `nil` when the badge must
+    /// be hidden (zero/negative count, or Privacy Mask engaged).
+    ///
+    /// - Parameters:
+    ///   - unreviewedCount: number of transactions awaiting review.
+    ///   - isMasked: whether Privacy Mask / App Lock is hiding financial values.
+    public static func text(unreviewedCount: Int, isMasked: Bool) -> String? {
+        guard isVisible(unreviewedCount: unreviewedCount, isMasked: isMasked) else { return nil }
+        return unreviewedCount >= overflowThreshold ? overflowText : "\(unreviewedCount)"
+    }
+
+    /// Whether the badge should be drawn at all. `true` exactly when
+    /// `text(unreviewedCount:isMasked:)` is non-nil.
+    public static func isVisible(unreviewedCount: Int, isMasked: Bool) -> Bool {
+        guard !isMasked else { return false }
+        return unreviewedCount > 0
+    }
+
+    /// VoiceOver label spoken for the badge, or `nil` when the badge is hidden.
+    ///
+    /// Unlike the visible string this always reads the *true* count (never the
+    /// capped `"99+"`) and pluralizes "transaction".
+    public static func accessibilityLabel(unreviewedCount: Int, isMasked: Bool) -> String? {
+        guard isVisible(unreviewedCount: unreviewedCount, isMasked: isMasked) else { return nil }
+        let noun = unreviewedCount == 1 ? "transaction" : "transactions"
+        return "\(unreviewedCount) \(noun) to review"
+    }
+}

--- a/Tests/PlaidBarCoreTests/MenuBarReviewBadgeTests.swift
+++ b/Tests/PlaidBarCoreTests/MenuBarReviewBadgeTests.swift
@@ -1,0 +1,77 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("MenuBarReviewBadge")
+struct MenuBarReviewBadgeTests {
+    // MARK: count → badge string
+
+    @Test("A positive unmasked count renders that number as the badge string")
+    func positiveCountRendersNumber() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 1, isMasked: false) == "1")
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 7, isMasked: false) == "7")
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 42, isMasked: false) == "42")
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 99, isMasked: false) == "99")
+    }
+
+    @Test("Counts above the cap render as the capped overflow string")
+    func largeCountIsCapped() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 100, isMasked: false) == "99+")
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 1234, isMasked: false) == "99+")
+    }
+
+    // MARK: zero → hidden
+
+    @Test("A zero count hides the badge")
+    func zeroHidesBadge() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 0, isMasked: false) == nil)
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: 0, isMasked: false) == false)
+    }
+
+    @Test("A negative count (defensive) hides the badge")
+    func negativeHidesBadge() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: -3, isMasked: false) == nil)
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: -3, isMasked: false) == false)
+    }
+
+    // MARK: masked → hidden (withheld under Privacy Mask)
+
+    @Test("Privacy Mask withholds the badge even with a positive count")
+    func maskedHidesBadge() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 5, isMasked: true) == nil)
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 100, isMasked: true) == nil)
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: 5, isMasked: true) == false)
+    }
+
+    @Test("Masked-and-zero is still hidden")
+    func maskedZeroHidesBadge() {
+        #expect(MenuBarReviewBadge.text(unreviewedCount: 0, isMasked: true) == nil)
+    }
+
+    // MARK: isVisible mirrors text presence
+
+    @Test("isVisible is true exactly when text is non-nil")
+    func visibilityMirrorsText() {
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: 3, isMasked: false) == true)
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: 99, isMasked: false) == true)
+        #expect(MenuBarReviewBadge.isVisible(unreviewedCount: 100, isMasked: false) == true)
+    }
+
+    // MARK: accessibility label
+
+    @Test("Accessibility label pluralizes and reads the real count, not the capped string")
+    func accessibilityLabelReadsRealCount() {
+        #expect(MenuBarReviewBadge.accessibilityLabel(unreviewedCount: 1, isMasked: false)
+            == "1 transaction to review")
+        #expect(MenuBarReviewBadge.accessibilityLabel(unreviewedCount: 4, isMasked: false)
+            == "4 transactions to review")
+        // Even when the visible badge caps at "99+", the spoken label uses the true count.
+        #expect(MenuBarReviewBadge.accessibilityLabel(unreviewedCount: 250, isMasked: false)
+            == "250 transactions to review")
+    }
+
+    @Test("Accessibility label is nil when the badge is hidden")
+    func accessibilityLabelNilWhenHidden() {
+        #expect(MenuBarReviewBadge.accessibilityLabel(unreviewedCount: 0, isMasked: false) == nil)
+        #expect(MenuBarReviewBadge.accessibilityLabel(unreviewedCount: 9, isMasked: true) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a small count badge for the **unreviewed review-inbox count** to the menu-bar status item. The badge is hidden when the count is zero and withheld under Privacy Mask, and updates live as the count changes.

The app's menu bar is a SwiftUI `MenuBarExtra`, but the underlying `NSStatusItem` is already reachable via `MenuBarExtraAccess` — the same hook `StatusItemContextMenuController` uses for the right-click menu and ⌥-click privacy toggle. So **no NSStatusItem migration was needed**: the badge renders through that existing custom-`NSStatusItem` access path, exactly as the delivery design prescribes.

Rather than fight SwiftUI for ownership of the button's image, a lightweight overlay subview is pinned to the button's top-trailing corner and draws the pill there. It never intercepts hit-testing, so clicks still open the popover normally.

## Linear (AND-534)

Implements **AND-534** ("`NSStatusItem` badge") under epic **AND-520** (Menu-bar count signal). Companion to AND-533 (inbox badge text), which already surfaces the count inside the popover/label via `menuBarReviewText`.

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`:
- §4: *"Menu-bar badge via custom `NSStatusItem` (per the documented MenuBarExtra-glass constraint)."* — satisfied via the `menuBarExtraAccess` `NSStatusItem` hook; the badge is drawn in AppKit, not as a SwiftUI label, avoiding glass-on-glass.
- §7 (Risks): *"menu-bar badge / glass constraints (custom `NSStatusItem`, no glass-on-glass)."* — the overlay is a plain pill over the button; no second glass material is introduced.
- §3: lists "menu-bar count badge" as part of Review Inbox parity ("triage to zero").

## Testing notes

- New pure helper `MenuBarReviewBadge` (PlaidBarCore) is fully unit-tested — **9 Swift Testing cases**: count→string, capped `"99+"` overflow, zero→hidden, negative→hidden, masked→hidden (incl. masked-and-zero), `isVisible` mirrors text, and an accessibility label that pluralizes and always reads the *true* count (never the capped string).
- Strict-concurrency CI build green: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.
- Full suite green: **1529 tests passed**.
- SwiftUI views in the app target aren't headlessly unit-testable, so all logic that *can* be tested (visibility + text + a11y rules) lives in the pure Core helper; the AppKit controller only renders its result.

## Architectural decisions

- **No NSStatusItem migration.** The supported `MenuBarExtraAccess` path already vends the real `NSStatusItem`, so the feature is additive — no scene/lifecycle rewrite.
- **Overlay subview, not image surgery.** Pinning an overlay (vs. compositing into the button's `NSImage`, which SwiftUI owns) keeps the badge independent of the label's render and avoids races on button recreation. `configure` is idempotent and re-pins if the button is rebuilt.
- **Pure logic in PlaidBarCore.** All visibility/text/a11y rules are `Sendable` and tested in `MenuBarReviewBadge`; the controller is a thin AppKit renderer.
- **Accessibility, not color-only.** Meaning is carried by the digits and a VoiceOver `staticText` label; the red pill is reinforcement, never the sole signal (`ACCESSIBILITY.md`).
- **Privacy Mask honored.** The unreviewed count is a financial signal, so it is withheld under Privacy Mask exactly like balances/amounts (`shouldMaskFinancialValues`), updated reactively via `.onChange`.

## Migration notes

None. Additive only — new `MenuBarReviewBadge` (Core) + `StatusItemBadgeController` (app) + wiring in `PlaidBarApp`. No schema, DTO, persistence, or public-API changes; no `ReviewInboxView` or dashboard changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)