### PR TITLE
fix(security): harden Plaid token Keychain accessibility to ThisDeviceOnly (AND-572)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,19 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
   stores only a `keychain:<item_id>` reference. Build/test environments without
   Keychain support may fall back to local SQLite token storage, so release
   claims must distinguish runtime Keychain behavior from fallback builds.
+- Keychain access-token items are hardened to stay on the user's machine. Each
+  item is written with the `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+  data-protection class and `kSecAttrSynchronizable = false`, so the token is
+  **never** copied to iCloud Keychain or any paired device, yet remains readable
+  by the headless companion server after the first post-boot unlock (including
+  while the screen is locked, which is required for background refresh). The
+  weaker `WhenUnlockedThisDeviceOnly` class is intentionally avoided because it
+  would block background reads on a locked screen, and the default
+  iCloud-syncable classes (`WhenUnlocked`, `AfterFirstUnlock`) are avoided
+  because they would let tokens leave the device. The protection is re-asserted
+  on every write, so items created by older builds are upgraded in place. The
+  accessibility-class decision is centralized in `KeychainAccessPolicy`
+  (`PlaidBarCore`) and unit-tested in CI without requiring a live Keychain.
 - Existing legacy `plaidbar.sqlite` data, SQLite sidecar files, and matching transaction cache are copied into a scoped database only when the legacy environment is explicit (`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from the existing transaction-cache context. Ambiguous legacy databases are left untouched to avoid sandbox/production token crossover. Explicit migration can replace an existing scoped store, backs up the previous scoped SQLite store and transaction cache before copying legacy data, and writes a migration marker so restarts do not reapply stale legacy data.
 - The app/server auth token is generated locally under `~/.vaultpeek/auth-token`
   (or `$PLAIDBAR_DATA_DIR/auth-token`).

--- a/Sources/PlaidBarCore/Utilities/KeychainAccessPolicy.swift
+++ b/Sources/PlaidBarCore/Utilities/KeychainAccessPolicy.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure, framework-free description of how Plaid access-token Keychain items
+/// must be protected. Extracting the decision here keeps it unit-testable in CI
+/// (no live Keychain, no Security framework) while the server's
+/// `PlaidTokenVault` maps these values onto the concrete `kSecAttr*` CFString
+/// constants when it talks to the Keychain.
+///
+/// Hardening rationale (AND-572):
+/// - **Device-only.** The token bytes must never leave this machine via iCloud
+///   Keychain, so the accessibility class is one of the `ThisDeviceOnly`
+///   variants and the item is explicitly **not** synchronizable.
+/// - **Readable by a background daemon after first unlock.** `PlaidBarServer`
+///   runs headless and must resolve the token to refresh data even while the
+///   screen is locked, as long as the device has been unlocked once since boot.
+///   `AfterFirstUnlockThisDeviceOnly` satisfies that; `WhenUnlockedThisDeviceOnly`
+///   would fail reads on a locked screen and break background refresh.
+public enum KeychainAccessPolicy: Sendable {
+    /// Accessibility classes VaultPeek can choose between. The associated raw
+    /// value mirrors Apple's documented `kSecAttrAccessible` string constants
+    /// (see `Security/SecItemConstants.c`) so the decision can be asserted in a
+    /// test without importing the Security framework.
+    public enum Accessibility: String, Sendable, CaseIterable {
+        /// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — device-only,
+        /// readable after the first post-boot unlock. The chosen policy.
+        case afterFirstUnlockThisDeviceOnly = "cku"
+        /// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — device-only but
+        /// unreadable while the screen is locked. Rejected: breaks headless
+        /// background reads.
+        case whenUnlockedThisDeviceOnly = "aku"
+        /// `kSecAttrAccessibleAfterFirstUnlock` — readable after first unlock
+        /// but **iCloud-syncable**. Rejected: tokens must stay on-device.
+        case afterFirstUnlock = "ck"
+        /// `kSecAttrAccessibleWhenUnlocked` — the Keychain default and
+        /// iCloud-syncable. Rejected for the same reasons.
+        case whenUnlocked = "ak"
+
+        /// Whether this class keeps the item pinned to a single device (its
+        /// name ends in `ThisDeviceOnly`). Apple forbids pairing a
+        /// `ThisDeviceOnly` class with `kSecAttrSynchronizable = true`.
+        public var isDeviceOnly: Bool {
+            switch self {
+            case .afterFirstUnlockThisDeviceOnly, .whenUnlockedThisDeviceOnly:
+                true
+            case .afterFirstUnlock, .whenUnlocked:
+                false
+            }
+        }
+    }
+
+    /// The accessibility class applied to every Plaid access-token Keychain
+    /// item, on both create and update.
+    public static let accessibility: Accessibility = .afterFirstUnlockThisDeviceOnly
+
+    /// Plaid access-token items are never synchronized to iCloud Keychain. The
+    /// item is added with `kSecAttrSynchronizable = false`; combined with a
+    /// `ThisDeviceOnly` accessibility class this guarantees on-device storage.
+    public static let isSynchronizable: Bool = false
+}

