### PR TITLE
fix(perf): bound large-history paging cost and stop dropping rows after re-sync

### DIFF
--- a/Sources/PlaidBar/Services/PagedTransactionSource.swift
+++ b/Sources/PlaidBar/Services/PagedTransactionSource.swift
@@ -117,11 +117,23 @@ final class PagedTransactionSource {
 
     /// Loads the next page when the list scrolls near the end. No-op outside the
     /// paged path, when a fetch is already running, or when there is nothing more.
+    ///
+    /// Before computing the next window it re-reads the cache `count()` and feeds
+    /// it back via `updateTotal`. The feed's `total` is captured when the first
+    /// page loads, so without this a concurrent re-sync that *grows* the history
+    /// would leave the window math believing there is nothing more to load and
+    /// silently drop the newly added newest transactions. Re-reading keeps the
+    /// window bound to the current size; the feed's per-id dedup keeps a row that
+    /// shifted between pages from rendering twice.
     func loadNextPageIfNeeded() async {
         guard mode == .paged, let store, let cacheKey, !isLoadingPage else { return }
-        guard let window = feed.nextWindow else { return }
         isLoadingPage = true
         defer { isLoadingPage = false }
+
+        if let currentTotal = try? await store.count(cacheKey: cacheKey) {
+            feed.updateTotal(currentTotal)
+        }
+        guard let window = feed.nextWindow else { return }
         guard let page = try? await store.page(cacheKey: cacheKey, window: window), !page.isEmpty else {
             // A failed page read just stops paging; already-loaded rows remain.
             return

--- a/Sources/PlaidBarCache/TransactionCacheStore.swift
+++ b/Sources/PlaidBarCache/TransactionCacheStore.swift
@@ -22,14 +22,32 @@ import SwiftData
 ///
 /// ## Paging
 /// A page is the `TransactionPageWindow` slice (`offset`/`limit` from the pure
-/// page-window math) of the newest-first ordering. Ordering and slicing run in
-/// Swift over the lightweight stored scalar columns (`sortDate` then
-/// `transactionId`, both descending), and **only the page's JSON payloads are
-/// decoded** — so a multi-thousand-row history decodes just one page of
-/// `TransactionDTO`s at a time. Both the sort and the cacheKey scope are done in
-/// Swift rather than via `FetchDescriptor(sortBy:)`/`#Predicate`, because those
-/// capture a non-`Sendable` `KeyPath` — an error under the project's Swift 6
-/// strict-concurrency gate, the same constraint ``ReadModelCacheStore`` documents.
+/// page-window math) of the newest-first ordering.
+///
+/// `FetchDescriptor(sortBy:)` and `#Predicate` are **not** usable here: both
+/// capture a non-`Sendable` `KeyPath`, which is an error under the project's
+/// Swift 6 strict-concurrency gate (the same constraint ``ReadModelCacheStore``
+/// documents). So the cacheKey scoping and the newest-first ordering (`sortDate`
+/// then `transactionId`, both descending) are done in Swift. To keep that from
+/// re-loading every payload blob and re-sorting on every page request, two
+/// bounds apply:
+///
+/// 1. **Scalar-only ordering fetch.** The fetch that builds the order sets
+///    `propertiesToFetch` to the lightweight scalar columns (`cacheKey`,
+///    `sortDate`, `transactionId`) and *excludes* the heavy `payload` blob.
+///    `propertiesToFetch` takes `PartialKeyPath`s, which — unlike `sortBy:` /
+///    `#Predicate` — do compile under strict concurrency, so the JSON blobs stay
+///    faulted out of memory while the order is computed.
+/// 2. **Cached ordering per data generation.** The sorted row references are
+///    memoized against a monotonically increasing generation counter that every
+///    write bumps. Consecutive `page()`/`count()` calls within one paging
+///    session reuse the sort instead of redoing `O(N log N)` each time; the
+///    first write invalidates it.
+///
+/// Only the requested page's `payload` blobs are then faulted in and decoded —
+/// so a multi-thousand-row history decodes just one page of `TransactionDTO`s at
+/// a time regardless of history size.
+///
 /// The store file is opened per data directory and the active environment is the
 /// only one seeded into it (an environment switch calls
 /// ``replaceAll(cacheKey:transactions:)`` which wipes first).
@@ -43,6 +61,19 @@ public actor TransactionCacheStore {
     /// Filename of the disposable per-transaction store. `v1` is namespaced so a
     /// future incompatible store can ship beside it and the old file be deleted.
     public static let storeFilename = "transaction-cache-v1.store"
+
+    /// Monotonic data generation, bumped by every write (`upsert`/`replaceAll`/
+    /// `clearAll`). The cached ordering (``orderCache``) is keyed off this so a
+    /// write invalidates the memoized sort without needing to clear it eagerly.
+    private var dataGeneration: UInt64 = 0
+
+    /// Memoized newest-first row ordering for one `cacheKey`, plus the generation
+    /// it was built for. Reused across consecutive reads of the same key within one
+    /// paging session so the `O(N log N)` filter+sort runs once per data
+    /// generation, not per page. Keyed by `cacheKey` as well as generation because
+    /// a single store file can briefly hold more than one environment (e.g. before
+    /// an environment switch wipes via `replaceAll`).
+    private var orderCache: (generation: UInt64, cacheKey: String, rows: [CachedTransaction])?
 
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -150,6 +181,7 @@ public actor TransactionCacheStore {
             }
         }
         try modelContext.save()
+        invalidateOrderCache()
         return plan
     }
 
@@ -168,40 +200,44 @@ public actor TransactionCacheStore {
     public func clearAll() throws {
         try modelContext.delete(model: CachedTransaction.self)
         try modelContext.save()
+        invalidateOrderCache()
     }
 
     // MARK: - Reads
 
     /// Total cached transactions for `cacheKey`.
+    ///
+    /// Reuses the memoized newest-first ordering (rebuilt only when a write bumped
+    /// the data generation), so a `count()` adjacent to `page()` calls in the same
+    /// paging session shares one scalar-only fetch+sort rather than redoing it.
     public func count(cacheKey: String) throws -> Int {
-        try existingTransactionIds(cacheKey: cacheKey).count
+        try orderedRows(cacheKey: cacheKey).count
     }
 
     /// Reads one newest-first page of transactions for `cacheKey`.
     ///
-    /// The DB does the heavy lifting: a `FetchDescriptor` sorted by `sortDate`
-    /// (then `transactionId`) descending with `fetchOffset`/`fetchLimit` taken from
-    /// `window`, so only up to `window.limit` rows are materialized. The decoded
-    /// DTOs are returned newest-first. A zero-limit window short-circuits to an
-    /// empty page without touching the store.
+    /// `FetchDescriptor(sortBy:)` + `fetchOffset/fetchLimit` is unavailable: the
+    /// `SortDescriptor(\.keyPath)` captures the model's `KeyPath`, which is
+    /// non-`Sendable` and an error under the project's Swift 6 strict-concurrency
+    /// gate — the same class of constraint AND-566 hit with `#Predicate`. So the
+    /// scope filter and newest-first ordering run in Swift instead, but bounded:
+    ///
+    /// - The ordering fetch sets `propertiesToFetch` to the scalar columns only,
+    ///   so the JSON `payload` blobs stay faulted out while the order is built.
+    /// - That ordering is memoized per data generation (``orderedRows``), so a
+    ///   multi-page scroll sorts once, not once per page.
+    /// - Only the requested page's rows have their `payload` faulted in and
+    ///   decoded — so a multi-thousand-row history still decodes just one page of
+    ///   `TransactionDTO`s.
+    ///
+    /// A zero-limit window short-circuits to an empty page without touching the
+    /// store.
     public func page(cacheKey: String, window: TransactionPageWindow) throws -> [TransactionDTO] {
         guard window.limit > 0 else { return [] }
-        // Why not `FetchDescriptor(sortBy:)` + `fetchOffset/fetchLimit`: a SwiftData
-        // `SortDescriptor(\.keyPath)` captures the model's `KeyPath`, which is
-        // non-`Sendable` and an error under the project's Swift 6 strict-concurrency
-        // gate — the same class of constraint AND-566 hit with `#Predicate`. So the
-        // ordering is done in Swift over the stored scalar columns instead.
-        //
-        // The sort key is the lightweight `(sortDate, transactionId)` columns, not
-        // the JSON blob, and crucially **only the requested page's payloads are
-        // decoded** — so a multi-thousand-row history still decodes just one page of
-        // `TransactionDTO`s, keeping per-page work bounded even though the row
-        // *references* are sorted in memory.
-        let rows = try modelContext.fetch(FetchDescriptor<CachedTransaction>())
-        let ordered = rows
-            .filter { $0.cacheKey == cacheKey }
-            .sorted(by: Self.isNewerFirst)
+        let ordered = try orderedRows(cacheKey: cacheKey)
         let pageSlice = ordered.dropFirst(window.offset).prefix(window.limit)
+        // `payload` was excluded from the ordering fetch; accessing it here faults
+        // in only this page's blobs — bounded to `window.limit` rows.
         return try pageSlice.map { try Self.decoder.decode(TransactionDTO.self, from: $0.payload) }
     }
 
@@ -218,8 +254,49 @@ public actor TransactionCacheStore {
 
     // MARK: - Private
 
+    /// A `FetchDescriptor` that materializes only the lightweight scalar columns
+    /// used for scoping/ordering and leaves the heavy `payload` blob faulted.
+    ///
+    /// `propertiesToFetch` takes `PartialKeyPath`s; unlike `sortBy:` / `#Predicate`
+    /// it compiles cleanly under the project's strict-concurrency gate, so this is
+    /// the one SwiftData lever available to keep the JSON blobs out of memory while
+    /// the order is computed.
+    private static func scalarOnlyDescriptor() -> FetchDescriptor<CachedTransaction> {
+        var descriptor = FetchDescriptor<CachedTransaction>()
+        descriptor.propertiesToFetch = [\.cacheKey, \.sortDate, \.transactionId]
+        return descriptor
+    }
+
+    /// The newest-first ordered rows for `cacheKey`, memoized per data generation.
+    ///
+    /// Built from a scalar-only fetch (no `payload`), filtered to `cacheKey`, and
+    /// sorted by ``isNewerFirst``. The result is cached against `(dataGeneration,
+    /// cacheKey)` so repeated reads of the same key in a paging session reuse it; a
+    /// read for a different key (or after a write) rebuilds.
+    private func orderedRows(cacheKey: String) throws -> [CachedTransaction] {
+        if let cached = orderCache, cached.generation == dataGeneration, cached.cacheKey == cacheKey {
+            return cached.rows
+        }
+        let rows = try modelContext.fetch(Self.scalarOnlyDescriptor())
+        let ordered = rows
+            .filter { $0.cacheKey == cacheKey }
+            .sorted(by: Self.isNewerFirst)
+        orderCache = (dataGeneration, cacheKey, ordered)
+        return ordered
+    }
+
+    /// Invalidates the memoized ordering by advancing the data generation. Called
+    /// after every write so the next read rebuilds the sort.
+    private func invalidateOrderCache() {
+        dataGeneration &+= 1
+        orderCache = nil
+    }
+
+    /// The transaction ids currently stored for `cacheKey`. Used inside `upsert`
+    /// to decide insert-vs-update, so it always reads live (scalar-only) rather
+    /// than the memoized ordering, which a half-applied write may not reflect.
     private func existingTransactionIds(cacheKey: String) throws -> Set<String> {
-        let rows = try modelContext.fetch(FetchDescriptor<CachedTransaction>())
+        let rows = try modelContext.fetch(Self.scalarOnlyDescriptor())
         return Set(rows.filter { $0.cacheKey == cacheKey }.map(\.transactionId))
     }
 }

--- a/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
@@ -139,4 +139,103 @@ struct TransactionCacheStoreTests {
         #expect(plan.writeCount == 0)
         #expect(try await store.count(cacheKey: key) == 0)
     }
+
+    // MARK: - Bounded ordering cache + invalidation (Finding A)
+
+    /// The newest-first ordering is memoized per data generation so a multi-page
+    /// scroll sorts once. Repeated page reads with no intervening write must return
+    /// stable, correct slices — the cache must not corrupt or stale the ordering.
+    @Test("repeated page reads reuse the cached ordering and stay correct")
+    func cachedOrderingStableAcrossPages() async throws {
+        let store = try TransactionCacheStore(inMemory: true)
+        let all = transactions(count: 30)
+        try await store.upsert(cacheKey: key, transactions: all)
+        let total = try await store.count(cacheKey: key)
+        let expected = all.sorted { $0.date > $1.date }.map(\.id)
+
+        let pageSize = 7
+        // Read every page twice in interleaved order; the memoized order must give
+        // identical, non-overlapping slices each time.
+        for round in 0..<2 {
+            var collected: [String] = []
+            var window: TransactionPageWindow? = .make(pageIndex: 0, pageSize: pageSize, total: total)
+            while let w = window {
+                let page = try await store.page(cacheKey: key, window: w)
+                collected.append(contentsOf: page.map(\.id))
+                window = w.next(pageSize: pageSize, total: total)
+            }
+            #expect(collected == expected, "round \(round): cached ordering yields the full newest-first history")
+        }
+    }
+
+    /// A write must bump the data generation and invalidate the memoized ordering,
+    /// so a later read reflects the new rows rather than serving a stale sort. This
+    /// is the cache-correctness guarantee behind the bounded paging path.
+    @Test("a write invalidates the cached ordering so later reads see new rows")
+    func writeInvalidatesCachedOrdering() async throws {
+        let store = try TransactionCacheStore(inMemory: true)
+        try await store.upsert(cacheKey: key, transactions: transactions(count: 5))
+
+        // Prime the order cache with a read.
+        #expect(try await store.count(cacheKey: key) == 5)
+        let firstPage = try await store.page(
+            cacheKey: key,
+            window: .make(pageIndex: 0, pageSize: 50, total: 5)
+        )
+        #expect(firstPage.count == 5)
+
+        // Grow the history (a concurrent re-sync). The generation must bump.
+        try await store.upsert(cacheKey: key, transactions: transactions(count: 12))
+        #expect(try await store.count(cacheKey: key) == 12, "count reflects the grown history, not the cached 5")
+
+        let afterGrowth = try await store.page(
+            cacheKey: key,
+            window: .make(pageIndex: 0, pageSize: 50, total: 12)
+        )
+        #expect(afterGrowth.count == 12, "the page read sees the new rows after invalidation")
+        let expected = transactions(count: 12).sorted { $0.date > $1.date }.map(\.id)
+        #expect(afterGrowth.map(\.id) == expected, "ordering is rebuilt correctly, newest-first")
+    }
+
+    /// The memoized ordering is keyed by `cacheKey`, not just generation: reading
+    /// two environments back-to-back within one generation must not serve the first
+    /// key's ordering for the second key.
+    @Test("the ordering cache does not bleed across cache keys within one generation")
+    func cachedOrderingScopedPerKey() async throws {
+        let store = try TransactionCacheStore(inMemory: true)
+        try await store.upsert(cacheKey: "sandbox|/x", transactions: transactions(count: 4))
+        try await store.upsert(cacheKey: "production|/x", transactions: transactions(count: 6))
+
+        // Read sandbox first (primes the cache for the current generation), then
+        // production in the same generation — production must not reuse sandbox's order.
+        #expect(try await store.count(cacheKey: "sandbox|/x") == 4)
+        #expect(try await store.count(cacheKey: "production|/x") == 6)
+        // And back again, exercising the cache miss-on-key-change in both directions.
+        #expect(try await store.count(cacheKey: "sandbox|/x") == 4)
+
+        let prodPage = try await store.page(
+            cacheKey: "production|/x",
+            window: .make(pageIndex: 0, pageSize: 100, total: 6)
+        )
+        #expect(prodPage.count == 6, "production page reads its own rows, not sandbox's cached order")
+    }
+
+    /// An updated payload (same id) must be reflected by a subsequent page read —
+    /// proving the cache is invalidated on update, not just on insert/delete, and
+    /// that the page path faults in the fresh blob rather than a stale one.
+    @Test("an in-place update is reflected after cache invalidation")
+    func updateReflectedAfterInvalidation() async throws {
+        let store = try TransactionCacheStore(inMemory: true)
+        let original = TransactionDTO(id: "t1", accountId: "chk", amount: 10, date: "2026-01-10", name: "Old")
+        try await store.upsert(cacheKey: key, transactions: [original])
+        // Prime the cache.
+        _ = try await store.page(cacheKey: key, window: .make(pageIndex: 0, pageSize: 10, total: 1))
+
+        let updated = TransactionDTO(id: "t1", accountId: "chk", amount: 99, date: "2026-01-10", name: "New")
+        try await store.upsert(cacheKey: key, transactions: [updated])
+
+        let page = try await store.page(cacheKey: key, window: .make(pageIndex: 0, pageSize: 10, total: 1))
+        #expect(page.first?.amount == 99, "the cached ordering did not serve the stale payload")
+        #expect(page.first?.name == "New")
+    }
 }

--- a/Tests/PlaidBarCoreTests/PagedTransactionFeedTests.swift
+++ b/Tests/PlaidBarCoreTests/PagedTransactionFeedTests.swift
@@ -130,6 +130,58 @@ struct PagedTransactionFeedTests {
         #expect(rendered == [tx(1)])
     }
 
+    // MARK: - Regression: stale captured total must not drop a transaction (Finding B)
+
+    /// Reproduces the `PagedTransactionSource.loadNextPageIfNeeded` regression: the
+    /// feed's `total` is captured when the first page loads, so a concurrent
+    /// re-sync that grows the history would make the window math believe paging is
+    /// done — silently dropping the newly added newest rows — unless the next-page
+    /// path re-reads `count()` and calls `updateTotal` first.
+    @Test("re-reading total before the next window recovers rows a concurrent re-sync added")
+    func staleTotalDoesNotDropRows() {
+        // Initial paging session over a 10-row history at 10/page: one full page.
+        var feed = PagedTransactionFeed(pageSize: 10, total: 10)
+        let firstWindow = feed.nextWindow!
+        feed.appendPage(fetch(firstWindow), window: firstWindow)
+        #expect(feed.loaded.count == 10)
+        #expect(!feed.hasMore, "with the captured total, the feed thinks it is done")
+
+        // A concurrent re-sync grew the cache to 15 rows. The OLD behavior (no
+        // re-read) would stop here and never surface rows 10..14.
+        let liveTotalAfterResync = 15
+
+        // NEW behavior: loadNextPageIfNeeded re-reads count() and updates the feed
+        // before asking for the next window.
+        feed.updateTotal(liveTotalAfterResync)
+        #expect(feed.hasMore, "after re-reading the grown total, a new page is available")
+
+        guard let recoveredWindow = feed.nextWindow else {
+            Issue.record("expected a next window after the total grew")
+            return
+        }
+        feed.appendPage(fetch(recoveredWindow), window: recoveredWindow)
+
+        #expect(feed.loaded.count == 15, "the 5 newly synced rows are no longer dropped")
+        #expect(feed.loaded.map(\.id) == (0..<15).map { "tx_\($0)" }, "newest-first order preserved")
+        #expect(!feed.hasMore, "paging completes once the live total is fully covered")
+    }
+
+    @Test("re-reading an unchanged total is a stable no-op (next page still loads)")
+    func reReadingUnchangedTotalIsStable() {
+        var feed = PagedTransactionFeed(pageSize: 10, total: 25)
+        let page0 = feed.nextWindow!
+        feed.appendPage(fetch(page0), window: page0)
+
+        // Simulate loadNextPageIfNeeded re-reading the same total each call.
+        feed.updateTotal(25)
+        let page1 = feed.nextWindow
+        #expect(page1?.pageIndex == 1, "an unchanged total still advances to the next page")
+        feed.appendPage(fetch(page1!), window: page1!)
+        feed.updateTotal(25)
+        #expect(feed.nextWindow?.pageIndex == 2)
+        #expect(feed.loaded.count == 20)
+    }
+
     @Test("last partial page loads the remaining rows then stops")
     func lastPartialPage() {
         var feed = PagedTransactionFeed(pageSize: 10, total: 23)


### PR DESCRIPTION
## Summary

Fixes two confirmed code-review findings on the large-history paged transaction path (AND-567), in `TransactionCacheStore` and `PagedTransactionSource`.

### (A) Unbounded paging fetch + misleading docs — MEDIUM perf/doc
`TransactionCacheStore.page()`, `count()`, and `existingTransactionIds()` each ran an unbounded `fetch(FetchDescriptor<CachedTransaction>())` — materializing **every** row including the heavy `payload` JSON blob, then filtering/sorting/slicing in Swift. So every page loaded the whole history and re-sorted `O(N log N)`, defeating the documented bounded-paging goal (the doc comment falsely claimed "the DB does the heavy lifting … only up to `window.limit` rows are materialized").

The `FetchDescriptor(sortBy:)` / `#Predicate` KeyPath-non-`Sendable` constraint under Swift 6 strict concurrency is real (verified by a standalone typecheck probe — both fail; `propertiesToFetch`, which takes `PartialKeyPath`, compiles). The fix bounds the cost with the levers that *are* available:

- **Scalar-only ordering fetch** — `propertiesToFetch = [\.cacheKey, \.sortDate, \.transactionId]` excludes the `payload` blob, so JSON stays faulted out while the order is computed. Only the page slice then faults in and decodes its payloads (bounded to `window.limit`).
- **Memoized ordering per (data generation, cacheKey)** — a monotonic generation counter bumped by every write (`upsert`/`replaceAll`/`clearAll`) invalidates the cache, so a multi-page scroll sorts once instead of once per page. Keyed by `cacheKey` too, since one store file can briefly hold two environments.
- Corrected the misleading doc comments to describe the actual behavior.

Correctness preserved (newest-first, no gaps/overlap); all existing `TransactionCacheStoreTests` stay green.

### (B) Stale captured total drops a transaction after re-sync — LOW bug
`PagedTransactionSource.loadNextPageIfNeeded` used the `total` captured when the first page loaded and never re-read it. A concurrent re-sync that *grew* the history left the window math believing paging was done, silently dropping the newly added newest rows. It now re-reads `count()` and `updateTotal()` before computing the next window; the feed's per-id dedup keeps a shifted row from rendering twice.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes
- `swift test` — 1785 tests pass
- New tests:
  - `TransactionCacheStoreTests`: cached ordering stable across repeated page reads; invalidated on insert/update/growth; scoped per `cacheKey` (no cross-key bleed within a generation).
  - `PagedTransactionFeedTests`: regression pinning the stale-total drop scenario + a stable re-read no-op. (`PagedTransactionSource` is in the `@main` app target and can't be `@testable import`ed, so the regression is pinned at the pure-Core feed layer the source's new control flow relies on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)