### PR TITLE
feat(nav): typed Route + per-window NavigationModel; retire dashboard @AppStorage UI state (AND-594)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -116,6 +116,40 @@ final class AppState {
     }
     var isPopoverPresented = false
 
+    /// Per-window navigation model (ADR-001 / AND-594). Owns the destination plus
+    /// the dashboard filter / account selection / heatmap metric that previously
+    /// lived as scattered view-level `@AppStorage` keys in `MainPopover`. This is
+    /// the menu-bar popover's window's model; a window-first `Window` scene
+    /// constructs its own, so two windows hold independent selection (R-10).
+    ///
+    /// `AppState` exposes this as a façade (R-02): the popover reads
+    /// `appState.dashboardFilter` / `dashboardSelectedAccountID` /
+    /// `dashboardHeatmapMode`, which delegate here and persist to the original
+    /// UserDefaults keys — so popover behavior and on-disk persistence are
+    /// unchanged.
+    let navigationModel: NavigationModel
+
+    /// The dashboard's account filter, persisted under `dashboard.accountFilter`.
+    /// Setting a *new* filter clears the account selection, exactly as the
+    /// popover's `.onChange(of:)` did (AND-373/375).
+    var dashboardFilter: DashboardAccountFilterKind {
+        get { navigationModel.dashboardFilter }
+        set { navigationModel.dashboardFilter = newValue }
+    }
+
+    /// The selected account id ("" when none), persisted under
+    /// `dashboard.selectedAccountId`.
+    var dashboardSelectedAccountID: String {
+        get { navigationModel.selectedAccountID }
+        set { navigationModel.selectedAccountID = newValue }
+    }
+
+    /// The 365-day heatmap metric, persisted under `dashboard.heatmapMode`.
+    var dashboardHeatmapMode: SpendingHeatmapMode {
+        get { navigationModel.heatmapMode }
+        set { navigationModel.heatmapMode = newValue }
+    }
+
     /// When true, the dashboard lives in a floating desktop window instead of
     /// the menu-bar popover (AND-384). Persisted so the window reopens on the
     /// next launch. While detached, a click on the menu-bar item raises the
