### PR TITLE
feat(perf): energy-aware background refresh scheduling (AND-568)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -503,6 +503,10 @@ final class AppState {
     private let notificationService: any NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
     private var localAISummaryRefreshTask: Task<Void, Never>?
+    /// Observer tokens for the OS power-state / thermal-state change
+    /// notifications that drive energy-aware background refresh (AND-568).
+    /// Retained so they can be removed in `deinit`.
+    private var energyStateObservers: [NSObjectProtocol] = []
     private let glanceSnapshotWriteDebouncer = GlanceSnapshotWriteDebouncer()
     private var glanceSnapshotWriteGeneration = 0
     private var reviewUndoStack: [(metadata: [TransactionReviewMetadata], rules: [TransactionRule])] = []
@@ -548,6 +552,20 @@ final class AppState {
         if CommandLine.arguments.contains("--demo") {
             loadDemoData()
         }
+        // Begin watching OS power/thermal transitions so the background refresh
+        // cadence re-evaluates the moment Low Power Mode or thermal pressure
+        // changes (AND-568). The observers only restart an already-running loop,
+        // so registering here (before the loop starts in `loadInitialData`) is
+        // safe and idempotent.
+        startEnergyStateObservers()
+    }
+
+    // `isolated deinit` (SE-0371) so teardown runs on the main actor and can read
+    // the actor-isolated observer tokens. Block-based NotificationCenter observers
+    // must be explicitly removed; doing it here avoids leaking the two energy
+    // observers if an AppState is ever torn down (e.g. in tests).
+    isolated deinit {
+        stopEnergyStateObservers()
     }
 
     private func loadSettings() {
@@ -2020,10 +2038,21 @@ final class AppState {
         if await consumePendingGlanceCommand() { return }
         let dashboardStart = performanceStart()
         await checkServerConnection()
+        // Energy-aware gate (AND-568): a `force` refresh is user-initiated and
+        // always pulls Plaid data; an automatic tick additionally backs off the
+        // network-and-CPU-heavy Plaid fetch while the device is in Low Power Mode
+        // or under serious/critical thermal pressure. The connectivity re-probe
+        // above and the category-budget recompute below still run every tick, so
+        // only the Plaid round-trip is deferred — never the cheap local work.
+        let plaidFetchAllowed = EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: currentEnergyConditions,
+            automaticRefreshIsDue: shouldAutoRefreshNow,
+            isManual: force
+        )
         // Setup state (credentials missing) cannot refresh anything from
         // Plaid; the status surfaces guide the user instead of surfacing a
         // 503 banner on every cycle.
-        if serverConnected, serverCredentialsConfigured != false, force || shouldAutoRefreshNow {
+        if serverConnected, serverCredentialsConfigured != false, plaidFetchAllowed {
             // A user-initiated (force) refresh pulls live balances via
             // /accounts/balance/get, but at most once per cooldown window so
             // rapid clicks can't run up per-call Plaid balance fees. Automatic
@@ -2240,12 +2269,26 @@ final class AppState {
                 if appLockPreferences.shouldRefreshFinancialData(isAppLocked: isAppLocked) {
                     // Automatic tick: only fetches Plaid data when due per the
                     // refresh policy; connectivity re-probe still runs each tick.
+                    // `refreshDashboard(force: false)` additionally defers the
+                    // Plaid round-trip while the device is energy-constrained
+                    // (AND-568).
                     await refreshDashboard(force: false)
                 }
                 if appLockPreferences.shouldEvaluateFinancialNotifications(isAppLocked: isAppLocked) {
                     await evaluateNotifications()
                 }
-                try? await Task.sleep(for: .seconds(refreshInterval))
+                // Energy-aware cadence (AND-568): lengthen the sleep while the
+                // device is in Low Power Mode or under serious/critical thermal
+                // pressure so a throttled / battery-saving machine wakes the app
+                // less often. A power/thermal change posts a notification that
+                // restarts this loop, so the longer sleep is re-evaluated as soon
+                // as conditions return to normal — it never strands the app on a
+                // stale long delay.
+                let delay = EnergyAwareRefreshPolicy.nextTickDelay(
+                    baseInterval: refreshInterval,
+                    conditions: currentEnergyConditions
+                )
+                try? await Task.sleep(for: .seconds(delay))
             }
         }
     }
@@ -2345,6 +2388,82 @@ final class AppState {
     func stopBackgroundRefresh() {
         refreshTask?.cancel()
         refreshTask = nil
+    }
+
+    // MARK: - Energy-aware refresh (AND-568)
+
+    /// Live device energy/thermal snapshot read from `ProcessInfo`, mapped onto
+    /// the framework-light `EnergyAwareRefreshPolicy` inputs. Read at the top of
+    /// each automatic refresh decision and when sizing the next loop sleep, so
+    /// the policy always sees the current Low Power Mode / thermal state.
+    var currentEnergyConditions: EnergyAwareRefreshPolicy.EnergyConditions {
+        let info = ProcessInfo.processInfo
+        return EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: info.isLowPowerModeEnabled,
+            thermalState: Self.energyThermalState(from: info.thermalState)
+        )
+    }
+
+    /// Maps the live `ProcessInfo.ThermalState` onto the pure Core mirror enum so
+    /// the decision logic stays testable without a real device.
+    nonisolated static func energyThermalState(
+        from state: ProcessInfo.ThermalState
+    ) -> EnergyAwareRefreshPolicy.EnergyThermalState {
+        switch state {
+        case .nominal: .nominal
+        case .fair: .fair
+        case .serious: .serious
+        case .critical: .critical
+        @unknown default: .nominal
+        }
+    }
+
+    /// Subscribes to the OS Low Power Mode and thermal-state change
+    /// notifications. When either changes we restart the background loop so the
+    /// next-tick delay and the automatic-refresh gate are re-evaluated against
+    /// the new conditions immediately — e.g. when the user plugs in and Low Power
+    /// Mode turns off, the loop drops back from the constrained cadence to the
+    /// normal interval without waiting out a stale long sleep. Idempotent: a
+    /// second call removes the prior observers first.
+    func startEnergyStateObservers() {
+        stopEnergyStateObservers()
+        let center = NotificationCenter.default
+        let powerObserver = center.addObserver(
+            forName: .NSProcessInfoPowerStateDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleEnergyStateChange()
+            }
+        }
+        let thermalObserver = center.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleEnergyStateChange()
+            }
+        }
+        energyStateObservers = [powerObserver, thermalObserver]
+    }
+
+    private func stopEnergyStateObservers() {
+        let center = NotificationCenter.default
+        for observer in energyStateObservers {
+            center.removeObserver(observer)
+        }
+        energyStateObservers = []
+    }
+
+    /// Re-evaluates the background cadence after a power/thermal transition by
+    /// restarting the loop (only when one is already running, so we never spin a
+    /// loop up before boot). The restart re-reads `currentEnergyConditions` for
+    /// both the gate and the sleep length.
+    private func handleEnergyStateChange() {
+        guard refreshTask != nil else { return }
+        startBackgroundRefresh()
     }
 
     func loadInitialData() async {

--- a/Sources/PlaidBarCore/Utilities/EnergyAwareRefreshPolicy.swift
+++ b/Sources/PlaidBarCore/Utilities/EnergyAwareRefreshPolicy.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Pure, framework-light decision for whether the resident menu-bar app's
+/// *automatic* background refresh should run right now, and how long to wait
+/// before the next tick, given the device's energy and thermal conditions
+/// (AND-568).
+///
+/// The resident app keeps a background loop that re-probes connectivity and
+/// (when due, per ``AutomaticRefreshPolicy``) pulls fresh Plaid data. On a
+/// laptop running on battery — Low Power Mode on, or the chassis already
+/// throttling under thermal pressure — that periodic Plaid fetch is exactly the
+/// kind of deferrable, non-urgent work the OS asks apps to back off. This type
+/// encodes that back-off so it can be unit-tested without a live device:
+///
+/// - **Manual refresh always runs.** The user explicitly asked, so energy state
+///   never suppresses it — only *automatic* (loop / popover-open) refreshes back
+///   off. This mirrors ``AutomaticRefreshPolicy``'s manual-always contract.
+/// - **Low Power Mode or hot thermal defers the automatic Plaid fetch.** The
+///   connectivity re-probe and notification evaluation in the loop are cheap and
+///   keep running; only the network-and-CPU-heavy data fetch is skipped.
+/// - **The loop's sleep lengthens while constrained**, so a throttled machine
+///   wakes the app less often instead of spinning a tight wall-clock timer.
+///
+/// The OS observers (`ProcessInfo.isLowPowerModeEnabled`,
+/// `ProcessInfo.thermalState`, and the `…PowerStateDidChange` /
+/// `thermalStateDidChange` notifications) live in the app layer and feed their
+/// values into this pure decider; nothing here imports AppKit or touches global
+/// state, so every branch is deterministic in tests.
+public enum EnergyAwareRefreshPolicy: Sendable {
+    /// Framework-light mirror of `ProcessInfo.ThermalState`. Mapping the live
+    /// enum onto this at the app boundary keeps the decision testable without
+    /// depending on the host machine's actual thermal state in CI (mirrors the
+    /// `KeychainAccessPolicy.Accessibility` pattern).
+    public enum EnergyThermalState: String, Sendable, CaseIterable, Equatable {
+        /// `ProcessInfo.ThermalState.nominal` — no thermal pressure.
+        case nominal
+        /// `ProcessInfo.ThermalState.fair` — slightly elevated; still fine to work.
+        case fair
+        /// `ProcessInfo.ThermalState.serious` — the system is shedding heat and
+        /// asks apps to reduce activity. Treated as constrained.
+        case serious
+        /// `ProcessInfo.ThermalState.critical` — the system is at risk and apps
+        /// must stop non-essential work. Treated as constrained.
+        case critical
+
+        /// Whether this thermal state is hot enough that the app should defer
+        /// non-urgent background work. `.serious` and `.critical` are the two
+        /// states Apple documents as "reduce / stop activity".
+        public var isConstrained: Bool {
+            switch self {
+            case .nominal, .fair: false
+            case .serious, .critical: true
+            }
+        }
+    }
+
+    /// A snapshot of the device energy/thermal conditions the decider reads.
+    /// Value type with no side effects so callers can build it from live
+    /// `ProcessInfo` readings or from fixtures in tests.
+    public struct EnergyConditions: Sendable, Equatable {
+        /// `ProcessInfo.processInfo.isLowPowerModeEnabled` at read time.
+        public let lowPowerMode: Bool
+        /// Mapped `ProcessInfo.processInfo.thermalState` at read time.
+        public let thermalState: EnergyThermalState
+
+        public init(lowPowerMode: Bool, thermalState: EnergyThermalState) {
+            self.lowPowerMode = lowPowerMode
+            self.thermalState = thermalState
+        }
+
+        /// Whether the device is energy-constrained: Low Power Mode is on, or the
+        /// thermal state is `.serious`/`.critical`. Under either condition the
+        /// app backs off its automatic background data fetch.
+        public var isConstrained: Bool {
+            lowPowerMode || thermalState.isConstrained
+        }
+
+        /// Convenience for the unconstrained baseline (used as a safe default).
+        public static let normal = EnergyConditions(lowPowerMode: false, thermalState: .nominal)
+    }
+
+    /// Multiplier applied to the loop's base sleep interval while the device is
+    /// energy-constrained, so a throttled / battery-saving machine wakes the app
+    /// less often. Strictly greater than 1 so constrained ticks are always less
+    /// frequent than normal ones.
+    public static let constrainedBackoffMultiplier: Double = 4
+
+    /// Whether an *automatic* refresh should actually run now.
+    ///
+    /// - Parameters:
+    ///   - conditions: live energy/thermal snapshot.
+    ///   - automaticRefreshIsDue: whether the time-based throttle
+    ///     (``AutomaticRefreshPolicy``) already says an automatic refresh is due.
+    ///     Ignored for manual refreshes.
+    ///   - isManual: whether the user explicitly triggered this refresh. Manual
+    ///     refreshes always run and bypass both the time throttle and the energy
+    ///     back-off.
+    /// - Returns: `true` only when the refresh should proceed. Manual refreshes
+    ///   always return `true`; automatic refreshes return `true` only when due
+    ///   *and* the device is not energy-constrained.
+    public static func shouldRunAutomaticRefresh(
+        conditions: EnergyConditions,
+        automaticRefreshIsDue: Bool,
+        isManual: Bool
+    ) -> Bool {
+        // The user asked — never let battery/thermal state suppress it.
+        if isManual { return true }
+        // Not yet due per the time-based policy: nothing to do regardless of energy.
+        guard automaticRefreshIsDue else { return false }
+        // Due, but back off while the device is energy-constrained.
+        return !conditions.isConstrained
+    }
+
+    /// The delay to sleep before the next background loop tick. Normal energy
+    /// keeps the configured base interval; a constrained device lengthens it by
+    /// ``constrainedBackoffMultiplier`` so the app wakes less often under battery
+    /// or thermal pressure.
+    ///
+    /// Degenerate base intervals (non-finite or non-positive) fall back to a
+    /// finite positive floor so the loop can never busy-spin or sleep forever.
+    public static func nextTickDelay(
+        baseInterval: TimeInterval,
+        conditions: EnergyConditions
+    ) -> TimeInterval {
+        let sanitizedBase = (baseInterval.isFinite && baseInterval > 0)
+            ? baseInterval
+            : PlaidBarConstants.backgroundRefreshInterval
+        guard conditions.isConstrained else { return sanitizedBase }
+        return sanitizedBase * constrainedBackoffMultiplier
+    }
+}

--- a/Tests/PlaidBarCoreTests/EnergyAwareRefreshPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/EnergyAwareRefreshPolicyTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Energy-aware refresh policy")
+struct EnergyAwareRefreshPolicyTests {
+    private let baseInterval: TimeInterval = 15 * 60 // matches PlaidBarConstants.backgroundRefreshInterval
+
+    // MARK: - Thermal severity mapping
+
+    @Test("Thermal severity classifies nominal/fair as normal and serious/critical as constrained")
+    func thermalSeverityClassification() {
+        #expect(EnergyAwareRefreshPolicy.EnergyThermalState.nominal.isConstrained == false)
+        #expect(EnergyAwareRefreshPolicy.EnergyThermalState.fair.isConstrained == false)
+        #expect(EnergyAwareRefreshPolicy.EnergyThermalState.serious.isConstrained == true)
+        #expect(EnergyAwareRefreshPolicy.EnergyThermalState.critical.isConstrained == true)
+    }
+
+    // MARK: - shouldRunAutomaticRefresh
+
+    @Test("Normal power and thermal: automatic refresh proceeds when otherwise due")
+    func normalConditionsProceed() {
+        let conditions = EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: false,
+            thermalState: .nominal
+        )
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: conditions,
+            automaticRefreshIsDue: true,
+            isManual: false
+        ) == true)
+    }
+
+    @Test("Low power mode defers an otherwise-due automatic refresh")
+    func lowPowerDefers() {
+        let conditions = EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: true,
+            thermalState: .nominal
+        )
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: conditions,
+            automaticRefreshIsDue: true,
+            isManual: false
+        ) == false)
+    }
+
+    @Test("Serious thermal state defers an otherwise-due automatic refresh")
+    func seriousThermalDefers() {
+        let conditions = EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: false,
+            thermalState: .serious
+        )
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: conditions,
+            automaticRefreshIsDue: true,
+            isManual: false
+        ) == false)
+    }
+
+    @Test("Critical thermal state defers an otherwise-due automatic refresh")
+    func criticalThermalDefers() {
+        let conditions = EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: false,
+            thermalState: .critical
+        )
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: conditions,
+            automaticRefreshIsDue: true,
+            isManual: false
+        ) == false)
+    }
+
+    @Test("Manual refresh always runs, even in low power and critical thermal")
+    func manualAlwaysAllowed() {
+        let worstCase = EnergyAwareRefreshPolicy.EnergyConditions(
+            lowPowerMode: true,
+            thermalState: .critical
+        )
+        // Manual runs even when the time-based policy says it is not due.
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: worstCase,
+            automaticRefreshIsDue: false,
+            isManual: true
+        ) == true)
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: worstCase,
+            automaticRefreshIsDue: true,
+            isManual: true
+        ) == true)
+    }
+
+    @Test("Automatic refresh that is not yet due never runs regardless of energy")
+    func notDueNeverRunsAutomatically() {
+        let normal = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .nominal)
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: normal,
+            automaticRefreshIsDue: false,
+            isManual: false
+        ) == false)
+    }
+
+    @Test("Constrained energy must back off even when low power mode is off but thermal is hot")
+    func constrainedByThermalOnly() {
+        let conditions = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .serious)
+        #expect(conditions.isConstrained == true)
+        #expect(EnergyAwareRefreshPolicy.shouldRunAutomaticRefresh(
+            conditions: conditions,
+            automaticRefreshIsDue: true,
+            isManual: false
+        ) == false)
+    }
+
+    // MARK: - Backoff math (next tick delay)
+
+    @Test("Next tick delay equals the base interval when energy is normal")
+    func normalDelayIsBaseInterval() {
+        let normal = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .nominal)
+        #expect(EnergyAwareRefreshPolicy.nextTickDelay(
+            baseInterval: baseInterval,
+            conditions: normal
+        ) == baseInterval)
+    }
+
+    @Test("Constrained energy lengthens the next tick delay by the backoff multiplier")
+    func constrainedDelayBacksOff() {
+        let lowPower = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .nominal)
+        let hot = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .critical)
+        let expected = baseInterval * EnergyAwareRefreshPolicy.constrainedBackoffMultiplier
+        #expect(EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: baseInterval, conditions: lowPower) == expected)
+        #expect(EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: baseInterval, conditions: hot) == expected)
+    }
+
+    @Test("Backoff multiplier is greater than one so constrained ticks are strictly less frequent")
+    func backoffMultiplierLengthens() {
+        #expect(EnergyAwareRefreshPolicy.constrainedBackoffMultiplier > 1)
+        let normal = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .nominal)
+        let constrained = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .nominal)
+        #expect(
+            EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: baseInterval, conditions: constrained)
+                > EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: baseInterval, conditions: normal)
+        )
+    }
+
+    @Test("Next tick delay is clamped to a sane finite floor for non-finite or non-positive base intervals")
+    func delayHandlesDegenerateBaseInterval() {
+        let normal = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .nominal)
+        let zero = EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: 0, conditions: normal)
+        let negative = EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: -42, conditions: normal)
+        let infinite = EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: .infinity, conditions: normal)
+        for value in [zero, negative, infinite] {
+            #expect(value.isFinite)
+            #expect(value > 0)
+        }
+    }
+
+    // MARK: - EnergyConditions.isConstrained
+
+    @Test("Energy conditions are constrained when either low power or hot thermal holds")
+    func constrainedConjunction() {
+        #expect(EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .nominal).isConstrained == false)
+        #expect(EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .fair).isConstrained == false)
+        #expect(EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .nominal).isConstrained == true)
+        #expect(EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: false, thermalState: .serious).isConstrained == true)
+        #expect(EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .critical).isConstrained == true)
+    }
+}


