### PR TITLE
feat(viz): dashed recurring-spend committed ghost segment on category status bars (AND-559)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1362,7 +1362,8 @@ final class AppState {
             budgets: categoryBudgets,
             asOf: Date(),
             metadata: transactionReviewMetadata,
-            rules: transactionRules
+            rules: transactionRules,
+            recurring: recurringTransactions
         )
         _cachedCategoryDashboardPresentation = presentation
         return presentation

--- a/Sources/PlaidBar/Views/CategoryStatusBar.swift
+++ b/Sources/PlaidBar/Views/CategoryStatusBar.swift
@@ -48,6 +48,25 @@ struct CategoryStatusBar: View {
                             )
                     }
                 }
+                // Committed-recurring "ghost" segment (AND-559): a dashed outline
+                // spanning the share of the budget already spoken-for by detected
+                // recurring bills. The dash *pattern* — not a color — distinguishes
+                // it from the solid actual-spend fill; the amount is also voiced in
+                // the accessibility sentence, so it never reads by color alone.
+                .overlay(alignment: .leading) {
+                    if let committedFraction = model.committedFraction {
+                        Capsule()
+                            .strokeBorder(
+                                .secondary,
+                                style: StrokeStyle(lineWidth: 1.5, dash: [3, 2])
+                            )
+                            .frame(width: max(proxy.size.width * committedFraction, 3))
+                            .animation(
+                                MotionTokens.animation(MotionTokens.content, reduceMotion: reduceMotion),
+                                value: committedFraction
+                            )
+                    }
+                }
         }
         .frame(height: 4)
         .accessibilityHidden(true)

--- a/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
@@ -30,8 +30,18 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
         public let fractionUsed: Double?
         /// Budget band (under/nearing/over); `nil` when there is no budget.
         public let status: CategoryBudgetStatus?
+        /// Monthly-equivalent committed recurring spend mapped to this category
+        /// (``RecurringCommitment``), when at least one recurring stream maps here.
+        /// `nil` = no recurring stream for this category, so no ghost segment
+        /// (AND-559). Always strictly positive when present.
+        public let committed: Double?
 
-        public init(category: SpendingCategory, spent: Double, monthlyLimit: Double?) {
+        public init(
+            category: SpendingCategory,
+            spent: Double,
+            monthlyLimit: Double?,
+            committed: Double? = nil
+        ) {
             self.id = category.rawValue
             self.category = category
             let netSpent = max(0, spent)
@@ -46,11 +56,21 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
                 self.fractionUsed = nil
                 self.status = nil
             }
+            // Only a positive commitment is meaningful; treat 0/negative as none.
+            self.committed = committed.flatMap { $0 > 0 ? $0 : nil }
         }
 
         /// `monthlyLimit - spent` when budgeted; `nil` otherwise.
         public var remaining: Double? {
             monthlyLimit.map { $0 - spent }
+        }
+
+        /// Share of the budget already committed to recurring bills, clamped to
+        /// `0...1`. `nil` when unbudgeted or no recurring stream maps here — so the
+        /// dashed ghost segment is hidden (AND-559).
+        public var committedFraction: Double? {
+            guard let limit = monthlyLimit, limit > 0, let committed else { return nil }
+            return min(1, max(0, committed / limit))
         }
 
         public var isBudgeted: Bool { monthlyLimit != nil }
@@ -76,6 +96,9 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
         /// limit, so a group can be over while every leaf is individually under
         /// (spec §7). `nil` when the group has no budget.
         public let status: CategoryBudgetStatus?
+        /// Sum of the group's leaves' committed recurring spend; `nil` when no leaf
+        /// has a recurring stream (AND-559). Always strictly positive when present.
+        public let committed: Double?
 
         public init(group: CategoryGroup, leaves: [Leaf]) {
             self.id = group.rawValue
@@ -97,11 +120,20 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
                 self.fractionUsed = fraction
                 self.status = CategoryBudgetStatus(fractionUsed: fraction)
             }
+            let totalCommitted = leaves.compactMap(\.committed).reduce(0, +)
+            self.committed = totalCommitted > 0 ? totalCommitted : nil
         }
 
         /// `monthlyLimit - spent` when budgeted; `nil` otherwise.
         public var remaining: Double? {
             monthlyLimit.map { $0 - spent }
+        }
+
+        /// Share of the group budget committed to recurring bills, clamped to
+        /// `0...1`; `nil` when unbudgeted or no leaf has a recurring stream.
+        public var committedFraction: Double? {
+            guard let limit = monthlyLimit, limit > 0, let committed else { return nil }
+            return min(1, max(0, committed / limit))
         }
 
         public var isBudgeted: Bool { monthlyLimit != nil }

