### PR TITLE
docs(strategy): macOS 26 window-first migration evaluation + ADR-001 (AND-578)

### DIFF
--- a/docs/strategy/macos26-migration/00-executive-recommendation.md
+++ b/docs/strategy/macos26-migration/00-executive-recommendation.md
@@ -1,0 +1,195 @@
+# Executive Recommendation — VaultPeek macOS 26 Window-First Architecture
+
+**Date:** 2026-06-19
+**Author:** Architecture evaluation (5-agent parallel research + synthesis)
+**Decision owner:** Felipe Chaves
+**Status:** Proposed — awaiting ratification
+**Supersedes:** the *product-model* half of AND-384 ("popover-primary, polish only")
+
+---
+
+## 1. Recommendation
+
+**Adopt a window-first *hybrid*: promote a dedicated native macOS 26 window to the
+primary VaultPeek experience, and reduce the menu bar to a first-class glance +
+launcher. Keep the menu-bar glance sacred — read + route only.**
+
+**Confidence: High.** This recommendation is reinforced independently by four of
+five research agents and, crucially, by the codebase itself.
+
+### The decisive finding
+
+VaultPeek is **already a multi-window application in everything but doctrine.**
+
+- **Three+ real `NSWindow` surfaces already ship today:** the detached dashboard
+  (AND-384, #357), the Category Dashboard window (AND-539), and the multi-select
+  Review Table window (AND-532) — all real `NSWindow`s (not panels), with
+  behind-window `NSVisualEffectView` vibrancy, frame autosave, lazy-singleton
+  reuse, App-Lock observation, and `.accessory↔.regular` activation elevation.
+- **The macOS 26 *platform* migration already landed** (AND-508–515, merged
+  2026-06-18): Liquid Glass, App Intents, WidgetKit, SwiftData read-model cache,
+  Dynamic Type, deploy floor — plus Foundation Models AI tiers since.
+- A `DashboardPresentation` environment enum *already* makes the main view render
+  host-agnostically in both popover and window.
+
+What is therefore **missing** is small and well-bounded:
+
+1. A coherent **navigation shell** — there is no `NavigationSplitView`/`NavigationStack`
+   anywhere today; routing is a flat `@AppStorage` filter band.
+2. A **declarative primary `Window` scene** — today windows are imperative AppKit
+   controllers bolted onto a `MenuBarExtra + Settings` scene graph.
+3. **Governance docs that match the code** — the decision log still says
+   "popover-primary"; the binary ships windows. This divergence is itself a risk.
+
+**Conclusion:** This is a *consolidation and formalization* of work that already
+exists, plus one net-new navigation layer — **not** a risky rewrite. That
+reframing is the single most important output of this evaluation.
+
+---
+
+## 2. Was the menu bar a real choice or the fastest path?
+
+**Both — and the product has outgrown the container.** (Full evidence: [02](02-product-strategy.md), [03](03-archaeology.md).)
+
+- The menu-bar form factor was the **founding thesis** ("RepoBar/CodexBar for
+  personal finance"), never an examined decision — the burden of proof was only
+  ever placed on *deviating* from it. The *glance* value is genuine and enduring.
+- But every **session workflow** that has since shipped — transaction review
+  triage, bulk recategorization, category budgets, weekly review, reconciliation —
+  has either escaped into an `NSWindow` or is structurally hostile to an
+  auto-dismissing popover. The popover ceiling has been breached repeatedly.
+- Reference precedent is unambiguous: Fantastical, Bartender, MoneyMoney all run a
+  **primary window + a menu-bar entry**. Hybrid is the mature form for exactly
+  this product shape.
+
+---
+
+## 3. Survives vs Rebuilds (summary)
+
+Full table: [survives-vs-rebuilds-matrix.md](survives-vs-rebuilds-matrix.md).
+
+| Bucket | ~Weight | What |
+|--------|--------|------|
+| **Survives as-is** | **~55%** | Server/Plaid/auth/Keychain boundary (separate process — untouched by a UI pivot); **all of `PlaidBarCore` (~25K LOC, ~45% of source, Sendable/tested)**; server SQLite; JSON/read-model caches; background services; widgets; AI tiers; ~30 view components & design tokens |
+| **Adapts** | **~30%** | Existing window controllers → declarative scenes; SwiftData read-model cache; menu-bar item → glance-only; host-switching via `DashboardPresentation`; `AppState` decomposition |
+| **Rebuilds (net-new)** | **~15%** | Navigation hierarchy (sidebar, `NavigationSplitView`, command palette, typed routing); `AppState` per-window UI-state split; popover reduced to glance; **Goals** (the one genuinely new feature) |
+
+**Risk level: MEDIUM.** All rework is isolated to the app target. The migration
+**never touches the security boundary or `PlaidBarCore`** — the two things most
+expensive to get wrong are out of scope.
+
+---
+
+## 4. Engineering effort estimate
+
+Judgment estimate, single developer accelerated by the agent loop. Ranges reflect
+uncertainty in the `AppState` decomposition (the one genuine unknown).
+
+| Phase | Scope | Estimate |
+|-------|-------|----------|
+| **P1** | App shell + navigation foundation (sidebar, split-view, routing, ⌘K skeleton) | 2–3 wk |
+| **P2** | Window lifecycle: declarative `Window` scene, retire imperative controllers, dual-run flag | 2 wk |
+| **P3** | Destination workspaces: Transactions, Budgets/Planning, Review Inbox consolidation, **Goals** | 4–6 wk |
+| **P4** | Insights & Intelligence; Widgets/App Intents expansion | 2–3 wk |
+| **P5** | Menu-bar simplification + Liquid Glass polish + a11y hardening | 2 wk |
+| | **Total** | **~12–16 engineer-weeks** (≈3–4 months solo; materially compressible with the autonomous loop) |
+
+This is low for a "migration" precisely because ~55% survives untouched and the
+hard platform/windowing primitives already ship.
+
+---
+
+## 5. Recommended implementation sequence
+
+```
+[Gate 0] Ratify ADR-001 + update doctrine (decision log, roadmap, CLAUDE.md, GOAL.md)
+   │
+   ▼
+Epic 1  macOS 26 Application Shell ──► Epic 2  Navigation Architecture ──► Epic 3  Window Lifecycle Migration
+                                                                                │
+                          ┌─────────────────────────────┬─────────────────────┘   (P3 workspaces parallelizable
+                          ▼                              ▼                            once shell+nav land)
+                  Epic 4 Transaction Workspace   Epic 5 Planning & Budgeting   Epic 6 Review Inbox
+                          └───────────────┬──────────────┴──────────────┬──────────────┘
+                                          ▼                              ▼
+                                  Epic 7 Insights & Intelligence   Epic 8 Widgets & App Intents
+                                          └──────────────┬───────────────┘
+                                                         ▼
+                                  Epic 9 Menu Bar Simplification  ← SHIPS LAST (guardrail)
+                                                         ▼
+                                  Epic 10 Liquid Glass Polish     ← continuous, finalized last
+```
+
+**Epic 9 (menu-bar simplification) ships LAST, deliberately.** Reducing the
+popover before the window reaches parity would strand users. Dual-run the popover
+and window behind a feature flag until parity is proven.
+
+---
+
+## 6. Non-negotiable guardrails
+
+These protect against the failure mode where this migration quietly destroys
+VaultPeek's only moat.
+
+1. **Keep the glance sacred.** The menu-bar surface stays read + route only —
+   status, sync, 2–4 glance metrics, attention chips that deep-link into the
+   window, "Open VaultPeek." It must never host triage, editing, settings,
+   tables, or any unfinishable workflow.
+2. **Parity before removal.** Do not delete the popover workflows until the window
+   reaches functional parity. Ship behind a flag; dual-run.
+3. **Update doctrine in lockstep.** The #1 history-derived risk is the next agent
+   "reverting" this work citing stale "popover-primary" docs. ADR + decision log +
+   roadmap + CLAUDE.md + GOAL.md must change together (Gate 0).
+4. **macOS 26 "Tahoe" is the floor.** Do **not** conflate it with macOS 27 /
+   WWDC26 (betas only as of June 2026): reorderable containers, toolbar-overflow
+   APIs, sectioned `@Query`, `ResultsObserver`/`HistoryObserver` must be gated
+   behind `if #available(macOS 27, *)`.
+5. **Liquid Glass on chrome only.** Never on lists, tables, charts, or dense data;
+   never glass-on-glass. Every custom-translucency surface needs a
+   `reduceTransparency` solid fallback; every chart needs an `AXChartDescriptor`.
+6. **Touch nothing across the security boundary.** No change to the server, Plaid
+   client, Keychain vault, or the localhost auth boundary is in scope.
+
+---
+
+## 7. The honest counter-case
+
+A real minority reading deserves to be on the record (raised independently by the
+product and archaeology agents):
+
+> *The autonomous build loop **overshot** the popover doctrine. VaultPeek's own
+> constitution (AND-384, the v1.0 "Menu Bar First" rule) says to treat "large
+> canvas / persistent workspace" with skepticism — yet windows crept in
+> feature-by-feature without a ratified decision. The disciplined move is to
+> **delete two of the three windows** and recommit to glance-first, not to bless
+> the drift.*
+
+**Why we reject it as the primary path (but preserve it as the explicit
+"do-not-migrate" option in the ADR):**
+
+- The shipped session workflows (review triage, budgeting, reconciliation) are
+  *genuinely* multi-step and structurally hostile to an ephemeral popover. Deleting
+  the windows deletes the workflows, not just the chrome.
+- Reference precedent (Fantastical, Bartender, MoneyMoney) shows hybrid — not
+  glance-only — is the mature form for a resident finance/utility app.
+- The expensive part (windowing, vibrancy, activation policy, host-agnostic view)
+  is *already built and merged*. The cost asymmetry favors ratify-and-consolidate
+  over rip-out-and-revert.
+
+**The condition under which the counter-case wins:** if VaultPeek's strategic
+identity is re-scoped to "ambient glance only, zero session workflows" (i.e., the
+review/budget/planning features are themselves deprecated). That is a product-scope
+decision, not an architecture one — and it is the question the decision owner must
+answer at Gate 0.
+
+---
+
+## 8. What the decision owner must decide at Gate 0
+
+1. **Ratify or reject** window-first hybrid (ADR-001).
+2. Confirm the **session-workflow scope** stays in-product (if yes → migrate; if
+   the product is re-scoped to glance-only → the counter-case path).
+3. Approve the **doctrine update** (decision log / roadmap / CLAUDE.md / GOAL.md).
+4. Approve **macOS 26 as the hard floor** (drops any pre-Tahoe support).
+
+Everything downstream (Epics 1–10) is sequenced to begin only after Gate 0.

--- a/docs/strategy/macos26-migration/01-current-state-architecture.md
+++ b/docs/strategy/macos26-migration/01-current-state-architecture.md
@@ -1,0 +1,232 @@
+# Current-State Architecture — VaultPeek (PlaidBar)
+
+**Audience:** Leadership evaluating a pivot from the menu-bar popover-primary model (AND-384) to a full native macOS 26 application where the primary experience lives in a dedicated window and the menu bar becomes a launcher/glance surface.
+
+**Scope:** Factual, evidence-based current-state picture. This document reports *what is*, with `file:line` evidence. It does not advocate for or against the migration.
+
+**Commit baseline:** branch `claude/fervent-thompson-649f21`, HEAD `2119292`. macOS deployment floor 26.0 (`Package.swift:28`).
+
+---
+
+## Executive summary
+
+- **Lifecycle is a hybrid, not pure `MenuBarExtra`.** The SwiftUI scene graph is `MenuBarExtra(.window)` + `Settings` only (`PlaidBarApp.swift:80-332`). There is **no `Window`/`WindowGroup` scene anywhere** (verified: `grep WindowGroup` returns nothing in the SwiftUI sense). All "real" app windows are built imperatively in AppKit. The menu-bar item is driven by `MenuBarExtra` + the `MenuBarExtraAccess` package to reach the live `NSStatusItem` (`PlaidBarApp.swift:265-321`), with a refcounted `AppActivationPolicyCoordinator` flipping the app between `.accessory` and `.regular` (`AppActivationPolicyCoordinator.swift:27-49`).
+- **Substantial real-window infrastructure already exists — this is the single most important finding.** Three independent AppKit `NSWindow` controllers are already built, shipped, and behaving like first-class app windows: the **detached full dashboard** (AND-384), the **Category Dashboard window** (AND-539), and the **Review Table window** (AND-532). All three use `NSWindow` (not `NSPanel`), behind-window `NSVisualEffectView` vibrancy, `NSHostingController`, frame autosave, lazy-singleton reuse, App-Lock key observation, and activation-policy elevation. A window-primary model would *extend a proven pattern*, not invent one.
+- **The same `MainPopover` view already renders in two hosts** (popover and floating window) via a `DashboardPresentation` environment enum (`DashboardPresentation.swift:12-23`). The view never touches AppKit window lifecycle; the host injects detach/redock closures. This is direct evidence the UI is already partially host-agnostic.
+- **Navigation is a flat filter-band, not a hierarchy.** No `NavigationStack`/`NavigationSplitView`/`TabView` anywhere in the app. Routing is a custom segmented control (`DashboardFilterBar`, `DashboardNavBand.swift:39`) plus `.sheet`/`.inspector` overlays. Filter and selected-account state live in **`@AppStorage` inside `MainPopover`** (`MainPopover.swift:14-15`), not in `AppState`.
+- **`AppState` is a 4,213-LOC `@Observable @MainActor` god object** (`AppState.swift` + 2 extensions) holding ~67 stored properties spanning data, preferences, ~12 service instances, derived caches, and UI flags. It is **not `Sendable`**. It contains two hard single-surface flags — `isPopoverPresented` (`AppState.swift:117`) and `isDashboardDetached` (`AppState.swift:126`) — plus singular menu-bar computed properties. This is the principal coupling liability for a multi-window model.
+- **The server / auth / Plaid boundary is a separate process and is completely independent of the UI.** A UI rearchitecture touches **zero** credential-handling code: server binds `127.0.0.1` only (`App.swift:153`), `/api/*` is bearer-gated (`App.swift:84-85`), access-token bytes live in Keychain with SQLite holding `keychain:<item_id>` refs (`PlaidTokenVault.swift:65-67`, `TokenStore.swift:63-68`). Verdict: survives untouched.
+- **Glance surfaces (widget, Control Center controls, App Intents, Spotlight) live out-of-process** and read a display-only App Group snapshot (`GlanceSnapshot`/`FinanceSnapshot` in `PlaidBarCore`). They are app-architecture-agnostic; the only coupling is the `vaultpeek://dashboard` deep link and the `writeGlanceSnapshot()` call site.
+- **Business logic is already heavily concentrated in `PlaidBarCore` (25,280 LOC across 153 files)** — DTOs, formatters, reducers, presentation models, energy policy, AI tiers. The app target is 23,769 LOC but ~half is SwiftUI views; the server is 6,593 LOC. The Core layer is `Sendable`/testable and survives any UI change.
+
+---
+
+## Process & lifecycle architecture
+
+### Two processes, three+ executables
+
+`Package.swift` declares four executables and two libraries (`Package.swift:30-36`):
+
+| Product | Type | Role |
+|---|---|---|
+| `PlaidBar` | executable | SwiftUI menu-bar app (UI layer) |
+| `PlaidBarServer` | executable | Hummingbird 2 companion server (owns Plaid creds) |
+| `PlaidBarWidgetExtension` | executable | WidgetKit bundle (widget + controls + intents) |
+| `plaidbar-cli` | executable | source-built CLI over the same authed localhost server |
+| `PlaidBarCore` | library | shared DTOs + pure utilities (`Sendable`) |
+| `PlaidBarCache` | library | app-only SwiftData `@Model` + `@ModelActor` stores |
+
+Data flow: `PlaidBar.app` → HTTP `127.0.0.1:8484` → `PlaidBarServer` → HTTPS → Plaid.
+
+### Lifecycle verdict: HYBRID (`MenuBarExtra` + AppKit windows), NOT pure MenuBarExtra and NOT custom-NSStatusItem
+
+The SwiftUI `App.body` contains exactly two scenes (`PlaidBarApp.swift:79-332`):
+
+1. `MenuBarExtra { MainPopover() } label: { MenuBarLabel() }` with `.menuBarExtraStyle(.window)` (`PlaidBarApp.swift:80, 322`).
+2. `Settings { SettingsView(...) }` (`PlaidBarApp.swift:324`).
+
+There is **no `Window`/`WindowGroup` SwiftUI scene**. Every other window is an AppKit `NSWindow` created in a controller (`makeWindow()` in `CategoryDashboardWindowController.swift:109`, `ReviewTableWindowController.swift:107`, `DetachedDashboardWindowController.swift`).
+
+The menu-bar status item is reached two ways simultaneously:
+- SwiftUI owns the popover window via `MenuBarExtra(.window)`.
+- The `MenuBarExtraAccess` package exposes the live `NSStatusItem` (`PlaidBarApp.swift:265`), onto which the app pins a **badge overlay** (`StatusItemBadgeController`) and a **right-click context menu** (`StatusItemContextMenuController`, `PlaidBarApp.swift:271-321`).
+
+So it is a *hybrid*: declarative `MenuBarExtra` for the popover, AppKit surgery for the status item and for all real windows.
+
+### Activation policy
+
+`AppActivationPolicyCoordinator` (`AppActivationPolicyCoordinator.swift:17-50`) is a `@MainActor` singleton that **refcounts** `.regular` elevation. The app is `.accessory` (menu-bar-only) at rest; any detached window requests `.regular` (Dock + ⌘-Tab) on show and releases on close. Refcounting prevents two simultaneous windows from stranding the app in `.regular` (`AppActivationPolicyCoordinator.swift:8-13`). CLI flag `--regular-activation` forces `.regular` at launch for automation (`PlaidBarApp.swift:69-73`).
+
+### Popover-window surgery
+
+`PopoverWindowAnchor` (`PopoverWindowAnchor.swift`) does **not** create a window — it reaches the `MenuBarExtra(.window)` host `NSWindow` via `NSViewRepresentable` and pins its leading X-edge across width changes (`setFrameOrigin`, ~line 190) because SwiftUI re-centers the popover on the status item when the inspector opens. This is a known fragility (AND-514/SPIKE F2) of the popover host that **goes away** under a window-primary model.
+
+---
+
+## Inventory of EXISTING window / detached surfaces
+
+This is the load-bearing section for the migration decision. **Four real windows already exist** (three app-built + the MenuBarExtra host), plus two status-item view surfaces.
+
+| # | Surface | Controller file | What it hosts | How invoked | Window class / chrome | Activation | Persistence | Lifecycle |
+|---|---|---|---|---|---|---|---|---|
+| 1 | **Detached full dashboard** (AND-384) | `DetachedDashboardWindowController.swift` + `DetachedDashboardCoordinator.swift` | `MainPopover()` (same view as popover) | Footer detach pin, context-menu "Open in Window", menu-bar click while detached, `vaultpeek://`, ⇧⌘V hotkey, `--detach` | `NSWindow` `[.titled,.closable,.miniaturizable,.resizable]`; `.normal` level (→`.floating` if "keep on top"); behind-window `NSVisualEffectView` `.underWindowBackground`; `NSHostingController<AnyView>` | `requestRegular()`/`releaseRegular()` | `setFrameAutosaveName` | Lazy singleton, reused, `isReleasedWhenClosed=false`, alpha-fade show/hide |
+| 2 | **Category Dashboard window** (AND-539) | `CategoryDashboardWindowController.swift` + `Coordinator` + `Environment` | `CategoryDashboardWindow()` | `openCategoryDashboard` env action from `CategoryDashboardCard` "Open dashboard" | `NSWindow` titled/resizable; 640×640 default, 520×480 min; behind-window vibrancy; `NSHostingController` | `requestRegular()`/release | autosave `VaultPeekCategoryDashboard` | Lazy singleton, re-raise, `isReleasedWhenClosed=false`, hide via `windowShouldClose→false` |
+| 3 | **Review Table window** (AND-532) | `ReviewTableWindowController.swift` + `Coordinator` + `Environment` | `ReviewTableWindow()` | `openReviewTable` env action from Review Inbox header | `NSWindow` titled/resizable; 760×560 default, 560×420 min; behind-window vibrancy; `NSHostingController` | `requestRegular()`/release | autosave `VaultPeekReviewTable` | Lazy singleton, re-raise, `isReleasedWhenClosed=false` |
+| 4 | **Menu-bar popover host** | owned by `MenuBarExtra(.window)`; frame pinned by `PopoverWindowAnchor.swift` | `MainPopover()` | Status-item click | SwiftUI-owned `NSWindow`; frame-pinned imperatively | n/a | frame pinned (not autosaved) | Owned by MenuBarExtra |
+| 5 | Status-item badge overlay | `StatusItemBadgeController.swift` | `NSView` subview on the status button (unreviewed count) | always-on | `NSView`, hit-testing disabled | n/a | n/a | re-attached idempotently |
+| 6 | Status-item context menu | `StatusItemContextMenuController.swift` | `NSMenu` (Open/Refresh/Settings/Updates/About/Privacy Mask) | right-click / ⌥-click | `NSMenu` | n/a | n/a | transient |
+
+**Shared, proven window pattern across #1–#3:** clear non-opaque `NSWindow` + behind-window `NSVisualEffectView` (AND-511 spike: real desktop read-through), `NSHostingController`, frame autosave, lazy-singleton reuse, `didBecomeKeyNotification` → App-Lock unlock prompt (AND-462), and `AppActivationPolicyCoordinator` elevation. Each surface has a 3-file coordinator/controller/environment split that already decouples views from AppKit lifecycle.
+
+**Implication:** the codebase has already solved (and ships) the hard parts of native windowing on macOS 26 — vibrancy, activation policy, frame persistence, App Lock, deep-link/hotkey summoning. The detached dashboard literally hosts the same `MainPopover` view a window-primary model would promote.
+
+---
+
+## Navigation architecture today
+
+- **No declarative navigation containers.** `grep` for `NavigationStack`/`NavigationSplitView`/`NavigationView`/`TabView`/`NavigationLink` across `Sources/PlaidBar/Views` and `App` returns **none**. The only routing primitives are `.sheet` (`MainPopover.swift:177`; `CategoryDashboardWindow.swift:59` budget editor) and a custom inspector morph (`MainPopover.swift:430`).
+- **Routing = a flat filter band.** `DashboardFilterBar` (`DashboardNavBand.swift:39`) is a custom segmented control (deliberately not `Picker(.segmented)` so a `matchedGeometryEffect` selection pill can glide — AND-577, `DashboardNavBand.swift:23-49`). Filters are the Core enum `DashboardAccountFilterKind` (Cash/Credit/Savings/Debt/Investments/Status) reused directly (`DashboardNavBand.swift:11`).
+- **UI navigation state lives in the view, not AppState.** `@AppStorage("dashboard.accountFilter")` and `@AppStorage("dashboard.selectedAccountId")` are declared in `MainPopover` (`MainPopover.swift:14-15`); `AppState` has zero references to `selectedAccountId`/`accountFilter` (verified: `grep -c` = 0). Account drill-in is single-selection via `selectedAccountId` (`MainPopover.swift:79-227`).
+- **One view, many hosts.** `MainPopover` (2,712 LOC) reads `\.dashboardPresentation` to decide whether to show a detach pin (popover) or a re-dock control (window) (`MainPopover.swift:2478`, `DashboardPresentation.swift:12-23`). This is the existing seam a window-primary model would build on.
+
+**Migration relevance:** a dedicated-window model with a sidebar would introduce `NavigationSplitView` (new construct for this codebase) and move filter/selection state out of `@AppStorage`-in-view into per-window state. The flat-band routing is shallow, so there is little hierarchy to untangle, but there is also little existing navigation scaffolding to reuse.
+
+---
+
+## AppState assessment
+
+**Size:** 4,213 LOC total — `AppState.swift` (3,972) + `AppState+ReadModelCache.swift` (139) + `AppState+TransactionCache.swift` (102).
+
+**Shape:** `@Observable @MainActor final class AppState` (`AppState.swift:9-11`). Correctly `@Observable` (not `ObservableObject`); `@MainActor`-isolated. **Not `Sendable`.** Injected via SwiftUI `@Environment(AppState.self)`.
+
+**~67 stored properties**, grouped:
+- Server/data state (~20): `accounts`, `liabilities`, `transactions`, `itemStatuses`, `balanceHistory`, `accountBalanceLedger`, `categoryBudgets`, server readiness fields (`AppState.swift:63-177`).
+- UI/presentation flags (~8) — includes the single-surface flags below (`AppState.swift:103-178`).
+- Preferences (~30): menu-bar mode/icon, thresholds, refresh policy, notification toggles, watchlist, App Lock, launch-at-login, summon hotkey, local-AI prefs (`AppState.swift:193-489`).
+- Caches & services (~18): `serverClient`, `localDataCache`, `readModelCacheStore`, `transactionCacheStore`, `merchantLogoStore`, `appLockService`, `reviewStorageWriter`, `localAIInsightsService`, `notificationService`, `foundationModelsProbe`, `glanceSnapshotWriteDebouncer`, plus `refreshTask`/`localAISummaryRefreshTask` and `_cached*` derived caches (`AppState.swift:497-548, 1310-1607`).
+
+**Single-surface coupling (the migration-critical part):**
+
+| Property | Line | Why it blocks multi-window |
+|---|---|---|
+| `isPopoverPresented` | `AppState.swift:117` | Tracks whether *the* popover is open; per-window presentation would need per-window state. The whole `MenuBarExtra` is bound to `$appState.isPopoverPresented` (`PlaidBarApp.swift:265`). |
+| `isDashboardDetached` | `AppState.swift:126` | A single persisted boolean ("docked vs floating"). In a multi-window world this must become a window registry. |
+| `menuBarText` / `menuBarStatusPresentation` / `menuBarSignalGlyph` | `AppState.swift:953-1009` | Singular computed values; fine for one menu bar, but they couple "current display" into the shared store. |
+| App Lock state (`isAppLocked`, `lastUnlockMessage`) | `AppState.swift:397-403` | App-wide today; multi-window must decide per-window vs global unlock. |
+
+Notably, account-filter/selection state is **not** in AppState (it's in the view via `@AppStorage`), which slightly *reduces* AppState's single-surface coupling — but also means there is no per-window UI-state container to inherit.
+
+**Coupling depth:** AppState instantiates and owns ~12 services and mixes networking, persistence, SwiftData caches, biometric lock, AI, notifications, energy scheduling, and UI flags in one type. Roughly 60% is legitimate app-wide state; ~40% is view-model-style derivation (`netBalance`, `categoryBudgetPresentation`, `transactionReviewInboxSnapshot`, `recurringTransactions`, `localAIActivitySummaries`, all cached via `_cached*` with `didSet` invalidation). Business logic is largely *delegated* to Core (`MenuBarSummary`, `CategoryBudgetPlanner`, `CategoryDashboardBuilder`, `RecurringDetector`, `TransactionReviewInbox`) but the orchestration and caching live here.
+
+**Verdict:** AppState is the central refactor target for a window-primary pivot. The data/services half is reusable as a shared app-wide store; the UI-flag/derivation half (popover presented, detached, menu-bar display, derived caches) assumes one surface and would need to split into per-window view models with a shared single background-refresh coordinator.
+
+---
+
+## Data layer & SwiftData strategy
+
+Three storage tiers:
+
+**Tier 1 — App-side SwiftData read-model cache (`PlaidBarCache` target, AND-566/567).** Two `@Model` types: `CachedDashboardReadModel` (single-row, `@Attribute(.unique) cacheKey`, JSON `payload`) and `CachedTransaction` (composite `@Attribute(.unique) uniqueKey` for `#Unique`-style upsert on re-sync). Accessed via two `@ModelActor` stores (`ReadModelCacheStore`, `TransactionCacheStore`) with on-disk containers in `~/.vaultpeek/` at `0o700/0o600`. Purpose: instant cold-render before the first HTTP refresh, plus paged transaction virtualization. **Disposable** — rebuilt on refresh, wiped on reset. Every op is `try?`-guarded in AppState, so SwiftData unavailability degrades cleanly. *Survives UI rearchitecture: PARTLY* — the data and stores are UI-agnostic, but the store *instances* are AppState properties (`AppState.swift:509,516`) and the hydrate/persist seams live in `AppState+*Cache.swift`; per-window AppState instances would need a shared container or scoped reopen.
+
+**Tier 2 — App-side JSON/local cache (`PlaidBarCore`).** `LocalDataStore`/`LocalDataCacheService` (actor) persist `accounts.json`, `transactions.json`, review metadata, rules under `~/.vaultpeek/`, scoped by environment + path. Authoritative warm path; SwiftData is a second cache layered on top. *Survives: YES* — pure path-scoped file I/O.
+
+**Tier 3 — Server-side Fluent/SQLite.** `ItemModel` (`items`) and `SyncCursorModel` (`sync_cursors`) with migrations `CreateItems`, `CreateSyncCursors`, `AddProviderToItems`, `AddOriginToItems` (`Database.swift`). Per-environment `plaidbar-<env>.sqlite`. *Survives: YES* — separate process, behind HTTP.
+
+**Core domain models:** `Sources/PlaidBarCore/Models/` holds ~70 files / ~194 type decls, all `Codable`/`Sendable` structs (`TransactionDTO`, `AccountDTO`, `BalanceDTO`, `DashboardReadModel`, etc.). *Survives: YES* — UI-agnostic.
+
+---
+
+## Sync, background services, Plaid/auth boundary
+
+**No separate `RefreshService`/`SyncService` types exist** (despite the CLAUDE.md mention — that is design intent). The background loop lives **inside AppState**: a single `refreshTask` (`AppState.swift:526`) ticks `refreshDashboard()` + `evaluateNotifications()`, sleeping a base 15-min interval (`Constants` `backgroundRefreshInterval`) scaled ×4 under energy pressure.
+
+- **`ServerClient`** — `actor` (`ServerClient.swift:4`); HTTP to `/api/*` with bearer auth from `~/.vaultpeek/auth-token`; UI-agnostic. *Survives: YES.*
+- **`ServerProcessService`** — `@MainActor` singleton; launches/supervises the bundled server, detects external servers via `/health`, SIGTERM on app exit. *Survives: YES.*
+- **`NotificationService`** — `@MainActor`; trigger evaluation + LRU dedup in UserDefaults. *Survives: YES.*
+- **`LaunchService`** — `SMAppService` wrapper. *Survives: YES.*
+- **`SummonHotkeyMonitor`** — `@MainActor`; Carbon `⇧⌘V` global hotkey. *Survives: YES* (callback injected; would just retarget the window).
+- **`PagedTransactionSource`** / **`MerchantLogoStore`** / **`HapticFeedback`** — `@Observable @MainActor` view-layer; fetch/policy logic is Core-side. *Survives: PARTLY.*
+- **Energy-aware scheduling** — `EnergyAwareRefreshPolicy` (Core) reads Low Power Mode + thermal state; `AutomaticRefreshPolicy` (`.twiceDaily` default / `.manualOnly`); observers restart the loop on power/thermal change (`AppState.swift:2548-2587`). UI-agnostic.
+
+**Plaid/auth security boundary — survives UI rearchitecture UNTOUCHED (verified):**
+- Server binds `127.0.0.1` only (`App.swift:150-156`); no override.
+- `/health`, `/oauth/callback`, `/webhook/*` open; everything under `/api` behind `APITokenMiddleware` (`App.swift:79-85,139,145`) with constant-time token compare + localhost-origin CSRF defense (`APITokenMiddleware.swift:16-32,82-95`).
+- Access-token bytes in macOS Keychain; SQLite stores `keychain:<item_id>` references (`PlaidTokenVault.swift:65-67`; `TokenStore.swift:63-68`).
+- `PlaidClient` is a server-only `actor` holding `client_secret`/`client_id` from `ServerConfig` (`PlaidClient.swift:45-71,114-121`); **no `PlaidClient`/`ServerConfig` in app code**.
+- `/api/status` is a readiness contract that explicitly excludes tokens/IDs/balances/transactions (`StatusRoutes.swift:34-87`; `ServerStatus.swift:5`).
+
+**Verdict:** the server/auth/Plaid layer is a black box behind localhost HTTP. A popover→window pivot touches none of it.
+
+---
+
+## Widget & AI tiers
+
+**Glance surfaces (out-of-process):**
+- Widget extension (`PlaidBarWidgetExtension`) hosts `PlaidBarGlanceWidget` (small/medium), Control Center controls (`RefreshBalancesIntent`, `SetPrivacyMaskIntent`, Safe-to-Spend + Credit-Utilization value displays), via `PlaidBarWidgetBundle.swift`.
+- App-side App Intents: `FinanceAppIntents` (Get Safe-to-Spend / Get Balance, privacy-gated), `FocusPrivacyFilterIntent` (mask while Focus active), Spotlight indexing via `AccountSpotlightIndexer` (salted-hash IDs, last-4 only).
+- Data crosses the boundary as **display-only** App Group snapshots: `GlanceSnapshot` and `FinanceSnapshot` in `PlaidBarCore` (group `group.com.ftchvs.PlaidBar`), written debounced (400 ms) by `GlanceSnapshotWriteDebouncer` (actor, Core). Extension → app commands are tiny JSON files consumed on `didBecomeActive`. No tokens/balances/IDs ever cross.
+- *Survives UI rearchitecture: YES* — only coupling is the `vaultpeek://dashboard` deep link and the `writeGlanceSnapshot()`/`writeFinanceSnapshot()` call sites, which move location but not contract.
+
+**Local AI tiers** (all UI-decoupled; produce Core presentation models):
+1. Apple Foundation Models (on-device, `#available(macOS 26)`), probed via `FoundationModelsAvailabilityProbe` (`SystemLanguageModel.default.availability`).
+2. Ollama local runtime (localhost-enforced, model auto-discovery).
+3. Apple NaturalLanguage categorizer (always-on, merchant hints only).
+4. Deterministic heuristic fallback.
+
+Resolved by `LocalAITierResolver` (Core). **Off by default** — no transaction data routes anywhere without explicit opt-in (`LocalAIInsightsService.swift:356-387`). Output is a display-safe `LocalAIInsightReceipt` (redacted evidence, reversible-action language; `LocalAIInsights.swift:176-457`). *Survives: YES.*
+
+---
+
+## Business-logic distribution (Core vs app vs server)
+
+LOC by target (`*.swift`):
+
+| Target | Files | LOC | Notes |
+|---|---|---:|---|
+| **PlaidBarCore** | 153 | **25,280** | Models (70 files, 11,503) + Utilities (82 files, 13,774). `Sendable`, testable, UI-free. **The center of gravity.** |
+| **PlaidBar (app)** | 83 | **23,769** | Views 11,979 (40 files) · App/lifecycle/windows 6,459 (17) · Settings 1,961 (1) · Services 2,264 (16) · Theme/Intents/Controls/Spotlight/Models ~1,106 |
+| **PlaidBarServer** | 35 | **6,593** | Routes 2,407 · Config 1,165 · Storage 1,048 · Plaid 840 · Auth 663 |
+| **PlaidBarWidgetExtension** | 2 | 502 | thin shells over Core |
+| **PlaidBarCache** | 6 | 526 | SwiftData `@Model` + `@ModelActor` |
+| **PlaidBarCLI** | 1 | 325 | CLI over localhost server |
+| **Tests** | 146 | 34,175 | Swift Testing; tests outweigh source |
+
+**Distribution read:** roughly **45% of source LOC is in Core** (UI-agnostic, survives). Of the app's 23.8K LOC, ~12K is SwiftUI views and ~6.5K is lifecycle/window/AppState plumbing — the part most exposed to a UI pivot. Two files dominate the app risk surface: `AppState.swift` (3,972) and `MainPopover.swift` (2,712). Server logic (6.6K) is fully insulated. The strong Core concentration is the single biggest asset for a migration: the model, reducers, presentation logic, energy policy, and AI tiers do not move.
+
+---
+
+## Technical-debt assessment (ranked)
+
+| # | Severity | Debt | Evidence |
+|---|---|---|---|
+| 1 | **High** | **`AppState` god object (4,213 LOC, ~67 props, ~12 services, not `Sendable`).** Mixes data, prefs, caches, AI, notifications, energy, and UI flags. Single-surface flags (`isPopoverPresented`, `isDashboardDetached`) and singular menu-bar computeds embed "one surface" assumptions. | `AppState.swift:9-11,117,126,953-1009,497-548` |
+| 2 | **High** | **`MainPopover` is a 2,712-LOC view** doing layout, filter routing, drill-in, inspector morphs, sheets, heatmap, and per-surface presentation switching in one file. Reused across 4 hosts, amplifying change risk. | `MainPopover.swift` (whole) |
+| 3 | **Medium** | **Popover-host window surgery is inherently fragile.** `PopoverWindowAnchor` reaches into the SwiftUI-owned `MenuBarExtra` window to pin its frame because SwiftUI re-centers it; this is a workaround (AND-514/SPIKE F2), not a supported API. | `PopoverWindowAnchor.swift` |
+| 4 | **Medium** | **UI navigation state in `@AppStorage` inside the view** (`dashboard.accountFilter`, `dashboard.selectedAccountId`). Global UserDefaults keys cannot represent per-window selection; multi-window would alias state across windows. | `MainPopover.swift:14-15` |
+| 5 | **Medium** | **Window controllers duplicate a ~3-file boilerplate** (controller + coordinator + environment) per surface with near-identical `NSWindow`/`NSVisualEffectView`/autosave/App-Lock code. No shared base class. | `DetachedDashboard*`, `CategoryDashboardWindow*`, `ReviewTableWindow*` |
+| 6 | **Low** | **Background sync embedded in AppState** rather than an extractable `SyncService`/`RefreshService` (contradicts CLAUDE.md intent). Works at current scale; couples loop to UI state. | `AppState.swift:526,2149-2193,1906-1976` |
+| 7 | **Low** | **Derived `_cached*` view-model caches with `didSet` invalidation in AppState** add invalidation complexity that would multiply with per-window filtering. | `AppState.swift:1310-1607` |
+
+---
+
+## Migration complexity assessment (per subsystem)
+
+Rating each subsystem **Survives-as-is / Adapts / Rebuilds**, with effort **S/M/L/XL**, for a pivot to a window-primary macOS 26 app (menu bar → launcher/glance).
+
+| Subsystem | Verdict | Effort | One-line reason |
+|---|---|---|---|
+| Server / Plaid / auth / Keychain | **Survives-as-is** | — | Separate process behind localhost HTTP; UI pivot touches zero credential code. |
+| `PlaidBarCore` (DTOs, reducers, presentation, energy, AI tiers) | **Survives-as-is** | S | UI-agnostic, `Sendable`, already 45% of LOC. |
+| Server-side SQLite / Fluent | **Survives-as-is** | — | Behind the HTTP boundary. |
+| JSON local cache (Tier 2) | **Survives-as-is** | S | Path-scoped file I/O. |
+| Glance surfaces (widget, controls, intents, Spotlight) | **Survives-as-is** | S | Out-of-process; only deep link + write-site move. |
+| Background services (ServerClient, ServerProcessService, Notification, Launch, hotkey) | **Survives-as-is** | S | UI-agnostic; hotkey/deep-link just retarget the window. |
+| Existing AppKit window controllers (#1–#3) | **Adapts** | M | Pattern is exactly what a window-primary model needs; refactor toward a shared `Window`/`WindowGroup` scene or a base controller; dedupe boilerplate. |
+| SwiftData read-model cache (Tier 1) | **Adapts** | M | Move store instances off AppState into a shared app-level container so multiple windows share one on-disk store. |
+| `DashboardPresentation` / `MainPopover` host-switching | **Adapts** | M | Already two-host-aware; extend to window-primary; split the 2,712-LOC view. |
+| Menu-bar item (status/badge/context menu) | **Adapts** | M | Demote popover to optional glance; keep `MenuBarExtra` label + context menu as launcher; remove popover-host surgery. |
+| Navigation / routing | **Rebuilds** | L | No `NavigationStack`/`SplitView` exists; a windowed app likely needs a sidebar + detail split, a new construct here. |
+| `AppState` (UI-flag + derivation half) | **Rebuilds** | L–XL | Split into a shared app-wide data/service store + per-window view models; replace `isPopoverPresented`/`isDashboardDetached` with a window registry; relocate `@AppStorage` filter/selection to per-window state. |
+| Activation policy | **Adapts** | S | `AppActivationPolicyCoordinator` already refcounts `.accessory`↔`.regular`; window-primary likely defaults `.regular` with the coordinator demoting to `.accessory` only for glance-only mode. |
+
+**Overall:** the *infrastructure* needed for a window-primary app (real `NSWindow`s, vibrancy, activation policy, frame persistence, App Lock, deep-link summoning, a host-agnostic dashboard view, a Core-heavy model layer, an insulated server) **already exists and ships today.** The concentrated risk is `AppState`'s single-surface coupling and the absence of any navigation hierarchy — both real, both squarely in the app target, neither touching the security boundary or Core.

--- a/docs/strategy/macos26-migration/02-product-strategy.md
+++ b/docs/strategy/macos26-migration/02-product-strategy.md
@@ -1,0 +1,395 @@
+---
+title: "Product Strategy — Is the Menu-Bar Popover VaultPeek's Enduring Model?"
+status: analysis
+audience: Felipe (DRI) + macOS 26 migration evaluation
+date: 2026-06-19
+linear_context: [AND-384, AND-385, AND-398, AND-532, AND-539, AND-367]
+verdict: "Hybrid — menu-bar-launcher + first-class primary window. Confidence: high."
+---
+
+# Product Strategy: Popover, Window, or Hybrid?
+
+> **The central question.** Is the menu-bar popover the correct *long-term* product
+> model for VaultPeek, or was it the fastest path to a shippable 1.0? Should
+> VaultPeek evolve into a full native macOS 26 application where the menu bar
+> becomes a launcher/glance entry point into a primary windowed experience?
+
+This document argues both sides honestly and then commits to a recommendation. It
+is written to be falsifiable: every claim is grounded in a repo doc, a shipped
+commit, or the current source tree, and the strongest counterarguments to the
+recommendation are listed at the end.
+
+---
+
+## Executive summary
+
+**The menu-bar popover was a genuinely deliberate choice for the *glance* — and it
+remains the right model for the glance. It was also, in retrospect, the
+fastest-path container for everything that came after it, and the product has
+already outgrown it.** VaultPeek's own roadmap classifies a detached window and the
+product-intelligence wedge (review inbox, category budgets, weekly review) as
+"Phase 5 / treat with skepticism" and "the most budgeting-suite-shaped work on the
+board." Yet the git history shows that *all of it has already shipped*: three
+persistent `NSWindow` surfaces (detached dashboard AND-384, review Table AND-532,
+category dashboard AND-539) plus the full intelligence wedge (AND-398–403). The
+doctrine says menu-bar-first; the codebase says menu-bar-*plus-windows*. **The
+strategy doc and the binary have diverged, and the binary is winning.**
+
+The popover is also straining physically. The active three-column design contract
+(`docs/three-column-popover-contract.md`) targets a **1122pt-wide** popover with a
+**mandatory** screen-constrained fallback ladder that overlays columns when the
+ideal width "does not fit on every display, especially near a screen edge or on
+narrow laptops." A finance instrument that needs 1122pt and a last-resort
+column-overlay tier is no longer a popover in spirit — it is a window wearing a
+popover's anchor.
+
+**Recommendation: go hybrid — keep the menu bar as a first-class glance + launcher,
+and promote the windowed experience from "opt-in detachment" to a designed,
+first-class primary surface for the multi-step workflows that already exist.** This
+is not a pivot away from menu-bar-first; it is *ratifying what already shipped* and
+designing it on purpose instead of by accretion. Confidence: **high** that the
+status quo (popover-as-only-real-surface) is wrong; **high** that hybrid beats
+window-only; **medium-high** on the exact division of labor between the two
+surfaces. The single biggest risk: a window-primary posture dilutes the "quiet,
+ambient, local-first" identity that is VaultPeek's *only* uncontested competitive
+moat (the empty "local-first + glanceable" quadrant). The hybrid is engineered
+specifically to hold that line — the glance stays sacred; the window is where work
+that was never glanceable goes to live honestly.
+
+---
+
+## 1. The original "why menu-bar" thesis
+
+The thesis is stated as product law, not preference. From the north star
+(`GOAL.md`):
+
+> "Build VaultPeek (formerly PlaidBar) into a local-first macOS menu bar dashboard
+> for Plaid data: RepoBar/CodexBar for personal finance. The app should make the
+> user's financial state glanceable without becoming a full budgeting product. One
+> click should answer: How much cash do I have? How much credit am I using? What
+> changed recently? Is my Plaid sync healthy? Do I need to act?"
+
+And the design principle (`docs/v1.0-roadmap.md` §"Menu Bar First"):
+
+> "VaultPeek should remain a menu bar utility, not a full desktop finance app that
+> happens to have a menu bar icon. … Any feature that needs a large canvas, long
+> workflow, or persistent workspace should be treated with skepticism unless it
+> strengthens the menu bar experience."
+
+The detachable-window question was explicitly adjudicated. The launch decision log
+(`docs/mvp-launch-decision-log.md`) classifies **AND-384 — Detachable pinnable
+window** as **Post-MVP / Native Expansion**, with this rationale (quoted verbatim):
+
+> "A persistent detached window is exactly the kind of 'large canvas / persistent
+> workspace' surface the product brief says to treat with skepticism unless it
+> strengthens the menu-bar experience (`docs/v1.0-roadmap.md` §Menu Bar First). It
+> is a deliberate post-MVP exploration, not a launch requirement, and it needs its
+> own data-boundary and menu-bar-first review before it earns a place."
+
+The post-MVP roadmap (`docs/post-mvp-roadmap.md` §Phase 5) reinforces it:
+
+> "A detached window is exactly the kind of 'large canvas / persistent workspace'
+> the brief says to treat with skepticism … Expanding the *number* of surfaces
+> before the *content* of the core surface is final would scatter effort across
+> canvases that the intelligence and design phases might still reshape."
+
+This is the genuine, enduring half of the thesis: **the glance is sacred, the
+popover answers a narrow set of questions in one click, and the product must not
+become a budgeting suite.** Nothing in this report disputes that. The glance is a
+real, defensible, differentiated product surface.
+
+---
+
+## 2. Was the popover fastest-path or a deliberate enduring choice? Evidence both ways.
+
+### 2a. Evidence it was a *deliberate, enduring* choice
+
+- **It is written as a constitution, not a milestone.** `v1.0-roadmap.md` lists
+  "Menu Bar First" as one of four foundational *principles* (alongside Local First,
+  Dense/Native, Recovery First), repeated across `GOAL.md`, `PRD.md`, `DESIGN.md`,
+  and `README.md`. Principles get restated; tactics get superseded.
+- **The competitive frame is popover-native.** RepoBar and CodexBar — the two named
+  inspirations in `GOAL.md` and `README.md` — are both menu-bar popovers. The
+  product's identity ("high-signal numbers one click away") is a popover idiom.
+- **The privacy story leans on the form factor.** `docs/strategy/consumer-experience-roadmap.md`
+  frames the menu-bar surface as "*the argument* for local-first positioning." An
+  ephemeral, no-persistent-workspace surface *feels* lighter-touch with sensitive
+  data — a quiet utility, not a finance OS that owns your screen.
+- **The three-column popover is an "Active contract"** (`docs/three-column-popover-contract.md`,
+  AND-368) spanning a dozen issues. Real, sustained, multi-PR investment went into
+  making the *popover* the terminal surface — that is not throwaway scaffolding.
+
+### 2b. Evidence it was the *fastest path*, and the product has outgrown it
+
+- **The doctrine-vs-shipped divergence is the headline.** The decision log
+  (dated, ratified 2026-06-14) puts AND-384 (detached window), AND-385 (widgets),
+  and the entire AND-398–403 intelligence wedge in **Post-MVP / treat-with-
+  skepticism**. The git log shows every one of them **already merged to `main`**:
+  - `85d6c42 feat(ui): detached multi-select review Table window … (AND-532)`
+  - `ff1bfa8 feat(ui): Category Dashboard card + detached window (AND-539)`
+  - `01a81f1 feat(widgets): Safe-to-Spend + Utilization Control Center controls (AND-503)`
+  - the safe-to-spend / category-budget / review-inbox / weekly-review cluster
+    (AND-401, AND-402, AND-403, AND-399, AND-527…AND-545).
+
+  The source inventory confirms **three real, frame-autosaved, resizable
+  `NSWindow` scenes** today: `DetachedDashboardWindowController` (AND-384),
+  `ReviewTableWindowController` (AND-532), `CategoryDashboardWindowController`
+  (AND-539) — each with `.regular` activation, Dock presence, and Mission Control /
+  Spaces / Stage Manager behavior. The "deliberate post-MVP exploration that needs
+  a menu-bar-first review before it earns a place" *shipped without that review ever
+  being recorded as gating it.* When the guardrail says "skepticism" and the product
+  ships the thing anyway, the guardrail was describing a constraint the product
+  no longer actually had.
+
+- **The popover is physically straining.** The active contract targets **1122pt**
+  (320 + 480 + 320 + dividers) and declares a **mandatory** fallback ladder:
+  > "The ideal three-column width (1122pt) does not fit on every display, especially
+  > near a screen edge or on narrow laptops. The fallback is **mandatory**, not
+  > optional." (`three-column-popover-contract.md` §5)
+
+  Tier 2 of that ladder *overlays the inspector on top of the center column* as a
+  last resort. A surface that needs a 1122pt anchor and an overlay-on-narrow-display
+  contingency is a window that has not admitted it is a window.
+
+- **The workflows that shipped are not glances.** Multi-select bulk recategorization
+  with staged blast-radius confirmation (AND-532), two-level category trees with per-
+  category budget editor sheets (AND-538/539/540), date-grouped review inboxes with
+  per-section approve and inline rule creation (AND-529/531/533) — these are
+  *sessions*, not glances. You do not "glance and dismiss" a reconciliation queue.
+
+**Synthesis:** the popover was a *genuine* choice for the glance and a *fast-path*
+container for everything else. The glance half is enduring. The container half has
+been quietly overloaded, and the codebase already voted with its feet — three
+windows deep.
+
+---
+
+## 3. Workflow-ceiling analysis: what the popover constrains
+
+The test from the brief: a menu-bar app implies "glance, then dismiss." Which
+current/planned workflows fight that?
+
+| Workflow | Shipped? | Glance or session? | Popover ceiling hit |
+|---|---|---|---|
+| Net-worth / cash / credit / sync posture | Yes | **Glance** | None — this is the popover's home turf. Keep it here. |
+| "What changed?" change receipt + heatmap | Yes | Glance | None. |
+| Account drill-in (inspector) | Yes | Glance→short task | Mild — inspector forces the 320pt third column and the 1122pt width. |
+| **Transaction review inbox** (date-grouped, per-section approve, rule prompts) | Yes (AND-529/531/533) | **Session** | **High** — review is iterative; an ephemeral popover that dismisses on focus-loss is hostile to a 20-minute reconciliation pass. Already spilled into a detached Table (AND-532). |
+| **Multi-select bulk recategorize** (staged, blast-radius confirm) | Yes (AND-532) | **Session** | **Ceiling already breached** — shipped *as its own window* because a popover Table with multi-select + bulk actions + sort is not a glance. |
+| **Category dashboard** (donut, 2-level tree, status bars) | Yes (AND-537/538/539) | Session | **Ceiling breached** — shipped as both a popover card *and* a detached window; the card is a teaser, the window is the real surface. |
+| **Category budgets** (set/edit/clear per category) | Yes (AND-540/541/542) | Session | High — budget editing is a `.sheet` today; budgets are inherently a recurring workspace, not a glance. |
+| **Weekly money review** (AND-403) | Card shipped | **Session** | **High** — a "review workflow canvas" is the single most window-shaped feature the roadmap names; even the consumer roadmap concedes it may need "a dedicated window if depth demands it." |
+| **Monthly financial review** (AND-355, Plus) | Planned | Session | High — month-over-month spend, top merchants, trends, subscription deltas. Spec already hedges toward a window. |
+| Safe-to-spend explainability (AND-401) | Yes | Glance→explain | Medium — the *number* glances; the *explanation* wants room. |
+| Local AI insights / Foundation Models (AND-564/565) | Yes | Glance | Low — streamed insight chips fit the popover. |
+| Redacted export, reconciliation history, large-history list (AND-567 virtualization) | Partly | Session | High — virtualized large-history lists exist *because* the data volume outgrew a glance. |
+
+**Pattern:** every workflow that is a *session* rather than a *glance* has either
+already escaped into a window or is hedged toward one in its own spec. The popover
+ceiling is not theoretical — the product has hit it five times and each time the
+escape hatch was an `NSWindow`.
+
+---
+
+## 4. UX tradeoff analysis: popover vs window vs hybrid
+
+| Dimension | Popover-primary (status quo doctrine) | Window-primary (full app) | **Hybrid (menu-bar launcher + first-class window)** |
+|---|---|---|---|
+| Glance speed | **Best** — one click, no Dock, no app-switch | Worst — window management overhead for a 2-second check | **Best** — glance stays in the popover, untouched |
+| Multi-step workflows | Poor — ephemeral, dismiss-on-focus-loss, width-constrained | **Best** — resizable, persistent, multi-pane | **Best** — workflows live in the window where they belong |
+| Identity / "quiet ambient finance" | **Best** — feels like a utility, not a finance OS | Risk — looks like Copilot/Monarch, loses the differentiator | **Strong** — glance preserves the ambient feel; window is opt-in depth |
+| Screen real estate | Poor — 1122pt + mandatory overlay fallback | Best — native resize | Best — window resizes; popover stays compact |
+| Privacy *perception* | **Best** — no persistent workspace | Neutral-to-worse — a resident finance window feels heavier | Strong — default surface stays light; window is summoned, not resident |
+| macOS 26 native fit | Good — Liquid Glass in popover works | **Best** — full window scenes, inspector API, toolbar, multiple windows | **Best** — uses the full SwiftUI `Window`/`WindowGroup` + `MenuBarExtra` idiom Apple designed for exactly this |
+| Discoverability of depth | Poor — features hide in a popover that begs to be dismissed | Best | Strong — window is a named, dockable destination |
+| Keyboard / power use | Limited — popover steals focus, no real multi-window | Best — `⌘1/2/3`, multiple windows, command palette | Best |
+| Distribution / App Store posture | Fine for DMG; an accessory-only app is an odd App Store citizen | **Best** — App Store expects a windowed app with a real main scene | Strong — a primary window makes an eventual App Store listing coherent without abandoning the menu bar |
+| Engineering cost *from here* | Zero new, but accruing debt (workflows cramped into popover) | High — would have to demote the popover, re-home the glance | **Low-to-medium — the three windows already exist; this is ratification + polish, not a rewrite** |
+| Risk to north star | Low (by doctrine) but **already violated in practice** | **High** — "full desktop finance app" is the named anti-goal | Medium — must actively guard the glance from window-creep |
+
+The decisive cell is the cost row. The expensive part of a window-primary product —
+building real windows with state, frame persistence, activation coordination, and
+Liquid Glass backdrops — **is already done and merged.** The hybrid is the only
+option that is simultaneously (a) where the code already is, (b) where the
+workflows already want to be, and (c) defensible against the north star, because it
+keeps the glance sacred.
+
+---
+
+## 5. Long-term platform strategy: where is VaultPeek in 18 months?
+
+A defensible 18-month picture, ordered by confidence:
+
+1. **A first-class primary window, summoned from a first-class menu bar glance.**
+   The menu bar stays the *default* touchpoint and the always-on glance. The window
+   becomes a *designed* destination (not an accidental detachment) that consolidates
+   the three windows that already exist into a coherent multi-pane workspace:
+   sidebar (accounts / review / categories / budgets), content, inspector. This is
+   the SwiftUI idiom Apple ships `MenuBarExtra` + `WindowGroup` to support.
+2. **A command palette / global summon as the power-user spine.** The global hotkey
+   (`⇧⌘V`, AND-487) already exists. Extending it to a `⌘K`-style palette ("go to
+   account," "review transactions," "set budget") is the natural power-surface for a
+   product whose users open it many times a day. Low cost, high leverage, reinforces
+   "fast" without bloating the popover.
+3. **Widgets + Control Center as the *true* ambient glance** (AND-385/503/513,
+   already shipped). The irony worth naming: once widgets carry the ambient glance,
+   the *popover* is freed to be either a richer launcher or be folded into the
+   window. The "quiet ambient finance" value prop migrates to the widget layer,
+   where it is even quieter.
+4. **App Store as a credible (not committed) distribution path** — *only* if
+   monetization is ever approved. `docs/strategy/pricing-and-launch.md` D9 currently
+   defaults to direct-Stripe distribution because the App Store cut "breaks the
+   margin table." But a windowed app is a far more natural App Store citizen than an
+   accessory-only menu-bar utility; if the business case ever flips, the hybrid keeps
+   that door open at no extra cost.
+5. **iOS: still "Resist," and the hybrid does not change that.** `GOAL.md` and
+   `v1.0-roadmap.md` list an iOS companion under "Resist," and `docs/strategy/ios-native-link-decision.md`
+   only pre-decides the *Link* technicality (LinkKit 7.x) *if* Felipe ever promotes
+   it. The hybrid is a macOS-shaped bet; it neither requires nor forecloses iOS.
+
+**What this is NOT:** it is not "rebuild VaultPeek as Copilot Money for the Mac."
+The budgeting-suite line (`GOAL.md`: "without becoming a full budgeting suite") still
+holds. The window is a better *container* for the workflows that already shipped — it
+is not a license to add envelope budgeting, forecasting, or portfolio tracking.
+
+---
+
+## 6. Competitive / reference framing
+
+**The full-window references the brief cites — and what they actually teach.**
+
+- **Linear, Craft, Reeder, Fantastical** are full-window apps because their core
+  loop *is* a session (planning, writing, reading, scheduling). The lesson is not
+  "be a window" — it is "match the surface to the loop." VaultPeek's loop is *two*
+  loops: a glance (window-hostile) and a review/budget session (popover-hostile).
+  That duality is the entire argument for hybrid.
+- **Fantastical and Bartender** are the precise precedent: a full-featured app with
+  a *real* main window **and** a persistent, first-class menu-bar entry. Nobody
+  accuses Fantastical of "not being menu-bar-first" because it also has a window.
+  This is the existence proof that hybrid is not a contradiction — it is the mature
+  form of a menu-bar product that grew real depth.
+- **MoneyMoney** (German, beloved, privacy-respecting, local-first banking app) is a
+  *window* app with a banking-data backend — and it is the closest spiritual analog
+  to VaultPeek's trust posture. It demonstrates that "local-first + a real window"
+  is not just viable but is the established shape for privacy-respecting personal
+  finance on the Mac. VaultPeek is currently the *only* serious entrant trying to do
+  that loop from a popover.
+- **Copilot Money / Monarch** are the cloud incumbents. `pricing-and-launch.md` §5.1
+  pinpoints the moat: "The local-first + glanceable quadrant is currently **empty** —
+  no maintained competitor occupies it." The risk of going window-primary is landing
+  *in* Copilot's quadrant (cloud-shaped UX) and losing the empty one. **The hybrid is
+  the precise hedge:** keep the glance (own the empty quadrant) and add the window
+  (match the depth) — be MoneyMoney's trust with RepoBar's glance.
+- **Balance (defunct, 2017)** — the menu-bar finance cautionary tale in
+  `pricing-and-launch.md` §5.1 — died on Plaid *unit economics*, not on form factor.
+  Worth stating plainly so the popover is not blamed for a pricing failure.
+
+**Framing verdict:** the references do not say "become a window." They say "Mac
+finance apps that respect privacy use a window for the work and (often) a menu-bar
+entry for the glance." VaultPeek already has both halves built. It just hasn't
+admitted that the window is a peer of the popover, not a footnote.
+
+---
+
+## 7. Recommendation
+
+**Go hybrid: menu-bar glance + launcher in front of a first-class, designed primary
+window.** Concretely:
+
+1. **Keep the popover as the default glance and the launcher.** Do not demote the
+   menu bar. The one-click posture + sync-health + "what changed" glance is the
+   product's signature and its trust-light surface. It stays.
+2. **Promote the window from "opt-in detachment" to a designed primary surface.**
+   Consolidate the three accidental windows (detached dashboard, review Table,
+   category dashboard) into one coherent, sidebar-driven workspace window. Stop
+   treating "detached" as an Easter egg; make "Open VaultPeek Window" a first-class,
+   discoverable destination with `⌘`-navigation between panes.
+3. **Re-home session workflows into the window by default**, with glance-able
+   *summaries* (cards, badges, the unreviewed count) remaining in the popover as
+   entry points. Review, category dashboard, budgets, weekly/monthly review, export,
+   and large-history browsing belong in the window; the popover shows the headline
+   and the "open in window" affordance.
+4. **Shrink the popover back toward a true glance.** The 1122pt three-column popover
+   with a mandatory overlay fallback is the symptom. Once the window owns the
+   inspector-heavy work, the popover can relax toward RepoBar density again — which
+   *restores* fidelity to the original thesis rather than abandoning it.
+5. **Ship a command palette** (extend AND-487's global summon) as the power spine.
+6. **Update the doctrine to match reality.** `v1.0-roadmap.md` §Menu Bar First and
+   the decision log should be amended from "menu-bar utility, *not* a desktop app"
+   to "menu-bar-glance-first, with a first-class window for sessions." The current
+   wording is already contradicted by `main`; leaving it creates an audit trap where
+   every shipped window looks like a governance violation.
+
+**Confidence levels.** High that popover-as-only-real-surface is wrong (the
+divergence + the 1122pt strain are dispositive). High that hybrid beats window-only
+(window-only would throw away the empty-quadrant moat and the glance). Medium-high
+on the exact pane taxonomy of the consolidated window (that is a design exercise,
+not a strategy question).
+
+### The three strongest counterarguments to my own recommendation
+
+1. **Identity dilution is real and possibly fatal.** The "quiet, ambient, local-
+   first, *not a budgeting suite*" position is the only thing no competitor has. A
+   prominent resident window makes VaultPeek *look* like Copilot/Monarch — exactly
+   the cloud-shaped UX the brand is counter-positioned against. If the window
+   becomes the gravity center, the product may win the feature war and lose the
+   identity war. *Mitigation in the rec:* glance stays default; window is summoned,
+   not resident; the budgeting-suite line stays hard. But mitigations can fail under
+   feature pressure, and feature pressure is exactly what shipped AND-398–403.
+2. **The doctrine might be right and the shipping might be the mistake.** An equally
+   honest reading of the divergence is: the guardrail worked as *intent* and the
+   autonomous build loop *overshot* it. In that reading the correct move is to
+   **pull workflows back out** of windows and re-narrow to the glance — not to
+   ratify the overshoot. This is the genuinely uncomfortable counter: maybe the
+   right answer is "delete two of the three windows," not "bless all three." The
+   product-intelligence wedge being the "most budgeting-suite-shaped work on the
+   board" is evidence for *this* reading, not mine.
+3. **Cost is not as free as it looks; consolidation is its own project.** "The
+   windows already exist" understates the work. Three independent window controllers
+   with separate frame-autosave, separate activation accounting, and a shared
+   `MainPopover` view shoehorned into a detached host is *accidental* architecture,
+   not a *designed* workspace. Turning it into one coherent, sidebar-driven primary
+   window — with navigation, state restoration, and a command palette — is a real
+   multi-sprint effort that competes with QA, the rename (AND-325, the last launch
+   blocker), and the deferred safety track. The opportunity cost of pulling
+   attention from "make the shipping 1.0 safe to launch publicly" toward "redesign
+   the surface model" is non-trivial and arguably premature pre-launch.
+
+**The single biggest risk of being wrong:** that the hybrid's "keep the glance
+sacred" guardrail erodes in practice exactly as the "menu-bar-first" guardrail
+already eroded — and VaultPeek slides from "RepoBar for finance with optional depth"
+into "a slower Copilot that also has a menu-bar icon," forfeiting the empty
+local-first + glanceable quadrant that is its entire reason to exist. The history in
+this very repo (doctrine said skepticism; product shipped three windows) is direct
+evidence that this guardrail *can* fail. If it does, the window will have eaten the
+product the popover was protecting.
+
+---
+
+## Appendix: evidence ledger
+
+- **North star / glance thesis:** `GOAL.md` (lines 1–14), `docs/v1.0-roadmap.md`
+  §"Menu Bar First", §"The Popover".
+- **AND-384 deferral decision (quoted §1):** `docs/mvp-launch-decision-log.md`
+  §"Native Expansion"; `docs/post-mvp-roadmap.md` §"Phase 5".
+- **Doctrine-vs-shipped divergence:** decision log classifies AND-384/385/398–403 as
+  Post-MVP; `git log` shows `85d6c42` (review Table window), `ff1bfa8` (category
+  dashboard window), AND-401/402/403 cluster all merged to `main`.
+- **Three real NSWindows today:** `Sources/PlaidBar/App/DetachedDashboardWindowController.swift`,
+  `ReviewTableWindowController.swift`, `CategoryDashboardWindowController.swift`
+  (each `NSWindow`, frame-autosaved, `.regular` activation via
+  `AppActivationPolicyCoordinator`).
+- **1122pt popover + mandatory fallback ladder:** `docs/three-column-popover-contract.md`
+  §3 (geometry) and §5 (screen-constrained fallback, "mandatory, not optional",
+  Tier 2 overlay).
+- **Empty competitive quadrant / pricing posture:** `docs/strategy/pricing-and-launch.md`
+  §5.1 ("local-first + glanceable quadrant is currently empty"), §5.1 Balance
+  cautionary tale, D9 (App Store cut breaks margins).
+- **Privacy-as-form-factor argument:** `docs/strategy/consumer-experience-roadmap.md`
+  §"Local-first compliance".
+- **Monthly review hedges toward a window:** `docs/strategy/consumer-experience-roadmap.md`
+  (AND-355: "a dedicated window if depth demands it").
+- **iOS deferred but Link pre-decided:** `docs/strategy/ios-native-link-decision.md`;
+  `GOAL.md`/`v1.0-roadmap.md` §"Resist".
+- **Global summon / command-palette seed:** AND-487 (`⇧⌘V`), shipped.
+- **Widgets/Control Center ambient layer:** AND-385/503/513 (shipped per `git log`).

--- a/docs/strategy/macos26-migration/03-archaeology.md
+++ b/docs/strategy/macos26-migration/03-archaeology.md
@@ -1,0 +1,190 @@
+# 03 — Repository Archaeology: How VaultPeek Became a Menu-Bar App, and Why That's Now in Tension
+
+**Purpose.** Reconstruct the architectural history of VaultPeek (formerly PlaidBar) to answer three questions for the proposed pivot from "menu-bar popover-primary" to "full native macOS 26 window app":
+
+1. **Why** was the menu-bar / popover architecture originally chosen?
+2. Which assumptions behind that choice are now **invalid**?
+3. Which past decisions should be **preserved** through any migration?
+
+Scope: read-only reconstruction from git history (859 commits, 2026-03-18 → 2026-06-19), the decision-trail docs, and the shipped source tree. All evidence is cited by commit SHA, PR number, AND-issue, or doc path. No real Plaid data appears here.
+
+---
+
+## Executive summary / timeline
+
+VaultPeek shipped as a menu-bar app on day one and never had an explicit "menu-bar vs window" decision — the menu bar *was* the product thesis ("RepoBar/CodexBar for personal finance"). Over 15 months the product hardened that thesis into a written constitution (`docs/v1.0-roadmap.md` §"Menu Bar First"), then — under real Apple-HIG UX review — quietly grew a series of detached `NSWindow` surfaces that the same constitution classifies as "treat with skepticism." Two distinct things people call "the macOS 26 migration" happened: a **platform** migration (Liquid Glass, App Intents, widgets — AND-508–515, merged 2026-06-18) that fully landed, and a **product-model** migration (popover → window) that was *deliberately declined* in the same window and only ever crept in feature-by-feature. That gap is the heart of this archaeology.
+
+| Date | Milestone | Evidence |
+|------|-----------|----------|
+| **2026-03-18** | Initial MVP: three-target SwiftPM package; `PlaidBar` is a `MenuBarExtra(.window)` app with `LSUIElement=true`; `PlaidBarServer` (Hummingbird) owns secrets; `PlaidBarCore` shared. Tab-based UI (`AccountsView`/`TransactionsView`/`SpendingView`/`CreditView`). | `546fe43`; original `ARCHITECTURE.md` |
+| **2026-05-27** | RepoBar-style redesign merged (PR #30): "open dashboard popover by default" — pivot from tab-first to glanceable dashboard-first popover. | `d080fd0` |
+| **2026-06** | Tab tree removed → single drill-in model (AND-312). | `99ca54e` (#272) |
+| **2026-06-12/13** | Three-column popover contract authored (AND-368) and shipped (AND-367/369–376): permanent Wealth Summary rail + center dashboard + right inspector. | `8a94948` (#310), `b2961d9` (#315), `docs/three-column-popover-contract.md` |
+| **2026-06-13** | First detached desktop window lands as a *floating utility `NSPanel`* (PR #351), bundled with the Hosted Link fix. | `b5be256` |
+| **2026-06-13** | UX audit against HIG/WWDC finds the panel is a non-native "utility HUD"; **owner constraint recorded: "keep the menu-bar popover as the primary, default surface … no architecture pivot."** | `docs/ux-audit-2026-06-13.md` |
+| **2026-06-14** | **AND-384 GUI pass (PR #357):** the detached panel is rebuilt as a real managed `NSWindow` with behind-window translucency; "3-columns-always"; `.accessory→.regular` activation on show. Popover stays primary; window is "on demand." | `c276291` |
+| **2026-06-14** | MVP cutline ratified: AND-384 (detachable window) and AND-385 (widget) classified **Post-MVP / Native Expansion**, "test against menu-bar-first." | `docs/mvp-launch-decision-log.md` |
+| **2026-06-18** | **macOS 26 platform migration (Epics A–G, AND-508–515)** merged via stacked PRs #514–520: macOS 26 deployment floor, drop macOS 15 fallbacks, Liquid Glass unconditional, App Group + Widget + Control Center + App Intents, Dynamic Type, SF Symbols 7 audit. | `f41f7f4`, `cf7e5a2`, `d672e0b`, `fda1427`, `ef49795`, merges `13a3e5e`…`63d6306` |
+| **2026-06-19** | **Two more detached `NSWindow`s** ship: Category Dashboard window (AND-539, #544) and multi-select Review Table window (AND-532/555/556, #552), both explicitly "reusing the proven AND-384 managed-NSWindow pattern." | `ff1bfa8`, `85d6c42` |
+| **2026-06-19** | Latest: animated shared-element reflow on the dashboard (AND-577, #571) — still polishing the popover. | `2119292` |
+
+**The arc in one line:** a menu-bar utility, by thesis, grew a constitution forbidding "large canvas / persistent workspace" surfaces — then shipped three of them anyway, each justified individually, while the platform underneath fully moved to macOS 26. The product-model never formally caught up to what the code now does.
+
+---
+
+## 1. WHY the menu-bar architecture was chosen
+
+The menu-bar form factor was **never debated — it was the founding premise.** The very first commit message is "*initial PlaidBar MVP — macOS menu bar app for Plaid banking data*" (`546fe43`), and the original README frames the entire product as filling the gap left by the defunct *Balance* menu-bar app:
+
+> "PlaidBar is an open-source macOS menu bar app … display bank account balances … all from your status bar. **No cloud. No telemetry. All data stays local.**"
+> "**Glanceable** — Net balance visible right in the menu bar" (README @ `546fe43`)
+
+The product north star codifies this as identity, not implementation detail:
+
+> "Build VaultPeek … into a local-first macOS menu bar dashboard for Plaid data: **RepoBar/CodexBar for personal finance.** The app should make the user's financial state glanceable without becoming a full budgeting product. **One click should answer** [posture / did it sync / what needs attention / has spending changed]." (`GOAL.md`)
+
+By the time the long-term brief was written, "Menu Bar First" was an explicit, load-bearing principle with a stated *anti-goal*:
+
+> "VaultPeek should remain a **menu bar utility, not a full desktop finance app that happens to have a menu bar icon.** … **Any feature that needs a large canvas, long workflow, or persistent workspace should be treated with skepticism** unless it strengthens the menu bar experience." (`docs/v1.0-roadmap.md` §"Menu Bar First")
+
+Three concrete forces locked it in:
+
+- **Glance value proposition.** The menu-bar label *is* the product's headline — "net cash, total cash, credit utilization, recent spend, or icon-only … The glance succeeds when the user can decide whether to open the popover" (`docs/v1.0-roadmap.md` §"The Glance"). A glance only exists if the app lives in the menu bar.
+- **Density / RepoBar lineage.** The CLAUDE.md north star is "RepoBar/CodexBar-style density: high-signal numbers one click away in a native macOS popover." The popover form forces compactness — "compact rows over large decorative cards" (`docs/v1.0-roadmap.md` §"Dense, Native, Readable").
+- **Background/resident posture.** `LSUIElement=true`, `.accessory` activation policy, and a companion server that "can restart independently of the UI" presume a quiet resident menu-bar agent, not a focused document app. Energy-aware background refresh (AND-568, `9462d0f`) is explicitly "for the **resident menu-bar app**."
+
+**Note the asymmetry:** the *two-process security boundary* got a written "Why not a single process?" rationale in the first ARCHITECTURE.md. The *menu-bar form factor never did* — it was assumed. There is no architecture-decision record arguing menu-bar over window; the burden of proof was only ever placed on *deviating* from it.
+
+---
+
+## 2. The AND-384 decision in full context
+
+AND-384 ("Detachable pinnable window") is where the popover-vs-window tension becomes explicit and documented, and it resolves in a way that is internally contradictory.
+
+**What was decided (2026-06-13, owner Felipe):** Faced with a Principal/Staff UX audit of the demo, the owner set a hard constraint, recorded verbatim:
+
+> "**User constraint (decided): keep the menu-bar popover as the primary, default surface** ('polish the popover only' + 'quick popover, window on demand'). The free-drag/resize requirement is therefore delivered by **fixing the existing on-demand detached window into a real native window, not by a desktop-first rewrite. No new SwiftUI `Window` scene; no architecture pivot.**" (`docs/ux-audit-2026-06-13.md` §intro)
+
+This is corroborated in user memory ("PlaidBar 2026-06-14 AND-384 GUI pass — user chose popover-primary 'polish only' (NOT desktop-first/Window scene)").
+
+**What actually shipped (2026-06-14, PR #357, `c276291`):** A *real, managed* `NSWindow` — not a HUD:
+
+- `NSPanel`→`NSWindow`, `[.titled,.closable,.miniaturizable,.resizable]`, `level=.normal`, default (Managed) collection behavior → "drags, resizes, minimizes, tiles, and joins Mission Control / Stage Manager / Spaces."
+- Non-opaque window + clear background + behind-window `NSVisualEffectView` for true translucency.
+- **The app elevates `.accessory → .regular` on show** (Dock + Cmd-Tab presence) and restores `.accessory` on re-dock.
+- "Three columns always"; "Open in Window" added to the status-item menu; `--detach` launch flag for QA.
+
+So the build delivered a window that behaves like a primary application window — Dock icon, Cmd-Tab, full window management — while the *decision* insisted the popover stays primary and "no architecture pivot." The reconciliation was a follow-up "Keep on top" toggle (added in the same PR) that re-introduces the floating-glance behavior *as opt-in*, so the default is a managed window but the original AND-384 acceptance criteria (floating glance panel) survive behind a preference.
+
+**How the cutline classified it (2026-06-14):** Despite the working detached window already in `main`, the MVP decision log lists AND-384 as **Post-MVP / "Native Expansion" / Backlog**, with the rationale:
+
+> "A persistent detached window is exactly the kind of 'large canvas / persistent workspace' surface the product brief says to treat with skepticism unless it strengthens the menu-bar experience. It is a deliberate post-MVP exploration, not a launch requirement, and it needs its own data-boundary and menu-bar-first review before it earns a place." (`docs/mvp-launch-decision-log.md` §"Native Expansion")
+
+**The contradiction, precisely stated:** the working code (a real activating `NSWindow`, shipped) and the governing doc (AND-384 is unproven backlog "treated with skepticism") describe two different products. The window exists, is wired into the menu, and was reused twice more — but the constitution still treats windowing as a hypothesis. A pivot to window-primary is therefore not a green-field move; it is **ratifying, formalizing, and de-risking something that already partially shipped under an explicitly contrary decision.**
+
+---
+
+## 3. What the "macOS 26 migration" actually did — platform vs product model
+
+There are two different migrations conflated under one name. Distinguishing them is essential.
+
+### What the macOS 26 migration (AND-508–515, Epics A–G) DID — platform adoption
+
+Merged 2026-06-18 via stacked PRs #514–520. It moved the *technology baseline* to macOS 26 (Tahoe), fully and unconditionally:
+
+- **Epic A (AND-509, `cf7e5a2`):** committed to the macOS 26 deployment floor — `MACOSX_DEPLOYMENT_TARGET 15.0→26.0`, CI runner `macos-15→macos-26`, Xcode 26; docs reframed Liquid Glass as *baseline*, not progressive enhancement.
+- **Epic B (AND-510, `d672e0b`):** dropped all macOS 15 fallbacks; Liquid Glass and ControlWidget paths made unconditional (net-negative LOC).
+- **Epic C (AND-511, `fda1427`):** adopted `.glassEffect`, `.buttonStyle(.glass)`, `glassEffectID` morphs, `GlassEffectContainer`, scroll-edge effects across popover/panels/controls.
+- **Epic D (AND-512):** App Group snapshot store + Finance App Intents bundle (Siri/Spotlight/Shortcuts).
+- **Epic E (AND-513):** Control Center controls + App-Group-backed widgets.
+- **Epic F (AND-514, `ef49795`):** SF Symbols 7 audit (kept the custom Vault glyph); "menu-bar/window scene modernization" — but the spike (F2) found "SwiftUI 7 still exposes **no declarative frame-origin/placement hook for a `MenuBarExtra(.window)` host window**," so the leading-edge pin *kept* its `NSViewRepresentable + setFrameOrigin` bridge.
+- **Epic G (AND-515):** macOS 26 QA matrix, Dynamic Type (`@ScaledMetric` hero balances), architecture notes.
+
+### What it did NOT do — change the product model
+
+The platform migration **preserved the menu-bar product model wholesale.** Critically:
+
+- The new glance surfaces (widget, Control Center, App Intents) are explicitly *out-of-process display-only* satellites of a menu-bar app, reading a redacted `GlanceSnapshot` through an App Group — "The extension cannot reach the app's `AppState` or the companion server" (`docs/architecture.md` §"Glance Surfaces"). These *reinforce* the resident-glance model rather than replace it with a window.
+- Epic F's scene-modernization spike confirmed the app is still a `MenuBarExtra(.window)` host, with its anchoring done by an AppKit bridge — not a SwiftUI `Window` scene.
+- The macOS 26 floor doc and the architecture vision still describe `PlaidBar` as the "native SwiftUI **menu bar** app" (`docs/v1.0-roadmap.md` §"Architecture Vision").
+
+**Bottom line for the pivot:** the *hard, framework-level part* of "macOS 26" — Liquid Glass, App Intents, widgets, Dynamic Type, the deployment floor — is **already done and shipping**. A window-primary pivot therefore inherits a modern macOS 26 foundation; it does **not** need to redo platform adoption. What it must do is the part the 2026-06-18 migration deliberately left untouched: change the **product model** from "resident glance + on-demand window" to "window-primary," which means resolving the activation-policy posture, the `MenuBarExtra` scene, and the constitution — none of which the platform migration addressed.
+
+---
+
+## 4. The popover-vs-window tension over time (every time windows crept in)
+
+Windowing did not arrive once; it accreted in four distinct, individually-justified steps, each one expanding the window surface while the governing docs held the menu-bar line.
+
+| When | What crept in | How it was justified | Tension with the constitution |
+|------|---------------|----------------------|-------------------------------|
+| **2026-06-13** (`b5be256`, #351) | First "detachable desktop window" — a floating utility `NSPanel`. Shipped *bundled* with a Hosted Link 500 fix and "consumer-prod foundation," not as a standalone windowing decision. | Buried in a multi-purpose PR; AND-407 hardening later flagged it as "partial." | A persistent window appears with no menu-bar-first review; arrived as a side effect. |
+| **2026-06-14** (`c276291`, #357) | The panel becomes a **real managed, activating `NSWindow`** with `.accessory→.regular` elevation, 3-columns-always, "Open in Window" menu item. | UX audit + explicit "popover stays primary, window on demand, no architecture pivot." | A primary-class application window now exists, but the decision says the popover is primary and there's "no pivot." `.regular` activation gives the app a Dock icon — the most un-menu-bar-utility thing possible — yet only on demand. |
+| **2026-06-14** | AND-384 + AND-385 codified as **Post-MVP "Native Expansion," "treat with skepticism."** | Cutline discipline: keep the MVP small; windowing is unproven. | The doc treats as hypothetical-backlog a window that already shipped to `main` and is in the menu. |
+| **2026-06-19** (`ff1bfa8` #544; `85d6c42` #552) | **Two more detached `NSWindow`s**: Category Dashboard (donut + sortable SPENT/BUDGET/LEFT Table) and a multi-select Review Table (power-review with bulk recategorize). Both "reuse the proven AND-384 managed-NSWindow + behind-window NSVisualEffectView pattern" and the "shared refcounted `AppActivationPolicyCoordinator`." | Each tied to a Copilot-parity feature spec (category dashboard, review inbox), Option A "no recompute." | These are squarely "large canvas / long workflow / persistent workspace" surfaces — a sortable financial table and a multi-select bulk-edit workflow — exactly what "Menu Bar First" says to resist. The product is *already* a multi-window app in practice. |
+
+**The pattern:** the menu-bar constitution was never overruled — it was *outgrown by accretion.* Each window was a local, defensible decision ("just polish the existing detach," "just surface the dashboard that already exists," "just a power-review table"). Summed, they make VaultPeek a three-window-plus-popover-plus-widgets application whose own roadmap still calls a detached window an unproven Post-MVP risk. The shared infrastructure (`DetachedDashboardWindowController`, `CategoryDashboardWindowController`, `ReviewTableWindowController`, `AppActivationPolicyCoordinator`, behind-window `NSVisualEffectView`) is now mature and reused — the window pattern is, de facto, a core part of the architecture.
+
+---
+
+## 5. ASSUMPTIONS NOW INVALID
+
+| # | Original assumption | Why it no longer holds | Evidence |
+|---|---------------------|------------------------|----------|
+| **A1** | **A single glanceable popover answers the user's questions; windows are at most an on-demand convenience.** | The product has shipped *three* detached windows for content the popover can't hold — a 3-column workspace, a sortable category Table, and a multi-select bulk-review Table. The "large canvas" the constitution forbade is now load-bearing for real features. | `c276291`, `ff1bfa8` (#544), `85d6c42` (#552); contrast `docs/v1.0-roadmap.md` §"Menu Bar First" |
+| **A2** | **AND-384 (detachable window) is unproven, skepticism-warranted backlog needing a menu-bar-first review before it "earns a place."** | It shipped, was hardened (AND-420, `c18cc66`), and was reused as the *foundation* for two later windows. The pattern is proven and depended-upon, not hypothetical. | `docs/mvp-launch-decision-log.md` §"Native Expansion" vs `c276291`, `ff1bfa8`, `85d6c42` |
+| **A3** | **The app is a quiet `.accessory` resident with no Dock presence.** | Every detached window elevates to `.regular` (Dock icon, Cmd-Tab) via a shared refcounted coordinator. The app *already* toggles into a normal app posture routinely; window-primary just makes that the default instead of transient. | `c276291` (`.accessory→.regular`), `85d6c42` (`AppActivationPolicyCoordinator`), regression-fix history `4f90b29`, `2a6e81d` |
+| **A4** | **`MenuBarExtra(.window)` is the right host; its width/anchoring quirks are worth living with.** | The popover's quirks generated repeated fixes — width on the active screen (`526d895`), three-column geometry on narrow displays (`5020832`), leading-edge pin via an AppKit bridge because SwiftUI offers no hook (`ef49795` F2). A real resizable `NSWindow`/`Window` scene removes this entire class of fragility. | `526d895`, `5020832`, `ef49795`, `docs/three-column-popover-contract.md` §4–5 |
+| **A5** | **Liquid Glass / macOS 26 is a "progressive enhancement, not a minimum."** | The macOS 26 migration made it the **unconditional baseline** and removed all fallbacks; the deployment floor is macOS 26. Any pivot can assume modern APIs (incl. SwiftUI `Window`, `windowResizability`, `.glassEffect`) are simply available. | `cf7e5a2`, `d672e0b`, `fda1427` |
+| **A6** | **The three-column popover width (~1122pt) is a reasonable popover size.** | A 1122pt popover is window-sized; the contract itself needs a mandatory multi-tier screen-constrained fallback (cap, flex, overlay) to fit displays. The audit's own dial-back suggestion was "apply always-3-columns only in the resizable detached window." A real window resolves the width problem natively. | `docs/three-column-popover-contract.md` §3, §5; `docs/ux-audit-2026-06-13.md` §5 |
+| **A7** | **Translucency can be achieved within the menu-bar popover host.** | Real behind-window read-through required dropping the `MenuBarExtra` host entirely for a non-opaque `NSWindow` + `NSVisualEffectView`; the C4 spike confirmed the behind-window effect only reads correctly on the detached window. (User memory: MenuBarExtra glass is effectively impossible via host-window surgery.) | `c276291` Wave 2, `fda1427` C4 spike; user memory "VaultPeek-menubarextra-glass-impossible" |
+
+**Single most important now-invalid assumption: A1.** The premise that one glanceable popover (plus an optional convenience window) is sufficient is empirically false in the shipped product — three windows now carry real, distinct workflows. The product is already multi-window; the pivot mostly admits in writing what the code already does.
+
+---
+
+## 6. DECISIONS TO PRESERVE through any migration
+
+These are the load-bearing decisions a window-primary pivot must **not** disturb. Most are orthogonal to the form factor — they are about security, data boundaries, and code structure, not about where pixels are drawn.
+
+| # | Decision | Why it must survive |
+|---|----------|---------------------|
+| **P1** | **Two-process security boundary** — `PlaidBar` (UI) talks only to `127.0.0.1` `PlaidBarServer` over HTTP; the server owns the Plaid `client_secret`/`access_token`; SQLite holds only `keychain:<item_id>` references. | This is the *one* architecture decision with a written "Why not a single process?" rationale (`546fe43` ARCHITECTURE.md): "Plaid's security model requires that `client_secret` and `access_token` never exist in client-side code." It is form-factor-independent and non-negotiable. A window app must still proxy through the local server. |
+| **P2** | **Core-centric, `Sendable`, testable business logic in `PlaidBarCore`.** | Swift 6 strict-concurrency (`-strict-concurrency=complete -warnings-as-errors`) is the CI gate that "most often fails" (CLAUDE.md). Summaries, formatters, recurring detection, sync reduction, *and the new window models* (`CategoryDashboardTableModel`, `ReviewTableRow`/`ReviewTableSort`) already live in Core with TDD tests. Window views must keep delegating to Core, not embed logic. |
+| **P3** | **Local-first, no hosted backend, no telemetry, no cloud.** | The North Star and the ratified 2026-06-14 MVP decision (defer all hosted/managed/monetization). Re-stated in every roadmap doc. A pivot changes the *window*, never the *data boundary*. |
+| **P4** | **Single drill-in model; no tab tree (AND-312).** | The removed `AccountsView`/`TransactionsView`/`SpendingView`/`CreditView`/`StatusView` tab tree (`99ca54e`) was a deliberate simplification; the three-column contract explicitly forbids reintroducing it ("New detail belongs in the inspector, not a tab container," `docs/three-column-popover-contract.md` §2). A bigger window must not be an excuse to bring tabs back. |
+| **P5** | **Recovery is a first-class surface; one width across states; settled-on-open.** | "Recovery Is A Primary Experience" (`docs/v1.0-roadmap.md`); the AND-384 fix made demo "open settled" by loading fixtures synchronously to kill the 480→801 jump (`c276291` Wave 1). Window mode must keep recovery states and avoid layout flashes. |
+| **P6** | **Accessibility: never meaning by color alone; Reduced Motion; Dynamic Type; VoiceOver.** | Enforced across the three-column contract §6, `ACCESSIBILITY.md`, the Review Table ("category pressure rides on glyph + text, never color alone," `85d6c42`), and Dynamic Type hero balances (AND-515). These constraints are UI-surface-agnostic and must carry over. |
+| **P7** | **Privacy Mask / App Lock + redacted glance snapshots.** | A second trust boundary (App Group) with write-time *and* read-time redaction (`docs/architecture.md`; AND-517 `b275d9e`; App Lock wiring `217ccc9`). Each window already participates (the Review Table "withholds merchant + amount under Privacy Mask"). Window-primary mode must preserve the masking contract on every surface. |
+| **P8** | **Sandbox/synthetic data only in tests, screenshots, examples; conservative distribution claims.** | CLAUDE.md hard rule; release-checklist discipline. Independent of form factor. |
+
+---
+
+## 7. Migration risks surfaced by history
+
+History shows exactly which areas are fragile, because they broke and were patched repeatedly.
+
+- **R1 — Activation-policy thrash (`.accessory` ↔ `.regular`).** The single most repeatedly-fixed area: "restore activation policy after opening settings" (`4f90b29`, #230), "clarify account drill-in activation path" (`6e8a26f`), AND-385 "activation refresh" follow-ups (`2a6e81d`), and the shared *refcounted* `AppActivationPolicyCoordinator` introduced precisely because "opening both [a window and Settings] at once can … strand the menu-bar app in `.regular` / the Dock" (`c276291` P2). **A window-primary app makes `.regular` the default** — which actually *removes* much of this hazard, but the migration must delete the now-obsolete refcounting carefully and not leave half-toggled policy paths. This is the area most likely to regress mid-migration.
+
+- **R2 — `MenuBarExtra` anchoring / width plumbing.** Popover width and the three-column geometry needed multiple fixes: active-screen width (`526d895`), narrow-display three-column geometry + persisted-selection open (`5020832`), and a leading-edge pin that *must* use an `NSViewRepresentable + setFrameOrigin` bridge because "SwiftUI 7 still exposes no declarative frame-origin hook for a `MenuBarExtra(.window)` host window" (`ef49795` F2). Migrating to a SwiftUI `Window` scene would delete this fragile bridge — a *benefit* — but the unit-tested `PopoverGeometry.clampedLeadingX` anchoring math and the three-column fallback tiers (`docs/three-column-popover-contract.md` §5) are tied to the popover host; they must be re-homed or retired deliberately, not orphaned.
+
+- **R3 — Translucency host surgery.** True translucency required abandoning the popover host for a non-opaque `NSWindow` + behind-window `NSVisualEffectView`; the C4 spike found SwiftUI glass did *not* read the desktop through on the transparent window and the AppKit backdrop was kept (`fda1427` C4). User memory records that behind-window translucency "can't be done via `MenuBarExtra(.window)` host-window surgery." **Do not re-attempt the failed popover-glass approaches**; the window path is the proven one, and a `Window` scene should reuse the behind-window vibrancy pattern, not SwiftUI-native glass alone, for desktop read-through.
+
+- **R4 — Appearance cascade.** Light/Dark was historically fragile: "three overlapping scheme sources," `NSApp.appearance` applied post-paint, a detached panel frozen at creation (`docs/ux-audit-2026-06-13.md` §1; fix `c276291` Wave 1). The lesson: **`NSApp.appearance` is the single authoritative API**, applied before first paint, with separately-hosted windows leaving `appearance==nil` to inherit. A new top-level window must follow this exact pattern or the flash/freeze bugs return. The P2 debt of "redundant `environment(\.colorScheme)` overrides" was explicitly deferred and is still outstanding (`docs/ux-audit-2026-06-13.md` §4) — migrate that debt, don't inherit it blindly.
+
+- **R5 — Windows bundled into unrelated PRs.** The first detached window arrived inside a Hosted-Link-fix PR (`b5be256`), and AND-407 had to do a "partial" post-merge hardening pass to catch up (`docs/qa/and407-post-merge-hardening.md` §5). A formal window-primary pivot should be its *own* tracked change with its own QA matrix, not smuggled alongside feature work — the history shows windowing slips through review when bundled.
+
+- **R6 — Doc/code divergence as a process risk.** The clearest systemic risk: working code (a shipped activating window, reused twice) and the governing constitution (AND-384 is unproven backlog "to treat with skepticism") have been out of sync for the entire windowing era. If the pivot is approved, the **decision log, v1.0-roadmap §"Menu Bar First," post-mvp-roadmap, and CLAUDE.md must be updated in lockstep** — otherwise the next agent will "correct" the window work back toward popover-primary citing the still-authoritative docs. (User memory repeatedly notes agents acting on stale repo state.)
+
+- **R7 — `MenuBarExtra` is still a hard product promise.** The menu-bar glance, the configurable menu-bar label modes, the live signal-meter glyph (AND-485, `9cd1201`), and the energy-aware *resident* refresh (AND-568, `9462d0f`) all assume the app lives in the menu bar. A pivot to window-*primary* must decide whether the menu-bar presence **stays as a secondary glance** (most consistent with history and the widget/Control Center investment) or is dropped (high-risk: discards the founding value proposition and the just-shipped glance-surface ecosystem). History strongly favors *keeping* the menu-bar glance and *adding* a primary window — i.e. a both/and, not an either/or.
+
+---
+
+## 8. Key lessons learned
+
+1. **The form factor was a thesis, not a decision.** Menu-bar was never argued for against alternatives; it was the premise. That means the bar for pivoting is *lower* than it looks — there is no rigorous "why menu-bar beats window" record to overturn, only an accreted constitution defending an assumption.
+2. **The product already pivoted in code; only the docs didn't.** Three detached windows, a refcounted activation coordinator, and a proven NSWindow+vibrancy pattern make VaultPeek a multi-window app today. The pivot is largely a *formalization*, which de-risks it substantially.
+3. **The two migrations are separable, and the hard one is done.** macOS 26 *platform* adoption (Liquid Glass, App Intents, widgets, Dynamic Type, deployment floor) fully landed 2026-06-18. The *product-model* migration (popover→window) is the remaining work and is mostly architectural posture (activation policy, scene type, constitution), not framework adoption.
+4. **The fragile zones are known and narrow:** activation policy, `MenuBarExtra` anchoring/width, translucency host, and appearance cascade. A window-primary model *removes or simplifies* most of them (R1, R2) rather than adding new ones — the popover host was the source of the fragility, not the cure.
+5. **Don't bundle windowing into feature PRs** (R5) and **update the governing docs in lockstep** (R6); both are repeated, history-proven failure modes.
+6. **Preserve the boundaries, change the surface.** Everything that makes VaultPeek trustworthy — two-process security, Core-centric `Sendable` logic, local-first, no telemetry, single drill-in, recovery-first, accessibility, privacy mask — is orthogonal to popover-vs-window. A pivot is safe precisely to the extent it touches only the presentation surface and leaves §6 intact.

--- a/docs/strategy/macos26-migration/04-platform-research.md
+++ b/docs/strategy/macos26-migration/04-platform-research.md
@@ -1,0 +1,585 @@
+# macOS 26 Platform Research — Building a Full Native Windowed App
+
+**Doc:** `docs/strategy/macos26-migration/04-platform-research.md`
+**Audience:** VaultPeek migration architecture working group
+**Status:** Research / decision input (not a commitment)
+**Date:** 2026-06-19
+**Author:** Platform research pass (Claude, macOS 26 / SwiftUI specialist)
+
+---
+
+## Purpose
+
+VaultPeek (formerly PlaidBar) is today a local-first macOS **menu-bar popover** dashboard for Plaid data. This document is the authoritative, *current* (June 2026) best-practices survey of what a full native **macOS 26 windowed application** can do, so the migration architecture rests on real platform capability — not stale assumptions. Every claim below was verified against live Apple documentation (Context7 mirror of `developer.apple.com`), WWDC session material, and the public web; sources are listed per topic and aggregated at the end.
+
+---
+
+## ⚠️ Read first — the version-numbering trap (this changes roadmap math)
+
+Apple switched to **year-based OS numbering** in 2025. There are **two distinct cycles** in scope, and conflating them will mis-target the build:
+
+| Cycle | OS | Announced | Shipped | Status (June 2026) | Doc availability tag |
+|---|---|---|---|---|---|
+| **WWDC25** | **macOS 26 "Tahoe"** (iOS 26) | 9 Jun 2025 | **15 Sept 2025** | **Current shipping OS** — the correct floor for VaultPeek now | `macOS 26.0+` |
+| **WWDC26** | **macOS 27** (iOS 27) | 8 Jun 2026 | ~Sept 2026 (betas now) | Just previewed; **betas only** | `macOS 27.0+ Beta` (docs label "2027 releases") |
+
+**Consequences for the pivot:**
+
+1. **Liquid Glass, `glassEffect`, `ToolbarSpacer`, `NSHostingSceneRepresentation`, App Intents interactive snippets (`SnippetIntent`), `supportedModes`, App Intents in Spotlight, the full `AXChartDescriptor` audio-graph stack, SwiftData `#Unique`/`#Index`/`@ModelActor`/History tracking — are ALL shippable on macOS 26 TODAY.** You do not need to wait.
+2. **The shiny WWDC26 (macOS 27) additions — reorderable containers, `swipeActionsContainer`, `visibilityPriority`/`toolbarOverflowMenu`/`topBarPinnedTrailing`, sectioned `@Query`, `HistoryObserver`/`ResultsObserver`, `Tab(role: .prominent)` — are NOT in stable macOS 26.** Treat them as a fast-follow, gated behind `if #available(macOS 27, *)`, and re-confirm signatures against Xcode 27 headers at GA.
+3. **Target macOS 26 as the deployment floor.** It carries everything VaultPeek's pivot needs.
+
+Sources: [MacRumors — macOS Tahoe](https://www.macrumors.com/roundup/macos-26/) · [TechRadar — macOS Tahoe 26 announced](https://www.techradar.com/computing/mac-os/macos-tahoe-26-announced-at-wwdc-2025-with-a-new-look-and-new-numbering-scheme-these-are-the-best-features-for-your-new-mac-or-macbook) · [TechCrunch — WWDC 2026 recap](https://techcrunch.com/2026/06/09/wwdc-2026-everything-announced-on-siri-ai-os-27-apple-intelligence-and-more/)
+
+---
+
+## Topic 1 — Liquid Glass (the macOS 26 material/design language)
+
+### What it is
+Liquid Glass is Apple's unified design language introduced at WWDC25 and shipping in macOS 26. It is a translucent, dynamic material that refracts/reflects surrounding content (real-time lensing), carries specular highlights, adaptive shadows, and interactive behaviors. It spans iOS/iPadOS/macOS/watchOS/tvOS/visionOS 26.
+
+### Current API / pattern (all `macOS 26.0+`)
+- **Automatic adoption:** recompile against the macOS 26 SDK and stock SwiftUI controls (toolbars, sidebars, sheets, buttons) adopt Liquid Glass automatically. Toolbar items float on a shared glass surface that adapts to content beneath.
+- **`glassEffect(_:in:)`** — apply glass to a custom view:
+  ```swift
+  func glassEffect(_ glass: Glass = .regular,
+                   in shape: some Shape = DefaultGlassEffectShape()) -> some View
+  // DefaultGlassEffectShape() is a Capsule.
+  Text("Safe to spend").padding()
+      .glassEffect(.regular.tint(.green).interactive(), in: .rect(cornerRadius: 12))
+  ```
+- **`Glass` variants:** `.regular` (default), `.clear` (more transparent — must add a dimming background for legibility), `.tint(_:)`, `.interactive()`.
+- **Button styles:** `.buttonStyle(.glass)`, `.buttonStyle(.glassProminent)`, `.buttonStyle(.glass(.clear))`.
+- **`GlassEffectContainer(spacing:) { }`** — REQUIRED when you have multiple custom glass elements near each other. Glass cannot sample other glass, so the container fuses them into one morphable surface and prevents glass-on-glass artifacts.
+- **Morphing / transitions:** `glassEffectID(_:in:)` + `@Namespace` for matched-geometry morphs; `glassEffectUnion(id:namespace:)` to merge geometries; `glassEffectTransition(.matchedGeometry / .materialize)`.
+- **Toolbar grouping:** `ToolbarSpacer(.fixed/.flexible)` splits toolbar items into distinct glass groups; `sharedBackgroundVisibility(_:)` (on `ToolbarContent`) pulls an item out of the shared glass capsule into its own group (e.g., a custom net-worth pill).
+- **Window-level translucency (SwiftUI-native):** `.containerBackground(.ultraThinMaterial, for: .window)` and `backgroundExtensionEffect()` to extend a detail background seamlessly under sidebar/inspector.
+
+### When to use
+Glass belongs to the **navigation/control layer that floats above content** — toolbars, sidebars, floating controls, KPI pills, badges. Use `GlassEffectContainer` whenever 2+ custom glass shapes coexist.
+
+### macOS-specific caveats / pitfalls
+- **Glass is for the navigation layer, NEVER the content itself.** Apple's explicit guidance: do not apply Liquid Glass to lists, tables, media, or large data surfaces. For a dense finance dashboard this is the dominant constraint — the transaction table, charts, and balance grids stay on solid/standard backgrounds; only the chrome is glass.
+- **Avoid glass-on-glass.** Stacking glass layers looks cluttered and is technically unsupported (glass can't sample glass). Group with `GlassEffectContainer`.
+- **Legibility:** `.clear` glass needs a dimming backing (`.background(.black.opacity(0.3))`) under text. Be judicious with tint so content shines through and stays legible.
+- **Accessibility degradation (mandatory — see Topic 10):** stock glass auto-degrades to more opaque/contrasty when *Reduce Transparency* or *Increase Contrast* is on, but **any custom glass or hand-rolled `NSVisualEffectView` translucency you add must handle this yourself** via `@Environment(\.accessibilityReduceTransparency)`.
+
+### UX opportunity vs popover
+A real `Window` gets `.containerBackground(.ultraThinMaterial, for: .window)` — **supported, declarative, window-level translucency through public API.** This directly resolves VaultPeek's documented dead-end where behind-window popover translucency could *not* be achieved via `MenuBarExtra(.window)` host-window surgery. In a window, the glance/glass aesthetic the team wants is a one-liner, not a fight with AppKit internals.
+
+Sources: [Liquid Glass overview](https://developer.apple.com/documentation/technologyoverviews/liquid-glass) · [Adopting Liquid Glass](https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass) · [Applying Liquid Glass to custom views](https://developer.apple.com/documentation/swiftui/applying-liquid-glass-to-custom-views) · [glassEffect(_:in:)](https://developer.apple.com/documentation/swiftui/view/glasseffect%28_%3Ain%3A%29) · [GlassEffectContainer](https://developer.apple.com/documentation/swiftui/glasseffectcontainer) · [LogRocket — adopting Liquid Glass best practices](https://blog.logrocket.com/ux-design/adopting-liquid-glass-examples-best-practices/)
+
+---
+
+## Topic 2 — SwiftUI windowing on macOS
+
+### What it is
+The SwiftUI scene graph: a declarative set of `Scene`s (`WindowGroup`, `Window`, `Settings`, `MenuBarExtra`, `DocumentGroup`) in the `App` body, plus environment actions to open/close windows. A hybrid app declares a primary window AND a menu-bar glance AND settings in the same `body`.
+
+### Current API / pattern
+- **`WindowGroup`** (macOS 11+; `id`/value variants 13+) — group of identical windows; supports multiple simultaneous instances. `WindowGroup(_:for:) { $value in … }` gives one window per value (e.g., one per account).
+- **`Window("Title", id:)`** (macOS 13+) — a single unique window. Cleaner than `WindowGroup` for "the one dashboard."
+- **`Settings { }`** (macOS 13+) — standard Settings/Preferences scene (wires ⌘,).
+- **`MenuBarExtra`** (macOS 13+) — `.menuBarExtraStyle(.menu)` (pull-down controls) vs `.window` (chromeless popover; what VaultPeek uses today). `MenuBarExtra(..., isInserted: $bool)` lets the user hide/show the item live.
+- **Environment actions:** `\.openWindow` → `openWindow(id:)`/`openWindow(value:)`; `\.dismissWindow`; `\.openSettings()` (macOS 14+). `\.pushWindow` is effectively **visionOS-only** — do not bank on it for macOS.
+- **Appearance:** `.windowStyle(.automatic/.titleBar/.hiddenTitleBar/.plain)` (`.hiddenTitleBar` = modern content-forward look), `.windowToolbarStyle(.unified/.unifiedCompact/.expanded)`.
+- **Sizing/placement:** `.windowResizability(.contentSize/.contentMinSize/.automatic)` (use `.contentMinSize` for a resizable dashboard), `.defaultSize`, `.defaultPosition`, `.defaultWindowPlacement { content, context in … }` (anchor near the menu bar via `context.defaultDisplay.visibleRect`).
+- **Behavior (macOS 15+):** `.windowLevel(.floating)` (always-on-top mini window), `.windowBackgroundDragBehavior(.enabled)` (drag chromeless windows by background), `.restorationBehavior(.automatic)` (reopen where left off), `.defaultLaunchBehavior(.suppressed)` (**launch menu-bar-only**, window appears on demand).
+- **NEW WWDC26-relevant (macOS 26):** `NSHostingSceneRepresentation` lets an **AppKit (`NSApplicationDelegate`) lifecycle app host SwiftUI scenes** — including a dynamically-inserted `MenuBarExtra`. This is the blessed escape hatch for the exact menu-bar window-surgery problems VaultPeek hit before. (Caveat: its environment can open `Settings` and `WindowGroup` but not a plain `Window`.)
+
+### Hybrid scene-graph skeleton (the load-bearing structure)
+```swift
+@main
+struct VaultPeekApp: App {
+    @State private var model = AppModel()
+    @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
+
+    var body: some Scene {
+        // 1) PRIMARY WINDOW — real, resizable dashboard, launch-suppressed.
+        Window("VaultPeek", id: "main") {
+            DashboardView().environment(model)
+                .containerBackground(.ultraThinMaterial, for: .window)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowToolbarStyle(.unifiedCompact(showsTitle: false))
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 920, height: 600)
+        .defaultLaunchBehavior(.suppressed)     // start menu-bar-only
+        .restorationBehavior(.automatic)        // reopen where left off
+
+        // 2) MENU-BAR GLANCE — compact, popover-style, user-removable.
+        MenuBarExtra("VaultPeek", systemImage: "creditcard",
+                     isInserted: $showMenuBarExtra) {
+            GlanceView().environment(model)      // top-line balances + "Open Dashboard"
+        }
+        .menuBarExtraStyle(.window)
+
+        // 3) SETTINGS.
+        Settings { SettingsView().environment(model) }
+    }
+}
+// GlanceView's CTA — the bridge from popover to window:
+//   @Environment(\.openWindow) var openWindow
+//   Button("Open Dashboard") { openWindow(id: "main") }
+```
+
+### When to use
+Use a single `Window` for the dashboard if it's conceptually singular; use `WindowGroup(_:for:)` if you want multiple windows (one per institution/account). Keep the `MenuBarExtra` as the always-available glance.
+
+### macOS-specific caveats
+- `.defaultLaunchBehavior(.suppressed)` is macOS 15+. Pair it with activation-policy handling (Topic 9) so the suppressed window comes to the front correctly when opened.
+- State restoration overrides `.defaultSize` with the last-used size (desirable for a dashboard).
+
+### UX opportunity vs popover
+A popover auto-dismisses on focus loss, is size-capped to the menu-bar anchor, is singular, and never restores. A window: **persists side-by-side with other apps, resizes to dense layouts, supports multiple instances, restores across launches, hosts a real toolbar/title-bar/full-screen, and can be pinned always-on-top.** See the ranked list at the end.
+
+Sources: [Windows (SwiftUI)](https://developer.apple.com/documentation/swiftui/windows) · [WindowGroup](https://developer.apple.com/documentation/SwiftUI/WindowGroup) · [Window](https://developer.apple.com/documentation/swiftui/window) · [MenuBarExtra](https://developer.apple.com/documentation/SwiftUI/MenuBarExtra) · [Building and customizing the menu bar with SwiftUI](https://developer.apple.com/documentation/swiftui/building-and-customizing-the-menu-bar-with-swiftui) · [windowResizability(_:)](https://developer.apple.com/documentation/swiftui/scene/windowresizability%28_%3A%29) · [defaultLaunchBehavior(_:)](https://developer.apple.com/documentation/swiftui/scene/defaultlaunchbehavior%28_%3A%29) · [NSHostingSceneRepresentation](https://developer.apple.com/documentation/swiftui/nshostingscenerepresentation) · [WWDC26 — Use SwiftUI with AppKit and UIKit (272)](https://developer.apple.com/videos/play/wwdc2026/272/)
+
+---
+
+## Topic 3 — NavigationSplitView / NavigationStack / Sidebar / Inspector
+
+### What it is
+The canonical macOS "sidebar + content + detail" shell. `NavigationSplitView` lays out 2 or 3 columns where leading-column selection drives the next column; `NavigationStack` provides value-based push/pop *inside* a column; `inspector` adds a trailing detail-of-detail pane.
+
+### Current API / pattern
+- **`NavigationSplitView`** (2-col macOS 13+, 3-col + `preferredCompactColumn` macOS 14+):
+  ```swift
+  NavigationSplitView(columnVisibility: $vis) {
+      sidebar
+  } content: {
+      list
+  } detail: {
+      detail
+  }
+  .navigationSplitViewStyle(.balanced)   // or .prominentDetail
+  ```
+- **`NavigationSplitViewVisibility`** (`.all`/`.doubleColumn`/`.detailOnly`/`.automatic`) for programmatic column collapse; **`NavigationSplitViewColumn`** (`.sidebar`/`.content`/`.detail`) with `preferredCompactColumn`.
+- **Column widths:** `.navigationSplitViewColumnWidth(min:ideal:max:)`.
+- **`NavigationStack(path: $path)`** + `.navigationDestination(for: T.self) { … }` — value-based, testable, restorable navigation. `path.append(_)` push, `path.removeLast()` pop, `path = []` pop-to-root.
+- **Sidebar:** `List(selection: $sel) { Section { Label(_, systemImage:).tag(_).badge(_) } }.listStyle(.sidebar)`. `Label` (glyph + text) satisfies the never-color-alone rule; `.badge(_)` + `.badgeProminence(.increased)` for high-signal counts ("3 accounts need re-auth").
+- **Inspector** (macOS 14+): `.inspector(isPresented:) { … }` trailing pane + `.inspectorColumnWidth(min:ideal:max:)` — the 4th region for transaction metadata / raw Plaid payload.
+- **`Table`** (macOS 12+, selection/sort/customization broadened 14+): the densest transaction surface, natively keyboard-navigable (see Topic 7).
+
+### Canonical shell skeleton (3-column + inspector)
+```swift
+NavigationSplitView(columnVisibility: $columnVisibility) {
+    List(SidebarSection.allCases, selection: $section) { s in
+        Label(s.title, systemImage: s.symbol).tag(s).badge(s.alertCount)
+    }
+    .listStyle(.sidebar)
+    .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
+} content: {
+    List(accounts(for: section), selection: $selectedAccountID) { AccountRow($0).tag($0.id) }
+        .navigationSplitViewColumnWidth(min: 260, ideal: 320)
+} detail: {
+    NavigationStack(path: $path) {
+        AccountDashboard(accountID: selectedAccountID)
+            .navigationDestination(for: Transaction.self) { TransactionDetail($0) }
+    }
+    .inspector(isPresented: $showInspector) {
+        InspectorPane(selectedAccountID: selectedAccountID)
+            .inspectorColumnWidth(min: 240, ideal: 300, max: 420)
+    }
+}
+.navigationSplitViewStyle(.balanced)
+```
+`tabViewStyle(.sidebarAdaptable)` (macOS 15+) is the lighter alternative *only* if top-level sections are genuinely tab-like rather than hierarchical.
+
+### When to use
+3-column `NavigationSplitView` is the recommended VaultPeek shell: sidebar filters (Cash/Credit/Savings/Debt/Status — already the popover's mental model) → account/list content → dashboard detail with a drill-down `NavigationStack` and an inspector for metadata. `.prominentDetail` keeps the hero chart stable while the user toggles the sidebar.
+
+### macOS-specific caveats
+- Column resizing is supported on macOS; a fixed inspector width still lets the user collapse it (add `.interactiveDismissDisabled()` to prevent).
+- Remove the auto sidebar toggle with `toolbar(removing: .sidebarToggle)` if you provide your own.
+
+### UX opportunity vs popover
+A popover is one transient surface; it **physically cannot show four coordinated regions** (sidebar + list + detail + inspector) simultaneously, cannot host a durable restorable navigation stack, and has no inspector analog. This multi-pane density IS the RepoBar/CodexBar north star.
+
+Sources: [NavigationSplitView](https://developer.apple.com/documentation/swiftui/navigationsplitview) · [NavigationSplitViewVisibility](https://developer.apple.com/documentation/swiftui/navigationsplitviewvisibility) · [Migrating to new navigation types](https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types) · [inspector(isPresented:content:)](https://developer.apple.com/documentation/swiftui/view/inspector%28ispresented%3Acontent%3A%29) · [Table](https://developer.apple.com/documentation/swiftui/table)
+
+---
+
+## Topic 4 — App Intents + Shortcuts + Spotlight
+
+### What it is
+App Intents exposes your app's **actions** (verbs) and **content** (nouns) to Siri, the Shortcuts app, Spotlight, widgets, Control Center, and Apple Intelligence — often without opening the app. VaultPeek's "show spending / review transactions / show net worth" map to three `AppIntent`s + supporting `AppEntity`s.
+
+### Current API / pattern
+- **`AppIntent`** (iOS 16 / macOS 13 baseline): `static title`, `IntentDescription`, `@Parameter`, `static parameterSummary`, `func perform() async throws -> some IntentResult`. Composable returns: `ReturnsValue<T>`, `ProvidesDialog`, `OpensIntent`, `ShowsSnippetView`.
+- **`AppShortcutsProvider` / `AppShortcut`** — zero-setup system shortcuts with `phrases` (must include `\(.applicationName)`), `shortTitle`, `systemImageName`. This is what auto-populates Spotlight/Shortcuts/Siri.
+- **`AppEntity` / `EntityQuery`** (iOS 16 / macOS 13) — expose accounts/transactions. Conform to **`IndexedEntity`** (macOS 15) + `CSSearchableIndex.default().indexAppEntities(_:)` to push into Spotlight's semantic index; auto-generates "Find" actions in Shortcuts.
+- **App Intents in Spotlight on Mac (macOS 26):** Spotlight can **run your intents directly from the search field**. Requirement: a complete `parameterSummary` covering all required-without-default params; intent must be discoverable with a real `perform()`.
+- **`supportedModes` (macOS 26):** `IntentModes` = `.background`, `.foreground(.immediate/.dynamic/.deferred)`. Replaces deprecated `openAppWhenRun`/`ForegroundContinuableIntent`. "Show net worth" → `.background` (returns a number, no window); "review transactions" → `.foreground` (opens the app).
+- **Interactive snippets — `SnippetIntent` (macOS 26):** return a **live SwiftUI view** that renders inline in Spotlight/Siri and stays interactive (`Button(intent:)` inside it runs other intents + `reload()`s). Effectively a **mini VaultPeek dashboard inside Spotlight**.
+- **`AppIntentsPackage` (macOS 26):** App Intents now work inside Swift packages — so intent + entity definitions can live in **`PlaidBarCore`** and be shared across app, widget, and Siri/Spotlight. `ProgressReportingIntent` for long syncs.
+
+### Code skeleton
+```swift
+struct ShowNetWorthIntent: AppIntent {
+    static let title: LocalizedStringResource = "Show Net Worth"
+    static let supportedModes: IntentModes = [.background, .foreground(.dynamic)]
+    func perform() async throws -> some ReturnsValue<Double> & ProvidesDialog & ShowsSnippetView {
+        let nw = await NetWorthStore.shared.current()
+        return .result(value: nw,
+                       dialog: "Your net worth is \(nw.formatted(.currency(code: "USD"))).",
+                       view: NetWorthSnippet(value: nw))
+    }
+}
+
+struct VaultPeekShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(intent: ShowNetWorthIntent(),
+                    phrases: ["What's my net worth in \(.applicationName)"],
+                    shortTitle: "Net Worth", systemImageName: "chart.line.uptrend.xyaxis")
+    }
+}
+```
+
+### When to use
+Read-only actions (net worth, spending total) → background intents returning a value/snippet, runnable from Spotlight/Siri with no window. Navigational actions (review transactions) → foreground intents that open the windowed app.
+
+### macOS-specific caveats
+- An accessory/menu-bar app **can** register intents, but the deep-link "open full UI" path needs a real window to foreground into — which is an argument *for* the pivot.
+- Apple Intelligence semantic-index features require Apple-silicon Macs. WWDC26 formally **deprecated SiriKit** in favor of App Intents (2–3 year migration window) — so investing in App Intents is the durable bet.
+
+### UX opportunity vs popover
+A popover only exists while open and lives nowhere in the system. App Intents put VaultPeek in **Spotlight (typed actions + interactive snippet dashboards), Siri (voice), the Shortcuts app (user automations), and system search (indexed transactions)** — distribution surfaces a popover cannot reach.
+
+Sources: [AppIntent](https://developer.apple.com/documentation/appintents/appintent) · [AppShortcut](https://developer.apple.com/documentation/appintents/appshortcut) · [SnippetIntent](https://developer.apple.com/documentation/appintents/snippetintent) · [Displaying static and interactive snippets](https://developer.apple.com/documentation/appintents/displaying-static-and-interactive-snippets) · [Making app entities available in Spotlight](https://developer.apple.com/documentation/appintents/making-app-entities-available-in-spotlight) · [Develop for Shortcuts and Spotlight with App Intents (WWDC25 260)](https://developer.apple.com/videos/play/wwdc2025/260/)
+
+---
+
+## Topic 5 — WidgetKit on macOS 26
+
+### What it is
+Glanceable, timeline-driven views rendered in **Notification Center and on the desktop** (macOS Sonoma+) and mirrored from iPhone via Continuity.
+
+### Current API / pattern
+- **Families on macOS:** `.systemSmall`, `.systemMedium`, `.systemLarge` (declare via `.supportedFamilies([...])`).
+- **Configuration:** `StaticConfiguration` + `TimelineProvider` (fixed) or **`AppIntentConfiguration` + `AppIntentTimelineProvider`** driven by a `WidgetConfigurationIntent` (user-configurable, e.g., "which account?"). (AppIntent config: iOS 17 / macOS 14.)
+- **Interactive widgets (iOS 17 / macOS 14):** `Button(intent:)` and `Toggle(intent:, isOn:)` (intent conforms to `SetValueIntent`) run an App Intent in the background and refresh the widget — same intents reused from Topic 4.
+- **App→widget data sharing:** App Group — `UserDefaults(suiteName:)` for small values, or a **shared SwiftData container** (`ModelConfiguration(groupContainer: .identifier("group.com.vaultpeek.shared"))`, widget side `allowsSave: false`). Call `WidgetCenter.shared.reloadTimelines(ofKind:)` after a sync.
+- **What's new (macOS 26 / WWDC25):** push-updated widgets (`WidgetPushHandler`, mostly moot for a local-first app), automatic Liquid Glass rendering of desktop/Notification-Center widgets (design for legibility on glass), RelevanceKit.
+
+### `ControlWidget` — the one macOS caveat to verify
+`ControlWidget` (Control Center / Lock Screen / Action button — `ControlWidgetButton`, `ControlWidgetToggle`) was introduced at **WWDC24 for iOS/iPadOS 18 and is documented iOS-only.** macOS 26 shipped a redesigned, third-party-extensible Control Center, but **authoritative confirmation that the `ControlWidget` WidgetKit API targets macOS could not be found.** **Action:** verify the `ControlWidget` `@available` annotation in Xcode 26 before roadmapping a macOS Control Center control. Everything else in this topic is confirmed for macOS.
+
+### Security note
+Putting balances in a shared App Group container widens VaultPeek's surface beyond the current Keychain/SQLite split. **Keep tokens out of the group; store only display-ready, non-sensitive read-model values; and respect the App-Lock / privacy-mask state in widget rendering** (the existing "glance snapshot not redacted on mask" risk carries straight into a widget reading SwiftData directly).
+
+### UX opportunity vs popover
+Persistent, always-visible desktop/Notification-Center widgets (net worth, spending), configurable per-account and interactive — a popover only exists while open and has no presence on the desktop or in Control Center.
+
+Sources: [What's new in widgets (WWDC25 278)](https://developer.apple.com/videos/play/wwdc2025/278/) · [WidgetPushHandler](https://developer.apple.com/documentation/widgetkit/widgetpushhandler) · [Extend your app's controls across the system (WWDC24 10157)](https://developer.apple.com/videos/play/wwdc2024/10157/) · [Meet WidgetKit (WWDC20 10028)](https://developer.apple.com/videos/play/wwdc2020/10028/)
+
+---
+
+## Topic 6 — SwiftData in macOS 26
+
+### What it is
+Apple's persistence framework (`@Model` classes over SQLite). VaultPeek already uses it for a disposable read-model cache and list virtualization, and stores potentially large transaction history.
+
+### Current API / pattern (all available on macOS 26 today)
+- **Modeling:** `@Model` (14+), `@Attribute(.unique)` (14+, upsert on collision), **`#Unique<T>([\.a, \.b])`** compound uniqueness (15+ — correct for transaction de-dup on `(accountID, plaidTransactionID)`), **`#Index<T>([\.date], [\.accountID, \.date])`** (15+ — index columns you filter/sort on; the single highest-leverage perf lever for large history).
+- **Container/context:** `ModelContainer`/`ModelContext` (14+), `@Environment(\.modelContext)`. `ModelConfiguration(_:schema:isStoredInMemoryOnly:allowsSave:groupContainer:cloudKitDatabase:)`. **Set `cloudKitDatabase: .none`** explicitly (local-first). In-memory config = the existing disposable cache + tests.
+- **Concurrency (critical for the strict-concurrency CI gate):** `@ModelActor` for off-main work (sync reduction, large upserts). **`PersistentModel` instances are NOT `Sendable`; `PersistentIdentifier` IS.** Hand off IDs across actors (`fetchIdentifiers` → `mainContext.model(for: id)`), never models. IDs are temporary until `save()`.
+- **History tracking (15+, shipped WWDC24 — available now):** `HistoryDescriptor<T>`, `DefaultHistoryToken`, `context.fetchHistory(_:)`, `HistoryChange` (`.insert/.update/.delete`). Persist the last token; on launch, reduce "changes since token" into the read-model. Handle `SwiftDataError.historyTokenExpired`.
+- **Large-dataset performance:** `FetchDescriptor.fetchLimit/fetchOffset` (paged fetch — already in use), `propertiesToFetch` (only render columns), `includePendingChanges = false`, `fetch(_:batchSize:)` → lazy `FetchResultsCollection` (backs a virtualized table), `enumerate(_:batchSize:)` (memory-bounded migration/recategorization), `fetchCount`, `fetchIdentifiers`, `DataStoreBatchDeleteRequest` (bulk purge). Avoid Swift-only closures in predicates (throws `.unsupportedPredicate`); set `context.undoManager = nil` during large imports.
+- **App+widget sharing:** `ModelConfiguration(groupContainer: .identifier(...))`, widget side `allowsSave: false` + History tracking for cross-process change detection.
+
+### NOT in macOS 26 (WWDC26 / `macOS 27.0+ Beta` — plan but gate)
+Sectioned `@Query` (`sectionBy:`), `@Attribute(.codable)`, `ResultsObserver<Model, SectionID>` (Query-style live fetch outside SwiftUI via Observation — clean fit for VaultPeek's `@Observable` services layer), `HistoryObserver` (reactive history). These are "2027 releases" — do not design the near-term pivot around them.
+
+### macOS-specific caveats
+- All large-history performance is solvable on macOS 26; nothing here requires waiting for macOS 27.
+- The `PersistentIdentifier`-not-models rule is the key Swift 6 constraint given VaultPeek's `-strict-concurrency=complete -warnings-as-errors` gate.
+
+### UX opportunity vs popover
+Not a UX surface per se, but SwiftData is what makes the **windowed dense table + charts over large history performant** (indexed, paged, lazy) — a capability a small popover never needed and never exercised. It also enables the **shared store the widget reads**.
+
+Sources: [SwiftData framework](https://developer.apple.com/documentation/swiftdata) · [FetchDescriptor](https://developer.apple.com/documentation/swiftdata/fetchdescriptor) · [@Index](https://developer.apple.com/documentation/swiftdata/index%28_%3A%29-7d4z0) · [ModelActor](https://developer.apple.com/documentation/swiftdata/modelactor) · [Track model changes with SwiftData history (WWDC24 10075)](https://developer.apple.com/videos/play/wwdc2024/10075/) · [What's new in SwiftData (WWDC26 274)](https://developer.apple.com/videos/play/wwdc2026/274/)
+
+---
+
+## Topic 7 — Command navigation / keyboard-first
+
+### What it is
+A real app menu bar of commands, global keyboard shortcuts, focus management, and a command-palette pattern — the keyboard-first power-user surface a popover cannot host.
+
+### Current API / pattern
+- **`.commands { }`** (Scene modifier): `CommandMenu("Accounts") { … }` (top-level menu), `CommandGroup(before:/after:/replacing: CommandGroupPlacement, …)` to inject/replace standard items (`.newItem`, `.sidebar`, `.toolbar`, `.appInfo`, …). `commandsRemoved()`, `commandsReplaced { }`.
+- **`.keyboardShortcut(_:modifiers:)`** (macOS 11+): `KeyEquivalent` (`"k"`, `.return`, `.escape`, arrows…), `EventModifiers` (`.command/.option/.shift/.control`). `KeyboardShortcut.defaultAction`/`.cancelAction`.
+- **Command palette (Cmd-K):** no built-in; compose a `sheet`/overlay with a `@FocusState`-focused `TextField` + filtered `List`, `.onKeyPress(.upArrow/.downArrow/.return)` for arrow selection, wired from a `CommandGroup` button with `.keyboardShortcut("k", modifiers: .command)`.
+- **Focus:** `@FocusState` (Bool or `Hashable?`), `.focusable()`, `.focused($field, equals:)`, `.onKeyPress(keys:phases:action:)` (macOS 14+, return `.handled`/`.ignored`), `onExitCommand`/`onDeleteCommand`.
+- **Context-aware commands:** `.focusedSceneValue(\.selectedTransaction, txn)` + `@FocusedValue(\.selectedTransaction)` in `.commands` → menu items enable/disable based on the focused pane. This is the glue that makes shortcuts act on whatever has focus.
+- **`Table` keyboard nav** (macOS 12+/14+): `Table(data, selection: $set, sortOrder: $order) { TableColumn(_, value:) … }` — arrow keys move selection, Shift+arrow extends, type-to-select, header click sorts via `KeyPathComparator`, `columnCustomization` + `.customizationID` for user-tunable columns (persist via `@SceneStorage`).
+
+### When to use
+A finance power-user wants keyboard everything: ⌘R refresh, ⌘N new link, ⌘K palette, arrow-key table navigation, ⌘F search. All require window+menu-bar presence.
+
+### macOS-specific caveats
+Shortcut resolution: key window → main window → command groups (first match wins). Define a clear, non-conflicting shortcut map.
+
+### UX opportunity vs popover
+A `MenuBarExtra` popover surfaces **no app menu** and no global command system. A window unlocks the full macOS menu bar, discoverable shortcuts, a Cmd-K palette, context-aware commands, and a keyboard-navigable dense `Table` — the densest possible transaction view.
+
+Sources: [Menus and commands](https://developer.apple.com/documentation/swiftui/menus-and-commands) · [keyboardShortcut(_:modifiers:)](https://developer.apple.com/documentation/swiftui/view/keyboardshortcut%28_%3Amodifiers%3A%29) · [FocusState](https://developer.apple.com/documentation/swiftui/focusstate) · [onKeyPress(keys:phases:action:)](https://developer.apple.com/documentation/swiftui/view/onkeypress%28keys%3Aphases%3Aaction%3A%29) · [Table](https://developer.apple.com/documentation/swiftui/table)
+
+---
+
+## Topic 8 — macOS 26 container / layout / scene APIs new this cycle
+
+### Shipping NOW (macOS 26 / WWDC25) — adopt today
+- **`ToolbarSpacer(.fixed/.flexible)`** — split toolbar into distinct glass groups (Mail-style leading/trailing groups).
+- **`sharedBackgroundVisibility(_:)`** (`ToolbarContent`) — pull an item out of the shared glass capsule.
+- **`toolbarMinimizeBehavior(_:for:)`** — auto-collapse bars on scroll to reclaim space.
+- **`backgroundExtensionEffect()`** — extend a detail background under sidebar/inspector for continuous glass.
+- **`containerBackground(_:for: .window/.navigation/.navigationSplitView)`** — declarative window/sidebar/detail backgrounds.
+- **`tabViewStyle(.sidebarAdaptable)`** + `tabViewSidebarBottomBar` (macOS 15+) — TabView that renders as an adaptive sidebar with a pinned footer (alternative shell).
+- **`glassEffect` family** (Topic 1).
+
+### ANNOUNCED — WWDC26 / macOS 27 (ships fall 2026; gate behind `if #available(macOS 27, *)`)
+- **Reorderable containers** (headline): `.reorderable()` on a `ForEach` + `.reorderContainer(for:_:)` on List/LazyVGrid/LazyVStack/custom layouts, applying a `ReorderDifference`. Drag-to-rearrange anywhere (pin/reorder accounts).
+- **Toolbar:** `visibilityPriority(_:)`, `ToolbarOverflowMenu { }`, `ToolbarItem(placement: .topBarPinnedTrailing)`.
+- **Others:** `swipeActionsContainer()` (swipe on any scroll view), `navigationTransition(.crossFade)`, `Tab(role: .prominent)`, item-binding `confirmationDialog`/`alert`, `appearsActive` environment value (style inactive windows — useful for a secondary dashboard window), `@State` becomes a macro with lazy init (back-ported to macOS 14 — audit existing `@State` class storage), `@ContentBuilder` (Xcode 27 build-time wins).
+
+### Caveat
+The WWDC26 toolbar/reorder symbol pages did not render bodies on direct fetch — confirm exact `@available` lines and enum spellings against Xcode 27 headers before writing code against them. The macOS 26 (WWDC25) APIs above are fully confirmed.
+
+### UX opportunity vs popover
+Adaptive, overflow-aware toolbars and reorderable lists are meaningless in a fixed popover — they exist to scale with a resizable window and a persistent multi-pane layout.
+
+Sources: [ToolbarSpacer](https://developer.apple.com/documentation/swiftui/toolbarspacer) · [toolbarMinimizeBehavior](https://developer.apple.com/documentation/swiftui/toolbarminimizebehavior) · [backgroundExtensionEffect()](https://developer.apple.com/documentation/swiftui/view/backgroundextensioneffect%28%29) · [What's new in SwiftUI (WWDC26 269)](https://developer.apple.com/videos/play/wwdc2026/269/) · [Reordering items in lists, stacks, grids, and custom layouts](https://developer.apple.com/documentation/SwiftUI/Reordering-items-in-lists-stacks-grids-and-custom-layouts) · [What is new in SwiftUI after WWDC26 — Majid](https://swiftwithmajid.com/2026/06/08/what-is-new-in-swiftui-after-wwdc26/)
+
+---
+
+## Topic 9 — Menu-bar app coexistence & activation policy
+
+### What it is
+How a primary-window app keeps a lightweight `MenuBarExtra` glance, and the activation-policy dance required so a real window can come to the front from an otherwise dock-less utility. **This is the single riskiest part of the pivot.**
+
+### Current API / pattern
+- **`NSApplication.ActivationPolicy`:** `.accessory` (no Dock icon, no app menus, **cannot reliably make a window key**) vs `.regular` (Dock + app menus + key windows). A clean menu-bar utility runs `.accessory` at rest.
+- **`LSUIElement` (Info.plist "Application is agent"):** static `.accessory`. **Recommendation: prefer runtime policy switching over the static plist flag** (no `LSUIElement`; set `.accessory` programmatically at launch) for cleaner accessory↔regular transitions.
+- **Open-window sequence:**
+  ```swift
+  @MainActor func openMainWindow(_ openWindow: OpenWindowAction) {
+      NSApp.setActivationPolicy(.regular)       // gain Dock + key-window ability
+      NSApp.activate(ignoringOtherApps: true)   // bring app forward
+      openWindow(id: "main")
+  }
+  // On last real window close → NSApp.setActivationPolicy(.accessory)
+  ```
+- **AppKit-lifecycle hybrid (macOS 26):** `NSHostingSceneRepresentation` hosts SwiftUI scenes inside an `NSApplicationDelegate`, giving precise control over policy/termination while authoring UI in SwiftUI. Use a `WindowGroup` (not `Window`) so `environment.openWindow(id:)` works.
+
+### macOS-specific caveats (the risk surface — budget engineering time)
+1. **No Dock icon ⇒ no key window.** `makeKeyAndOrderFront` is a no-op while `.accessory`; switch to `.regular` first. Root cause of "window opens behind everything."
+2. Switching `.accessory → .regular` doesn't immediately light up your own app menus — test ⌘, and Quit after switching.
+3. **Opening `Settings` from accessory context is the most fragile path** and has a **reported macOS 26 regression** around `openSettings()`. Mitigation: the WWDC26-blessed `NSHostingSceneRepresentation.environment.openSettings()` route. **Validate the Settings-open path on macOS 26 hardware specifically.**
+4. The policy-switch → activate → order-front sequence is timing-racy (often needs 100–200 ms sleeps). Wrap it in one well-tested helper; don't scatter it.
+
+### UX opportunity vs popover
+This is the *enabling* mechanism, not a feature: it's what lets VaultPeek **keep the lightweight glance AND gain a real workspace** — the hybrid that defines the pivot.
+
+Sources: [Building and customizing the menu bar with SwiftUI](https://developer.apple.com/documentation/swiftui/building-and-customizing-the-menu-bar-with-swiftui) · [NSHostingSceneRepresentation](https://developer.apple.com/documentation/swiftui/nshostingscenerepresentation) · [Keep your macOS app's menu bar item running after quitting (Pol Piella)](https://www.polpiella.dev/keep-menu-bar-running-after-quitting-app) · [Showing Settings from macOS Menu Bar Items (Steinberger)](https://steipete.me/posts/2025/showing-settings-from-macos-menu-bar-items)
+
+---
+
+## Topic 10 — Accessibility on macOS 26
+
+For a windowed finance dashboard with charts, three of these are **mandatory, not nice-to-have.**
+
+### Accessibility Nutrition Labels (App Store)
+Standardized accessibility disclosures on the App Store product page, configured in App Store Connect, **rendering on macOS 26+ product pages.** Currently voluntary, trending mandatory; Guideline 2.3 governs accuracy (over-claiming = review risk). **The rule:** to claim a feature, *every common task* (primary functionality + onboarding + login + purchase + settings) must be completable with it. For VaultPeek: linking an account, viewing balances, filtering transactions, and **reading charts** must all pass under each claimed feature.
+
+### Audio Graphs / `AXChartDescriptor` — MANDATORY
+A Swift Chart is opaque to VoiceOver; audio graphs are the only way a blind user perceives a balance trend or spending breakdown — and a non-audible chart **blocks the VoiceOver Nutrition Label claim.** This is the biggest a11y task of the pivot.
+```swift
+struct BalanceTrendDescriptor: AXChartDescriptorRepresentable {  // macOS 12.0+
+    let points: [BalancePoint]
+    func makeChartDescriptor() -> AXChartDescriptor {
+        let x = AXNumericDataAxisDescriptor(title: "Date", range: minDay...maxDay,
+                                            gridlinePositions: []) { dateLabel($0) }
+        let y = AXNumericDataAxisDescriptor(title: "Balance", range: minBal...maxBal,
+                                            gridlinePositions: []) { currency($0) }
+        let series = AXDataSeriesDescriptor(name: "Account balance", isContinuous: true,
+            dataPoints: points.map { AXDataPoint(x: $0.day, y: $0.balance) })
+        return AXChartDescriptor(title: "Account balance over time",
+            summary: "Balance rose from \(currency(first)) to \(currency(last)) over 90 days.",
+            xAxis: x, yAxis: y, series: [series])
+    }
+    func updateChartDescriptor(_ d: AXChartDescriptor) { /* refresh on data change */ }
+}
+Chart(points) { /* marks */ }
+    .accessibilityChartDescriptor(BalanceTrendDescriptor(points: points))
+```
+The `summary` field (the spoken insight) is the highest-value piece. Verify exact `AXChartDescriptor`/`AXNumericDataAxisDescriptor` initializer parameter order in Xcode Quick Help (the raw doc page 404'd; the SwiftUI bridge is confirmed).
+
+### Reduce Transparency × Liquid Glass — MANDATORY (VaultPeek uses translucency)
+```swift
+@Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+// background:
+reduceTransparency ? AnyShapeStyle(.background) : AnyShapeStyle(.ultraThinMaterial)
+```
+Stock glass auto-degrades under Reduce Transparency / Increase Contrast, but **custom glass and any hand-rolled `NSVisualEffectView` translucency (the detached-window design) is your responsibility.** Test with both Reduce Transparency and Increase Contrast on. Related: `accessibilityDifferentiateWithoutColor` (drive the never-color-alone rule), `accessibilityReduceMotion` (gate the matchedGeometryEffect reflow + haptics), `accessibilityPrefersCrossFadeTransitions` (macOS 26.4+).
+
+### Never color alone (already a VaultPeek hard rule)
+Positive/negative balance, utilization risk, sync errors, chart series must never be hue-only. Pair color with SF Symbols (arrow.up/down, exclamationmark.triangle), +/− signs, text, or chart shape/pattern. This overlaps the "Differentiate Without Color Alone" Nutrition Label.
+
+### Dynamic Type — caveat
+`@Environment(\.dynamicTypeSize)` **does not scale text on macOS**, and "Larger Text" is **not** a Mac Nutrition Label. Lower priority while Mac-only — but use semantic fonts (`.font(.body)`) and `@ScaledMetric` for layout resilience, and it becomes **mandatory** if an iOS/iPad companion is added.
+
+### VoiceOver core (macOS 11/12+)
+`accessibilityLabel/Value/Hint`, `accessibilityElement(children:)` (combine a stat card into one stop), `accessibilityRepresentation { }` (custom gauge → `Slider`/`ProgressView`), `accessibilityInputLabels` (Voice Control / Full Keyboard Access).
+
+### UX opportunity vs popover
+A windowed chart-heavy app *raises* the accessibility bar — but also makes it achievable: a window has the room for properly-labeled multi-pane content and audible charts. The point is that **shipping charts in a window without audio graphs would be an accessibility regression**, so the pivot must budget for it.
+
+Sources: [Overview of Accessibility Nutrition Labels](https://developer.apple.com/help/app-store-connect/manage-app-accessibility/overview-of-accessibility-nutrition-labels/) · [Evaluate your app for Accessibility Nutrition Labels (WWDC25 224)](https://developer.apple.com/videos/play/wwdc2025/224/) · [accessibilityChartDescriptor(_:)](https://developer.apple.com/documentation/swiftui/view/accessibilitychartdescriptor%28_%3A%29) · [AXChartDescriptorRepresentable](https://developer.apple.com/documentation/swiftui/axchartdescriptorrepresentable) · [Bring accessibility to charts (WWDC21 10122)](https://developer.apple.com/videos/play/wwdc2021/10122/) · [accessibilityReduceTransparency](https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityreducetransparency)
+
+---
+
+## Recommended architecture patterns — the canonical macOS 26 VaultPeek shell
+
+**Scene graph:** primary `Window` (dashboard) + `MenuBarExtra` (glance) + `Settings` + a Widget extension (App Group) + App Intents (in `PlaidBarCore` via `AppIntentsPackage`).
+
+```swift
+// ───────── App target ─────────
+@main
+struct VaultPeekApp: App {
+    @State private var model = AppModel()
+    @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
+
+    var body: some Scene {
+        // Primary windowed dashboard: 3-column shell, launch-suppressed, glass chrome.
+        Window("VaultPeek", id: "main") {
+            VaultPeekShell()                         // NavigationSplitView (Topic 3)
+                .environment(model)
+                .containerBackground(.ultraThinMaterial, for: .window)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 980, height: 640)
+        .defaultLaunchBehavior(.suppressed)          // menu-bar-only on launch
+        .restorationBehavior(.automatic)
+        .commands {                                  // real menu bar + shortcuts (Topic 7)
+            CommandMenu("Accounts") {
+                Button("Refresh All") { model.refresh() }.keyboardShortcut("r")
+                Button("Command Palette…") { model.showPalette = true }
+                    .keyboardShortcut("k", modifiers: .command)
+            }
+        }
+
+        MenuBarExtra("VaultPeek", systemImage: "creditcard",
+                     isInserted: $showMenuBarExtra) {
+            GlanceView().environment(model)          // .window style popover glance
+        }
+        .menuBarExtraStyle(.window)
+
+        Settings { SettingsView().environment(model) }
+    }
+}
+
+// ───────── PlaidBarCore (shared, via AppIntentsPackage) ─────────
+//   ShowNetWorthIntent / ShowSpendingIntent / ReviewTransactionsIntent
+//   + AccountEntity / TransactionEntity (IndexedEntity) + VaultPeekShortcuts
+//   reused by app, widget, Siri, and Spotlight.
+
+// ───────── Widget extension ─────────
+//   AppIntentConfiguration widget (net worth / spending), interactive via Button(intent:),
+//   reads the shared SwiftData store: ModelConfiguration(groupContainer: .identifier(...),
+//   allowsSave: false), redacting under privacy-mask.
+```
+
+Activation policy (Topic 9) is handled in a single `@MainActor` helper that flips `.accessory ↔ .regular` around `openWindow(id: "main")`. SwiftData (Topic 6) backs the dense table with indexed, paged, lazy fetches. Liquid Glass (Topic 1) stays on the chrome only; the data surfaces stay solid. Every chart carries an `AXChartDescriptor` and every translucent surface honors Reduce Transparency (Topic 10).
+
+**Architectural fit with the existing codebase:** the two-process security boundary (UI ↔ local server) is unaffected — the window is still a pure HTTP client. Intents/entities/summaries belong in `PlaidBarCore` (keeps them `Sendable`/testable and shareable to the widget), exactly matching the project's "put shared logic in Core" rule.
+
+---
+
+## UX opportunities unavailable in popover architecture (ranked)
+
+1. **Persistence + side-by-side use.** A window stays open beside the browser/spreadsheet; a popover auto-dismisses on focus loss. ("Glance and go" → "live workspace.")
+2. **Multi-pane density (sidebar + list + detail + inspector).** Four coordinated regions at once — the RepoBar/CodexBar north star. Impossible in one transient popover.
+3. **Spotlight / Siri / Shortcuts reach via App Intents + interactive snippets.** Typed actions and a mini-dashboard *inside Spotlight*; voice; user automations; indexed transactions. A popover lives nowhere in the system.
+4. **Desktop & Notification Center widgets.** Always-visible net-worth/spending glances, per-account configurable, interactive — present even when the app is closed.
+5. **Keyboard-first power use.** Full app menu bar, discoverable shortcuts, ⌘K command palette, context-aware commands (`focusedSceneValue`), and a keyboard-navigable dense `Table`.
+6. **Resizability + state restoration.** Tune column widths, grow to show large charts/tables, reopen exactly where you left off. Popovers are fixed-size and ephemeral.
+7. **Multiple simultaneous windows.** One per institution/account/time-range, compared side by side (`WindowGroup(_:for:)`).
+8. **Always-on-top utility mode.** `windowLevel(.floating)` pinned mini "safe-to-spend" ticker.
+9. **Supported, declarative translucency.** `containerBackground(.ultraThinMaterial, for: .window)` — resolves the prior behind-window-popover translucency dead-end.
+10. **Deep linking to specific surfaces.** A notification or the glance opens straight to an account window (`openWindow(value:)`).
+
+---
+
+## Adoption risks & minimum OS targets
+
+### Recommended floor: **macOS 26.0**
+Everything the pivot needs is available there: Liquid Glass + `glassEffect`, the full windowing/scene/MenuBarExtra surface, `NavigationSplitView`/inspector/`Table`, App Intents (interactive snippets, supportedModes, Spotlight actions, `AppIntentsPackage`), WidgetKit interactive widgets + App-Group SwiftData sharing, SwiftData `#Unique`/`#Index`/`@ModelActor`/History tracking, and the `AXChartDescriptor` audio-graph stack.
+
+### Requires macOS 26 (degrades or absent below)
+- Liquid Glass (`glassEffect`, `GlassEffectContainer`, `ToolbarSpacer`, `containerBackground(_:for:.window)`), App Intents interactive snippets/`supportedModes`/Spotlight-run actions, `NSHostingSceneRepresentation`. On macOS 25 these simply aren't present — if a lower floor is ever required, gate behind `#available` and fall back to standard materials/controls.
+
+### Requires macOS 27 (WWDC26 — NOT yet shippable; gate behind `if #available(macOS 27, *)`)
+Reorderable containers, `swipeActionsContainer`, toolbar `visibilityPriority`/`ToolbarOverflowMenu`/`.topBarPinnedTrailing`, sectioned `@Query`, `ResultsObserver`/`HistoryObserver`, `Tab(role: .prominent)`, `appearsActive`. Plan as fast-follow; confirm signatures at GA.
+
+### Top risks
+1. **Activation policy (highest).** The `.accessory ↔ .regular` dance and the **reported macOS 26 `openSettings()` regression** are timing-racy and version-specific. Mitigation: one tested helper + `NSHostingSceneRepresentation` for Settings; validate on macOS 26 hardware early.
+2. **Accessibility debt becomes mandatory.** Shipping charts in a window without audio graphs is a regression and blocks the VoiceOver Nutrition Label. Budget `AXChartDescriptor` work + Reduce-Transparency fallbacks for the custom glass.
+3. **Widget data-sharing widens the security surface.** Shared App Group SwiftData must hold only non-sensitive display values and respect the privacy mask (the existing "glance snapshot not redacted on mask" gap carries over).
+4. **`ControlWidget` on macOS unconfirmed.** Verify the `@available` annotation in Xcode 26 before roadmapping a Control Center control.
+5. **WWDC26 signatures unstable.** The macOS 27 toolbar/reorder/SwiftData APIs are corroborated across session writeups but some symbol pages didn't render bodies — re-confirm against Xcode 27 headers before coding.
+
+---
+
+## Sources
+
+**Apple — SwiftUI / windowing / navigation**
+- https://developer.apple.com/documentation/swiftui/windows
+- https://developer.apple.com/documentation/SwiftUI/WindowGroup · https://developer.apple.com/documentation/swiftui/window · https://developer.apple.com/documentation/SwiftUI/MenuBarExtra
+- https://developer.apple.com/documentation/swiftui/building-and-customizing-the-menu-bar-with-swiftui
+- https://developer.apple.com/documentation/swiftui/scene/windowresizability%28_%3A%29 · https://developer.apple.com/documentation/swiftui/scene/defaultlaunchbehavior%28_%3A%29
+- https://developer.apple.com/documentation/swiftui/nshostingscenerepresentation
+- https://developer.apple.com/documentation/swiftui/navigationsplitview · https://developer.apple.com/documentation/swiftui/navigationsplitviewvisibility
+- https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types · https://developer.apple.com/documentation/swiftui/view/inspector%28ispresented%3Acontent%3A%29
+- https://developer.apple.com/documentation/swiftui/table
+- https://developer.apple.com/documentation/swiftui/menus-and-commands · https://developer.apple.com/documentation/swiftui/view/keyboardshortcut%28_%3Amodifiers%3A%29 · https://developer.apple.com/documentation/swiftui/focusstate · https://developer.apple.com/documentation/swiftui/view/onkeypress%28keys%3Aphases%3Aaction%3A%29
+
+**Apple — Liquid Glass**
+- https://developer.apple.com/documentation/technologyoverviews/liquid-glass · https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass
+- https://developer.apple.com/documentation/swiftui/applying-liquid-glass-to-custom-views · https://developer.apple.com/documentation/swiftui/view/glasseffect%28_%3Ain%3A%29 · https://developer.apple.com/documentation/swiftui/glasseffectcontainer
+- https://developer.apple.com/documentation/swiftui/toolbarspacer · https://developer.apple.com/documentation/swiftui/toolbarminimizebehavior · https://developer.apple.com/documentation/swiftui/view/backgroundextensioneffect%28%29
+
+**Apple — App Intents / WidgetKit**
+- https://developer.apple.com/documentation/appintents/appintent · https://developer.apple.com/documentation/appintents/appshortcut · https://developer.apple.com/documentation/appintents/snippetintent
+- https://developer.apple.com/documentation/appintents/displaying-static-and-interactive-snippets · https://developer.apple.com/documentation/appintents/making-app-entities-available-in-spotlight
+- https://developer.apple.com/videos/play/wwdc2025/260/ (Shortcuts & Spotlight) · https://developer.apple.com/videos/play/wwdc2025/278/ (widgets)
+- https://developer.apple.com/documentation/widgetkit/widgetpushhandler · https://developer.apple.com/videos/play/wwdc2024/10157/ (controls) · https://developer.apple.com/videos/play/wwdc2020/10028/ (WidgetKit)
+
+**Apple — SwiftData**
+- https://developer.apple.com/documentation/swiftdata · https://developer.apple.com/documentation/swiftdata/fetchdescriptor · https://developer.apple.com/documentation/swiftdata/index%28_%3A%29-7d4z0 · https://developer.apple.com/documentation/swiftdata/modelactor
+- https://developer.apple.com/videos/play/wwdc2024/10075/ (history) · https://developer.apple.com/videos/play/wwdc2026/274/ (what's new, WWDC26)
+
+**Apple — Accessibility**
+- https://developer.apple.com/help/app-store-connect/manage-app-accessibility/overview-of-accessibility-nutrition-labels/ · https://developer.apple.com/videos/play/wwdc2025/224/
+- https://developer.apple.com/documentation/swiftui/view/accessibilitychartdescriptor%28_%3A%29 · https://developer.apple.com/documentation/swiftui/axchartdescriptorrepresentable · https://developer.apple.com/videos/play/wwdc2021/10122/
+- https://developer.apple.com/documentation/swiftui/environmentvalues/accessibilityreducetransparency
+
+**Apple — WWDC26 / version**
+- https://developer.apple.com/wwdc26/guides/swiftui/ · https://developer.apple.com/videos/play/wwdc2026/269/ · https://developer.apple.com/videos/play/wwdc2026/272/
+- https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes
+
+**Secondary (corroboration / community)**
+- https://www.macrumors.com/roundup/macos-26/ · https://techcrunch.com/2026/06/09/wwdc-2026-everything-announced-on-siri-ai-os-27-apple-intelligence-and-more/
+- https://swiftwithmajid.com/2026/06/08/what-is-new-in-swiftui-after-wwdc26/ · https://swiftwithmajid.com/2025/07/01/glassifying-toolbars-in-swiftui/
+- https://blog.logrocket.com/ux-design/adopting-liquid-glass-examples-best-practices/ · https://www.polpiella.dev/keep-menu-bar-running-after-quitting-app · https://steipete.me/posts/2025/showing-settings-from-macos-menu-bar-items
+
+---
+
+## Verification flags (for the architecture working group)
+
+- **macOS 27 / WWDC26 signatures** (reorderable containers, toolbar overflow APIs, sectioned `@Query`, `ResultsObserver`/`HistoryObserver`) are corroborated across WWDC26 session writeups but some symbol pages did not render bodies on fetch — confirm `@available` lines against Xcode 27 headers before coding.
+- **`ControlWidget` on macOS** is documented iOS-18-only; macOS support is unconfirmed — verify in Xcode 26.
+- **`openSettings()` from accessory context** has a reported macOS 26 regression — validate the Settings-open path on macOS 26 hardware early; prefer the `NSHostingSceneRepresentation` route.
+- **`AXChartDescriptor` initializer parameter order** — the raw doc page 404'd; confirm in Xcode Quick Help (the SwiftUI `accessibilityChartDescriptor` bridge is confirmed).

--- a/docs/strategy/macos26-migration/04a-apple-docs-sosumi.md
+++ b/docs/strategy/macos26-migration/04a-apple-docs-sosumi.md
@@ -1,0 +1,53 @@
+# Apple Docs Verification (via sosumi.ai)
+
+Companion to [04-platform-research.md](04-platform-research.md). These are the
+authoritative Apple Developer Documentation pages, retrieved through
+**sosumi.ai** (an Apple-docs→markdown proxy; the `sosumi` MCP is not connected in
+this workspace, so the pages were fetched over the web at `sosumi.ai/<path>`).
+They confirm the recommended architecture and add a few specifics.
+
+## MenuBarExtra — `sosumi.ai/documentation/swiftui/menubarextra`
+- Generic scene `MenuBarExtra<Label, Content>`; inits `init(_:content:)`,
+  `init(_:systemImage:content:)`, `init(_:isInserted:content:)`.
+- `.window` style via `menuBarExtraStyle(.window)` → "a popover-like window from
+  the menu bar icon." This is exactly the glance surface VaultPeek keeps.
+- **Combines with `WindowGroup` in the same `@main` body** — confirms the hybrid
+  scene graph (primary window + menu-bar glance) is the supported pattern.
+- No-dock utility posture via `LSUIElement = true` (VaultPeek already does this;
+  Epic 1/9 must keep it consistent with the activation-policy helper).
+- Availability: **macOS 13.0+** (the scene type itself is not new to macOS 26).
+
+## NavigationSplitView — `sosumi.ai/documentation/swiftui/navigationsplitview`
+- **2-column:** `init(sidebar:detail:)`. **3-column:** `init(sidebar:content:detail:)`
+  (first column drives second, second drives third). Directly validates the
+  per-destination 2-col/3-col policy in [05-information-architecture.md](05-information-architecture.md).
+- Programmatic column control: `init(columnVisibility:...)` with
+  `NavigationSplitViewVisibility`; `init(preferredCompactColumn:...)` with
+  `NavigationSplitViewColumn` for the collapsed/narrow case (use this for the
+  screen-fallback ladder the old three-column popover contract needed).
+- Roles: **Sidebar** (leading) · **Content** (middle, 3-col only) · **Detail**
+  (trailing). Availability: **macOS 13.0+**.
+
+## Adopting Liquid Glass — `sosumi.ai/documentation/technologyoverviews/adopting-liquid-glass`
+- Apply to **navigation/chrome only**: "tab and sidebars float in this Liquid
+  Glass layer to help people focus on the underlying content." Confirms guardrail 5
+  / Epic 10 / risk **R-08**.
+- Explicit warning against custom backgrounds on controls/data and against
+  overuse — "overusing this material… can provide a subpar user experience."
+- APIs: SwiftUI **`glassEffect(_:in:)`** + **`GlassEffectContainer`** (perf +
+  morphing); UIKit `UIGlassEffect`; **AppKit `NSGlassEffectView`**. The AppKit
+  symbol matters for VaultPeek — today it uses `NSVisualEffectView`; evaluate
+  `NSGlassEffectView` where chrome is AppKit-hosted.
+- Accessibility: the material adapts to **Reduce Transparency / Reduce Motion**;
+  standard components adapt automatically, **custom elements must be tested**
+  across those settings (R-08). VaultPeek's custom translucency = self-managed
+  fallback required.
+
+## Net effect on the plan
+No changes to the recommendation. Three refinements folded into the epics:
+1. The hybrid `MenuBarExtra + WindowGroup`/`Window` scene graph is Apple's
+   documented pattern (Epic 1).
+2. Use `preferredCompactColumn` (`NavigationSplitViewColumn`) for narrow-width
+   collapse instead of bespoke overlay logic (Epic 2).
+3. Consider `NSGlassEffectView` for AppKit-hosted chrome, alongside the SwiftUI
+   `glassEffect`/`GlassEffectContainer` path (Epic 10).

--- a/docs/strategy/macos26-migration/05-information-architecture.md
+++ b/docs/strategy/macos26-migration/05-information-architecture.md
@@ -1,0 +1,911 @@
+# VaultPeek macOS 26 — Information Architecture & Navigation Specification
+
+Status: **Design proposal** (future-state). Part of the `macos26-migration`
+strategy series. This document specifies the information architecture, navigation
+model, and per-destination screen hierarchy for VaultPeek as a **single
+integrated macOS 26 application** — a persistent windowed shell with a sidebar,
+plus a reduced menu-bar glance.
+
+> No real account identifiers, balances, institution names, Plaid payloads,
+> tokens, local SQLite data, or private screenshots appear in this document. All
+> examples use demo fixtures, per `CLAUDE.md` and the three-column popover
+> contract.
+
+This spec **reuses** the existing design language (`DESIGN.md`), accessibility
+rules (`ACCESSIBILITY.md`), tokens (`Theme/DesignTokens`, `Typography`, the 8pt
+`Spacing` grid), and the shipped SwiftUI components. It does not invent a parallel
+system. Where it proposes new structure it names exactly which existing component
+carries over and what new shell-level scaffolding is required.
+
+---
+
+## 0. Scope and the one structural change
+
+Today VaultPeek is a **menu-bar popover** that became, through AND-367, a
+three-column workspace (Wealth Summary rail · Dashboard center · Review/Inspector
+column) with an on-demand detached `NSWindow` (AND-384, ux-audit-2026-06-13).
+That three-column popover is dense and well-loved, but it forces *every* surface —
+Review Inbox, Recurring, Category Dashboard, Settings — to either cram into a
+320pt column or escape into a detached satellite window
+(`ReviewTableWindow`, `CategoryDashboardWindow`, `RecurringPaymentsView`).
+
+The macOS 26 future state inverts the default: **the window is primary, the
+popover is a glance.** One `NavigationSplitView` shell hosts every destination as
+a first-class sidebar item. The satellite windows collapse back into the shell as
+sidebar destinations. No critical workflow lives in a popover.
+
+This is the migration the ux-audit-2026-06-13 explicitly deferred ("SwiftUI
+`Window` scene migration … out of scope given the popover-primary decision;
+revisit if the product ever goes desktop-first"). This document is that revisit.
+
+---
+
+## 1. Design philosophy & principles
+
+VaultPeek is a **finance instrument**, not a budgeting funnel. The product north
+star (CLAUDE.md, GOAL.md) is RepoBar/CodexBar density: high-signal numbers one
+keystroke away, native macOS restraint, privacy-first local presentation. Three
+tensions define the design.
+
+### 1.1 Trust before flash
+
+Money UI lives or dies on trust. Every number must be sourced, dated, and
+reversible. This is already encoded across the codebase and must carry into the
+shell:
+
+- **Sourced.** The Local Insight Receipt (`LocalAIInsightReceipt`) names its
+  evidence — row count, time window, top category — and never invents. The
+  "What the bank said" ledger (`BalanceTimeMachineView`) shows raw reported
+  balances next to derived ones. The shell keeps this provenance visible, not
+  buried.
+- **Dated.** Safe-to-Spend shows "Updated 2 minutes ago"; sync freshness rides on
+  every account row. No vague "recently."
+- **Reversible.** Category overrides, rules, and bulk review actions are local
+  overlays that never mutate raw Plaid records, and every one is undoable
+  (`⌘Z`). The shell surfaces an explicit Undo affordance in the toolbar of any
+  destination that mutates review/budget state.
+- **Honest about storage.** The "Where your data lives" / Local Trust Receipt
+  disclosure (`LocalTrustReceiptView`) appears in onboarding and Settings →
+  Privacy, never hidden behind marketing language.
+
+### 1.2 Calm under density
+
+The shell must be *dense* (many numbers visible) and *calm* (no anxiety, no
+clutter) at the same time. The levers, all already in the design system:
+
+- **Hierarchy from size, casing, and opacity — not boldness or color.** Weights
+  cap at semibold (`Typography.swift`). One hero number per surface
+  (`.displayBalance()`); section labels are uppercase `.sectionTitle()`; data is
+  `.dataText()` monospaced for column alignment.
+- **Spacing, not cards, for grouping.** The `glassSurface(.raised/.inset/
+  .emphasized)` three-rank system (SharedModifiers.swift) never nests more than
+  two ranks; default surfaces draw no stroke. The shell extends this: sidebar and
+  content are vibrancy-backed regions, not stacked web cards.
+- **Color is reserved for meaning, never decoration.** Green = money in,
+  red = debt/loss, orange = warning/pending, indigo = recurring, blue = brand.
+  The same semantic palette governs every destination.
+
+### 1.3 Glanceable everywhere
+
+The same fact should read the same way in three places — menu-bar glance, sidebar
+badge, and full destination — so the user builds one mental model. Example: the
+Review queue count appears as (a) an optional menu-bar glance metric, (b) a count
+badge on the **Review** sidebar row, and (c) the section headers inside the Review
+Inbox. The attention rollup (`AttentionQueue`, max 3 rows) is the canonical
+"do I need to act?" signal and surfaces identically in all three.
+
+### 1.4 Operating principles (carried from GOAL.md, made shell-aware)
+
+| Principle | Shell expression |
+|-----------|------------------|
+| At-a-glance first | Menu-bar glance + sidebar badges answer the 5 north-star questions without opening a destination |
+| Dense but calm | `glassSurface` ranks; size/casing/opacity hierarchy; compact density mode |
+| Status-rich | Persistent connection-health strip; per-destination empty/loading/error states |
+| Finance-native semantics | One semantic color map across all 11 destinations |
+| Keyboard-first | Command palette (`⌘K`) + global shortcut map + per-row keys; every action reachable without the mouse |
+| Accessible by default | No meaning by color alone; VoiceOver labels; Reduce Motion; audio graphs for charts |
+| Local-first / private | Privacy Mask + App Lock gate every destination uniformly |
+
+---
+
+## 2. Information architecture — destination tree
+
+The sidebar is grouped into four bands. **Overview** is the daily landing zone;
+**Workflows** are the verbs (where time is spent); **Money** is the noun reference
+(accounts, the source of truth); **System** is configuration. Grouping the verbs
+together is the Linear move — the sidebar reads as a list of *jobs to do*, not a
+list of *data tables*.
+
+```
+VaultPeek (NavigationSplitView shell)
+│
+├── ▸ OVERVIEW
+│   └── Dashboard ........................ [⌘1]  default landing destination
+│         ├── Wealth Summary band (net worth hero, assets/debt, balance mix, 30D cashflow, credit)
+│         ├── Attention rollup (≤3 rows, AttentionQueue)
+│         ├── 365-day financial heatmap (Spend | Net toggle)
+│         ├── Safe-to-Spend card (explainable headline)
+│         ├── Spending-by-category preview → deep-links to Budgets
+│         └── Recent / large transactions → deep-links to Transactions
+│
+├── ▸ WORKFLOWS
+│   ├── Review .......................... [⌘2]  badge: unreviewed count
+│   │     ├── List pane (date sections: Today / Yesterday / This Week / Earlier)
+│   │     ├── Detail/triage pane (selected transaction: approve, recategorize, rule, rename, transfer, ignore)
+│   │     └── Inspector (optional): rule preview / blast-radius / merchant history
+│   │
+│   ├── Budgets ......................... [⌘3]  badge: over-budget count
+│   │     ├── Category tree (2-level groups → leaves, CategoryTreeView)
+│   │     ├── Donut + totals header (SpendDonutChart)
+│   │     ├── Flat sortable table (Category · Spent · Budget · Left · Status · Plan)
+│   │     └── Budget editor (inspector/sheet: limit, suggested "ghost guardrail")
+│   │
+│   ├── Planning ........................ [⌘4]
+│   │     ├── Projected balance forecast (ProjectedBalanceChart, 30–90D)
+│   │     ├── Recurring obligations / subscriptions (RecurringPaymentsView)
+│   │     ├── Income → category flow (IncomeCategoryFlowChart, Sankey)
+│   │     └── Cashflow runway / what-if horizon controls
+│   │
+│   └── Goals ........................... [⌘5]  (new destination; see §5.6)
+│         ├── Goal list (savings targets, payoff targets)
+│         ├── Goal detail (progress ring, contribution pace, projected completion)
+│         └── New-goal editor (inspector)
+│
+├── ▸ INSIGHTS
+│   ├── Insights ........................ [⌘6]
+│   │     ├── Local Insight Receipt feed (LocalAIInsightReceipt, sourced + dated)
+│   │     ├── Weekly Review checklist (WeeklyReviewCard → full surface)
+│   │     └── Trends (spend deltas, category drift, recurring changes)
+│   │
+│   └── Alerts .......................... [⌘7]  badge: unacknowledged count
+│         ├── Alert feed (large txn, low balance, high utilization, recurring change, broken connection)
+│         ├── Watchlist (merchant/category thresholds, AND-501)
+│         └── Alert rule editor (inspector) → mirrors Notifications settings
+│
+├── ▸ MONEY
+│   └── Accounts ........................ [⌘8]
+│         ├── Institution groups (connection health, account count, sync state)
+│         ├── Account list rows (type icon, balance, utilization, freshness)
+│         └── Account inspector (AccountDetailFlyout: status, balances, 30D changes, to-review, top categories, recent activity, reconnect/remove)
+│
+└── ▸ SYSTEM
+    └── Settings ........................ [⌘,]  (native Settings scene; tabs unchanged)
+          └── General · Accounts · Appearance · Notifications · Privacy · About
+```
+
+Notes on the tree:
+
+- **11 primary destinations** as required: Dashboard, Transactions (= the
+  Transactions *view*, reachable from Review/Accounts deep-links and as a
+  filtered list — see §5.2), Budgets, Planning, Goals, Review, Insights, Alerts,
+  Accounts, Settings. Review and Transactions are distinct: **Review is the
+  triage *inbox* (a queue of items needing a decision); Transactions is the full
+  searchable *ledger*.** Both render the same `TransactionRow` vocabulary.
+- **Transactions** is listed in the sidebar under WORKFLOWS between Review and
+  Budgets (omitted from the band diagram above for brevity; see §5.2). It is the
+  reference ledger; Review is the action queue over a subset of it.
+- The four satellite windows that exist today (`ReviewTableWindow`,
+  `CategoryDashboardWindow`, `RecurringPaymentsView` window, the detached
+  dashboard panel) all become **content of a sidebar destination**, not separate
+  windows. Power users can still tear a destination into its own window via the
+  standard macOS `⌘N`-new-window / "Open in New Window" path (see §3.6).
+
+### 2.1 Selection & deep-linking model
+
+A single `@Observable` `NavigationModel` owns the selected destination, the
+selection within a destination (e.g. `selectedTransactionID`,
+`selectedAccountID`, `selectedCategory`, `selectedGoalID`), and the inspector
+state. This replaces today's scattered `@AppStorage("dashboard.selectedAccountId")`
+/ `"dashboard.accountFilter"` keys with one routable state.
+
+Deep links use a typed `Route` enum so any surface can navigate anywhere:
+
+```
+enum Route {
+  case dashboard
+  case review(itemID: String?)
+  case transactions(filter: TransactionFilter, focus: String?)
+  case budgets(category: SpendingCategory?)
+  case planning(section: PlanningSection)
+  case goals(id: UUID?)
+  case insights(section: InsightSection)
+  case alerts(id: String?)
+  case accounts(itemID: String?)
+  case settings(tab: SettingsTab)
+}
+```
+
+Examples of routing that the shell must support:
+- Dashboard "category preview" row → `budgets(category: .food)` (opens Budgets
+  with that leaf focused).
+- Account inspector "To review (N)" → `review(itemID: firstID)` (jumps to Review
+  with that item selected).
+- Alert "High utilization on card" → `accounts(itemID:)` (opens Accounts with the
+  card inspector).
+- Weekly Review checklist item → its `WeeklyReviewNavigationTarget`
+  (`.reviewInbox` / `.recurring` / `.safeToSpend`) maps onto the new routes.
+- Menu-bar glance "Open VaultPeek" → `dashboard`; a glance attention chip →
+  `review` or `alerts`.
+
+Selection persistence: the last destination and per-destination selection persist
+across launches (as today via `@AppStorage`), but now keyed on the `Route` so a
+relaunch lands exactly where the user left off — modulo App Lock, which forces the
+gate first.
+
+---
+
+## 3. Navigation model
+
+### 3.1 The shell — `NavigationSplitView`
+
+The shell is a single `NavigationSplitView`. Every destination chooses **2-column**
+(sidebar + content) or **3-column** (sidebar + content + detail/inspector) based on
+whether it has a meaningful master→detail relationship. macOS 26
+`NavigationSplitView` handles column visibility, the unified toolbar, and sidebar
+collapse natively.
+
+| Destination | Columns | Rationale |
+|-------------|---------|-----------|
+| **Dashboard** | **2** | A composed overview canvas; no list→detail. Drill-ins deep-link to other destinations rather than opening a local third column. |
+| **Review** | **3** | The core triage flow is list ↔ detail; the optional third pane shows rule-preview / blast-radius. This is the marquee 3-column case. |
+| **Transactions** | **3** | Table (list) → transaction inspector (detail). Filter rail folds into a toolbar + optional left filter section. |
+| **Budgets** | **3** | Category tree/table (list) → budget editor inspector (detail). |
+| **Planning** | **2** | A composed analytical canvas (forecast + recurring + flow); sub-sections switch via a segmented control, not a master list. |
+| **Goals** | **3** | Goal list → goal detail/progress → new-goal editor inspector. |
+| **Insights** | **2** | A feed of receipts + weekly review; reading surface, not master→detail. Selecting a receipt expands in place. |
+| **Alerts** | **3** | Alert feed (list) → alert detail / rule editor (inspector). |
+| **Accounts** | **3** | Institution/account list → `AccountDetailFlyout` inspector (the existing, proven master→detail). |
+| **Settings** | n/a | Native macOS `Settings` scene (separate window, tabbed) — unchanged. |
+
+**Verdict in one line:** Dashboard, Planning, Insights are **2-column**; Review,
+Transactions, Budgets, Goals, Alerts, Accounts are **3-column**; Settings stays a
+native tabbed Settings window.
+
+The third column is **content-gated, not existence-gated** — the lesson the
+ux-audit-2026-06-13 made explicit and the three-column contract codified: keep the
+column, vary its content. With nothing selected, the inspector shows a
+`ContentUnavailableView` prompt (e.g. "Select a transaction to review"), never a
+collapse. `NavigationSplitView`'s `.detailColumnWidth` and the `preferredCompact`
+behavior cover the screen-constrained fallback the popover had to hand-roll
+(AND-374); on narrow displays the detail column collapses to a push-navigation
+sheet rather than overlaying.
+
+### 3.2 Sidebar
+
+The sidebar is a new shell-level `List` with `Section` headers for the four bands.
+Each row: SF Symbol + label + optional **count badge** (trailing, secondary,
+text — never a color-only dot). Badges:
+
+| Destination | Badge source | Hidden when |
+|-------------|-------------|-------------|
+| Review | `TransactionReviewInboxSnapshot.totalCount` (high-priority emphasized) | queue clear |
+| Budgets | `CategoryBudgetPresentation.overBudgetCount` | nothing over |
+| Alerts | unacknowledged alert count | none unacked |
+| Accounts | items needing reconnect (`AttentionQueue` blocked rows) | all healthy |
+
+The sidebar footer holds a **persistent connection-health strip**
+(`ConnectionHealthStripView`) and the data-mode chip (Demo / Sandbox /
+Production) — the status the popover footer carries today, now always visible.
+
+Sidebar is collapsible (`⌘\` and the native control); collapsing favors the dense
+content+detail layout for small screens.
+
+### 3.3 Command palette (`⌘K`)
+
+A new shell-level component (the single most important new piece). A
+spotlight-style overlay with fuzzy search across three action classes:
+
+1. **Navigate** — "Go to Budgets", "Open Review", "Accounts → Chase". Jump to any
+   `Route`, including a specific account, category, or goal.
+2. **Act** — verbs that work from anywhere: "Refresh", "Add account", "Set budget
+   for Groceries", "Mark all reviewed", "Create rule…", "Toggle Privacy Mask",
+   "Export CSV", "Undo".
+3. **Find** — search transactions by merchant/amount/category and jump to the
+   match in Transactions or Review.
+
+Implementation: a `CommandRegistry` of `Command { id, title, subtitle, symbol,
+shortcut?, action, isEnabled }`. Each destination registers its contextual
+commands when active; global commands (refresh, add account, privacy, navigate)
+are always registered. The palette respects Privacy Mask (no merchant names in
+results while masked) and App Lock (unavailable while locked).
+
+This is what makes the app **keyboard-first**: any action that exists is one
+`⌘K`-and-type away, so the keyboard map below is a fast-path layer over the
+palette, not the only way in.
+
+### 3.4 Global keyboard map
+
+A real `CommandGroup` / `CommandMenu` structure (the codebase has *no* centralized
+command menu today — shortcuts are ad-hoc per-view). The shell introduces menu-bar
+menus (View, Go, Account, Edit) so shortcuts are discoverable in the menu bar and
+in the `⌘K` palette.
+
+| Shortcut | Action | Scope |
+|----------|--------|-------|
+| `⌘K` | Open command palette | Global |
+| `⌘1`…`⌘8` | Go to destination N (Dashboard…Accounts) | Global |
+| `⌘,` | Settings | Global |
+| `⌘R` | Refresh / sync now | Global (carries over) |
+| `⌘N` | Add account / connect bank | Global (carries over) |
+| `⌘F` | Focus search (current destination) | Global |
+| `⌘⇧P` | Toggle Privacy Mask | Global (carries over) |
+| `⇧⌘V` | Summon VaultPeek from any app | System hotkey (carries over) |
+| `⌘\` | Toggle sidebar | Global |
+| `⌘Z` / `⇧⌘Z` | Undo / Redo last review or budget action | Global (carries over) |
+| `↑` / `↓` or `J` / `K` | Move selection in list pane | List destinations |
+| `Return` | Open / confirm selection | List destinations |
+| `Esc` | Clear selection → (2nd press) close inspector / dismiss | Global |
+
+Per-row triage keys inside **Review** (carried verbatim from `ReviewInboxView`):
+
+| Key | Action |
+|-----|--------|
+| `A` | Approve selected |
+| `C` | Recategorize (opens category menu) |
+| `T` | Toggle transfer / not transfer |
+| `R` | Rule menu (create durable rule) |
+| `M` | Rename merchant |
+| `I` | Ignore |
+| `⌘Z` | Undo last review action |
+
+> Conflict note: today `A/C/T/I/M/R` are bare keys inside the Review surface. In
+> the windowed shell they remain bare-key accelerators **only while focus is in
+> the Review list/detail**; they are never global (so typing in a search field is
+> safe). The `⌘1–8` navigation and `⌘K` palette take precedence at the shell
+> level.
+
+### 3.5 Selection & focus behavior
+
+- Selecting a list row fills the detail column and shows the native accent
+  highlight; the two stay synchronized (one selection state), exactly the
+  contract the three-column popover already guarantees (§6 of
+  `three-column-popover-contract.md`).
+- `Esc` clears the selection first (detail reverts to its `ContentUnavailableView`
+  prompt), then on a second press dismisses any inspector sheet — never both at
+  once.
+- After a triage action that removes the row from the queue (approve/ignore),
+  focus advances to the **next** item so the user can clear the inbox without
+  touching the mouse (Linear/Reeder inbox behavior). After deselect, focus
+  returns to the previously selected row.
+
+### 3.6 Menu-bar glance → window hand-off
+
+The menu bar keeps a `MenuBarExtra` but its content shrinks to a **glance**
+(see §6). The hand-off:
+
+- Click "Open VaultPeek" (or the menu-bar icon's primary action) →
+  `NSApp.activate` + bring the main window forward at the last `Route`. If the
+  window is closed, create it; if minimized, deminiaturize.
+- A glance attention chip ("3 to review", "Card over 75%") is a button that opens
+  the window **at the relevant destination** (`review` / `alerts` / `accounts`),
+  not just the dashboard.
+- `⇧⌘V` (summon hotkey) does the same window-forward, from any app.
+- The glance never opens a popover workflow; it is a launcher + status readout.
+
+---
+
+## 4. Component reuse map
+
+What carries over unchanged, what adapts, and what is genuinely new.
+
+### 4.1 Carries over unchanged (tokens + components)
+
+| Asset | Where it lives | Reuse in shell |
+|-------|----------------|----------------|
+| `Spacing` (8pt grid), `Radius`, `Sizing` | DesignTokens | All shell layout |
+| `Typography` modifiers (`.displayBalance`, `.sectionTitle`, `.dataText`, `.detailText`, `.microText`) | Typography.swift | All text |
+| Semantic colors + utilization ladder | DESIGN.md / SemanticColors | All destinations |
+| `glassSurface(.raised/.inset/.emphasized)` | SharedModifiers.swift | Content panels everywhere |
+| `MotionTokens` (+ Reduce Motion gating) | SharedModifiers.swift | All animation |
+| `AccountDetailFlyout` + `AccountDetailInsights` | Views / Core | **Accounts** detail column verbatim |
+| `ReviewInboxView` (+ rows, banners, rule prompt) | ReviewInboxView.swift | **Review** list pane |
+| `ReviewTableWindow` table + bulk model | ReviewTableWindow.swift | **Transactions/Review** table mode |
+| `CategoryTreeView`, `CategoryDashboardWindow`, `CategoryStatusBar`, `CategoryDashboardCard` | Views | **Budgets** |
+| `BudgetEditorSheet`, `SuggestedBudgetAcceptButton` | Views | **Budgets** editor |
+| `SafeToSpendCard` | Views | Dashboard + Planning |
+| `RecurringPaymentsView`, `RecurringObligationsSection` | Views | **Planning** |
+| `ProjectedBalanceChart`, `IncomeCategoryFlowChart`, `SpendDonutChart`, `BalanceTrendChart` | Charts | Planning / Budgets / Dashboard |
+| `WealthSummaryFlyout` sections | WealthSummaryFlyout.swift | **Dashboard** overview band |
+| `WeeklyReviewCard` | WeeklyReviewCard.swift | **Insights** |
+| `AttentionQueueView` + `AttentionQueue` model | Views / Core | Dashboard + sidebar badges + glance |
+| `BalanceTimeMachineView` ("What the bank said") | Views | Accounts / Planning |
+| `LocalAIInsightReceipt` + `LocalInsightsCard` | Core / MainPopover | **Insights** feed |
+| `ConnectionHealthStripView` | Views | Sidebar footer |
+| Privacy Mask + App Lock gate, snapshots | AppState | Shell-wide overlay |
+| `SettingsView` (6 tabs) | Settings | **Settings** scene verbatim |
+| All pure presentation/Core models | PlaidBarCore | Unchanged |
+
+### 4.2 Adapts (same component, new host)
+
+- **`MainPopover`'s three-column body** → decomposed: the Wealth Summary becomes
+  the **Dashboard** overview band; the center heatmap/filters/rows split between
+  **Dashboard** and **Transactions**; the inspector logic moves into per-
+  destination detail columns. `PopoverGeometry`/`PopoverWindowAnchor` retire
+  (the window manages its own geometry).
+- **The detached `NSWindow` host** (`DetachedDashboardCoordinator`) → becomes the
+  *main* window; the popover-as-primary plumbing inverts. True translucency
+  (`NSVisualEffectView(.behindWindow)`, `isOpaque=false`) carries over for the
+  Liquid Glass backdrop the audit already shipped.
+- **`MenuBarLabel`** → keeps the summary-mode picker logic but feeds the reduced
+  glance, not a full popover.
+- **Esc / selection / focus contract** → generalizes from the inspector column to
+  every 3-column destination.
+
+### 4.3 New shell-level components
+
+| New component | Responsibility |
+|---------------|----------------|
+| `AppShellView` (NavigationSplitView host) | Sidebar + content + detail; column policy per destination |
+| `SidebarView` + `SidebarItem` | Banded list, count badges, footer health strip + mode chip |
+| `NavigationModel` (`@Observable`) | Selected `Route`, per-destination selection, inspector state, persistence |
+| `CommandPalette` + `CommandRegistry` | `⌘K` overlay; navigate / act / find |
+| `AppCommands` (`CommandMenu`/`CommandGroup`) | Menu-bar menus + global shortcut definitions |
+| `DestinationToolbar` | Per-destination unified toolbar (search, filter, refresh, Undo) |
+| `TransactionsView` | The full searchable ledger destination (new framing over existing rows/table) |
+| `GoalsView` + `GoalEditor` + `GoalProgressRing` | The new Goals destination (§5.6) |
+| `AlertsView` | Alert feed over existing notification/watchlist models |
+| `GlanceView` | The reduced menu-bar content (§6) |
+
+Everything in 4.3 is **scaffolding** — it composes existing dense components into
+a shell. No new finance logic; per CLAUDE.md, any genuinely new logic (e.g. Goals
+math) lands in `PlaidBarCore` as pure, `Sendable`, tested types.
+
+---
+
+## 5. Screen hierarchy — per destination
+
+Each destination below: regions, key components (reused names), density treatment,
+primary/secondary actions, and states. Deepest treatment for **Review**,
+**Transactions**, **Budgets/Planning**, **Insights**, per the brief.
+
+### 5.1 Dashboard (2-column) — `[⌘1]`
+
+**Purpose:** answer the five north-star questions in one glance. The composed
+landing canvas.
+
+**Regions (content column, single scroll):**
+1. **Header** — one net-worth hero (`.displayBalance()`) + `BalanceTrendChart`
+   sparkline + sync-health pill. *(One hero per surface; the rule the contract
+   enforces — net worth lives here, not duplicated elsewhere.)*
+2. **Attention rollup** — `AttentionQueueView`, ≤3 rows, each with an action
+   button (reconnect / refresh / add account). Hidden when all healthy.
+3. **Metric band** — assets / debt / balance mix / 30D cashflow (income · spend ·
+   net) from `WealthSummaryFlyout` sections, laid out as inline separator-backed
+   metrics (not nested cards — the AND-372 flatten lesson).
+4. **365-day heatmap** — Spend | Net toggle, neutral Less/More ramp in Spend mode,
+   bidirectional legend in Net mode. The signature RepoBar surface.
+5. **Safe-to-Spend** — `SafeToSpendCard`, collapsed by default, expandable
+   breakdown.
+6. **Category preview** — `CategoryDashboardCard` top-3 groups → "Open dashboard"
+   deep-links to **Budgets**.
+7. **Recent / large transactions** — a few `TransactionRow`s → deep-link to
+   **Transactions**.
+
+**Density:** highest-density destination; everything visible without expansion.
+Comfortable vs Compact density preference (`AppDensityPreference`) tightens row
+padding.
+
+**Primary actions:** Refresh (`⌘R`), Add account (`⌘N`). **Secondary:** toggle
+heatmap mode, expand Safe-to-Spend, any deep-link.
+
+**States:** Loading → skeletons (`LoadingSkeletons`, `.loadingRedaction()`).
+Empty (no accounts) → `ContentUnavailableView` "Connect a bank to begin" + Connect
+button (no fake cards). Offline/error → attention rollup carries the recovery
+action; the rest of the shell stays usable. Masked → values dotted, structure
+intact.
+
+### 5.2 Transactions (3-column) — the ledger
+
+**Purpose:** the full, searchable transaction history. The *reference*, distinct
+from Review's *queue*.
+
+**Regions:**
+- **List/table column** — `ReviewTableWindow`'s table engine reframed as the
+  ledger: columns **Merchant · Amount · Date · Category · Account · Status**,
+  sortable (`ReviewTableSort` extended). Rows are `TransactionRow` /
+  `ReviewTableRow`. Date-grouped or flat (toolbar toggle).
+- **Toolbar** — `⌘F` search field (merchant / amount / category); filter controls
+  reusing `DashboardAccountFilter` (All · Cash · Credit · Savings · Debt ·
+  Investments) + category + date-range chips (`FilterChipsView` vocabulary);
+  Export menu (CSV / JSON, disabled while masked/locked).
+- **Detail column (inspector)** — `TransactionDetailView` content (category icon,
+  merchant, raw name, amount, date, account, status) **plus** the same triage
+  controls Review offers (recategorize, rule, transfer, rename) so the user can
+  act without bouncing to Review.
+
+**Density:** table density; monospaced amounts; zebra-free, hairline separators.
+Virtualized list (the large-history virtualization + paged fetch already shipped,
+AND-567) carries over.
+
+**Primary actions:** Search (`⌘F`), filter, sort, recategorize/rule from
+inspector. **Secondary:** export, jump-to-account, "Review this" → `review(itemID)`.
+
+**States:** Loading → paged skeleton rows. Empty distinguishes **no synced
+history** ("No transactions yet — sync to populate") from **filters return zero**
+("No matches — clear filters"), per GOAL.md's sharper-empty-states requirement.
+Error → "Couldn't load history" + retry. Masked → amounts/merchants dotted.
+
+### 5.3 Review (3-column) — the triage inbox **[deepest]** — `[⌘2]`
+
+**Purpose:** clear the queue of transactions needing a human decision. This is the
+flagship keyboard-driven workflow — the Linear/Reeder inbox, applied to money.
+
+**The flow, end to end:**
+
+1. **List column** — `ReviewInboxView(embedded:)` content, date-sectioned
+   (**Today / Yesterday / This Week / Earlier**). Each `ReviewInboxRow`: merchant
+   · amount · `CategoryPill` · reason chips (uncategorized / new merchant /
+   unusual amount / possible transfer / recurring changed / pending changed /
+   changed since review — `TransactionReviewReason`, text + glyph, never color
+   alone). High-priority reasons sort to the top.
+2. **Detail/triage column** — the selected item's full triage surface:
+   - **Approve** (`A`) — mark reviewed, advance to next.
+   - **Recategorize** (`C`) — category menu; on apply, offers the inline
+     `InlineCategoryRulePromptBanner` — *"Always categorize {merchant} as
+     {category}?"* → **Create rule** / **Dismiss** (suppressed if masked, blank,
+     or a duplicate rule exists).
+   - **Rule** (`R`) — create a durable `TransactionRule` (merchant→category or
+     transfer) without recategorizing first.
+   - **Transfer / Not transfer** (`T`) — toggle the transfer override (excludes
+     from budgets).
+   - **Rename merchant** (`M`) — text field + Rename.
+   - **Ignore** (`I`) — mark reviewed unless materially changed.
+   - Every action fires a `ReviewActionConfirmationBanner` (auto-dismiss 2.5s) +
+     haptic (AND-576) + VoiceOver announcement; all are `⌘Z`-undoable.
+3. **Inspector (optional 3rd region within detail, or a slide-over)** —
+   **rule preview / blast radius**: when creating a rule or staging a bulk action,
+   show exactly which transactions it will touch
+   (`ReviewBulkActionPlan.blastRadiusDescription` — "Mark N reviewed: A, B, C, and
+   M more") *before* applying. Also: merchant history (prior categorizations) to
+   inform the decision.
+
+**Bulk / multi-select:** the `ReviewTableWindow` model becomes a **table mode**
+toggle inside Review (segmented: *Triage* | *Table*). Table mode gives
+multi-select with `Recategorize` / `Mark transfer` / `Mark reviewed` over a
+selection, each gated by a blast-radius confirmation dialog (titles + confirm
+labels from `PendingReviewBulkAction`). Per-section **"Approve N"** stays in
+triage mode for fast section-clearing.
+
+**Density & progressive disclosure:** the list is compact (one two-line row); the
+*selected* row's full control set lives in the detail column, not inline, so the
+list stays scannable (progressive disclosure done right). Compact density mode
+tightens row height further.
+
+**Keyboard-first:** the whole loop is `↓` to next, `A`/`C`/`T`/`R`/`M`/`I` to act,
+`⌘Z` to undo — no mouse. This is the destination that most embodies the
+keyboard-first principle.
+
+**States:**
+- **Empty / clear** — `ContentUnavailableView` "Inbox Clear — New or unusual
+  transactions show up here to review, recategorize, or rename." (verbatim copy).
+- **Loading** — skeleton rows; never an offline verdict while `isBooting`.
+- **Masked** — "Review items, merchants, and amounts are hidden while Privacy Mask
+  or App Lock is active." (verbatim); triage controls disabled.
+- **No selection** — detail shows "Select a transaction to review."
+- **Error** — sync error banner with retry; queue from last good snapshot stays
+  readable.
+
+### 5.4 Budgets (3-column) **[deep]** — `[⌘3]`
+
+**Purpose:** see where the month's money went by category and set/keep limits.
+Copilot-style category dashboard, now a first-class destination.
+
+**Regions:**
+- **List column** — `CategoryTreeView`: 2-level disclosure (group rollups →
+  leaves). Each row a `CategoryStatusBar` (track fill + verdict: **On track /
+  Close to limit / Over budget / No budget set** — text + glyph, never color
+  alone; 80% = nearing threshold). Groups that are *over* or *nearing* expand by
+  default. Toolbar toggle to a **flat sortable table**
+  (`CategoryDashboardWindow` table: Category · Spent · Budget · Left · Status ·
+  Plan; sort by Spend↓ or Group-then-Spend; footer totals).
+- **Header band** — `SpendDonutChart` (this month, by `CategoryGroup`, center
+  total) + Spent / Budgeted / Left totals.
+- **Detail column (editor inspector)** — `BudgetEditorSheet` content inline:
+  monthly-limit field, validation footer ("Enter a positive dollar amount." /
+  "Sets the monthly limit to $X." / "Saving 0 removes this budget."), and the
+  **suggested "ghost guardrail"** row with one-tap `SuggestedBudgetAcceptButton`
+  ("Set $X limit", `wand.and.stars`). Income/transfer categories show the
+  read-only advisory "Income and transfer categories can't have a budget."
+
+**Density:** tree rows are compact; the status bar packs spend/limit/% into one
+line. Progressive disclosure: groups collapse; the editor lives in the inspector,
+not inline per row.
+
+**Primary actions:** Set/Edit budget (per row → inspector), Accept suggestion.
+**Secondary:** sort, switch tree/table, deep-link a category from Dashboard.
+
+**States:** Empty → "No category spending yet — Spending appears here once this
+month's transactions arrive." Loading → skeleton rows. No-suggestion → "Not enough
+history." Masked → amounts dotted, structure intact.
+
+### 5.5 Planning (2-column) **[deep]** — `[⌘4]`
+
+**Purpose:** look forward — runway, recurring obligations, and where income flows.
+
+**Regions (segmented sub-sections, not a master list):**
+1. **Forecast** — `ProjectedBalanceChart`: solid recorded trend → dashed forward
+   30–90D, "today" anchor rule, projected-low marker, confidence cue ("Forecast
+   from recurring patterns" / "Indicative only"). Horizon control (30 / 60 / 90D)
+   + a what-if input (manual expected income, safety buffer — feeds
+   `SafeToSpendInputs`).
+2. **Recurring & subscriptions** — `RecurringPaymentsView` content: per-row
+   merchant · amount · frequency · last/next dates · confidence · flag
+   explanations (price increase / stale / forgotten) · "How to cancel" link.
+   Monthly-estimate header.
+3. **Income → category flow** — `IncomeCategoryFlowChart` (Sankey): income sources
+   → spending categories, proportional ribbons, text legend, "aggregate-
+   proportional, not per-transaction" caveat.
+
+**Density:** chart-forward (more whitespace than the ledger); legends are
+text+glyph for color independence; audio graphs (`ChartAudioGraphDescriptor`) for
+VoiceOver.
+
+**Primary actions:** change horizon, what-if inputs, "How to cancel" (per
+subscription). **Secondary:** jump to a category's budget; jump to an account.
+
+**States:** Forecast needs history → "Forecast appears after ~7 days of data."
+Recurring empty → "No recurring payments detected — VaultPeek will list
+subscriptions here after enough history." Offline/error → "Recurring charges
+unavailable" + cause + retry (verbatim load-state copy). Masked → amounts dotted.
+
+### 5.6 Goals (3-column) — `[⌘5]` (new destination)
+
+**Purpose:** track savings/payoff targets against real balances. GOAL.md scopes
+VaultPeek away from "full budgeting," so Goals stays **lightweight and
+observational**: it reads balances + recurring + safe-to-spend and projects pace;
+it does not move money or enforce.
+
+**Regions:**
+- **List column** — goal rows: name · target · current · progress ring
+  (`GoalProgressRing`, % + text label) · projected-completion date. Two kinds:
+  *savings target* (account balance → target) and *payoff target* (debt → $0).
+- **Detail column** — progress ring large, contribution pace (derived from 30D
+  cashflow / recurring), projected completion, and a "on pace / behind / ahead"
+  verdict (text + glyph). Links to the underlying account.
+- **Editor inspector** — name, kind, target amount, target date, linked
+  account(s).
+
+**New logic** (`PlaidBarCore`, pure + tested): `Goal`, `GoalProgress`,
+`GoalProjection` (pace from cashflow, ETA, on-pace verdict). No network surface;
+goals are local overlays.
+
+**Density:** medium; progress rings give a fast read; numbers monospaced.
+
+**States:** Empty → "No goals yet — Create a savings or payoff goal." Insufficient
+data → "Add more history to project a completion date." Masked → amounts dotted,
+ring + label still shown.
+
+### 5.7 Insights (2-column) **[deep]** — `[⌘6]`
+
+**Purpose:** the local-AI / deterministic insight surface and the weekly ritual.
+Strictly local, strictly sourced — the trust principle made a destination.
+
+**Regions (feed):**
+1. **Local Insight Receipts** — `LocalAIInsightReceipt` cards: one-line headline,
+   evidence chips (source-row count, time window e.g. `2026-06-05 to 2026-06-11`,
+   top display category, recurring estimate), confidence + limitations rows, an
+   always-visible **Local-only** badge, and reversible-action copy. Receipts never
+   show raw IDs/tokens; headlines redact known local identifiers.
+2. **Weekly Review** — `WeeklyReviewCard` expanded into a full checklist:
+   outcome badge ("Looks good" / "Review these few items" / "Pay attention" /
+   "Transaction review required"), N/M complete, items each with a checkbox +
+   severity icon + action button routing to `reviewInbox` / `recurring` /
+   `safeToSpend`. A "Complete Review" affordance.
+3. **Trends** — spend deltas vs prior period (`SpendingComparison`: arrow +
+   signed amount + "vs last period", color *and* arrow), category drift, recurring
+   changes.
+
+**Density:** reading-density (generous), but each receipt is compact. Progressive
+disclosure: receipts expand to show full evidence/limitations; weekly items expand
+to detail.
+
+**Primary actions:** complete a weekly item, accept/reject a category hint
+(reversible local overlay), check local-AI availability. **Secondary:** route to
+the source destination.
+
+**States:** Local AI off / no runtime → the receipt states it plainly ("Local
+runtime unavailable") *without blocking* — deterministic receipts still render;
+the rest of the app is unaffected. Not-enough-history → confidence downgrades and
+says so. Weekly not due → "Weekly review not ready" + next date. Waiting on data →
+"Weekly review will appear once transaction data is ready." Masked → headlines/
+evidence use display-safe counts only (already the contract).
+
+### 5.8 Alerts (3-column) — `[⌘7]`
+
+**Purpose:** a feed of things VaultPeek flagged, plus the watchlist that generates
+them. Mirrors Notifications settings but as a *destination* (history + state),
+not just a config screen.
+
+**Regions:**
+- **List column** — alert feed: large-transaction, low-balance, high-utilization,
+  recurring-change, broken-connection, and watchlist hits. Each row: severity
+  glyph + title + detail + timestamp + acknowledged state.
+- **Detail column** — the triggering transaction/account/recurring stream + a
+  jump-to action (deep-links to Transactions / Accounts / Planning).
+- **Watchlist editor (inspector)** — AND-501 watchlist: add by Merchant or
+  Category + threshold; saved watches list. Plus a link to Settings →
+  Notifications for the trigger toggles + thresholds.
+
+**Density:** feed-density; unacknowledged emphasized (weight + glyph, not color
+alone). Sidebar badge = unacknowledged count.
+
+**Primary actions:** acknowledge / acknowledge-all, add watch. **Secondary:** jump
+to source, mute a trigger (routes to Notifications).
+
+**States:** Empty → "No alerts — You're all caught up." Notifications permission
+denied → status row + "Open System Settings". Masked → alert bodies use safe copy
+(no merchant/exact balance), matching the lock-screen notification policy.
+
+### 5.9 Accounts (3-column) — `[⌘8]`
+
+**Purpose:** the source-of-truth ledger of connected institutions and accounts.
+
+**Regions:**
+- **List column** — institution groups (`AccountSettingsView` grouping):
+  institution name + connection-health (icon + signal label) + account count +
+  sync state; recovery action (Reconnect / Refresh) when login-required / error /
+  stale; Remove (destructive). Account rows: type icon + name + type + balance
+  (monospaced) + utilization (for credit) + sync freshness.
+- **Detail column** — `AccountDetailFlyout` **verbatim**: header (name /
+  institution / type / mask), Status (connection badge + freshness + recovery),
+  Balances (Available / Current / Utilization), Changes · 30 days (signed deltas,
+  arrow + sign + color), To review (pending + large, with reason chips, → Review),
+  Top categories · 30 days, Recent activity (6 rows), account actions (reconnect /
+  remove / settings) + "What the bank said" ledger (`BalanceTimeMachineView`).
+
+**Density:** the proven account-row density (one shared two-line rhythm across all
+account families, T021). Detail is sectioned by spacing, never nested cards.
+
+**Primary actions:** Add account (`⌘N`), Reconnect, Refresh, Remove. **Secondary:**
+"To review" → Review; settings.
+
+**States:** Empty → "No accounts connected" + Connect. Degraded item →
+Status section recovery detail + Reconnect. Loading → shimmer on amounts, name/
+avatar visible. Disconnected → dimmed row + inline Reconnect + "—" amount.
+
+### 5.10 Settings (native Settings scene) — `[⌘,]`
+
+Unchanged: the native macOS `Settings` window, 6 tabs — **General · Accounts ·
+Appearance · Notifications · Privacy · About** — each a grouped `Form`. The shell
+opens it via `⌘,` and the app menu; it is a separate window, as macOS expects. The
+in-shell **Accounts** destination handles the *operational* (reconnect/inspect)
+side; Settings → Accounts keeps the *configuration* side (this is fine — they
+serve different intents and already coexist).
+
+---
+
+## 6. Menu-bar glance spec
+
+The menu bar shrinks from a full workspace to a **glance**: a launcher with status
+and 2–4 metrics. This is the deliberate inversion — the popover stops being where
+work happens.
+
+**What the glance shows (top to bottom):**
+1. **Menu-bar label** (`MenuBarLabel`, unchanged) — the chosen summary mode
+   (Net worth / Total cash / Credit utilization / Recent spend / Icon-only) +
+   optional live signal meter (AND-485). Privacy-mask aware (dots).
+2. **Status line** — data mode (Demo / Sandbox / Production) · server state
+   (Connected / Offline / Syncing / Error) · last-sync freshness. The
+   `ConnectionHealthStripView` condensed to one line.
+3. **2–4 glance metrics** — a tight grid, user-relevant, read-only:
+   - Net cash (or net worth) · highest credit utilization · safe-to-spend ·
+     "N to review". Each is a `dataText` number + a one-word label; attention
+     items (over-utilization, items to review) render as **buttons** that open the
+     window at the right destination.
+4. **Attention chips** — up to 3 `AttentionQueue` rows (reconnect needed, sync
+   error) — tappable, route into the window.
+5. **"Open VaultPeek"** — the primary affordance; `⇧⌘V` also summons. Plus a
+   compact Refresh and a Privacy-Mask toggle (`⌘⇧P`).
+
+**What the glance must NOT do:**
+- No triage (no approve/recategorize/rule) — that is Review in the window.
+- No budget editing, no goal editing, no settings forms.
+- No tables, no charts beyond the menu-bar signal meter, no account inspector.
+- No multi-column layout, no detached-workspace mode.
+- No scrolling lists of transactions.
+- Never present a workflow that can't be finished in the glance — if it needs a
+  decision, the glance routes to the window.
+
+The glance is **read + route**, period. It answers "do I need to open the app?"
+and gets you there in one click. (A future iteration could mirror this as a
+WidgetKit widget + Control Center control reusing the same `Glance` model — the
+App Intents `FinanceSnapshot` already exists.)
+
+---
+
+## 7. Onboarding / first run (windowed)
+
+The existing `SetupView` three-stage flow (Choose → Link-prep → Connecting) is
+sound; it moves from "popover at 480pt" to **the main window's content column with
+the sidebar hidden** until setup completes (the contract's "Setup renders alone"
+rule, generalized).
+
+**Flow:**
+1. **Choose** — window opens centered, sidebar suppressed. App icon + "VaultPeek"
+   + three `OnboardingChoiceButton`s: **View Demo** (instant fixtures) ·
+   **Connect Sandbox** · **Connect Production**. The "Where your data lives"
+   disclosure (`LocalTrustReceiptView`) is present before any link — storage path,
+   credential location, no-cloud statement.
+2. **Link-prep** — storage disclosure + preflight panel (per-check rows: ready /
+   blocked / unknown) + (production) plan preview (`PlanSelectionShell`,
+   count-only). "Open Link" (disabled if preflight blocked) · "Back".
+3. **Connecting** — progress through "Waiting for Plaid Link" → "Item linked" →
+   "First sync" → "Dashboard ready" with `FirstRunCompletionPanel`.
+4. **First success** — sidebar reveals (animated, Reduce-Motion-gated); the window
+   lands on **Dashboard** with `FirstRunSnapshotView` (Cash / Net worth / MTD /
+   Credit + large recent transactions), self-dismissible.
+
+**Empty-state coaching:** newly revealed destinations with no data show
+purposeful empties (Review "Inbox Clear", Budgets "No category spending yet",
+Goals "Create a savings or payoff goal") rather than blank columns — so the
+sidebar teaches the app's vocabulary on first run.
+
+A lightweight **what's-here tour** (optional, dismissible) can highlight the
+sidebar bands and `⌘K` once, the first time the window is shown post-setup.
+
+---
+
+## 8. Accessibility & keyboard-first notes
+
+Per `ACCESSIBILITY.md` and the three-column contract, these are non-negotiable and
+apply to **every** destination:
+
+- **No meaning by color alone.** Already enforced component-by-component
+  (utilization ladder = icon change; income = `+` prefix; pending = "Pending"
+  text; status bars = verdict text + glyph; selection = native highlight + state
+  announced). The shell adds: **sidebar badges are text counts, not color dots;
+  attention/severity always carry a glyph + label; over-budget and behind-pace
+  verdicts are text-first.**
+- **VoiceOver.** Each destination is a labeled landmark; the sidebar announces
+  destination + badge ("Review, 4 items to review"). The Review triage loop
+  announces every action ("Approved {merchant}") and the inspector announces
+  "Shows transaction detail." Charts ship audio graphs
+  (`ChartAudioGraphDescriptor`) and a summary string ("Spending by category.
+  Largest: {category} at {percent}.").
+- **Keyboard-first / focus order.** Sidebar → content → detail is the tab order;
+  `⌘1–8` jump destinations; `⌘K` reaches any action; `↑/↓` + `Return` drive lists;
+  `Esc` clears-then-dismisses; the Review per-row keys work only with list focus
+  (never global, so search fields are safe). Every inspector close affordance has
+  a label and a focus stop. No action is mouse-only.
+- **Reduce Motion.** Column reveal, sidebar collapse, selection transitions, chart
+  entry, and the matched-geometry filter reflow (AND-577) all route through
+  `MotionTokens.animation(_:reduceMotion:)` — opacity instead of slide/spring when
+  on.
+- **Contrast / Increase Contrast / Reduce Transparency.** Honor the
+  `AppContrastPreference` and the transparency slider; the glass backdrop must
+  degrade to a legible solid under Reduce Transparency (the audit's open P2 — the
+  shell should dim *under* the glass, not paint over it).
+- **Text size & density.** macOS ignores system Dynamic Type, so the
+  `TextSizePreference` lever and Comfortable/Compact `AppDensityPreference` are the
+  knobs; the largest steps must reflow, not clip — the multi-pane layout makes this
+  easier than the fixed-width popover did.
+- **Privacy as accessibility of trust.** Privacy Mask and App Lock gate every
+  destination uniformly; masked surfaces keep structure (so VoiceOver users still
+  get layout) while withholding values, and the command palette / search hide
+  merchant names while masked.
+
+---
+
+## 9. Migration sequencing (non-normative)
+
+A suggested order so the shell can land incrementally without a big-bang rewrite
+(each step ships behind the existing strict-concurrency gate):
+
+1. **Shell skeleton** — `AppShellView` (NavigationSplitView) + `SidebarView` +
+   `NavigationModel`, hosting the *existing* dashboard as the Dashboard
+   destination. Window becomes primary; popover reduced to the glance.
+2. **Lift satellites into destinations** — Review (from `ReviewTableWindow` +
+   `ReviewInboxView`), Budgets (from `CategoryDashboardWindow`), Planning (from
+   `RecurringPaymentsView` + charts), Accounts (from `AccountDetailFlyout` +
+   `AccountSettingsView`). Retire the satellite `NSWindow` coordinators.
+3. **New destinations** — Transactions (ledger framing), Alerts (over existing
+   notification/watchlist models), Insights (receipts + weekly review).
+4. **Command palette + global command menus** — `⌘K`, `CommandRegistry`,
+   `AppCommands`.
+5. **Goals** — the one genuinely new feature; pure `Goal*` models in Core first,
+   then the destination.
+6. **Polish** — Reduce-Transparency degradation, density reflow at large text,
+   widget/Control Center parity for the glance.
+
+This document governs the *target IA*; the sequencing above is a path, not a
+contract.

--- a/docs/strategy/macos26-migration/ADR-001-window-first-architecture.md
+++ b/docs/strategy/macos26-migration/ADR-001-window-first-architecture.md
@@ -1,0 +1,153 @@
+# ADR-001: VaultPeek Window-First Hybrid Architecture
+
+- **Status:** Proposed (awaiting ratification by Felipe Chaves at Gate 0)
+- **Date:** 2026-06-19
+- **Supersedes:** the product-model decision in AND-384 ("popover-primary, polish
+  only; NOT desktop-first / Window scene") and the v1.0 roadmap "Menu Bar First"
+  guardrail, **to the extent they forbid a primary window**.
+- **Preserves:** the security, concurrency, and local-first decisions of AND-384
+  and all prior ADR-equivalent decisions (see §"What we explicitly preserve").
+- **Related:** [00-executive-recommendation.md](00-executive-recommendation.md),
+  [survives-vs-rebuilds-matrix.md](survives-vs-rebuilds-matrix.md)
+
+---
+
+## Context
+
+AND-384 (2026-06-14) decided VaultPeek would stay **popover-primary** and treat any
+"large canvas / persistent workspace" with skepticism — explicitly declining a
+desktop-first `Window` scene. That decision was correct *for the MVP*: it minimized
+surface area and shipped fast.
+
+Since then, three facts changed the ground under that decision:
+
+1. **The product grew session workflows.** Transaction review triage, multi-select
+   bulk recategorization, category budgets, weekly review, and reconciliation all
+   shipped. These are multi-step, dwell-time workflows — not glance-and-dismiss.
+
+2. **The code already went multi-window.** Three real `NSWindow` surfaces ship
+   today (detached dashboard AND-384, Category Dashboard AND-539, Review Table
+   AND-532), each with vibrancy, frame autosave, activation elevation, and App-Lock
+   observation. A `DashboardPresentation` enum already renders the main view
+   host-agnostically. **The doctrine says popover-first; the binary ships windows.**
+
+3. **The macOS 26 platform layer already landed.** AND-508–515 adopted Liquid
+   Glass, App Intents, WidgetKit, SwiftData, and Dynamic Type. The platform
+   migration is done; only the *product-model* migration was deliberately declined.
+
+This ADR resolves the doctrine-vs-code divergence and formalizes the architecture
+the product has been drifting toward.
+
+---
+
+## Decision
+
+**VaultPeek adopts a window-first hybrid architecture on a macOS 26 floor:**
+
+- A **dedicated primary `Window` scene** becomes the main experience: a
+  `NavigationSplitView` shell (sidebar → content → optional detail/inspector) with
+  destinations Dashboard, Transactions, Budgets, Planning, Goals, Review Inbox,
+  Insights, Alerts, Accounts, Settings. Keyboard-first, command-palette (⌘K)
+  navigable, Liquid-Glass-polished on chrome only.
+- The **`MenuBarExtra` glance is retained as a first-class, reduced surface**:
+  status, sync state, 2–4 glance metrics, attention chips that deep-link into the
+  window, and "Open VaultPeek." **Read + route only.**
+- The existing **imperative AppKit window controllers are migrated to declarative
+  scenes** and their workflows fold back into sidebar destinations.
+- **`PlaidBarCore`, the server, the Plaid client, the Keychain vault, and the
+  localhost auth boundary are unchanged.**
+
+The menu bar becomes an **entry point into** the primary experience, not the
+primary experience itself.
+
+---
+
+## Options considered
+
+### Option A — Keep popover-primary (status quo doctrine) — REJECTED
+Honor AND-384 literally; treat the shipped windows as exceptions; do not build a
+navigation shell.
+- **Pro:** zero migration cost; preserves the purest glance identity.
+- **Con:** the doctrine already does not match the code; session workflows remain
+  cramped in an auto-dismissing popover; the divergence keeps regenerating risk
+  (next agent "reverts" or re-adds windows ad hoc). Does not scale to the roadmap.
+
+### Option B — Window-only (delete the menu-bar surface) — REJECTED
+Become a conventional `.regular` dock app; drop the glance.
+- **Pro:** simplest mental model; full dock/Stage Manager citizenship.
+- **Con:** forfeits VaultPeek's **only uncontested moat** — the "local-first +
+  glanceable" quadrant (`pricing-and-launch.md`). The ambient glance is the
+  differentiator vs. Copilot/Monarch. Throwing it away to win a crowded quadrant is
+  strategically backwards.
+
+### Option C — Window-first hybrid — **CHOSEN**
+Primary window + retained glance. See Decision above.
+- **Pro:** matches the code; unlocks the session workflows; preserves the moat;
+  ~55% of the system survives untouched; precedent-aligned (Fantastical/Bartender/
+  MoneyMoney).
+- **Con:** requires discipline to keep the glance from re-bloating; doctrine must
+  be rewritten; introduces a net-new navigation layer (the one real build cost).
+
+### Option D — "Do not migrate; delete the drift" (the counter-case) — REJECTED, conditionally
+Delete two of the three windows; recommit to glance-only; deprecate session
+workflows.
+- **Pro:** maximal doctrinal purity; smallest maintenance surface.
+- **Con:** deletes shipped, working, multi-step workflows users value; discards
+  already-merged windowing investment; mistakes "the build loop overshot" for "the
+  product should be smaller."
+- **Wins only if** the product is deliberately re-scoped to ambient-glance-only
+  with no session workflows — a product-scope call for the decision owner, not an
+  architecture call. Recorded here so the choice is explicit, not implicit.
+
+---
+
+## What we explicitly preserve (do NOT touch)
+
+These were correct and remain correct; the migration must not regress them.
+
+1. **Two-process security boundary.** UI talks only to `127.0.0.1`; the server owns
+   Plaid `client_secret` / `access_token`; SQLite holds only `keychain:<item_id>`
+   references; tokens live in the Keychain vault (now `ThisDeviceOnly`, AND-572).
+   *The single decision in the repo with a written rationale — form-factor independent.*
+2. **Core-centric, `Sendable`, TDD'd logic in `PlaidBarCore`.** Strict-concurrency
+   (`-strict-concurrency=complete -warnings-as-errors`) is the CI gate. New finance
+   logic (e.g., Goals) lands in Core as pure Sendable types.
+3. **Local-first, no hosted backend, no telemetry** (ratified 2026-06-14).
+4. **Single drill-in, no tab tree** (AND-312); recovery-first UX; accessibility
+   rules (never encode meaning via color alone; Privacy Mask; redacted glance
+   snapshots; audio graphs).
+
+---
+
+## Consequences
+
+**Positive**
+- Doctrine and code reconverge; future agents stop oscillating.
+- Session workflows get the canvas they need (3-column density = the original
+  RepoBar/CodexBar north star, physically impossible in one popover).
+- Spotlight/Siri/Shortcuts/widgets reach expands via App Intents.
+- ~55% of the system (Core + server + boundary) is provably out of scope.
+
+**Negative / costs**
+- A net-new navigation shell and `AppState` UI-state decomposition (the only real
+  build risk — see [risk-register.md](risk-register.md) R-02).
+- Activation-policy logic must be retired cleanly (the most-patched area in repo
+  history — R-01).
+- The menu-bar glance must be actively defended from re-bloat forever (guardrail 1).
+
+**Migration approach**
+- **Dual-run behind a feature flag.** The window and the existing popover coexist
+  until the window reaches parity. The popover/legacy windows are removed only in
+  Epic 9, last.
+- **Reversibility:** until Epic 9, reverting is flipping the flag. After Epic 9,
+  reverting requires restoring the popover host — so Epic 9 is gated on a parity
+  sign-off.
+
+---
+
+## Ratification
+
+This ADR takes effect only when the decision owner completes **Gate 0**
+(see [00-executive-recommendation.md §8](00-executive-recommendation.md#8-what-the-decision-owner-must-decide-at-gate-0)):
+ratify, confirm session-workflow scope, approve the doctrine update, and approve
+the macOS 26 floor. Until then: **Proposed**.

--- a/docs/strategy/macos26-migration/README.md
+++ b/docs/strategy/macos26-migration/README.md
@@ -1,0 +1,64 @@
+# VaultPeek macOS 26 — Window-First Architecture Evaluation
+
+**Date:** 2026-06-19 · **Status:** Proposed (pending ratification) · **Supersedes the product-model half of AND-384**
+
+This folder is the formal evaluation of whether VaultPeek should evolve from a
+menu-bar **popover-primary** application into a full native macOS 26 application
+where the primary experience lives in a dedicated window and the menu bar becomes
+a launcher + glance surface. It was produced by a 5-agent parallel research pass
+plus synthesis.
+
+## The one-sentence answer
+
+**Yes — adopt a window-first *hybrid* — but understand that this is a
+*consolidation of what VaultPeek already shipped*, not a risky greenfield
+migration.** The app is already multi-window in code; only its doctrine, its
+navigation shell, and one declarative scene are missing.
+
+## Read in this order
+
+| # | Document | Deliverable |
+|---|----------|-------------|
+| 00 | [Executive Recommendation](00-executive-recommendation.md) | Exec rec · effort · sequence · survives/rebuilds % |
+| — | [ADR-001: Window-First Architecture](ADR-001-window-first-architecture.md) | ADR replacing AND-384 |
+| 01 | [Current-State Architecture](01-current-state-architecture.md) | Architecture assessment · tech debt · complexity |
+| 02 | [Product Strategy](02-product-strategy.md) | Product recommendation · UX tradeoffs · platform strategy |
+| 03 | [Repository Archaeology](03-archaeology.md) | History · lessons · migration risks |
+| 04 | [macOS 26 Platform Research](04-platform-research.md) | Best practices · recommended patterns · UX opportunities |
+| 04a | [Apple Docs Verification (sosumi.ai)](04a-apple-docs-sosumi.md) | Authoritative Apple-docs confirmation of 04 |
+| 05 | [Information Architecture](05-information-architecture.md) | IA · navigation model · screen hierarchy · principles |
+| — | [Survives vs Rebuilds Matrix](survives-vs-rebuilds-matrix.md) | What survives / adapts / rebuilds |
+| — | [Migration Roadmap](migration-roadmap.md) | Phased roadmap + sequencing |
+| — | [Risk Register](risk-register.md) | Risks, likelihood, impact, mitigation |
+
+## Linear
+
+Filed under team **Andeslab (AND)**, project
+[VaultPeek macOS 26 — Window-First Architecture](https://linear.app/andeslab/project/vaultpeek-macos-26-window-first-architecture-80d1c1afaa2c)
+— 11 epics + 30 sub-issues, all in **Backlog pending Gate 0**, with dependencies,
+acceptance criteria, technical/design notes, and sequencing.
+
+| Epic | Linear | Sub-issues |
+|------|--------|-----------|
+| Gate 0 — Decision & Doctrine | AND-578 | AND-589, 590 |
+| 1 — Application Shell | AND-579 | AND-591, 592, 593 |
+| 2 — Navigation Architecture | AND-580 | AND-594, 595, 596, 597 |
+| 3 — Window Lifecycle Migration | AND-581 | AND-598, 599, 600 |
+| 4 — Transaction Workspace | AND-582 | AND-601, 602, 603 |
+| 5 — Planning & Budgeting (+ Goals) | AND-583 | AND-604, 605, 606 |
+| 6 — Review Inbox | AND-584 | AND-607, 608, 609 |
+| 7 — Insights & Intelligence | AND-585 | AND-610, 611 |
+| 8 — Widgets & App Intents | AND-586 | AND-612, 613, 614 |
+| 9 — Menu Bar Simplification | AND-587 | AND-615, 616 |
+| 10 — Liquid Glass Polish | AND-588 | AND-617, 618 |
+
+Critical path: **AND-578 → 579 → 580 → 581 → {582, 583, 584, 585} → 587**.
+
+## How to challenge this
+
+Every document includes the strongest counter-argument to its own conclusion.
+The headline counter-case — *"the autonomous build loop overshot the popover
+doctrine; the disciplined move is to delete windows, not bless them"* — is taken
+seriously and rebutted explicitly in
+[00](00-executive-recommendation.md#the-honest-counter-case) and the ADR's
+rejected options. If you disagree, that is the section to attack.

--- a/docs/strategy/macos26-migration/migration-roadmap.md
+++ b/docs/strategy/macos26-migration/migration-roadmap.md
@@ -1,0 +1,108 @@
+# Migration Roadmap & Sequencing
+
+Phased plan for the window-first hybrid ([ADR-001](ADR-001-window-first-architecture.md)).
+Each epic maps to a Linear epic (team **Andeslab / AND**, project **"VaultPeek
+macOS 26 — Window-First Architecture"**). Effort key: S ≤2d · M ~1wk · L ~2–3wk · XL >3wk.
+
+---
+
+## Gate 0 — Decision & doctrine (blocks everything)
+
+Not an epic — a ratification gate owned by Felipe.
+
+- Ratify ADR-001 (or choose the counter-case / status quo).
+- Confirm session-workflow scope stays in-product.
+- Update doctrine **in lockstep**: `docs/mvp-launch-decision-log.md`,
+  `docs/post-mvp-roadmap.md`, `docs/v1.0-roadmap.md`, `CLAUDE.md`, `GOAL.md`,
+  `PRD.md` — replace "popover-primary" with "window-first hybrid" and link ADR-001.
+- Approve macOS 26 "Tahoe" as the hard minimum OS.
+
+**Exit criteria:** ADR-001 status → Accepted; doctrine PR merged. No code epic
+starts before this.
+
+---
+
+## Phase 1 — Foundation
+
+### Epic 1 — macOS 26 Application Shell  *(M–L)*
+Declarative `Window("VaultPeek", id: "main")` scene + `AppShellView`
+(`NavigationSplitView`), `MenuBarExtra(style:.window)` retained, `Settings` scene,
+`.defaultLaunchBehavior(.suppressed)` + `.restorationBehavior(.automatic)`,
+`.containerBackground(.ultraThinMaterial, for:.window)`, single tested
+`@MainActor` activation-policy helper. **Feature-flagged on; popover still default.**
+Blocks: 2, 3. Blocked by: Gate 0.
+
+### Epic 2 — Navigation Architecture Refactor  *(L)*
+Typed `Route` enum, single `@Observable NavigationModel` replacing scattered
+`@AppStorage`; sidebar (4 groups: Overview / Workflows / Insights / Money /
+System) with text-count badges; 2-col vs 3-col policy per destination;
+`⌘K` command palette (`CommandRegistry`) + `CommandMenu`/`CommandGroup` global
+keymap; deep-linking + selection restoration. Blocks: 4–9. Blocked by: 1.
+
+### Epic 3 — Window Lifecycle Migration  *(L)*
+Migrate imperative AppKit controllers (detached dashboard, Category Dashboard,
+Review Table) to the declarative scene + destinations; retire
+`AppActivationPolicyCoordinator` refcounting (R-01) and `PopoverWindowAnchor`;
+per-window state via `NavigationModel` (not view `@AppStorage`); frame autosave /
+restoration. Blocks: 4, 5, 6. Blocked by: 1, 2.
+
+---
+
+## Phase 2 — Workspaces *(parallelizable once Phase 1 lands)*
+
+### Epic 4 — Transaction Workspace  *(L)*
+Dense, keyboard-navigable `Table`; filters + search; inspector (3-col); reuse
+existing transaction components; large-history virtualization + paged fetch
+(already shipped) wired to the table. Blocked by: 2, 3.
+
+### Epic 5 — Planning & Budgeting Workspace  *(L)*
+Budgets (category tree, `BudgetEditorSheet`, status bars), Planning canvas,
+safe-to-spend; override-aware spend math (reuse Core). 2-col Planning, 3-col
+Budgets. Blocked by: 2, 3.
+
+### Epic 6 — Review Inbox  *(M–L)*
+Consolidate the detached Review Table into a first-class destination: date-sectioned
+list ↔ triage detail; single-key actions (A/C/T/R/M/I) with undo + haptics +
+auto-advance; inline "always categorize…" rule prompt; Triage|Table mode with the
+existing bulk engine + blast-radius confirmation. Blocked by: 2, 3.
+
+### Epic 7 — Insights & Intelligence  *(M)*
+Insights destination surfacing Foundation Models `@Generable` streaming insights +
+weekly review + LocalAIInsightReceipt; trend/donut/heatmap charts with
+`AXChartDescriptor` audio graphs. Blocked by: 2. Related: 4, 5.
+
+---
+
+## Phase 3 — Reach, simplification, polish
+
+### Epic 8 — Widgets & App Intents  *(M)*
+Expand WidgetKit families + interactive widgets; `AppIntentsPackage` in
+`PlaidBarCore` (reused by app/widget/Siri/Spotlight); `SnippetIntent` mini-dashboard
+in Spotlight; investigate `ControlWidget` (verify macOS availability). App-Group
+shared SwiftData store. Blocked by: 2. Related: 1.
+
+### Epic 9 — Menu Bar Simplification  *(M)*  — **SHIPS LAST**
+Reduce the popover to glance-only (status, sync, 2–4 metrics, attention chips,
+"Open VaultPeek"); remove migrated workflows from the popover; flip the default
+from popover to window; remove the dual-run flag. **Gated on a window-parity
+sign-off.** Blocked by: 4, 5, 6, 7 (parity).
+
+### Epic 10 — Liquid Glass Polish  *(M, continuous)*
+Apply Liquid Glass to chrome only (sidebar/toolbar/nav), never data; group with
+`GlassEffectContainer`; `reduceTransparency` solid fallbacks; motion polish
+(matched-geometry reflow already shipped); final a11y pass (Dynamic Type, audio
+graphs, Privacy Mask gating uniform across windows). Runs alongside 1–9; finalized
+last. Blocked by: 1 (starts), 9 (finalizes).
+
+---
+
+## Critical path
+
+`Gate 0 → Epic 1 → Epic 2 → Epic 3 → (Epics 4/5/6 parallel) → Epic 7 → Epic 9`.
+Epics 8 and 10 run alongside and do not gate the critical path (10 finalizes after 9).
+
+## Dual-run / reversibility
+
+Epics 1–8 are reversible by flipping the feature flag (window hidden, popover
+default). Epic 9 removes the popover path and is therefore **gated on parity** —
+the point of no easy return.

--- a/docs/strategy/macos26-migration/risk-register.md
+++ b/docs/strategy/macos26-migration/risk-register.md
@@ -1,0 +1,27 @@
+# Risk Register — Window-First Migration
+
+Likelihood (L) / Impact (I): Low / Med / High. Sourced from the archaeology
+([03](03-archaeology.md)), architecture audit ([01](01-current-state-architecture.md)),
+and platform research ([04](04-platform-research.md)).
+
+| ID | Risk | L | I | Mitigation | Owner/Epic |
+|----|------|---|---|------------|-----------|
+| **R-01** | **Activation-policy thrash.** `.accessory↔.regular` is the most-repeatedly-patched area in repo history; window-primary changes its semantics and stale refcounting can strip the dock icon or wedge the window. | High | High | Window-primary *simplifies* this; replace the refcount coordinator with one tested `@MainActor` helper; integration test the accessory→regular→accessory cycle. | Epic 3 |
+| **R-02** | **`AppState` decomposition overruns.** 4,213-LOC, ~67-prop, non-`Sendable` god object with hard single-surface flags; the split is the highest-uncertainty work. | Med | High | Decompose incrementally behind the flag; extract per-window `@Observable` nav/selection models first; keep `AppState` as a façade until callers migrate; lean on strict-concurrency CI to catch leaks. | Epic 2/3 |
+| **R-03** | **Translucency host surgery regressions.** True read-through required abandoning the `MenuBarExtra` host for a non-opaque `NSWindow` + behind-window `NSVisualEffectView`; SwiftUI-native glass did *not* read through (C4 spike). | Med | Med | Reuse the already-shipped window vibrancy approach verbatim; do not re-attempt SwiftUI-only glass for read-through; snapshot-test appearance. | Epic 1/10 |
+| **R-04** | **Appearance cascade / first-paint flash.** `NSApp.appearance` must be the single authoritative owner set before first paint or windows flash wrong theme. | Med | Med | Centralize appearance ownership in the shell scene init; assert in a launch test. | Epic 1 |
+| **R-05** | **Doc/code divergence regenerates.** The next agent "reverts" window work citing stale "popover-primary" docs (this is *why* we are here). | High | High | Gate 0 updates all doctrine in lockstep; ADR-001 linked from CLAUDE.md/GOAL.md/decision log; no code epic before doctrine merges. | Gate 0 |
+| **R-06** | **Glance re-bloat.** "Menu-bar-first" already eroded once; the reduced glance silently re-accretes workflows and VaultPeek becomes "a slower Copilot with a menu-bar icon," forfeiting the local-first+glanceable moat. | Med | High | Guardrail 1 (glance = read+route only) encoded as a contract doc + PR-review checklist; Epic 9 defines the allowed glance surface explicitly. | Epic 9 |
+| **R-07** | **macOS 27 / WWDC26 API misuse.** Reorderable containers, toolbar-overflow, sectioned `@Query`, `ResultsObserver`/`HistoryObserver` are macOS 27 *beta* (June 2026); using them unguarded breaks the macOS 26 floor. | Med | High | macOS 26 "Tahoe" is the hard floor; gate every macOS 27 symbol behind `if #available(macOS 27,*)`; CI builds against the macOS 26 SDK. | All |
+| **R-08** | **Accessibility degradation under Liquid Glass.** Custom translucency + charts can fail VoiceOver/Reduce-Transparency, blocking the Accessibility Nutrition Label claim. | Med | High | `reduceTransparency` solid fallback on every glass/`NSVisualEffectView` surface; `AXChartDescriptor` audio graph on every chart (already shipped for trend/donut/heatmap — extend coverage). | Epic 10/7 |
+| **R-09** | **Parity gap at popover removal.** Removing the popover (Epic 9) before the window truly matches strands users mid-workflow. | Low | High | Dual-run behind a flag through Epics 1–8; Epic 9 gated on an explicit parity sign-off checklist. | Epic 9 |
+| **R-10** | **Per-window state correctness.** UI filter/selection lives in view-level `@AppStorage` today, which cannot represent two windows with different selections. | Med | Med | Move selection/filter into `NavigationModel` scoped per window scene; test two simultaneous windows. | Epic 2 |
+| **R-11** | **Widget/App-Group store contention.** Sharing the SwiftData store with the widget across an App Group can race the app's writes. | Low | Med | Read-only widget access to a snapshot; reuse the disposable read-model cache; document write ownership. | Epic 8 |
+| **R-12** | **Scope creep into the security boundary.** A tempting "while we're here" change to the server/auth during UI work. | Low | High | ADR-001 explicitly fences Core + server + boundary out of scope; reject such changes in review. | All |
+| **R-13** | **`openSettings()` from `.accessory` regression** reported on macOS 26. | Low | Med | Validate on hardware early in Epic 1; fall back to programmatic Settings window if needed. | Epic 1 |
+
+## Top 3 to watch
+
+1. **R-05 doc/code divergence** — the root cause of this whole exercise; fix at Gate 0 or the work gets reverted.
+2. **R-01 activation-policy thrash** — historically the most fragile code; concentrated in Epic 3.
+3. **R-06 glance re-bloat** — the strategic failure mode that quietly destroys the moat even if every epic "succeeds."

--- a/docs/strategy/macos26-migration/survives-vs-rebuilds-matrix.md
+++ b/docs/strategy/macos26-migration/survives-vs-rebuilds-matrix.md
@@ -1,0 +1,67 @@
+# Survives vs Rebuilds Matrix
+
+Source: [01-current-state-architecture.md](01-current-state-architecture.md) (architecture audit) + synthesis.
+Effort key: **S** ≤2d · **M** ~1wk · **L** ~2–3wk · **XL** >3wk. Verdicts:
+**Survives** (use as-is) · **Adapts** (modify/wrap) · **Rebuilds** (net-new).
+
+## Summary
+
+| Bucket | ~Weight | Risk |
+|--------|--------|------|
+| Survives as-is | ~55% | None — out of migration scope |
+| Adapts | ~30% | Low–Medium |
+| Rebuilds (net-new) | ~15% | Medium (concentrated in navigation + AppState) |
+
+The migration **never crosses the security boundary** and **never touches
+`PlaidBarCore`** (~45% of LOC). The two most expensive things to get wrong are out
+of scope by construction.
+
+---
+
+## What Survives (as-is)
+
+| Subsystem | Verdict | Effort | Notes |
+|-----------|---------|--------|-------|
+| Server process (`PlaidBarServer`) | Survives | — | Separate process behind localhost HTTP; a UI pivot cannot reach it |
+| Plaid client + token vault + `APITokenMiddleware` | Survives | — | Security boundary; explicitly out of scope |
+| Keychain storage / SQLite item store / sync cursors | Survives | — | No schema change required |
+| **`PlaidBarCore` (~25K LOC, ~45% of source)** | Survives | — | Sendable, TDD'd; summaries, formatters, recurring detection, sync reduction, presentation mapping. New logic adds here |
+| Background services (RefreshService, SyncService, energy-aware scheduling, NotificationService, LaunchService) | Survives | S | Window model changes *callers*, not the services |
+| JSON read-model cache / SwiftData disposable cache (read path) | Survives | S | Cold-render cache pattern carries over |
+| Widget extension (`PlaidBarWidgetExtension`) | Survives | S | Expands in Epic 8; foundation unchanged |
+| Local AI tiers (NaturalLanguage → Foundation Models, `@Generable` insights) | Survives | — | Service layer; UI surfaces consume it |
+| Design tokens / Typography / 8pt grid (`Theme/`) | Survives | — | Reused by the shell |
+| ~30 view components (AccountDetailFlyout, ReviewInboxView, CategoryTreeView, CategoryStatusBar, BudgetEditorSheet, SafeToSpendCard, all `Charts/`, WeeklyReviewCard, LocalAIInsightReceipt, SettingsView) | Survives | S | Re-hosted into destinations; internals intact |
+
+## What Adapts (modify / wrap)
+
+| Subsystem | Verdict | Effort | Notes |
+|-----------|---------|--------|-------|
+| Existing window controllers (Detached dashboard, Category Dashboard, Review Table) | Adapts | M | Imperative AppKit → declarative scenes / destinations; the *hard* windowing (vibrancy, autosave, activation) is already solved and reused |
+| `MenuBarExtra` item + `MenuBarExtraAccess` + badge/context-menu controllers | Adapts | M | Reduced to glance-only; status item logic mostly retained |
+| `DashboardPresentation` host-switching enum | Adapts | S | Already exists to render host-agnostically — extend, don't invent |
+| `AppActivationPolicyCoordinator` (.accessory↔.regular refcount) | Adapts | M | Window-primary *simplifies* this; retire obsolete refcounting carefully (R-01) |
+| SwiftData read-model cache (write/coordination path) | Adapts | M | Per-window contexts; App-Group sharing for widget |
+| `MainPopover` (2,712 LOC, 4 hosts today) | Adapts | L | Decompose into destination views; reuse subviews |
+| Demo/Sandbox/Production mode plumbing | Adapts | S | Surfaced in shell footer + Settings |
+
+## What Rebuilds (net-new)
+
+| Subsystem | Verdict | Effort | Notes |
+|-----------|---------|--------|-------|
+| **Navigation hierarchy** (sidebar, `NavigationSplitView` 2/3-col, `NavigationStack`, typed `Route`, deep-linking) | Rebuilds | L | None exists today — flat `@AppStorage` filter band only. The core build cost |
+| **Command palette (⌘K)** + `CommandMenu`/`CommandGroup` keyboard map | Rebuilds | M | No centralized command structure today |
+| **`AppState` UI-state decomposition** | Rebuilds | L | 4,213 LOC god object, ~67 props, not Sendable, single-surface flags (`isPopoverPresented`, `isDashboardDetached`); split into per-window `@Observable` navigation/selection models. Highest-uncertainty item (R-02) |
+| Menu-bar **popover → glance** reduction | Rebuilds | M | Ships LAST (Epic 9, guardrail); glance view is small but the removal is gated on parity |
+| **Goals** destination + Core logic | Rebuilds | M | The one genuinely new feature; finance math lands in `PlaidBarCore` |
+| `PopoverWindowAnchor` (host-window surgery) | Rebuilds→Delete | S | Fragile workaround; disappears under a real window model |
+| Onboarding/first-run in a windowed model | Rebuilds | S | Re-host existing FirstRunSnapshotView into the shell |
+
+---
+
+## Reading the percentages
+
+These are *judgment* weights by subsystem importance, not LOC. By raw LOC the
+"survives" share is higher still (Core alone is ~45%). The point is directional and
+robust: **the migration is bounded to the app target's presentation layer, and the
+genuinely net-new work is one navigation shell plus an `AppState` split.**


### PR DESCRIPTION
## Summary

A 5-agent evaluation of whether VaultPeek should pivot from menu-bar **popover-primary** (AND-384) to a full native **macOS 26 window-first** app. **This PR adds evaluation deliverables only — no code changes.**

**Recommendation: window-first hybrid (High confidence)** — promote a dedicated native window to the primary experience; reduce the menu bar to a first-class glance + launcher (read + route only).

Key reframe: VaultPeek is **already multi-window in code** (detached dashboard AND-384, Category Dashboard AND-539, Review Table AND-532) and already on the macOS 26 platform layer (AND-508–515). So this is a **consolidation, not a greenfield migration.**

- Survives ~55% (all of `PlaidBarCore`, the server, the Plaid/Keychain/auth boundary — untouched) / Adapts ~30% / Rebuilds ~15%
- Risk: Medium (isolated to the app target) · Effort: ~12–16 engineer-weeks

## What's in this PR (`docs/strategy/macos26-migration/`)
- `ADR-001-window-first-architecture.md` — supersedes AND-384's product-model decision (status: **Proposed**)
- `00-executive-recommendation.md`, `survives-vs-rebuilds-matrix.md`, `migration-roadmap.md`, `risk-register.md`
- 5 research reports: `01` architecture · `02` product · `03` archaeology · `04` platform (+ `04a` Apple-docs verified via sosumi.ai) · `05` information architecture
- `README.md` — index + Linear mapping

## Blocked on Gate 0 (a decision, not code)
This is a proposal. It is gated on **AND-578**: ratify ADR-001, confirm session-workflow scope, approve the doctrine update (decision log / roadmap / CLAUDE.md / GOAL.md / PRD.md), approve macOS 26 "Tahoe" as the floor. No epic starts until then; nothing is implemented.

The honest counter-case ("the build loop overshot; delete windows instead") is recorded in ADR-001's rejected options — it only wins if the product is re-scoped to glance-only.

## Linear
Project **VaultPeek macOS 26 — Window-First Architecture** · Gate 0 **AND-578** · Epics **AND-579..588** · sub-issues **AND-589..618** (all Backlog, pending Gate 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
