### PR TITLE
feat(a11y): AXChartDescriptor audio graphs for trend/donut/heatmap charts (AND-569)

### DIFF
--- a/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
+++ b/Sources/PlaidBar/Views/Charts/BalanceTrendChart.swift
@@ -52,6 +52,8 @@ struct BalanceTrendChart: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(trend.accessibilitySummary)
+        // VoiceOver audio graph: scrub the net-worth series tone-by-tone (AND-569).
+        .audioGraph(ChartAudioGraph.trend(trend))
     }
 
     private var tint: Color {

--- a/Sources/PlaidBar/Views/Charts/ChartAudioGraphDescriptor.swift
+++ b/Sources/PlaidBar/Views/Charts/ChartAudioGraphDescriptor.swift
@@ -32,12 +32,17 @@ struct ChartAudioGraphRepresentable: AXChartDescriptorRepresentable {
             String(Int(value.rounded()))
         }
 
+        let isMasked = model.isPrivacyMasked
         let yAxis = AXNumericDataAxisDescriptor(
             title: model.yAxis.title,
             range: model.yAxis.lowerBound ... model.yAxis.upperBound,
             gridlinePositions: []
         ) { value in
-            Formatters.currency(value, format: .full)
+            // VoiceOver speaks this while scrubbing the value axis — a third place an
+            // exact amount can leak past Privacy Mask, alongside the (already-masked)
+            // point labels and summary. Redact here too; pitch still conveys relative
+            // magnitude (AND-569).
+            ChartAudioGraph.yAxisValueDescription(value, isMasked: isMasked)
         }
 
         let dataPoints = model.points.map { point in

--- a/Sources/PlaidBar/Views/Charts/ChartAudioGraphDescriptor.swift
+++ b/Sources/PlaidBar/Views/Charts/ChartAudioGraphDescriptor.swift
@@ -1,0 +1,82 @@
+import Accessibility
+import PlaidBarCore
+import SwiftUI
+
+/// Bridges a pure ``ChartAudioGraph/Descriptor`` (built + unit-tested in
+/// PlaidBarCore) into the `Accessibility` framework's `AXChartDescriptor`, so
+/// VoiceOver exposes the *audio graph* rotor action ("Describe Chart" → "Play
+/// Audio Graph") on VaultPeek's charts (AND-569).
+///
+/// The descriptor is the scrubbable, tone-by-tone counterpart to each chart's
+/// existing spoken `accessibilityLabel`: the same series, but the user can walk
+/// it point-by-point or hear it played as pitch. Meaning never relies on color
+/// (ACCESSIBILITY.md) — the audio graph conveys the series purely through pitch
+/// plus the labeled numeric axes carried here.
+///
+/// `AX*` descriptor types are reference types and aren't `Sendable`; this struct
+/// holds only the `Sendable` value model and constructs the `AX*` graph lazily
+/// inside `makeChartDescriptor()`, on demand, when VoiceOver requests it.
+struct ChartAudioGraphRepresentable: AXChartDescriptorRepresentable {
+    let descriptor: ChartAudioGraph.Descriptor
+
+    func makeChartDescriptor() -> AXChartDescriptor {
+        let model = descriptor
+
+        let xAxis = AXNumericDataAxisDescriptor(
+            title: model.xAxis.title,
+            range: model.xAxis.lowerBound ... model.xAxis.upperBound,
+            gridlinePositions: []
+        ) { value in
+            // X is an opaque index (day / rank); the per-point label carries the
+            // human-readable position, so the axis value reads as a plain number.
+            String(Int(value.rounded()))
+        }
+
+        let yAxis = AXNumericDataAxisDescriptor(
+            title: model.yAxis.title,
+            range: model.yAxis.lowerBound ... model.yAxis.upperBound,
+            gridlinePositions: []
+        ) { value in
+            Formatters.currency(value, format: .full)
+        }
+
+        let dataPoints = model.points.map { point in
+            AXDataPoint(x: point.xValue, y: point.yValue, additionalValues: [], label: point.label)
+        }
+
+        let series = AXDataSeriesDescriptor(
+            name: model.seriesName,
+            isContinuous: model.isContinuous,
+            dataPoints: dataPoints
+        )
+
+        return AXChartDescriptor(
+            title: model.title,
+            summary: model.summary,
+            xAxis: xAxis,
+            yAxis: yAxis,
+            additionalAxes: [],
+            series: [series]
+        )
+    }
+
+    func updateChartDescriptor(_ descriptor: AXChartDescriptor) {
+        // The representable is rebuilt whenever the underlying value model
+        // changes, so there is no incremental state to reconcile here.
+    }
+}
+
+extension View {
+    /// Attach a VoiceOver audio graph built from a pure
+    /// ``ChartAudioGraph/Descriptor``. No-op when the descriptor has no points
+    /// (nothing to sonify) so empty/loading charts don't advertise an empty
+    /// audio graph (AND-569).
+    @ViewBuilder
+    func audioGraph(_ descriptor: ChartAudioGraph.Descriptor) -> some View {
+        if descriptor.isEmpty {
+            self
+        } else {
+            accessibilityChartDescriptor(ChartAudioGraphRepresentable(descriptor: descriptor))
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/Charts/SpendDonutChart.swift
+++ b/Sources/PlaidBar/Views/Charts/SpendDonutChart.swift
@@ -60,6 +60,9 @@ struct SpendDonutChart: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(chartAccessibilityLabel)
+        // VoiceOver audio graph: walk each category's spend as pitch. Honors
+        // Privacy Mask — pitch conveys relative magnitude, labels hide amounts.
+        .audioGraph(ChartAudioGraph.donut(model, isPrivacyMasked: isPrivacyMasked))
         .onAppear(perform: animateReveal)
     }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1060,6 +1060,21 @@ private struct BalanceActivityHeatmap: View {
                 ? (loadState?.loadingAccessibilityLabel ?? "Loading activity heatmap.")
                 : "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription). Select a day to see its detail."
         )
+        // VoiceOver audio graph over the active days. Suppressed during the first
+        // sync (placeholder grid) and honors Privacy Mask (AND-569).
+        .audioGraph(
+            isInitialLoad
+                ? ChartAudioGraph.Descriptor(
+                    title: layout.mode.summaryTitle,
+                    summary: "Loading activity heatmap.",
+                    xAxis: .init(title: "Active day", lowerBound: 0, upperBound: 0),
+                    yAxis: .init(title: layout.mode.shortLabel, lowerBound: 0, upperBound: 0),
+                    seriesName: layout.mode.shortLabel,
+                    isContinuous: false,
+                    points: []
+                )
+                : ChartAudioGraph.heatmap(layout, isPrivacyMasked: appState.shouldMaskFinancialValues)
+        )
     }
 
     @ViewBuilder

--- a/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
+++ b/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/// Pure, `Sendable` audio-graph descriptors for VaultPeek's charts (AND-569).
+///
+/// VoiceOver's *audio graph* (the "Describe Chart" / "Play Audio Graph" rotor
+/// action) is driven by `AXChartDescriptor` from the `Accessibility` framework.
+/// Those `AX*` reference types live in the UI layer and aren't `Sendable`, so we
+/// keep the **data → descriptor-point mapping** here as plain value types that
+/// are trivially unit-testable without a host view, and let the thin SwiftUI
+/// wrappers (`*AudioGraphDescriptor`) translate these into `AXChartDescriptor`.
+///
+/// This is the audio-graph analogue of the spoken `accessibilityLabel` each
+/// chart already exposes: same data, but scrubbable tone-by-tone instead of a
+/// single sentence. Meaning never rides on color (ACCESSIBILITY.md) — the audio
+/// graph conveys the series purely through pitch + the labeled axes here.
+public enum ChartAudioGraph {
+    /// One plotted point in an audio graph. `xValue` is the position the audio
+    /// graph scrubs along (numeric); `xLabel` is the human-readable category the
+    /// view exposes as the data point's label / categorical x-value; `yValue` is
+    /// the pitch-mapped magnitude.
+    public struct Point: Sendable, Hashable {
+        /// Numeric x position (e.g. a day offset or slice index). Monotonic and
+        /// unique within a series so the audio graph scrubs left-to-right.
+        public let xValue: Double
+        /// Human-readable x label, e.g. a date or a category name. Spoken when the
+        /// user lands on the point.
+        public let xLabel: String
+        /// Pitch-mapped magnitude on the y axis.
+        public let yValue: Double
+        /// Optional spoken label for the whole point (defaults to `xLabel` when nil).
+        public let label: String
+
+        public init(xValue: Double, xLabel: String, yValue: Double, label: String? = nil) {
+            self.xValue = xValue
+            self.xLabel = xLabel
+            self.yValue = yValue
+            self.label = label ?? xLabel
+        }
+    }
+
+    /// A numeric axis: title plus the inclusive value range the audio graph maps
+    /// to its pitch / scrub span. `lowerBound <= upperBound` always (the builders
+    /// pad a degenerate single-value range so the audio graph has a span to map).
+    public struct NumericAxis: Sendable, Hashable {
+        public let title: String
+        public let lowerBound: Double
+        public let upperBound: Double
+
+        public init(title: String, lowerBound: Double, upperBound: Double) {
+            self.title = title
+            // Guarantee a non-empty, non-inverted range even for flat/empty data.
+            if lowerBound <= upperBound {
+                self.lowerBound = lowerBound
+                self.upperBound = upperBound
+            } else {
+                self.lowerBound = upperBound
+                self.upperBound = lowerBound
+            }
+        }
+    }
+
+    /// Everything a chart needs to build an `AXChartDescriptor`: title, summary,
+    /// labeled axes, and the ordered series points. Empty `points` means there is
+    /// nothing to sonify — callers should not attach a descriptor in that case.
+    public struct Descriptor: Sendable, Hashable {
+        public let title: String
+        public let summary: String
+        public let xAxis: NumericAxis
+        public let yAxis: NumericAxis
+        public let seriesName: String
+        /// True when the series is a continuous line (trend); false for discrete
+        /// bars/sectors (donut, heatmap) — maps to `AXDataSeriesDescriptor.isContinuous`.
+        public let isContinuous: Bool
+        public let points: [Point]
+
+        public init(
+            title: String,
+            summary: String,
+            xAxis: NumericAxis,
+            yAxis: NumericAxis,
+            seriesName: String,
+            isContinuous: Bool,
+            points: [Point]
+        ) {
+            self.title = title
+            self.summary = summary
+            self.xAxis = xAxis
+            self.yAxis = yAxis
+            self.seriesName = seriesName
+            self.isContinuous = isContinuous
+            self.points = points
+        }
+
+        /// No points to sonify.
+        public var isEmpty: Bool { points.isEmpty }
+    }
+
+    // MARK: - Net-worth trend
+
+    /// Audio graph for the net-worth trend line. The x axis is a day index over
+    /// the covered span (each point also labeled with its date); the y axis is
+    /// the recorded net-worth balance. Continuous, since the chart is a line.
+    ///
+    /// Returns a descriptor with no points when fewer than two snapshots exist —
+    /// the line chart itself isn't drawn below `BalanceTrend.requiredPointCount`,
+    /// so there is nothing to sonify.
+    public static func trend(_ trend: BalanceTrend, currencyCode: String = "USD") -> Descriptor {
+        let points = trend.points.enumerated().map { index, snapshot in
+            Point(
+                xValue: Double(index),
+                xLabel: Formatters.displayDate(snapshot.date),
+                yValue: snapshot.balance,
+                label: "\(Formatters.displayDate(snapshot.date)), "
+                    + Formatters.currency(snapshot.balance, format: .full, currencyCode: currencyCode)
+            )
+        }
+
+        let balances = trend.points.map(\.balance)
+        let yAxis = NumericAxis(
+            title: "Net worth",
+            lowerBound: balances.min() ?? 0,
+            upperBound: balances.max() ?? 0
+        )
+        let xAxis = NumericAxis(
+            title: "Day",
+            lowerBound: 0,
+            upperBound: Double(max(points.count - 1, 0))
+        )
+
+        return Descriptor(
+            title: "Net worth trend",
+            summary: trend.accessibilitySummary,
+            xAxis: xAxis,
+            yAxis: yAxis,
+            seriesName: "Net worth",
+            isContinuous: true,
+            points: points
+        )
+    }
+
+    // MARK: - Spend donut
+
+    /// Audio graph for the spend-by-category donut. Each slice becomes one
+    /// discrete point: x is the slice's rank index (spend-heaviest first, labeled
+    /// with the group title), y is the slice's spend amount. Discrete series.
+    ///
+    /// When Privacy Mask is on, amounts are still sonified (the pitch conveys
+    /// *relative* magnitude, not an exact figure) but the spoken summary omits the
+    /// dollar total — matching how the donut's spoken label hides exact amounts.
+    public static func donut(_ model: SpendDonutModel, isPrivacyMasked: Bool = false) -> Descriptor {
+        let points = model.slices.enumerated().map { index, slice in
+            Point(
+                xValue: Double(index),
+                xLabel: slice.title,
+                yValue: slice.amount,
+                label: isPrivacyMasked
+                    ? "\(slice.title), \(slice.shareText)"
+                    : "\(slice.title), \(slice.amountText), \(slice.shareText)"
+            )
+        }
+
+        let amounts = model.slices.map(\.amount)
+        let yAxis = NumericAxis(
+            title: "Spend",
+            lowerBound: 0,
+            upperBound: amounts.max() ?? 0
+        )
+        let xAxis = NumericAxis(
+            title: "Category rank",
+            lowerBound: 0,
+            upperBound: Double(max(points.count - 1, 0))
+        )
+
+        let summary: String = if isPrivacyMasked {
+            "Spending by category across \(model.sliceCount) "
+                + "\(model.sliceCount == 1 ? "group" : "groups"). Amounts hidden while Privacy Mask is on."
+        } else {
+            model.accessibilityLabel
+        }
+
+        return Descriptor(
+            title: "Spending by category",
+            summary: summary,
+            xAxis: xAxis,
+            yAxis: yAxis,
+            seriesName: "Spend by category",
+            isContinuous: false,
+            points: points
+        )
+    }
+
+    // MARK: - Activity heatmap
+
+    /// Audio graph for the 365-day activity heatmap. Only days with activity are
+    /// sonified (silent days carry no information and would flood the graph with
+    /// zero-pitch noise). x is a day index across the active days (each labeled
+    /// with its date), y is the day's signed value in the active mode. Discrete.
+    ///
+    /// When Privacy Mask is on, the per-point spoken label drops the exact amount
+    /// but keeps the date + transaction count, mirroring the heatmap's masked
+    /// header total. Returns no points when there is no activity.
+    public static func heatmap(
+        _ layout: SpendingHeatmapLayout,
+        isPrivacyMasked: Bool = false
+    ) -> Descriptor {
+        let activeDays = layout.days.filter { $0.transactionCount > 0 }
+
+        let points = activeDays.enumerated().map { index, day -> Point in
+            let dateText = Formatters.displayTransactionDate(day.date)
+            let amountText = SpendingHeatmap.amountText(for: day, mode: layout.mode)
+            let countText = SpendingHeatmap.transactionText(for: day)
+            let label = isPrivacyMasked
+                ? "\(dateText), \(countText)"
+                : "\(dateText), \(amountText), \(countText)"
+            return Point(
+                xValue: Double(index),
+                xLabel: dateText,
+                yValue: day.value,
+                label: label
+            )
+        }
+
+        let values = activeDays.map(\.value)
+        let yAxis = NumericAxis(
+            title: layout.mode == .spending ? "Spend" : "Net cashflow",
+            lowerBound: values.min() ?? 0,
+            upperBound: values.max() ?? 0
+        )
+        let xAxis = NumericAxis(
+            title: "Active day",
+            lowerBound: 0,
+            upperBound: Double(max(points.count - 1, 0))
+        )
+
+        let summary = "\(layout.mode.summaryTitle) heatmap with \(layout.activeDayCount) active "
+            + "\(layout.activeDayCount == 1 ? "day" : "days"). \(layout.mode.semanticDescription)."
+
+        return Descriptor(
+            title: layout.mode.summaryTitle,
+            summary: summary,
+            xAxis: xAxis,
+            yAxis: yAxis,
+            seriesName: layout.mode.shortLabel,
+            isContinuous: false,
+            points: points
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
+++ b/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
@@ -71,6 +71,12 @@ public enum ChartAudioGraph {
         /// True when the series is a continuous line (trend); false for discrete
         /// bars/sectors (donut, heatmap) — maps to `AXDataSeriesDescriptor.isContinuous`.
         public let isContinuous: Bool
+        /// True when Privacy Mask is on. The descriptor's point labels + summary are
+        /// already built masked by the relevant builder; this flag lets the SwiftUI
+        /// bridge also redact the y-axis *value descriptions* VoiceOver speaks while
+        /// scrubbing the audio graph (see `yAxisValueDescription(_:isMasked:)`), so a
+        /// masked chart never announces an exact figure through any channel (AND-569).
+        public let isPrivacyMasked: Bool
         public let points: [Point]
 
         public init(
@@ -80,6 +86,7 @@ public enum ChartAudioGraph {
             yAxis: NumericAxis,
             seriesName: String,
             isContinuous: Bool,
+            isPrivacyMasked: Bool = false,
             points: [Point]
         ) {
             self.title = title
@@ -88,11 +95,33 @@ public enum ChartAudioGraph {
             self.yAxis = yAxis
             self.seriesName = seriesName
             self.isContinuous = isContinuous
+            self.isPrivacyMasked = isPrivacyMasked
             self.points = points
         }
 
         /// No points to sonify.
         public var isEmpty: Bool { points.isEmpty }
+    }
+
+    // MARK: - Y-axis value description (privacy-aware)
+
+    /// The spoken description for a y-axis value in the audio graph.
+    ///
+    /// VoiceOver reads these as it scrubs the audio graph's value axis, so this is
+    /// a *third* place an exact amount can leak — alongside the per-point labels and
+    /// the summary, both of which the builders already redact under Privacy Mask.
+    /// When `isMasked` is true we return the masked placeholder instead of a
+    /// formatted currency figure; the audio graph's *pitch* still conveys relative
+    /// magnitude (that's not a figure), so the graph stays usable without speaking a
+    /// dollar amount (AND-569).
+    public static func yAxisValueDescription(
+        _ value: Double,
+        isMasked: Bool,
+        currencyCode: String = "USD"
+    ) -> String {
+        isMasked
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(value, format: .full, currencyCode: currencyCode)
     }
 
     // MARK: - Net-worth trend
@@ -185,6 +214,7 @@ public enum ChartAudioGraph {
             yAxis: yAxis,
             seriesName: "Spend by category",
             isContinuous: false,
+            isPrivacyMasked: isPrivacyMasked,
             points: points
         )
     }
@@ -242,6 +272,7 @@ public enum ChartAudioGraph {
             yAxis: yAxis,
             seriesName: layout.mode.shortLabel,
             isContinuous: false,
+            isPrivacyMasked: isPrivacyMasked,
             points: points
         )
     }

--- a/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
+++ b/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("ChartAudioGraph data → audio-graph descriptor mapping (AND-569)")
+struct ChartAudioGraphTests {
+    // MARK: - NumericAxis invariants
+
+    @Test("numeric axis keeps an ordered range")
+    func axisKeepsOrderedRange() {
+        let axis = ChartAudioGraph.NumericAxis(title: "Y", lowerBound: 10, upperBound: 100)
+        #expect(axis.lowerBound == 10)
+        #expect(axis.upperBound == 100)
+    }
+
+    @Test("numeric axis normalizes an inverted range")
+    func axisNormalizesInvertedRange() {
+        let axis = ChartAudioGraph.NumericAxis(title: "Y", lowerBound: 100, upperBound: 10)
+        #expect(axis.lowerBound == 10)
+        #expect(axis.upperBound == 100)
+    }
+
+    // MARK: - Trend
+
+    private func snapshot(_ daysAgo: Int, _ balance: Double, now: Date = Date()) -> BalanceSnapshot {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: now) ?? now
+        return BalanceSnapshot(date: date, balance: balance)
+    }
+
+    @Test("trend maps every snapshot to an ordered continuous point")
+    func trendMapsPoints() {
+        let now = Date()
+        let history = [snapshot(2, 1000, now: now), snapshot(1, 1500, now: now), snapshot(0, 1200, now: now)]
+        let trend = try! #require(BalanceTrend.evaluate(history: history, now: now, windowDays: 90))
+
+        let descriptor = ChartAudioGraph.trend(trend)
+
+        #expect(!descriptor.isEmpty)
+        #expect(descriptor.points.count == 3)
+        #expect(descriptor.isContinuous)
+        // x is a 0-based, monotonically increasing day index.
+        #expect(descriptor.points.map(\.xValue) == [0, 1, 2])
+        // y carries the real recorded balances in chronological order.
+        #expect(descriptor.points.map(\.yValue) == [1000, 1500, 1200])
+        // y axis spans the min/max balance.
+        #expect(descriptor.yAxis.lowerBound == 1000)
+        #expect(descriptor.yAxis.upperBound == 1500)
+        #expect(descriptor.yAxis.title == "Net worth")
+        // x axis spans the index range.
+        #expect(descriptor.xAxis.lowerBound == 0)
+        #expect(descriptor.xAxis.upperBound == 2)
+        // Summary reuses the chart's spoken summary so audio + label agree.
+        #expect(descriptor.summary == trend.accessibilitySummary)
+    }
+
+    @Test("trend point labels include the formatted balance")
+    func trendPointLabelsHaveAmounts() {
+        let now = Date()
+        let history = [snapshot(1, 1000, now: now), snapshot(0, 2000, now: now)]
+        let trend = try! #require(BalanceTrend.evaluate(history: history, now: now, windowDays: 90))
+
+        let descriptor = ChartAudioGraph.trend(trend)
+        // Last point is "today" with the $2,000 balance.
+        let last = try! #require(descriptor.points.last)
+        #expect(last.label.contains("2,000"))
+        #expect(last.xLabel == Formatters.displayDate(history[1].date))
+    }
+
+    // MARK: - Donut
+
+    private func donutModel(_ pairs: [(CategoryGroup, SpendingCategory, Double)]) -> SpendDonutModel {
+        let groups = pairs.map { group, leaf, spent in
+            CategoryDashboardPresentation.GroupRollup(
+                group: group,
+                leaves: [CategoryDashboardPresentation.Leaf(category: leaf, spent: spent, monthlyLimit: nil)]
+            )
+        }
+        return SpendDonutModel(presentation: CategoryDashboardPresentation(groups: groups))
+    }
+
+    @Test("donut maps each slice to a discrete point, spend-heaviest first")
+    func donutMapsSlices() {
+        let model = donutModel([
+            (.shopping, .shopping, 100),
+            (.foodAndDining, .foodAndDrink, 400),
+            (.transportation, .transportation, 250),
+        ])
+
+        let descriptor = ChartAudioGraph.donut(model)
+
+        #expect(descriptor.points.count == 3)
+        #expect(!descriptor.isContinuous)
+        // Ordered spend-heaviest first (inherited from the donut model order).
+        #expect(descriptor.points.map(\.yValue) == [400, 250, 100])
+        #expect(descriptor.points.map(\.xValue) == [0, 1, 2])
+        #expect(descriptor.points.map(\.xLabel) == ["Food & Dining", "Transportation", "Shopping"])
+        // y axis upper bound is the heaviest slice; floored at 0.
+        #expect(descriptor.yAxis.lowerBound == 0)
+        #expect(descriptor.yAxis.upperBound == 400)
+        // Unmasked summary is the donut's full spoken label.
+        #expect(descriptor.summary == model.accessibilityLabel)
+    }
+
+    @Test("donut point label carries amount + share when unmasked")
+    func donutLabelsHaveAmounts() {
+        let model = donutModel([(.foodAndDining, .foodAndDrink, 400)])
+        let descriptor = ChartAudioGraph.donut(model)
+        let point = try! #require(descriptor.points.first)
+        #expect(point.label.contains("Food & Dining"))
+        #expect(point.label.contains("$400"))
+        #expect(point.label.contains("100%"))
+    }
+
+    @Test("donut masks amounts in labels + summary when Privacy Mask is on")
+    func donutMaskedHidesAmounts() {
+        let model = donutModel([
+            (.foodAndDining, .foodAndDrink, 400),
+            (.shopping, .shopping, 100),
+        ])
+        let descriptor = ChartAudioGraph.donut(model, isPrivacyMasked: true)
+
+        // Pitch still carries relative magnitude (values are intact)...
+        #expect(descriptor.points.map(\.yValue) == [400, 100])
+        // ...but no spoken label or summary leaks a dollar amount.
+        for point in descriptor.points {
+            #expect(!point.label.contains("$"))
+            #expect(point.label.contains("%")) // share is kept
+        }
+        #expect(!descriptor.summary.contains("$"))
+        #expect(descriptor.summary.contains("Privacy Mask"))
+    }
+
+    @Test("empty donut yields an empty descriptor")
+    func donutEmpty() {
+        let model = SpendDonutModel(presentation: .empty)
+        let descriptor = ChartAudioGraph.donut(model)
+        #expect(descriptor.isEmpty)
+        #expect(descriptor.points.isEmpty)
+        // Degenerate index range stays non-inverted.
+        #expect(descriptor.xAxis.lowerBound == 0)
+        #expect(descriptor.xAxis.upperBound == 0)
+    }
+
+    // MARK: - Heatmap
+
+    private func transaction(_ date: String, amount: Double, category: SpendingCategory = .shopping) -> TransactionDTO {
+        TransactionDTO(
+            id: "\(date)-\(amount)",
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: "tx",
+            category: category
+        )
+    }
+
+    private func heatmapLayout(_ transactions: [TransactionDTO], mode: SpendingHeatmapMode = .spending) -> SpendingHeatmapLayout {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -10, to: end) ?? end
+        return SpendingHeatmapLayout.compute(
+            from: transactions,
+            startDate: start,
+            endDate: end,
+            mode: mode,
+            calendar: calendar
+        )
+    }
+
+    @Test("heatmap sonifies only active days, in order")
+    func heatmapActiveDaysOnly() {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let day1 = Formatters.transactionDateString(calendar.date(byAdding: .day, value: -3, to: end)!)
+        let day2 = Formatters.transactionDateString(calendar.date(byAdding: .day, value: -1, to: end)!)
+
+        let layout = heatmapLayout([
+            transaction(day1, amount: 50),
+            transaction(day2, amount: 120),
+        ])
+
+        let descriptor = ChartAudioGraph.heatmap(layout)
+
+        // Only the two days with transactions become points (silent days dropped).
+        #expect(descriptor.points.count == 2)
+        #expect(!descriptor.isContinuous)
+        #expect(descriptor.points.map(\.xValue) == [0, 1])
+        // Chronological: day1 (older) before day2 (newer).
+        #expect(descriptor.points[0].yValue == 50)
+        #expect(descriptor.points[1].yValue == 120)
+        #expect(descriptor.yAxis.title == "Spend")
+    }
+
+    @Test("heatmap point labels carry the amount when unmasked and hide it when masked")
+    func heatmapLabelMasking() {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let day = Formatters.transactionDateString(calendar.date(byAdding: .day, value: -2, to: end)!)
+        let layout = heatmapLayout([transaction(day, amount: 75)])
+
+        let unmasked = ChartAudioGraph.heatmap(layout)
+        #expect(try! #require(unmasked.points.first).label.contains("$75"))
+
+        let masked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: true)
+        let maskedPoint = try! #require(masked.points.first)
+        #expect(!maskedPoint.label.contains("$"))
+        #expect(maskedPoint.label.contains("transaction"))
+    }
+
+    @Test("empty heatmap yields an empty descriptor")
+    func heatmapEmpty() {
+        let layout = heatmapLayout([])
+        let descriptor = ChartAudioGraph.heatmap(layout)
+        #expect(descriptor.isEmpty)
+        #expect(descriptor.points.isEmpty)
+    }
+}

--- a/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
+++ b/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
@@ -214,4 +214,70 @@ struct ChartAudioGraphTests {
         #expect(descriptor.isEmpty)
         #expect(descriptor.points.isEmpty)
     }
+
+    // MARK: - Y-axis value description (Privacy Mask)
+
+    // This is the value description VoiceOver speaks while scrubbing the audio
+    // graph's value axis — the SwiftUI representable's `yAxis` provider calls this
+    // exact function, so testing it here covers the representable-level masking
+    // without a host view.
+
+    @Test("y-axis value description carries the exact amount when unmasked")
+    func yAxisValueUnmaskedHasAmount() {
+        let description = ChartAudioGraph.yAxisValueDescription(1234.56, isMasked: false)
+        #expect(description == Formatters.currency(1234.56, format: .full))
+        #expect(description.contains("1,234"))
+        #expect(description.contains("$"))
+    }
+
+    @Test("y-axis value description redacts the amount when masked")
+    func yAxisValueMaskedHidesAmount() {
+        let description = ChartAudioGraph.yAxisValueDescription(1234.56, isMasked: true)
+        // No exact figure / currency leaks through the spoken value axis.
+        #expect(!description.contains("$"))
+        #expect(!description.contains("1,234"))
+        #expect(!description.contains("1234"))
+        #expect(description == PrivacyMaskPresentation.compactValue)
+    }
+
+    @Test("donut descriptor carries the mask flag so the y-axis provider can redact")
+    func donutDescriptorPropagatesMaskFlag() {
+        let model = donutModel([(.foodAndDining, .foodAndDrink, 400)])
+
+        let unmasked = ChartAudioGraph.donut(model, isPrivacyMasked: false)
+        #expect(!unmasked.isPrivacyMasked)
+        #expect(ChartAudioGraph.yAxisValueDescription(unmasked.points[0].yValue, isMasked: unmasked.isPrivacyMasked).contains("$400"))
+
+        let masked = ChartAudioGraph.donut(model, isPrivacyMasked: true)
+        #expect(masked.isPrivacyMasked)
+        // y values are intact for pitch...
+        #expect(masked.points.map(\.yValue) == [400])
+        // ...but the spoken value description leaks no amount.
+        #expect(!ChartAudioGraph.yAxisValueDescription(masked.points[0].yValue, isMasked: masked.isPrivacyMasked).contains("$"))
+    }
+
+    @Test("heatmap descriptor carries the mask flag so the y-axis provider can redact")
+    func heatmapDescriptorPropagatesMaskFlag() {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let day = Formatters.transactionDateString(calendar.date(byAdding: .day, value: -2, to: end)!)
+        let layout = heatmapLayout([transaction(day, amount: 75)])
+
+        let unmasked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: false)
+        #expect(!unmasked.isPrivacyMasked)
+        #expect(ChartAudioGraph.yAxisValueDescription(unmasked.points[0].yValue, isMasked: unmasked.isPrivacyMasked).contains("$"))
+
+        let masked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: true)
+        #expect(masked.isPrivacyMasked)
+        #expect(!ChartAudioGraph.yAxisValueDescription(masked.points[0].yValue, isMasked: masked.isPrivacyMasked).contains("$"))
+    }
+
+    @Test("trend descriptor is unmasked (trend chart is not privacy-masked)")
+    func trendDescriptorIsUnmasked() {
+        let now = Date()
+        let history = [snapshot(1, 1000, now: now), snapshot(0, 2000, now: now)]
+        let trend = try! #require(BalanceTrend.evaluate(history: history, now: now, windowDays: 90))
+        let descriptor = ChartAudioGraph.trend(trend)
+        #expect(!descriptor.isPrivacyMasked)
+    }
 }