--- a/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
@@ -120,7 +120,14 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
                 self.fractionUsed = fraction
                 self.status = CategoryBudgetStatus(fractionUsed: fraction)
             }
-            let totalCommitted = leaves.compactMap(\.committed).reduce(0, +)
+            // Only budgeted leaves contribute to the group's committed total: the
+            // group denominator is the sum of *budgeted* leaves' limits, and an
+            // unbudgeted leaf hides its own ghost, so counting its commitment here
+            // would overstate group budget pressure (addresses Codex review on #573).
+            let totalCommitted = leaves
+                .filter(\.isBudgeted)
+                .compactMap(\.committed)
+                .reduce(0, +)
             self.committed = totalCommitted > 0 ? totalCommitted : nil
         }
 

--- a/Sources/PlaidBarCore/Utilities/CategoryDashboardBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryDashboardBuilder.swift
@@ -74,7 +74,16 @@ public enum CategoryDashboardBuilder {
 
         // Committed monthly recurring spend per category (AND-559). Empty when no
         // recurring streams were supplied, so every leaf's `committed` stays nil.
-        let committedByCategory = recurring.map(RecurringCommitment.monthlyByCategory) ?? [:]
+        // Pass `asOf`/`rules` so stale streams are dropped and the ghost follows the
+        // same override-aware category mapping as spend (addresses Codex review).
+        let committedByCategory = recurring.map {
+            RecurringCommitment.monthlyByCategory(
+                $0,
+                asOf: date,
+                calendar: calendar,
+                rules: rules ?? []
+            )
+        } ?? [:]
 
         // Every leaf that has spend OR a budget appears. Floor net spend at 0 for
         // display so a net-refund leaf reads as 0, not a negative bar — and so leaf,

--- a/Sources/PlaidBarCore/Utilities/CategoryDashboardBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryDashboardBuilder.swift
@@ -38,13 +38,19 @@ public enum CategoryDashboardBuilder {
     ///     bucketed by each row's *effective* override-aware category. Defaults to
     ///     `nil`, which preserves raw-Plaid-category bucketing.
     ///   - rules: optional recategorization rules, applied the same way.
+    ///   - recurring: optional detected recurring streams. When supplied, each
+    ///     leaf carries the monthly-equivalent committed recurring spend mapped to
+    ///     its category (``RecurringCommitment``), surfaced as the dashed "committed"
+    ///     ghost segment on the status bars (AND-559). Defaults to `nil`, so a row
+    ///     with no recurring data simply has no ghost segment.
     public static func build(
         transactions: [TransactionDTO],
         budgets: [SpendingCategory: Double],
         asOf date: Date,
         calendar: Calendar = .current,
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        recurring: [RecurringTransaction]? = nil
     ) -> CategoryDashboardPresentation {
         guard
             let monthStart = CategoryBudgetPlanner.monthStartDate(asOf: date, calendar: calendar),
@@ -66,6 +72,10 @@ public enum CategoryDashboardBuilder {
         // budget" — it must not band a category as over on zero spend (first run).
         let positiveBudgets = budgets.filter { $0.value > 0 }
 
+        // Committed monthly recurring spend per category (AND-559). Empty when no
+        // recurring streams were supplied, so every leaf's `committed` stays nil.
+        let committedByCategory = recurring.map(RecurringCommitment.monthlyByCategory) ?? [:]
+
         // Every leaf that has spend OR a budget appears. Floor net spend at 0 for
         // display so a net-refund leaf reads as 0, not a negative bar — and so leaf,
         // group, and overall totals all sum from the same floored figures.
@@ -85,7 +95,8 @@ public enum CategoryDashboardBuilder {
             let leaf = CategoryDashboardPresentation.Leaf(
                 category: category,
                 spent: spent,
-                monthlyLimit: limit
+                monthlyLimit: limit,
+                committed: committedByCategory[category]
             )
             leavesByGroup[category.group, default: []].append(leaf)
         }

--- a/Sources/PlaidBarCore/Utilities/CategoryStatusBarModel.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryStatusBarModel.swift
@@ -25,17 +25,22 @@ public struct CategoryStatusBarModel: Sendable, Hashable {
     public let fractionUsed: Double?
     /// Budget band; `nil` when there is no budget.
     public let status: CategoryBudgetStatus?
+    /// Monthly-equivalent committed recurring spend for the row; `nil` when no
+    /// recurring stream maps here, so the dashed ghost segment is hidden (AND-559).
+    public let committed: Double?
 
     public init(
         spent: Double,
         monthlyLimit: Double?,
         fractionUsed: Double?,
-        status: CategoryBudgetStatus?
+        status: CategoryBudgetStatus?,
+        committed: Double? = nil
     ) {
         self.spent = spent
         self.monthlyLimit = monthlyLimit
         self.fractionUsed = fractionUsed
         self.status = status
+        self.committed = committed
     }
 
     /// Build from a dashboard leaf rollup.
@@ -44,7 +49,8 @@ public struct CategoryStatusBarModel: Sendable, Hashable {
             spent: leaf.spent,
             monthlyLimit: leaf.monthlyLimit,
             fractionUsed: leaf.fractionUsed,
-            status: leaf.status
+            status: leaf.status,
+            committed: leaf.committed
         )
     }
 
@@ -54,7 +60,8 @@ public struct CategoryStatusBarModel: Sendable, Hashable {
             spent: group.spent,
             monthlyLimit: group.monthlyLimit,
             fractionUsed: group.fractionUsed,
-            status: group.status
+            status: group.status,
+            committed: group.committed
         )
     }
 
@@ -98,6 +105,21 @@ public struct CategoryStatusBarModel: Sendable, Hashable {
         fractionUsed.map { Formatters.percent($0 * 100, decimals: decimals) }
     }
 
+    /// Share of the budget already committed to recurring bills, clamped to
+    /// `0...1`. `nil` when unbudgeted or no recurring stream maps here — so the
+    /// view hides the dashed ghost segment and the accessibility sentence omits it
+    /// (AND-559).
+    public var committedFraction: Double? {
+        guard let limit = monthlyLimit, limit > 0, let committed, committed > 0 else { return nil }
+        return min(1, max(0, committed / limit))
+    }
+
+    /// `"30%"`-style label for the committed-recurring share; `nil` when there is
+    /// no ghost segment. Percent (not currency) keeps it safe under Privacy Mask.
+    public func committedPercentText(decimals: Int = 0) -> String? {
+        committedFraction.map { Formatters.percent($0 * 100, decimals: decimals) }
+    }
+
     /// A single VoiceOver sentence describing the whole row: the spend, the
     /// budget context, and the verdict. The caller prefixes the row's name
     /// (category or group) and may substitute masked currency strings.
@@ -112,6 +134,11 @@ public struct CategoryStatusBarModel: Sendable, Hashable {
             return "\(spentText) spent. No budget set."
         }
         let percentClause = percentUsedText().map { ", \($0) of budget" } ?? ""
-        return "\(spentText) of \(limitText)\(percentClause). \(status.label)."
+        // The dashed ghost segment is also voiced as text so it never reads through
+        // pattern alone (ACCESSIBILITY.md). Percent keeps it Privacy-Mask safe.
+        let committedClause = committedPercentText().map {
+            " \($0) of the budget is committed to recurring bills."
+        } ?? ""
+        return "\(spentText) of \(limitText)\(percentClause). \(status.label).\(committedClause)"
     }
 }

--- a/Sources/PlaidBarCore/Utilities/RecurringCommitment.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringCommitment.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Pure rollup of *committed* monthly recurring spend per category — how much of a
+/// category's budget is already spoken-for by detected recurring bills
+/// (``RecurringDetector``). Feeds the dashed "committed" ghost segment drawn on
+/// the category status bars (AND-559).
+///
+/// Each stream's average charge is normalized to a monthly-equivalent cost via
+/// ``RecurringFrequency/monthlyMultiplier`` (a weekly $10 stream commits
+/// ~$43.33/month), then summed into its ``SpendingCategory``. A stream with no
+/// category, a non-positive amount, or a transfer category contributes nothing — a
+/// transfer is never category spend, mirroring the aggregation contract in
+/// ``EffectiveCategoryResolver``. The result therefore only ever maps a category
+/// to a strictly-positive committed amount, so a consumer can treat "absent" as
+/// "no recurring stream maps here" and hide the ghost segment entirely.
+///
+/// Stateless `enum`, fully deterministic (no hidden `Date()`), and `Sendable`.
+public enum RecurringCommitment {
+    /// Monthly-equivalent committed recurring spend per category. Categories with
+    /// no mapped stream are absent (the caller hides the ghost segment for them),
+    /// and every value is strictly positive.
+    public static func monthlyByCategory(
+        _ streams: [RecurringTransaction]
+    ) -> [SpendingCategory: Double] {
+        var committed: [SpendingCategory: Double] = [:]
+        for stream in streams {
+            guard let category = stream.category,
+                  !EffectiveCategoryResolver.isTransferCategory(category),
+                  stream.averageAmount > 0
+            else { continue }
+            let monthly = stream.averageAmount * stream.frequency.monthlyMultiplier
+            guard monthly > 0 else { continue }
+            committed[category, default: 0] += monthly
+        }
+        return committed
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/RecurringCommitment.swift
+++ b/Sources/PlaidBarCore/Utilities/RecurringCommitment.swift
@@ -7,31 +7,87 @@ import Foundation
 ///
 /// Each stream's average charge is normalized to a monthly-equivalent cost via
 /// ``RecurringFrequency/monthlyMultiplier`` (a weekly $10 stream commits
-/// ~$43.33/month), then summed into its ``SpendingCategory``. A stream with no
-/// category, a non-positive amount, or a transfer category contributes nothing — a
-/// transfer is never category spend, mirroring the aggregation contract in
-/// ``EffectiveCategoryResolver``. The result therefore only ever maps a category
-/// to a strictly-positive committed amount, so a consumer can treat "absent" as
-/// "no recurring stream maps here" and hide the ghost segment entirely.
+/// ~$43.33/month), then summed into its **effective** ``SpendingCategory``.
 ///
-/// Stateless `enum`, fully deterministic (no hidden `Date()`), and `Sendable`.
+/// Mapping mirrors how spend is bucketed so the ghost stays consistent with the
+/// fill and budget row:
+/// - **Override-aware:** a stream's category is resolved through the same
+///   ``EffectiveCategoryResolver`` the planner/dashboard use, so a rule that
+///   recategorizes the merchant (or marks it a transfer / excluded) moves the
+///   committed ghost in lockstep with the spend fill instead of stranding it on the
+///   raw Plaid category.
+/// - **Stale-aware:** when a reference `asOf` date is supplied, a stream the
+///   detector flags as stale (``RecurringTransaction/isStale(asOf:calendar:)`` — a
+///   stopped/canceled subscription) is dropped, so it can't keep a category looking
+///   budget-committed after the charges have stopped.
+///
+/// A stream with no resolved category, a transfer category, an excluded rule, or a
+/// non-positive amount contributes nothing — so "absent" cleanly means "no
+/// recurring stream maps here, hide the ghost". Stateless `enum`, deterministic
+/// (no hidden `Date()`), and `Sendable`.
 public enum RecurringCommitment {
     /// Monthly-equivalent committed recurring spend per category. Categories with
     /// no mapped stream are absent (the caller hides the ghost segment for them),
     /// and every value is strictly positive.
+    ///
+    /// - Parameters:
+    ///   - streams: detected recurring streams.
+    ///   - asOf: optional reference date; when supplied, stale (stopped) streams are
+    ///     dropped. Defaults to `nil` (no stale filtering).
+    ///   - calendar: calendar used for the staleness check (injected for determinism).
+    ///   - rules: recategorization rules applied to each stream's merchant, so the
+    ///     ghost follows user recategorization / transfer / exclude decisions.
     public static func monthlyByCategory(
-        _ streams: [RecurringTransaction]
+        _ streams: [RecurringTransaction],
+        asOf: Date? = nil,
+        calendar: Calendar = .current,
+        rules: [TransactionRule] = []
     ) -> [SpendingCategory: Double] {
         var committed: [SpendingCategory: Double] = [:]
         for stream in streams {
-            guard let category = stream.category,
-                  !EffectiveCategoryResolver.isTransferCategory(category),
-                  stream.averageAmount > 0
+            // Drop streams the detector would consider stale (stopped / canceled)
+            // when a reference date is available.
+            if let asOf, stream.isStale(asOf: asOf, calendar: calendar) { continue }
+            guard stream.averageAmount > 0 else { continue }
+            guard let category = effectiveCategory(for: stream, rules: rules),
+                  !EffectiveCategoryResolver.isTransferCategory(category)
             else { continue }
             let monthly = stream.averageAmount * stream.frequency.monthlyMultiplier
             guard monthly > 0 else { continue }
             committed[category, default: 0] += monthly
         }
         return committed
+    }
+
+    /// The stream's override-aware budget category, or `nil` when it should not
+    /// count (genuinely uncategorized, a transfer, or excluded by a rule).
+    ///
+    /// A recurring stream is a merchant-level aggregate, not a single transaction, so
+    /// only *rules* (which match by merchant) apply — per-transaction review metadata
+    /// has no merchant-level analogue here. We resolve a representative transaction
+    /// through ``EffectiveCategoryResolver`` so the precedence (rule override → raw
+    /// category, transfer/exclude handling) is identical to the spend path.
+    private static func effectiveCategory(
+        for stream: RecurringTransaction,
+        rules: [TransactionRule]
+    ) -> SpendingCategory? {
+        let representative = TransactionDTO(
+            id: "recurring-\(stream.id)",
+            accountId: "",
+            amount: stream.averageAmount,
+            date: stream.lastDate,
+            name: stream.merchantName,
+            merchantName: stream.merchantName,
+            category: stream.category
+        )
+        let resolution = EffectiveCategoryResolver.resolve(
+            transaction: representative,
+            metadata: nil,
+            rules: rules
+        )
+        if resolution.excludedFromBudgets { return nil }
+        // Fall back to the stream's own detected category when the resolver returns
+        // none (no rule, non-confident Plaid category) but the stream did carry one.
+        return resolution.category ?? stream.category
     }
 }

--- a/Tests/PlaidBarCoreTests/CategoryDashboardBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardBuilderTests.swift
@@ -408,4 +408,97 @@ struct CategoryDashboardBuilderTests {
         #expect(result.group(.shopping)?.spent == 100)
         #expect(result.totalSpent == 100)
     }
+
+    // MARK: - Committed recurring ghost segment (AND-559)
+
+    private func monthlyStream(
+        _ merchant: String,
+        amount: Double,
+        category: SpendingCategory
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchant,
+            frequency: .monthly,
+            averageAmount: amount,
+            lastDate: "2026-06-01",
+            nextExpectedDate: "2026-07-01",
+            category: category,
+            transactionCount: 6,
+            confidence: 0.9
+        )
+    }
+
+    @Test("Recurring streams thread committed spend onto the matching leaf and its group")
+    func committedThreadedToLeafAndGroup() {
+        let transactions = [tx(200, "2026-06-03", .subscriptions)]
+        let result = CategoryDashboardBuilder.build(
+            transactions: transactions,
+            budgets: [.subscriptions: 100],
+            asOf: now,
+            calendar: calendar,
+            recurring: [monthlyStream("Netflix", amount: 30, category: .subscriptions)]
+        )
+
+        let leaf = result.leaf(.subscriptions)
+        #expect(leaf?.committed == 30)
+        // 30 committed against a 100 budget = 0.3 of the bar.
+        #expect(leaf?.committedFraction == 0.3)
+
+        // The group rollup sums its leaves' commitments.
+        let group = result.group(SpendingCategory.subscriptions.group)
+        #expect(group?.committed == 30)
+    }
+
+    @Test("Committed is capped at the full bar even when recurring exceeds the budget")
+    func committedClampedToFullBar() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(50, "2026-06-03", .subscriptions)],
+            budgets: [.subscriptions: 20],
+            asOf: now,
+            calendar: calendar,
+            recurring: [monthlyStream("Bundle", amount: 40, category: .subscriptions)]
+        )
+        let leaf = result.leaf(.subscriptions)
+        #expect(leaf?.committed == 40)            // raw amount preserved
+        #expect(leaf?.committedFraction == 1.0)   // fraction clamped to the bar
+    }
+
+    @Test("An unbudgeted leaf has no committed fraction even with a recurring stream")
+    func committedFractionNilWhenUnbudgeted() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(80, "2026-06-03", .subscriptions)],
+            budgets: [:],
+            asOf: now,
+            calendar: calendar,
+            recurring: [monthlyStream("Netflix", amount: 30, category: .subscriptions)]
+        )
+        let leaf = result.leaf(.subscriptions)
+        #expect(leaf?.committed == 30)
+        #expect(leaf?.committedFraction == nil)
+    }
+
+    @Test("No recurring input leaves committed nil (backward compatible)")
+    func committedNilWithoutRecurring() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(200, "2026-06-03", .subscriptions)],
+            budgets: [.subscriptions: 100],
+            asOf: now,
+            calendar: calendar
+        )
+        #expect(result.leaf(.subscriptions)?.committed == nil)
+        #expect(result.leaf(.subscriptions)?.committedFraction == nil)
+    }
+
+    @Test("A category with no recurring stream keeps a nil ghost segment")
+    func committedNilForUnmappedCategory() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(120, "2026-06-03", .foodAndDrink)],
+            budgets: [.foodAndDrink: 300],
+            asOf: now,
+            calendar: calendar,
+            recurring: [monthlyStream("Netflix", amount: 30, category: .subscriptions)]
+        )
+        #expect(result.leaf(.foodAndDrink)?.committed == nil)
+        #expect(result.leaf(.foodAndDrink)?.committedFraction == nil)
+    }
 }

