### PR TITLE
fix(app): wire FM availability re-probe, live FM categorization, and gate energy-loop restarts

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -529,6 +529,19 @@ final class AppState {
     /// notifications that drive energy-aware background refresh (AND-568).
     /// Retained so they can be removed in `deinit`.
     private var energyStateObservers: [NSObjectProtocol] = []
+    /// The last energy-constrained verdict the power/thermal observers acted on.
+    /// Cached so a power/thermal notification only restarts the refresh loop (and
+    /// issues its connectivity probe) when the constrained verdict actually flips
+    /// — not on every transition that stays on the same side of the boundary
+    /// (e.g. `.nominal` → `.fair`, both unconstrained). `nil` until the first
+    /// notification establishes a baseline.
+    private var lastEnergyConstrainedVerdict: Bool?
+    /// Observer token for `NSApplication.didBecomeActiveNotification`, used to
+    /// re-probe Apple Foundation Models availability when the app reactivates so a
+    /// transient FM state (model still downloading, Apple Intelligence just turned
+    /// on in System Settings) recovers within the session instead of requiring a
+    /// relaunch (AND-563/564). Retained so it can be removed in `deinit`.
+    private var appActivationObserver: NSObjectProtocol?
     private let glanceSnapshotWriteDebouncer = GlanceSnapshotWriteDebouncer()
     private var glanceSnapshotWriteGeneration = 0
     private var reviewUndoStack: [(metadata: [TransactionReviewMetadata], rules: [TransactionRule])] = []
@@ -1588,12 +1601,79 @@ final class AppState {
     /// Apple Intelligence in System Settings) and rebuild the insight service so a
     /// now-available FM tier starts generating insights (AND-564) — or a
     /// now-unavailable one disengages and the existing engine resumes unchanged.
+    ///
+    /// Wired to `NSApplication.didBecomeActiveNotification` (see
+    /// `startEnergyStateObservers`) so a transient FM state — the model still
+    /// downloading (`.modelNotReady`), or Apple Intelligence only just enabled in
+    /// System Settings (`.appleIntelligenceNotEnabled`) — recovers the next time
+    /// the app reactivates, instead of being stuck until the user relaunches. The
+    /// `previous == current` guard makes the common no-change reactivation a cheap
+    /// no-op.
     func refreshFoundationModelsAvailability() {
         let previous = foundationModelsTierState
         foundationModelsTierState = foundationModelsProbe.currentState()
         guard foundationModelsTierState != previous else { return }
         rebuildLocalAIInsightsService()
         invalidateLocalAIActivitySummaries()
+        // The FM categorization tier just flipped availability; any cached FM
+        // category suggestions were computed against the prior state, so drop them
+        // and let the Review Inbox recompute on its next appearance.
+        _foundationModelsCategorySuggestions = [:]
+    }
+
+    /// Display-only Foundation Models category *suggestions*, keyed by transaction
+    /// id (AND-565). Populated by `refreshFoundationModelsCategorySuggestions()`
+    /// only on an `.available` FM device; empty everywhere else, so the no-FM path
+    /// is unchanged. These are SUGGESTIONS, never persisted categories: they never
+    /// touch `transactionReviewMetadata.userCategory`, never feed budget/export
+    /// totals, and never bypass the review/override flow — exactly the contract the
+    /// NL "Suggested" badge already follows.
+    private var _foundationModelsCategorySuggestions: [String: MerchantCategorySuggestion] = [:]
+
+    /// The on-device Foundation Models category suggestion for a transaction, if
+    /// one has been computed this session. `nil` on every non-`.available` device
+    /// (the dictionary stays empty there), so callers degrade to the existing NL
+    /// path with no change.
+    func foundationModelsCategorySuggestion(for transactionID: String) -> MerchantCategorySuggestion? {
+        _foundationModelsCategorySuggestions[transactionID]
+    }
+
+    /// Drive the live Foundation Models categorization tier (AND-565): for the
+    /// current Review Inbox items that still need a category, ask the wired
+    /// categorizer for an on-device suggestion and cache the `.foundationModels`
+    /// results for display. A no-op unless the FM probe reports `.available`, so
+    /// the no-FM device never makes a model call and behaves exactly as before.
+    ///
+    /// Only the redaction-safe merchant string crosses into the model (the
+    /// categorizer enforces this); no identifiers, amounts, or Plaid payloads.
+    /// Results are display-only suggestions — they are never auto-applied and never
+    /// bypass the review/override flow (`EffectiveCategoryResolver` stays the
+    /// source of truth for persisted categories).
+    func refreshFoundationModelsCategorySuggestions() async {
+        guard foundationModelsTierState.isAvailable else { return }
+        let categorizer = merchantCategorizer
+        // Only items still flagged as needing a category benefit from a
+        // suggestion; a row the user already categorized must not be second-
+        // guessed. Skip ones already suggested this session to avoid redundant
+        // model calls on every inbox reopen.
+        let pending = transactionReviewInboxSnapshot.items.filter { item in
+            item.reasonCodes.contains(.uncategorized)
+                && _foundationModelsCategorySuggestions[item.id] == nil
+        }
+        guard !pending.isEmpty else { return }
+
+        var produced: [String: MerchantCategorySuggestion] = [:]
+        for item in pending {
+            guard let suggestion = await categorizer.suggest(for: item.transaction),
+                  suggestion.tier == .foundationModels else { continue }
+            produced[item.id] = suggestion
+        }
+        guard !produced.isEmpty else { return }
+        // Merge rather than replace: concurrent passes (e.g. a refresh landing
+        // mid-iteration) must not clobber suggestions another pass already wrote.
+        for (id, suggestion) in produced {
+            _foundationModelsCategorySuggestions[id] = suggestion
+        }
     }
 
     /// Cached local summaries — invalidated via accounts.didSet and transactions.didSet.
@@ -2560,6 +2640,18 @@ final class AppState {
             }
         }
         energyStateObservers = [powerObserver, thermalObserver]
+        // Re-probe Apple Foundation Models availability on app reactivation so a
+        // transient FM state recovers within the session (AND-563/564). The probe
+        // is cheap and the refresh self-guards against no-change reactivations.
+        appActivationObserver = center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshFoundationModelsAvailability()
+            }
+        }
     }
 
     private func stopEnergyStateObservers() {
@@ -2568,14 +2660,30 @@ final class AppState {
             center.removeObserver(observer)
         }
         energyStateObservers = []
+        if let appActivationObserver {
+            center.removeObserver(appActivationObserver)
+            self.appActivationObserver = nil
+        }
     }
 
     /// Re-evaluates the background cadence after a power/thermal transition by
     /// restarting the loop (only when one is already running, so we never spin a
     /// loop up before boot). The restart re-reads `currentEnergyConditions` for
     /// both the gate and the sleep length.
