### PR TITLE
fix(core): clamp energy back-off product to a finite ceiling

### DIFF
--- a/Sources/PlaidBarCore/Utilities/EnergyAwareRefreshPolicy.swift
+++ b/Sources/PlaidBarCore/Utilities/EnergyAwareRefreshPolicy.swift
@@ -126,6 +126,11 @@ public enum EnergyAwareRefreshPolicy: Sendable {
             ? baseInterval
             : PlaidBarConstants.backgroundRefreshInterval
         guard conditions.isConstrained else { return sanitizedBase }
-        return sanitizedBase * constrainedBackoffMultiplier
+        // Sanitize the *product*, not just the base: a finite-but-very-large base
+        // (e.g. near `.greatestFiniteMagnitude`) can overflow to `.infinity` once
+        // multiplied, which would break the "never sleep forever" guarantee. When
+        // that happens, fall back to the finite sanitized base.
+        let constrained = sanitizedBase * constrainedBackoffMultiplier
+        return (constrained.isFinite && constrained > 0) ? constrained : sanitizedBase
     }
 }

--- a/Tests/PlaidBarCoreTests/EnergyAwareRefreshPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/EnergyAwareRefreshPolicyTests.swift
@@ -153,6 +153,28 @@ struct EnergyAwareRefreshPolicyTests {
         }
     }
 
+    @Test("Constrained back-off never overflows to infinity for a finite-but-huge base interval")
+    func constrainedDelayNeverOverflowsToInfinity() {
+        let constrained = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .nominal)
+        // A finite, positive base that overflows once multiplied by the backoff
+        // multiplier: the product is no longer finite, so the policy must fall
+        // back to the (finite) sanitized base rather than sleeping forever.
+        let hugeBase = Double.greatestFiniteMagnitude
+        let result = EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: hugeBase, conditions: constrained)
+        #expect(result.isFinite)
+        #expect(result > 0)
+        #expect(result == hugeBase)
+    }
+
+    @Test("Constrained back-off keeps multiplying for a normal finite base interval")
+    func constrainedDelayMultipliesForNormalBase() {
+        let constrained = EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: true, thermalState: .nominal)
+        let baseInterval: TimeInterval = 120
+        let result = EnergyAwareRefreshPolicy.nextTickDelay(baseInterval: baseInterval, conditions: constrained)
+        #expect(result == baseInterval * EnergyAwareRefreshPolicy.constrainedBackoffMultiplier)
+        #expect(result.isFinite)
+    }
+
     // MARK: - EnergyConditions.isConstrained
 
     @Test("Energy conditions are constrained when either low power or hot thermal holds")


### PR DESCRIPTION
## Summary

Fixes a LOW-severity audit finding in `EnergyAwareRefreshPolicy.nextTickDelay`.

The constrained branch sanitized the **base** interval (`isFinite && > 0`) but multiplied the sanitized base by `constrainedBackoffMultiplier` **without sanitizing the product**. A finite-but-very-large base (e.g. near `Double.greatestFiniteMagnitude`) overflows to `.infinity` once multiplied, which silently violates the type's documented "the loop can never busy-spin or sleep forever" guarantee.

## Fix

After multiplying, guard the product: if it is not finite/positive, fall back to the (finite) sanitized base. Pure `PlaidBarCore` change, no behavior change for normal inputs.

```swift
let constrained = sanitizedBase * constrainedBackoffMultiplier
return (constrained.isFinite && constrained > 0) ? constrained : sanitizedBase
```

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes
- `swift test` — 1781 tests pass
- Added two Swift Testing cases:
  - **overflow**: huge finite base under constrained conditions returns a finite, positive delay (falls back to the base) instead of `.infinity`
  - **normal**: ordinary finite base still multiplies by the backoff multiplier

🤖 Generated with [Claude Code](https://claude.com/claude-code)