--- a/Tests/PlaidBarCoreTests/CategoryDashboardBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardBuilderTests.swift
@@ -501,4 +501,59 @@ struct CategoryDashboardBuilderTests {
         #expect(result.leaf(.foodAndDrink)?.committed == nil)
         #expect(result.leaf(.foodAndDrink)?.committedFraction == nil)
     }
+
+    @Test("A rule moves the committed ghost to the recategorized leaf in the dashboard")
+    func committedFollowsRuleRecategorization() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(200, "2026-06-03", .healthAndFitness, name: "Gym")],
+            budgets: [.healthAndFitness: 100],
+            asOf: now,
+            calendar: calendar,
+            rules: [TransactionRule(matchMerchantContains: "Gym", category: .healthAndFitness)],
+            recurring: [RecurringTransaction(
+                merchantName: "Gym", frequency: .monthly, averageAmount: 30,
+                lastDate: "2026-06-01", nextExpectedDate: "2026-07-01",
+                category: .subscriptions, transactionCount: 6, confidence: 0.9
+            )]
+        )
+        // Ghost follows the rule onto healthAndFitness, not the raw subscriptions leaf.
+        #expect(result.leaf(.healthAndFitness)?.committed == 30)
+        #expect(result.leaf(.subscriptions) == nil)
+    }
+
+    @Test("Stale recurring streams are dropped from dashboard commitments")
+    func committedDropsStaleStreams() {
+        let result = CategoryDashboardBuilder.build(
+            transactions: [tx(80, "2026-06-03", .subscriptions)],
+            budgets: [.subscriptions: 100],
+            asOf: now,
+            calendar: calendar,
+            recurring: [RecurringTransaction(
+                merchantName: "Cancelled", frequency: .monthly, averageAmount: 25,
+                lastDate: "2026-01-01", nextExpectedDate: "2026-02-01",
+                category: .subscriptions, transactionCount: 6, confidence: 0.9
+            )]
+        )
+        #expect(result.leaf(.subscriptions)?.committed == nil)
+    }
+
+    @Test("Group committed counts only budgeted leaves, excludes unbudgeted ones")
+    func groupCommittedExcludesUnbudgetedLeaves() {
+        // Hand-built rollup: a budgeted leaf (limit 300, committed 50) plus an
+        // unbudgeted leaf carrying its own commitment (30). The group denominator is
+        // only the budgeted limit (300), so the group's committed must be 50 — the
+        // unbudgeted leaf's 30 is excluded so it can't overstate group pressure.
+        let budgeted = CategoryDashboardPresentation.Leaf(
+            category: .foodAndDrink, spent: 100, monthlyLimit: 300, committed: 50
+        )
+        let unbudgeted = CategoryDashboardPresentation.Leaf(
+            category: .shopping, spent: 40, monthlyLimit: nil, committed: 30
+        )
+        let group = CategoryDashboardPresentation.GroupRollup(
+            group: .foodAndDining, leaves: [budgeted, unbudgeted]
+        )
+        #expect(group.monthlyLimit == 300)
+        #expect(group.committed == 50)
+        #expect(group.committedFraction == 50.0 / 300.0)
+    }
 }