@@ -570,11 +604,16 @@ final class AppState {
 
     init(
         notificationService: (any NotificationServiceProtocol)? = nil,
-        readModelCacheEnabled: Bool = true
+        readModelCacheEnabled: Bool = true,
+        navigationModel: NavigationModel? = nil
     ) {
         _ = try? LocalDataStore.migrateLegacyDefaultStorageIfNeeded()
         self.notificationService = notificationService ?? NotificationService.shared
         self.readModelCacheEnabled = readModelCacheEnabled
+        // The popover-window navigation model. Hydrates the last
+        // filter/selection/heatmap from the original UserDefaults keys, so
+        // persistence is preserved across the migration (R-02 façade).
+        self.navigationModel = navigationModel ?? NavigationModel()
         loadSettings()
         // Record whether Apple Foundation Models is available so the tier resolver
         // can prefer it (AND-563) and, when available, the insight service routes

--- a/Sources/PlaidBar/App/NavigationModel.swift
+++ b/Sources/PlaidBar/App/NavigationModel.swift
@@ -1,0 +1,155 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Per-window navigation model for the window-first shell (ADR-001, AND-594).
+///
+/// Wraps the pure ``NavigationState`` (PlaidBarCore) with the `@Observable`
+/// `@MainActor` machinery SwiftUI needs and the UserDefaults persistence the
+/// migrated `@AppStorage` keys used to own. It is **per-window scene state, not a
+/// singleton** (R-10): the menu-bar popover gets one instance (via `AppState`),
+/// and any additional window-first `Window` scene constructs its own — so two
+/// windows hold independent selection. The state-transition logic stays in the
+/// pure value type; this is a thin, testable shell over it.
+///
+/// Persistence preserves the *exact* prior keys
+/// (`dashboard.accountFilter`, `dashboard.selectedAccountId`,
+/// `dashboard.heatmapMode`) and raw values, so a user who upgrades keeps their
+/// last filter / selection / heatmap metric. Reading/writing through these keys
+/// (rather than scattered view-level `@AppStorage`) is the R-02 façade move: one
+/// routable state, same on-disk footprint.
+@Observable
+@MainActor
+final class NavigationModel {
+    /// UserDefaults keys — identical to the retired view-level `@AppStorage`
+    /// keys so persisted selections decode exactly as before.
+    enum Keys {
+        static let dashboardFilter = "dashboard.accountFilter"
+        static let selectedAccountID = "dashboard.selectedAccountId"
+        static let heatmapMode = "dashboard.heatmapMode"
+    }
+
+    /// The pure state. Mutations route through the typed accessors below (which
+    /// also persist), so direct assignment is avoided outside hydration.
+    private(set) var state: NavigationState
+
+    private let defaults: UserDefaults
+    /// While hydrating from UserDefaults, suppress write-back so loading a value
+    /// does not immediately persist it again.
+    private var isHydrating = false
+
+    /// Creates a window's navigation model.
+    ///
+    /// - Parameters:
+    ///   - defaults: the store to persist to. Tests inject an isolated suite so
+    ///     two models can prove independent selection without sharing global
+    ///     defaults; production uses `.standard`.
+    ///   - persistRestore: when `true` (default), the last filter / selection /
+    ///     heatmap metric are restored from `defaults`. A fresh second window can
+    ///     opt out to start from defaults.
+    init(defaults: UserDefaults = .standard, persistRestore: Bool = true) {
+        self.defaults = defaults
+        self.state = NavigationState()
+        if persistRestore {
+            hydrate()
+        }
+    }
+
+    // MARK: - Façade surface (read identically to the old @AppStorage)
+
+    var destination: RouteDestination { state.destination }
+
+    var dashboardFilter: DashboardAccountFilterKind {
+        get { state.dashboardFilter }
+        set {
+            state.setDashboardFilter(newValue)
+            persistDashboardFilter()
+            // setDashboardFilter clears the selection on a real change; mirror
+            // that to disk so the cleared selection survives a relaunch.
+            persistSelectedAccountID()
+        }
+    }
+
+    var selectedAccountID: String {
+        get { state.selectedAccountID }
+        set {
+            state.selectAccount(id: newValue)
+            persistSelectedAccountID()
+        }
+    }
+
+    var heatmapMode: SpendingHeatmapMode {
+        get { state.heatmapMode }
+        set {
+            state.heatmapMode = newValue
+            persistHeatmapMode()
+        }
+    }
+
+    // MARK: - Navigation
+
+    func go(to destination: RouteDestination) {
+        state.go(to: destination)
+    }
+
+    func apply(_ route: Route) {
+        state.apply(route)
+        // A route may carry an account selection; persist it so a deep-link
+        // landing point survives like a manual selection did.
+        persistSelectedAccountID()
+    }
+
+    func deselectAccount() {
+        state.deselectAccount()
+        persistSelectedAccountID()
+    }
+
+    /// Self-heal: drop a persisted selection that is no longer visible (the
+    /// `MainPopover` filter-populate edge). Persists the cleared value.
+    @discardableResult
+    func reconcileSelection(visibleAccountIDs: [String]) -> Bool {
+        let didClear = state.reconcileSelection(visibleAccountIDs: visibleAccountIDs)
+        if didClear { persistSelectedAccountID() }
+        return didClear
+    }
+
+    /// The selected id resolved against the visible accounts (or `nil`).
+    func resolvedSelectedID(visibleAccountIDs: [String]) -> String? {
+        state.resolvedSelectedID(visibleAccountIDs: visibleAccountIDs)
+    }
+
+    // MARK: - Persistence
+
+    private func hydrate() {
+        isHydrating = true
+        defer { isHydrating = false }
+
+        var restored = NavigationState()
+        if let raw = defaults.string(forKey: Keys.dashboardFilter),
+           let filter = DashboardAccountFilterKind(rawValue: raw) {
+            restored.dashboardFilter = filter
+        }
+        if let id = defaults.string(forKey: Keys.selectedAccountID) {
+            restored.selectedAccountID = id
+        }
+        if let rawMode = defaults.string(forKey: Keys.heatmapMode),
+           let mode = SpendingHeatmapMode(rawValue: rawMode) {
+            restored.heatmapMode = mode
+        }
+        state = restored
+    }
+
+    private func persistDashboardFilter() {
+        guard !isHydrating else { return }
+        defaults.set(state.dashboardFilter.rawValue, forKey: Keys.dashboardFilter)
+    }
+
+    private func persistSelectedAccountID() {
+        guard !isHydrating else { return }
+        defaults.set(state.selectedAccountID, forKey: Keys.selectedAccountID)
+    }
+
+    private func persistHeatmapMode() {
+        guard !isHydrating else { return }
+        defaults.set(state.heatmapMode.rawValue, forKey: Keys.heatmapMode)
+    }
+}

--- a/Sources/PlaidBar/Views/DashboardNavBand.swift
+++ b/Sources/PlaidBar/Views/DashboardNavBand.swift
@@ -4,10 +4,10 @@ import SwiftUI
 // MARK: - Account Filters
 
 /// The dashboard account filter is the core `DashboardAccountFilterKind`
-/// reused directly. The persisted `@AppStorage("dashboard.accountFilter")`
-/// raw values ("All", "Cash", "Credit", "Savings", "Debt", "Investments",
-/// "Status") are the core enum's raw values, so stored selections decode
-/// exactly as before.
+/// reused directly. It is persisted by the per-window `NavigationModel` under the
+/// `dashboard.accountFilter` key (AND-594) using the core enum's raw values
+/// ("All", "Cash", "Credit", "Savings", "Debt", "Investments", "Status"), so
+/// stored selections decode exactly as the previous view-level `@AppStorage` did.
 typealias DashboardAccountFilter = DashboardAccountFilterKind
 
 extension DashboardAccountFilterKind {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -11,9 +11,32 @@ struct MainPopover: View {
     /// desktop window (AND-384). Detached, the host window owns width/height, so
     /// the popover's fixed-width frame and screen-edge anchor are skipped.
     @Environment(\.dashboardPresentation) private var dashboardPresentation
-    @AppStorage("dashboard.accountFilter") private var selectedFilterRawValue = DashboardAccountFilter.all.rawValue
-    @AppStorage("dashboard.selectedAccountId") private var selectedAccountId = ""
+    // Dashboard filter + account selection moved out of view-level `@AppStorage`
+    // into the per-window `NavigationModel` behind the `AppState` façade (AND-594).
+    // These computed accessors keep the rest of this view byte-identical while the
+    // state and its persistence now live in one routable model. Persistence is
+    // unchanged: the model writes the same `dashboard.accountFilter` /
+    // `dashboard.selectedAccountId` keys, so a relaunch restores the same filter
+    // and selection the popover always did.
     @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
+
+    /// The persisted filter raw value, delegated to the navigation model. Kept as
+    /// a raw `String` so the existing `.onChange(of: selectedFilterRawValue)` and
+    /// `filterBinding` call sites are unchanged.
+    private var selectedFilterRawValue: String {
+        get { appState.dashboardFilter.rawValue }
+        nonmutating set {
+            appState.dashboardFilter = DashboardAccountFilter(rawValue: newValue) ?? .all
+        }
+    }
+
+    /// The persisted selected-account id (""=none), delegated to the navigation
+    /// model. `nonmutating set` mirrors `@AppStorage`'s settable-from-`let`-view
+    /// semantics so the assignment sites below (`= ""`, `= $0.id`) are unchanged.
+    private var selectedAccountId: String {
+        get { appState.dashboardSelectedAccountID }
+        nonmutating set { appState.dashboardSelectedAccountID = newValue }
+    }
     @State private var isShowingAccountSetup = false
     @State private var shouldShowSetupRecoveryDashboard = false
     @State private var dashboardContentHeight: CGFloat = 0
@@ -885,7 +908,15 @@ private struct BalanceActivityHeatmap: View {
     let transactions: [TransactionDTO]
     var loadState: DashboardLoadState?
 
-    @AppStorage("dashboard.heatmapMode") private var modeRawValue = SpendingHeatmapMode.spending.rawValue
+    // Heatmap metric moved out of view-level `@AppStorage` into the per-window
+    // `NavigationModel` behind the `AppState` façade (AND-594). Persistence is
+    // unchanged: the model writes the same `dashboard.heatmapMode` key.
+    private var modeRawValue: String {
+        get { appState.dashboardHeatmapMode.rawValue }
+        nonmutating set {
+            appState.dashboardHeatmapMode = SpendingHeatmapMode(rawValue: newValue) ?? .spending
+        }
+    }
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Day key (yyyy-MM-dd) of the selected cell, or nil when none is selected.

--- a/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
+++ b/Sources/PlaidBarCore/Models/DashboardAccountEmptyState.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public enum DashboardAccountFilterKind: String, CaseIterable, Sendable {
+// `Codable`/`Hashable` added so the filter can be persisted as part of the
+// routable `NavigationState` (AND-594); free for a `String`-raw enum.
+public enum DashboardAccountFilterKind: String, CaseIterable, Sendable, Codable, Hashable {
     case all = "All"
     case cash = "Cash"
     case credit = "Credit"

--- a/Sources/PlaidBarCore/Models/NavigationState.swift
+++ b/Sources/PlaidBarCore/Models/NavigationState.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Pure, value-type navigation state for one window of the window-first shell
+/// (ADR-001). Holds the current destination plus the per-destination selection
+/// and filter state that used to live as scattered view-level
+/// `@AppStorage` keys in `MainPopover` (`dashboard.accountFilter`,
+/// `dashboard.selectedAccountId`, `dashboard.heatmapMode`).
+///
+/// This is a **value type**, so two windows that each own their own copy hold
+/// *independent* selection — the R-10 contract (a per-window model, never a
+/// singleton). The `@Observable @MainActor` `NavigationModel` wrapper in the app
+/// target wraps one of these per window; the pure transitions all live here so
+/// they are testable without SwiftUI (CLAUDE.md: shared logic in `PlaidBarCore`).
+///
+/// All transitions are pure functions returning a new value (or mutating `self`),
+/// which makes the "two windows, independent selection" property trivially
+/// testable at the Core layer.
+public struct NavigationState: Sendable, Equatable, Codable {
+    /// The currently selected destination (sidebar selection / window content).
+    public var destination: RouteDestination
+
+    // MARK: Dashboard / shared selection state (migrated from MainPopover)
+
+    /// The dashboard's account filter (Cash / Credit / Savings / Debt / Status /
+    /// Investments / All). Previously `@AppStorage("dashboard.accountFilter")`.
+    public var dashboardFilter: DashboardAccountFilterKind
+
+    /// The selected account id, or empty when none. Previously
+    /// `@AppStorage("dashboard.selectedAccountId")`. Empty string (not `nil`)
+    /// preserves the popover's existing "" sentinel so the persistence value and
+    /// the deselect/resolve rules behave byte-identically.
+    public var selectedAccountID: String
+
+    /// The 365-day heatmap's metric (Spend / Net cashflow). Previously
+    /// `@AppStorage("dashboard.heatmapMode")` on the heatmap subview.
+    public var heatmapMode: SpendingHeatmapMode
+
+    public init(
+        destination: RouteDestination = .dashboard,
+        dashboardFilter: DashboardAccountFilterKind = .all,
+        selectedAccountID: String = "",
+        heatmapMode: SpendingHeatmapMode = .spending
+    ) {
+        self.destination = destination
+        self.dashboardFilter = dashboardFilter
+        self.selectedAccountID = selectedAccountID
+        self.heatmapMode = heatmapMode
+    }
+
+    // MARK: - Pure transitions
+
+    /// Navigate to a bare destination, preserving the per-destination selection
+    /// already held. (Selection within a destination is preserved across
+    /// destination switches — the IA's selection-restoration contract.)
+    public mutating func go(to destination: RouteDestination) {
+        self.destination = destination
+    }
+
+    /// Apply a typed ``Route``: select its destination and fold any carried
+    /// selection into the matching state slot. Only the selection slots this PR
+    /// owns (dashboard account selection) are written here; richer per-destination
+    /// selection (transaction id, category, goal id) is added as those
+    /// destinations land in later Epic 2 subs.
+    public mutating func apply(_ route: Route) {
+        destination = route.destination
+        switch route {
+        case .accounts(let itemID):
+            // An account deep-link selects that account on the dashboard surface
+            // too, so the existing inspector follows the link.
+            if let itemID { selectedAccountID = itemID }
+        case .dashboard,
+             .review,
+             .transactions,
+             .budgets,
+             .planning,
+             .goals,
+             .insights,
+             .alerts,
+             .settings:
+            break
+        }
+    }
+
+    /// Change the dashboard filter. Changing the filter clears the account
+    /// selection — the rule `MainPopover` enforced via
+    /// `.onChange(of: selectedFilterRawValue) { selectedAccountId = "" }`
+    /// (AND-373/375). No-op (and no deselect) when the filter is unchanged, so a
+    /// redundant set does not surprise-deselect.
+    public mutating func setDashboardFilter(_ filter: DashboardAccountFilterKind) {
+        guard filter != dashboardFilter else { return }
+        dashboardFilter = filter
+        selectedAccountID = ""
+    }
+
+    /// Select an account on the dashboard.
+    public mutating func selectAccount(id: String) {
+        selectedAccountID = id
+    }
+
+    /// Clear the dashboard account selection.
+    public mutating func deselectAccount() {
+        selectedAccountID = ""
+    }
+
+    /// Drop a persisted selection that no longer maps to a visible account — the
+    /// self-heal `MainPopover` performed in `.onChange(of: filteredAccounts)`
+    /// when accounts first populate. Returns `true` when a stale selection was
+    /// cleared so a caller can react (e.g. animate the column collapse).
+    @discardableResult
+    public mutating func reconcileSelection(visibleAccountIDs: [String]) -> Bool {
+        guard !selectedAccountID.isEmpty,
+              !visibleAccountIDs.contains(selectedAccountID) else {
+            return false
+        }
+        selectedAccountID = ""
+        return true
+    }
+
+    /// The selected id resolved against the currently visible accounts — `nil`
+    /// when nothing is selected or the selection is no longer visible. Mirrors
+    /// `DashboardAccountSelection.resolvedSelectedId`, exposed here so the
+    /// migrated `selectedAccount` computed property reads identically.
+    public func resolvedSelectedID(visibleAccountIDs: [String]) -> String? {
+        DashboardAccountSelection.resolvedSelectedId(
+            selectedAccountID,
+            visibleAccountIds: visibleAccountIDs
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+// MARK: - Route destinations
+
+/// The 11 primary destinations of the window-first navigation shell (ADR-001,
+/// `docs/strategy/macos26-migration/05-information-architecture.md`).
+///
+/// This is the *bare destination identity* — the sidebar selection token and the
+/// thing `⌘1…⌘8` jump to. The richer ``Route`` carries the per-destination
+/// selection (e.g. which transaction, which category) on top of one of these.
+///
+/// Pure and `Sendable`, so the navigation state and its transitions are testable
+/// without the SwiftUI app target (CLAUDE.md: shared logic lives in
+/// `PlaidBarCore`). The order of `allCases` is the sidebar order; the `⌘`
+/// shortcut ordinal is derived from it (Dashboard…Accounts = ⌘1…⌘8; Settings is
+/// the native `⌘,` scene and has no numeric shortcut).
+public enum RouteDestination: String, CaseIterable, Sendable, Hashable, Codable {
+    case dashboard
+    case review
+    case transactions
+    case budgets
+    case planning
+    case goals
+    case insights
+    case alerts
+    case accounts
+    case settings
+
+    /// The IA sidebar band a destination lives in (Overview / Workflows /
+    /// Insights / Money / System). Grouping the verbs together is the IA's
+    /// "list of jobs to do" model (§2 of the IA doc).
+    public enum Band: String, CaseIterable, Sendable, Hashable, Codable {
+        case overview
+        case workflows
+        case insights
+        case money
+        case system
+
+        public var title: String {
+            switch self {
+            case .overview: "Overview"
+            case .workflows: "Workflows"
+            case .insights: "Insights"
+            case .money: "Money"
+            case .system: "System"
+            }
+        }
+    }
+
+    public var band: Band {
+        switch self {
+        case .dashboard: .overview
+        case .review, .transactions, .budgets, .planning, .goals: .workflows
+        case .insights, .alerts: .insights
+        case .accounts: .money
+        case .settings: .system
+        }
+    }
+
+    /// Sidebar / window-title label.
+    public var title: String {
+        switch self {
+        case .dashboard: "Dashboard"
+        case .review: "Review"
+        case .transactions: "Transactions"
+        case .budgets: "Budgets"
+        case .planning: "Planning"
+        case .goals: "Goals"
+        case .insights: "Insights"
+        case .alerts: "Alerts"
+        case .accounts: "Accounts"
+        case .settings: "Settings"
+        }
+    }
+
+    /// SF Symbol for the sidebar row (chrome only — never the sole carrier of
+    /// meaning; the label always accompanies it).
+    public var systemImage: String {
+        switch self {
+        case .dashboard: "rectangle.3.group"
+        case .review: "tray.full"
+        case .transactions: "list.bullet.rectangle"
+        case .budgets: "chart.pie"
+        case .planning: "calendar.badge.clock"
+        case .goals: "target"
+        case .insights: "lightbulb"
+        case .alerts: "bell"
+        case .accounts: "building.columns"
+        case .settings: "gearshape"
+        }
+    }
+
+    /// The `⌘N` shortcut number for the destination, matching the IA keymap's
+    /// explicit `[⌘1]…[⌘8]` assignments (§3.4 and the destination tree):
+    /// Dashboard 1 · Review 2 · Budgets 3 · Planning 4 · Goals 5 · Insights 6 ·
+    /// Alerts 7 · Accounts 8. `Transactions` is reachable via the sidebar / ⌘K /
+    /// deep-links but has no number (the IA tree assigns none), and `Settings`
+    /// uses the native `⌘,` scene — both return `nil`.
+    public var commandShortcutNumber: Int? {
+        switch self {
+        case .dashboard: 1
+        case .review: 2
+        case .budgets: 3
+        case .planning: 4
+        case .goals: 5
+        case .insights: 6
+        case .alerts: 7
+        case .accounts: 8
+        case .transactions, .settings: nil
+        }
+    }
+
+    /// Whether the destination renders a 3-column (list → detail) layout, per the
+    /// IA's column-policy table (§3.1). 2-column destinations are composed
+    /// canvases with no master→detail relationship.
+    public var prefersThreeColumnLayout: Bool {
+        switch self {
+        case .review, .transactions, .budgets, .goals, .alerts, .accounts:
+            true
+        case .dashboard, .planning, .insights, .settings:
+            false
+        }
+    }
+}
+
+// MARK: - Sub-section enums
+
+/// The native Settings scene's tabs, expressed in `PlaidBarCore` so a ``Route``
+/// can target one without coupling Core to the app target's private
+/// `SettingsTab`. Raw values match the app's `@AppStorage("settings.selectedTab")`
+/// values so a routed tab decodes against the same persisted key.
+public enum SettingsRouteTab: String, CaseIterable, Sendable, Hashable, Codable {
+    case general
+    case accounts
+    case appearance
+    case notifications
+    case privacy
+    case about
+}
+
+/// Planning's segmented sub-sections (§5.5 of the IA doc) — Planning is a
+/// composed 2-column canvas, so these select a section rather than a list item.
+public enum PlanningSection: String, CaseIterable, Sendable, Hashable, Codable {
+    case forecast
+    case recurring
+    case incomeFlow
+}
+
+/// Insights' feed sub-sections (§5.7 of the IA doc).
+public enum InsightSection: String, CaseIterable, Sendable, Hashable, Codable {
+    case receipts
+    case weeklyReview
+    case trends
+}
+
+// MARK: - Route
+
+/// A typed deep-link target. Any surface can navigate anywhere by constructing a
+/// `Route`; the associated values carry the per-destination selection so a link
+/// can land on a specific transaction, category, account, or sub-section.
+///
+/// Mirrors the IA doc's `Route` sketch (§2.1). `Equatable`/`Hashable`/`Sendable`
+/// + `Codable` so it can be persisted (selection restoration across launches)
+/// and compared in tests. The actual sidebar / ⌘K / deep-link *UI* is later in
+/// Epic 2 (AND-595/596/597); this PR introduces the model and migrates state.
+public enum Route: Sendable, Hashable, Codable {
+    case dashboard
+    case review(itemID: String? = nil)
+    case transactions(filter: TransactionFilterCriteria? = nil, focus: String? = nil)
+    case budgets(category: SpendingCategory? = nil)
+    case planning(section: PlanningSection = .forecast)
+    case goals(id: UUID? = nil)
+    case insights(section: InsightSection = .receipts)
+    case alerts(id: String? = nil)
+    case accounts(itemID: String? = nil)
+    case settings(tab: SettingsRouteTab = .general)
+
+    /// The bare destination this route resolves to — what the sidebar selects and
+    /// what a `⌘N` shortcut jumps to.
+    public var destination: RouteDestination {
+        switch self {
+        case .dashboard: .dashboard
+        case .review: .review
+        case .transactions: .transactions
+        case .budgets: .budgets
+        case .planning: .planning
+        case .goals: .goals
+        case .insights: .insights
+        case .alerts: .alerts
+        case .accounts: .accounts
+        case .settings: .settings
+        }
+    }
+
+    /// The canonical route for a bare destination, using each case's default
+    /// selection. Lets the sidebar (which selects a `RouteDestination`) produce a
+    /// full `Route` without inventing selection.
+    public static func canonical(for destination: RouteDestination) -> Route {
+        switch destination {
+        case .dashboard: .dashboard
+        case .review: .review()
+        case .transactions: .transactions()
+        case .budgets: .budgets()
+        case .planning: .planning()
+        case .goals: .goals()
+        case .insights: .insights()
+        case .alerts: .alerts()
+        case .accounts: .accounts()
+        case .settings: .settings()
+        }
+    }
+
+    /// Maps a weekly-review navigation target onto a route, so the existing
+    /// `WeeklyReviewNavigationTarget` deep-links land on the new destinations
+    /// (§2.1 of the IA doc). `.safeToSpend` lives on the Dashboard canvas.
+    public static func from(weeklyReview target: WeeklyReviewNavigationTarget) -> Route {
+        switch target {
+        case .reviewInbox: .review()
+        case .recurring: .planning(section: .recurring)
+        case .safeToSpend: .dashboard
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/TransactionFilter.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionFilter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public struct TransactionFilterCriteria: Equatable, Sendable {
+// `Codable` is added so this can ride inside the typed `Route.transactions`
+// deep-link (AND-594); all members are already Codable, so synthesis is free.
+public struct TransactionFilterCriteria: Equatable, Sendable, Codable, Hashable {
     public let searchText: String
     public let category: SpendingCategory?
     public let accountId: String?

--- a/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
@@ -1,0 +1,277 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+// MARK: - Route enum
+
+@Suite("Route destinations")
+struct RouteDestinationTests {
+    @Test("All 11 IA destinations exist (10 sidebar + the Settings scene)")
+    func hasEveryDestination() {
+        // IA §2: Dashboard, Review, Transactions, Budgets, Planning, Goals,
+        // Insights, Alerts, Accounts, Settings. (Transactions counts as the 11th
+        // primary destination alongside Review per IA notes; both are present.)
+        let expected: Set<RouteDestination> = [
+            .dashboard, .review, .transactions, .budgets, .planning,
+            .goals, .insights, .alerts, .accounts, .settings,
+        ]
+        #expect(Set(RouteDestination.allCases) == expected)
+        #expect(RouteDestination.allCases.count == 10)
+    }
+
+    @Test("Command shortcut numbers match the IA keymap ⌘1…⌘8 (Dashboard…Accounts)")
+    func commandShortcutNumbers() {
+        // IA §3.4: ⌘1 Dashboard, ⌘2 Review, ⌘3 Budgets, ⌘4 Planning, ⌘5 Goals,
+        // ⌘6 Insights, ⌘7 Alerts, ⌘8 Accounts. Transactions and Settings have none.
+        #expect(RouteDestination.dashboard.commandShortcutNumber == 1)
+        #expect(RouteDestination.review.commandShortcutNumber == 2)
+        #expect(RouteDestination.budgets.commandShortcutNumber == 3)
+        #expect(RouteDestination.planning.commandShortcutNumber == 4)
+        #expect(RouteDestination.goals.commandShortcutNumber == 5)
+        #expect(RouteDestination.insights.commandShortcutNumber == 6)
+        #expect(RouteDestination.alerts.commandShortcutNumber == 7)
+        #expect(RouteDestination.accounts.commandShortcutNumber == 8)
+        // Transactions is reachable via sidebar / ⌘K but has no number.
+        #expect(RouteDestination.transactions.commandShortcutNumber == nil)
+        // Settings is the native ⌘, scene — no numeric shortcut.
+        #expect(RouteDestination.settings.commandShortcutNumber == nil)
+        // The numbers ⌘1–8 are unique and complete.
+        let numbers = RouteDestination.allCases.compactMap(\.commandShortcutNumber).sorted()
+        #expect(numbers == [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    @Test("Bands group the destinations per the IA tree")
+    func bandGrouping() {
+        #expect(RouteDestination.dashboard.band == .overview)
+        for d in [RouteDestination.review, .transactions, .budgets, .planning, .goals] {
+            #expect(d.band == .workflows)
+        }
+        #expect(RouteDestination.insights.band == .insights)
+        #expect(RouteDestination.alerts.band == .insights)
+        #expect(RouteDestination.accounts.band == .money)
+        #expect(RouteDestination.settings.band == .system)
+    }
+
+    @Test("3-column policy matches IA §3.1")
+    func columnPolicy() {
+        let threeColumn: Set<RouteDestination> = [.review, .transactions, .budgets, .goals, .alerts, .accounts]
+        for d in RouteDestination.allCases {
+            #expect(d.prefersThreeColumnLayout == threeColumn.contains(d))
+        }
+    }
+
+    @Test("Every destination has a non-empty title and SF Symbol")
+    func titlesAndSymbols() {
+        for d in RouteDestination.allCases {
+            #expect(!d.title.isEmpty)
+            #expect(!d.systemImage.isEmpty)
+        }
+    }
+}
+
+@Suite("Route")
+struct RouteTests {
+    @Test("Each route resolves to its destination")
+    func destinationMapping() {
+        #expect(Route.dashboard.destination == .dashboard)
+        #expect(Route.review(itemID: "x").destination == .review)
+        #expect(Route.transactions().destination == .transactions)
+        #expect(Route.budgets(category: .foodAndDrink).destination == .budgets)
+        #expect(Route.planning(section: .recurring).destination == .planning)
+        #expect(Route.goals(id: UUID()).destination == .goals)
+        #expect(Route.insights(section: .trends).destination == .insights)
+        #expect(Route.alerts(id: "a").destination == .alerts)
+        #expect(Route.accounts(itemID: "acct").destination == .accounts)
+        #expect(Route.settings(tab: .privacy).destination == .settings)
+    }
+
+    @Test("Canonical route for each destination uses default selection")
+    func canonicalRoutes() {
+        for d in RouteDestination.allCases {
+            #expect(Route.canonical(for: d).destination == d)
+        }
+        #expect(Route.canonical(for: .review) == .review())
+        #expect(Route.canonical(for: .settings) == .settings())
+    }
+
+    @Test("Weekly-review navigation targets map onto routes")
+    func weeklyReviewMapping() {
+        #expect(Route.from(weeklyReview: .reviewInbox) == .review())
+        #expect(Route.from(weeklyReview: .recurring) == .planning(section: .recurring))
+        #expect(Route.from(weeklyReview: .safeToSpend) == .dashboard)
+    }
+
+    @Test("Route round-trips through Codable (deep-link persistence ready)")
+    func codableRoundTrip() throws {
+        let routes: [Route] = [
+            .dashboard,
+            .review(itemID: "txn_1"),
+            .transactions(filter: TransactionFilterCriteria(searchText: "coffee", category: .foodAndDrink), focus: "txn_9"),
+            .budgets(category: .travel),
+            .planning(section: .incomeFlow),
+            .goals(id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
+            .insights(section: .weeklyReview),
+            .alerts(id: "alert_2"),
+            .accounts(itemID: "acct_7"),
+            .settings(tab: .notifications),
+        ]
+        for route in routes {
+            let data = try JSONEncoder().encode(route)
+            let decoded = try JSONDecoder().decode(Route.self, from: data)
+            #expect(decoded == route)
+        }
+    }
+}
+
+// MARK: - NavigationState transitions
+
+@Suite("NavigationState transitions")
+struct NavigationStateTransitionTests {
+    private let visible = ["demo_checking", "demo_savings", "demo_visa"]
+
+    @Test("Defaults match the migrated @AppStorage defaults")
+    func defaults() {
+        let state = NavigationState()
+        #expect(state.destination == .dashboard)
+        #expect(state.dashboardFilter == .all)
+        #expect(state.selectedAccountID == "")
+        #expect(state.heatmapMode == .spending)
+    }
+
+    @Test("Changing the dashboard filter clears the account selection (AND-373/375)")
+    func filterChangeClearsSelection() {
+        var state = NavigationState()
+        state.selectAccount(id: "demo_visa")
+        #expect(state.selectedAccountID == "demo_visa")
+
+        state.setDashboardFilter(.credit)
+        #expect(state.dashboardFilter == .credit)
+        #expect(state.selectedAccountID == "", "Filter change must deselect, as the popover did")
+    }
+
+    @Test("Setting the same filter is a no-op and does NOT deselect")
+    func sameFilterDoesNotDeselect() {
+        var state = NavigationState(dashboardFilter: .cash)
+        state.selectAccount(id: "demo_checking")
+        state.setDashboardFilter(.cash)
+        #expect(state.selectedAccountID == "demo_checking", "A redundant filter set must not surprise-deselect")
+    }
+
+    @Test("reconcileSelection drops a selection no longer visible, keeps a visible one")
+    func reconcileSelection() {
+        var state = NavigationState()
+        state.selectAccount(id: "vanished_account")
+        let cleared = state.reconcileSelection(visibleAccountIDs: visible)
+        #expect(cleared)
+        #expect(state.selectedAccountID == "")
+
+        state.selectAccount(id: "demo_savings")
+        let kept = state.reconcileSelection(visibleAccountIDs: visible)
+        #expect(!kept)
+        #expect(state.selectedAccountID == "demo_savings")
+    }
+
+    @Test("resolvedSelectedID mirrors DashboardAccountSelection")
+    func resolvedSelection() {
+        var state = NavigationState()
+        #expect(state.resolvedSelectedID(visibleAccountIDs: visible) == nil)
+        state.selectAccount(id: "demo_visa")
+        #expect(state.resolvedSelectedID(visibleAccountIDs: visible) == "demo_visa")
+        state.selectAccount(id: "not_visible")
+        #expect(state.resolvedSelectedID(visibleAccountIDs: visible) == nil)
+    }
+
+    @Test("apply(.accounts(itemID:)) selects destination and folds in the account")
+    func applyAccountRoute() {
+        var state = NavigationState()
+        state.apply(.accounts(itemID: "acct_42"))
+        #expect(state.destination == .accounts)
+        #expect(state.selectedAccountID == "acct_42")
+    }
+
+    @Test("go(to:) switches destination and preserves dashboard selection")
+    func goPreservesSelection() {
+        var state = NavigationState()
+        state.selectAccount(id: "demo_checking")
+        state.setDashboardFilter(.cash) // clears selection
+        state.selectAccount(id: "demo_checking")
+        state.go(to: .budgets)
+        #expect(state.destination == .budgets)
+        // Per-destination selection persists across a destination switch.
+        #expect(state.selectedAccountID == "demo_checking")
+        #expect(state.dashboardFilter == .cash)
+    }
+
+    @Test("NavigationState round-trips through Codable")
+    func codable() throws {
+        let state = NavigationState(
+            destination: .accounts,
+            dashboardFilter: .debt,
+            selectedAccountID: "demo_visa",
+            heatmapMode: .netCashflow
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(NavigationState.self, from: data)
+        #expect(decoded == state)
+    }
+}
+
+// MARK: - R-10: per-window independence
+
+@Suite("R-10 per-window navigation independence")
+struct NavigationStateIndependenceTests {
+    private let visible = ["demo_checking", "demo_savings", "demo_visa"]
+
+    @Test("Two windows hold independent selection — mutating one never touches the other (R-10)")
+    func twoWindowsIndependentSelection() {
+        // Each window owns its own value-type state — the per-window-not-singleton
+        // contract that prevents the two-window selection bug.
+        var windowA = NavigationState()
+        var windowB = NavigationState()
+
+        windowA.selectAccount(id: "demo_checking")
+        windowA.setDashboardFilter(.cash)
+        windowA.heatmapMode = .netCashflow
+        windowA.go(to: .budgets)
+
+        // Window B must be entirely unaffected by Window A's mutations.
+        #expect(windowB.selectedAccountID == "")
+        #expect(windowB.dashboardFilter == .all)
+        #expect(windowB.heatmapMode == .spending)
+        #expect(windowB.destination == .dashboard)
+
+        // And Window B can hold its OWN, different selection simultaneously.
+        windowB.setDashboardFilter(.credit)
+        windowB.selectAccount(id: "demo_visa")
+        windowB.go(to: .accounts)
+
+        #expect(windowA.selectedAccountID == "")     // cleared by A's own filter change
+        #expect(windowA.dashboardFilter == .cash)
+        #expect(windowA.destination == .budgets)
+
+        #expect(windowB.selectedAccountID == "demo_visa")
+        #expect(windowB.dashboardFilter == .credit)
+        #expect(windowB.destination == .accounts)
+
+        // The two states are genuinely distinct.
+        #expect(windowA != windowB)
+    }
+
+    @Test("Independent reconcile: clearing a stale selection in one window leaves the other")
+    func independentReconcile() {
+        var windowA = NavigationState()
+        var windowB = NavigationState()
+        windowA.selectAccount(id: "demo_savings")
+        windowB.selectAccount(id: "stale_in_B_only")
+
+        // A's selection is visible; B's is not. (`reconcileSelection` is
+        // mutating, so call it outside `#expect` and assert the returned flag.)
+        let aCleared = windowA.reconcileSelection(visibleAccountIDs: visible)
+        let bCleared = windowB.reconcileSelection(visibleAccountIDs: visible)
+        #expect(!aCleared)
+        #expect(bCleared)
+
+        #expect(windowA.selectedAccountID == "demo_savings")
+        #expect(windowB.selectedAccountID == "")
+    }
+}

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -590,6 +590,70 @@ struct PlaidBarTests {
         #expect(restarts == 3)
     }
 
+    // MARK: - Navigation state migration (mirrors AppState/NavigationModel façade, AND-594)
+    //
+    // The app's `NavigationModel` (app target, not @testable-importable here)
+    // persists the dashboard filter / account selection / heatmap metric to the
+    // SAME UserDefaults keys the retired view-level `@AppStorage` used, so a
+    // relaunch restores identically. These pin the migrated-key contract at the
+    // pure layer: the raw values stored are the enum raw values MainPopover read.
+
+    @Test("Migrated NavigationState raw values match the retired @AppStorage keys' encoding")
+    func navigationStateMatchesAppStorageEncoding() {
+        // The popover read DashboardAccountFilter.rawValue ("Cash" …),
+        // SpendingHeatmapMode.rawValue ("netCashflow"), and a "" account-id
+        // sentinel. A persisted NavigationState carries exactly those raw values.
+        let state = NavigationState(
+            destination: .dashboard,
+            dashboardFilter: .credit,
+            selectedAccountID: "demo_visa",
+            heatmapMode: .netCashflow
+        )
+        #expect(state.dashboardFilter.rawValue == "Credit")
+        #expect(state.heatmapMode.rawValue == "netCashflow")
+        #expect(state.selectedAccountID == "demo_visa")
+
+        // Defaults match the popover's old @AppStorage defaults exactly.
+        let defaults = NavigationState()
+        #expect(defaults.dashboardFilter.rawValue == DashboardAccountFilterKind.all.rawValue)
+        #expect(defaults.dashboardFilter.rawValue == "All")
+        #expect(defaults.selectedAccountID == "")
+        #expect(defaults.heatmapMode.rawValue == SpendingHeatmapMode.spending.rawValue)
+    }
+
+    @Test("Persisted raw values restore the same NavigationState (relaunch parity)")
+    func navigationStateRestoreParity() {
+        // Simulate the model's hydrate(): decode the three stored raw values into
+        // a NavigationState exactly as NavigationModel.hydrate does, proving a
+        // round-trip through the migrated keys preserves the user's selection.
+        let storedFilter = "Debt"
+        let storedAccountID = "demo_checking"
+        let storedHeatmap = "netCashflow"
+
+        var restored = NavigationState()
+        if let filter = DashboardAccountFilterKind(rawValue: storedFilter) {
+            restored.dashboardFilter = filter
+        }
+        restored.selectedAccountID = storedAccountID
+        if let mode = SpendingHeatmapMode(rawValue: storedHeatmap) {
+            restored.heatmapMode = mode
+        }
+
+        #expect(restored.dashboardFilter == .debt)
+        #expect(restored.selectedAccountID == "demo_checking")
+        #expect(restored.heatmapMode == .netCashflow)
+    }
+
+    @Test("Filter-change-clears-selection holds through the façade contract")
+    func facadeFilterChangeClearsSelection() {
+        // The popover relied on `.onChange(of: filter) { selectedAccountId = "" }`;
+        // the migrated model folds that rule into setDashboardFilter, so the
+        // façade behaves identically without the view-level onChange.
+        var state = NavigationState(dashboardFilter: .all, selectedAccountID: "demo_visa")
+        state.setDashboardFilter(.credit)
+        #expect(state.selectedAccountID == "")
+    }
+
     // MARK: - Foundation Models categorization tier (mirrors AppState.refreshFoundationModelsCategorySuggestions)
 
     @Test("FM categorizer produces a foundationModels suggestion when Apple Intelligence is available")


### PR DESCRIPTION
## Summary

Foundation of **Epic 2 — Navigation Architecture** ([AND-580](https://linear.app/andeslab/issue/AND-580)) for the window-first migration (**ADR-001**). This is **AND-594**: the route model + state migration only — no sidebar UI (AND-595), ⌘K palette (AND-596), or deep-linking/glance routing (AND-597). `AppShellView` stays the empty skeleton from Epic 1.

What landed:

- **`PlaidBarCore/Models/Route.swift`** — a pure, `Sendable` typed `Route` enum with the 11 IA destinations and typed deep-link associated values (mirrors `05-information-architecture.md` §2.1), plus `RouteDestination` (bare identity: band grouping, `⌘1–8` keymap, 2-vs-3-column policy) and the `SettingsRouteTab` / `PlanningSection` / `InsightSection` sub-section enums.
- **`PlaidBarCore/Models/NavigationState.swift`** — a pure **value type** holding `destination` + `dashboardFilter` + `selectedAccountID` + `heatmapMode`, with all transition logic (filter-change-clears-selection, reconcile-stale-selection, resolve-against-visible, `apply(Route)`). Value semantics are what give **two windows independent selection (R-10)**.
- **`PlaidBar/App/NavigationModel.swift`** — an `@Observable @MainActor` **per-window** wrapper over `NavigationState`. It persists to the *same* UserDefaults keys the retired view `@AppStorage` used, so user-visible persistence is preserved. **Not a singleton** — the popover's window gets one (via `AppState`); a window-first `Window` scene constructs its own (R-10).
- **`AppState` façade (R-02)** — `AppState` owns one `NavigationModel` and re-exposes `dashboardFilter` / `dashboardSelectedAccountID` / `dashboardHeatmapMode`. `MainPopover` reads through `appState` instead of view-level `@AppStorage`, so the popover behaves identically.
- Made `DashboardAccountFilterKind` and `TransactionFilterCriteria` `Codable`/`Hashable` (free for these value types) so they can ride inside the persisted state / route.

Refs: **AND-594** (this issue), **AND-580** (Epic 2), **ADR-001** (`docs/strategy/macos26-migration/ADR-001-window-first-architecture.md`), IA spec `docs/strategy/macos26-migration/05-information-architecture.md`.

## Behavior preservation

The #1 rule was **no popover regression**. The three view-level dashboard UI-selection/filter `@AppStorage` keys were retired into the `NavigationModel` behind the `AppState` façade, persisting to the identical keys & raw values:

| Retired view `@AppStorage` key | Type / raw values | Now owned by | Persistence |
|---|---|---|---|
| `dashboard.accountFilter` (`MainPopover`) | `DashboardAccountFilterKind.rawValue` ("All"/"Cash"/"Credit"/"Savings"/"Debt"/"Investments"/"Status") | `NavigationModel.dashboardFilter` via `AppState.dashboardFilter` | same key, same raw values |
| `dashboard.selectedAccountId` (`MainPopover`) | `String` (`""` = none) | `NavigationModel.selectedAccountID` via `AppState.dashboardSelectedAccountID` | same key, same `""` sentinel |
| `dashboard.heatmapMode` (`BalanceActivityHeatmap`) | `SpendingHeatmapMode.rawValue` ("spending"/"netCashflow") | `NavigationModel.heatmapMode` via `AppState.dashboardHeatmapMode` | same key, same raw values |

How the popover stays identical:
- In `MainPopover`, `selectedFilterRawValue` / `selectedAccountId` are now **computed accessors with `nonmutating set`** delegating to `appState` — they keep `@AppStorage`'s settable-from-`let`-view semantics, so every existing call site (`= ""`, `= $0.id`, `filterBinding`, the `.onChange(of:)` handlers) is unchanged. Same for `modeRawValue` in the heatmap subview.
- The "changing the filter deselects the account" rule (AND-373/375) is folded into `NavigationState.setDashboardFilter` (only deselects on a *real* change), so the popover's `.onChange(of: selectedFilterRawValue) { selectedAccountId = "" }` is now redundant-but-harmless rather than load-bearing — behavior is byte-identical, and a redundant same-filter set no longer surprise-deselects.
- Defaults match exactly (`.all` / `""` / `.spending`); hydration suppresses write-back so loading a value doesn't re-persist.

No remaining UI selection state lives in view-level `@AppStorage` (`grep '@AppStorage("dashboard.'` over `Sources/PlaidBar/` returns only a doc comment). The other `@AppStorage` keys left in place are *preferences*, not navigation/selection state (popover transparency, appearance mode/contrast/density/text-size, haptics, settings tab) — out of AND-594's scope.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **passes** (Swift 6 strict-concurrency gate, all `Sendable`/`@MainActor` correct).
- `swift test` — **1834 tests pass** (~1812 baseline + 22 new; no regressions; the only non-passes are pre-existing Keychain "accepts test writes" skips).
- New `Tests/PlaidBarCoreTests/RouteNavigationTests.swift`:
  - `Route` / `RouteDestination`: destination mapping, canonical routes, band grouping, ⌘1–8 keymap, 2-vs-3-column policy, weekly-review→route mapping, Codable round-trip.
  - `NavigationState` transitions: defaults parity, filter-change-clears-selection (and same-filter no-op), reconcile, resolve, `apply`, `go` preserves selection, Codable.
  - **R-10 two-window test** (`NavigationStateIndependenceTests`): two `NavigationState` values; mutating one (select / filter / heatmap / destination) never touches the other, and each holds its own distinct selection simultaneously; plus an independent-reconcile case.
- New parity tests in `Tests/PlaidBarTests/PlaidBarTests.swift` pin the migrated-key encoding (`NavigationModel` itself isn't `@testable`-importable from an executable target, so the persistence contract is verified at the pure `NavigationState` layer).

## Out of scope / follow-ups

- `Route`'s richer per-destination selection slots (transaction id, category, goal id) are modeled but `NavigationState.apply` only writes the account-selection slot this PR owns; the others land with their destinations in later Epic 2 subs.
- Sidebar (AND-595), ⌘K palette (AND-596), deep-linking/glance routing (AND-597) intentionally not built here; `AppShellView` remains the Epic 1 skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)