### PR TITLE
docs(server): correct PlaidTokenVault keychain-write comment

### DIFF
--- a/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
+++ b/Sources/PlaidBarServer/Storage/PlaidTokenVault.swift
@@ -96,10 +96,20 @@ enum PlaidTokenVault {
 
     private static func saveToKeychain(accessToken: String, itemId: String, service: String) throws {
         let query = keychainQuery(itemId: itemId, service: service)
-        // Re-assert the hardened protection on every write so an item created by
-        // an older build (or whose policy drifted) is upgraded in place: the
-        // accessibility class is pinned device-only and synchronization stays
-        // off, which keeps the token out of iCloud Keychain.
+        // Re-assert the hardened accessibility on every write. The query omits
+        // `kSecAttrSynchronizable`, so it matches only the existing
+        // non-synchronizable item (Keychain's default search semantics), and
+        // `SecItemUpdate` rewrites `kSecAttrAccessible` in place — refreshing
+        // the device-only protection class for tokens an older build may have
+        // written under a weaker class.
+        //
+        // `kSecAttrSynchronizable = false` below is redundant with the Keychain
+        // default (omitting the key already yields a non-synchronizable item;
+        // it can never be paired with a `ThisDeviceOnly` accessibility class).
+        // It is kept only as an explicit, self-documenting assertion of the
+        // on-device-only policy — it does not, and cannot, migrate a token that
+        // was somehow already synced to iCloud Keychain, because such an item
+        // would not match this query in the first place.
         let attributes: [String: Any] = [
             kSecValueData as String: Data(accessToken.utf8),
             kSecAttrAccessible as String: accessibleClass,


### PR DESCRIPTION
## Summary

Fixes a LOW security/doc audit finding on `PlaidTokenVault.saveToKeychain` (`Sources/PlaidBarServer/Storage/PlaidTokenVault.swift`, ~99-107).

The save-path comment made two inaccurate claims:

1. It said the write "upgrades older items in place" with respect to synchronization. It cannot: the `SecItemUpdate` query omits `kSecAttrSynchronizable`, and by the Keychain's default search semantics such a query matches **only** non-synchronizable items. An item that was already synced to iCloud Keychain would never match this query, so the write cannot find-and-migrate it.
2. It implied `kSecAttrSynchronizable = false` was load-bearing hardening. It is redundant with the Keychain default — omitting the key already yields a non-synchronizable item, and `kSecAttrSynchronizable` can never be paired with a `ThisDeviceOnly` accessibility class.

## What changed

- Rewrote the comment to describe accurately what `SecItemUpdate` does: it re-applies the device-only `kSecAttrAccessible` class **in place**, refreshing the protection class for tokens an older build may have written under a weaker class.
- Documented that the explicit `kSecAttrSynchronizable = false` is kept as a self-documenting assertion of the on-device-only policy, not as a migration mechanism.

This is a **doc-only** change. Runtime behavior and the hardened write attributes (`kSecAttrAccessible` device-only + explicit `kSecAttrSynchronizable = false`) are deliberately left unchanged — this is the token vault, so the conservative choice is to not alter the write at all and only correct the misleading prose.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes
- `swift test` — 1779 tests pass (includes the Keychain-gated `Token and storage safety` suite)

No behavioral change, so no test additions; the existing `TokenStorageSafetyTests` continue to cover the vault round-trip and reference-only persistence invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)