### PR TITLE
feat(ui): inline "always categorize…" rule prompt at correction (AND-531)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -22,6 +22,18 @@ struct ReviewInboxView: View {
     /// scheduled for — a newer action (which bumps the token) is never wiped by
     /// an older timer.
     @State private var confirmationGeneration = 0
+    /// The inline "always categorize <merchant> as <category>?" offer staged the
+    /// moment the user recategorizes a row (AND-531). One at a time, dismissible;
+    /// a newer correction replaces an older offer. Accepting routes through the
+    /// existing `AppState.createRule` path. Nil when no offer is pending. The pure
+    /// `InlineCategoryRulePrompt` decides whether an offer is even worth showing
+    /// (suppressed for a blank merchant or a duplicate rule), so this stays
+    /// non-nagging.
+    @State private var rulePrompt: InlineCategoryRulePrompt?
+    /// The row the staged `rulePrompt` was offered for, captured so an Accept can
+    /// route through the existing `AppState.createRule(from:category:)` path even
+    /// after the recategorization removed the row from the live snapshot.
+    @State private var rulePromptItem: TransactionReviewItem?
 
     private var snapshot: TransactionReviewInboxSnapshot {
         appState.transactionReviewInboxSnapshot
@@ -75,6 +87,18 @@ struct ReviewInboxView: View {
                         .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
                 }
 
+                // Inline "always categorize …?" offer (AND-531). Suppressed while
+                // masked — the offer names the merchant, a value the Privacy Mask
+                // hides — so it appears only when rows themselves are visible.
+                if !appState.shouldMaskFinancialValues, let rulePrompt {
+                    InlineCategoryRulePromptBanner(
+                        prompt: rulePrompt,
+                        onCreate: { acceptRulePrompt(rulePrompt) },
+                        onDismiss: { dismissRulePrompt() }
+                    )
+                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                }
+
                 if appState.shouldMaskFinancialValues {
                     privateInboxPlaceholder
                 } else if items.isEmpty {
@@ -104,7 +128,11 @@ struct ReviewInboxView: View {
                 // banner so the inbox can collapse out of the popover instead of
                 // sitting in an empty "0 items" state with a stuck banner.
                 if newCount == 0 {
-                    withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) { actionConfirmation = nil }
+                    withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+                        actionConfirmation = nil
+                        rulePrompt = nil
+                        rulePromptItem = nil
+                    }
                 }
             }
             .onMoveCommand(perform: moveSelection)
@@ -233,6 +261,10 @@ struct ReviewInboxView: View {
             onCategory: { category in
                 recordAction(.categorized(category), for: item)
                 animatingResolution { appState.updateReviewCategory(item.id, category: category) }
+                // Offer to promote this one-off correction into a durable rule
+                // (AND-531). The pure model suppresses the offer for a blank
+                // merchant or a rule that already exists, so this never nags.
+                stageRulePrompt(for: item, category: category)
             },
             onRename: {
                 recordAction(.renamed, for: item)
@@ -430,6 +462,52 @@ struct ReviewInboxView: View {
             withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) { actionConfirmation = nil }
         }
     }
+
+    /// Stages the inline "always categorize <merchant> as <category>?" offer for a
+    /// just-recategorized row (AND-531). The pure `InlineCategoryRulePrompt.make`
+    /// decides whether an offer is even worth showing — it returns nil for a blank
+    /// merchant or a category rule that already exists — so a no-op or duplicate
+    /// correction never produces a prompt. A newer correction replaces any older
+    /// pending offer (one prompt at a time, non-nagging).
+    private func stageRulePrompt(for item: TransactionReviewItem, category: SpendingCategory) {
+        let prompt = InlineCategoryRulePrompt.make(
+            transactionID: item.id,
+            merchantName: item.effectiveMerchantName,
+            category: category,
+            existingRules: appState.transactionRules
+        )
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            rulePrompt = prompt
+            rulePromptItem = prompt == nil ? nil : item
+        }
+    }
+
+    /// Accepts the inline offer: creates the merchant→category rule through the
+    /// EXISTING `AppState.createRule(from:category:)` path (so the rule flows into
+    /// the override-aware spend math like any other rule), announces it, and clears
+    /// the offer. Routing through the captured row keeps the matcher/merchant/
+    /// exclusion context identical to a rule made from the row's Rule menu.
+    private func acceptRulePrompt(_ prompt: InlineCategoryRulePrompt) {
+        defer { clearRulePrompt() }
+        guard let item = rulePromptItem, item.id == prompt.transactionID else { return }
+        appState.createRule(from: item, category: prompt.category)
+        AccessibilityNotification.Announcement(
+            "Created rule: always categorize \(prompt.merchantName) as \(prompt.category.displayName)"
+        ).post()
+    }
+
+    /// Dismisses the inline offer without creating a rule. The one-off correction
+    /// already applied stands; only the durable-rule offer is declined.
+    private func dismissRulePrompt() {
+        clearRulePrompt()
+    }
+
+    private func clearRulePrompt() {
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            rulePrompt = nil
+            rulePromptItem = nil
+        }
+    }
 }
 
 /// In the standalone (center) layout the inbox owns a raised surface; in the
