### PR TITLE
refactor: extract sync-staleness derivation from AppState into PlaidBarCore

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1371,29 +1371,21 @@ final class AppState {
     }
 
     var isSyncStale: Bool {
-        // Staleness is a verdict about completed syncs. During the boot
-        // handshake the first sync is still in flight, so stale warnings
-        // (menu bar badge, row tints, status strip) stay reserved for real
-        // staleness measured after the check completes.
-        if isBootLoadInFlight { return false }
-        guard let lastSyncDate else { return true }
-        // Align the stale threshold with the automatic-refresh floor so a normally
-        // behaving install (now refreshing at most ~twice a day) doesn't flag
-        // "stale"/broken-connection between refreshes. Manual-only has no floor,
-        // so allow a full day before nagging.
-        let policyFloor = automaticRefreshPolicy.minimumInterval ?? (24 * 60 * 60)
-        let staleAfter = max(
-            refreshInterval * 2,
-            PlaidBarConstants.transactionSyncInterval * 2,
-            policyFloor + 60 * 60
+        SyncStaleness.isStale(
+            isBootLoadInFlight: isBootLoadInFlight,
+            lastSyncDate: lastSyncDate,
+            refreshInterval: refreshInterval,
+            refreshPolicy: automaticRefreshPolicy,
+            asOf: Date()
         )
-        return Date().timeIntervalSince(lastSyncDate) > staleAfter
     }
 
     var statusSyncText: String {
-        if isBootLoadInFlight { return "Syncing" }
-        guard let lastSyncRelative else { return "Never synced" }
-        return isSyncStale ? "Stale \(lastSyncRelative)" : "Synced \(lastSyncRelative)"
+        SyncStaleness.statusText(
+            isBootLoadInFlight: isBootLoadInFlight,
+            lastSyncRelative: lastSyncRelative,
+            isStale: isSyncStale
+        )
     }
 
     var creditAccounts: [AccountDTO] {

--- a/Sources/PlaidBarCore/Utilities/SyncStaleness.swift
+++ b/Sources/PlaidBarCore/Utilities/SyncStaleness.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Pure derivation of whether the last completed sync is "stale" and the
+/// corresponding status-strip text. Extracted from `AppState` so the threshold
+/// math and the boot/never-synced fall-throughs are unit-testable by both
+/// processes without standing up the SwiftUI app state.
+///
+/// Staleness is a verdict about *completed* syncs: during the boot handshake the
+/// first sync is still in flight, so stale warnings (menu-bar badge, row tints,
+/// status strip) stay reserved for real staleness measured after the check
+/// completes.
+public enum SyncStaleness {
+    /// Default fall-back floor used when the refresh policy imposes no minimum
+    /// interval (manual-only): wait a full day before nagging about staleness.
+    public static let manualOnlyFloor: TimeInterval = 24 * 60 * 60
+
+    /// Slack added on top of the policy floor so a normally behaving install
+    /// (refreshing at most ~twice a day) doesn't flag "stale" between refreshes.
+    private static let policyFloorSlack: TimeInterval = 60 * 60
+
+    /// The elapsed-time threshold after which a completed sync is considered
+    /// stale. Aligns with the automatic-refresh floor so a normally behaving
+    /// install doesn't flag "stale"/broken-connection between scheduled refreshes;
+    /// manual-only has no floor, so it allows a full day.
+    public static func staleThreshold(
+        refreshInterval: TimeInterval,
+        transactionSyncInterval: TimeInterval = PlaidBarConstants.transactionSyncInterval,
+        refreshPolicy: AutomaticRefreshPolicy
+    ) -> TimeInterval {
+        let policyFloor = refreshPolicy.minimumInterval ?? manualOnlyFloor
+        return max(
+            refreshInterval * 2,
+            transactionSyncInterval * 2,
+            policyFloor + policyFloorSlack
+        )
+    }
+
+    /// Whether the last completed sync is stale.
+    ///
+    /// - During the boot handshake (`isBootLoadInFlight`) the first sync is still
+    ///   in flight, so this is always `false`.
+    /// - A never-synced state (`lastSyncDate == nil`) past boot is treated as
+    ///   stale, so the UI nudges the user to connect/refresh.
+    public static func isStale(
+        isBootLoadInFlight: Bool,
+        lastSyncDate: Date?,
+        refreshInterval: TimeInterval,
+        transactionSyncInterval: TimeInterval = PlaidBarConstants.transactionSyncInterval,
+        refreshPolicy: AutomaticRefreshPolicy,
+        asOf now: Date
+    ) -> Bool {
+        if isBootLoadInFlight { return false }
+        guard let lastSyncDate else { return true }
+        let staleAfter = staleThreshold(
+            refreshInterval: refreshInterval,
+            transactionSyncInterval: transactionSyncInterval,
+            refreshPolicy: refreshPolicy
+        )
+        return now.timeIntervalSince(lastSyncDate) > staleAfter
+    }
+
+    /// The status-strip sync text. `lastSyncRelative` is the human-readable
+    /// relative timestamp of the last sync (e.g. "2h ago"), or `nil` if never
+    /// synced.
+    public static func statusText(
+        isBootLoadInFlight: Bool,
+        lastSyncRelative: String?,
+        isStale: Bool
+    ) -> String {
+        if isBootLoadInFlight { return "Syncing" }
+        guard let lastSyncRelative else { return "Never synced" }
+        return isStale ? "Stale \(lastSyncRelative)" : "Synced \(lastSyncRelative)"
+    }
+}

--- a/Tests/PlaidBarCoreTests/SyncStalenessTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncStalenessTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("SyncStaleness Tests")
+struct SyncStalenessTests {
+    private let oneHour: TimeInterval = 60 * 60
+    private let twelveHours: TimeInterval = 12 * 60 * 60
+
+    // MARK: - staleThreshold
+
+    @Test("threshold: twiceDaily floor (policyFloor + 1h) wins for a short refresh interval")
+    func thresholdTwiceDailyPolicyFloorWins() {
+        // refreshInterval*2 = 7200, transactionSyncInterval*2 = 3600,
+        // policyFloor (12h) + 1h slack = 46800 → max is 46800.
+        let threshold = SyncStaleness.staleThreshold(
+            refreshInterval: oneHour,
+            refreshPolicy: .twiceDaily
+        )
+        #expect(threshold == twelveHours + oneHour)
+    }
+
+    @Test("threshold: a long refresh interval dominates the floor")
+    func thresholdRefreshIntervalWins() {
+        // refreshInterval*2 = 120000 > 46800.
+        let threshold = SyncStaleness.staleThreshold(
+            refreshInterval: 60_000,
+            refreshPolicy: .twiceDaily
+        )
+        #expect(threshold == 120_000)
+    }
+
+    @Test("threshold: manualOnly uses the 24h fallback floor + 1h slack")
+    func thresholdManualOnlyFallbackFloor() {
+        // minimumInterval is nil → manualOnlyFloor (86400) + 3600 = 90000,
+        // which beats refreshInterval*2 (7200) and transactionSyncInterval*2 (3600).
+        let threshold = SyncStaleness.staleThreshold(
+            refreshInterval: oneHour,
+            refreshPolicy: .manualOnly
+        )
+        #expect(threshold == SyncStaleness.manualOnlyFloor + oneHour)
+        #expect(threshold == 90_000)
+    }
+
+    @Test("threshold: transactionSyncInterval*2 can win for a tiny refresh interval")
+    func thresholdTransactionSyncWins() {
+        // refreshInterval*2 = 100, transactionSyncInterval*2 = 3600,
+        // policyFloor: pass a tiny override via manualOnly with explicit txn interval.
+        // Use a degenerate refresh interval and a manual policy with a small slice:
+        // here transactionSyncInterval is overridden large to dominate.
+        let threshold = SyncStaleness.staleThreshold(
+            refreshInterval: 1,
+            transactionSyncInterval: 100_000,
+            refreshPolicy: .twiceDaily
+        )
+        #expect(threshold == 200_000)
+    }
+
+    // MARK: - isStale
+
+    @Test("isStale: boot load in flight is never stale, even with no prior sync")
+    func isStaleBootSuppressed() {
+        #expect(SyncStaleness.isStale(
+            isBootLoadInFlight: true,
+            lastSyncDate: nil,
+            refreshInterval: oneHour,
+            refreshPolicy: .twiceDaily,
+            asOf: Date()
+        ) == false)
+    }
+
+    @Test("isStale: never synced past boot is stale")
+    func isStaleNeverSynced() {
+        #expect(SyncStaleness.isStale(
+            isBootLoadInFlight: false,
+            lastSyncDate: nil,
+            refreshInterval: oneHour,
+            refreshPolicy: .twiceDaily,
+            asOf: Date()
+        ) == true)
+    }
+
+    @Test("isStale: just past the threshold is stale; just under is fresh")
+    func isStaleThresholdBoundary() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let threshold = SyncStaleness.staleThreshold(
+            refreshInterval: oneHour,
+            refreshPolicy: .twiceDaily
+        ) // 46800
+        let staleSync = now.addingTimeInterval(-(threshold + 1))
+        let freshSync = now.addingTimeInterval(-(threshold - 1))
+        // Exactly at the threshold is NOT stale (strict greater-than).
+        let exactSync = now.addingTimeInterval(-threshold)
+
+        #expect(SyncStaleness.isStale(
+            isBootLoadInFlight: false, lastSyncDate: staleSync,
+            refreshInterval: oneHour, refreshPolicy: .twiceDaily, asOf: now
+        ) == true)
+        #expect(SyncStaleness.isStale(
+            isBootLoadInFlight: false, lastSyncDate: freshSync,
+            refreshInterval: oneHour, refreshPolicy: .twiceDaily, asOf: now
+        ) == false)
+        #expect(SyncStaleness.isStale(
+            isBootLoadInFlight: false, lastSyncDate: exactSync,
+            refreshInterval: oneHour, refreshPolicy: .twiceDaily, asOf: now
+        ) == false)
+    }
+
+    // MARK: - statusText
+
+    @Test("statusText: boot load shows Syncing")
+    func statusTextBoot() {
+        #expect(SyncStaleness.statusText(
+            isBootLoadInFlight: true, lastSyncRelative: "2h ago", isStale: true
+        ) == "Syncing")
+    }
+
+    @Test("statusText: no relative timestamp shows Never synced")
+    func statusTextNeverSynced() {
+        #expect(SyncStaleness.statusText(
+            isBootLoadInFlight: false, lastSyncRelative: nil, isStale: false
+        ) == "Never synced")
+    }
+
+    @Test("statusText: stale and fresh prefix the relative timestamp")
+    func statusTextStaleFresh() {
+        #expect(SyncStaleness.statusText(
+            isBootLoadInFlight: false, lastSyncRelative: "2h ago", isStale: true
+        ) == "Stale 2h ago")
+        #expect(SyncStaleness.statusText(
+            isBootLoadInFlight: false, lastSyncRelative: "2h ago", isStale: false
+        ) == "Synced 2h ago")
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `AppState.isSyncStale` + `statusSyncText` — the only untested copy of the stale-sync threshold ladder and its status-strip copy — into a new pure, `Sendable` `SyncStaleness` type in `PlaidBarCore`.
- `Date()` becomes an explicit `asOf:` parameter so the threshold boundary is deterministically testable; AppState's two computed properties now delegate (−14 lines of inline logic).
- Behavior-preserving: byte-identical threshold math (manual-only 24h fallback floor, 1h policy slack, strict `>` comparison) and identical status-text branches.

