### PR TITLE
feat(core): make exports & summaries override-aware (AND-527)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
@@ -70,11 +70,54 @@ public enum DataExportBuilder {
         return ([header] + rows).joined(separator: "\n") + "\n"
     }
 
-    public static func transactionsCSV(_ transactions: [TransactionDTO]) -> String {
+    /// CSV of transactions. `metadata`/`rules` (AND-527) are optional and default
+    /// to `nil`, which writes the raw Plaid `category` column unchanged (legacy
+    /// behavior — existing importers and tests keep working). When supplied, the
+    /// `category` column reflects the *effective* category (user override → rule →
+    /// raw Plaid → empty) via the persisted-only `EffectiveCategoryResolver`, so an
+    /// exported file matches what the user reviewed in-app rather than the raw Plaid
+    /// guess. NL suggestions are display-only and never exported. Pending-phase
+    /// review metadata stored under a charge's `pendingTransactionId` is carried
+    /// into its posted replacement (mirrors `CategoryBudgetPlanner`). The row count
+    /// and every other column are unchanged — only the `category` cell may differ.
+    public static func transactionsCSV(
+        _ transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]? = nil,
+        rules: [TransactionRule]? = nil
+    ) -> String {
         let header = row([
             "transaction_id", "account_id", "date", "name", "merchant_name",
             "amount", "currency", "category", "pending",
         ])
+
+        // Legacy path: no review state supplied → raw Plaid category.
+        let resolveCategory: (TransactionDTO) -> String
+        if metadata == nil, rules == nil {
+            resolveCategory = { $0.category?.rawValue ?? "" }
+        } else {
+            let metadataById = Dictionary(
+                (metadata ?? []).map { ($0.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            let activeRules = rules ?? []
+            resolveCategory = { transaction in
+                // Carry pending-phase review metadata into the posted charge
+                // (mirrors `CategoryBudgetPlanner.netSpendByCategory`).
+                let effectiveMetadata = metadataById[transaction.id]
+                    ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
+                let resolution = EffectiveCategoryResolver.resolve(
+                    transaction: transaction,
+                    metadata: effectiveMetadata,
+                    rules: activeRules
+                )
+                // The effective budget category (override/rule/confident Plaid);
+                // when none resolved, fall back to the raw Plaid category so the
+                // export keeps a genuinely-categorized row's bucket and leaves a
+                // truly-uncategorized row blank — an NL suggestion is never written.
+                return (resolution.category ?? transaction.category)?.rawValue ?? ""
+            }
+        }
+
         let rows = transactions.map { transaction in
             row([
                 transaction.id,
@@ -84,7 +127,7 @@ public enum DataExportBuilder {
                 transaction.merchantName ?? "",
                 decimalString(transaction.amount),
                 transaction.isoCurrencyCode ?? "",
-                transaction.category?.rawValue ?? "",
+                resolveCategory(transaction),
                 transaction.pending ? "true" : "false",
             ])
         }

--- a/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
@@ -21,10 +21,18 @@ public struct SpendingPeriodSummary: Sendable {
 }
 
 public enum SpendingSummary {
+    /// Period summary of spend. `metadata`/`rules` (AND-527) are optional and
+    /// default to `nil`, which reproduces the legacy raw-`transaction.category`
+    /// behavior. When supplied, the current-period category breakdown resolves the
+    /// *effective* category (user override → rule → raw Plaid → `.other`) and drops
+    /// excluded/transfer rows via `EffectiveCategoryResolver`, so a recategorization
+    /// in the Review Inbox moves the summarized totals to match the dashboard.
     public static func periodSummary(
         from transactions: [TransactionDTO],
         currentStart: String,
-        previousStart: String
+        previousStart: String,
+        metadata: [TransactionReviewMetadata]? = nil,
+        rules: [TransactionRule]? = nil
     ) -> SpendingPeriodSummary {
         let currentExpenses = expenseTransactions(
             from: transactions,
@@ -36,7 +44,11 @@ public enum SpendingSummary {
             endingBefore: currentStart
         )
 
-        let categories = spendingByCategory(from: currentExpenses)
+        let categories = spendingByCategory(
+            from: currentExpenses,
+            metadata: metadata,
+            rules: rules
+        )
         let currentTotal = categories.reduce(0) { $0 + $1.1 }
         let previousTotal = previousExpenses.reduce(0) { $0 + $1.displayAmount }
 
@@ -47,15 +59,64 @@ public enum SpendingSummary {
         )
     }
 
+    /// Spend grouped by category, descending. `metadata`/`rules` (AND-527) are
+    /// optional and default to `nil` → the legacy path buckets by raw
+    /// `transaction.category ?? .other`. When supplied, each row is resolved to its
+    /// *effective* category via the persisted-only `EffectiveCategoryResolver`
+    /// (user override → rule → raw Plaid → `.other`, NL suggestions excluded), and
+    /// excluded/transfer rows drop out — so the summary matches the override-aware
+    /// dashboard. Pending-phase review metadata stored under a charge's
+    /// `pendingTransactionId` is carried into its posted replacement (mirrors
+    /// `CategoryBudgetPlanner.netSpendByCategory`).
     public static func spendingByCategory(
-        from transactions: [TransactionDTO]
+        from transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]? = nil,
+        rules: [TransactionRule]? = nil
     ) -> [(SpendingCategory, Double)] {
-        let grouped = Dictionary(grouping: expenseTransactions(from: transactions)) {
-            $0.category ?? .other
+        let expenses = expenseTransactions(from: transactions)
+
+        // Legacy path: no review state supplied → bucket by raw Plaid category.
+        guard metadata != nil || rules != nil else {
+            let grouped = Dictionary(grouping: expenses) { $0.category ?? .other }
+            return grouped.map { category, transactions in
+                (category, transactions.reduce(0) { $0 + $1.displayAmount })
+            }.sorted { $0.1 > $1.1 }
         }
-        return grouped.map { category, transactions in
-            (category, transactions.reduce(0) { $0 + $1.displayAmount })
-        }.sorted { $0.1 > $1.1 }
+
+        let metadataById = Dictionary(
+            (metadata ?? []).map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let activeRules = rules ?? []
+
+        var totals: [SpendingCategory: Double] = [:]
+        for transaction in expenses {
+            // Carry pending-phase review metadata into the posted charge (mirrors
+            // `CategoryBudgetPlanner.netSpendByCategory`): prefer the transaction's
+            // own record, then the carried-forward pending record.
+            let effectiveMetadata = metadataById[transaction.id]
+                ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
+
+            let resolution = EffectiveCategoryResolver.resolve(
+                transaction: transaction,
+                metadata: effectiveMetadata,
+                rules: activeRules
+            )
+
+            // Drop excluded rows (explicit user/rule exclusion or transfers) — the
+            // override surface can re-classify a row as a transfer the raw Plaid
+            // category did not flag.
+            if resolution.excludedFromBudgets || resolution.isTransfer { continue }
+
+            // Fall back to the raw Plaid bucket (or `.other`) when no confident
+            // override/rule/Plaid category resolved, matching the legacy bucket —
+            // a display-only NL suggestion is never counted (it lives on
+            // `resolution.suggestedCategory`, not on the aggregation category).
+            let category = resolution.category ?? (transaction.category ?? .other)
+            totals[category, default: 0] += transaction.displayAmount
+        }
+
+        return totals.map { ($0.key, $0.value) }.sorted { $0.1 > $1.1 }
     }
 
     public static func expenseTransactions(

--- a/Tests/PlaidBarCoreTests/DataExportBuilderOverrideTests.swift
+++ b/Tests/PlaidBarCoreTests/DataExportBuilderOverrideTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// Tests for the override-aware additions to `DataExportBuilder.transactionsCSV`
+/// (AND-527): the CSV `category` column must reflect the *effective* category
+/// (user override → rule → raw Plaid → empty) so an exported file matches what the
+/// user saw and reviewed in-app, instead of the raw Plaid guess. Passing no
+/// metadata/rules (the default) must reproduce the legacy raw-`transaction.category`
+/// column so existing importers and tests are unchanged.
+///
+/// All inputs are synthetic; no real Plaid data.
+@Suite("Data Export Builder Override Tests")
+struct DataExportBuilderOverrideTests {
+    private func tx(
+        id: String,
+        category: SpendingCategory?,
+        name: String = "MERCHANT",
+        merchantName: String? = "Merchant",
+        pendingTransactionId: String? = nil
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acc1",
+            amount: 12.34,
+            date: "2026-06-15",
+            name: name,
+            merchantName: merchantName,
+            category: category,
+            pending: false,
+            pendingTransactionId: pendingTransactionId,
+            isoCurrencyCode: "USD"
+        )
+    }
+
+    private func categoryColumn(_ csv: String) -> [String] {
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        // category is the 8th field (index 7) in the declared header order.
+        return lines.dropFirst().map { line in
+            let fields = line.split(separator: ",", omittingEmptySubsequences: false).map(String.init)
+            return fields.count > 7 ? fields[7] : ""
+        }
+    }
+
+    // MARK: - Legacy behavior preserved (default nil params)
+
+    @Test("Default (no metadata/rules) writes the raw Plaid category, unchanged")
+    func legacyWritesRawCategory() {
+        let transactions = [tx(id: "a", category: .shopping)]
+
+        let legacy = DataExportBuilder.transactionsCSV(transactions)
+        let explicitNil = DataExportBuilder.transactionsCSV(
+            transactions,
+            metadata: nil,
+            rules: nil
+        )
+
+        #expect(legacy == explicitNil)
+        // `.shopping` serializes to its Plaid PFCv2 rawValue "GENERAL_MERCHANDISE".
+        #expect(categoryColumn(legacy) == ["GENERAL_MERCHANDISE"])
+    }
+
+    // MARK: - Override changes the exported category column
+
+    @Test("A user override changes the exported category column")
+    func userOverrideChangesColumn() {
+        let transactions = [tx(id: "a", category: .shopping)]
+        let metadata = [TransactionReviewMetadata(id: "a", userCategory: .foodAndDrink)]
+
+        let csv = DataExportBuilder.transactionsCSV(transactions, metadata: metadata)
+
+        #expect(categoryColumn(csv) == ["FOOD_AND_DRINK"])
+    }
+
+    @Test("A matching rule changes the exported category column")
+    func ruleChangesColumn() {
+        let transactions = [tx(id: "a", category: .shopping, name: "BLUE BOTTLE", merchantName: "Blue Bottle")]
+        let rules = [TransactionRule(matchMerchantContains: "Blue Bottle", category: .foodAndDrink)]
+
+        let csv = DataExportBuilder.transactionsCSV(transactions, rules: rules)
+
+        #expect(categoryColumn(csv) == ["FOOD_AND_DRINK"])
+    }
+
+    // MARK: - Uncategorized stays empty (no NL leakage)
+
+    @Test("An unapproved NL-suggestable row keeps an empty category column")
+    func nlSuggestionDoesNotLeakIntoExport() {
+        // Blue Bottle would get an NL suggestion, but with no override/rule and no
+        // Plaid category the export must stay blank (suggestions are display-only).
+        let transactions = [tx(id: "a", category: nil, name: "BLUE BOTTLE COFFEE", merchantName: nil)]
+
+        let csv = DataExportBuilder.transactionsCSV(transactions, metadata: [], rules: [])
+
+        #expect(categoryColumn(csv) == [""])
+    }
+
+    // MARK: - Pending → posted carry-forward
+
+    @Test("Review metadata under a pending id carries into the exported posted row")
+    func pendingMetadataCarriesForward() {
+        let transactions = [
+            tx(id: "posted-1", category: .shopping, pendingTransactionId: "pending-1"),
+        ]
+        let metadata = [TransactionReviewMetadata(id: "pending-1", userCategory: .foodAndDrink)]
+
+        let csv = DataExportBuilder.transactionsCSV(transactions, metadata: metadata)
+
+        #expect(categoryColumn(csv) == ["FOOD_AND_DRINK"])
+    }
+
+    // MARK: - Row count / other columns unchanged
+
+    @Test("Override-aware export keeps one row per transaction and other columns intact")
+    func rowCountAndOtherColumnsUnchanged() {
+        let transactions = [
+            tx(id: "tx1", category: .shopping),
+            tx(id: "tx2", category: .foodAndDrink),
+        ]
+        let metadata = [TransactionReviewMetadata(id: "tx1", userCategory: .travel)]
+
+        let csv = DataExportBuilder.transactionsCSV(transactions, metadata: metadata)
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+
+        #expect(lines.count == 3) // header + 2 rows
+        #expect(lines[1].hasPrefix("tx1,acc1,2026-06-15,MERCHANT,Merchant,12.34,USD,TRAVEL,false"))
+        #expect(lines[2].hasPrefix("tx2,acc1,2026-06-15,MERCHANT,Merchant,12.34,USD,FOOD_AND_DRINK,false"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/SpendingSummaryOverrideTests.swift
+++ b/Tests/PlaidBarCoreTests/SpendingSummaryOverrideTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// Tests for the override-aware additions to `SpendingSummary` (AND-527): the
+/// summary surface that aggregates spend by category must resolve the *effective*
+/// category (user override → rule → raw Plaid → `.other`) so a recategorization in
+/// the Review Inbox moves the summarized totals, matching what the user sees in the
+/// dashboard. Passing no metadata/rules (the default) must reproduce the legacy
+/// raw-`transaction.category` behavior so existing callers/tests are unchanged.
+///
+/// All inputs are synthetic; no real Plaid data.
+@Suite("Spending Summary Override Tests")
+struct SpendingSummaryOverrideTests {
+    private func tx(
+        id: String,
+        amount: Double = 40,
+        date: String = "2026-06-10",
+        name: String = "MERCHANT",
+        category: SpendingCategory?,
+        merchantName: String? = "Merchant",
+        pendingTransactionId: String? = nil,
+        lowConfidence: Bool = false
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acc",
+            amount: amount,
+            date: date,
+            name: name,
+            merchantName: merchantName,
+            category: category,
+            pending: false,
+            pendingTransactionId: pendingTransactionId,
+            isLowConfidenceCategory: lowConfidence
+        )
+    }
+
+    // MARK: - Legacy behavior preserved (default nil params)
+
+    @Test("Default (no metadata/rules) buckets by raw Plaid category, unchanged")
+    func legacyBucketsByRawCategory() {
+        let transactions = [
+            tx(id: "a", amount: 30, category: .shopping),
+            tx(id: "b", amount: 20, category: .foodAndDrink),
+        ]
+
+        let legacy = SpendingSummary.spendingByCategory(from: transactions)
+        let explicitNil = SpendingSummary.spendingByCategory(
+            from: transactions,
+            metadata: nil,
+            rules: nil
+        )
+
+        let legacyDict = Dictionary(uniqueKeysWithValues: legacy)
+        let explicitDict = Dictionary(uniqueKeysWithValues: explicitNil)
+        #expect(legacyDict == explicitDict)
+        #expect(legacyDict[.shopping] == 30)
+        #expect(legacyDict[.foodAndDrink] == 20)
+    }
+
+    // MARK: - Override moves the summarized category
+
+    @Test("A user category override moves spend to the overridden category")
+    func userOverrideMovesSpend() {
+        let transactions = [tx(id: "a", amount: 40, category: .shopping)]
+        let metadata = [TransactionReviewMetadata(id: "a", userCategory: .foodAndDrink)]
+
+        let resolved = SpendingSummary.spendingByCategory(
+            from: transactions,
+            metadata: metadata
+        )
+        let dict = Dictionary(uniqueKeysWithValues: resolved)
+
+        // Raw Plaid said .shopping; the override re-attributes the $40 to food.
+        #expect(dict[.foodAndDrink] == 40)
+        #expect(dict[.shopping] == nil)
+    }
+
+    @Test("A matching rule re-categorizes summarized spend")
+    func ruleMovesSpend() {
+        let transactions = [tx(id: "a", amount: 25, name: "BLUE BOTTLE", category: .shopping, merchantName: "Blue Bottle")]
+        let rules = [TransactionRule(matchMerchantContains: "Blue Bottle", category: .foodAndDrink)]
+
+        let resolved = SpendingSummary.spendingByCategory(
+            from: transactions,
+            rules: rules
+        )
+        let dict = Dictionary(uniqueKeysWithValues: resolved)
+
+        #expect(dict[.foodAndDrink] == 25)
+        #expect(dict[.shopping] == nil)
+    }
+
+    // MARK: - Exclusions / transfers drop out of the summary
+
+    @Test("An excluded-from-budgets override drops the row from the summary")
+    func excludedRowDropsOut() {
+        let transactions = [
+            tx(id: "keep", amount: 15, category: .foodAndDrink),
+            tx(id: "drop", amount: 99, category: .shopping),
+        ]
+        let metadata = [
+            TransactionReviewMetadata(id: "drop", excludedFromBudgets: true),
+        ]
+
+        let resolved = SpendingSummary.spendingByCategory(
+            from: transactions,
+            metadata: metadata
+        )
+        let dict = Dictionary(uniqueKeysWithValues: resolved)
+
+        #expect(dict[.foodAndDrink] == 15)
+        #expect(dict[.shopping] == nil)
+    }
+
+    @Test("A transfer override drops the row even with a spend category")
+    func transferOverrideDropsOut() {
+        let transactions = [tx(id: "x", amount: 200, category: .shopping)]
+        let metadata = [TransactionReviewMetadata(id: "x", isTransferOverride: true)]
+
+        let resolved = SpendingSummary.spendingByCategory(
+            from: transactions,
+            metadata: metadata
+        )
+
+        #expect(resolved.isEmpty)
+    }
+
+    // MARK: - Pending → posted carry-forward
+
+    @Test("Review metadata under a pending id carries into the posted charge")
+    func pendingMetadataCarriesForward() {
+        // A charge first seen as pending under id "pending-1"; the user recategorized
+        // it. Plaid re-posts it as id "posted-1" linking back via pendingTransactionId.
+        let transactions = [
+            tx(id: "posted-1", amount: 50, category: .shopping, pendingTransactionId: "pending-1"),
+        ]
+        let metadata = [TransactionReviewMetadata(id: "pending-1", userCategory: .foodAndDrink)]
+
+        let resolved = SpendingSummary.spendingByCategory(
+            from: transactions,
+            metadata: metadata
+        )
+        let dict = Dictionary(uniqueKeysWithValues: resolved)
+
+        #expect(dict[.foodAndDrink] == 50)
+        #expect(dict[.shopping] == nil)
+    }
+
+    // MARK: - periodSummary honors overrides
+
+    @Test("periodSummary categories reflect overrides")
+    func periodSummaryHonorsOverrides() {
+        let transactions = [
+            tx(id: "cur", amount: 40, date: "2026-06-10", category: .shopping),
+        ]
+        let metadata = [TransactionReviewMetadata(id: "cur", userCategory: .foodAndDrink)]
+
+        let summary = SpendingSummary.periodSummary(
+            from: transactions,
+            currentStart: "2026-06-01",
+            previousStart: "2026-05-01",
+            metadata: metadata
+        )
+        let dict = Dictionary(uniqueKeysWithValues: summary.categories)
+
+        #expect(dict[.foodAndDrink] == 40)
+        #expect(dict[.shopping] == nil)
+        #expect(summary.currentTotal == 40)
+    }
+}


### PR DESCRIPTION
## Summary

Epic 1 (AND-518) follow-up. VaultPeek's spend math became override-aware in AND-526 (`CategoryBudgetPlanner`), but two *other* PlaidBarCore consumers still read the raw `transaction.category`:

- `SpendingSummary.spendingByCategory` / `periodSummary` — the spend-by-category summary
- `DataExportBuilder.transactionsCSV` — the transactions CSV export

So a recategorization, exclusion, or transfer override made in the Review Inbox moved the dashboard but **not** these surfaces — an exported CSV or a summary no longer matched what the user saw. This PR closes that gap by routing both through the same persisted-only `EffectiveCategoryResolver` path.

## Linear (AND-527)

`AND-527` — "exports follow-up" under epic **AND-518** (override-aware spend math), the third leaf after AND-525 (extract resolver) → AND-526 (override-aware planner). Related to completed epic AND-398.

## Spec alignment

Per `docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md` §2/§5:

- Resolves the **effective** category via the persisted-only precedence: `userCategory → rule → raw Plaid → .other`. NL suggestions stay **display-only** and are never counted/exported (they live on `Resolution.suggestedCategory`, not the aggregation category).
- Carries pending-phase review metadata stored under a charge's `pendingTransactionId` into its posted replacement, mirroring `CategoryBudgetPlanner.netSpendByCategory` (§4 edge case: pending→posted must not lose a category/transfer decision).
- **Additive optional `metadata`/`rules` params, default `nil` → existing behavior unchanged.** Legacy callers (`SettingsView` export, `WatchlistEvaluator`, `IncomeCategoryFlow`) compile and behave identically.

## Testing notes

- New `SpendingSummaryOverrideTests` (7) + `DataExportBuilderOverrideTests` (6): each proves an override/rule/exclusion/transfer/pending-carry-forward changes the summarized or exported category, and that default-nil reproduces the legacy raw-`transaction.category` output byte-for-byte.
- One test caught a real fact: `.shopping.rawValue == "GENERAL_MERCHANDISE"` (Plaid PFCv2); assertions corrected.
- Strict-concurrency CI build green: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.
- Full suite green: **1533 tests passed** (Keychain-env tests skipped as usual; LocalInsight flake did not trigger).

## Architectural decisions

- **Summary drops excluded/transfer rows; export keeps every row.** A summary is a budget-style aggregation, so resolved exclusions/transfers fall out (matching the dashboard). The transactions CSV is a full-data backup / portability artifact — dropping rows would lose data and break JSON-envelope round-trip symmetry, so it keeps every row and only re-attributes the `category` *cell*. This is the "skip excluded/transfer where semantically right for that export" call from the issue.
- **Fall back to raw Plaid bucket when nothing resolves**, so a confidently-categorized row keeps its bucket and a genuinely-uncategorized row stays `.other`/blank — never an unapproved NL guess.
- File ownership respected: only PlaidBarCore export/summary utilities touched. `CategoryBudgetPlanner` (AND-526) and all views are untouched.

## Migration notes

None. No schema, no DTO, no `SpendingCategory` rawValue, no server changes. Pure additive nil-default parameters — zero migration, zero behavior change for existing callers until they opt in by passing live metadata/rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)