--- a/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
+++ b/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
@@ -77,11 +77,33 @@ enum PlaidTokenVault {
     }
 
     #if canImport(Security)
+    /// Concrete `kSecAttrAccessible` CFString for the hardened policy
+    /// (`KeychainAccessPolicy`). Tokens are pinned to this device, readable by
+    /// the background server after the first post-boot unlock, and never synced
+    /// to iCloud Keychain (AND-572).
+    private static var accessibleClass: CFString {
+        switch KeychainAccessPolicy.accessibility {
+        case .afterFirstUnlockThisDeviceOnly:
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        case .whenUnlockedThisDeviceOnly:
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        case .afterFirstUnlock:
+            kSecAttrAccessibleAfterFirstUnlock
+        case .whenUnlocked:
+            kSecAttrAccessibleWhenUnlocked
+        }
+    }
+
     private static func saveToKeychain(accessToken: String, itemId: String, service: String) throws {
         let query = keychainQuery(itemId: itemId, service: service)
+        // Re-assert the hardened protection on every write so an item created by
+        // an older build (or whose policy drifted) is upgraded in place: the
+        // accessibility class is pinned device-only and synchronization stays
+        // off, which keeps the token out of iCloud Keychain.
         let attributes: [String: Any] = [
             kSecValueData as String: Data(accessToken.utf8),
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            kSecAttrAccessible as String: accessibleClass,
+            kSecAttrSynchronizable as String: KeychainAccessPolicy.isSynchronizable
         ]
 
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)

