### PR TITLE
fix(tests): remove redundant Swift Testing requires

### DIFF
--- a/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
@@ -237,8 +237,11 @@ struct BalanceProjectorTests {
             now: Self.asOf,
             calendar: Self.calendar
         )
-        let projection = try? #require(presentation.projection)
-        #expect(projection?.anchorBalance == 1_200)
+        guard case let .available(projection) = presentation else {
+            Issue.record("expected available projection")
+            return
+        }
+        #expect(projection.anchorBalance == 1_200)
     }
 
     @Test("Demo data produces a non-trivial projection in-window")
@@ -253,9 +256,12 @@ struct BalanceProjectorTests {
             horizonDays: 30,
             calendar: Self.calendar
         )
-        let projection = try? #require(presentation.projection)
+        guard case let .available(projection) = presentation else {
+            Issue.record("expected available projection")
+            return
+        }
         // The forward line should step (not stay perfectly flat) given demo bills.
-        let balances = Set(projection?.series.map(\.balance) ?? [])
+        let balances = Set(projection.series.map(\.balance))
         #expect(balances.count > 1)
     }
 

--- a/Tests/PlaidBarCoreTests/InlineCategoryRulePromptTests.swift
+++ b/Tests/PlaidBarCoreTests/InlineCategoryRulePromptTests.swift
@@ -16,12 +16,11 @@ struct InlineCategoryRulePromptTests {
 
         let rule = prompt.buildRule()
 
-        let unwrapped = try? #require(rule)
-        #expect(unwrapped?.matchMerchantContains == "Blue Bottle Coffee")
-        #expect(unwrapped?.category == .foodAndDrink)
+        #expect(rule?.matchMerchantContains == "Blue Bottle Coffee")
+        #expect(rule?.category == .foodAndDrink)
         // A category rule never silently sets transfer/exclusion flags.
-        #expect(unwrapped?.isTransfer == nil)
-        #expect(unwrapped?.excludedFromBudgets == nil)
+        #expect(rule?.isTransfer == nil)
+        #expect(rule?.excludedFromBudgets == nil)
     }
 
     @Test("Built rule actually matches a transaction from that merchant")

--- a/Tests/PlaidBarCoreTests/WatchlistEvaluatorTests.swift
+++ b/Tests/PlaidBarCoreTests/WatchlistEvaluatorTests.swift
@@ -148,8 +148,11 @@ struct WatchlistEvaluatorTests {
             calendar: Self.calendar,
             config: config
         )
-        let decision = try? #require(first.decisions.first { $0.kind == .merchantWatch })
-        #expect(decision != nil)
+        guard let decision = first.decisions.first(where: { $0.kind == .merchantWatch }) else {
+            Issue.record("expected merchant watch decision")
+            return
+        }
+        #expect(decision.kind == .merchantWatch)
 
         let second = NotificationTriggerSelection.evaluate(
             transactions: transactions,
@@ -157,9 +160,9 @@ struct WatchlistEvaluatorTests {
             now: Self.now,
             calendar: Self.calendar,
             config: config,
-            deliveredDedupKeys: [decision!.dedupKey]
+            deliveredDedupKeys: [decision.dedupKey]
         )
-        #expect(!second.decisions.contains { $0.dedupKey == decision!.dedupKey })
+        #expect(!second.decisions.contains { $0.dedupKey == decision.dedupKey })
     }
 
     @Test("dedupKey is stable per target+month+threshold but changes when any of them changes")


### PR DESCRIPTION
## Summary

- Removes redundant Swift Testing `try? #require(...)` wrappers that are diagnosed as errors under `-warnings-as-errors`.
- Preserves the same test intent with direct optional assertions or explicit guard/pattern checks.
- Keeps this as a test-only strict-build hygiene fix.

Fixes #561
Linear: AND-574

## Verification

```bash
git diff --check
swift test --filter 'InlineCategoryRulePromptTests|BalanceProjectorTests|WatchlistEvaluatorTests|AppLockPresentationTests' \
  -Xswiftc -strict-concurrency=complete \
  -Xswiftc -warnings-as-errors
```

Result: focused strict command built successfully and ran 60 tests, all passed.

## Privacy/security

No Plaid credentials, access/public tokens, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies are touched. Test-only change.
