### PR TITLE
feat(ui): discrete unreviewed-count badge on review inbox header (AND-533)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -299,11 +299,44 @@ struct ReviewInboxView: View {
         .transition(reduceMotion ? .opacity : .move(edge: .trailing).combined(with: .opacity))
     }
 
+    /// The discrete Copilot-style unreviewed-count chip sat next to the title
+    /// (AND-533). Sourced from the pure Core helper, which returns nil when the
+    /// queue is empty or while Privacy Mask / App Lock is active (so the count
+    /// never leaks — the AND-483 contract). Nil here hides the chip entirely.
+    private var unreviewedBadgeText: String? {
+        ReviewInboxPrivacyPresentation.unreviewedBadge(
+            count: snapshot.totalCount,
+            isMasked: appState.shouldMaskFinancialValues
+        )
+    }
+
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
             VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text("Review Inbox")
-                    .sectionTitle()
+                HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+                    Text("Review Inbox")
+                        .sectionTitle()
+
+                    // Discrete at-a-glance unreviewed-count chip (AND-533). The
+                    // meaning rides the number itself plus the VoiceOver label
+                    // "N to review" — never color alone (ACCESSIBILITY.md). Hidden
+                    // at 0 and under Privacy Mask (Core helper returns nil), so no
+                    // count leaks (AND-483). This is additive: the subtitle below
+                    // and the high-priority badge are unchanged.
+                    if let unreviewedBadgeText {
+                        Text("\(snapshot.totalCount)")
+                            .font(.caption2.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(SemanticColors.brand)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 2)
+                            .background(SemanticColors.brand.opacity(0.12), in: Capsule())
+                            .overlay {
+                                Capsule().stroke(SemanticColors.brand.opacity(0.20), lineWidth: 1)
+                            }
+                            .accessibilityLabel(unreviewedBadgeText)
+                    }
+                }
 
                 Text(headerPresentation.subtitle)
                     .microText()

--- a/Sources/PlaidBarCore/Models/AppLockPresentation.swift
+++ b/Sources/PlaidBarCore/Models/AppLockPresentation.swift
@@ -189,6 +189,22 @@ public struct ReviewInboxPrivacyPresentation: Sendable, Equatable {
     public let highPriorityAccessibilityLabel: String?
     public let accessibilityLabel: String
 
+    /// The discrete at-a-glance unreviewed-count badge chip shown next to the
+    /// "Review Inbox" title (AND-533). Returns the VoiceOver phrasing "N to
+    /// review", or `nil` when there is nothing to badge: an empty queue, or
+    /// while Privacy Mask / App Lock is active (so the count never leaks — the
+    /// AND-483 contract). The badge is purely additive — it does not replace the
+    /// `subtitle` ("N items need attention") or the `highPriorityBadge`; it is
+    /// the compact chip the header carries on the title row.
+    ///
+    /// The chip's visible glyph is the count itself; this string is the
+    /// accessibility label only, so meaning never rides on color or shape alone
+    /// (ACCESSIBILITY.md).
+    public static func unreviewedBadge(count: Int, isMasked: Bool) -> String? {
+        guard !isMasked, count > 0 else { return nil }
+        return "\(count) to review"
+    }
+
     public static func make(
         totalCount: Int,
         highPriorityCount: Int,

--- a/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AppLockPresentationTests.swift
@@ -74,6 +74,25 @@ struct AppLockPresentationTests {
         #expect(presentation.accessibilityLabel == "Review inbox. 2 transactions need attention.")
     }
 
+    @Test("unreviewed count badge shows 'N to review' when unmasked with a non-empty queue")
+    func unreviewedBadgeShowsCountWhenUnmasked() {
+        #expect(ReviewInboxPrivacyPresentation.unreviewedBadge(count: 5, isMasked: false) == "5 to review")
+        #expect(ReviewInboxPrivacyPresentation.unreviewedBadge(count: 1, isMasked: false) == "1 to review")
+    }
+
+    @Test("unreviewed count badge is hidden under Privacy Mask so no count leaks")
+    func unreviewedBadgeHiddenWhileMasked() {
+        // AND-483: the masked surface must never expose the queue size.
+        #expect(ReviewInboxPrivacyPresentation.unreviewedBadge(count: 7, isMasked: true) == nil)
+    }
+
+    @Test("unreviewed count badge is hidden when the queue is empty")
+    func unreviewedBadgeHiddenWhenEmpty() {
+        #expect(ReviewInboxPrivacyPresentation.unreviewedBadge(count: 0, isMasked: false) == nil)
+        // Masked-and-empty also yields nil (no count to leak, nothing to badge).
+        #expect(ReviewInboxPrivacyPresentation.unreviewedBadge(count: 0, isMasked: true) == nil)
+    }
+
     @Test("private Review Inbox confirmation hides merchant details")
     func privateReviewInboxConfirmationHidesMerchantDetails() {
         let presentation = ReviewActionConfirmationPrivacyPresentation.make(


### PR DESCRIPTION
## Summary

Adds a small Copilot-style **count-badge chip** next to the "Review Inbox" title showing the live unreviewed queue size at a glance. This is purely additive: the existing "N items need attention" subtitle, the high-priority badge, and the masking behavior (AND-483) are all unchanged. The chip is a discrete capsule whose meaning rides the number itself plus a VoiceOver label "N to review" — never color alone (ACCESSIBILITY.md). It is hidden at 0 and under Privacy Mask / App Lock, so the queue count never leaks.

## Linear

[AND-533](https://linear.app/and/issue/AND-533) — Unreviewed count badge on the inbox header.

## Spec alignment (§3)

- At-a-glance discrete count chip on the header, distinct from the secondary subtitle and the high-priority badge.
- Sourced from `snapshot.totalCount`; gated on `!appState.shouldMaskFinancialValues && totalCount > 0`.
- VoiceOver phrasing `"N to review"` via `.accessibilityLabel`.
- Hidden at 0 and under Privacy Mask — no count leaks (AND-483 contract).
- Meaning carried by the number + accessibility label, never by color alone (ACCESSIBILITY.md).

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — 1584 tests pass (3 new).
- New pure Core helper `ReviewInboxPrivacyPresentation.unreviewedBadge(count:isMasked:)` unit-tested:
  - `unreviewed count badge shows 'N to review' when unmasked with a non-empty queue`
  - `unreviewed count badge is hidden under Privacy Mask so no count leaks`
  - `unreviewed count badge is hidden when the queue is empty`

## Architectural decisions

- The badge's visibility/label text is decided by a new pure helper in `PlaidBarCore` (`ReviewInboxPrivacyPresentation.unreviewedBadge`), keeping the masking/empty-queue logic `Sendable`, testable, and consistent with the sibling `make(totalCount:highPriorityCount:isPrivate:)` presentation rather than embedding it in the view. The view is a thin capsule renderer that resolves the chip's accessibility label from the helper.
- Scope limited to `ReviewInboxView.swift` + the Core helper + its test. No changes to `ReviewTableWindow`, `AppState`, dashboard, or budget files.

## Migration notes

None — additive UI + a new pure helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)