### PR TITLE
feat(a11y): in-app text size control overriding macOS Dynamic Type (AND-570)

### DIFF
--- a/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
@@ -177,6 +177,10 @@ final class CategoryDashboardWindowController: NSObject, NSWindowDelegate {
             CategoryDashboardWindow()
                 .environment(appState)
                 .forcedCategoryDashboardColorScheme(forcedColorScheme)
+                // Apply the in-app text-size preference here too so the detached
+                // Category Dashboard scales with the same control as the popover
+                // (AND-570). Reads @AppStorage, so it tracks live changes.
+                .appliesAppTextSize()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
     }

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -417,6 +417,9 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                 // window's live (NSApp-driven) appearance and follows Light/Dark
                 // changes made while the window is open.
                 .forcedDetachedColorScheme(forcedColorScheme)
+                // Apply the in-app text-size preference so the floating desktop
+                // dashboard scales with the same control as the popover (AND-570).
+                .appliesAppTextSize()
                 // The panel owns its own width via resize; let the dashboard fill
                 // it rather than imposing the popover's screen-anchored width math.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -107,6 +107,12 @@ struct PlaidBarApp: App {
                 })
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
+                // Apply the in-app text-size preference once at the popover root
+                // so every @ScaledMetric/Text below it scales together — macOS
+                // ignores the system Dynamic Type setting for third-party apps,
+                // so this control is the only way users can enlarge VaultPeek's
+                // text (AND-570).
+                .appliesAppTextSize()
         } label: {
             MenuBarLabel()
                 .environment(appState)
@@ -320,6 +326,9 @@ struct PlaidBarApp: App {
                 .environment(appState)
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
+                // Scale the Settings window too, so the user sees the text-size
+                // change reflected in the very control they are adjusting (AND-570).
+                .appliesAppTextSize()
         }
     }
 
@@ -413,6 +422,15 @@ struct PlaidBarApp: App {
         }
     }
 
+    /// The in-app text-size preference forced by the `--text-size` CLI flag
+    /// (QA/screenshot aid: `--text-size default|large|xLarge|accessibility`), or
+    /// `nil` to follow the stored preference. Mirrors `forcedColorScheme`; lets a
+    /// QA pass cover the enlarged layouts without leaving a durable preference
+    /// behind (AND-570).
+    static var forcedTextSizePreference: TextSizePreference? {
+        CommandLineOptions.value(for: "--text-size").flatMap(TextSizePreference.init(rawValue:))
+    }
+
     private static func applyScreenshotDefaults() {
         guard CommandLine.arguments.contains("--demo") else { return }
 
@@ -480,6 +498,45 @@ private struct AppAppearanceApplier: ViewModifier {
     }
 }
 
+/// Applies the stored in-app text-size preference as a `dynamicTypeSize`
+/// environment value at the scene root, so every `@ScaledMetric`/`Text` below it
+/// scales together (AND-570). macOS ignores the system Dynamic Type setting for
+/// third-party apps, so this is the only lever users have to enlarge VaultPeek's
+/// text. The `--text-size` CLI override (QA aid) wins over the stored preference,
+/// mirroring `ForcedAppColorScheme`. Reading `@AppStorage` here means the whole
+/// subtree re-renders live the moment the Settings picker changes the value.
+struct AppTextSizeApplier: ViewModifier {
+    @AppStorage(TextSizePreference.storageKey) private var preferenceRaw = TextSizePreference.defaultValue.rawValue
+
+    private var resolvedSize: DynamicTypeSize {
+        let stored = TextSizePreference(rawValue: preferenceRaw) ?? .default
+        let forced = TextSizePreference.resolved(
+            cliOverride: PlaidBarApp.forcedTextSizePreference,
+            storedPreference: stored
+        )
+        return DynamicTypeSize(forced)
+    }
+
+    func body(content: Content) -> some View {
+        content.dynamicTypeSize(resolvedSize)
+    }
+}
+
+/// Bridges the SwiftUI-free Core `ForcedDynamicTypeSize` to SwiftUI's
+/// `DynamicTypeSize`. The Core enum keeps the case → size decision testable
+/// without importing SwiftUI; this 1:1 switch is the only place the two enums
+/// meet (parity with `ForcedColorScheme` → `ColorScheme`).
+extension DynamicTypeSize {
+    init(_ forced: ForcedDynamicTypeSize) {
+        switch forced {
+        case .large: self = .large
+        case .xLarge: self = .xLarge
+        case .xxLarge: self = .xxLarge
+        case .accessibility1: self = .accessibility1
+        }
+    }
+}
+
 /// Single mapping from the stored appearance mode to `NSApplication.appearance`,
 /// shared by the launch-time application (`PlaidBarApp.applyStoredAppearance`,
 /// before first paint) and the live `AppAppearanceApplier` (`onChange`). Making