### PR DESCRIPTION
## Summary

VoiceOver users can now play and scrub an **audio graph** on VaultPeek's three data charts — the same series each chart already speaks as a one-line summary, but now navigable tone-by-tone via the "Describe Chart" → "Play Audio Graph" rotor action:

- **Net-worth trend line** (`BalanceTrendChart`) — a continuous series over the covered day span; each point labeled with its date + balance.
- **Spend-by-category donut** (`SpendDonutChart`, AND-537) — a discrete series, one point per category slice (spend-heaviest first), pitch-mapped to spend amount. It had **no** descriptor before (spoken label only); this adds one.
- **365-day activity heatmap** (`BalanceActivityHeatmap` in `MainPopover`) — a discrete series over *active* days only (silent days carry no signal), pitch-mapped to the day's signed value in the active mode (Spend / Net cashflow).

The pure data → audio-graph-point mapping lives in **PlaidBarCore** (`ChartAudioGraph`) as `Sendable` value types and is fully unit-tested without a host view. The thin SwiftUI bridge (`ChartAudioGraphRepresentable` + `.audioGraph(_:)`) translates those points into the `Accessibility`-framework `AXChartDescriptor` on demand.

## Linear (AND-569)

Implements **AND-569** (Audio Graph accessibility for charts) under parent epic **AND-562** (accessibility). Related to **AND-380** (chart VoiceOver summaries + scrub, Done) — the audio graph is the scrubbable counterpart to the spoken summaries that work shipped, and reuses each chart's existing `accessibilitySummary` / `accessibilityLabel` as the descriptor summary so audio and text stay in lockstep.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **green** (CI gate).
- `swift test` — **green**, 1602 tests (11 new in `ChartAudioGraphTests`).
- New tests cover: continuous trend point ordering + axis spans; donut discrete ordering + spend-heaviest-first + amount/share labels; heatmap active-days-only sonification + chronological order; **Privacy-Mask redaction** (pitch preserved, dollar amounts dropped from labels and summary); empty-data → empty descriptor (no-op); and `NumericAxis` range normalization (degenerate / inverted ranges).

