### PR TITLE
docs: nightly documentation sync (2026-06-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,21 +465,23 @@ PlaidBar/                            # repo checkout (repo rename pending)
 │   │   ├── Models/                  # Local cache models
 │   │   ├── Services/                # HTTP client, refresh, launch
 │   │   └── Settings/                # Preferences window
+│   ├── PlaidBarWidgetExtension/     # Widget + Control Center control + App Intents (App Group glance surfaces)
 │   ├── PlaidBarServer/              # Local companion server
 │   │   ├── Routes/                  # REST endpoints
 │   │   ├── Plaid/                   # Plaid API client + models
 │   │   ├── Storage/                 # Fluent models + migrations
 │   │   └── Config/                  # Server configuration
+│   ├── PlaidBarCLI/                 # plaidbar-cli — command-line access to the local server
 │   └── PlaidBarCore/                # Shared library
 │       ├── Models/                  # DTOs, dashboard presenters, local AI receipts
 │       └── Utilities/               # Currency formatters, constants, reducers
-├── Tests/                           # Swift Testing suites for all 3 targets
+├── Tests/                           # Swift Testing suites for the app, server, and core library
 ├── Scripts/                         # build.sh, run.sh, screenshots.sh
 ├── Assets/                          # README screenshots
 ├── DESIGN.md                        # Design system spec
 ├── PRD.md                           # Product requirements
 ├── .github/workflows/ci.yml        # GitHub Actions CI
-├── Package.swift                    # SPM with 3 targets
+├── Package.swift                    # SPM with 5 source targets (app, widget extension, server, CLI, core)
 └── LICENSE                          # Proprietary
 ```
 
@@ -491,11 +493,11 @@ VaultPeek uses these Plaid endpoints:
 |----------|---------|------|-----------|
 | `/link/token/create` | Account setup | Free | On-demand |
 | `/item/public_token/exchange` | Account setup | Free | Once per bank |
-| `/accounts/get` | Cached balances | Free | Every 15 min |
+| `/accounts/get` | Cached balances | Free | ≤ Twice a day (default) or manual |
 | `/accounts/balance/get` | Real-time balances | Per-request | Manual refresh |
-| `/transactions/sync` | Transactions | Per-item | Every 30 min |
+| `/transactions/sync` | Transactions | Per-item | ≤ Twice a day (default) or manual |
 
-Rate limits are well within Plaid's allowances for personal use (~2-4 requests/hour/item).
+Rate limits are well within Plaid's allowances for personal use — automatic refresh is capped at roughly twice a day per item by default, plus on-demand manual refreshes.
 
 ## Security
 


### PR DESCRIPTION
Automated nightly documentation sync. Brings `README.md` back in line with the codebase after the 2026-06-17/18 macOS 26 glance-surface and refresh-policy work. **Documentation only — no code changes.**

## What changed and why

### `README.md` — Project Structure tree
- **Added `PlaidBarWidgetExtension/`** to the `Sources/` tree. This target (widget + Control Center control + App Intents over an App Group) was built out on 2026-06-18 in AND-513 ([#540](https://github.com/ftchvs/VaultPeek/pull/540), [#542](https://github.com/ftchvs/VaultPeek/pull/542)) and is already documented in `ARCHITECTURE.md`, but the README tree still omitted it.
- **Added `PlaidBarCLI/`** (`plaidbar-cli`), a source target the tree had never listed.
- **Corrected the stale target count** in two annotations: `Tests/` "for all 3 targets" → "for the app, server, and core library", and `Package.swift` "SPM with 3 targets" → "SPM with 5 source targets (app, widget extension, server, CLI, core)". `Package.swift` now defines 5 source targets.

### `README.md` — Plaid API Usage table
- Replaced the obsolete automatic-refresh cadence ("Every 15 min" for `/accounts/get`, "Every 30 min" for `/transactions/sync`) with the current `AutomaticRefreshPolicy` default: **≤ twice a day, or manual only**. Introduced in AND-486 ([#486](https://github.com/ftchvs/VaultPeek/pull/486)) and enforced by [#495](https://github.com/ftchvs/VaultPeek/pull/495); see `Sources/PlaidBarCore/Models/AutomaticRefreshPolicy.swift`.
- Updated the rate-limit note to match the lighter cadence.

## Deliberately left unchanged
- **`ARCHITECTURE.md` / `docs/architecture.md`** — already synced for the macOS 26 glance surfaces in-window (`d7c6363`, `cf7e5a2`).
- **`CLAUDE.md`** — carries the same stale "3 targets" wording, but it has **uncommitted local WIP** (a Context7 MCP section) in the working tree. Left untouched to avoid bundling/clobbering that pending work. Flagged here as a follow-up: its "Build all 3 targets" / "Three SPM targets" lines should get the same correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)