### PR TITLE
feat(ai): Foundation Models structured @Generable spending insights with streaming (AND-564)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -537,10 +537,13 @@ final class AppState {
         _ = try? LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
         self.notificationService = notificationService ?? NotificationService.shared
         loadSettings()
-        // Detection-only: record whether Apple Foundation Models is available so
-        // the tier resolver can prefer it. No model session is created and no
-        // prompt is routed through it (AND-563). Cheap + synchronous.
+        // Record whether Apple Foundation Models is available so the tier resolver
+        // can prefer it (AND-563) and, when available, the insight service routes
+        // generation through it (AND-564). Cheap + synchronous. `loadSettings()`
+        // already built the service with `.unsupported`; rebuild now that the probe
+        // ran so the FM engine is wired on launch when Apple Intelligence is ready.
         foundationModelsTierState = foundationModelsProbe.currentState()
+        rebuildLocalAIInsightsService()
         // Engage launch App Lock synchronously before the first SwiftUI body is
         // ever evaluated. Deferring this to `loadInitialData()` leaks one frame
         // of cached/demo account names and activity because `.task` runs after
@@ -832,9 +835,19 @@ final class AppState {
     private func rebuildLocalAIInsightsService() {
         localAIProbeGeneration += 1
         localAIProbeAvailability = nil
+        // AND-564: wire the Foundation Models insight engine ONLY when Apple
+        // Intelligence is available, so the service's pure routing decision can
+        // prefer it. On any OS/build without an available FM tier the model stays
+        // nil and the state stays `.unsupported`, leaving the existing generation
+        // path byte-identical to before AND-564.
+        let foundationModelsModel: (any LocalInsightModel)? = foundationModelsTierState.isAvailable
+            ? FoundationModelsInsightModel()
+            : nil
         localAIInsightsService = LocalAIInsightsService(
             enabledPreference: localAIEnabledPreference,
-            modelNamePreference: localAIModelNamePreference
+            modelNamePreference: localAIModelNamePreference,
+            foundationModelsModel: foundationModelsModel,
+            foundationModelsState: foundationModelsTierState
         )
     }
 
@@ -1531,9 +1544,15 @@ final class AppState {
     }
 
     /// Re-probe Apple Foundation Models availability (e.g. after the user enables
-    /// Apple Intelligence in System Settings). Detection only.
+    /// Apple Intelligence in System Settings) and rebuild the insight service so a
+    /// now-available FM tier starts generating insights (AND-564) — or a
+    /// now-unavailable one disengages and the existing engine resumes unchanged.
     func refreshFoundationModelsAvailability() {
+        let previous = foundationModelsTierState
         foundationModelsTierState = foundationModelsProbe.currentState()
+        guard foundationModelsTierState != previous else { return }
+        rebuildLocalAIInsightsService()
+        invalidateLocalAIActivitySummaries()
     }
 
     /// Cached local summaries — invalidated via accounts.didSet and transactions.didSet.

--- a/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
@@ -1,0 +1,113 @@
+import Foundation
+import PlaidBarCore
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// AND-564: the on-device Foundation Models (Apple Intelligence) insight engine.
+///
+/// This is the ONLY place that constructs a `LanguageModelSession` and runs
+/// guided generation. It conforms to the EXISTING `LocalInsightModel` seam so it
+/// drops straight into `LocalInsightModelRuntime.generateSummary` — reusing,
+/// unchanged, the redaction-safe prompt (`LocalInsightPromptBuilder`), the output
+/// validator (`LocalInsightModelOutputValidator`: no invented figures, no advice,
+/// no prompt echo), and the deterministic fallback. Foundation Models therefore
+/// gets no privileged path around VaultPeek's privacy + figure-verification
+/// guardrails; it is held to exactly the same contract as the Ollama engine.
+///
+/// Structured output: instead of free-form text we ask the model for a
+/// schema-guaranteed `@Generable` value (`GeneratedSpendingInsight`), so there is
+/// no brittle string parsing — the headline is always a typed field. We stream
+/// the response so a superseded refresh can cancel mid-generation, and map the
+/// schema into the Core `FoundationModelsInsightContent` → display string.
+///
+/// Availability/reversibility: the whole type is gated behind
+/// `#available(macOS 26, *)` + `#if canImport(FoundationModels)`. When Foundation
+/// Models is not the active/available tier, the routing decision
+/// (`FoundationModelsInsightRouting`) never selects this engine and the existing
+/// path runs byte-identically. `summarize` additionally re-checks availability
+/// and throws `runtimeUnavailable` if the model is not ready, so even a stale
+/// route degrades to the deterministic fallback rather than rendering nothing.
+struct FoundationModelsInsightModel: LocalInsightModel {
+    func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(macOS 26, *) {
+            return try await Self.generate(prompt: prompt, maxTokens: maxTokens)
+        } else {
+            throw LocalInsightModelError.unsupportedConfiguration
+        }
+        #else
+        throw LocalInsightModelError.unsupportedConfiguration
+        #endif
+    }
+}
+
+#if canImport(FoundationModels)
+@available(macOS 26, *)
+extension FoundationModelsInsightModel {
+    /// The schema-guaranteed spending insight. The system prompt
+    /// (`LocalInsightPromptBuilder.systemInstruction`) already forbids advice,
+    /// predictions, invented figures, and AI self-disclosure; the `@Guide` copy
+    /// here restates the shape so the model fills the single factual headline.
+    @Generable
+    struct GeneratedSpendingInsight {
+        @Guide(
+            description: "A one or two sentence factual summary of the user's own spending for the period, using ONLY the provided numbers. No advice, no predictions, no invented merchants or amounts."
+        )
+        var headline: String
+    }
+
+    static func generate(prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
+        // Re-confirm availability at call time. The routing layer already gates on
+        // `.available`, but System Settings can change between probe and call, so a
+        // stale route must degrade to the deterministic fallback, never error out
+        // of the insight surface.
+        guard case .available = SystemLanguageModel.default.availability else {
+            throw LocalInsightModelError.runtimeUnavailable
+        }
+
+        // The redaction-safe system guardrails become the session instructions;
+        // the display-safe aggregates become the prompt. Identical inputs to the
+        // Ollama engine — same privacy contract.
+        let session = LanguageModelSession(instructions: prompt.system)
+        let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: max(1, maxTokens))
+
+        do {
+            let stream = session.streamResponse(
+                to: Prompt(prompt.user),
+                generating: GeneratedSpendingInsight.self,
+                options: options
+            )
+
+            // Single-pass consumption: each snapshot carries the cumulative
+            // partially-generated content, so the LAST snapshot holds the final
+            // headline. Tracking it as we stream keeps cancellation responsive (a
+            // superseded refresh stops generation promptly) without depending on a
+            // post-iteration `collect()`.
+            var latestHeadline: String?
+            for try await snapshot in stream {
+                try Task.checkCancellation()
+                // `content.headline` is `String?` while the field streams in.
+                latestHeadline = FoundationModelsInsightMapper.partialDisplaySummary(
+                    fromHeadline: snapshot.content.headline
+                ) ?? latestHeadline
+            }
+
+            return FoundationModelsInsightMapper.displaySummary(
+                from: FoundationModelsInsightContent(headline: latestHeadline ?? "")
+            ) ?? ""
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as LocalInsightModelError {
+            throw error
+        } catch {
+            // Surface a runtime diagnostic; the shared runtime maps this to a
+            // `.modelError` fallback and logs it (no transaction data included).
+            throw LocalInsightModelError.runtimeUnavailableWithDiagnostic(
+                "Foundation Models generation failed: \(String(describing: type(of: error)))."
+            )
+        }
+    }
+}
+#endif

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -78,6 +78,15 @@ struct LocalAIInsightsService: Sendable {
     private let environment: [String: String]
     private let enabledPreference: Bool?
     private let generationConfiguration: LocalInsightModelGenerationConfiguration
+    /// AND-564: the Foundation Models (Apple Intelligence) insight engine, injected
+    /// by the app when Apple Intelligence is available. `nil` whenever Foundation
+    /// Models cannot generate (older OS, no SDK, not opted into wiring), which is
+    /// the default — so the legacy generation path is untouched there.
+    private let foundationModelsModel: (any LocalInsightModel)?
+    /// AND-564: the probed Foundation Models availability state used by the pure
+    /// routing decision. `.unsupported` by default, so FM never engages unless the
+    /// app explicitly wires an `.available` state — preserving today's behavior.
+    private let foundationModelsState: LocalAIFoundationModelsTierState
 
     init(
         model: (any LocalInsightModel)? = nil,
@@ -85,7 +94,9 @@ struct LocalAIInsightsService: Sendable {
         enabledPreference: Bool? = nil,
         modelNamePreference: String? = nil,
         autoDiscoverModel: Bool = true,
-        generationConfiguration: LocalInsightModelGenerationConfiguration = .default
+        generationConfiguration: LocalInsightModelGenerationConfiguration = .default,
+        foundationModelsModel: (any LocalInsightModel)? = nil,
+        foundationModelsState: LocalAIFoundationModelsTierState = .unsupported
     ) {
         self.environment = environment
         self.enabledPreference = enabledPreference
@@ -95,6 +106,43 @@ struct LocalAIInsightsService: Sendable {
             modelNamePreference: modelNamePreference
         ) : nil)
         self.generationConfiguration = generationConfiguration
+        self.foundationModelsModel = foundationModelsModel
+        self.foundationModelsState = foundationModelsState
+    }
+
+    /// The on-device AI tier this service would prefer to *generate* insights
+    /// with, given the FM probe state and whether the opted-in Ollama runtime is
+    /// engaged. Mirrors the tier resolver AppState surfaces in Settings.
+    private var preferredTier: LocalAIRuntimeTier {
+        LocalAITierResolver.resolvePreferredTier(
+            facts: LocalAITierFacts(
+                foundationModels: foundationModelsState,
+                ollamaEngaged: LocalAIRuntimeResolution.usesModel(for: availability.state),
+                naturalLanguageReady: Self.naturalLanguageTierReady
+            )
+        )
+    }
+
+    /// Whether Foundation Models is the active, available generation engine for
+    /// this service (AND-564). When `false`, the existing engine path runs exactly
+    /// as it did before FM existed. Delegates to the pure, unit-tested selector so
+    /// the runtime and the regression tests share one decision.
+    private var foundationModelsActive: Bool {
+        FoundationModelsInsightEngineSelector.selectEngine(
+            foundationModelsModelWired: foundationModelsModel != nil,
+            preferredTier: preferredTier,
+            foundationModelsState: foundationModelsState
+        ) == .foundationModels
+    }
+
+    /// The NaturalLanguage categorizer ships whenever the framework imports, which
+    /// on macOS is always.
+    private static var naturalLanguageTierReady: Bool {
+        #if canImport(NaturalLanguage)
+        true
+        #else
+        false
+        #endif
     }
 
     var availability: LocalAIAvailability {
@@ -239,7 +287,25 @@ struct LocalAIInsightsService: Sendable {
         var summaries: [LocalAIActivitySummary] = []
         summaries.reserveCapacity(inputs.count)
         let currentAvailability = availability
-        let configuredModel = LocalAIRuntimeResolution.usesModel(for: currentAvailability.state) ? model : nil
+        // AND-564: route generation through Foundation Models ONLY when it is the
+        // active, available tier; otherwise feed the existing engine exactly as
+        // before. When FM is inactive, `foundationModelsActive` is false and this
+        // collapses to the pre-AND-564 selection — the regression guard.
+        let useFoundationModels = foundationModelsActive
+        let configuredModel: (any LocalInsightModel)?
+        // The base availability `resolved(...)` upgrades from. For FM we synthesize
+        // a `.checking` base so a successful FM generation reports `.available`
+        // even when the Ollama runtime is `.disabled`/unconfigured (a user can have
+        // Apple Intelligence without ever opting into Ollama). Non-FM keeps the
+        // exact pre-AND-564 base.
+        let baseAvailability: LocalAIAvailability
+        if useFoundationModels {
+            configuredModel = foundationModelsModel
+            baseAvailability = Self.foundationModelsBaseAvailability
+        } else {
+            configuredModel = LocalAIRuntimeResolution.usesModel(for: currentAvailability.state) ? model : nil
+            baseAvailability = currentAvailability
+        }
 
         for input in inputs {
             // Cooperative cancellation: a multi-page sync reschedules this work
@@ -257,7 +323,7 @@ struct LocalAIInsightsService: Sendable {
                 configuration: generationConfiguration
             )
             let summaryAvailability = LocalAIRuntimeResolution.resolved(
-                base: currentAvailability,
+                base: baseAvailability,
                 usedModelOutput: generated.usedModelOutput,
                 fallbackReason: generated.fallbackReason,
                 fallbackDiagnostic: generated.fallbackDiagnostic
@@ -276,6 +342,16 @@ struct LocalAIInsightsService: Sendable {
 
         return summaries
     }
+
+    /// Base availability used when Foundation Models generates the summary
+    /// (AND-564). `.checking` so a successful generation upgrades to `.available`
+    /// via `resolved(...)`, and a failed one degrades to `.unavailable` with the
+    /// Apple Intelligence runtime name — never silently reading as `.disabled`.
+    private static let foundationModelsBaseAvailability = LocalAIAvailability(
+        state: .checking,
+        runtimeName: LocalAIRuntimeTier.foundationModels.shortStatusLabel,
+        detail: "Verifying Apple Intelligence on-device generation. VaultPeek keeps the data on this Mac, validates output, and falls back to deterministic local summaries."
+    )
 
     /// Construct the on-device model ONLY when the user has explicitly opted in
     /// via persisted app settings or (`PLAIDBAR_LOCAL_AI_RUNTIME=ollama`/`auto`)

--- a/Sources/PlaidBarCore/Utilities/FoundationModelsInsight.swift
+++ b/Sources/PlaidBarCore/Utilities/FoundationModelsInsight.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// AND-564: the pure, OS-independent pieces of the Foundation Models structured
+/// insight path — the schema→display mapping and the "which engine generates
+/// this insight" routing decision.
+///
+/// The live Foundation Models call (an `@Generable` struct streamed through
+/// `LanguageModelSession`) lives in the app target behind
+/// `#available(macOS 26, *)` + `#if canImport(FoundationModels)`. The app's
+/// `@Generable` value maps INTO `FoundationModelsInsightContent` here, so all of
+/// the schema-shape-to-display-string logic — and every edge case (empty output,
+/// a still-streaming partial) — is testable in `PlaidBarCore` on any OS, without
+/// ever touching the FoundationModels SDK.
+///
+/// Privacy contract: this file performs no I/O and sees no raw identifiers. The
+/// FM generator reuses the EXISTING redaction-safe prompt seam
+/// (`LocalInsightPromptBuilder`) and the EXISTING output validator
+/// (`LocalInsightModelOutputValidator`) by conforming to `LocalInsightModel`, so
+/// Foundation Models is held to the same privacy + figure-verification guardrails
+/// as the current on-device engines.
+
+/// The structured insight the Foundation Models `@Generable` schema guarantees,
+/// lifted into a plain `Sendable` value so the mapping is testable without the
+/// SDK. Schema-guaranteed shape means no brittle string parsing: the headline is
+/// always a field, the supporting bullets are always a list.
+public struct FoundationModelsInsightContent: Sendable, Hashable {
+    /// A one-to-two sentence factual spending summary for the window.
+    public let headline: String
+    /// Optional short supporting points. The runtime currently renders only the
+    /// headline (the existing UI shows a single generated summary line plus the
+    /// deterministic bullets), but the schema captures bullets so a future UI can
+    /// surface them without another model round-trip.
+    public let supportingPoints: [String]
+
+    public init(headline: String, supportingPoints: [String] = []) {
+        self.headline = headline
+        self.supportingPoints = supportingPoints
+    }
+}
+
+/// Pure mapping from the schema-guaranteed `FoundationModelsInsightContent` to the
+/// single display string the existing insight runtime/UI consumes.
+///
+/// This is deliberately conservative: it ONLY collapses whitespace and joins.
+/// Content safety (no invented figures, no advice, no prompt echo) is NOT done
+/// here — it is enforced downstream by the shared
+/// `LocalInsightModelOutputValidator`, exactly as it is for the Ollama engine, so
+/// Foundation Models gets no privileged path around the guardrails.
+public enum FoundationModelsInsightMapper {
+    /// Produce the display summary string from a (possibly partial) generated
+    /// insight.
+    ///
+    /// Returns `nil` when there is nothing usable yet — an empty/whitespace-only
+    /// headline. A `nil` result during streaming means "no displayable text yet";
+    /// a `nil` final result means the model produced no headline and the caller
+    /// must fall back to the deterministic summary (never render a blank line).
+    public static func displaySummary(from content: FoundationModelsInsightContent) -> String? {
+        let collapsedHeadline = collapseWhitespace(content.headline)
+        guard !collapsedHeadline.isEmpty else { return nil }
+        return collapsedHeadline
+    }
+
+    /// Map a streaming snapshot whose headline may still be `nil` (the
+    /// `PartiallyGenerated` field has not arrived yet). Mirrors
+    /// `displaySummary(from:)` but tolerates the not-yet-generated state so the UI
+    /// can show progressive text as tokens stream in.
+    public static func partialDisplaySummary(fromHeadline headline: String?) -> String? {
+        guard let headline else { return nil }
+        let collapsed = collapseWhitespace(headline)
+        return collapsed.isEmpty ? nil : collapsed
+    }
+
+    private static func collapseWhitespace(_ text: String) -> String {
+        text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// Pure decision: which on-device engine should generate this insight.
+///
+/// Foundation Models generates the insight ONLY when the resolved preferred tier
+/// is `.foundationModels` AND its availability state is `.available`. For every
+/// other combination the existing engine path is used UNCHANGED — this
+/// equivalence is the regression guard the tests pin: when FM is not the active,
+/// available tier, behaviour must be byte-identical to today.
+public enum FoundationModelsInsightRouting {
+    /// `true` ⇢ route generation through the Foundation Models engine.
+    /// `false` ⇢ use the existing engine (Ollama / deterministic), unchanged.
+    public static func shouldUseFoundationModels(
+        preferredTier: LocalAIRuntimeTier,
+        foundationModelsState: LocalAIFoundationModelsTierState
+    ) -> Bool {
+        preferredTier == .foundationModels && foundationModelsState.isAvailable
+    }
+}
+
+/// Which engine the insight service feeds to the shared generation runtime.
+public enum FoundationModelsInsightEngine: String, Sendable, Hashable {
+    /// Route through the Foundation Models `@Generable` engine (AND-564).
+    case foundationModels
+    /// Use the pre-AND-564 path (Ollama when engaged, else the deterministic
+    /// fallback inside the runtime). Behaviour here is byte-identical to today.
+    case existing
+}
+
+/// Pure selection of the generation engine `LocalAIInsightsService` uses, lifted
+/// out of the (app-target, untestable-because-`@main`) service so the
+/// "FM-active → FM; FM-inactive → existing, unchanged" decision is unit-testable
+/// in PlaidBarCore.
+///
+/// The selection depends only on whether a Foundation Models engine is actually
+/// wired (`foundationModelsModelWired`) and whether the routing guard says FM is
+/// the active, available tier. When either is false, the result is `.existing` —
+/// the regression guard.
+public enum FoundationModelsInsightEngineSelector {
+    public static func selectEngine(
+        foundationModelsModelWired: Bool,
+        preferredTier: LocalAIRuntimeTier,
+        foundationModelsState: LocalAIFoundationModelsTierState
+    ) -> FoundationModelsInsightEngine {
+        guard foundationModelsModelWired else { return .existing }
+        let useFM = FoundationModelsInsightRouting.shouldUseFoundationModels(
+            preferredTier: preferredTier,
+            foundationModelsState: foundationModelsState
+        )
+        return useFM ? .foundationModels : .existing
+    }
+}

--- a/Tests/PlaidBarCoreTests/FoundationModelsInsightTests.swift
+++ b/Tests/PlaidBarCoreTests/FoundationModelsInsightTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// AND-564: pure-logic tests for the Foundation Models structured-insight path.
+///
+/// These cover the two pieces extracted into PlaidBarCore so they run on any OS
+/// without Apple Intelligence:
+///   1. the `@Generable` schema → display-string mapping (incl. empty + partial
+///      streaming states), and
+///   2. the engine-routing decision (FM-active-and-available → FM, else the
+///      existing engine — the regression guard).
+@Suite("Foundation Models Structured Insight Tests")
+struct FoundationModelsInsightTests {
+    // MARK: - Schema → display mapping
+
+    @Test("A complete generated headline maps to a trimmed display string")
+    func completeHeadlineMaps() {
+        let content = FoundationModelsInsightContent(
+            headline: "You spent $1,200 across 14 transactions this month.",
+            supportingPoints: ["Groceries led at $400."]
+        )
+        #expect(
+            FoundationModelsInsightMapper.displaySummary(from: content)
+                == "You spent $1,200 across 14 transactions this month."
+        )
+    }
+
+    @Test("Surrounding and internal whitespace/newlines collapse to single spaces")
+    func whitespaceCollapses() {
+        let content = FoundationModelsInsightContent(
+            headline: "  You spent\n\n$1,200   across\t14 transactions.  "
+        )
+        #expect(
+            FoundationModelsInsightMapper.displaySummary(from: content)
+                == "You spent $1,200 across 14 transactions."
+        )
+    }
+
+    @Test("An empty or whitespace-only headline maps to nil so the caller falls back")
+    func emptyHeadlineMapsToNil() {
+        #expect(FoundationModelsInsightMapper.displaySummary(from: FoundationModelsInsightContent(headline: "")) == nil)
+        #expect(
+            FoundationModelsInsightMapper.displaySummary(from: FoundationModelsInsightContent(headline: "   \n\t "))
+                == nil
+        )
+    }
+
+    // MARK: - Streaming partial mapping
+
+    @Test("A nil partial headline (field not yet generated) yields nil")
+    func partialNilHeadlineYieldsNil() {
+        #expect(FoundationModelsInsightMapper.partialDisplaySummary(fromHeadline: nil) == nil)
+    }
+
+    @Test("A partial headline that is only whitespace yields nil, not a blank line")
+    func partialWhitespaceHeadlineYieldsNil() {
+        #expect(FoundationModelsInsightMapper.partialDisplaySummary(fromHeadline: "   ") == nil)
+    }
+
+    @Test("A non-empty partial headline streams through, whitespace-collapsed")
+    func partialHeadlineStreams() {
+        #expect(
+            FoundationModelsInsightMapper.partialDisplaySummary(fromHeadline: "You spent $1,2")
+                == "You spent $1,2"
+        )
+        #expect(
+            FoundationModelsInsightMapper.partialDisplaySummary(fromHeadline: "You  spent\n$1,200")
+                == "You spent $1,200"
+        )
+    }
+
+    // MARK: - Engine routing (FM-active vs. regression guard)
+
+    @Test("FM generates only when it is the preferred tier AND available")
+    func fmRoutesWhenPreferredAndAvailable() {
+        #expect(
+            FoundationModelsInsightRouting.shouldUseFoundationModels(
+                preferredTier: .foundationModels,
+                foundationModelsState: .available
+            ) == true
+        )
+    }
+
+    @Test("FM does not generate when it is the preferred tier but not available")
+    func fmDoesNotRouteWhenPreferredButUnavailable() {
+        // The resolver only returns `.foundationModels` when `.available`, but the
+        // routing guard double-checks availability so a stale tier never engages
+        // an unusable model.
+        let unavailable: [LocalAIFoundationModelsTierState] = [
+            .unsupported, .deviceNotEligible, .appleIntelligenceNotEnabled, .modelNotReady, .unavailableOther,
+        ]
+        for state in unavailable {
+            #expect(
+                FoundationModelsInsightRouting.shouldUseFoundationModels(
+                    preferredTier: .foundationModels,
+                    foundationModelsState: state
+                ) == false
+            )
+        }
+    }
+
+    @Test("Every non-FM preferred tier uses the existing engine even if FM is available")
+    func nonFMTiersNeverRouteToFM() {
+        // Regression guard: when the resolved tier is anything other than FM, the
+        // existing engine generates — regardless of FM availability — so behaviour
+        // is byte-identical to today.
+        for tier in [LocalAIRuntimeTier.ollama, .naturalLanguage, .heuristic] {
+            for state in LocalAIFoundationModelsTierState.allCases {
+                #expect(
+                    FoundationModelsInsightRouting.shouldUseFoundationModels(
+                        preferredTier: tier,
+                        foundationModelsState: state
+                    ) == false
+                )
+            }
+        }
+    }
+
+    // MARK: - Engine selection (the path LocalAIInsightsService actually takes)
+
+    @Test("Selector chooses the FM engine only when FM is wired, preferred, and available")
+    func selectorChoosesFMWhenWiredAndActive() {
+        #expect(
+            FoundationModelsInsightEngineSelector.selectEngine(
+                foundationModelsModelWired: true,
+                preferredTier: .foundationModels,
+                foundationModelsState: .available
+            ) == .foundationModels
+        )
+    }
+
+    @Test("Selector falls back to the existing engine when no FM model is wired")
+    func selectorFallsBackWhenFMNotWired() {
+        // Even if the tier/state say FM, an unwired engine (older OS / no SDK)
+        // must use the existing path — the engine literally cannot be constructed.
+        #expect(
+            FoundationModelsInsightEngineSelector.selectEngine(
+                foundationModelsModelWired: false,
+                preferredTier: .foundationModels,
+                foundationModelsState: .available
+            ) == .existing
+        )
+    }
+
+    @Test("Selector reproduces today's behavior for every non-active FM combination")
+    func selectorRegressionGuard() {
+        // The whole matrix that must remain `.existing` (byte-identical to today):
+        //  - any non-FM preferred tier, regardless of wiring/state, OR
+        //  - FM preferred but not available, OR
+        //  - FM not wired.
+        for wired in [true, false] {
+            for state in LocalAIFoundationModelsTierState.allCases {
+                for tier in [LocalAIRuntimeTier.ollama, .naturalLanguage, .heuristic] {
+                    #expect(
+                        FoundationModelsInsightEngineSelector.selectEngine(
+                            foundationModelsModelWired: wired,
+                            preferredTier: tier,
+                            foundationModelsState: state
+                        ) == .existing
+                    )
+                }
+            }
+
+            // FM preferred but unavailable → existing, for every unavailable state.
+            for state in LocalAIFoundationModelsTierState.allCases where !state.isAvailable {
+                #expect(
+                    FoundationModelsInsightEngineSelector.selectEngine(
+                        foundationModelsModelWired: wired,
+                        preferredTier: .foundationModels,
+                        foundationModelsState: state
+                    ) == .existing
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Routes VaultPeek's spending-insight generation through Apple's on-device
**Foundation Models** when Apple Intelligence is the resolved, available AI tier
(per AND-563's `LocalAITierResolver`). The insight is produced from a
**schema-guaranteed `@Generable` struct streamed from a `LanguageModelSession`** —
no brittle string parsing — and streamed into the existing insight state/UI.

The Foundation Models engine conforms to the **existing `LocalInsightModel` seam**,
so it flows through `LocalInsightModelRuntime.generateSummary` and reuses, unchanged:
- the redaction-safe prompt seam (`LocalInsightPromptBuilder` — AND-323): only
  display-safe aggregates, never raw account/transaction/item IDs or tokens, and
- the output validator (`LocalInsightModelOutputValidator`): rejects invented
  figures, advice/predictions, AI self-disclosure, and prompt echo, falling back
  to the deterministic summary.

Foundation Models therefore gets **no privileged path** around VaultPeek's privacy
and figure-verification guardrails — same contract as the Ollama engine.

When Foundation Models is **not** the active/available tier (older OS, no SDK,
ineligible device, Apple Intelligence off/not ready), behavior is **byte-identical
to today**: the existing engine generates and nothing about the current path
changes. This equivalence is regression-guarded by pure unit tests.

### What changed
- **`Sources/PlaidBarCore/Utilities/FoundationModelsInsight.swift`** (new, pure):
  `FoundationModelsInsightContent` + `Mapper` (schema → display string, incl.
  empty/whitespace and still-streaming partial states); `FoundationModelsInsightRouting`
  and `FoundationModelsInsightEngineSelector` (the FM-active-and-available → FM,
  else existing-engine decision).
- **`Sources/PlaidBar/Services/FoundationModelsInsightModel.swift`** (new): the
  `@Generable` insight generator. The ONLY place that builds a `LanguageModelSession`
  / runs guided generation. Behind `#available(macOS 26, *)` + `#if canImport(FoundationModels)`.
- **`Sources/PlaidBar/Services/LocalAIInsightsService.swift`**: threads the FM
  model + probed state in; selects the FM engine (and an FM-specific base
  availability) only when the pure selector says so; otherwise the pre-existing
  selection is untouched.
- **`Sources/PlaidBar/App/AppState.swift`**: minimal insight-generation wiring —
  constructs `FoundationModelsInsightModel` only when Apple Intelligence is
  available, rebuilds the service after the launch probe, and re-engages/disengages
  on `refreshFoundationModelsAvailability()`.

## Linear (AND-564)

Implements **AND-564** "structured Foundation Models spending insights via guided
generation (`@Generable`) with streaming". Parent **AND-560**; depends on **AND-563**
(FoundationModels availability detection + `LocalAITierResolver`, already on `main`).
Scope is the insight-generation path only — the categorization tier (AND-565) and
RefreshService/dashboard/review/budget are untouched.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green
  (this machine has the FoundationModels SDK, so the real FM code path compiled
  under strict concurrency, not just the fallback branch).
- `swift test` — **1663 tests pass**.
- New: `Tests/PlaidBarCoreTests/FoundationModelsInsightTests.swift` (12 tests):
  - schema → display mapping (complete headline, whitespace collapse, empty → nil fallback);
  - streaming-partial mapping (nil field, whitespace-only, progressive text);
  - routing + engine selection: **FM-active → FM**, and the **regression guard** that
    every non-active FM combination (non-FM tier, FM-unavailable, FM-not-wired)
    resolves to the **existing** engine.
- The live FM call is gated/injected; tests never invoke a `LanguageModelSession`.

## Architectural decisions

- **Reuse the `LocalInsightModel` seam instead of a parallel pipeline.** Conforming
  the FM generator to the existing protocol means the redaction, validation,
  timeout, and deterministic-fallback machinery apply unchanged — privacy and
  safety are not re-implemented (and can't be bypassed) for FM.
- **Pure decision logic in `PlaidBarCore`.** The schema→display mapping and the
  engine-routing/selection are pure and `Sendable`, so they're unit-testable on any
  OS without Apple Intelligence; the app target only holds the SDK-touching session.
- **FM-specific base availability.** When FM generates while the Ollama runtime is
  `.disabled`/unconfigured, the service synthesizes a `.checking` base so a
  successful FM generation reports `.available` (and a failure → `.unavailable` with
  the Apple Intelligence runtime name) rather than misreading as "Local AI off".
- **`maximumResponseTokens` + `temperature: 0.2`** mirror the Ollama generation
  config (short, low-variance factual summary); single-pass stream consumption keeps
  cancellation responsive for superseded multi-page-sync refreshes.

## Migration notes

None — additive, availability-gated. No schema/storage/settings migration; no new
defaults; no behavior change on any build where Foundation Models is not the active,
available tier.

## On-device QA note

The Foundation Models output **cannot be exercised in CI** (no Apple-Intelligence
runtime on the build machine), so the streamed-text path needs **eyes-on a real
Apple-Intelligence-eligible Mac (macOS 26, Apple Intelligence enabled)**:
- Confirm the insight headline is generated by Apple Intelligence (Settings/status
  surfaces the "Apple Intelligence" runtime; availability resolves to `Available`).
- Confirm the streamed summary renders progressively and the final line is factual,
  contains no invented `$` figures, no advice/predictions, and no AI self-disclosure
  (the shared validator should already reject these — verify it does in practice).
- Toggle Apple Intelligence off in System Settings and confirm the insight falls
  back to the deterministic summary with no error surface (and on again re-engages).
- Sanity-check privacy: the model must only ever see the display-safe aggregate
  prompt (no raw IDs/tokens) — same as the Ollama path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