This continues the AppState→Core extraction thesis (follows PR #524's 5 steps).

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` pass (2026-06-19)
- Backlog slice: behavior-preserving Core extraction (one PR-sized step)
- Scope note: one cohesive pure-logic cluster; no product behavior change

## Agent coordination

- Builder agent: Claude (Opus 4.8), autonomous scheduled task
- Builder branch/worktree: `refactor/auto-2026-06-19` (worktree off `origin/main`)
- Reviewer/merge steward: Otto
- Coordination note: review only — no other agent should push to this branch

## Changed files

- `Sources/PlaidBarCore/Utilities/SyncStaleness.swift` (new, pure type)
- `Sources/PlaidBar/App/AppState.swift` (delegate `isSyncStale` / `statusSyncText`)
- `Tests/PlaidBarCoreTests/SyncStalenessTests.swift` (new, 10 tests)

## Local gates

- [x] `git diff --check`
- [x] Strict-concurrency build clean: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- [x] `swift test` — full suite 1638 green (incl. the sometimes-flaky `LocalInsightModelRuntime` timeout test)
- [x] Demo app boot-smoke: `.build/debug/PlaidBar --demo` alive 9s, no crash
- [x] Secret scan completed over the diff (no credentials/tokens/account IDs/balances)

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.
- [ ] `otto-openclaw-merge-gate` is green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)