### PR TITLE
feat(window): tested activation-policy + appearance owner for window-first scene (AND-620)

### DIFF
--- a/Sources/PlaidBar/App/AppActivationPolicyCoordinator.swift
+++ b/Sources/PlaidBar/App/AppActivationPolicyCoordinator.swift
@@ -1,9 +1,12 @@
 import AppKit
+import PlaidBarCore
 
 /// Single owner of `NSApplication.activationPolicy` elevation, shared by every
 /// surface that needs the menu-bar (`.accessory`) app to temporarily become a
-/// regular, front-and-Dock app: the detached dashboard window and the Settings
-/// window.
+/// regular, front-and-Dock app: the detached dashboard window, the Category
+/// Dashboard / Review Table windows, the Settings window, and — behind the
+/// window-first flag — the declarative primary `Window` (via
+/// ``WindowActivationPolicy``, ADR-001 / AND-620).
 ///
 /// It is **refcounted**. The pre-elevation baseline policy is captured only on
 /// the *first* request and restored only when the *last* request is released, so
@@ -12,6 +15,15 @@ import AppKit
 /// captured the already-elevated `.regular` as its baseline, leaving a spurious
 /// Dock / ⌘-Tab presence after both closed.
 ///
+/// The fragile refcount + baseline-capture *decision* lives in the pure,
+/// `@testable`-importable ``ActivationPolicyRefcount`` in `PlaidBarCore` (the app
+/// target is not test-importable). This shim is the only place that touches
+/// `NSApplication`: it maps the live `NSApp.activationPolicy()` into the pure
+/// decision and applies the policy the decision returns, mutating
+/// `NSApp.setActivationPolicy` only when it actually changes. The window-first
+/// helper drives this same instance, so every surface shares one authoritative
+/// refcount (R-01).
+///
 /// `@MainActor`-isolated; all `NSApplication` mutation happens on the main actor.
 @MainActor
 final class AppActivationPolicyCoordinator {
@@ -19,18 +31,15 @@ final class AppActivationPolicyCoordinator {
 
     private init() {}
 
-    private var requestCount = 0
-    private var baselinePolicy: NSApplication.ActivationPolicy?
+    /// The pure refcount/baseline state. Every decision is computed here; this
+    /// shim only reads/writes `NSApp` around it.
+    private var refcount = ActivationPolicyRefcount()
 
     /// Elevate to `.regular` for a surface that needs front/Dock presence. Balance
     /// every call with exactly one `releaseRegular()`.
     func requestRegular() {
-        if requestCount == 0 {
-            baselinePolicy = NSApp.activationPolicy()
-        }
-        requestCount += 1
-        if NSApp.activationPolicy() != .regular {
-            NSApp.setActivationPolicy(.regular)
+        if let target = refcount.request(currentPolicy: Self.currentPolicy()) {
+            NSApp.setActivationPolicy(target.appKitPolicy)
         }
     }
 
@@ -38,13 +47,36 @@ final class AppActivationPolicyCoordinator {
     /// released, restore the policy captured before the first elevation (the
     /// menu-bar app's `.accessory`, unless a launch flag had already set `.regular`).
     func releaseRegular() {
-        guard requestCount > 0 else { return }
-        requestCount -= 1
-        guard requestCount == 0 else { return }
-        let restore = baselinePolicy ?? .accessory
-        baselinePolicy = nil
-        if NSApp.activationPolicy() != restore {
-            NSApp.setActivationPolicy(restore)
+        if let target = refcount.release(currentPolicy: Self.currentPolicy()) {
+            NSApp.setActivationPolicy(target.appKitPolicy)
+        }
+    }
+
+    /// The live `NSApp` policy mapped into the pure `ActivationPolicy` domain.
+    private static func currentPolicy() -> ActivationPolicyRefcount.ActivationPolicy {
+        ActivationPolicyRefcount.ActivationPolicy(NSApp.activationPolicy())
+    }
+}
+
+extension ActivationPolicyRefcount.ActivationPolicy {
+    /// Map a live `NSApplication.ActivationPolicy` into the pure domain. Any future
+    /// AppKit case (there is none today) falls back to `.accessory`, the safe
+    /// menu-bar default.
+    init(_ policy: NSApplication.ActivationPolicy) {
+        switch policy {
+        case .regular: self = .regular
+        case .accessory: self = .accessory
+        case .prohibited: self = .prohibited
+        @unknown default: self = .accessory
+        }
+    }
+
+    /// The `NSApplication.ActivationPolicy` to apply for this pure decision.
+    var appKitPolicy: NSApplication.ActivationPolicy {
+        switch self {
+        case .regular: .regular
+        case .accessory: .accessory
+        case .prohibited: .prohibited
         }
     }
 }

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -21,6 +21,14 @@ struct PlaidBarApp: App {
     /// Owns the global summon hotkey (⇧⌘V, AND-487). `@State` so the Carbon
     /// registration survives `body` recomputes for the process lifetime.
     @State private var summonHotkeyMonitor = SummonHotkeyMonitor()
+    /// Routes the window-first primary `Window`'s open/close lifecycle through the
+    /// shared refcounted activation-policy coordinator (ADR-001 / AND-620): elevate
+    /// `.accessory → .regular` when the window opens, return to `.accessory` when
+    /// the last managed window closes. `@State` so the single outstanding request it
+    /// can hold survives `body` recomputes for the process lifetime. Inert unless
+    /// the `Window` actually opens, which only happens behind the window-first flag,
+    /// so flag-OFF activation behavior is unchanged.
+    @State private var windowActivationPolicy = WindowActivationPolicy()
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -372,8 +380,23 @@ struct PlaidBarApp: App {
             AppShellView()
                 .environment(appState)
                 .forcedAppColorScheme(Self.forcedColorScheme)
+                // Fold the primary `Window` into the single `NSApp.appearance`
+                // source of truth (`AppAppearance`, also applied before first paint
+                // in `applyStoredAppearance()`): this carries the same live
+                // appearance updater the popover/label/Settings use, so flipping
+                // Light/Dark re-applies on this window too and there is no second,
+                // competing setter to flash a wrong first-paint theme (R-04).
                 .appliesAppAppearance()
                 .appliesAppTextSize()
+                // Elevate `.accessory → .regular` while this window is on screen and
+                // drop back when the last managed window closes, via the shared
+                // refcounted coordinator (ADR-001 / AND-620, R-01). SwiftUI gives a
+                // declarative `Window` no `NSWindowController`, so the lifecycle is
+                // bridged here; the helper is idempotent against repeated
+                // appear/disappear. Only ever reached when the window opens (behind
+                // the window-first flag), so flag-OFF behavior is unchanged.
+                .onAppear { windowActivationPolicy.onWindowAppear() }
+                .onDisappear { windowActivationPolicy.onWindowDisappear() }
                 // Liquid Glass on chrome only (ADR-001): the window background is
                 // the ultra-thin material; data surfaces inside stay opaque. This
                 // is a content modifier (it walks up to the window), so it lives on

--- a/Sources/PlaidBar/App/WindowActivationPolicy.swift
+++ b/Sources/PlaidBar/App/WindowActivationPolicy.swift
@@ -1,0 +1,72 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// Routes the declarative window-first `Window`'s open/close lifecycle through the
+/// shared, refcounted ``AppActivationPolicyCoordinator`` so the menu-bar app
+/// (`.accessory`) elevates to `.regular` while the primary workspace is on screen
+/// and drops back to `.accessory` when the last managed window closes (ADR-001 /
+/// AND-620, R-01).
+///
+/// SwiftUI gives a declarative `Window` no `NSWindowController` to hang
+/// `windowDidLoad` / `windowWillClose` on, so this helper bridges the gap with
+/// `.onAppear` / `.onDisappear` on the scene's root view. The legacy AppKit
+/// windows (detached dashboard, Category Dashboard, Review Table, Settings) keep
+/// their own imperative `requestRegular()` / `releaseRegular()` calls; retiring
+/// those controllers is Epic 3 (R-01). Because this helper drives the *same*
+/// shared coordinator instance, the new `Window` and the legacy windows share one
+/// authoritative refcount — opening a legacy window while the primary window is up,
+/// then closing one, does not prematurely drop the app to `.accessory`.
+///
+/// Idempotent guard: SwiftUI can deliver `.onAppear` / `.onDisappear` more than
+/// once for a single visible window (re-layout, occlusion). `held` ensures this
+/// instance contributes at most **one** outstanding request to the shared
+/// refcount, so a redundant appear/disappear pair cannot unbalance it.
+///
+/// Flag-OFF safety: nothing constructs or drives this helper unless the
+/// window-first `Window` actually opens, and that only happens behind
+/// `WindowFirstFeatureFlag` (the scene is `.defaultLaunchBehavior(.suppressed)`
+/// and its only opener is gated). With the flag OFF the window never appears, so
+/// `onWindowAppear` / `onWindowDisappear` never fire and activation behavior is
+/// byte-identical to the popover-first build.
+///
+/// `@MainActor`-isolated and `@Observable` so it can be held as `@State` across
+/// `body` recomputes for the process lifetime, mirroring the other window
+/// coordinators in `App/`.
+@MainActor
+@Observable
+final class WindowActivationPolicy {
+    /// The shared coordinator this helper drives. Injectable so a future test or
+    /// alternate surface can target a different instance; defaults to the app-wide
+    /// `.shared` so the new `Window` and the legacy AppKit windows share one
+    /// refcount.
+    private let coordinator: AppActivationPolicyCoordinator
+
+    /// True while this helper holds exactly one outstanding `.regular` request with
+    /// the shared coordinator. Prevents a duplicate `.onAppear` from double-counting
+    /// and a duplicate `.onDisappear` from over-releasing.
+    private(set) var held = false
+
+    init(coordinator: AppActivationPolicyCoordinator = .shared) {
+        self.coordinator = coordinator
+    }
+
+    /// Called when the primary `Window`'s root view appears. Elevates to `.regular`
+    /// via the shared coordinator the first time, then no-ops until a matching
+    /// `onWindowDisappear`.
+    func onWindowAppear() {
+        guard !held else { return }
+        held = true
+        coordinator.requestRegular()
+    }
+
+    /// Called when the primary `Window`'s root view disappears (the window closed).
+    /// Releases this helper's single outstanding request; the shared coordinator
+    /// only drops the app back to its baseline (`.accessory`) once *every* surface
+    /// — legacy windows included — has released.
+    func onWindowDisappear() {
+        guard held else { return }
+        held = false
+        coordinator.releaseRegular()
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ActivationPolicyRefcount.swift
+++ b/Sources/PlaidBarCore/Utilities/ActivationPolicyRefcount.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Pure, `Sendable` refcount + baseline-capture decision for the menu-bar app's
+/// `.accessory ↔ .regular` activation policy (ADR-001 R-01, AND-620).
+///
+/// `.accessory↔.regular` thrash is the single most-repeatedly-patched area in repo
+/// history: every surface that needs front/Dock presence (the detached dashboard,
+/// the Category Dashboard / Review Table windows, Settings, and — now — the
+/// window-first primary `Window`) must elevate to `.regular` while it is open and
+/// the app must drop back to `.accessory` only when the **last** of them closes.
+/// When each surface saved its own "previous" policy, whichever opened second
+/// captured the already-elevated `.regular` as its baseline and stranded a
+/// spurious Dock / ⌘-Tab presence after both closed.
+///
+/// This type concentrates that fragile bookkeeping into one value type with **no
+/// AppKit dependency**, so the whole policy is unit-testable without launching the
+/// app or touching `NSApplication`. The decision is expressed as a pure
+/// `ActivationPolicy` enum (mirroring the three `NSApplication.ActivationPolicy`
+/// cases the app uses); the thin `@MainActor` `AppActivationPolicyCoordinator`
+/// shim in the app target maps it to `NSApp.setActivationPolicy` and the
+/// window-first helper drives the same instance, so every surface shares one
+/// authoritative refcount.
+///
+/// Contract:
+/// - The pre-elevation **baseline** is captured only on the *first* outstanding
+///   request and restored only when the *last* request is released. A launch flag
+///   that already set `.regular` (e.g. `--regular-activation`) is preserved as the
+///   baseline, so releasing the last surface does not strip an intentional Dock
+///   presence.
+/// - `request`/`release` each return the policy that *should now be applied*, or
+///   `nil` when no change is needed — so the AppKit shim only mutates
+///   `NSApp.activationPolicy` when it actually differs, and a balanced
+///   request→release cycle leaves the app exactly where it started.
+/// - `release` past zero is a no-op (`nil`), so an over-release can never wedge the
+///   policy or strand a negative refcount.
+public struct ActivationPolicyRefcount: Sendable, Equatable {
+    /// The activation policies the menu-bar app moves between. A SwiftUI/AppKit-free
+    /// mirror of the three `NSApplication.ActivationPolicy` cases VaultPeek uses, so
+    /// the decision stays in Core and is `Equatable` for tests.
+    public enum ActivationPolicy: String, Sendable, Equatable {
+        /// Menu-bar-only: no Dock icon, not in ⌘-Tab. The shipping default.
+        case accessory
+        /// Conventional foreground app: Dock icon + ⌘-Tab. Elevated while a window
+        /// or Settings is open.
+        case regular
+        /// Background-only (no UI). VaultPeek never sets this itself, but it can be
+        /// the live policy momentarily during launch; modeled so a captured baseline
+        /// round-trips faithfully.
+        case prohibited
+    }
+
+    /// Outstanding `.regular` elevation requests. `.accessory` (or the captured
+    /// baseline) is restored when this returns to zero.
+    public private(set) var requestCount: Int = 0
+
+    /// The policy captured before the first elevation, restored when the last
+    /// request is released. `nil` while no request is outstanding.
+    public private(set) var baseline: ActivationPolicy?
+
+    public init() {}
+
+    /// Register one `.regular` elevation request for a surface that needs
+    /// front/Dock presence. `currentPolicy` is the live policy *before* this call —
+    /// captured as the baseline only on the first outstanding request.
+    ///
+    /// - Returns: `.regular` when the policy must change to elevate, or `nil` when
+    ///   the app is already `.regular` (e.g. a second surface opening). Balance every
+    ///   `request` with exactly one `release`.
+    public mutating func request(currentPolicy: ActivationPolicy) -> ActivationPolicy? {
+        if requestCount == 0 {
+            baseline = currentPolicy
+        }
+        requestCount += 1
+        return currentPolicy == .regular ? nil : .regular
+    }
+
+    /// Release one previous `request`. When the last outstanding request is
+    /// released, return the captured baseline so the app drops back to where it was
+    /// before the first elevation (normally `.accessory`).
+    ///
+    /// - Returns: the policy to restore when the last request is released and it
+    ///   differs from `currentPolicy`; `nil` when requests remain, when releasing
+    ///   past zero, or when no change is needed.
+    public mutating func release(currentPolicy: ActivationPolicy) -> ActivationPolicy? {
+        guard requestCount > 0 else { return nil }
+        requestCount -= 1
+        guard requestCount == 0 else { return nil }
+        let restore = baseline ?? .accessory
+        baseline = nil
+        return currentPolicy == restore ? nil : restore
+    }
+}

--- a/Tests/PlaidBarCoreTests/ActivationPolicyRefcountTests.swift
+++ b/Tests/PlaidBarCoreTests/ActivationPolicyRefcountTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Activation-policy refcount (ADR-001 R-01 / AND-620)")
+struct ActivationPolicyRefcountTests {
+    typealias Policy = ActivationPolicyRefcount.ActivationPolicy
+
+    // MARK: - Single-surface cycle: accessory → regular → accessory
+
+    @Test("One window open then close round-trips .accessory → .regular → .accessory")
+    func singleSurfaceCycle() {
+        var refcount = ActivationPolicyRefcount()
+        var policy: Policy = .accessory
+
+        // Window opens: elevate.
+        let onOpen = refcount.request(currentPolicy: policy)
+        #expect(onOpen == .regular)
+        policy = onOpen ?? policy
+        #expect(policy == .regular)
+        #expect(refcount.requestCount == 1)
+
+        // Window closes: drop back to the captured baseline.
+        let onClose = refcount.release(currentPolicy: policy)
+        #expect(onClose == .accessory)
+        policy = onClose ?? policy
+        #expect(policy == .accessory)
+        #expect(refcount.requestCount == 0)
+        // No leaked baseline once balanced.
+        #expect(refcount.baseline == nil)
+    }
+
+    @Test("A balanced open/close leaves the refcount equal to a fresh instance")
+    func balancedCycleLeavesNoState() {
+        var refcount = ActivationPolicyRefcount()
+        _ = refcount.request(currentPolicy: .accessory)
+        _ = refcount.release(currentPolicy: .regular)
+        #expect(refcount == ActivationPolicyRefcount())
+    }
+
+    // MARK: - Multi-surface refcount: last close wins
+
+    @Test("Two surfaces: closing one does not prematurely drop to .accessory")
+    func twoSurfacesLastCloseDropsPolicy() {
+        var refcount = ActivationPolicyRefcount()
+        var policy: Policy = .accessory
+
+        // First surface (e.g. the primary Window) opens: elevate.
+        policy = refcount.request(currentPolicy: policy) ?? policy
+        #expect(policy == .regular)
+
+        // Second surface (e.g. a legacy AppKit window or Settings) opens while
+        // already .regular: no change needed, but the count rises.
+        let secondOpen = refcount.request(currentPolicy: policy)
+        #expect(secondOpen == nil)
+        #expect(policy == .regular)
+        #expect(refcount.requestCount == 2)
+
+        // First surface closes: still one outstanding request, stay .regular.
+        let firstClose = refcount.release(currentPolicy: policy)
+        #expect(firstClose == nil)
+        #expect(policy == .regular)
+        #expect(refcount.requestCount == 1)
+
+        // Last surface closes: now drop to .accessory.
+        let lastClose = refcount.release(currentPolicy: policy)
+        #expect(lastClose == .accessory)
+        policy = lastClose ?? policy
+        #expect(policy == .accessory)
+        #expect(refcount.requestCount == 0)
+        #expect(refcount.baseline == nil)
+    }
+
+    @Test("Interleaved open/close across surfaces never leaks .regular")
+    func interleavedSurfacesNeverLeakRegular() {
+        var refcount = ActivationPolicyRefcount()
+        var policy: Policy = .accessory
+
+        // open A, open B, close A, open C, close B, close C
+        policy = refcount.request(currentPolicy: policy) ?? policy // A → regular
+        policy = refcount.request(currentPolicy: policy) ?? policy // B
+        policy = refcount.release(currentPolicy: policy) ?? policy // close A
+        policy = refcount.request(currentPolicy: policy) ?? policy // C
+        policy = refcount.release(currentPolicy: policy) ?? policy // close B
+        #expect(policy == .regular) // C still open
+
+        policy = refcount.release(currentPolicy: policy) ?? policy // close C
+        #expect(policy == .accessory)
+        #expect(refcount.requestCount == 0)
+        #expect(refcount.baseline == nil)
+    }
+
+    // MARK: - Baseline preservation (launch flag set .regular intentionally)
+
+    @Test("A pre-elevated .regular baseline is preserved across the cycle")
+    func preElevatedBaselinePreserved() {
+        var refcount = ActivationPolicyRefcount()
+        // Launch flag (e.g. --regular-activation) already set .regular before any
+        // surface requested elevation.
+        var policy: Policy = .regular
+
+        // Window opens while already .regular: no change, but baseline captured.
+        let onOpen = refcount.request(currentPolicy: policy)
+        #expect(onOpen == nil)
+        #expect(refcount.baseline == .regular)
+
+        // Window closes: restore the captured .regular baseline — do NOT strip the
+        // intentional Dock presence down to .accessory.
+        let onClose = refcount.release(currentPolicy: policy)
+        #expect(onClose == nil) // already .regular, no change needed
+        policy = onClose ?? policy
+        #expect(policy == .regular)
+        #expect(refcount.requestCount == 0)
+    }
+
+    @Test("Baseline is captured only on the first of several requests")
+    func baselineCapturedOnFirstRequestOnly() {
+        var refcount = ActivationPolicyRefcount()
+        _ = refcount.request(currentPolicy: .accessory) // first → baseline = .accessory
+        // A second request observing .regular must NOT overwrite the baseline.
+        _ = refcount.request(currentPolicy: .regular)
+        #expect(refcount.baseline == .accessory)
+
+        _ = refcount.release(currentPolicy: .regular) // still 1 outstanding
+        let last = refcount.release(currentPolicy: .regular) // last → restore .accessory
+        #expect(last == .accessory)
+    }
+
+    // MARK: - Over-release safety
+
+    @Test("Releasing past zero is a no-op and cannot wedge the policy")
+    func releasePastZeroIsNoOp() {
+        var refcount = ActivationPolicyRefcount()
+        // Release with nothing outstanding.
+        #expect(refcount.release(currentPolicy: .accessory) == nil)
+        #expect(refcount.requestCount == 0)
+
+        // Balanced cycle, then an extra spurious release.
+        _ = refcount.request(currentPolicy: .accessory)
+        _ = refcount.release(currentPolicy: .regular)
+        #expect(refcount.release(currentPolicy: .accessory) == nil)
+        #expect(refcount.requestCount == 0)
+        #expect(refcount.baseline == nil)
+    }
+
+    // MARK: - Feature-flag toggle simulation
+
+    @Test("Flag toggle off→on→off: opening then closing the window leaves no leaked policy")
+    func flagToggleCycleLeavesNoLeak() {
+        // Models AND-620's flag-toggle acceptance: with the flag OFF the window
+        // never opens, so the refcount is never touched and the policy stays
+        // .accessory; flipping the flag ON and opening/closing the window must
+        // round-trip cleanly back to .accessory with no leaked activation state.
+        var refcount = ActivationPolicyRefcount()
+        var policy: Policy = .accessory
+
+        // Flag OFF — window never opens. No requests; policy unchanged.
+        #expect(refcount.requestCount == 0)
+        #expect(policy == .accessory)
+
+        // Flag flipped ON — window opens.
+        policy = refcount.request(currentPolicy: policy) ?? policy
+        #expect(policy == .regular)
+
+        // Window closes (user closes it, or flips the flag back OFF).
+        policy = refcount.release(currentPolicy: policy) ?? policy
+        #expect(policy == .accessory)
+
+        // Flag OFF again — fully clean, identical to the never-opened state.
+        #expect(refcount == ActivationPolicyRefcount())
+    }
+
+    @Test("Repeated open/close cycles each round-trip to .accessory")
+    func repeatedCyclesAreStable() {
+        var refcount = ActivationPolicyRefcount()
+        var policy: Policy = .accessory
+        for _ in 0 ..< 5 {
+            policy = refcount.request(currentPolicy: policy) ?? policy
+            #expect(policy == .regular)
+            policy = refcount.release(currentPolicy: policy) ?? policy
+            #expect(policy == .accessory)
+            #expect(refcount.requestCount == 0)
+            #expect(refcount.baseline == nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remainder of **Epic 1** (ADR-001 window-first migration, **AND-579**): the tested activation-policy helper and the appearance-owner wiring for the declarative window-first `Window` scene that shipped behind a flag in **AND-591** (#581).

### Activation policy (R-01)
- Extracted the fragile `.accessory↔.regular` **refcount + baseline-capture decision** into a pure, `Sendable`, `@testable`-importable `ActivationPolicyRefcount` in `PlaidBarCore` (the app target is not test-importable).
- Refactored `AppActivationPolicyCoordinator` to delegate every decision to that pure type. The coordinator is now the *only* place that touches `NSApplication`; it maps the live `NSApp.activationPolicy()` into the pure decision and applies what the decision returns, mutating `NSApp.setActivationPolicy` only when it actually changes. **Behavior-preserving** for the existing legacy AppKit windows (detached dashboard, Category Dashboard, Review Table) and Settings.
- Added a `@MainActor WindowActivationPolicy` helper that routes the declarative `Window`'s open/close lifecycle through the **same shared coordinator**, so the new window and the legacy windows share one authoritative refcount — closing one of several open windows never prematurely drops the app to `.accessory`. The helper is idempotent against repeated `.onAppear`/`.onDisappear` (SwiftUI can deliver them more than once for a single visible window).
- The legacy `AppActivationPolicyCoordinator` is intentionally **not** retired — that's Epic 3 / R-01. Both the new `Window` path and the legacy windows call into the one shared, tested decision.

### Appearance owner (R-04)
- Folded the `Window` into the **single authoritative `NSApp.appearance` source of truth** (`AppAppearance`, applied before first paint in `applyStoredAppearance()` and live via `AppAppearanceApplier`) by carrying `.appliesAppAppearance()` on the scene root. There is no second / competing app-wide setter (audited: only `applyForcedAppearance()` for the `--appearance` CLI override and `AppAppearance.applyToNSApp()` for the stored preference set `NSApplication.shared.appearance`; the per-window `window.appearance` setters on the legacy windows are window-scoped, not app-scoped). The new `Window` deliberately does not set a per-window appearance — it inherits `NSApp.appearance`. No first-paint theme flash.

### Translucency (R-03)
- Reuses the already-shipped window-vibrancy approach verbatim (`.containerBackground(.ultraThinMaterial, for: .window)` from AND-591; glass on chrome only). **No** re-attempt at SwiftUI-only glass for read-through (the C4 spike failed).

## Flag-off stays byte-identical
Nothing constructs or drives `WindowActivationPolicy` unless the `Window` actually opens, and that only happens behind `WindowFirstFeatureFlag` (default **OFF**: the scene is `.defaultLaunchBehavior(.suppressed)` and its sole opener — the "Open VaultPeek" command — is flag-gated). With the flag OFF the window never appears, so the lifecycle hooks never fire and activation/appearance behavior is identical to the popover-first build. The coordinator refactor is behavior-preserving for every existing call site.

## Testing notes
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — **1812 passed** (baseline ~1803; +9 new).
- New `ActivationPolicyRefcountTests` (9 tests): single-surface `.accessory → .regular → .accessory` cycle; multi-surface last-close-wins; interleaved opens/closes; pre-elevated `.regular` baseline preservation (e.g. `--regular-activation`); over-release safety; and a **feature-flag off→on→off toggle cycle** asserting no leaked activation state.
- Appearance resolution is already covered by `AppearancePreferencesTests` (the pure `resolvedScheme` seam).

## Hardware QA needed (Felipe)
These cannot be validated in CI / headless and need an on-hardware pass with the flag ON (`--window-first on`):
- **macOS 26 `openSettings()`-from-`.accessory` regression (R-13):** open the primary window (app becomes `.regular`), then trigger Settings; confirm Settings opens and focuses. Then with no window open (app `.accessory`) confirm Settings still opens. Fallback is a programmatic Settings window if the regression reproduces.
- **Live Light/Dark flip:** with the window open, flip the system appearance and the in-app Appearance preference; confirm the window chrome + Liquid Glass material update live with no first-paint flash, in both directions.
- **Activation round-trip visual check:** open the window (Dock icon appears), open a legacy window (detached dashboard) too, close them one at a time, and confirm the Dock icon disappears only after the *last* window closes — and the app returns to menu-bar-only `.accessory`.

Refs: **AND-620**, **AND-579**, **ADR-001** (R-01, R-04, R-03, R-13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
