### PR TITLE
fix(ui): address Codex review on review Table — masked-dialog, blast-radius confirm, stale rows, not-transfer (AND-532)

### DIFF
--- a/Sources/PlaidBar/Views/ReviewTableWindow.swift
+++ b/Sources/PlaidBar/Views/ReviewTableWindow.swift
@@ -37,9 +37,13 @@ struct ReviewTableWindow: View {
     /// unit-tested ``ReviewTableSort/sorted(_:)`` comparator instead, and chosen via
     /// a `Picker` rather than `Table`'s `sortOrder:` binding.
     @State private var sort: ReviewTableSort = .amountDescending
-    /// Staged bulk-recategorize plan — set when the user picks a category for the
-    /// selection; drives the blast-radius confirmation before anything is applied.
-    @State private var pendingBulkPlan: ReviewBulkRecategorizePlan?
+    /// Staged blast-radius action — set when the user picks a bulk/multi-row
+    /// recategorize or transfer; drives the confirmation dialog before anything is
+    /// applied. A single piece of state so every multi-row action (selection bar OR
+    /// context menu) routes through the same confirm-then-apply path, and so the
+    /// masked-state guard can clear it in one place (cached merchant names in the
+    /// dialog must never render under Privacy Mask / App Lock).
+    @State private var pendingBulkAction: PendingReviewBulkAction?
 
     private var isMasked: Bool { appState.shouldMaskFinancialValues }
 
@@ -69,15 +73,22 @@ struct ReviewTableWindow: View {
         .frame(minWidth: 560, minHeight: 420, alignment: .topLeading)
         .accessibilityElement(children: .contain)
         .confirmationDialog(
-            pendingBulkPlan.map { "Set \($0.count) to \($0.category.displayName)?" } ?? "Recategorize?",
+            pendingBulkAction?.confirmationTitle ?? "Confirm?",
             isPresented: bulkConfirmationBinding,
             titleVisibility: .visible,
-            presenting: pendingBulkPlan
-        ) { plan in
-            Button("Set \(plan.count) to \(plan.category.displayName)") { applyBulkRecategorize(plan) }
+            presenting: pendingBulkAction
+        ) { action in
+            Button(action.confirmButtonTitle) { applyBulkAction(action) }
             Button("Cancel", role: .cancel) {}
-        } message: { plan in
-            Text(plan.blastRadiusDescription())
+        } message: { action in
+            Text(action.blastRadiusDescription())
+        }
+        // Privacy Mask / App Lock can engage mid-flow. The dialog message echoes
+        // cached merchant names, so withhold (drop) any staged action the instant
+        // the window starts masking — the masked placeholder must never sit behind
+        // a dialog that spells out merchants (SECURITY.md).
+        .onChange(of: isMasked) { _, masked in
+            if masked { pendingBulkAction = nil }
         }
     }
 
@@ -132,7 +143,7 @@ struct ReviewTableWindow: View {
                 bulkRecategorizeMenu
 
                 Button {
-                    bulkMarkTransfer()
+                    stageBulkMarkTransfer(ids: selection)
                 } label: {
                     Label("Mark transfer", systemImage: "arrow.left.arrow.right")
                 }
@@ -277,7 +288,11 @@ struct ReviewTableWindow: View {
             Menu("Recategorize") {
                 ForEach(SpendingCategory.allCases, id: \.self) { category in
                     Button {
-                        recategorize(rows: scoped, to: category)
+                        // A multi-row recategorize goes through the SAME blast-radius
+                        // confirmation as the selection bar (count + which merchants +
+                        // category) so a context-menu bulk change is never silent; a
+                        // single row applies directly.
+                        recategorizeOrStage(ids: ids, to: category)
                     } label: {
                         Label(category.displayName, systemImage: category.iconName)
                     }
@@ -301,12 +316,30 @@ struct ReviewTableWindow: View {
             }
 
             Button {
-                markTransfer(rows: scoped)
+                // Multi-row transfer marking confirms first (it excludes rows from
+                // budgets); a single row applies directly.
+                markTransferOrStage(ids: ids)
             } label: {
                 Label(
                     ids.count == 1 ? "Mark transfer" : "Mark \(scoped.count) transfers",
                     systemImage: "arrow.left.arrow.right"
                 )
+            }
+
+            // The inverse of "Mark transfer" — restores a mistaken/misclassified
+            // transfer to spend (clears the transfer override + budget exclusion).
+            // Recategorizing alone does NOT clear an explicit transfer override, so
+            // this is the only way to fix the budget exclusion from this window.
+            // Offered only when at least one scoped row is actually a transfer.
+            if scoped.contains(where: \.isTransfer) {
+                Button {
+                    markNotTransfer(rows: scoped)
+                } label: {
+                    Label(
+                        ids.count == 1 ? "Mark not transfer" : "Mark \(scoped.count) not transfers",
+                        systemImage: "arrow.uturn.left"
+                    )
+                }
             }
 
             Divider()
@@ -333,14 +366,60 @@ struct ReviewTableWindow: View {
             category: category
         )
         guard !plan.isEmpty else { return }
-        pendingBulkPlan = plan
+        pendingBulkAction = .recategorize(plan)
     }
 
-    /// Apply a confirmed bulk recategorize: route every affected id through the SAME
-    /// per-row `updateReviewCategory` path the inbox uses, inside one animation, then
-    /// announce the count + category (never a silent change) and clear the selection.
-    private func applyBulkRecategorize(_ plan: ReviewBulkRecategorizePlan) {
-        pendingBulkPlan = nil
+    /// Context-menu recategorize: a single row applies directly (one undo snapshot,
+    /// matching the inbox), but more than one row routes through the SAME
+    /// blast-radius confirmation as the selection bar so a context-menu bulk change
+    /// is never silent.
+    private func recategorizeOrStage(ids: Set<ReviewTableRow.ID>, to category: SpendingCategory) {
+        let plan = ReviewBulkRecategorizePlan.make(rows: rows, selection: ids, category: category)
+        guard !plan.isEmpty else { return }
+        if plan.count > 1 {
+            pendingBulkAction = .recategorize(plan)
+        } else {
+            applyRecategorize(plan)
+        }
+    }
+
+    /// Context-menu transfer marking: a single row applies directly, but more than
+    /// one row confirms first (it removes rows from budget/spend math).
+    private func markTransferOrStage(ids: Set<ReviewTableRow.ID>) {
+        let plan = ReviewBulkTransferPlan.make(rows: rows, selection: ids)
+        guard !plan.isEmpty else { return }
+        if plan.count > 1 {
+            pendingBulkAction = .markTransfer(plan)
+        } else {
+            applyMarkTransfer(plan)
+        }
+    }
+
+    /// Selection-bar "Mark transfer": always confirms (it is a multi-row affordance
+    /// and excludes rows from budgets).
+    private func stageBulkMarkTransfer(ids: Set<ReviewTableRow.ID>) {
+        let plan = ReviewBulkTransferPlan.make(rows: rows, selection: ids)
+        guard !plan.isEmpty else { return }
+        pendingBulkAction = .markTransfer(plan)
+    }
+
+    /// Apply a confirmed bulk action. Re-resolves the staged plan against the
+    /// *current* rows first (a row may have left the inbox while the dialog sat
+    /// open), so a stale id can never act on a transaction the user no longer sees.
+    private func applyBulkAction(_ action: PendingReviewBulkAction) {
+        pendingBulkAction = nil
+        switch action {
+        case let .recategorize(plan):
+            applyRecategorize(plan.reResolved(against: rows))
+        case let .markTransfer(plan):
+            applyMarkTransfer(plan.reResolved(against: rows))
+        }
+    }
+
+    /// Route every affected id through the SAME per-row `updateReviewCategory` path
+    /// the inbox uses, inside one undo-batched animation, then announce the count +
+    /// category (never a silent change) and clear the selection.
+    private func applyRecategorize(_ plan: ReviewBulkRecategorizePlan) {
         guard !plan.isEmpty else { return }
         animatingResolution {
             appState.withBatchedReviewUndo {
@@ -356,33 +435,40 @@ struct ReviewTableWindow: View {
         ).post()
     }
 
-    /// Recategorize a scoped set of rows (single from a context-menu, or many).
-    /// The whole scope is one undo unit — for a single row that is exactly one
-    /// snapshot, matching the inbox's per-row behavior.
-    private func recategorize(rows scoped: [ReviewTableRow], to category: SpendingCategory) {
+    /// Route every affected id through the existing per-row `markReviewItemTransfer`
+    /// path, inside one undo-batched animation, then announce + clear the selection.
+    private func applyMarkTransfer(_ plan: ReviewBulkTransferPlan) {
+        guard !plan.isEmpty else { return }
         animatingResolution {
             appState.withBatchedReviewUndo {
-                for row in scoped {
-                    appState.updateReviewCategory(row.id, category: category)
+                for id in plan.affectedIDs {
+                    appState.markReviewItemTransfer(id)
                 }
             }
         }
-        selection.subtract(scoped.map(\.id))
+        selection.subtract(plan.affectedIDs)
+        let noun = plan.count == 1 ? "transaction" : "transactions"
+        AccessibilityNotification.Announcement(
+            "Marked \(plan.count) \(noun) as transfers"
+        ).post()
     }
 
-    private func markTransfer(rows scoped: [ReviewTableRow]) {
+    /// Restore scoped transfer rows to spend — the inverse of "Mark transfer".
+    /// Clears the explicit transfer override + budget exclusion via the existing
+    /// `markReviewItemTransfer(_:isTransfer:)` path (the same call the inbox row's
+    /// "Not transfer" uses), so a misclassified transfer can be fixed from this
+    /// window. One undo unit; a single row is exactly one snapshot.
+    private func markNotTransfer(rows scoped: [ReviewTableRow]) {
+        let affected = scoped.filter(\.isTransfer)
+        guard !affected.isEmpty else { return }
         animatingResolution {
             appState.withBatchedReviewUndo {
-                for row in scoped {
-                    appState.markReviewItemTransfer(row.id)
+                for row in affected {
+                    appState.markReviewItemTransfer(row.id, isTransfer: false)
                 }
             }
         }
-        selection.subtract(scoped.map(\.id))
-    }
-
-    private func bulkMarkTransfer() {
-        markTransfer(rows: scopedRows(selection))
+        selection.subtract(affected.map(\.id))
     }
 
     private func approve(rows scoped: [ReviewTableRow]) {
@@ -448,8 +534,8 @@ struct ReviewTableWindow: View {
 
     private var bulkConfirmationBinding: Binding<Bool> {
         Binding(
-            get: { pendingBulkPlan != nil },
-            set: { presented in if !presented { pendingBulkPlan = nil } }
+            get: { pendingBulkAction != nil },
+            set: { presented in if !presented { pendingBulkAction = nil } }
         )
     }
 
@@ -479,5 +565,48 @@ struct ReviewTableWindow: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityLabel("Review inbox clear. New or unusual transactions will appear here.")
+    }
+}
+
+/// A staged multi-row review action awaiting blast-radius confirmation. Both bulk
+/// affordances that change budget-relevant state — recategorize and mark-transfer —
+/// flow through this one piece of state so every multi-row change confirms count +
+/// merchants first (never silent), and so the masked-state guard can clear all of
+/// them in one place. Single-row context actions apply directly and never stage.
+private enum PendingReviewBulkAction {
+    case recategorize(ReviewBulkRecategorizePlan)
+    case markTransfer(ReviewBulkTransferPlan)
+
+    /// Affected-row count, for the confirm button.
+    var count: Int {
+        switch self {
+        case let .recategorize(plan): plan.count
+        case let .markTransfer(plan): plan.count
+        }
+    }
+
+    /// Short dialog title.
+    var confirmationTitle: String {
+        switch self {
+        case let .recategorize(plan): "Set \(plan.count) to \(plan.category.displayName)?"
+        case .markTransfer: count == 1 ? "Mark transfer?" : "Mark \(count) transfers?"
+        }
+    }
+
+    /// Confirm-button label (the destructive verb + count).
+    var confirmButtonTitle: String {
+        switch self {
+        case let .recategorize(plan): "Set \(plan.count) to \(plan.category.displayName)"
+        case .markTransfer: count == 1 ? "Mark transfer" : "Mark \(count) transfers"
+        }
+    }
+
+    /// Plain-language "which rows + what changes" message (delegates to the pure
+    /// plan), so the dialog spells out the blast radius, never a bare count.
+    func blastRadiusDescription() -> String {
+        switch self {
+        case let .recategorize(plan): plan.blastRadiusDescription()
+        case let .markTransfer(plan): plan.blastRadiusDescription()
+        }
     }
 }

--- a/Sources/PlaidBarCore/Models/ReviewTableRow.swift
+++ b/Sources/PlaidBarCore/Models/ReviewTableRow.swift
@@ -183,6 +183,23 @@ public struct ReviewBulkRecategorizePlan: Sendable, Equatable {
         )
     }
 
+    /// Re-resolves a staged plan against the *currently* listed rows at apply time.
+    ///
+    /// A plan is captured when the confirmation dialog opens, but the inbox can
+    /// change while the dialog sits open (a row gets approved from the popover, a
+    /// refresh removes it). Re-running the same intersection drops any id that no
+    /// longer exists, so confirming can never recategorize a transaction the user
+    /// can no longer see (consistent with how AND-528's bulk path re-resolves stale
+    /// ids before applying). The category is preserved; merchant names are re-read
+    /// from the surviving rows so the recorded "which" stays in sync.
+    public func reResolved(against rows: [ReviewTableRow]) -> ReviewBulkRecategorizePlan {
+        ReviewBulkRecategorizePlan.make(
+            rows: rows,
+            selection: Set(affectedIDs),
+            category: category
+        )
+    }
+
     /// Plain-language description of which rows resolve and to which category —
     /// count first, then the category, then a bounded list of merchant names — for a
     /// confirmation prompt and a VoiceOver announcement, so meaning never rides on a
@@ -196,6 +213,79 @@ public struct ReviewBulkRecategorizePlan: Sendable, Equatable {
         let names = affectedMerchantNames.prefix(max(previewLimit, 0))
         let remainder = count - names.count
         let head = "Set \(count) \(noun) to \(category.displayName)"
+        guard !names.isEmpty else { return head }
+        var preview = names.joined(separator: ", ")
+        if remainder > 0 {
+            preview += ", and \(remainder) more"
+        }
+        return "\(head): \(preview)"
+    }
+}
+
+/// Pure description of the *blast radius* of a bulk **mark-transfer** across a
+/// multi-select review `Table` selection (AND-532, Codex follow-up).
+///
+/// Marking a transfer sets `excludedFromBudgets = true`, so a bulk transfer quietly
+/// removes several transactions from budget/spend math. Like
+/// ``ReviewBulkRecategorizePlan``, this surfaces the scope — how many rows and which
+/// merchants — *before* applying, so a single accidental click can never drop more
+/// from the budget than the user can see. It has no SwiftUI / AppState dependency,
+/// so the "which rows" decision is unit-testable, and the application reuses the
+/// existing per-row `markReviewItemTransfer` path (state blast radius) so bulk and
+/// single transfer marking can never diverge in meaning.
+///
+/// Scope rule mirrors the recategorize plan: the radius is the intersection of the
+/// explicit selection with the currently-listed rows, in **list order**, so a stale
+/// id can never mark a transaction that is no longer shown.
+public struct ReviewBulkTransferPlan: Sendable, Equatable {
+    /// Transaction ids that will be marked as transfers, in table-list order.
+    public let affectedIDs: [String]
+    /// Merchant names of the affected rows, list order, for the "which" preview.
+    public let affectedMerchantNames: [String]
+
+    public var count: Int { affectedIDs.count }
+    public var isEmpty: Bool { affectedIDs.isEmpty }
+
+    public init(affectedIDs: [String], affectedMerchantNames: [String]) {
+        self.affectedIDs = affectedIDs
+        self.affectedMerchantNames = affectedMerchantNames
+    }
+
+    /// Computes the mark-transfer blast radius for a `Table` selection.
+    ///
+    /// - Parameters:
+    ///   - rows: the rows currently listed in the table (already the visible set).
+    ///   - selection: the user's multi-select set of row ids.
+    public static func make(
+        rows: [ReviewTableRow],
+        selection: Set<String>
+    ) -> ReviewBulkTransferPlan {
+        let scoped = rows.filter { selection.contains($0.id) }
+        return ReviewBulkTransferPlan(
+            affectedIDs: scoped.map(\.id),
+            affectedMerchantNames: scoped.map(\.merchantName)
+        )
+    }
+
+    /// Re-resolves a staged plan against the *currently* listed rows at apply time,
+    /// dropping any id that is no longer shown (same staleness guard the
+    /// recategorize plan uses).
+    public func reResolved(against rows: [ReviewTableRow]) -> ReviewBulkTransferPlan {
+        ReviewBulkTransferPlan.make(rows: rows, selection: Set(affectedIDs))
+    }
+
+    /// Plain-language description of which rows will be marked as transfers — count
+    /// first, then a bounded list of merchant names — for a confirmation prompt and
+    /// a VoiceOver announcement, so meaning never rides on a bare number or color.
+    ///
+    /// - Parameter previewLimit: how many merchant names to spell out before
+    ///   collapsing the rest into "and N more".
+    public func blastRadiusDescription(previewLimit: Int = 3) -> String {
+        guard count > 0 else { return "No transactions to mark as transfers" }
+        let noun = count == 1 ? "transaction" : "transactions"
+        let names = affectedMerchantNames.prefix(max(previewLimit, 0))
+        let remainder = count - names.count
+        let head = "Mark \(count) \(noun) as transfers and exclude from budgets"
         guard !names.isEmpty else { return head }
         var preview = names.joined(separator: ", ")
         if remainder > 0 {

--- a/Tests/PlaidBarCoreTests/ReviewTableModelTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewTableModelTests.swift
@@ -158,6 +158,88 @@ struct ReviewTableModelTests {
         #expect(plan.blastRadiusDescription(previewLimit: 3).contains("and 2 more"))
     }
 
+    // MARK: - Re-resolving a staged recategorize plan against current rows
+
+    @Test("Re-resolving a recategorize plan drops rows that left the table")
+    func recategorizeReResolveDropsVanishedRows() {
+        let staged = ReviewBulkRecategorizePlan(
+            affectedIDs: ["a", "b", "c"],
+            affectedMerchantNames: ["A", "B", "C"],
+            category: .foodAndDrink
+        )
+        // Between staging and applying, "b" left the inbox (approved elsewhere).
+        let current = [
+            ReviewTableRow(item: item(id: "a", merchant: "A", amount: 1, date: "d", category: nil, reasons: [.uncategorized])),
+            ReviewTableRow(item: item(id: "c", merchant: "C", amount: 3, date: "d", category: nil, reasons: [.uncategorized])),
+        ]
+
+        let reResolved = staged.reResolved(against: current)
+        #expect(reResolved.affectedIDs == ["a", "c"])
+        #expect(reResolved.affectedMerchantNames == ["A", "C"])
+        // Category survives re-resolution.
+        #expect(reResolved.category == .foodAndDrink)
+    }
+
+    @Test("Re-resolving a recategorize plan against an empty table yields an empty plan")
+    func recategorizeReResolveAllGone() {
+        let staged = ReviewBulkRecategorizePlan(affectedIDs: ["a"], affectedMerchantNames: ["A"], category: .foodAndDrink)
+        #expect(staged.reResolved(against: []).isEmpty)
+    }
+
+    // MARK: - Bulk transfer blast radius
+
+    @Test("Bulk transfer scopes to the selection intersected with listed rows, list order")
+    func bulkTransferScopes() {
+        let rows = [
+            ReviewTableRow(item: item(id: "a", merchant: "A", amount: 1, date: "d", category: nil, reasons: [.uncategorized])),
+            ReviewTableRow(item: item(id: "b", merchant: "B", amount: 2, date: "d", category: nil, reasons: [.uncategorized])),
+            ReviewTableRow(item: item(id: "c", merchant: "C", amount: 3, date: "d", category: nil, reasons: [.uncategorized])),
+        ]
+
+        let plan = ReviewBulkTransferPlan.make(rows: rows, selection: ["c", "a"])
+        #expect(plan.affectedIDs == ["a", "c"])
+        #expect(plan.affectedMerchantNames == ["A", "C"])
+        #expect(plan.count == 2)
+        #expect(!plan.isEmpty)
+    }
+
+    @Test("Bulk transfer drops a stale id and an empty selection")
+    func bulkTransferStaleAndEmpty() {
+        let rows = [ReviewTableRow(item: item(id: "a", merchant: "A", amount: 1, date: "d", category: nil, reasons: [.uncategorized]))]
+        #expect(ReviewBulkTransferPlan.make(rows: rows, selection: ["ghost"]).isEmpty)
+        #expect(ReviewBulkTransferPlan.make(rows: rows, selection: []).isEmpty)
+    }
+
+    @Test("Bulk transfer description states count, budget exclusion, and which merchants")
+    func bulkTransferDescription() {
+        let rows = [
+            ReviewTableRow(item: item(id: "a", merchant: "Corner Store", amount: 1, date: "d", category: nil, reasons: [.uncategorized])),
+            ReviewTableRow(item: item(id: "b", merchant: "Coffee Shop", amount: 2, date: "d", category: nil, reasons: [.uncategorized])),
+        ]
+        let plan = ReviewBulkTransferPlan.make(rows: rows, selection: ["a", "b"])
+        let description = plan.blastRadiusDescription()
+        #expect(description.contains("2"))
+        #expect(description.contains("budgets"))
+        #expect(description.contains("Corner Store"))
+        #expect(description.contains("Coffee Shop"))
+    }
+
+    @Test("Bulk transfer uses singular noun for a single row")
+    func bulkTransferSingular() {
+        let rows = [ReviewTableRow(item: item(id: "a", merchant: "Corner Store", amount: 1, date: "d", category: nil, reasons: [.uncategorized]))]
+        let plan = ReviewBulkTransferPlan.make(rows: rows, selection: ["a"])
+        #expect(plan.blastRadiusDescription().contains("1 transaction "))
+    }
+
+    @Test("Re-resolving a transfer plan drops rows that left the table")
+    func bulkTransferReResolveDropsVanishedRows() {
+        let staged = ReviewBulkTransferPlan(affectedIDs: ["a", "b"], affectedMerchantNames: ["A", "B"])
+        let current = [ReviewTableRow(item: item(id: "a", merchant: "A", amount: 1, date: "d", category: nil, reasons: [.uncategorized]))]
+        let reResolved = staged.reResolved(against: current)
+        #expect(reResolved.affectedIDs == ["a"])
+        #expect(reResolved.affectedMerchantNames == ["A"])
+    }
+
     // MARK: - Sorting
 
     @Test("Amount descending sorts by largest spend first; id breaks ties")


### PR DESCRIPTION
## Summary

Follow-up to #552 (AND-532 detached review Table window). Codex left 6 unaddressed review findings on that PR (1 P1 + 5 P2). This PR resolves them so AND-532 meets "no unresolved review feedback". All changes are in `ReviewTableWindow.swift` plus pure, unit-tested logic in `PlaidBarCore`.

## Findings addressed

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| [3441123463](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123463) | P1 | Bulk confirmation dialog kept showing cached merchant names if Privacy Mask / App Lock engaged mid-flow | `.onChange(of: isMasked)` clears any staged `pendingBulkAction` the instant masking turns on, so the masked placeholder never sits behind a dialog spelling out merchants |
| [3441123467](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123467) | P2 | Multi-row context-menu recategorize applied immediately, bypassing the blast-radius confirmation | `recategorizeOrStage` routes `count > 1` through the SAME confirmation as the selection bar; a single row still applies directly |
| [3441123476](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123476) / [3441123479](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123479) | P2 | Bulk "Mark transfer" excluded rows from budgets with no count/merchant confirmation | New pure `ReviewBulkTransferPlan`; selection-bar and multi-row context-menu transfer both confirm count + which merchants first |
| [3441123474](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123474) | P2 | Staged plan could be stale at apply time (a row left the inbox while the dialog was open) | `applyBulkAction` re-resolves via `plan.reResolved(against: rows)` before applying, dropping vanished ids (consistent with AND-528's bulk path) |
| [3441123480](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123480) | P2 | Context menu had "Mark transfer" but no inverse | Added "Mark not transfer" (shown when a scoped row is a transfer), routed through the existing `markReviewItemTransfer(_:isTransfer:false)` path the inbox row uses |
| [3441123471](https://github.com/ftchvs/VaultPeek/pull/552#discussion_r3441123471) | P2 | One ⌘Z should revert a whole confirmed bulk operation | **Already fixed on `main` in 7edb0e7** via `AppState.withBatchedReviewUndo`; every bulk path here routes through it |

## Design

A single `pendingBulkAction: PendingReviewBulkAction?` enum (recategorize | markTransfer) backs the one confirmation dialog, so every multi-row action that changes budget-relevant state confirms count + merchants (text, never color alone) and the masked-state guard clears all of them in one place. Single-row context actions apply directly. All apply paths reuse the existing per-row AppState review mutators inside `withBatchedReviewUndo` — no forked mutators.

Pure logic (`ReviewBulkTransferPlan`, `reResolved(against:)` on both plans) lives in `PlaidBarCore` and is unit-tested; the view stays a thin renderer.

## Tests

7 new `PlaidBarCoreTests` (`ReviewTableModelTests`):
- `recategorizeReResolveDropsVanishedRows`, `recategorizeReResolveAllGone`
- `bulkTransferScopes`, `bulkTransferStaleAndEmpty`, `bulkTransferDescription`, `bulkTransferSingular`, `bulkTransferReResolveDropsVanishedRows`

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green
- `swift test` — 1588 tests pass (+7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)