@@ -519,6 +597,70 @@ private struct ReviewActionConfirmationBanner: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(presentation.accessibilityLabel)
+    }
+}
+
+/// The inline, dismissible "always categorize <merchant> as <category>?" offer
+/// shown the moment the user recategorizes a review row (AND-531).
+///
+/// Turning a one-off correction into a durable `TransactionRule` is the whole
+/// value of Copilot-style review — but the offer must never nag, so it is a
+/// single inline banner (one at a time), it is dismissible, and accepting routes
+/// through the same `AppState.createRule` path the row's Rule menu uses. The
+/// banner names the merchant and category as text (never color alone — the
+/// "Create rule" affordance always carries its label + glyph), matching the
+/// ACCESSIBILITY rule. Privacy: the parent suppresses this banner entirely while
+/// Privacy Mask / App Lock is active, so the merchant name never renders masked.
+private struct InlineCategoryRulePromptBanner: View {
+    let prompt: InlineCategoryRulePrompt
+    let onCreate: () -> Void
+    let onDismiss: () -> Void
+
+    private var message: String {
+        "Always categorize \(prompt.merchantName) as \(prompt.category.displayName)?"
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label {
+                Text(message)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            } icon: {
+                Image(systemName: "wand.and.stars")
+            }
+            .foregroundStyle(SemanticColors.brand)
+
+            Spacer(minLength: Spacing.xs)
+
+            Button(action: onCreate) {
+                Label("Create rule", systemImage: "checkmark")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.mini)
+            .help("Always categorize \(prompt.merchantName) as \(prompt.category.displayName) from now on")
+            .accessibilityHint("Creates a rule so future transactions from this merchant are categorized automatically.")
+
+            Button(action: onDismiss) {
+                Label("Dismiss", systemImage: "xmark")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.mini)
+            .help("Dismiss without creating a rule")
+            .accessibilityLabel("Dismiss rule suggestion")
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SemanticColors.brand.opacity(0.10), in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10).stroke(SemanticColors.brand.opacity(0.20), lineWidth: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(message)
     }
 }
 

