### PR TITLE
feat(ux): animated shared-element reflow on dashboard filter switch (matchedGeometryEffect) (AND-577)

### DIFF
--- a/Sources/PlaidBar/Views/DashboardNavBand.swift
+++ b/Sources/PlaidBar/Views/DashboardNavBand.swift
@@ -20,17 +20,33 @@ extension DashboardAccountFilterKind {
 
 // MARK: - Filter Bar
 
-/// Native segmented control for the dashboard's primary filter. Native
-/// before novel: the system control brings focus rings, vibrancy, light
-/// mode, and RTL for free. ⌘1–7 shortcuts are preserved via hidden
-/// equivalents; the per-filter counts live in the rows themselves and in
-/// each segment's help/accessibility text rather than in segment labels.
+/// Segmented control for the dashboard's primary filter with an animated
+/// shared-element reflow (AND-577): a single glass selection pill glides between
+/// segments via `matchedGeometryEffect` rather than the selection cutting
+/// instantly from one to the next. Quiet and premium, not flashy.
+///
+/// This is a custom control rather than `Picker(.segmented)` because the
+/// AppKit-bridged `NSSegmentedControl` does not expose its selection indicator
+/// to SwiftUI's geometry system, so a matched-geometry glide is impossible on
+/// it. The custom control re-earns the affordances the bridge gave for free:
+/// per-segment VoiceOver label/value, a container rollup label, ⌘1–⌘N
+/// shortcuts, the Status attention glyph, light/dark, and RTL (the `HStack`
+/// flips with layout direction, and the pill glides along with it).
+///
+/// Additive + reversible: with Reduce Motion on, the pill snaps instantly with
+/// no geometry animation — the exact end state the native control produced
+/// before this change. The selection itself is never altered here.
 struct DashboardFilterBar: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Binding var selection: DashboardAccountFilter
     /// Whether an account row is drilled in, so the container's VoiceOver
     /// label keeps the row-selection state the old caption used to announce.
     let hasSelectedAccount: Bool
+
+    /// Namespace for the gliding selection pill. Scoped to this view so the
+    /// matched-geometry pair never collides with the popover's glass namespace.
+    @Namespace private var pillNamespace
 
     var body: some View {
         let items = DashboardNavBarModel.items(
@@ -40,50 +56,21 @@ struct DashboardFilterBar: View {
         let statusItem = items.first { $0.kind == .status }
 
         HStack(spacing: Spacing.xs) {
-            Picker("Account filter", selection: $selection) {
-                ForEach(items) { item in
-                    Text(item.title)
-                        .accessibilityLabel(item.accessibilityLabel)
-                        .accessibilityValue(item.accessibilityValue)
-                        .tag(item.kind)
-                }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .controlSize(.small)
-            .help(rollupText(items: items))
-            .background {
-                // Hidden, non-interactive keyboard equivalents: ⌘1-6 switch
-                // filters exactly as the old custom segments did.
-                ForEach(items) { item in
-                    Button("") { selection = item.kind }
-                        .keyboardShortcut(
-                            KeyEquivalent(Character("\(item.shortcutOrdinal)")),
-                            modifiers: .command
-                        )
-                        .buttonStyle(.plain)
-                        .focusable(false)
-                        .frame(width: 0, height: 0)
-                        .opacity(0)
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
-            }
-            .accessibilityElement(children: .contain)
-            // The selected-filter rollup lives in the container *label*, not the
-            // container value: macOS VoiceOver announces a group's label when
-            // entering it but does not reliably read a group's AXValue. The
-            // per-segment counts are rolled into the label too, because per-item
-            // modifiers do not reliably survive NSSegmentedControl bridging.
-            .accessibilityLabel(
-                "\(DashboardNavBarModel.containerAccessibilityLabel(selected: selection, items: items, hasSelectedAccount: hasSelectedAccount)). \(rollupText(items: items))"
-            )
+            segmentedControl(items: items)
+                .background { keyboardShortcuts(items: items) }
+                .accessibilityElement(children: .contain)
+                // The selected-filter rollup lives in the container *label*, not the
+                // container value: macOS VoiceOver announces a group's label when
+                // entering it but does not reliably read a group's AXValue. The
+                // per-segment counts are rolled into the label too, for one
+                // glanceable announcement of the whole bar.
+                .accessibilityLabel(
+                    "\(DashboardNavBarModel.containerAccessibilityLabel(selected: selection, items: items, hasSelectedAccount: hasSelectedAccount)). \(rollupText(items: items))"
+                )
 
-            // Visible, non-color attention signal for the Status segment.
-            // NSSegmentedControl bridging drops per-item SF Symbols, so the
-            // warning glyph lives adjacent to the picker. The symbol's shape
-            // (not its tint) carries the meaning; the warning color is
-            // redundant reinforcement only.
+            // Visible, non-color attention signal for the Status segment. The
+            // symbol's shape (not its tint) carries the meaning; the warning
+            // color is redundant reinforcement only.
             if let statusItem, statusItem.showsAttentionBadge, let iconName = statusItem.statusIconName {
                 Image(systemName: iconName)
                     .font(.caption)
@@ -91,6 +78,109 @@ struct DashboardFilterBar: View {
                     .help(statusItem.statusIndicatorAccessibilityLabel ?? "Needs attention")
                     .accessibilityLabel(statusItem.statusIndicatorAccessibilityLabel ?? "Needs attention")
             }
+        }
+    }
+
+    // MARK: - Segmented control
+
+    private func segmentedControl(items: [DashboardNavBarItem]) -> some View {
+        HStack(spacing: 0) {
+            ForEach(items) { item in
+                segment(for: item)
+            }
+        }
+        .padding(SegmentMetrics.trackPadding)
+        .background(track)
+        .help(rollupText(items: items))
+    }
+
+    private func segment(for item: DashboardNavBarItem) -> some View {
+        let isSelected = DashboardFilterReflowModel.isSelected(item.kind, selected: selection)
+
+        return Button {
+            select(item.kind)
+        } label: {
+            Text(item.title)
+                .font(.caption.weight(isSelected ? .semibold : .regular))
+                .foregroundStyle(isSelected ? Color.primary : AppearanceTextColors.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, SegmentMetrics.horizontalPadding)
+                .padding(.vertical, SegmentMetrics.verticalPadding)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .background {
+                    // The single gliding pill: rendered only behind the selected
+                    // segment. matchedGeometryEffect carries the same logical view
+                    // from one segment's frame to the next on selection change, so
+                    // the pill interpolates its position — it slides rather than
+                    // cross-fades. Under Reduce Motion the assignment happens with
+                    // no animation, so the pill jumps (today's behavior).
+                    if isSelected {
+                        selectionPill
+                            .matchedGeometryEffect(
+                                id: DashboardFilterReflowModel.geometryIDPrefix,
+                                in: pillNamespace
+                            )
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(item.accessibilityLabel)
+        .accessibilityValue(item.accessibilityValue)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .help(item.helpText)
+    }
+
+    private var selectionPill: some View {
+        RoundedRectangle(cornerRadius: SegmentMetrics.pillRadius, style: .continuous)
+            .fill(Color.primary.opacity(SurfaceTokens.selectedFillOpacity))
+            .overlay {
+                RoundedRectangle(cornerRadius: SegmentMetrics.pillRadius, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(SurfaceTokens.panelStrokeOpacity), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.12), radius: 3, x: 0, y: 1)
+    }
+
+    private var track: some View {
+        RoundedRectangle(cornerRadius: SegmentMetrics.trackRadius, style: .continuous)
+            .fill(Color.primary.opacity(SurfaceTokens.insetFillOpacity))
+            .overlay {
+                RoundedRectangle(cornerRadius: SegmentMetrics.trackRadius, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(SurfaceTokens.panelStrokeOpacity), lineWidth: 1)
+            }
+    }
+
+    /// Applies the selection and, unless Reduce Motion is on, glides the pill to
+    /// the new segment. With Reduce Motion on the assignment is made outside any
+    /// animation, so the pill snaps instantly — identical to the prior control.
+    private func select(_ kind: DashboardAccountFilter) {
+        guard kind != selection else { return }
+        if DashboardFilterReflowModel.shouldAnimateGlide(reduceMotion: reduceMotion) {
+            withAnimation(MotionTokens.standard) {
+                selection = kind
+            }
+        } else {
+            selection = kind
+        }
+    }
+
+    /// Hidden, non-interactive keyboard equivalents: ⌘1-N switch filters exactly
+    /// as the prior segmented control did. They route through `select(_:)` so
+    /// keyboard switches glide too (and snap under Reduce Motion).
+    private func keyboardShortcuts(items: [DashboardNavBarItem]) -> some View {
+        ForEach(items) { item in
+            Button("") { select(item.kind) }
+                .keyboardShortcut(
+                    KeyEquivalent(Character("\(item.shortcutOrdinal)")),
+                    modifiers: .command
+                )
+                .buttonStyle(.plain)
+                .focusable(false)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
         }
     }
 
@@ -103,5 +193,13 @@ struct DashboardFilterBar: View {
                 : "\(item.title) \(item.count)"
         }
         .joined(separator: ", ")
+    }
+
+    private enum SegmentMetrics {
+        static let horizontalPadding: CGFloat = Spacing.sm
+        static let verticalPadding: CGFloat = Spacing.xxs + 1
+        static let trackPadding: CGFloat = 2
+        static let trackRadius: CGFloat = Radius.control
+        static let pillRadius: CGFloat = Radius.control - 1
     }
 }

--- a/Sources/PlaidBarCore/Models/DashboardFilterReflowModel.swift
+++ b/Sources/PlaidBarCore/Models/DashboardFilterReflowModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pure presenter for the animated shared-element reflow of the dashboard
+/// filter bar's selection pill (AND-577).
+///
+/// The view layer renders a single glass "pill" behind the active filter
+/// segment and uses `matchedGeometryEffect` to glide it from one segment to the
+/// next on selection change. All of the policy that decides *which* segment owns
+/// the pill and *whether* the glide animates lives here so it stays `Sendable`,
+/// testable without SwiftUI, and identical across the popover and the detached
+/// window.
+///
+/// Additive + reversible: when the glide is disabled (Reduce Motion on) the
+/// pill snaps instantly, exactly matching the native segmented control's prior
+/// behavior — the selection itself is never changed by this model.
+public enum DashboardFilterReflowModel {
+    /// Fixed namespace prefix for the pill's `matchedGeometryEffect` id. Keeps
+    /// the id collision-resistant against any other matched-geometry pair in
+    /// the same SwiftUI `Namespace` and keeps it human-debuggable.
+    public static let geometryIDPrefix = "dashboard.filter.pill"
+
+    /// Stable `matchedGeometryEffect` id for a filter segment.
+    ///
+    /// Derived only from the kind's raw value, so a given kind always yields the
+    /// same id — the pill matches the same logical segment across renders,
+    /// windows, and processes. Distinct per kind, so the matched-geometry pair
+    /// never fuses two segments.
+    public static func geometryID(for kind: DashboardAccountFilterKind) -> String {
+        "\(geometryIDPrefix).\(kind.rawValue)"
+    }
+
+    /// Whether the selection pill should *glide* (animated reflow) rather than
+    /// snap when the filter changes.
+    ///
+    /// Reduce Motion on ⇒ `false`: no geometry animation, instant snap, byte-for-
+    /// byte the same end state as today. This is the single gate that satisfies
+    /// the project's one-place Reduce-Motion policy (`MotionTokens`).
+    public static func shouldAnimateGlide(reduceMotion: Bool) -> Bool {
+        !reduceMotion
+    }
+
+    /// True only for the currently selected segment. The view uses this to place
+    /// the single pill (`matchedGeometryEffect(isSource: true)`) on exactly one
+    /// segment and to weight that segment's label.
+    public static func isSelected(
+        _ candidate: DashboardAccountFilterKind,
+        selected: DashboardAccountFilterKind
+    ) -> Bool {
+        candidate == selected
+    }
+}

--- a/Tests/PlaidBarCoreTests/DashboardFilterReflowModelTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardFilterReflowModelTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("DashboardFilterReflowModel Tests")
+struct DashboardFilterReflowModelTests {
+    // MARK: - Geometry id stability
+
+    @Test("Each filter kind maps to a distinct, stable geometry id")
+    func geometryIdsAreDistinctAndStable() {
+        let kinds = DashboardAccountFilterKind.allCases
+        let ids = kinds.map { DashboardFilterReflowModel.geometryID(for: $0) }
+
+        // Distinct: the glide pill must never share an id between two segments,
+        // otherwise matchedGeometryEffect would fuse them and the pill would
+        // not know which segment to settle on.
+        #expect(Set(ids).count == kinds.count)
+
+        // Stable: the id is derived only from the kind's raw value, so a given
+        // kind yields the same id across renders (and across processes/windows).
+        for kind in kinds {
+            #expect(
+                DashboardFilterReflowModel.geometryID(for: kind)
+                    == DashboardFilterReflowModel.geometryID(for: kind)
+            )
+        }
+    }
+
+    @Test("Geometry id is namespaced and contains the raw value")
+    func geometryIdNamespacedByRawValue() {
+        // The id stays human-debuggable and collision-resistant against any
+        // other matchedGeometryEffect namespace by carrying a fixed prefix plus
+        // the filter's stable raw value.
+        #expect(DashboardFilterReflowModel.geometryID(for: .all) == "dashboard.filter.pill.All")
+        #expect(DashboardFilterReflowModel.geometryID(for: .status) == "dashboard.filter.pill.Status")
+        #expect(DashboardFilterReflowModel.geometryID(for: .credit) == "dashboard.filter.pill.Credit")
+    }
+
+    // MARK: - Reduce Motion gate
+
+    @Test("Glide animates only when Reduce Motion is off")
+    func glideGatedByReduceMotion() {
+        // Reduce Motion off => the pill glides (animated reflow).
+        #expect(DashboardFilterReflowModel.shouldAnimateGlide(reduceMotion: false))
+        // Reduce Motion on => no geometry animation; the pill snaps instantly,
+        // exactly as the native control behaved before this change. This is the
+        // additive/reversible guarantee.
+        #expect(!DashboardFilterReflowModel.shouldAnimateGlide(reduceMotion: true))
+    }
+
+    @Test("Selected predicate is true only for the active kind")
+    func selectionPredicate() {
+        for selected in DashboardAccountFilterKind.allCases {
+            for candidate in DashboardAccountFilterKind.allCases {
+                #expect(
+                    DashboardFilterReflowModel.isSelected(candidate, selected: selected)
+                        == (candidate == selected)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Switching the dashboard filter segment (Cash / Credit / Savings / Debt / Status …) now **glides** the selection indicator between segments instead of cutting instantly. A single glass "pill" is carried from the old segment's frame to the new one with `matchedGeometryEffect`, so it slides — quiet and premium, not flashy.

`DashboardFilterBar` previously used `Picker(.segmented)` (an AppKit-bridged `NSSegmentedControl`). That bridge does **not** expose its selection indicator to SwiftUI's geometry system, so a matched-geometry glide is impossible on it. This PR replaces it with a custom segmented control that re-earns every affordance the bridge gave for free:

- per-segment VoiceOver `accessibilityLabel` / `accessibilityValue`
- the container rollup label ("Account filters. Cash: 3 of 8 accounts; …")
- ⌘1–⌘N keyboard shortcuts (now routed through the same glide path)
- the adjacent Status attention glyph (shape carries meaning; color is redundant)
- light/dark, and RTL (the `HStack` flips with layout direction and the pill glides along with it)
- `.isSelected` / `.isButton` traits on each segment

Pure policy lives in a new `Sendable` `PlaidBarCore` presenter, `DashboardFilterReflowModel` (stable matched-geometry id per filter kind, the Reduce-Motion gate, and the selection predicate), so it is unit-testable without SwiftUI and identical across the popover and the detached window.

## Linear (AND-577)

Implements **AND-577** — animated shared-element reflow when switching dashboard filter segments, via `matchedGeometryEffect`. Parent **AND-575**; related to **AND-295** (quiet filter bar, Done) and the established `MotionTokens` Reduce-Motion gating (**AND-339 / AND-378**).

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green
- `swift build -c release` — green (the CI gate)
- `swift test` — **1739 tests pass**, including 4 new `DashboardFilterReflowModelTests` (geometry-id distinctness/stability/namespacing, the Reduce-Motion glide gate, and the selection predicate)
- No redundant `try? #require` introduced (AND-574 strict test gate).

The pill glide is view-layer animation and not headlessly unit-testable; the pure decision logic it depends on is fully tested, and the rest needs eyes-on (see below).

## Architectural decisions

- **Custom control over native picker.** Chosen only because `NSSegmentedControl`'s indicator is opaque to `matchedGeometryEffect`. Every a11y/RTL/shortcut affordance the native control supplied is reconstructed explicitly so this is a no-regression swap on behavior.
- **Pure logic in Core.** `geometryID(for:)`, `shouldAnimateGlide(reduceMotion:)`, and `isSelected(_:selected:)` are `Sendable` and SwiftUI-free in `PlaidBarCore`, matching the repo convention and keeping the view thin.
- **One Reduce-Motion gate.** The glide flows through the existing `MotionTokens.standard` animation, applied only when `shouldAnimateGlide(reduceMotion:)` is true. **Additive + reversible:** with Reduce Motion on, the selection is assigned with no animation, so the pill snaps instantly — the exact end state the native control produced before this change. The selection value itself is never altered by the animation path.
- **Scoped `@Namespace`.** The pill's namespace is local to `DashboardFilterBar`, so the matched-geometry pair never collides with the popover's existing glass namespace (AND-511).

## On-device QA note

These two need eyes-on (they are not unit-testable):

1. **Glide:** Open the popover, click between Cash / Credit / Savings / Debt / Status (and try ⌘1–⌘N). The pill should *slide* smoothly between segments, settling without overshoot — not jump or cross-fade.
2. **Reduce-Motion fallback:** Enable System Settings → Accessibility → Display → **Reduce Motion**, then switch filters. The pill must **snap instantly** with no slide — identical to today's behavior. Also confirm VoiceOver still announces each segment's label/value and the container rollup, and that the Status attention glyph still appears when an item is degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)