+    ///
+    /// Restarting the loop also tears down the current sleep and immediately runs
+    /// a refresh tick, which issues a server connectivity probe (HTTP). The energy
+    /// cadence only changes when the *constrained* verdict crosses its boundary
+    /// (Low Power Mode on/off, or thermal entering/leaving `.serious`/`.critical`),
+    /// so a transition that stays on the same side — e.g. `.nominal` → `.fair`, or
+    /// `.serious` → `.critical`, both already constrained — would have produced the
+    /// same next-tick delay. Restart (and probe) ONLY when the verdict actually
+    /// flips; otherwise this is a cheap no-op (AND-568 perf).
     private func handleEnergyStateChange() {
         guard refreshTask != nil else { return }
+        let constrained = currentEnergyConditions.isConstrained
+        guard constrained != lastEnergyConstrainedVerdict else { return }
+        lastEnergyConstrainedVerdict = constrained
         startBackgroundRefresh()
     }
 

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -130,6 +130,15 @@ struct ReviewInboxView: View {
                 isFocused = true
                 clampSelection()
             }
+            // Drive the live on-device Foundation Models categorization tier
+            // (AND-565). A no-op unless Apple Intelligence is `.available`, so the
+            // no-FM device makes no model call. Re-runs when the queue changes so
+            // newly-arrived uncategorized rows get a suggestion. Results are
+            // display-only suggestions surfaced via the "Suggested" badge; they
+            // never auto-apply.
+            .task(id: snapshot.totalCount) {
+                await appState.refreshFoundationModelsCategorySuggestions()
+            }
             .onChange(of: snapshot.totalCount) { _, newCount in
                 clampSelection()
                 // When the queue drains to empty, drop any lingering confirmation
@@ -259,6 +268,7 @@ struct ReviewInboxView: View {
     private func reviewRow(item: TransactionReviewItem, globalIndex: Int) -> some View {
         ReviewInboxRow(
             item: item,
+            foundationModelsSuggestion: appState.foundationModelsCategorySuggestion(for: item.id),
             isSelected: globalIndex == selectedIndex,
             merchantDraft: merchantDraftBinding(for: item),
             onSelect: { selectedIndex = globalIndex },
@@ -751,6 +761,12 @@ private struct InlineCategoryRulePromptBanner: View {
 
 private struct ReviewInboxRow: View {
     let item: TransactionReviewItem
+    /// On-device Foundation Models category *suggestion* for this row, when an
+    /// `.available` FM device produced one (AND-565). Display-only: it badges the
+    /// row but never auto-applies — the user still approves through the existing
+    /// review flow. `nil` on every non-FM device and for rows the model skipped,
+    /// so the row renders exactly as before there.
+    var foundationModelsSuggestion: MerchantCategorySuggestion?
     let isSelected: Bool
     @Binding var merchantDraft: String
     let onSelect: () -> Void
@@ -831,9 +847,9 @@ private struct ReviewInboxRow: View {
                     // name as text + a glyph, so meaning never rides on color
                     // (ACCESSIBILITY.md). The pure CategoryPillModel owns the
                     // category→{title, glyph, accent} mapping.
-                    CategoryPill(model: CategoryPillModel.make(category: item.effectiveCategory))
+                    CategoryPill(model: CategoryPillModel.make(category: displayCategory))
 
-                    if item.isNLSuggestedCategory {
+                    if isShowingSuggestion {
                         suggestedBadge
                     }
 
@@ -1031,14 +1047,32 @@ private struct ReviewInboxRow: View {
         item.reasonCodes.contains(where: \.isHighPriority) ? SemanticColors.warning : .secondary
     }
 
+    /// The category the row displays. Prefers the persisted/Plaid/NL effective
+    /// category; only when none exists does it fall back to a display-only
+    /// Foundation Models *suggestion* so an `.available` FM device fills the pill
+    /// instead of showing "Uncategorized". This is display-only — it never
+    /// persists and never bypasses the review/override flow (AND-565).
+    private var displayCategory: SpendingCategory? {
+        item.effectiveCategory ?? foundationModelsSuggestion?.category
+    }
+
+    /// Whether the displayed category is an on-device *suggestion* (NL backfill or
+    /// a Foundation Models fill of an otherwise-uncategorized row) and so should
+    /// carry the "Suggested" badge. A real Plaid/user category never badges, even
+    /// if FM also produced a (now-unused) suggestion.
+    private var isShowingSuggestion: Bool {
+        item.isNLSuggestedCategory
+            || (item.effectiveCategory == nil && foundationModelsSuggestion != nil)
+    }
+
     private var accessibilitySummary: String {
         let reasons = item.reasonCodes.map(\.displayName).joined(separator: ", ")
         // The row Button's label overrides the child "Suggested" badge, so fold
         // the on-device provenance into the spoken category — otherwise VoiceOver
-        // announces an NL suggestion identically to a Plaid/user category even
-        // though the visual UI shows the "Suggested" badge.
-        let baseCategory = item.effectiveCategory?.displayName ?? "Uncategorized"
-        let category = item.isNLSuggestedCategory ? "\(baseCategory) (suggested on device)" : baseCategory
+        // announces a suggestion identically to a Plaid/user category even though
+        // the visual UI shows the "Suggested" badge.
+        let baseCategory = displayCategory?.displayName ?? "Uncategorized"
+        let category = isShowingSuggestion ? "\(baseCategory) (suggested on device)" : baseCategory
         let amount = Formatters.currency(item.transaction.displayAmount, format: .full)
         return "\(item.effectiveMerchantName), \(amount), \(category), reasons: \(reasons)"
     }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -539,4 +539,113 @@ struct PlaidBarTests {
 
         #expect(abs(estimated - 112.66) < 0.01)
     }
+
+    // MARK: - Energy-aware loop restart gating (mirrors AppState.handleEnergyStateChange)
+    //
+    // AppState caches the last constrained verdict and only restarts the
+    // background refresh loop (which issues a server HTTP probe) when that verdict
+    // flips. The verdict itself is `EnergyConditions.isConstrained` (pure Core).
+    // These pin the boundary semantics the cache relies on so a fair→serious style
+    // change inside the same constrained band does NOT cross the boundary.
+
+    @Test("Energy constrained verdict only flips across the constrained boundary")
+    func energyConstrainedVerdictBoundary() {
+        func constrained(_ lowPower: Bool, _ thermal: EnergyAwareRefreshPolicy.EnergyThermalState) -> Bool {
+            EnergyAwareRefreshPolicy.EnergyConditions(lowPowerMode: lowPower, thermalState: thermal).isConstrained
+        }
+
+        // Same side of the boundary — a restart would be redundant.
+        #expect(constrained(false, .nominal) == constrained(false, .fair)) // both unconstrained
+        #expect(constrained(false, .serious) == constrained(false, .critical)) // both constrained
+        #expect(constrained(true, .serious) == constrained(true, .critical)) // both constrained
+
+        // Crossing the boundary — a restart is warranted.
+        #expect(constrained(false, .fair) != constrained(false, .serious))
+        #expect(constrained(false, .nominal) != constrained(true, .nominal)) // low power flips it
+    }
+
+    @Test("Constrained verdict flip emits exactly one restart across a fair→serious→critical→nominal walk")
+    func energyVerdictFlipCount() {
+        // Mirror AppState's cache: start with no baseline (nil), then feed a
+        // sequence of conditions and count how many times the verdict flips —
+        // i.e. how many loop restarts (and HTTP probes) AppState would issue.
+        let walk: [EnergyAwareRefreshPolicy.EnergyConditions] = [
+            .init(lowPowerMode: false, thermalState: .nominal),  // baseline: false
+            .init(lowPowerMode: false, thermalState: .fair),     // false → no flip
+            .init(lowPowerMode: false, thermalState: .serious),  // true  → flip #1
+            .init(lowPowerMode: false, thermalState: .critical), // true  → no flip
+            .init(lowPowerMode: false, thermalState: .nominal),  // false → flip #2
+        ]
+        var last: Bool?
+        var restarts = 0
+        for conditions in walk {
+            let verdict = conditions.isConstrained
+            if verdict != last {
+                restarts += 1
+                last = verdict
+            }
+        }
+        // Naive "restart on every notification" would be 5; gating yields 3
+        // (the initial baseline establish + the two real boundary crossings).
+        #expect(restarts == 3)
+    }
+
+    // MARK: - Foundation Models categorization tier (mirrors AppState.refreshFoundationModelsCategorySuggestions)
+
+    @Test("FM categorizer produces a foundationModels suggestion when Apple Intelligence is available")
+    func fmCategorizerProducesSuggestionWhenAvailable() async {
+        let categorizer = FMMerchantCategorizer(
+            foundationModelsState: .available,
+            nlCategorizer: NLMerchantCategorizer(),
+            fmCategorizer: StubFMCategorizer(result: .foodAndDrink)
+        )
+        let txn = TransactionDTO(id: "fm1", accountId: "a", amount: 12, date: "2026-01-15", name: "Local Cafe", category: nil)
+
+        let suggestion = await categorizer.suggest(for: txn)
+
+        #expect(suggestion?.tier == .foundationModels)
+        #expect(suggestion?.category == .foodAndDrink)
+        #expect(suggestion?.isTrusted == true)
+    }
+
+    @Test("FM categorizer skips the model when Apple Intelligence is not available")
+    func fmCategorizerSkippedWhenUnavailable() async {
+        // The stub would force a (wrong) FM result if it were ever consulted; an
+        // unavailable state must bypass it entirely, matching AppState's guard
+        // that makes the no-FM device never call the model.
+        let stub = StubFMCategorizer(result: .travel)
+        let categorizer = FMMerchantCategorizer(
+            foundationModelsState: .unsupported,
+            nlCategorizer: NLMerchantCategorizer(),
+            fmCategorizer: stub
+        )
+        let txn = TransactionDTO(id: "fm2", accountId: "a", amount: 12, date: "2026-01-15", name: "Local Cafe", category: nil)
+
+        let suggestion = await categorizer.suggest(for: txn)
+
+        #expect(suggestion?.tier != .foundationModels)
+        #expect(stub.callCount == 0)
+    }
+}
+
+/// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.
+/// Mirrors the in-app FoundationModels seam without importing the app target
+/// (which an executable target cannot expose to tests).
+private final class StubFMCategorizer: FMMerchantCategorizing, @unchecked Sendable {
+    private let result: SpendingCategory?
+    private let lock = NSLock()
+    private var _callCount = 0
+    var callCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _callCount
+    }
+
+    init(result: SpendingCategory?) {
+        self.result = result
+    }
+
+    func suggestCategory(merchant: String) async -> SpendingCategory? {
+        lock.lock(); _callCount += 1; lock.unlock()
+        return result
+    }
 }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -644,8 +644,8 @@ private final class StubFMCategorizer: FMMerchantCategorizing, @unchecked Sendab
         self.result = result
     }
 
-    func suggestCategory(merchant: String) async -> SpendingCategory? {
+    func suggestCategory(merchant: String) async -> String? {
         lock.lock(); _callCount += 1; lock.unlock()
-        return result
+        return result?.rawValue
     }
 }


### PR DESCRIPTION
## Summary

Three AppState runtime-wiring findings from the **appstate-runtime** audit stream. All fixes are additive, reversible, and unchanged on a non-FM / unconstrained-energy device.

### (A) FM availability never re-probed — `refreshFoundationModelsAvailability()` was dead code
Foundation Models availability was probed once in `AppState.init` and never again, and `refreshFoundationModelsAvailability()` had **zero callers**. Transient states (`.modelNotReady` while the model downloads, `.appleIntelligenceNotEnabled`) never recovered within a session — the user had to relaunch.

**Fix:** wired `refreshFoundationModelsAvailability()` to `NSApplication.didBecomeActiveNotification` (registered alongside the existing energy observers, removed in `deinit`). The function already guards `previous == current`, so the common no-change reactivation is a cheap no-op.

### (B) FM merchant categorizer wired but `suggest(for:)` never called — tier dormant
`merchantCategorizer` was built and wired but its `suggest(for:)` API was never invoked at runtime, so the FM categorization tier produced nothing.

**Fix:** added `refreshFoundationModelsCategorySuggestions()` (a no-op unless the probe reports `.available`) that calls the **existing** categorizer API for uncategorized Review Inbox rows and caches the `.foundationModels` results as **display-only** suggestions. `ReviewInboxView` triggers it via `.task` and surfaces the result through the existing "Suggested" badge + category pill. Suggestions never persist, never feed budget/export totals, and never bypass the review/override flow (`EffectiveCategoryResolver` stays the source of truth). The categorizer's own source files were **not** touched.

### (C) Energy observer restarted the loop + HTTP-probed on every notification
`handleEnergyStateChange()` restarted the whole refresh loop (which immediately issues a server connectivity probe) on **every** power/thermal notification, even transitions that don't cross the constrained boundary (e.g. `.nominal` → `.fair`).

**Fix:** cache the last `EnergyConditions.isConstrained` verdict and restart only when it actually flips.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes
- `swift test` — **1783 tests pass**

The `PlaidBar` app target is an executable and cannot be `@testable`-imported (the test target depends only on `PlaidBarCore`, matching the existing "mirror AppState logic" pattern). New Swift Testing cases pin the pure decisions the wiring depends on:
- constrained-verdict boundary semantics + flip-count gating (mirrors `handleEnergyStateChange`)
- FM categorizer producing a `.foundationModels` suggestion when available, and skipping the model entirely when not

## Follow-ups
- Extract the verdict-flip gating decision (C) into a pure `EnergyAwareRefreshPolicy` Core helper so the gating itself (not just the underlying `isConstrained`) is directly unit-testable. Not done here because `EnergyAwareRefreshPolicy.swift` is owned by another stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)