--- a/Sources/PlaidBarCore/Models/InlineCategoryRulePrompt.swift
+++ b/Sources/PlaidBarCore/Models/InlineCategoryRulePrompt.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Pure model for the inline "always categorize <merchant> as <category>?" rule
+/// prompt the Review Inbox surfaces the moment a user recategorizes a row
+/// (AND-531).
+///
+/// When the user assigns a category to a transaction in the inbox, that is a
+/// one-off correction. Copilot-style review turns that single correction into a
+/// durable signal by offering — *inline and dismissible* — to create a
+/// deterministic `TransactionRule` ("always categorize this merchant as this
+/// category"). Accepting flows through the **existing** rule path
+/// (`AppState.createRule`), so the same rule then feeds the override-aware spend
+/// math on `main`.
+///
+/// This is the pure, `Sendable`, testable half. It owns two decisions so the
+/// view and `AppState` stay thin:
+/// 1. **Should we even prompt?** — `make` returns `nil` (no prompt) when the
+///    merchant is blank or an identical rule already exists, so the offer never
+///    nags about a rule the user already created.
+/// 2. **What rule would Accept create?** — `buildRule` produces the exact
+///    `TransactionRule` the existing `createRule(from:category:)` path appends,
+///    so the prompt's "this is what will happen" copy and the dedupe check match
+///    the rule that is actually written.
+///
+/// Privacy: the prompt carries only a (possibly user-renamed) merchant label and
+/// a category name — never an amount or other sensitive figure. The view also
+/// suppresses it entirely while Privacy Mask / App Lock is active (the inbox
+/// renders no rows at all in that state), so nothing leaks.
+public struct InlineCategoryRulePrompt: Sendable, Equatable, Identifiable {
+    /// Stable identity so SwiftUI can animate one prompt in/out and so a newer
+    /// correction's prompt replaces an older one rather than stacking.
+    public var id: String { transactionID }
+
+    /// The review row that was just recategorized — used to drive the existing
+    /// `createRule(from:category:)` path on accept (it carries the matcher,
+    /// merchant name, and transfer/exclusion context).
+    public let transactionID: String
+    /// The display merchant label shown in the prompt copy ("always categorize
+    /// **<merchant>** as …"). Always the row's effective (possibly renamed) name.
+    public let merchantName: String
+    /// The category the user just assigned — the rule's target category.
+    public let category: SpendingCategory
+
+    public init(transactionID: String, merchantName: String, category: SpendingCategory) {
+        self.transactionID = transactionID
+        self.merchantName = merchantName
+        self.category = category
+    }
+
+    /// The merchant token a rule built from `(merchantName, category)` matches on.
+    /// Mirrors `AppState.createRule`'s `matchMerchantContains` exactly (trimmed
+    /// effective merchant name) so the dedupe check and the rule that is actually
+    /// written can never drift apart.
+    public var ruleMatcher: String {
+        merchantName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Builds the `TransactionRule` an Accept would create.
+    ///
+    /// Mirrors the category branch of `AppState.createRule(from:category:)`: a
+    /// merchant-contains matcher on the trimmed effective merchant name, carrying
+    /// the chosen category and the normalized merchant label. Returns `nil` when
+    /// the merchant is blank (no stable token to match on) — the same guard
+    /// `createRule` applies — so an unmatchable rule is never produced.
+    public func buildRule(id: UUID = UUID(), createdAt: Date = Date()) -> TransactionRule? {
+        let matcher = ruleMatcher
+        guard !matcher.isEmpty else { return nil }
+        return TransactionRule(
+            id: id,
+            matchMerchantContains: matcher,
+            matchOriginalNameContains: nil,
+            category: category,
+            merchantName: matcher,
+            isTransfer: nil,
+            excludedFromBudgets: nil,
+            createdAt: createdAt
+        )
+    }
+
+    /// Whether `rules` already contains a rule equivalent to the one this prompt
+    /// would create — same merchant matcher (case-insensitive) **and** same target
+    /// category. When true the prompt is redundant and `make` suppresses it.
+    public func isAlreadyCovered(by rules: [TransactionRule]) -> Bool {
+        let matcher = ruleMatcher
+        guard !matcher.isEmpty else { return false }
+        return rules.contains { rule in
+            rule.category == category
+                && (rule.matchMerchantContains?.compare(matcher, options: .caseInsensitive) == .orderedSame)
+        }
+    }
+
+    /// Builds a prompt for a just-applied recategorization, or `nil` when no
+    /// prompt should be shown.
+    ///
+    /// Returns `nil` (non-nagging) when:
+    /// - the merchant has no stable token to match on (blank after trimming), or
+    /// - an identical rule (same merchant + category) already exists, so creating
+    ///   another would be a no-op duplicate.
+    ///
+    /// - Parameters:
+    ///   - transactionID: the recategorized row's id.
+    ///   - merchantName: the row's effective (possibly renamed) merchant name.
+    ///   - category: the category the user just assigned.
+    ///   - existingRules: the current rule set, to suppress duplicate offers.
+    public static func make(
+        transactionID: String,
+        merchantName: String,
+        category: SpendingCategory,
+        existingRules: [TransactionRule]
+    ) -> InlineCategoryRulePrompt? {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: transactionID,
+            merchantName: merchantName,
+            category: category
+        )
+        guard !prompt.ruleMatcher.isEmpty else { return nil }
+        guard !prompt.isAlreadyCovered(by: existingRules) else { return nil }
+        return prompt
+    }
+}