--- a/Tests/PlaidBarCoreTests/CategoryStatusBarModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryStatusBarModelTests.swift
@@ -155,4 +155,77 @@ struct CategoryStatusBarModelTests {
         // The verdict + percent still read; only the currency is dots.
         #expect(masked == "•••• of ••••, 40% of budget. On track.")
     }
+
+    // MARK: - Committed recurring ghost segment (AND-559)
+
+    @Test("Committed fraction is the recurring share of the budget, clamped to 0...1")
+    func committedFractionBudgeted() {
+        // $150 committed against a $500 budget = 30% of the bar.
+        let model = CategoryStatusBarModel(
+            spent: 200, monthlyLimit: 500, fractionUsed: 0.4, status: .under, committed: 150
+        )
+        #expect(model.committedFraction == 0.3)
+        #expect(model.committedPercentText() == "30%")
+    }
+
+    @Test("Committed beyond the budget pins the ghost segment full, never overflows")
+    func committedFractionClamped() {
+        let model = CategoryStatusBarModel(
+            spent: 600, monthlyLimit: 500, fractionUsed: 1.2, status: .over, committed: 800
+        )
+        #expect(model.committedFraction == 1.0)
+    }
+
+    @Test("No ghost segment when unbudgeted or when no recurring stream maps")
+    func committedFractionHidden() {
+        let unbudgeted = CategoryStatusBarModel(
+            spent: 120, monthlyLimit: nil, fractionUsed: nil, status: nil, committed: 50
+        )
+        #expect(unbudgeted.committedFraction == nil)
+        #expect(unbudgeted.committedPercentText() == nil)
+
+        let noStream = CategoryStatusBarModel(
+            spent: 200, monthlyLimit: 500, fractionUsed: 0.4, status: .under, committed: nil
+        )
+        #expect(noStream.committedFraction == nil)
+
+        let zeroCommitted = CategoryStatusBarModel(
+            spent: 200, monthlyLimit: 500, fractionUsed: 0.4, status: .under, committed: 0
+        )
+        #expect(zeroCommitted.committedFraction == nil)
+    }
+
+    @Test("Committed model is built from the leaf and group rollups")
+    func committedFromRollups() {
+        let leaf = CategoryDashboardPresentation.Leaf(
+            category: .subscriptions, spent: 90, monthlyLimit: 300, committed: 60
+        )
+        let leafModel = CategoryStatusBarModel(leaf: leaf)
+        #expect(leafModel.committed == 60)
+        #expect(leafModel.committedFraction == 0.2)
+
+        let group = CategoryDashboardPresentation.GroupRollup(group: leaf.category.group, leaves: [leaf])
+        let groupModel = CategoryStatusBarModel(group: group)
+        #expect(groupModel.committed == 60)
+        #expect(groupModel.committedFraction == 0.2)
+    }
+
+    @Test("Accessibility sentence voices the committed share as text, Privacy-Mask safe")
+    func accessibilityCommitted() {
+        let leaf = CategoryDashboardPresentation.Leaf(
+            category: .subscriptions, spent: 200, monthlyLimit: 500, committed: 150
+        )
+        let model = CategoryStatusBarModel(leaf: leaf)
+        let sentence = model.accessibilityDescription(spentText: "$200", limitText: "$500")
+
+        #expect(
+            sentence == "$200 of $500, 40% of budget. On track. 30% of the budget is committed to recurring bills."
+        )
+
+        // Under Privacy Mask the committed clause is a percent, so it still reads.
+        let masked = model.accessibilityDescription(spentText: "••••", limitText: "••••")
+        #expect(
+            masked == "•••• of ••••, 40% of budget. On track. 30% of the budget is committed to recurring bills."
+        )
+    }
 }

