### PR TITLE
fix(ai): single FM boundary parser + bounded FM categorization (audit fm-core)

### DIFF
--- a/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
@@ -82,9 +82,17 @@ extension FoundationModelsInsightModel {
 
             // Single-pass consumption: each snapshot carries the cumulative
             // partially-generated content, so the LAST snapshot holds the final
-            // headline. Tracking it as we stream keeps cancellation responsive (a
-            // superseded refresh stops generation promptly) without depending on a
+            // headline. Tracking it as we stream lets generation stop at the next
+            // snapshot boundary once this task is cancelled, without depending on a
             // post-iteration `collect()`.
+            //
+            // NOTE: cancellation here is only responsive when *this* task is
+            // cancelled. Today `LocalInsightModelRuntime.withTimeout` runs the
+            // model in an unstructured `Task {}` that does not inherit the outer
+            // (superseded-refresh) cancellation, so a superseded refresh still runs
+            // to the runtime's 8s deadline. The structural fix lives in that shared
+            // runtime helper (run the operation as a `withThrowingTaskGroup` child
+            // so parent cancellation propagates); see PR follow-up.
             var latestHeadline: String?
             for try await snapshot in stream {
                 try Task.checkCancellation()

--- a/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
@@ -23,10 +23,20 @@ import FoundationModels
 /// a sanitized merchant string — never raw account ids, transaction ids, item
 /// ids, tokens, dates, amounts, or Plaid payloads. Generation runs entirely
 /// on-device; nothing is transmitted off the machine. Failures (model error,
-/// guardrail, timeout) are swallowed to `nil` so the categorizer never throws
-/// across the boundary and always degrades to the deterministic NL floor.
+/// guardrail) are swallowed to `nil` so the categorizer never throws across the
+/// boundary and always degrades to the deterministic NL floor.
+///
+/// Bounded generation: an on-device generation can block its `await` unbounded
+/// (model warm-up, contention, a stuck guardrail), so the call is raced against
+/// `FMGenerationLimits.generationTimeout` and outer-task
+/// cancellation; on timeout or cancellation it returns `nil` so the NL fallback
+/// engages promptly instead of hanging.
+///
+/// Boundary contract: the result crosses to `PlaidBarCore` as the constrained
+/// `SpendingCategory.rawValue` string (not a resolved enum), so Core owns the
+/// single tested string→enum mapping (`FMSpendingCategoryMapper`).
 struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
-    func suggestCategory(merchant: String) async -> SpendingCategory? {
+    func suggestCategory(merchant: String) async -> String? {
         let cleaned = Self.sanitizedMerchant(merchant)
         guard !cleaned.isEmpty else { return nil }
 
@@ -115,9 +125,12 @@ extension FoundationModelsMerchantCategorizer {
     details. The data is processed locally on the user's Mac.
     """
 
-    /// Run the on-device guided generation. Any failure (unavailable, guardrail,
-    /// model error) is swallowed to `nil` so the caller degrades to NL.
-    static func generate(merchant: String) async -> SpendingCategory? {
+    /// Run the on-device guided generation, bounded by an explicit deadline and
+    /// outer-task cancellation. Returns the constrained `SpendingCategory.rawValue`
+    /// string, or `nil` on any failure (unavailable, guardrail, model error,
+    /// timeout, or cancellation) so the caller degrades to NL. The string boundary
+    /// keeps the string→enum mapping in `PlaidBarCore` (`FMSpendingCategoryMapper`).
+    static func generate(merchant: String) async -> String? {
         // A fresh session per call keeps the categorizer stateless and avoids
         // cross-merchant context bleed. Greedy sampling makes the choice
         // deterministic for a given merchant.
@@ -125,15 +138,40 @@ extension FoundationModelsMerchantCategorizer {
         let prompt = "Categorize this merchant: \"\(merchant)\""
         let options = GenerationOptions(sampling: .greedy)
 
-        do {
-            let response = try await session.respond(
-                to: prompt,
-                generating: GeneratedSpendingCategory.self,
-                options: options
-            )
-            return response.content.spendingCategory
-        } catch {
-            return nil
+        // Race the generation against an explicit deadline so an on-device call
+        // can never block unbounded. A structured task group propagates outer-task
+        // cancellation into the generation child, so a superseded categorization
+        // also stops promptly; whichever child finishes first wins and the other
+        // is cancelled when the group tears down.
+        let timeoutNanoseconds = UInt64(
+            max(0, FMGenerationLimits.generationTimeout) * 1_000_000_000
+        )
+
+        return await withTaskGroup(of: String?.self) { group in
+            group.addTask {
+                do {
+                    let response = try await session.respond(
+                        to: prompt,
+                        generating: GeneratedSpendingCategory.self,
+                        options: options
+                    )
+                    return response.content.spendingCategory.rawValue
+                } catch {
+                    return nil
+                }
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    return nil // deadline reached → degrade to NL
+                } catch {
+                    return nil // group cancelled → stop waiting
+                }
+            }
+
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            return result
         }
     }
 }

--- a/Sources/PlaidBarCore/Utilities/FMMerchantCategorizer.swift
+++ b/Sources/PlaidBarCore/Utilities/FMMerchantCategorizer.swift
@@ -52,6 +52,20 @@ public struct MerchantCategorySuggestion: Sendable, Equatable, Hashable {
     }
 }
 
+/// Centralized limits for on-device Foundation Models generation (AND-564/565).
+///
+/// An on-device generation can block its `await` unbounded (model warm-up,
+/// contention, a stuck guardrail), so the app-side FM seams race generation
+/// against this deadline and return `nil` on timeout — degrading to the
+/// deterministic NL/heuristic floor rather than hanging. Defined here in
+/// `PlaidBarCore` (not the app target) so the value is shared, pure, and unit-
+/// testable; the value is intentionally aligned with the insight runtime's 8s
+/// generation timeout.
+public enum FMGenerationLimits {
+    /// Hard deadline (seconds) for a single on-device FM generation call.
+    public static let generationTimeout: TimeInterval = 8
+}
+
 /// Pure decision: should the Foundation Models categorization step be *attempted*
 /// for this run, given the probed FM tier state (AND-565)?
 ///
@@ -117,11 +131,17 @@ public enum FMSpendingCategoryMapper {
 /// entirely on-device and is given ONLY a redaction-safe merchant string — never
 /// raw account ids, transaction ids, item ids, tokens, or Plaid payloads.
 public protocol FMMerchantCategorizing: Sendable {
-    /// Suggest a `SpendingCategory` for a redaction-safe merchant string using
-    /// guided generation constrained to the 16-case enum. Returns `nil` when the
-    /// model produced no usable result (so the caller falls back to NL). Must
-    /// never throw across the boundary — failures degrade to `nil`.
-    func suggestCategory(merchant: String) async -> SpendingCategory?
+    /// Suggest a category for a redaction-safe merchant string using guided
+    /// generation constrained to the 16-case enum.
+    ///
+    /// The result crosses the app→Core boundary as the *constrained string* (the
+    /// `SpendingCategory.rawValue` the guided generation was restricted to), not a
+    /// resolved enum, so Core stays free of any FoundationModels dependency and
+    /// `FMSpendingCategoryMapper` remains the single, unit-tested place that string
+    /// is turned back into a `SpendingCategory`. Returns `nil` when the model
+    /// produced no usable result (so the caller falls back to NL). Must never throw
+    /// across the boundary — failures (incl. timeout/cancellation) degrade to `nil`.
+    func suggestCategory(merchant: String) async -> String?
 }
 
 /// The Foundation Models categorization tier, sitting ABOVE NaturalLanguage in
@@ -129,11 +149,14 @@ public protocol FMMerchantCategorizing: Sendable {
 ///
 /// Strategy:
 /// 1. If FM is `.available` AND a categorizer is wired, ask it for a constrained
-///    suggestion using only the redaction-safe merchant string. A result is
-///    returned as a `.foundationModels` suggestion (trusted — a constrained-enum
-///    output is always a valid case, but still a *suggestion*, never applied).
-/// 2. On FM unavailable, no wired categorizer, or an FM miss, fall back to the
-///    existing `NLMerchantCategorizer` — byte-identically to today's behavior.
+///    suggestion using only the redaction-safe merchant string. The constrained
+///    string is resolved back to a `SpendingCategory` through `FMSpendingCategory-
+///    Mapper` (the single tested boundary parser); a resolved result is returned
+///    as a `.foundationModels` suggestion (trusted — the generation is constrained
+///    to the 16 cases — but still a *suggestion*, never applied).
+/// 2. On FM unavailable, no wired categorizer, an FM miss, or an unparseable
+///    string, fall back to the existing `NLMerchantCategorizer` — byte-identically
+///    to today's behavior.
 ///
 /// The categorizer is a pure value type; the only side effect is the injected,
 /// on-device FM call, which is gated by the availability decision above.
@@ -162,7 +185,12 @@ public struct FMMerchantCategorizer: Sendable {
            let fmCategorizer {
             // Only the redaction-safe merchant string is sent to the model.
             let merchant = Self.redactionSafeMerchantString(for: transaction)
-            if !merchant.isEmpty, let fmCategory = await fmCategorizer.suggestCategory(merchant: merchant) {
+            if !merchant.isEmpty,
+               let rawCategory = await fmCategorizer.suggestCategory(merchant: merchant),
+               // Resolve the constrained string back to an enum through the single,
+               // unit-tested boundary parser. A malformed/unknown value degrades to
+               // the NL fallback rather than a wrong guess.
+               let fmCategory = FMSpendingCategoryMapper.category(from: rawCategory) {
                 return MerchantCategorySuggestion(
                     category: fmCategory,
                     tier: .foundationModels,

--- a/Tests/PlaidBarCoreTests/FMMerchantCategorizerTests.swift
+++ b/Tests/PlaidBarCoreTests/FMMerchantCategorizerTests.swift
@@ -13,16 +13,25 @@ import Testing
 ///      regression guard for the reversible, availability-gated design.
 @Suite("FM Merchant Categorizer Tests")
 struct FMMerchantCategorizerTests {
-    // A deterministic FM stub that returns a fixed category (or nil = a miss),
-    // and records every merchant string it was asked about so privacy/redaction
-    // can be asserted.
+    // A deterministic FM stub that returns a fixed constrained string (or nil =
+    // a miss), and records every merchant string it was asked about so
+    // privacy/redaction can be asserted. The live boundary returns the constrained
+    // `SpendingCategory.rawValue` string (resolved back to an enum by
+    // `FMSpendingCategoryMapper` inside `FMMerchantCategorizer`), so the stub
+    // mirrors that contract.
     final class StubFMCategorizer: FMMerchantCategorizing, @unchecked Sendable {
-        let fixedCategory: SpendingCategory?
+        let fixedRawCategory: String?
         private let lock = NSLock()
         private var _seenMerchants: [String] = []
 
         init(returning category: SpendingCategory?) {
-            fixedCategory = category
+            fixedRawCategory = category?.rawValue
+        }
+
+        /// Return an arbitrary raw string (incl. malformed values) to exercise the
+        /// mapper-resolution boundary.
+        init(returningRaw raw: String?) {
+            fixedRawCategory = raw
         }
 
         var seenMerchants: [String] {
@@ -30,11 +39,11 @@ struct FMMerchantCategorizerTests {
             return _seenMerchants
         }
 
-        func suggestCategory(merchant: String) async -> SpendingCategory? {
+        func suggestCategory(merchant: String) async -> String? {
             lock.lock()
             _seenMerchants.append(merchant)
             lock.unlock()
-            return fixedCategory
+            return fixedRawCategory
         }
     }
 
@@ -142,6 +151,32 @@ struct FMMerchantCategorizerTests {
         let suggestion = await categorizer.suggest(for: txn)
         let nlOnly = categorizer.nlSuggestion(for: txn)
         #expect(suggestion == nlOnly)
+        #expect(suggestion?.tier == .naturalLanguage)
+    }
+
+    @Test("FM raw string is resolved through FMSpendingCategoryMapper at the boundary")
+    func fmRawStringResolvedThroughMapper() async {
+        // The live seam returns the constrained SpendingCategory.rawValue string;
+        // FMMerchantCategorizer must resolve it via FMSpendingCategoryMapper.
+        let stub = StubFMCategorizer(returningRaw: SpendingCategory.shopping.rawValue)
+        let categorizer = FMMerchantCategorizer(foundationModelsState: .available, fmCategorizer: stub)
+        let txn = transaction(name: "NETFLIX.COM", merchantName: "Netflix")
+
+        let suggestion = await categorizer.suggest(for: txn)
+        #expect(suggestion?.category == .shopping)
+        #expect(suggestion?.tier == .foundationModels)
+    }
+
+    @Test("An unparseable FM string degrades to the NaturalLanguage fallback, never a wrong guess")
+    func fmUnparseableStringFallsBackToNL() async {
+        // A malformed value that the mapper cannot resolve must not become an FM
+        // suggestion; the categorizer falls back to NL exactly as on a miss.
+        let stub = StubFMCategorizer(returningRaw: "NOT_A_REAL_CATEGORY")
+        let categorizer = FMMerchantCategorizer(foundationModelsState: .available, fmCategorizer: stub)
+        let txn = transaction(name: "NETFLIX.COM", merchantName: "Netflix")
+
+        let suggestion = await categorizer.suggest(for: txn)
+        #expect(suggestion == categorizer.nlSuggestion(for: txn))
         #expect(suggestion?.tier == .naturalLanguage)
     }
 


### PR DESCRIPTION
## Summary

Fixes three Foundation-Models robustness findings from the code-review audit (stream `fm-core`). Scoped to the FM categorization/insight seam; does **not** touch `AppState.swift` (owned by another stream).

### (A) Dead `FMSpendingCategoryMapper` → made the live, single boundary parser
`FMSpendingCategoryMapper` (PlaidBarCore) was dead: the FM seam returned `SpendingCategory` directly, so the constrained string never crossed the boundary the mapper parses.

- `FMMerchantCategorizing.suggestCategory` now returns the **constrained `SpendingCategory.rawValue` String**.
- `FMMerchantCategorizer` resolves it via `FMSpendingCategoryMapper.category(from:)` — now the single, unit-tested string→enum boundary.
- PlaidBarCore stays free of any FoundationModels dependency.
- An unparseable/unknown value degrades to the NL fallback (never a wrong guess).

### (C) `FoundationModelsMerchantCategorizer.generate()` had no timeout/cancellation
The doc claimed timeouts were swallowed, but the `await` could block unbounded.

- Generation now races a structured `withTaskGroup` timeout child against `FMGenerationLimits.generationTimeout` (8s, defined in PlaidBarCore so it is shared/pure/testable).
- On timeout **or** outer-task cancellation it returns `nil`, so the NL fallback engages promptly and a superseded categorization stops.
- Doc comment aligned with reality.

### (B) Superseded-refresh cancellation in `FoundationModelsInsightModel` — documented follow-up
The root cause is upstream in `LocalInsightModelRuntime.withTimeout`, which runs the model in an unstructured `Task {}` that does **not** inherit outer (superseded-refresh) cancellation — so `Task.checkCancellation()` in the stream loop never fires for a superseded refresh and it runs to the 8s deadline. That helper file is owned by another stream, so I corrected the misleading "stops promptly" comment to state the limitation and the structural fix (run the operation as a `withThrowingTaskGroup` child). See follow-up.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — **1781 tests pass**.
- Added: `fmRawStringResolvedThroughMapper`, `fmUnparseableStringFallsBackToNL`; updated the FM stub to the new `String` contract.

## Follow-up
- (B) Fix `LocalInsightModelRuntime.withTimeout` to run its operation as a `withThrowingTaskGroup` child so outer cancellation propagates, making superseded FM insight refreshes stop without waiting out the 8s deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)