--- a/Tests/PlaidBarCoreTests/KeychainAccessPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/KeychainAccessPolicyTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// Pure-decision coverage for `KeychainAccessPolicy` (AND-572). The real
+/// Keychain round-trip is environment-gated and skipped in CI (see
+/// `TokenStorageSafetyTests`), so this suite locks the *choice* of
+/// accessibility class and synchronizability — the part that actually hardens
+/// Plaid access-token storage — with no live Keychain required.
+@Suite("Keychain access policy")
+struct KeychainAccessPolicyTests {
+    @Test("Plaid tokens use AfterFirstUnlockThisDeviceOnly")
+    func usesAfterFirstUnlockThisDeviceOnly() {
+        #expect(KeychainAccessPolicy.accessibility == .afterFirstUnlockThisDeviceOnly)
+        // Raw value mirrors Apple's documented kSecAttrAccessible string ("cku").
+        #expect(KeychainAccessPolicy.accessibility.rawValue == "cku")
+    }
+
+    @Test("Chosen class is device-only so tokens never leave the machine")
+    func chosenClassIsDeviceOnly() {
+        #expect(KeychainAccessPolicy.accessibility.isDeviceOnly)
+    }
+
+    @Test("Plaid tokens are never marked synchronizable")
+    func tokensAreNotSynchronizable() {
+        #expect(KeychainAccessPolicy.isSynchronizable == false)
+    }
+
+    @Test("Device-only accessibility and synchronizable=true are never combined")
+    func deviceOnlyAndSynchronizableAreMutuallyExclusive() {
+        // Apple forbids pairing a `ThisDeviceOnly` accessibility class with
+        // kSecAttrSynchronizable=true; the policy must not produce that pair.
+        if KeychainAccessPolicy.accessibility.isDeviceOnly {
+            #expect(KeychainAccessPolicy.isSynchronizable == false)
+        }
+    }
+
+    @Test("Accessibility classification stays consistent across all cases")
+    func accessibilityClassificationIsConsistent() {
+        for accessibility in KeychainAccessPolicy.Accessibility.allCases {
+            let endsInThisDeviceOnly = String(describing: accessibility)
+                .lowercased()
+                .contains("thisdeviceonly")
+            #expect(accessibility.isDeviceOnly == endsInThisDeviceOnly)
+        }
+    }
+
+    @Test("Rejected classes are distinct from the chosen one")
+    func rejectedClassesDifferFromChosen() {
+        let chosen = KeychainAccessPolicy.accessibility
+        let rejected: [KeychainAccessPolicy.Accessibility] = [
+            .whenUnlockedThisDeviceOnly,
+            .afterFirstUnlock,
+            .whenUnlocked,
+        ]
+        for accessibility in rejected {
+            #expect(accessibility != chosen)
+        }
+        // The two iCloud-syncable classes must not be device-only.
+        #expect(!KeychainAccessPolicy.Accessibility.afterFirstUnlock.isDeviceOnly)
+        #expect(!KeychainAccessPolicy.Accessibility.whenUnlocked.isDeviceOnly)
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the Plaid access-token Keychain storage so tokens are pinned to the user's machine and never reach iCloud Keychain.

- **New `KeychainAccessPolicy` (PlaidBarCore)** — a pure, framework-free type that centralizes the data-protection decision: accessibility class `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` and `synchronizable = false`. Its raw values mirror Apple's documented `kSecAttrAccessible` string constants so the choice is unit-testable in CI with no live Keychain.
- **`PlaidTokenVault` re-asserts the hardened protection on every write.** Both `SecItemAdd` and `SecItemUpdate` now set the device-only accessibility class **and** `kSecAttrSynchronizable = false`, sourced from the policy. Items written by older builds are upgraded in place on the next save.
- **SECURITY.md** documents the hardened storage policy and the rationale for the class choice.

## Linear (AND-572)

Implements AND-572: audit then harden the Plaid access-token Keychain item's accessibility / data-protection.

Audit finding: the item was already using `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` on add (introduced in #488), but the choice was an inline literal, was **not** re-asserted with an explicit `kSecAttrSynchronizable = false`, and had no CI-runnable test guarding it. This PR closes those gaps.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — green (1597 tests).
- New `KeychainAccessPolicyTests` (6 tests, PlaidBarCore) assert the chosen class is `afterFirstUnlockThisDeviceOnly` (raw `"cku"`), that it is device-only, that `synchronizable == false`, and that a `ThisDeviceOnly` class is never paired with `synchronizable = true`. These run in CI without a Keychain.
- The live Keychain round-trip tests (`TokenStorageSafetyTests`) stay environment-gated behind `PLAIDBAR_TEST_KEYCHAIN` and continue to pass when enabled; they exercise the real add/resolve/delete path that now writes the hardened attributes.

## Architectural decisions

- **`AfterFirstUnlockThisDeviceOnly`, not `WhenUnlockedThisDeviceOnly`.** `PlaidBarServer` is a headless background daemon that must resolve the token to refresh data even while the screen is locked (after the first post-boot unlock). `WhenUnlockedThisDeviceOnly` would fail those reads.
- **`ThisDeviceOnly` + `synchronizable = false`.** Apple forbids pairing a `ThisDeviceOnly` accessibility class with `kSecAttrSynchronizable = true`; setting it explicitly to `false` documents intent and keeps tokens off iCloud Keychain and paired devices. Lookups already match only non-synchronizable items by default, so reads/writes are consistent.
- **Decision lives in `PlaidBarCore`, mapping to CFStrings lives in the server.** Keeps the policy `Sendable`, CI-testable, and free of a Security-framework dependency, while `PlaidTokenVault` owns the concrete `kSecAttr*` constants.

## Migration notes

No schema or data migration. Existing Keychain items are upgraded in place: the next time an item's token is saved, `SecItemUpdate` re-asserts the device-only accessibility class and `synchronizable = false`. The SQLite `keychain:<item_id>` reference scheme is unchanged, and the `PlaidBar.PlaidAccessToken` service name is preserved, so existing references continue to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)