### PR DESCRIPTION
## Summary

Makes the resident menu-bar app's **automatic** background refresh respect the device's energy and thermal conditions. When `ProcessInfo.isLowPowerModeEnabled` is `true`, or `ProcessInfo.thermalState` is `.serious`/`.critical`, the periodic Plaid data fetch backs off:

- The cheap **connectivity re-probe, notification evaluation, and category-budget recompute keep running** every tick.
- Only the **network-and-CPU-heavy Plaid round-trip is deferred** while constrained.
- The background loop **sleeps longer** (base interval × `4`) so a throttled / battery-saving machine wakes the app less often, instead of spinning a tight wall-clock timer.
- **Manual refresh always runs** — energy state never suppresses a user-initiated refresh.
- Behavior is **unchanged when power and thermal are normal.**

The app subscribes to `NSProcessInfoPowerStateDidChange` and `ProcessInfo.thermalStateDidChangeNotification` and restarts the loop on a transition, so the cadence re-evaluates the moment conditions change (e.g. plug in → Low Power Mode off → loop drops back to the normal interval without waiting out a stale long sleep).

## Linear (AND-568)

Implements **AND-568** — energy-aware background refresh for the resident menu-bar app. Parent **AND-561**; related to **AND-422** (latency/cost) and **AND-425** (avoid full-cache rewrites), both Done.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — **1641 tests pass**, including **13 new** `EnergyAwareRefreshPolicyTests` covering: low-power defers, serious/critical thermal defers, normal proceeds, manual always allowed, not-yet-due never runs, the backoff multiplier (>1, lengthens the delay), and degenerate-base-interval clamping.
- The OS observers/timer live in the app; the pure decision (`shouldRunAutomaticRefresh` / `nextTickDelay`) lives in `PlaidBarCore` and is fully deterministic in CI (no live device thermal state).

## Architectural decisions

- **Pure decider in Core, observers in the app.** `EnergyAwareRefreshPolicy` (Sendable, framework-light) owns the gate + backoff math and a mirror of `ProcessInfo.ThermalState`, mirroring the existing `KeychainAccessPolicy` extraction pattern. `AppState` maps live `ProcessInfo` readings onto it. This keeps every branch unit-testable without a real device.
- **Gate placed inside `refreshDashboard(force:)`**, around the Plaid-fetch block, so the connectivity re-probe and budget recompute are never skipped — only the Plaid round-trip backs off. `force` (manual) bypasses the gate entirely.
- **Backoff multiplier co-located with the policy** rather than in `Constants.swift`, since it is policy-specific rather than a global tunable (the `refreshInterval` base remains the user-facing tunable).
- **`isolated deinit` (SE-0371)** removes the two block-based notification observers on the main actor, avoiding a leak without weakening actor isolation.

## Migration notes

None — additive, availability-gated. The power/thermal APIs are long-standing Foundation APIs (no macOS-26-only frameworks), so older OSes and non-Apple-Intelligence machines are unaffected and existing behavior is preserved when power/thermal are normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)