## Architectural decisions

- **Core does the mapping; the view does the `AX*` translation.** `AXChartDescriptor` / `AXDataPoint` / `AXDataSeriesDescriptor` are reference types and not `Sendable`, so they can't live in `PlaidBarCore` (Swift 6 strict-concurrency boundary). `ChartAudioGraph.Descriptor` is a `Sendable` value model that is trivially unit-testable; `ChartAudioGraphRepresentable` builds the `AX*` graph lazily inside `makeChartDescriptor()` only when VoiceOver requests it.
- **`.audioGraph(_:)` is a no-op when the descriptor has no points**, so empty/loading charts never advertise an empty audio graph.
- **Privacy Mask aware** (per `SECURITY.md`/`ACCESSIBILITY.md`): when masking is on, pitch still conveys *relative* magnitude (the series values are intact), but no spoken point label or summary leaks an exact dollar figure — matching how the donut and heatmap already mask their visible totals. Meaning is never color-only: the audio graph carries the series purely through pitch + labeled numeric axes.
- API shapes (`AXChartDescriptorRepresentable`, `AXNumericDataAxisDescriptor`, `AXDataPoint(x:y:additionalValues:label:)`, `AXDataSeriesDescriptor(name:isContinuous:dataPoints:)`) confirmed against current Apple Accessibility docs via Context7 rather than guessed.

## Migration notes

None. Additive only — no API, schema, persisted-data, or behavior changes for sighted users. No new dependencies (`import Accessibility` is part of the SDK). Deployment target (macOS 26) already exceeds the macOS 12 minimum for `accessibilityChartDescriptor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