@@ -506,5 +563,16 @@ private extension View {
 
     func appliesAppAppearance() -> some View {
         modifier(AppAppearanceApplier())
+    }
+}
+
+extension View {
+    /// Applies the stored in-app text-size preference at this point in the tree
+    /// (AND-570). Used at every scene/window root — the popover, Settings, and
+    /// the three detached AppKit-hosted windows — so the choice scales every
+    /// surface uniformly. Internal (not file-private) so the window controllers
+    /// in `App/` can share the one definition.
+    func appliesAppTextSize() -> some View {
+        modifier(AppTextSizeApplier())
     }
 }

--- a/Sources/PlaidBar/App/ReviewTableWindowController.swift
+++ b/Sources/PlaidBar/App/ReviewTableWindowController.swift
@@ -175,6 +175,9 @@ final class ReviewTableWindowController: NSObject, NSWindowDelegate {
             ReviewTableWindow()
                 .environment(appState)
                 .forcedReviewTableColorScheme(forcedColorScheme)
+                // Scale the detached review Table with the same in-app text-size
+                // preference as every other surface (AND-570).
+                .appliesAppTextSize()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
     }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -76,6 +76,7 @@ struct AppearanceSettingsView: View {
     @AppStorage(AppContrastPreference.storageKey) private var contrastRaw = AppContrastPreference.defaultValue.rawValue
     @AppStorage(DecorativeEffectsPreference.storageKey) private var decorativeRaw = DecorativeEffectsPreference.defaultValue.rawValue
     @AppStorage(AppDensityPreference.storageKey) private var densityRaw = AppDensityPreference.defaultValue.rawValue
+    @AppStorage(TextSizePreference.storageKey) private var textSizeRaw = TextSizePreference.defaultValue.rawValue
     @Environment(\.colorSchemeContrast) private var systemContrast
 
     private var transparencySetting: PopoverTransparencySetting {
@@ -86,6 +87,7 @@ struct AppearanceSettingsView: View {
     private var contrastPreference: AppContrastPreference { AppContrastPreference(rawValue: contrastRaw) ?? .followSystem }
     private var decorativePreference: DecorativeEffectsPreference { DecorativeEffectsPreference(rawValue: decorativeRaw) ?? .followSystem }
     private var density: AppDensityPreference { AppDensityPreference(rawValue: densityRaw) ?? .comfortable }
+    private var textSize: TextSizePreference { TextSizePreference(rawValue: textSizeRaw) ?? .default }
 
     /// Increased contrast applies when the app pref asks for it OR the system
     /// Increase Contrast accessibility setting is on (system always wins).
@@ -208,6 +210,38 @@ struct AppearanceSettingsView: View {
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            Section("Text Size") {
+                // macOS does not honor the system Dynamic Type setting for
+                // third-party apps, so this control is the only way to enlarge
+                // VaultPeek's text. The picker writes the persisted preference;
+                // the scene roots read it and set `.dynamicTypeSize` app-wide so
+                // every surface scales together (AND-570).
+                Picker("Text Size", selection: Binding(
+                    get: { textSize },
+                    set: { textSizeRaw = $0.rawValue }
+                )) {
+                    ForEach(TextSizePreference.allCases) { Text($0.title).tag($0) }
+                }
+                .accessibilityValue(textSize.title)
+                .accessibilityHint("Sets the text size for all of VaultPeek")
+
+                // Live preview: synthetic text scaled to the selected size, so the
+                // effect is visible the instant the picker changes — privacy-safe
+                // (no real account data). `.dynamicTypeSize` here mirrors what the
+                // scene roots apply app-wide.
+                TextSizePreviewRow()
+                    .dynamicTypeSize(DynamicTypeSize(textSize.forcedDynamicTypeSize))
+                    .padding(.vertical, Spacing.xxs)
+
+                Text(textSize.detail)
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("macOS ignores the system Dynamic Type setting for apps, so use this to make VaultPeek's text larger everywhere. The largest steps reflow some layouts to keep numbers legible.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -312,6 +346,31 @@ private struct AppearancePreviewCard: View {
         .accessibilityLabel(
             "Live preview of the popover at \(setting.displayPercent) percent transparency, with sample data only."
         )
+    }
+}
+
+/// Privacy-safe live preview of the in-app text size (AND-570). Synthetic labels
+/// scaled by the caller's `.dynamicTypeSize` — never real account data — so the
+/// user sees the effect of the Text Size picker the instant it changes. Uses a
+/// semantic text style and the hero-balance modifier so the preview tracks the
+/// same scaling path as the real dashboard surfaces.
+private struct TextSizePreviewRow: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("Net Worth")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text("$12,345.67")
+                .heroBalance()
+            Text("Preview only — sample data")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.sm)
+        .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Live preview of the selected text size, with sample data only.")
     }
 }
 

--- a/Sources/PlaidBarCore/Models/TextSizePreference.swift
+++ b/Sources/PlaidBarCore/Models/TextSizePreference.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// In-app text-size / display-scaling preference (AND-570).
+///
+/// macOS does **not** honor the system Dynamic Type setting for third-party
+/// apps, so users cannot enlarge VaultPeek's text from System Settings the way
+/// they can on iOS. VaultPeek's typography already *responds* to a
+/// `DynamicTypeSize` environment value (`@ScaledMetric`, shipped in AND-515) —
+/// this preference is the missing user control that *sets* that value, applied
+/// once at the scene root so every surface scales together.
+///
+/// This is a pure, `Sendable`, SwiftUI-free Core model so the case → size
+/// mapping, persisted `rawValue`, and display label can be unit-tested without
+/// importing SwiftUI. The app layer maps `ForcedDynamicTypeSize` to the actual
+/// `SwiftUI.DynamicTypeSize` (mirroring how `AppAppearanceMode` maps to
+/// `ForcedColorScheme` → `SwiftUI.ColorScheme`).
+///
+/// The case set is intentionally clamped to the `.large … .accessibility3`
+/// band that the hero/display typography in `Typography.swift` already supports
+/// (`.dynamicTypeSize(.xSmall ... .accessibility3)`), so no surface is pushed
+/// past a step it has decided to cap at.
+public enum TextSizePreference: String, CaseIterable, Sendable, Identifiable {
+    /// The macOS-standard text size — VaultPeek's default, equivalent to
+    /// `DynamicTypeSize.large` (the system's "L" default step).
+    case `default`
+    /// One step up — `DynamicTypeSize.xLarge`.
+    case large
+    /// Two steps up — `DynamicTypeSize.xxLarge`.
+    case xLarge
+    /// The first accessibility step — `DynamicTypeSize.accessibility1`. Large
+    /// enough to noticeably reflow layout; still within the typography clamp.
+    case accessibility
+
+    public static let storageKey = "appearance.textSize"
+    public static let defaultValue: TextSizePreference = .default
+
+    public var id: String { rawValue }
+
+    /// Human-readable label shown in Settings.
+    public var title: String {
+        switch self {
+        case .default: "Default"
+        case .large: "Large"
+        case .xLarge: "Extra Large"
+        case .accessibility: "Accessibility"
+        }
+    }
+
+    /// A short caption describing the relative effect, used as supplementary
+    /// (never color-only) feedback next to the control.
+    public var detail: String {
+        switch self {
+        case .default: "Standard macOS text size."
+        case .large: "Slightly larger text across VaultPeek."
+        case .xLarge: "Noticeably larger text across VaultPeek."
+        case .accessibility: "Largest text — best for low vision; some layouts reflow."
+        }
+    }
+
+    /// The SwiftUI-free Dynamic Type step this preference maps to. The app layer
+    /// converts this to `SwiftUI.DynamicTypeSize` at the scene root.
+    public var forcedDynamicTypeSize: ForcedDynamicTypeSize {
+        switch self {
+        case .default: .large
+        case .large: .xLarge
+        case .xLarge: .xxLarge
+        case .accessibility: .accessibility1
+        }
+    }
+
+    /// Resolves the effective step. A `--text-size` CLI override (QA aid) wins
+    /// over the stored preference, mirroring how `--appearance` overrides the
+    /// stored appearance mode. `nil` override → stored preference decides.
+    public static func resolved(
+        cliOverride: TextSizePreference?,
+        storedPreference: TextSizePreference
+    ) -> ForcedDynamicTypeSize {
+        (cliOverride ?? storedPreference).forcedDynamicTypeSize
+    }
+}
+
+/// A concrete Dynamic Type step, kept SwiftUI-free so it lives in Core and can
+/// be unit-tested. The raw values match `SwiftUI.DynamicTypeSize` case names so
+/// the app-layer bridge is an unambiguous 1:1 mapping.
+public enum ForcedDynamicTypeSize: String, CaseIterable, Sendable, Equatable {
+    case large
+    case xLarge
+    case xxLarge
+    case accessibility1
+
+    /// Monotonic rank (smallest → largest) for ordering/clamping logic and
+    /// assertions, independent of the SwiftUI enum's `Comparable` conformance.
+    public var rank: Int {
+        switch self {
+        case .large: 0
+        case .xLarge: 1
+        case .xxLarge: 2
+        case .accessibility1: 3
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/TextSizePreferenceTests.swift
+++ b/Tests/PlaidBarCoreTests/TextSizePreferenceTests.swift
@@ -1,0 +1,124 @@
+import PlaidBarCore
+import Testing
+
+@Suite("In-app text size preference (AND-570)")
+struct TextSizePreferenceTests {
+    // MARK: Case → Dynamic Type mapping
+
+    @Test("Each case maps to the expected Dynamic Type step")
+    func mapsToExpectedStep() {
+        #expect(TextSizePreference.default.forcedDynamicTypeSize == .large)
+        #expect(TextSizePreference.large.forcedDynamicTypeSize == .xLarge)
+        #expect(TextSizePreference.xLarge.forcedDynamicTypeSize == .xxLarge)
+        #expect(TextSizePreference.accessibility.forcedDynamicTypeSize == .accessibility1)
+    }
+
+    @Test("Larger preferences map to monotonically larger Dynamic Type ranks")
+    func mappingIsMonotonic() {
+        let ordered: [TextSizePreference] = [.default, .large, .xLarge, .accessibility]
+        let ranks = ordered.map(\.forcedDynamicTypeSize.rank)
+        #expect(ranks == ranks.sorted())
+        // And strictly increasing: no two preferences collapse to one step.
+        #expect(Set(ranks).count == ranks.count)
+    }
+
+    // MARK: Default
+
+    @Test("Default preference is the macOS-standard (.default → .large) size")
+    func defaultIsStandard() {
+        #expect(TextSizePreference.defaultValue == .default)
+        #expect(TextSizePreference.defaultValue.forcedDynamicTypeSize == .large)
+        #expect(ForcedDynamicTypeSize.large.rank == 0)
+    }
+
+    // MARK: CLI override precedence
+
+    @Test("The --text-size CLI override wins over the stored preference")
+    func cliOverrideWins() {
+        // Override says accessibility, stored says default → override wins.
+        #expect(
+            TextSizePreference.resolved(cliOverride: .accessibility, storedPreference: .default)
+                == .accessibility1
+        )
+        // No override → stored preference decides.
+        #expect(
+            TextSizePreference.resolved(cliOverride: nil, storedPreference: .xLarge) == .xxLarge
+        )
+        #expect(
+            TextSizePreference.resolved(cliOverride: nil, storedPreference: .default) == .large
+        )
+    }
+
+    // MARK: Persistence round-trip
+
+    @Test("Raw values are stable and round-trip through the persisted string")
+    func rawValueRoundTrip() {
+        // Stable persisted identifiers — changing these would silently reset
+        // every user's stored choice on upgrade.
+        #expect(TextSizePreference.default.rawValue == "default")
+        #expect(TextSizePreference.large.rawValue == "large")
+        #expect(TextSizePreference.xLarge.rawValue == "xLarge")
+        #expect(TextSizePreference.accessibility.rawValue == "accessibility")
+
+        for preference in TextSizePreference.allCases {
+            #expect(TextSizePreference(rawValue: preference.rawValue) == preference)
+        }
+    }
+
+    @Test("ForcedDynamicTypeSize raw values mirror the SwiftUI case names")
+    func forcedRawValuesMirrorSwiftUI() {
+        #expect(ForcedDynamicTypeSize.large.rawValue == "large")
+        #expect(ForcedDynamicTypeSize.xLarge.rawValue == "xLarge")
+        #expect(ForcedDynamicTypeSize.xxLarge.rawValue == "xxLarge")
+        #expect(ForcedDynamicTypeSize.accessibility1.rawValue == "accessibility1")
+    }
+
+    @Test("An unknown persisted raw value decodes to nil (caller falls back to default)")
+    func unknownRawValueIsNil() {
+        #expect(TextSizePreference(rawValue: "humongous") == nil)
+    }
+
+    // MARK: Identifiable + storage key
+
+    @Test("Identifiable id mirrors the persisted raw value for every case")
+    func identifiersMatchRawValues() {
+        for preference in TextSizePreference.allCases {
+            #expect(preference.id == preference.rawValue)
+        }
+    }
+
+    @Test("Storage key is namespaced under appearance.* and distinct from siblings")
+    func storageKey() {
+        #expect(TextSizePreference.storageKey == "appearance.textSize")
+        // Distinct from the other appearance.* keys so it never collides.
+        let siblings = Set([
+            AppAppearanceMode.storageKey,
+            AppContrastPreference.storageKey,
+            DecorativeEffectsPreference.storageKey,
+            AppDensityPreference.storageKey,
+            PopoverTransparencySetting.storageKey,
+        ])
+        #expect(!siblings.contains(TextSizePreference.storageKey))
+    }
+
+    @Test("CaseIterable exposes every option")
+    func caseCount() {
+        #expect(TextSizePreference.allCases.count == 4)
+        #expect(ForcedDynamicTypeSize.allCases.count == 4)
+    }
+
+    // MARK: Human-readable labels
+
+    @Test("Each preference exposes a stable, non-empty title and detail")
+    func labels() {
+        #expect(TextSizePreference.default.title == "Default")
+        #expect(TextSizePreference.large.title == "Large")
+        #expect(TextSizePreference.xLarge.title == "Extra Large")
+        #expect(TextSizePreference.accessibility.title == "Accessibility")
+
+        for preference in TextSizePreference.allCases {
+            #expect(!preference.title.isEmpty)
+            #expect(!preference.detail.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

macOS does **not** honor the system Dynamic Type setting for third-party apps, so VaultPeek users had no way to enlarge the app's text. The typography already *responds* to a `DynamicTypeSize` environment value (`@ScaledMetric`, shipped in AND-515) — this PR adds the missing user control that *sets* that value, applied once at every scene/window root so every surface scales together.

- **Core model** — new `TextSizePreference` (`default` / `large` / `xLarge` / `accessibility`) with a SwiftUI-free `ForcedDynamicTypeSize` mapping, stable persisted `rawValue`, display `title`/`detail`, and a `--text-size` CLI-override resolver. Mirrors the existing `AppearancePreferences` pattern (`storageKey` / `defaultValue` / `Identifiable`). Cases are clamped to the `.large … .accessibility1` band that the hero/display typography already supports.
- **App-wide application** — a shared `.appliesAppTextSize()` modifier reads `@AppStorage(TextSizePreference.storageKey)` and sets `.dynamicTypeSize` at the popover root, the Settings root, and the three detached AppKit-hosted window roots (floating dashboard, Category Dashboard, Review Table). A `DynamicTypeSize(ForcedDynamicTypeSize)` initializer is the single SwiftUI/Core meeting point (parity with `ForcedColorScheme` → `ColorScheme`).
- **Settings** — a dedicated "Text Size" section in Appearance with a labeled, VoiceOver-hinted `Picker` and a privacy-safe live preview (synthetic `$12,345.67` net-worth row, never real data) that scales as you change the picker.

## Linear

[AND-570](https://linear.app/and/issue/AND-570) — In-app text size / display scaling control. Parent epic AND-562 (accessibility); related AND-365 (appearance/display comfort) and AND-515 (`@ScaledMetric` typography).

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green (CI gate).
- `swift test` — **1624 tests pass**, including 11 new `TextSizePreferenceTests`: case→`DynamicTypeSize` mapping, strict monotonicity, default (`.default` → `.large`), `--text-size` CLI-override precedence, `rawValue` round-trip + unknown-value → `nil`, `appearance.*` storage-key isolation, `Identifiable`/case-count, and non-empty labels.

## Architectural decisions

- **Pure logic in Core, SwiftUI bridge in app.** `TextSizePreference` keeps the case→size decision testable without importing SwiftUI; `ForcedDynamicTypeSize` (raw values match the SwiftUI case names) crosses into `SwiftUI.DynamicTypeSize` in one app-layer `init`. This is the same split AND-365 uses for `ForcedColorScheme`.
- **Apply at roots, not per-view.** Setting `.dynamicTypeSize` once at each scene/window root means every `@ScaledMetric`/`Text` below it scales — no view edits required, and the three detached windows stay in sync because the modifier reads `@AppStorage` (live updates).
- **Menu-bar label intentionally unscaled.** The status-item text lives in the system menu bar; enlarging it would clip/misalign the item, so the label root does not get `.appliesAppTextSize()`.
- **Case set clamped to the supported band.** Hero/display surfaces already cap at `.accessibility3`; keeping the preference at `.accessibility1` max guarantees no surface is pushed past a step it has decided to clamp.

## Migration notes

None. New persisted key `appearance.textSize` defaults to `.default` (raw value `"default"`), which maps to `DynamicTypeSize.large` — the current/standard rendering — so existing installs see no visual change until a user opts in. No data migration; unknown stored values fall back to the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)