--- a/Tests/PlaidBarCoreTests/InlineCategoryRulePromptTests.swift
+++ b/Tests/PlaidBarCoreTests/InlineCategoryRulePromptTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Inline Category Rule Prompt Tests")
+struct InlineCategoryRulePromptTests {
+    // MARK: buildRule
+
+    @Test("Built rule matches the merchant and carries the assigned category")
+    func buildRuleMatchesMerchantAndCategory() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx1",
+            merchantName: "Blue Bottle Coffee",
+            category: .foodAndDrink
+        )
+
+        let rule = prompt.buildRule()
+
+        let unwrapped = try? #require(rule)
+        #expect(unwrapped?.matchMerchantContains == "Blue Bottle Coffee")
+        #expect(unwrapped?.category == .foodAndDrink)
+        // A category rule never silently sets transfer/exclusion flags.
+        #expect(unwrapped?.isTransfer == nil)
+        #expect(unwrapped?.excludedFromBudgets == nil)
+    }
+
+    @Test("Built rule actually matches a transaction from that merchant")
+    func builtRuleMatchesTransaction() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx1",
+            merchantName: "Blue Bottle",
+            category: .foodAndDrink
+        )
+        let rule = prompt.buildRule()
+
+        let transaction = TransactionDTO(
+            id: "tx1",
+            accountId: "acc1",
+            amount: 6.50,
+            date: "2026-06-18",
+            name: "SQ *BLUE BOTTLE 0421",
+            merchantName: "Blue Bottle",
+            category: nil,
+            pending: false
+        )
+
+        #expect(rule?.matches(transaction) == true)
+    }
+
+    @Test("Merchant token is trimmed of surrounding whitespace")
+    func ruleMatcherTrimsWhitespace() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx1",
+            merchantName: "  Trader Joe's  ",
+            category: .shopping
+        )
+
+        #expect(prompt.ruleMatcher == "Trader Joe's")
+        #expect(prompt.buildRule()?.matchMerchantContains == "Trader Joe's")
+    }
+
+    @Test("Blank merchant yields no rule")
+    func blankMerchantBuildsNoRule() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx1",
+            merchantName: "   ",
+            category: .shopping
+        )
+
+        #expect(prompt.buildRule() == nil)
+    }
+
+    // MARK: dedupe / make
+
+    @Test("make returns a prompt when no matching rule exists")
+    func makeReturnsPromptWhenNoExistingRule() {
+        let prompt = InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "Netflix",
+            category: .subscriptions,
+            existingRules: []
+        )
+
+        #expect(prompt != nil)
+        #expect(prompt?.merchantName == "Netflix")
+        #expect(prompt?.category == .subscriptions)
+    }
+
+    @Test("make suppresses the prompt when an identical rule already exists")
+    func makeDedupesIdenticalRule() {
+        let existing = TransactionRule(
+            matchMerchantContains: "Netflix",
+            category: .subscriptions
+        )
+
+        let prompt = InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "Netflix",
+            category: .subscriptions,
+            existingRules: [existing]
+        )
+
+        #expect(prompt == nil)
+    }
+
+    @Test("Dedupe is case-insensitive on the merchant token")
+    func dedupeIsCaseInsensitive() {
+        let existing = TransactionRule(
+            matchMerchantContains: "netflix",
+            category: .subscriptions
+        )
+
+        #expect(InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "Netflix",
+            category: .subscriptions,
+            existingRules: [existing]
+        ) == nil)
+    }
+
+    @Test("Same merchant but a different category still offers a prompt")
+    func differentCategoryStillPrompts() {
+        let existing = TransactionRule(
+            matchMerchantContains: "Amazon",
+            category: .shopping
+        )
+
+        let prompt = InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "Amazon",
+            category: .entertainment,
+            existingRules: [existing]
+        )
+
+        // The existing rule targets a different category, so a new offer is not a
+        // duplicate — the user may genuinely want to recategorize.
+        #expect(prompt != nil)
+        #expect(prompt?.category == .entertainment)
+    }
+
+    @Test("A transfer-only rule for the merchant does not suppress a category prompt")
+    func transferRuleDoesNotDedupeCategoryPrompt() {
+        let existing = TransactionRule(
+            matchMerchantContains: "Venmo",
+            category: nil,
+            isTransfer: true
+        )
+
+        let prompt = InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "Venmo",
+            category: .other,
+            existingRules: [existing]
+        )
+
+        // The existing rule carries no category, so it does not cover this
+        // category assignment.
+        #expect(prompt != nil)
+    }
+
+    @Test("make returns nil for a blank merchant")
+    func makeReturnsNilForBlankMerchant() {
+        #expect(InlineCategoryRulePrompt.make(
+            transactionID: "tx1",
+            merchantName: "",
+            category: .shopping,
+            existingRules: []
+        ) == nil)
+    }
+
+    @Test("isAlreadyCovered is false for a blank merchant")
+    func isAlreadyCoveredFalseForBlankMerchant() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx1",
+            merchantName: "  ",
+            category: .shopping
+        )
+        let existing = TransactionRule(matchMerchantContains: "", category: .shopping)
+
+        #expect(prompt.isAlreadyCovered(by: [existing]) == false)
+    }
+
+    @Test("Prompt identity is the transaction id so a newer correction replaces an older")
+    func identityIsTransactionID() {
+        let prompt = InlineCategoryRulePrompt(
+            transactionID: "tx-42",
+            merchantName: "Spotify",
+            category: .subscriptions
+        )
+
+        #expect(prompt.id == "tx-42")
+    }
+}