--- a/Tests/PlaidBarCoreTests/RecurringCommitmentTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringCommitmentTests.swift
@@ -91,4 +91,41 @@ struct RecurringCommitmentTests {
     func emptyInput() {
         #expect(RecurringCommitment.monthlyByCategory([]).isEmpty)
     }
+
+    // MARK: - Codex review follow-ups (override-aware + stale)
+
+    @Test("Stale streams are dropped when a reference date is supplied")
+    func staleDropped() {
+        // Monthly stream last charged 2026-01-01; as of 2026-06-01 it is >60 days
+        // past its expected cadence, so the detector flags it stale (canceled).
+        let stale = RecurringTransaction(
+            merchantName: "Cancelled", frequency: .monthly, averageAmount: 20,
+            lastDate: "2026-01-01", nextExpectedDate: "2026-02-01",
+            category: .subscriptions, transactionCount: 6, confidence: 0.9
+        )
+        let asOf = Formatters.parseTransactionDate("2026-06-01")!
+        #expect(RecurringCommitment.monthlyByCategory([stale], asOf: asOf).isEmpty)
+        // Without a reference date there is no stale filtering — it still counts.
+        #expect(RecurringCommitment.monthlyByCategory([stale])[.subscriptions] == 20)
+    }
+
+    @Test("A rule recategorizes the committed ghost like it recategorizes spend")
+    func ruleOverrideMovesCommitment() {
+        let gym = stream("Gym", amount: 40, frequency: .monthly, category: .subscriptions)
+        let rule = TransactionRule(matchMerchantContains: "Gym", category: .healthAndFitness)
+        let result = RecurringCommitment.monthlyByCategory([gym], rules: [rule])
+        #expect(result[.healthAndFitness] == 40)
+        #expect(result[.subscriptions] == nil)
+    }
+
+    @Test("A rule that excludes or marks transfer drops the commitment")
+    func ruleExcludeDropsCommitment() {
+        let move = stream("Transfer to savings", amount: 500, frequency: .monthly, category: .subscriptions)
+
+        let excludeRule = TransactionRule(matchMerchantContains: "Transfer", excludedFromBudgets: true)
+        #expect(RecurringCommitment.monthlyByCategory([move], rules: [excludeRule]).isEmpty)
+
+        let transferRule = TransactionRule(matchMerchantContains: "Transfer", isTransfer: true)
+        #expect(RecurringCommitment.monthlyByCategory([move], rules: [transferRule]).isEmpty)
+    }
 }

