### PR TITLE
feat(window): feature-flagged window-first scene skeleton (AND-591)

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -22,7 +22,18 @@ struct PlaidBarApp: App {
     /// registration survives `body` recomputes for the process lifetime.
     @State private var summonHotkeyMonitor = SummonHotkeyMonitor()
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Identifier of the window-first primary workspace `Window` scene (ADR-001,
+    /// Epic 1 / AND-591). Shared by the scene declaration and the
+    /// `openWindow(id:)` affordances so they never drift.
+    private static let mainWindowID = "main"
+    /// Window-first hybrid opt-in (`WindowFirstFeatureFlag`, default OFF). Resolved
+    /// once at launch from the CLI override / stored preference. While OFF the
+    /// "Open VaultPeek" affordance never targets the `Window` scene, so the app
+    /// behaves byte-identically to the popover-first build (the scene itself uses
+    /// `.defaultLaunchBehavior(.suppressed)`, so an unopened window is inert).
+    private let isWindowFirstEnabled = WindowFirstFeatureFlag.resolved()
     private let updaterController: SPUStandardUpdaterController
     private let statusItemContextMenuController = StatusItemContextMenuController()
     /// Draws the unreviewed review-inbox count badge on the menu-bar status item
@@ -321,6 +332,23 @@ struct PlaidBarApp: App {
         }
         .menuBarExtraStyle(.window)
 
+        .commands {
+            // "Open VaultPeek" affordance in the app menu, gated by the
+            // window-first flag (ADR-001, Epic 1 / AND-591). When the flag is OFF
+            // this command is not added, so the menu — and the whole app — is
+            // identical to today's popover-first build. When ON it raises the
+            // primary `Window` workspace via `openWindow(id:)`. The empty `if`
+            // produces no commands, satisfying the `Commands` builder.
+            if isWindowFirstEnabled {
+                CommandGroup(after: .windowList) {
+                    Button("Open VaultPeek") {
+                        openWindow(id: Self.mainWindowID)
+                    }
+                    .keyboardShortcut("0", modifiers: .command)
+                }
+            }
+        }
+
         Settings {
             SettingsView(updater: updaterController.updater)
                 .environment(appState)
@@ -330,6 +358,36 @@ struct PlaidBarApp: App {
                 // change reflected in the very control they are adjusting (AND-570).
                 .appliesAppTextSize()
         }
+
+        // Window-first primary workspace (ADR-001, Epic 1 / AND-591). The scene is
+        // always declared so the scene graph is stable, but it is inert until
+        // explicitly opened: `.defaultLaunchBehavior(.suppressed)` keeps it from
+        // appearing at launch, and the only affordance that opens it (the
+        // "Open VaultPeek" command above) is gated behind the window-first flag.
+        // So with the flag OFF — the shipping default — the window never appears
+        // and the app behaves byte-identically to the popover-first build. The
+        // shell is an empty `NavigationSplitView` skeleton; routing/destinations
+        // and the activation-policy/appearance wiring land in later Epic 1/2 PRs.
+        Window("VaultPeek", id: Self.mainWindowID) {
+            AppShellView()
+                .environment(appState)
+                .forcedAppColorScheme(Self.forcedColorScheme)
+                .appliesAppAppearance()
+                .appliesAppTextSize()
+                // Liquid Glass on chrome only (ADR-001): the window background is
+                // the ultra-thin material; data surfaces inside stay opaque. This
+                // is a content modifier (it walks up to the window), so it lives on
+                // the scene's root view, not on the `Window` scene itself.
+                .containerBackground(.ultraThinMaterial, for: .window)
+        }
+        // Do not steal launch/activation: the window only appears when opened.
+        .defaultLaunchBehavior(.suppressed)
+        // Let macOS restore the window across launches once the user opts in.
+        .restorationBehavior(.automatic)
+        // Content-driven sizing with a sensible floor so the 3-column workspace
+        // never collapses below a usable width.
+        .windowResizability(.contentMinSize)
+        .defaultSize(width: 1080, height: 720)
     }
 
     /// Registers or unregisters the global summon hotkey to match the persisted

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Skeleton for the window-first primary workspace (ADR-001, Epic 1 / AND-579,
+/// first code step AND-591).
+///
+/// This is an **empty** `NavigationSplitView` shell — a sidebar placeholder and a
+/// content placeholder, with **no routing or destinations yet**. The typed
+/// `Route` enum, the `@Observable` navigation model, the sidebar groups, and the
+/// ⌘K command palette all land in Epic 2 (AND-580+). Keeping this PR to the scene
+/// + skeleton makes the window scaffolding reviewable on its own and lets it ship
+/// behind a flag (`WindowFirstFeatureFlag`, default OFF) without touching the
+/// popover.
+///
+/// Liquid Glass on chrome is applied at the scene level via
+/// `.containerBackground(.ultraThinMaterial, for: .window)` in `PlaidBarApp`, not
+/// here — per ADR-001 the glass goes on chrome only, never on data.
+struct AppShellView: View {
+    var body: some View {
+        NavigationSplitView {
+            // Sidebar placeholder. Epic 2 replaces this with the 4 navigation
+            // groups (Overview / Workflows / Insights / Money / System) backed by
+            // a typed `Route` enum and a single `@Observable` navigation model.
+            ContentUnavailableView {
+                Label("VaultPeek", systemImage: "sidebar.left")
+            } description: {
+                Text("Navigation arrives in a later step.")
+            }
+            .navigationTitle("VaultPeek")
+            .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
+        } detail: {
+            // Content placeholder. Epic 2 routes the selected sidebar destination
+            // (Dashboard, Transactions, Budgets, …) into this column.
+            ContentUnavailableView(
+                "Window-First Workspace",
+                systemImage: "macwindow",
+                description: Text("The primary workspace is under construction.")
+            )
+        }
+    }
+}
+
+#Preview {
+    AppShellView()
+}

--- a/Sources/PlaidBarCore/Utilities/WindowFirstFeatureFlag.swift
+++ b/Sources/PlaidBarCore/Utilities/WindowFirstFeatureFlag.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Feature flag gating the window-first hybrid experience (ADR-001, Epic 1 /
+/// AND-579, first code step AND-591).
+///
+/// The migration to a primary `Window` workspace runs **dual-run behind this
+/// flag**: while it is OFF the app behaves byte-identically to the popover-first
+/// build that shipped today — the menu-bar glance is the only surface and the
+/// declarative `Window` scene must not change launch or activation behavior. The
+/// window is opt-in until the workspace reaches parity (Epic 9 flips the default
+/// and removes the flag).
+///
+/// The flag defaults **OFF** on purpose: a fresh install, and every existing
+/// user who never toggles it, keeps the current popover-only experience. The
+/// resolution rule is pure and lives here in `PlaidBarCore` so it is `Sendable`,
+/// testable without launching the app, and shared by the UI process. The
+/// `CommandLine`/`UserDefaults` plumbing in `resolved()` is a thin wrapper over
+/// the pure `resolve(...)` decision.
+public enum WindowFirstFeatureFlag {
+    /// `UserDefaults` key persisting the user's opt-in. Absent ⇒ OFF (default).
+    public static let storageKey = "featureFlag.windowFirst"
+
+    /// CLI override (QA/screenshot aid, mirrors `--appearance` / `--text-size`):
+    /// `--window-first on|off|true|false|1|0`. Lets a QA pass exercise the window
+    /// without leaving a durable preference behind, and lets a flag-ON build be
+    /// forced OFF for a regression capture. The override wins over the stored
+    /// preference when present and parseable.
+    public static let commandLineFlag = "--window-first"
+
+    /// The flag's default when neither a CLI override nor a stored preference is
+    /// present. **OFF** — popover-first stays the shipping default.
+    public static let defaultValue = false
+
+    /// Pure resolution: CLI override (if parseable) wins, else the stored
+    /// preference, else `defaultValue`. No I/O — every input is passed in, so the
+    /// whole policy is unit-testable. `cliOverrideRaw` is the raw string that
+    /// followed `--window-first` (or `nil` when the flag was absent).
+    public static func resolve(
+        cliOverrideRaw: String?,
+        storedValue: Bool?
+    ) -> Bool {
+        if let parsed = parse(cliOverrideRaw) {
+            return parsed
+        }
+        if let storedValue {
+            return storedValue
+        }
+        return defaultValue
+    }
+
+    /// Parses a CLI override token into a bool, or `nil` when it is absent or not
+    /// a recognized on/off spelling (in which case the caller falls through to the
+    /// stored preference / default — an unparseable value never silently enables).
+    public static func parse(_ raw: String?) -> Bool? {
+        guard let token = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !token.isEmpty else {
+            return nil
+        }
+        switch token {
+        case "on", "true", "yes", "1":
+            return true
+        case "off", "false", "no", "0":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    /// Resolves the live flag from the CLI arguments and a `UserDefaults` store.
+    /// Defaults to the process arguments and `.standard`; both are injectable so
+    /// tests drive the wrapper without touching real global state.
+    public static func resolved(
+        arguments: [String] = CommandLine.arguments,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        resolve(
+            cliOverrideRaw: CommandLineOptions.value(for: commandLineFlag, in: arguments),
+            storedValue: defaults.object(forKey: storageKey) == nil
+                ? nil
+                : defaults.bool(forKey: storageKey)
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/WindowFirstFeatureFlagTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowFirstFeatureFlagTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Window-first feature flag")
+struct WindowFirstFeatureFlagTests {
+    // MARK: - Default
+
+    @Test("Defaults OFF when neither a CLI override nor a stored preference is set")
+    func defaultsOff() {
+        #expect(WindowFirstFeatureFlag.defaultValue == false)
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: nil) == false)
+    }
+
+    @Test("With no override, the stored preference wins")
+    func storedPreferenceWins() {
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: true) == true)
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: false) == false)
+    }
+
+    // MARK: - CLI override
+
+    @Test("A parseable CLI override wins over the stored preference", arguments: [
+        ("on", true), ("true", true), ("yes", true), ("1", true),
+        ("off", false), ("false", false), ("no", false), ("0", false),
+        ("ON", true), (" Off ", false),
+    ])
+    func cliOverrideWins(token: String, expected: Bool) {
+        // Override wins regardless of the opposite stored value.
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: token, storedValue: !expected) == expected)
+    }
+
+    @Test("An unparseable or empty CLI override falls through to the stored value / default")
+    func unparseableOverrideFallsThrough() {
+        #expect(WindowFirstFeatureFlag.parse("maybe") == nil)
+        #expect(WindowFirstFeatureFlag.parse("") == nil)
+        #expect(WindowFirstFeatureFlag.parse("   ") == nil)
+        #expect(WindowFirstFeatureFlag.parse(nil) == nil)
+        // Falls through to stored value when present, else the OFF default.
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: true) == true)
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: nil) == false)
+    }
+
+    // MARK: - resolved() wiring (UserDefaults + arguments)
+
+    @Test("resolved() returns OFF for an empty store and no CLI flag")
+    func resolvedDefaultsOff() {
+        let defaults = Self.emptyDefaults()
+        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == false)
+    }
+
+    @Test("resolved() reads the stored preference when no CLI flag is present")
+    func resolvedReadsStoredPreference() {
+        let defaults = Self.emptyDefaults()
+        defaults.set(true, forKey: WindowFirstFeatureFlag.storageKey)
+        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == true)
+    }
+
+    @Test("resolved() lets the CLI flag override the stored preference")
+    func resolvedCLIOverridesStore() {
+        let defaults = Self.emptyDefaults()
+        defaults.set(true, forKey: WindowFirstFeatureFlag.storageKey)
+        let args = ["PlaidBar", WindowFirstFeatureFlag.commandLineFlag, "off"]
+        #expect(WindowFirstFeatureFlag.resolved(arguments: args, defaults: defaults) == false)
+    }
+
+    /// An isolated, empty `UserDefaults` suite so the test never reads or writes
+    /// the real `.standard` domain.
+    private static func emptyDefaults() -> UserDefaults {
+        let suiteName = "WindowFirstFeatureFlagTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

First **code** step of Epic 1 ([AND-579](https://linear.app/andeslab/issue/AND-579)) for the window-first hybrid migration ([ADR-001](docs/strategy/macos26-migration/ADR-001-window-first-architecture.md), ratified at Gate 0 / AND-578). This stands up the **feature-flagged scene skeleton only** — the popover remains the default surface; the primary `Window` workspace is opt-in behind a default-OFF flag.

Implements [AND-591](https://linear.app/andeslab/issue/AND-591) exactly to its acceptance criteria.

## What's in this PR

- **`WindowFirstFeatureFlag`** (`PlaidBarCore`) — a pure, `Sendable`, testable resolver. Precedence: CLI override (`--window-first on|off|…`, a QA aid mirroring `--appearance`/`--text-size`) > stored `UserDefaults` preference (`featureFlag.windowFirst`) > **OFF default**. The decision (`resolve(...)`) takes all inputs as parameters; `resolved(arguments:defaults:)` is a thin, injectable wrapper.
- **`AppShellView`** (`Sources/PlaidBar/Views/`) — an **empty** `NavigationSplitView` skeleton (sidebar placeholder + content placeholder). No routing/destinations — that's Epic 2.
- **`PlaidBarApp`** scene graph:
  - `Window("VaultPeek", id: "main")` with `.defaultLaunchBehavior(.suppressed)`, `.restorationBehavior(.automatic)`, `.windowResizability(.contentMinSize)`, `.defaultSize(1080×720)`.
  - `.containerBackground(.ultraThinMaterial, for: .window)` applied on the scene's root view (it's a content modifier that walks up to the window — Liquid Glass on chrome only, per ADR-001).
  - An **"Open VaultPeek"** `CommandGroup` (⌘0) that opens the window via `@Environment(\.openWindow)` → `openWindow(id: "main")`, **gated behind the flag**.
- **7 Swift Testing cases** for the flag (OFF default, stored-preference precedence, CLI override parsing/precedence, and the `resolved()` wiring against an isolated `UserDefaults` suite).

No `#available(macOS 26, *)` guards were needed — the floor is macOS 26, so these APIs are available directly.

## Feature-flag-OFF is byte-identical

The flag defaults **OFF**, so a fresh install and every existing user keep the current popover-only experience:

- The `Window` scene is always *declared* (stable scene graph) but **inert**: `.defaultLaunchBehavior(.suppressed)` keeps it from appearing at launch, and the only affordance that opens it (the "Open VaultPeek" command) is **not added** to the menu when the flag is OFF.
- The menu-bar glance, the status-item context menu, `Settings`, and all existing detached-window behavior are untouched.

Reverting the whole window-first effort (through Epic 8) remains "flip the flag," per ADR-001's dual-run plan.

## Untouched boundaries

`PlaidBarCore` business logic, the server, the Plaid client, and the Keychain boundary are unchanged. The new flag is additive Core code with no dependencies on the security layers.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — **1803 passed** (was ~1796; +7 from this PR). No regressions.

## Epic-1 follow-ups deferred to the next PR (intentionally out of scope here)

Per the AND-591 scope guard, this PR is a clean skeleton. The rest of Epic 1 lands separately:

- **Single tested `@MainActor` activation-policy helper** — retire/replace the most-patched `AppActivationPolicyCoordinator` refcounting (R-01) so opening/closing the window elevates activation cleanly.
- **Appearance owner for the window** — fold the new window into the single `NSApp.appearance` source of truth (`AppAppearance`) and verify Light/Dark flips it live alongside the popover/Settings/detached windows.
- **Flag-toggle / open-close cycle test** — an integration test that toggles the flag, opens and closes the window, and asserts no leaked activation policy or appearance state.
- A Settings UI toggle for the flag (currently CLI/`UserDefaults`-only) can come with the activation-policy PR.

Navigation/routing internals (Epic 2) and the AppKit-window migration (Epic 3) are separate epics.