### PR DESCRIPTION
## Summary

When a user assigns a category to a transaction in the Review Inbox (the recategorize action), VaultPeek now surfaces an inline, dismissible prompt offering to turn that one-off correction into a durable rule: **"Always categorize \<merchant\> as \<category\>?"**. This is the Copilot-style "correct once, remember forever" affordance at the exact moment the correction happens — instead of the user having to dig into the row's Rule menu separately.

Accepting routes through the **existing** `AppState.createRule(from:category:)` path (no new rule plumbing), so the rule then flows into the override-aware spend math already on `main` like any other rule. The offer is deliberately **non-nagging**:

- one prompt at a time; a newer correction replaces an older offer
- dismissible (a small ✕), and dismissing leaves the applied correction in place
- suppressed automatically when the merchant is blank or an identical (merchant + category) rule already exists
- cleared when the inbox drains
- hidden entirely under Privacy Mask / App Lock (it names the merchant)

## Linear (AND-531)

AND-531 — *inline rule prompt at the moment a user recategorizes a review-inbox item* (Epic AND-519, Review Inbox parity). Related to the completed AND-398 and the override-aware spend-math foundation (AND-518) the created rule feeds.

## Spec alignment (§3 / §5; Option A)

- **§3 Target experience** lists "inline rule prompt" as a Review Inbox parity item — this delivers it.
- **§5** maps AND-531 under Epic AND-519. Option A (display-only rollups over the existing taxonomy, no schema migration): this change adds **no** schema, no new `AppState` state, and reuses `TransactionRule` / the existing add-rule path verbatim. The rule it creates is exactly the one the row's "Always categorize as" menu already produces, so it feeds the persisted-only override-aware resolver with no new source of truth.

## Testing notes

- New pure logic extracted to `PlaidBarCore/Models/InlineCategoryRulePrompt.swift`, unit-tested in `InlineCategoryRulePromptTests` (12 tests): the built rule matches the merchant and carries the category, the matcher mirrors `createRule` (trimmed effective merchant name), an identical merchant+category rule dedupes case-insensitively, a different category or a transfer-only rule still offers a prompt, and a blank merchant yields no rule / no prompt.
- Strict-concurrency CI gate green: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.
- Full suite green: `swift test` — 1566 tests pass.

## Architectural decisions

- **Pure-model split:** the "should we prompt / what rule would Accept create / is this a duplicate" decisions live in a `Sendable` PlaidBarCore type, not the SwiftUI view (views aren't headlessly testable). The view is a thin renderer + wiring.
- **Reuse, don't fork:** Accept calls `appState.createRule(from:category:)` — the same path the Rule menu and undo stack already use — so the inline prompt can never diverge from how rules are otherwise created (matcher, merchant label, transfer/exclusion context, undo, persistence).
- **Captured row on accept:** the recategorization marks the row reviewed (it leaves the live snapshot), so the offered `TransactionReviewItem` is captured alongside the prompt to drive `createRule` even after the row is gone.
- **Accessibility:** the offer and its actions are always text + glyph labelled (`wand.and.stars`, "Create rule", "Dismiss"); meaning never rides on color alone. Creating a rule posts a VoiceOver announcement.

## Migration notes

None. No schema, no DTO, no `SpendingCategory` rawValue, and no new `AppState` state changes. Rules continue to live in the existing app-local `transaction-rules.json` (local-first), written through the existing persistence path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)