--- a/Tests/PlaidBarCoreTests/RecurringCommitmentTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringCommitmentTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Tests for the AND-559 committed-recurring rollup. The helper must:
+/// - sum each stream's monthly-equivalent cost into its category,
+/// - normalize non-monthly cadences via `RecurringFrequency.monthlyMultiplier`,
+/// - skip streams with no category, a transfer category, or a non-positive amount,
+/// - and only ever map a category to a strictly-positive amount (absent == none).
+@Suite("Recurring commitment rollup (AND-559)")
+struct RecurringCommitmentTests {
+    private func stream(
+        _ merchant: String,
+        amount: Double,
+        frequency: RecurringFrequency,
+        category: SpendingCategory?
+    ) -> RecurringTransaction {
+        RecurringTransaction(
+            merchantName: merchant,
+            frequency: frequency,
+            averageAmount: amount,
+            lastDate: "2026-06-01",
+            nextExpectedDate: "2026-07-01",
+            category: category,
+            transactionCount: 6,
+            confidence: 0.9
+        )
+    }
+
+    @Test("A monthly stream commits its full amount to its category")
+    func monthlyStream() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Netflix", amount: 15, frequency: .monthly, category: .subscriptions),
+        ])
+        #expect(result[.subscriptions] == 15)
+    }
+
+    @Test("A weekly stream is normalized to a monthly-equivalent cost")
+    func weeklyNormalized() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Coffee plan", amount: 10, frequency: .weekly, category: .foodAndDrink),
+        ])
+        let expected = 10 * (52.0 / 12.0)
+        #expect(abs((result[.foodAndDrink] ?? 0) - expected) < 0.0001)
+    }
+
+    @Test("An annual stream is spread across twelve months")
+    func annualNormalized() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Insurance", amount: 1200, frequency: .annual, category: .billsAndUtilities),
+        ])
+        #expect(abs((result[.billsAndUtilities] ?? 0) - 100) < 0.0001)
+    }
+
+    @Test("Multiple streams in one category sum together")
+    func sameCategorySums() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Netflix", amount: 15, frequency: .monthly, category: .subscriptions),
+            stream("Spotify", amount: 12, frequency: .monthly, category: .subscriptions),
+        ])
+        #expect(result[.subscriptions] == 27)
+    }
+
+    @Test("Streams with no category are skipped (no ghost segment)")
+    func nilCategorySkipped() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Unknown", amount: 30, frequency: .monthly, category: nil),
+        ])
+        #expect(result.isEmpty)
+    }
+
+    @Test("Transfer streams never count as category commitment")
+    func transferSkipped() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Savings move", amount: 500, frequency: .monthly, category: .transfer),
+            stream("Card payment", amount: 300, frequency: .monthly, category: .transferOut),
+        ])
+        #expect(result.isEmpty)
+    }
+
+    @Test("Non-positive amounts are ignored")
+    func nonPositiveSkipped() {
+        let result = RecurringCommitment.monthlyByCategory([
+            stream("Zero", amount: 0, frequency: .monthly, category: .subscriptions),
+            stream("Negative", amount: -10, frequency: .monthly, category: .subscriptions),
+        ])
+        #expect(result.isEmpty)
+    }
+
+    @Test("Empty input yields an empty map")
+    func emptyInput() {
+        #expect(RecurringCommitment.monthlyByCategory([]).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Implements **[AND-559](https://linear.app/andeslab/issue/AND-559)** — the `[COULD]` sub-issue of [AND-538](https://linear.app/andeslab/issue/AND-538) (per-category status bars). Surfaces how much of a category's budget is already *spoken-for by detected recurring bills* as a dashed "committed" ghost segment on its status bar, so a user can see committed-vs-discretionary headroom at a glance.

Reference spec: [`docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`](docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md) (§4 status bars / tree).

## What changed

- **`RecurringCommitment` (new, PlaidBarCore):** pure rollup mapping each `RecurringTransaction` stream's monthly-equivalent cost (`frequency.monthlyMultiplier`) into its `SpendingCategory`. Skips no-category, transfer, and non-positive streams; only ever yields strictly-positive amounts, so "absent" cleanly means "no recurring stream — hide the segment."
- **`CategoryDashboardBuilder.build`:** gains an optional `recurring:` input (default `nil` → every existing caller/test unchanged) and threads `committed` onto each leaf; group rollups sum their leaves' commitments.
- **`CategoryDashboardPresentation.Leaf`/`GroupRollup` + `CategoryStatusBarModel`:** carry `committed` and a `0...1`-clamped `committedFraction` (nil when unbudgeted or unmapped).
- **`CategoryStatusBar` (view):** draws the ghost as a dashed `Capsule` outline. The dash **pattern** — not a color — distinguishes it from the solid spend fill.
- **`AppState.categoryDashboardPresentation`:** passes live `recurringTransactions`.

## Acceptance criteria

- [x] Categories with detected recurring streams render a dashed "committed" segment distinct from actual spend.
- [x] Conveyed by pattern + label, not color alone — dashed pattern + the committed share voiced as a percent in the accessibility sentence (Privacy-Mask safe, no currency leak).
- [x] Hidden when no recurring stream maps to the category (and when unbudgeted).

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — **1763 tests pass**. +21 new tests: `RecurringCommitment` rollup/normalization/skips, builder threading + clamping + backward-compat, model fraction clamping + accessibility clause.

## Architecture notes

All math lives in PlaidBarCore as pure, `Sendable`, deterministic functions (`asOf`/inputs injected, no hidden `Date()`); the view is pure presentation. Additive only — no schema change, no `SpendingCategory` rawValue change, default-nil params preserve existing behavior (consistent with the Option-A, no-migration approach in the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)