### PR TITLE
feat(ai): detect Foundation Models availability + prefer it in the local-AI tier resolver (AND-563)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -515,6 +515,12 @@ final class AppState {
     private var localAIModelNamePreference: String?
     private var localAIProbeAvailability: LocalAIAvailability?
     private var localAIProbeGeneration = 0
+    /// Detection-only Foundation Models (Apple Intelligence) tier state (AND-563).
+    /// Probed cheaply via `FoundationModelsAvailabilityProbe`; `.unsupported` on
+    /// any OS/build without Foundation Models, so the tier order is unchanged
+    /// there. No insight generation is routed through Foundation Models yet.
+    private let foundationModelsProbe = FoundationModelsAvailabilityProbe()
+    private var foundationModelsTierState: LocalAIFoundationModelsTierState = .unsupported
     private var isLoadingLocalAISettings = false
     private var isLoadingAppLockPreferences = false
     private var isUpgradingManagedServer = false
@@ -527,6 +533,10 @@ final class AppState {
         _ = try? LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
         self.notificationService = notificationService ?? NotificationService.shared
         loadSettings()
+        // Detection-only: record whether Apple Foundation Models is available so
+        // the tier resolver can prefer it. No model session is created and no
+        // prompt is routed through it (AND-563). Cheap + synchronous.
+        foundationModelsTierState = foundationModelsProbe.currentState()
         // Engage launch App Lock synchronously before the first SwiftUI body is
         // ever evaluated. Deferring this to `loadInitialData()` leaks one frame
         // of cached/demo account names and activity because `.task` runs after
@@ -1469,6 +1479,43 @@ final class AppState {
             return generatedAvailability
         }
         return localAIInsightsService.availability
+    }
+
+    /// Detection-only Foundation Models tier state for Settings surfacing
+    /// (AND-563). `.unsupported` whenever Apple Intelligence can't be probed on
+    /// this OS/build.
+    var foundationModelsAvailability: LocalAIFoundationModelsTierState {
+        foundationModelsTierState
+    }
+
+    /// The on-device AI tier VaultPeek would currently prefer, highest first.
+    /// Apple Foundation Models sits on top WHEN available; otherwise this is
+    /// exactly the tier order that existed before AND-563. Detection/ordering
+    /// only — insight generation still runs on the existing path.
+    var localAIPreferredTier: LocalAIRuntimeTier {
+        LocalAITierResolver.resolvePreferredTier(
+            facts: LocalAITierFacts(
+                foundationModels: foundationModelsTierState,
+                ollamaEngaged: LocalAIRuntimeResolution.usesModel(for: localAIAvailability.state),
+                naturalLanguageReady: Self.naturalLanguageTierReady
+            )
+        )
+    }
+
+    /// The always-on NaturalLanguage categorizer (AND-507) ships whenever the
+    /// framework is importable, which on macOS is always.
+    private static var naturalLanguageTierReady: Bool {
+        #if canImport(NaturalLanguage)
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// Re-probe Apple Foundation Models availability (e.g. after the user enables
+    /// Apple Intelligence in System Settings). Detection only.
+    func refreshFoundationModelsAvailability() {
+        foundationModelsTierState = foundationModelsProbe.currentState()
     }
 
     /// Cached local summaries — invalidated via accounts.didSet and transactions.didSet.

--- a/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
@@ -1,0 +1,64 @@
+import Foundation
+import PlaidBarCore
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Detects whether Apple's on-device Foundation Models (Apple Intelligence) is
+/// available, mapping the platform `SystemLanguageModel.Availability` into the
+/// OS-independent `LocalAIFoundationModelsTierState` the pure tier resolver
+/// understands (AND-563).
+///
+/// This is the ONLY place that touches the FoundationModels framework. It is
+/// fully additive and reversible:
+///   - When the SDK is absent (`canImport` false) or the OS is older than
+///     macOS 26, the probe returns `.unsupported`, so the tier resolver behaves
+///     exactly as it did before this type existed.
+///   - It performs detection only. It never constructs a session or routes any
+///     transaction-derived prompt through Foundation Models — insight generation
+///     stays on the existing path until a separate, held follow-up wires it.
+///
+/// The probe is cheap and synchronous (`SystemLanguageModel.default.availability`
+/// is a stored/computed property, not a network or model call), so callers can
+/// read it on demand without scheduling work.
+struct FoundationModelsAvailabilityProbe: Sendable {
+    /// Returns the current Foundation Models availability as a Core tier state.
+    ///
+    /// Safe to call on any OS/build: returns `.unsupported` whenever Foundation
+    /// Models cannot be queried here.
+    func currentState() -> LocalAIFoundationModelsTierState {
+        #if canImport(FoundationModels)
+        if #available(macOS 26, *) {
+            return Self.map(SystemLanguageModel.default.availability)
+        } else {
+            return .unsupported
+        }
+        #else
+        return .unsupported
+        #endif
+    }
+}
+
+#if canImport(FoundationModels)
+@available(macOS 26, *)
+extension FoundationModelsAvailabilityProbe {
+    /// Maps `SystemLanguageModel.Availability` to the Core tier state. Unknown or
+    /// future unavailability reasons collapse to `.unavailableOther` so new SDK
+    /// cases never break the build or silently read as available.
+    static func map(_ availability: SystemLanguageModel.Availability) -> LocalAIFoundationModelsTierState {
+        switch availability {
+        case .available:
+            return .available
+        case .unavailable(.deviceNotEligible):
+            return .deviceNotEligible
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return .appleIntelligenceNotEnabled
+        case .unavailable(.modelNotReady):
+            return .modelNotReady
+        case .unavailable:
+            return .unavailableOther
+        }
+    }
+}
+#endif

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -599,6 +599,25 @@ struct GeneralSettingsView: View {
                 }
                 .accessibilityElement(children: .combine)
 
+                LabeledContent("Preferred tier") {
+                    VStack(alignment: .trailing, spacing: Spacing.xxs) {
+                        Text(appState.localAIPreferredTier.displayName)
+                            .font(.body.weight(.medium))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+
+                        if let cause = appState.foundationModelsAvailability.causeLabel {
+                            Text(cause)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                }
+                .accessibilityElement(children: .combine)
+                .help("Highest-preference on-device AI tier. Apple Intelligence (Foundation Models) is used when available; otherwise VaultPeek uses the existing local tiers.")
+
                 LabeledContent("Runtime") {
                     VStack(alignment: .trailing, spacing: Spacing.xxs) {
                         Text(appState.localAIAvailability.runtimeName ?? "None configured")

--- a/Sources/PlaidBarCore/Utilities/LocalAITierResolver.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAITierResolver.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// The ordered on-device AI tiers VaultPeek can draw on, highest preference
+/// first. This is the *generation/preference* order — which on-device facility
+/// is the best available producer of insight/categorization output — not a
+/// privacy boundary (that stays in `LocalAIRuntimeResolution`).
+///
+/// AND-563 adds `foundationModels` at the TOP. The lower three rungs are exactly
+/// the tiers that existed before:
+///   - `ollama`         — the toggle-gated local Ollama insight runtime.
+///   - `naturalLanguage`— the always-on zero-setup Apple NaturalLanguage
+///                        categorizer (AND-507).
+///   - `heuristic`      — deterministic local summaries/totals; always present.
+///
+/// This issue is detection + ordering only. It does NOT route insight generation
+/// through Foundation Models — that wiring is a held follow-up (AND-564/565). The
+/// resolver merely reports which tier would be preferred so Settings/status can
+/// surface it; the existing generation path is unchanged.
+public enum LocalAIRuntimeTier: String, Codable, Sendable, Hashable, CaseIterable {
+    case foundationModels
+    case ollama
+    case naturalLanguage
+    case heuristic
+
+    /// Lower rank == higher preference. Stable, test-pinned ordering so the
+    /// resolver and any UI agree on "which tier is on top."
+    public var rank: Int {
+        switch self {
+        case .foundationModels: 0
+        case .ollama: 1
+        case .naturalLanguage: 2
+        case .heuristic: 3
+        }
+    }
+
+    /// Full, user-facing name for Settings copy.
+    public var displayName: String {
+        switch self {
+        case .foundationModels: "Apple Intelligence (Foundation Models)"
+        case .ollama: "Local Ollama runtime"
+        case .naturalLanguage: "Apple NaturalLanguage (on-device)"
+        case .heuristic: "Deterministic local summaries"
+        }
+    }
+
+    /// Compact label for dense menu/popover status.
+    public var shortStatusLabel: String {
+        switch self {
+        case .foundationModels: "Apple Intelligence"
+        case .ollama: "Local Ollama"
+        case .naturalLanguage: "On-device NL"
+        case .heuristic: "Deterministic"
+        }
+    }
+}
+
+/// Configuration-level availability of Apple Foundation Models, mirroring
+/// `SystemLanguageModel.Availability` but as a plain, `Sendable`, OS-independent
+/// value so the pure resolver and its tests never touch FoundationModels APIs.
+///
+/// The app target maps the real `SystemLanguageModel.default.availability` into
+/// one of these cases behind `#available(macOS 26, *)` + `canImport`; everywhere
+/// else (older OS, no FoundationModels SDK) it stays `.unsupported`.
+public enum LocalAIFoundationModelsTierState: String, Codable, Sendable, Hashable, CaseIterable {
+    /// Foundation Models cannot be probed on this build/OS (no SDK or < macOS 26).
+    case unsupported
+    /// The on-device model is available and ready.
+    case available
+    /// `SystemLanguageModel.Availability.UnavailableReason.deviceNotEligible`.
+    case deviceNotEligible
+    /// `…UnavailableReason.appleIntelligenceNotEnabled`.
+    case appleIntelligenceNotEnabled
+    /// `…UnavailableReason.modelNotReady`.
+    case modelNotReady
+    /// Any other / future unavailability reason.
+    case unavailableOther
+
+    /// Only `.available` engages the Foundation Models tier; every other state
+    /// (including `.unsupported`) leaves the legacy order untouched.
+    public var isAvailable: Bool {
+        self == .available
+    }
+
+    /// Short remediation cause for Settings, or `nil` when there is nothing the
+    /// user can act on (available, or generically unsupported on this OS/build).
+    public var causeLabel: String? {
+        switch self {
+        case .available, .unsupported, .unavailableOther:
+            nil
+        case .deviceNotEligible:
+            "This Mac doesn't support Apple Intelligence"
+        case .appleIntelligenceNotEnabled:
+            "Apple Intelligence is turned off in System Settings"
+        case .modelNotReady:
+            "Apple Intelligence model is still preparing"
+        }
+    }
+}
+
+/// The facts the pure tier resolver needs, one boolean-ish per rung. Gathering
+/// these (probing FM, checking the Ollama opt-in/liveness, asking whether NL can
+/// categorize) happens in the app/Core call sites; the decision itself is pure.
+public struct LocalAITierFacts: Sendable, Hashable {
+    /// Result of the Foundation Models availability probe (injected from the app).
+    public let foundationModels: LocalAIFoundationModelsTierState
+    /// True when the opted-in local Ollama runtime is engaged (i.e. the existing
+    /// resolution would feed it prompts — `LocalAIRuntimeResolution.usesModel`).
+    public let ollamaEngaged: Bool
+    /// True when the always-on NaturalLanguage categorizer can run on this build
+    /// (i.e. `canImport(NaturalLanguage)` at the call site).
+    public let naturalLanguageReady: Bool
+
+    public init(
+        foundationModels: LocalAIFoundationModelsTierState,
+        ollamaEngaged: Bool,
+        naturalLanguageReady: Bool
+    ) {
+        self.foundationModels = foundationModels
+        self.ollamaEngaged = ollamaEngaged
+        self.naturalLanguageReady = naturalLanguageReady
+    }
+}
+
+/// Pure decision: given the per-rung facts, which on-device tier is preferred.
+///
+/// Foundation Models sits at the top *only* when its probe reports `.available`.
+/// For every other FM state the function ignores FM entirely and returns the
+/// same tier the runtime resolved before AND-563 — this equivalence is the
+/// regression guard the unit tests pin.
+public enum LocalAITierResolver {
+    public static func resolvePreferredTier(facts: LocalAITierFacts) -> LocalAIRuntimeTier {
+        if facts.foundationModels.isAvailable {
+            return .foundationModels
+        }
+        // Legacy order, unchanged by AND-563.
+        if facts.ollamaEngaged {
+            return .ollama
+        }
+        if facts.naturalLanguageReady {
+            return .naturalLanguage
+        }
+        return .heuristic
+    }
+}

--- a/Tests/PlaidBarCoreTests/LocalAITierResolverTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAITierResolverTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// AND-563 foundation: the pure tier-ordering decision that slots Apple
+/// Foundation Models at the TOP of the on-device AI tier order when available,
+/// and otherwise resolves EXACTLY as the runtime did before FM existed.
+///
+/// The availability *probe* (the actual `SystemLanguageModel` call) lives in the
+/// app target behind `#available`; only its boolean result is injected here, so
+/// these tests run on any OS without Apple Intelligence.
+@Suite("Local AI Tier Resolver Tests")
+struct LocalAITierResolverTests {
+    // Facts that reproduce "today" (pre-FM) for each rung.
+    private func legacyFacts(
+        foundationModels: LocalAIFoundationModelsTierState = .unsupported,
+        ollamaEngaged: Bool = false,
+        naturalLanguageReady: Bool = true
+    ) -> LocalAITierFacts {
+        LocalAITierFacts(
+            foundationModels: foundationModels,
+            ollamaEngaged: ollamaEngaged,
+            naturalLanguageReady: naturalLanguageReady
+        )
+    }
+
+    // MARK: - Foundation Models preference (the new behavior)
+
+    @Test("Foundation Models is preferred at the top of the order when available")
+    func foundationModelsPreferredWhenAvailable() {
+        // Even with Ollama engaged AND NaturalLanguage ready, FM wins.
+        let resolved = LocalAITierResolver.resolvePreferredTier(
+            facts: legacyFacts(
+                foundationModels: .available,
+                ollamaEngaged: true,
+                naturalLanguageReady: true
+            )
+        )
+        #expect(resolved == .foundationModels)
+    }
+
+    @Test("Foundation Models outranks every lower rung individually")
+    func foundationModelsOutranksEachRung() {
+        for ollama in [true, false] {
+            for nl in [true, false] {
+                let resolved = LocalAITierResolver.resolvePreferredTier(
+                    facts: LocalAITierFacts(
+                        foundationModels: .available,
+                        ollamaEngaged: ollama,
+                        naturalLanguageReady: nl
+                    )
+                )
+                #expect(resolved == .foundationModels)
+            }
+        }
+    }
+
+    // MARK: - Regression guard: FM unavailable == today's resolution
+
+    @Test("FM unavailable for any reason resolves identically to the pre-FM order")
+    func fmUnavailableMatchesLegacyResolution() {
+        // For every non-available FM state, the resolver must behave as if FM did
+        // not exist: the outcome depends only on the legacy rungs.
+        let unavailableStates: [LocalAIFoundationModelsTierState] = [
+            .unsupported,
+            .deviceNotEligible,
+            .appleIntelligenceNotEnabled,
+            .modelNotReady,
+            .unavailableOther,
+        ]
+
+        for state in unavailableStates {
+            // Ollama engaged → Ollama is the preferred generation tier (today).
+            #expect(
+                LocalAITierResolver.resolvePreferredTier(
+                    facts: legacyFacts(foundationModels: state, ollamaEngaged: true, naturalLanguageReady: true)
+                ) == .ollama
+            )
+            // No Ollama, NL ready → NaturalLanguage (today's zero-setup tier).
+            #expect(
+                LocalAITierResolver.resolvePreferredTier(
+                    facts: legacyFacts(foundationModels: state, ollamaEngaged: false, naturalLanguageReady: true)
+                ) == .naturalLanguage
+            )
+            // No Ollama, no NL → deterministic heuristic floor (always present).
+            #expect(
+                LocalAITierResolver.resolvePreferredTier(
+                    facts: legacyFacts(foundationModels: state, ollamaEngaged: false, naturalLanguageReady: false)
+                ) == .heuristic
+            )
+        }
+    }
+
+    // MARK: - Fallback rungs (each one explicitly)
+
+    @Test("Ollama is preferred over NaturalLanguage and heuristic when engaged and FM is absent")
+    func ollamaRungPreferredOverLowerTiers() {
+        let resolved = LocalAITierResolver.resolvePreferredTier(
+            facts: legacyFacts(foundationModels: .unsupported, ollamaEngaged: true, naturalLanguageReady: true)
+        )
+        #expect(resolved == .ollama)
+    }
+
+    @Test("NaturalLanguage is preferred over heuristic when ready and no higher tier is engaged")
+    func naturalLanguageRungPreferredOverHeuristic() {
+        let resolved = LocalAITierResolver.resolvePreferredTier(
+            facts: legacyFacts(foundationModels: .unsupported, ollamaEngaged: false, naturalLanguageReady: true)
+        )
+        #expect(resolved == .naturalLanguage)
+    }
+
+    @Test("Heuristic is the floor when nothing else is available")
+    func heuristicIsTheFloor() {
+        let resolved = LocalAITierResolver.resolvePreferredTier(
+            facts: legacyFacts(foundationModels: .unsupported, ollamaEngaged: false, naturalLanguageReady: false)
+        )
+        #expect(resolved == .heuristic)
+    }
+
+    // MARK: - Tier ordering metadata
+
+    @Test("Tier rank places Foundation Models strictly above all legacy tiers")
+    func tierRankOrders() {
+        #expect(LocalAIRuntimeTier.foundationModels.rank < LocalAIRuntimeTier.ollama.rank)
+        #expect(LocalAIRuntimeTier.ollama.rank < LocalAIRuntimeTier.naturalLanguage.rank)
+        #expect(LocalAIRuntimeTier.naturalLanguage.rank < LocalAIRuntimeTier.heuristic.rank)
+    }
+
+    @Test("Only Foundation Models is considered available from its tier state")
+    func foundationModelsStateAvailability() {
+        #expect(LocalAIFoundationModelsTierState.available.isAvailable == true)
+        #expect(LocalAIFoundationModelsTierState.unsupported.isAvailable == false)
+        #expect(LocalAIFoundationModelsTierState.deviceNotEligible.isAvailable == false)
+        #expect(LocalAIFoundationModelsTierState.appleIntelligenceNotEnabled.isAvailable == false)
+        #expect(LocalAIFoundationModelsTierState.modelNotReady.isAvailable == false)
+        #expect(LocalAIFoundationModelsTierState.unavailableOther.isAvailable == false)
+    }
+
+    // MARK: - Display surfacing parity (tier appears like existing tiers)
+
+    @Test("Every tier has a non-empty display name and short status label")
+    func tierDisplayMetadataExists() {
+        for tier in LocalAIRuntimeTier.allCases {
+            #expect(!tier.displayName.isEmpty)
+            #expect(!tier.shortStatusLabel.isEmpty)
+        }
+        // The FM tier surfaces an Apple Intelligence affordance distinct from Ollama.
+        #expect(LocalAIRuntimeTier.foundationModels.displayName.contains("Apple"))
+    }
+
+    @Test("Foundation Models unavailability reasons map to human-readable cause copy")
+    func foundationModelsCauseCopy() {
+        #expect(LocalAIFoundationModelsTierState.deviceNotEligible.causeLabel != nil)
+        #expect(LocalAIFoundationModelsTierState.appleIntelligenceNotEnabled.causeLabel != nil)
+        #expect(LocalAIFoundationModelsTierState.modelNotReady.causeLabel != nil)
+        // "available" and the generic unsupported case have no remediation cause.
+        #expect(LocalAIFoundationModelsTierState.available.causeLabel == nil)
+        #expect(LocalAIFoundationModelsTierState.unsupported.causeLabel == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Foundation-only slice of **AND-563**: detect Apple **Foundation Models** (Apple Intelligence) and slot it at the **top** of the on-device AI tier order when available. This is detection + tier representation + preference ordering + graceful fallback **only** — it does not build FM-backed insight generation (AND-564) or FM categorization (AND-565), both of which are held.

What landed:

- **Pure tier resolver in `PlaidBarCore`** — new `LocalAITierResolver.resolvePreferredTier(facts:)` plus `LocalAIRuntimeTier` (ordered enum), `LocalAITierFacts`, and `LocalAIFoundationModelsTierState`. The resolver returns `.foundationModels` **only** when the FM probe reports `.available`; for every other FM state it returns **exactly** the pre-FM order: `ollama → naturalLanguage → heuristic`. That equivalence is the regression guard.
- **App-side probe** — `FoundationModelsAvailabilityProbe`, gated behind `#available(macOS 26, *)` + `canImport(FoundationModels)`, maps `SystemLanguageModel.default.availability` (`.available` / `.deviceNotEligible` / `.appleIntelligenceNotEnabled` / `.modelNotReady` / other) into the OS-independent Core tier state. **Detection only** — it never constructs a model session or routes any transaction-derived prompt through Foundation Models. Returns `.unsupported` when FM can't be probed, leaving the legacy order untouched.
- **Surfacing** — `AppState` exposes `localAIPreferredTier`, `foundationModelsAvailability`, and `refreshFoundationModelsAvailability()`; the Settings "Local AI" section shows a new **Preferred tier** row next to the existing Availability/Runtime rows, with FM unavailability cause copy (device not eligible / Apple Intelligence off / model preparing).

Insight generation stays on the existing path; a follow-up wires generation.

## Linear (AND-563)

Implements AND-563 scoped to the foundation only (detection + tier representation + preference ordering + graceful fallback). AND-564 (FM-backed insight generation) and AND-565 (FM categorization) remain held and are intentionally out of scope here.

## Testing notes

- New `Tests/PlaidBarCoreTests/LocalAITierResolverTests.swift` (10 tests): FM preferred when available; FM outranks every lower rung; **FM-unavailable-for-any-reason resolves identically to the pre-FM order** (regression guard across all unavailable states); each fallback rung (Ollama → NL → heuristic); rank ordering; tier-state availability; display/cause metadata. The probe result is injected as a plain Core value, so the suite runs on any OS without Apple Intelligence.
- Strict-concurrency CI build clean: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → Build complete.
- Full suite green: `swift test` → **1638 tests passed, 0 failures**.

## Architectural decisions

- **Pure decision in Core, probe in app.** The tier-ordering decision is a pure `Sendable` function in `PlaidBarCore`; the only code that touches the FoundationModels framework is the app-target probe, behind `#available` + `canImport`. This keeps the decision unit-testable on any machine and confines all OS-version/SDK gating to one file.
- **FM state modeled as an OS-independent Core enum.** `SystemLanguageModel.Availability` is mapped into `LocalAIFoundationModelsTierState` so neither Core nor its tests import FoundationModels; unknown/future unavailability reasons collapse to `.unavailableOther` (never silently "available").
- **Preference order, not a privacy boundary.** The new resolver is purely about *which on-device tier is the best available producer*. The opt-in / localhost privacy boundary stays in the existing `LocalAIRuntimeResolution` and is unchanged.
- **`#available(macOS 26, *)` kept even though the deployment target is macOS 26.** Makes the FM access path explicit and keeps the code defensive/reversible if the floor ever lowers; `canImport(FoundationModels)` covers SDKs/toolchains without the framework.

## Migration notes

None — additive, availability-gated. On older OS, machines without Apple Intelligence, or builds without the FoundationModels SDK, the probe returns `.unsupported` and the tier order is byte-for-byte what it was before this change. No data migration, no settings migration, no behavior change on non-capable machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)