### PR TITLE
feat(ux): haptic feedback for direct-manipulation interactions (AND-576)

### DIFF
--- a/Sources/PlaidBar/Services/HapticFeedback.swift
+++ b/Sources/PlaidBar/Services/HapticFeedback.swift
@@ -1,0 +1,46 @@
+import AppKit
+import PlaidBarCore
+
+/// Thin app-side bridge from the pure `HapticFeedbackPolicy` (Core) to AppKit's
+/// `NSHapticFeedbackManager` (AND-576).
+///
+/// The *policy* — which interaction maps to which pattern, and whether haptics
+/// fire at all — lives in `PlaidBarCore` so it stays `Sendable` and unit-tested.
+/// This helper is the only place that touches AppKit: it resolves the pattern
+/// for an interaction (gated by the user preference) and, when one is returned,
+/// performs it on `NSHapticFeedbackManager.defaultPerformer`.
+///
+/// Force Touch trackpads give a small tactile confirmation; on hardware without
+/// a haptic engine the performer is a silent no-op, which AppKit handles — so
+/// this is safe to call unconditionally on any Mac. When the preference is off
+/// (or `enabled: false` is passed) `pattern(for:enabled:)` returns `nil` and
+/// nothing is performed, so behavior equals today.
+@MainActor
+enum HapticFeedback {
+    /// Plays the feedback pattern the policy maps `interaction` to, if any.
+    ///
+    /// - Parameters:
+    ///   - interaction: the committed direct-manipulation kind.
+    ///   - enabled: the resolved user preference (default on). When `false`,
+    ///     no feedback is performed.
+    static func play(_ interaction: HapticInteraction, enabled: Bool) {
+        guard let pattern = HapticFeedbackPolicy.pattern(for: interaction, enabled: enabled) else { return }
+        NSHapticFeedbackManager.defaultPerformer.perform(
+            feedbackPattern(for: pattern),
+            performanceTime: .default
+        )
+    }
+
+    /// Maps the Core, AppKit-free `HapticPattern` token onto AppKit's concrete
+    /// `NSHapticFeedbackManager.FeedbackPattern`. Kept private and exhaustive so
+    /// adding a Core pattern forces a decision here.
+    private static func feedbackPattern(
+        for pattern: HapticPattern
+    ) -> NSHapticFeedbackManager.FeedbackPattern {
+        switch pattern {
+        case .alignment: .alignment
+        case .levelChange: .levelChange
+        case .generic: .generic
+        }
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -77,6 +77,7 @@ struct AppearanceSettingsView: View {
     @AppStorage(DecorativeEffectsPreference.storageKey) private var decorativeRaw = DecorativeEffectsPreference.defaultValue.rawValue
     @AppStorage(AppDensityPreference.storageKey) private var densityRaw = AppDensityPreference.defaultValue.rawValue
     @AppStorage(TextSizePreference.storageKey) private var textSizeRaw = TextSizePreference.defaultValue.rawValue
+    @AppStorage(HapticFeedbackPreference.storageKey) private var hapticRaw = HapticFeedbackPreference.defaultValue.rawValue
     @Environment(\.colorSchemeContrast) private var systemContrast
 
     private var transparencySetting: PopoverTransparencySetting {
@@ -88,6 +89,7 @@ struct AppearanceSettingsView: View {
     private var decorativePreference: DecorativeEffectsPreference { DecorativeEffectsPreference(rawValue: decorativeRaw) ?? .followSystem }
     private var density: AppDensityPreference { AppDensityPreference(rawValue: densityRaw) ?? .comfortable }
     private var textSize: TextSizePreference { TextSizePreference(rawValue: textSizeRaw) ?? .default }
+    private var hapticPreference: HapticFeedbackPreference { HapticFeedbackPreference(rawValue: hapticRaw) ?? .on }
 
     /// Increased contrast applies when the app pref asks for it OR the system
     /// Increase Contrast accessibility setting is on (system always wins).
@@ -239,6 +241,24 @@ struct AppearanceSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text("macOS ignores the system Dynamic Type setting for apps, so use this to make VaultPeek's text larger everywhere. The largest steps reflow some layouts to keep numbers legible.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Feedback") {
+                // Direct-manipulation haptics (AND-576). On by default; a no-op on
+                // Macs without a Force Touch haptic engine, so this only affects
+                // hardware that can play feedback. Committed direct manipulations —
+                // resolving/ignoring a review row, the quick Privacy Mask toggle —
+                // get a small tactile confirmation. It is intentionally limited to
+                // those committed gestures, never every minor state change.
+                Toggle("Haptic feedback", isOn: Binding(
+                    get: { hapticPreference.isEnabled },
+                    set: { hapticRaw = ($0 ? HapticFeedbackPreference.on : .off).rawValue }
+                ))
+                .accessibilityHint("Plays a small trackpad click when you approve, ignore, or toggle directly.")
+
+                Text("Plays a subtle Force Touch trackpad click when you directly approve, ignore, or toggle. No effect on Macs without a haptic trackpad.")
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -2372,6 +2372,10 @@ private func accountTrendAccessibility(_ trend: BalanceTrend) -> String {
 private struct DashboardFooter: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dashboardPresentation) private var dashboardPresentation
+    /// Direct-manipulation haptics preference (AND-576). Drives the quick
+    /// Privacy Mask toggle's tactile confirmation; off-state is a no-op. The
+    /// pure mapping lives in Core.
+    @AppStorage(HapticFeedbackPreference.storageKey) private var hapticRaw = HapticFeedbackPreference.defaultValue.rawValue
     let settingsActivation: SettingsWindowActivationRestorer
     let openSettings: OpenSettingsAction
     let onAddAccount: () -> Void
@@ -2416,6 +2420,14 @@ private struct DashboardFooter: View {
             // so the glyph reflects exactly what the button controls; meaning is
             // carried by the eye/eye.slash SHAPE, never color.
             Button {
+                // Tactile confirmation for the in-popover mask/reveal flip
+                // (AND-576) — a binary direct manipulation. No-op when the
+                // preference is off or the trackpad lacks a haptic engine, so
+                // behavior matches today.
+                HapticFeedback.play(
+                    .toggle,
+                    enabled: (HapticFeedbackPreference(rawValue: hapticRaw) ?? .on).isEnabled
+                )
                 appState.togglePrivacyMask()
             } label: {
                 Image(systemName: PrivacyMaskPresentation.toggleSymbolName(

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -13,6 +13,11 @@ struct ReviewInboxView: View {
     /// Opens the detached multi-select review Table window for power review (AND-532).
     /// Injected by the app scene; a no-op in previews / headless renders.
     @Environment(\.openReviewTable) private var openReviewTable
+    /// Whether direct-manipulation haptics fire (AND-576). Read here so the
+    /// review actions — the highest-value direct manipulations in the app — give
+    /// a tactile confirmation on Force Touch trackpads when enabled. Off-state is
+    /// a no-op (behavior equals today). The pure mapping lives in Core.
+    @AppStorage(HapticFeedbackPreference.storageKey) private var hapticRaw = HapticFeedbackPreference.defaultValue.rawValue
     @FocusState private var isFocused: Bool
     @State private var selectedIndex = 0
     @State private var merchantDrafts: [String: String] = [:]
@@ -487,7 +492,17 @@ struct ReviewInboxView: View {
         AccessibilityNotification.Announcement("Marked \(plan.count) \(noun) reviewed").post()
     }
 
+    /// Resolved haptic preference (default on). Off makes every `play` a no-op,
+    /// so behavior with haptics disabled equals today.
+    private var hapticsEnabled: Bool {
+        (HapticFeedbackPreference(rawValue: hapticRaw) ?? .on).isEnabled
+    }
+
     private func recordBulkAction(count: Int) {
+        // Bulk "mark N reviewed" is a committed positive resolution — same
+        // tactile confirmation as a single-row approve (AND-576). No-op when the
+        // preference is off or the hardware lacks a haptic engine.
+        HapticFeedback.play(.reviewResolved, enabled: hapticsEnabled)
         confirmationGeneration &+= 1
         let generation = confirmationGeneration
         withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
@@ -501,6 +516,12 @@ struct ReviewInboxView: View {
     }
 
     private func recordAction(_ action: ReviewActionConfirmation.Action, for item: TransactionReviewItem) {
+        // Every committed single-row review action is a direct manipulation that
+        // resolves or recategorizes a row — give a tactile confirmation on Force
+        // Touch trackpads (AND-576). Ignore reads as a softer "removed" click;
+        // all other resolutions share the positive confirmation. No-op when the
+        // preference is off, matching today's behavior exactly.
+        HapticFeedback.play(action.hapticInteraction, enabled: hapticsEnabled)
         confirmationGeneration &+= 1
         let generation = confirmationGeneration
         withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
@@ -606,6 +627,18 @@ private struct ReviewActionConfirmation: Equatable {
                 "Rule created"
             case let .bulkReviewed(count):
                 "Marked \(count) reviewed"
+            }
+        }
+
+        /// The haptic interaction kind this action plays (AND-576). Ignore is the
+        /// one "removed" gesture that gets the softer level-change click; every
+        /// other committed resolution shares the positive confirmation. The pure
+        /// `HapticFeedbackPolicy` maps these kinds to concrete patterns.
+        var hapticInteraction: HapticInteraction {
+            switch self {
+            case .ignored: .reviewIgnored
+            case .approved, .categorized, .renamed, .markedTransfer, .markedSpend, .ruleCreated, .bulkReviewed:
+                .reviewResolved
             }
         }
     }

--- a/Sources/PlaidBarCore/Models/HapticFeedbackPolicy.swift
+++ b/Sources/PlaidBarCore/Models/HapticFeedbackPolicy.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Local-only haptic-feedback policy for VaultPeek (AND-576).
+///
+/// Force Touch trackpads can give a small tactile confirmation when the user
+/// directly manipulates a control — approving a review row, flipping a toggle,
+/// reordering. The app uses `NSHapticFeedbackManager` nowhere today, so this
+/// pure model owns the *policy*: which interaction maps to which feedback
+/// pattern, and whether haptics fire at all. The actual AppKit call stays in
+/// the app target behind a thin helper; keeping the decision here makes it
+/// `Sendable` and unit-testable without AppKit.
+///
+/// Two cardinal rules are encoded:
+/// 1. **Respectful by default but opt-out-able.** A user setting gates the whole
+///    system. When disabled, `pattern(for:)` returns `nil` and the app performs
+///    no feedback — behavior equals today.
+/// 2. **Only meaningful, committed direct manipulations get feedback.** This is
+///    a fixed, finite set of interaction kinds; minor/continuous state changes
+///    are intentionally absent so haptics never fire on every keystroke or
+///    hover.
+
+// MARK: - Interaction kinds
+
+/// The committed direct-manipulation interactions that may emit haptic
+/// feedback. Deliberately small: only discrete, user-initiated commitments —
+/// not hover, scroll, focus, or every transient state change.
+public enum HapticInteraction: String, CaseIterable, Sendable {
+    /// A review row was approved / marked reviewed (single-row or bulk). The
+    /// primary "this is done" confirmation.
+    case reviewResolved
+    /// A review row was ignored / dismissed from the queue. A softer "removed"
+    /// confirmation, distinct from a positive resolution.
+    case reviewIgnored
+    /// A binary control (toggle/switch) was flipped by the user.
+    case toggle
+    /// A row/item was pinned or unpinned, or a discrete selection committed.
+    case pinToggle
+    /// A drag-to-reorder move was committed (drop), not the continuous drag.
+    case reorder
+}
+
+/// A SwiftUI/AppKit-free token for the kind of tactile feedback to play. The
+/// app maps each case onto `NSHapticFeedbackManager.FeedbackPattern`; keeping
+/// the enum here lets the mapping be asserted in pure tests.
+///
+/// - `alignment`: light, for snapping/committing a position (reorder, pin).
+/// - `levelChange`: a firmer click for a discrete state change (toggle, ignore).
+/// - `generic`: the default confirmation for a committed action (resolve).
+public enum HapticPattern: String, CaseIterable, Sendable {
+    case alignment
+    case levelChange
+    case generic
+}
+
+// MARK: - User preference
+
+/// Whether direct-manipulation haptics fire. Local-only, opt-out-able, and on
+/// by default (sensible default for Force Touch hardware; a no-op on hardware
+/// without a haptic engine, which AppKit handles silently).
+public enum HapticFeedbackPreference: String, CaseIterable, Sendable, Identifiable {
+    case on
+    case off
+
+    public static let storageKey = "interaction.hapticFeedback"
+    public static let defaultValue: HapticFeedbackPreference = .on
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .on: "On"
+        case .off: "Off"
+        }
+    }
+
+    /// Whether haptics are enabled under this preference.
+    public var isEnabled: Bool { self == .on }
+}
+
+// MARK: - Policy
+
+/// Pure mapping from an interaction to the feedback pattern that should play,
+/// gated by the enabled flag. The single source of truth the app helper calls.
+public enum HapticFeedbackPolicy {
+    /// The pattern to play for `interaction`, or `nil` when haptics are disabled.
+    ///
+    /// `nil` is the off-state contract: the app performs no feedback, so behavior
+    /// with haptics disabled (or on Reduce-Motion-style opt-out) equals today.
+    public static func pattern(for interaction: HapticInteraction, enabled: Bool) -> HapticPattern? {
+        guard enabled else { return nil }
+        return pattern(for: interaction)
+    }
+
+    /// The pattern an interaction maps to when haptics are enabled. Stable,
+    /// total mapping — every interaction has exactly one pattern.
+    public static func pattern(for interaction: HapticInteraction) -> HapticPattern {
+        switch interaction {
+        case .reviewResolved:
+            // A committed positive resolution — the default confirmation.
+            .generic
+        case .reviewIgnored:
+            // A discrete "removed" state change — a firmer click distinguishes
+            // it from a positive resolution.
+            .levelChange
+        case .toggle:
+            // Binary control flip — the canonical discrete state change.
+            .levelChange
+        case .pinToggle:
+            // Snapping a discrete selection/pin into place — light alignment.
+            .alignment
+        case .reorder:
+            // Committing a reorder drop — light alignment, matching macOS list
+            // reordering feel.
+            .alignment
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/HapticFeedbackPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/HapticFeedbackPolicyTests.swift
@@ -1,0 +1,59 @@
+import PlaidBarCore
+import Testing
+
+@Suite("Haptic feedback policy (AND-576)")
+struct HapticFeedbackPolicyTests {
+    // MARK: Preference
+
+    @Test("Haptics default to on, opt-out-able")
+    func preferenceDefault() {
+        #expect(HapticFeedbackPreference.defaultValue == .on)
+        #expect(HapticFeedbackPreference.on.isEnabled)
+        #expect(!HapticFeedbackPreference.off.isEnabled)
+    }
+
+    @Test("Preference round-trips through its storage raw value")
+    func preferenceRawValueRoundTrip() {
+        for pref in HapticFeedbackPreference.allCases {
+            #expect(HapticFeedbackPreference(rawValue: pref.rawValue) == pref)
+        }
+        #expect(HapticFeedbackPreference(rawValue: "garbage") == nil)
+    }
+
+    // MARK: Enabled gate
+
+    @Test("Disabled returns no pattern for every interaction (behavior equals today)")
+    func disabledSuppressesAllFeedback() {
+        for interaction in HapticInteraction.allCases {
+            #expect(HapticFeedbackPolicy.pattern(for: interaction, enabled: false) == nil)
+        }
+    }
+
+    @Test("Enabled returns the same pattern the unguarded mapping yields")
+    func enabledMatchesUnguardedMapping() {
+        for interaction in HapticInteraction.allCases {
+            #expect(
+                HapticFeedbackPolicy.pattern(for: interaction, enabled: true)
+                    == HapticFeedbackPolicy.pattern(for: interaction)
+            )
+        }
+    }
+
+    // MARK: Mapping
+
+    @Test("Each interaction maps to its expected pattern")
+    func interactionMapping() {
+        #expect(HapticFeedbackPolicy.pattern(for: .reviewResolved) == .generic)
+        #expect(HapticFeedbackPolicy.pattern(for: .reviewIgnored) == .levelChange)
+        #expect(HapticFeedbackPolicy.pattern(for: .toggle) == .levelChange)
+        #expect(HapticFeedbackPolicy.pattern(for: .pinToggle) == .alignment)
+        #expect(HapticFeedbackPolicy.pattern(for: .reorder) == .alignment)
+    }
+
+    @Test("The mapping is total — every interaction yields a non-nil pattern when enabled")
+    func mappingIsTotal() {
+        for interaction in HapticInteraction.allCases {
+            #expect(HapticFeedbackPolicy.pattern(for: interaction, enabled: true) != nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The app called `NSHapticFeedbackManager` **nowhere**, so on Force Touch trackpads direct manipulations — approving/ignoring a review row, flipping the in-popover Privacy Mask toggle — gave no tactile confirmation. This adds a small, centralized, opt-out-able haptic system for *committed* direct manipulations.

- **`PlaidBarCore/Models/HapticFeedbackPolicy.swift`** — the pure policy: `HapticInteraction` (the finite set of committed direct manipulations) mapped to a SwiftUI/AppKit-free `HapticPattern` (`alignment` / `levelChange` / `generic`), gated by an `enabled` flag. Disabled → `nil` → no feedback. Plus `HapticFeedbackPreference` (on by default, opt-out-able). Fully `Sendable`, no AppKit.
- **`PlaidBar/Services/HapticFeedback.swift`** — a thin `@MainActor` helper that resolves the Core pattern and performs it on `NSHapticFeedbackManager.defaultPerformer`. The only place that touches AppKit. No-op on hardware without a haptic engine (AppKit handles that silently).
- **Wiring (high-value committed direct manipulations only):**
  - Review inbox — every single-row action (approve / ignore / recategorize / rename / transfer / rule) and bulk *Mark N reviewed*, funneled through the existing `recordAction` / `recordBulkAction` central points. Ignore plays the softer `levelChange`; the rest share the positive `generic` confirmation.
  - The quick **Privacy Mask** toggle in the dashboard footer (`toggle` → `levelChange`).
- **`Settings → Appearance → Feedback → Haptic feedback`** toggle to turn it off.

Deliberately **not** wired into hover, scroll, focus, every keystroke, the Settings `Form` toggles (the macOS switch already has its own feel), or — per file ownership — the dashboard **filter bar / segment switching** (AND-577 owns that this wave).

## Linear

AND-576 (parent AND-575). Direct-manipulation haptic feedback.

## Testing notes

- New `Tests/PlaidBarCoreTests/HapticFeedbackPolicyTests.swift` (6 tests): default-on preference + raw-value round-trip; **disabled → no pattern for every interaction** (behavior equals today); enabled matches the unguarded mapping; each interaction maps to its expected pattern; the mapping is total. No redundant `try? #require` (AND-574 test gate).
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — **1741 tests pass** (incl. the 6 new).

## Architectural decisions

- **Policy in Core, AppKit call in the app.** The interaction→pattern decision and the enabled gate are pure and unit-tested; only the bridge touches `NSHapticFeedbackManager`. Keeps the logic `Sendable` and testable, per the repo's "shared logic in `PlaidBarCore`" rule.
- **Opt-out-able, sensible default-on.** A `HapticFeedbackPreference` (AppStorage) gates the whole system; off makes every call a no-op so behavior equals today. Respects users who want no haptics.
- **Respectful scope.** A fixed, finite set of *committed* interaction kinds — never every minor/continuous state change — so haptics never fire on hover, scroll, or partial edits.
- **Additive + reversible.** With the toggle off (or no haptic hardware), the diff is behavior-neutral.

## On-device QA note

Needs a hands-on pass on a **Force Touch trackpad** (the haptic engine is hardware-gated and not exercised by `swift test`): confirm a subtle click on review approve vs. a distinct softer click on ignore, on bulk *Mark N reviewed*, and on the Privacy Mask toggle; then flip `Settings → Appearance → Feedback → Haptic feedback` off and confirm all four go silent. On a Mac without a Force Touch trackpad, confirm no errors and no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)