### PR TITLE
feat(nav): real banded sidebar in window-first shell (AND-595)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1482,6 +1482,42 @@ final class AppState {
         transactionReviewInboxSnapshot.totalCount
     }
 
+    // MARK: - Window-first sidebar (ADR-001 / AND-595)
+
+    /// Items needing reconnect — the actionable degraded items the connection
+    /// health strip surfaces in its reconnect-needed bucket (IA §3.2). Drives the
+    /// Accounts sidebar badge; excludes provider-outage items, which are
+    /// non-actionable (VaultPeek retries them automatically).
+    var sidebarReconnectNeededCount: Int {
+        ConnectionHealthStrip.evaluate(itemStatuses)
+            .buckets
+            .first { $0.state == .reconnectNeeded }?
+            .count ?? 0
+    }
+
+    /// Unacknowledged "alerts" backing the Alerts sidebar badge (IA §3.2 /
+    /// §5.8). The dedicated Alerts feed lands in Epic 6; until then this is the
+    /// count of non-healthy `AttentionQueue` rows — the same "do I need to act?"
+    /// rollup the menu-bar glance and Dashboard already key off (IA §1.3), so the
+    /// badge stays truthful and consistent across all three surfaces.
+    var sidebarUnacknowledgedAlertCount: Int {
+        attentionQueue.rows.filter { $0.severity != .healthy }.count
+    }
+
+    /// The per-destination textual count badges for the window-first sidebar
+    /// (ADR-001, IA §3.2). Pure assembly lives in `SidebarBadgeModel.make`
+    /// (PlaidBarCore) so the view stays thin and the hide-when-zero / a11y-phrase
+    /// policy is unit-tested; this just feeds it the live counts. Window-first
+    /// surface only — the menu-bar popover never reads it.
+    var sidebarBadgeModel: SidebarBadgeModel {
+        SidebarBadgeModel.make(
+            unreviewedCount: transactionReviewCount,
+            overBudgetCount: categoryBudgetPresentation.overBudgetCount,
+            unacknowledgedAlertCount: sidebarUnacknowledgedAlertCount,
+            reconnectNeededCount: sidebarReconnectNeededCount
+        )
+    }
+
     var notificationPermissionPresentation: NotificationPermissionPresentation {
         NotificationPermissionPresentation.evaluate(kind: notificationPermissionState.presentationKind)
     }

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -1,44 +1,211 @@
+import PlaidBarCore
 import SwiftUI
 
-/// Skeleton for the window-first primary workspace (ADR-001, Epic 1 / AND-579,
-/// first code step AND-591).
+/// The window-first primary workspace shell (ADR-001, Epic 2 / AND-580, sidebar
+/// step AND-595).
 ///
-/// This is an **empty** `NavigationSplitView` shell — a sidebar placeholder and a
-/// content placeholder, with **no routing or destinations yet**. The typed
-/// `Route` enum, the `@Observable` navigation model, the sidebar groups, and the
-/// ⌘K command palette all land in Epic 2 (AND-580+). Keeping this PR to the scene
-/// + skeleton makes the window scaffolding reviewable on its own and lets it ship
-/// behind a flag (`WindowFirstFeatureFlag`, default OFF) without touching the
-/// popover.
+/// A `NavigationSplitView` whose sidebar lists the IA's **5 bands → 11
+/// destinations** (`05-information-architecture.md` §2), driven by the
+/// per-window `NavigationModel` / typed `Route` (`PlaidBarCore`). Selecting a row
+/// sets the window's destination and routes the content column; destinations
+/// whose real workspaces land in later epics (4–7) show a labeled
+/// `ContentUnavailableView` placeholder. **Settings** is the native macOS
+/// `Settings` scene, so its sidebar row triggers `openSettings()` rather than an
+/// in-split pane (IA §5.10).
+///
+/// This is built **only** in the window-first surface — the menu-bar popover is
+/// untouched. The window never opens unless `WindowFirstFeatureFlag` is ON
+/// (default OFF), so with the flag off this view is never instantiated and there
+/// is zero behavior change.
 ///
 /// Liquid Glass on chrome is applied at the scene level via
 /// `.containerBackground(.ultraThinMaterial, for: .window)` in `PlaidBarApp`, not
-/// here — per ADR-001 the glass goes on chrome only, never on data.
+/// here — per ADR-001 glass goes on chrome only, never on data.
 struct AppShellView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
+
     var body: some View {
-        NavigationSplitView {
-            // Sidebar placeholder. Epic 2 replaces this with the 4 navigation
-            // groups (Overview / Workflows / Insights / Money / System) backed by
-            // a typed `Route` enum and a single `@Observable` navigation model.
-            ContentUnavailableView {
-                Label("VaultPeek", systemImage: "sidebar.left")
-            } description: {
-                Text("Navigation arrives in a later step.")
+        // The per-window navigation model owns the selected destination (R-10).
+        // Bind the sidebar selection to it; Settings is excluded from the
+        // selectable set (it opens the native Settings scene instead), so the
+        // binding maps a Settings tap to `openSettings()` and never parks the
+        // split-view selection on a destination with no content column.
+        let selection = Binding<RouteDestination?>(
+            get: { appState.navigationModel.destination },
+            set: { newValue in
+                guard let newValue else { return }
+                if newValue == .settings {
+                    openSettings()
+                } else {
+                    appState.navigationModel.go(to: newValue)
+                }
             }
-            .navigationTitle("VaultPeek")
-            .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
+        )
+
+        NavigationSplitView {
+            SidebarView(selection: selection)
         } detail: {
-            // Content placeholder. Epic 2 routes the selected sidebar destination
-            // (Dashboard, Transactions, Budgets, …) into this column.
-            ContentUnavailableView(
-                "Window-First Workspace",
-                systemImage: "macwindow",
-                description: Text("The primary workspace is under construction.")
-            )
+            ShellContentColumn(destination: appState.navigationModel.destination)
         }
+    }
+}
+
+// MARK: - Sidebar
+
+/// The banded navigation sidebar: 5 IA bands → 11 destinations, each a
+/// SF Symbol + label + optional textual count badge, with a footer carrying the
+/// connection-health strip and the data-mode chip (IA §3.2).
+private struct SidebarView: View {
+    @Environment(AppState.self) private var appState
+    @Binding var selection: RouteDestination?
+
+    var body: some View {
+        let badges = appState.sidebarBadgeModel
+
+        List(selection: $selection) {
+            // One Section per IA band, bands in their canonical order, each
+            // listing its destinations in sidebar order. Driving both off
+            // `RouteDestination` keeps the sidebar and the model in lockstep —
+            // no second hand-maintained list of destinations.
+            ForEach(RouteDestination.Band.allCases, id: \.self) { band in
+                Section(band.title) {
+                    ForEach(destinations(in: band), id: \.self) { destination in
+                        SidebarRow(
+                            destination: destination,
+                            badge: badges.badge(for: destination)
+                        )
+                        .tag(destination)
+                    }
+                }
+            }
+        }
+        .navigationTitle("VaultPeek")
+        .navigationSplitViewColumnWidth(min: 220, ideal: 248, max: 320)
+        .safeAreaInset(edge: .bottom) {
+            SidebarFooter()
+        }
+    }
+
+    /// The destinations in a band, in `allCases` (sidebar) order.
+    private func destinations(in band: RouteDestination.Band) -> [RouteDestination] {
+        RouteDestination.allCases.filter { $0.band == band }
+    }
+}
+
+/// A single sidebar destination row: icon + label + optional trailing count
+/// badge. The badge is a **number** (never a color-only dot — `ACCESSIBILITY.md`)
+/// and is folded into the row's VoiceOver label so it is announced, not just
+/// seen.
+private struct SidebarRow: View {
+    let destination: RouteDestination
+    let badge: SidebarBadgeModel.Badge?
+
+    var body: some View {
+        Label {
+            HStack(spacing: Spacing.sm) {
+                Text(destination.title)
+                if let badge {
+                    Spacer(minLength: Spacing.sm)
+                    Text(badge.text)
+                        .dataText()
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .accessibilityHidden(true)
+                }
+            }
+        } icon: {
+            Image(systemName: destination.systemImage)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// "Review, 4 items to review" — destination name plus the badge phrase when
+    /// present (IA §8: the sidebar announces destination + badge).
+    private var accessibilityLabel: String {
+        guard let badge else { return destination.title }
+        return "\(destination.title), \(badge.accessibilityText)"
+    }
+}
+
+// MARK: - Sidebar footer
+
+/// Persistent sidebar footer (IA §3.2): the connection-health strip plus the
+/// data-mode chip (Demo / Sandbox / Production). Reuses the existing
+/// `ConnectionHealthStripView` and `AppState.statusModeText` — no new signals.
+private struct SidebarFooter: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Divider()
+            ConnectionHealthStripView()
+            DataModeChip(mode: appState.statusModeText)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+    }
+}
+
+/// The Demo / Sandbox / Production data-mode chip shown in the sidebar footer.
+/// Text-first (the mode word is the label), with a glyph for shape — meaning is
+/// never carried by color alone.
+private struct DataModeChip: View {
+    let mode: String
+
+    private var iconName: String {
+        switch mode {
+        case "Demo": "theatermasks"
+        case "Sandbox": "testtube.2"
+        case "Production": "checkmark.seal"
+        default: "questionmark.circle"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: iconName)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(mode)
+                .microText()
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
+        .glassSurface(.inset)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Data mode: \(mode)")
+    }
+}
+
+// MARK: - Content column
+
+/// The detail (content) column. For now every destination shows a labeled
+/// `ContentUnavailableView` placeholder — the real workspaces are decomposed from
+/// the popover in Epics 4–7 (AND-595 is scope-limited to the sidebar). Settings
+/// is never routed here: its sidebar row opens the native Settings scene instead.
+private struct ShellContentColumn: View {
+    let destination: RouteDestination
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(destination.title, systemImage: destination.systemImage)
+        } description: {
+            Text(placeholderDescription)
+        }
+        .navigationTitle(destination.title)
+    }
+
+    /// Honest "under construction" copy naming the destination, so the shell is
+    /// demoable (via `--window-first on`) without pretending the workspaces exist.
+    private var placeholderDescription: String {
+        "The \(destination.title) workspace is coming soon."
     }
 }
 
 #Preview {
     AppShellView()
+        .environment(AppState())
 }

--- a/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
+++ b/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Pure, `Sendable` model assembling the window-first sidebar's per-destination
+/// count badges (ADR-001, IA §3.2, AND-595).
+///
+/// The IA mandates **textual count badges, never color-only dots**
+/// (`ACCESSIBILITY.md`: no meaning by color alone) — so each badge is a number
+/// plus a spoken accessibility phrase, and a badge **hides when its count is
+/// zero**. Keeping the derivation here (rather than in the SwiftUI sidebar) makes
+/// the "which destinations badge, what counts, when do they hide" policy
+/// unit-testable without the app target (CLAUDE.md: shared logic lives in
+/// `PlaidBarCore`); the view stays a thin renderer over `badges`.
+///
+/// Four destinations badge, each from a live `AppState` signal (IA §3.2):
+///
+/// | Destination | Count source | Hidden when |
+/// |-------------|--------------|-------------|
+/// | Review   | unreviewed inbox count (`TransactionReviewInboxSnapshot.totalCount`) | queue clear |
+/// | Budgets  | over-budget category count (`CategoryBudgetPresentation.overBudgetCount`) | nothing over |
+/// | Alerts   | unacknowledged-alert count (non-healthy `AttentionQueue` rows — the canonical "do I need to act?" signal until the Alerts feed lands in Epic 6) | none unacked |
+/// | Accounts | reconnect-needed count (`ConnectionHealthStrip` reconnect bucket) | all healthy |
+///
+/// All other destinations carry no badge.
+public struct SidebarBadgeModel: Sendable, Equatable {
+    /// One destination's badge. Only constructed for a positive count, so a
+    /// `Badge` is always visible — a zero count yields no `Badge` at all, which
+    /// is the "hide when zero" contract expressed in the type.
+    public struct Badge: Sendable, Equatable, Identifiable {
+        public let destination: RouteDestination
+        /// The number shown (always `> 0`).
+        public let count: Int
+        /// The trailing text shown next to the row (the count as a string).
+        public let text: String
+        /// The phrase folded into the row's VoiceOver label, e.g.
+        /// `"4 items to review"` — so the badge is announced, not just seen.
+        public let accessibilityText: String
+
+        public var id: RouteDestination { destination }
+
+        public init(
+            destination: RouteDestination,
+            count: Int,
+            accessibilityText: String
+        ) {
+            self.destination = destination
+            self.count = count
+            self.text = String(count)
+            self.accessibilityText = accessibilityText
+        }
+    }
+
+    /// The visible badges, in `RouteDestination.allCases` (sidebar) order. Only
+    /// destinations with a positive count appear.
+    public let badges: [Badge]
+
+    public init(badges: [Badge]) {
+        self.badges = badges
+    }
+
+    /// The badge for a destination, or `nil` when it has none (no source, or a
+    /// zero count). The sidebar row calls this to decide whether to draw a badge.
+    public func badge(for destination: RouteDestination) -> Badge? {
+        badges.first { $0.destination == destination }
+    }
+
+    /// An empty model — every destination badge hidden.
+    public static let empty = SidebarBadgeModel(badges: [])
+
+    // MARK: - Derivation
+
+    /// Builds the badge model from the four live counts `AppState` already
+    /// computes. Each negative input is clamped to zero, and a zero count
+    /// produces no badge (the hide-when-zero rule). The resulting badges are
+    /// ordered by `RouteDestination.allCases` so the model's order matches the
+    /// sidebar's.
+    ///
+    /// - Parameters:
+    ///   - unreviewedCount: items awaiting review
+    ///     (`AppState.transactionReviewCount`).
+    ///   - overBudgetCount: categories over their limit
+    ///     (`AppState.categoryBudgetPresentation.overBudgetCount`).
+    ///   - unacknowledgedAlertCount: alerts needing acknowledgement. Until the
+    ///     Alerts feed lands (Epic 6) the caller passes the count of non-healthy
+    ///     `AttentionQueue` rows — the same "do I need to act?" rollup the
+    ///     menu-bar glance and Dashboard use (IA §1.3).
+    ///   - reconnectNeededCount: items needing reconnect
+    ///     (`ConnectionHealthStrip` reconnect-needed bucket).
+    public static func make(
+        unreviewedCount: Int,
+        overBudgetCount: Int,
+        unacknowledgedAlertCount: Int,
+        reconnectNeededCount: Int
+    ) -> SidebarBadgeModel {
+        var badges: [Badge] = []
+
+        func appendBadge(
+            _ destination: RouteDestination,
+            count: Int,
+            accessibility: (Int) -> String
+        ) {
+            let clamped = max(0, count)
+            guard clamped > 0 else { return }
+            badges.append(
+                Badge(
+                    destination: destination,
+                    count: clamped,
+                    accessibilityText: accessibility(clamped)
+                )
+            )
+        }
+
+        // Emit in sidebar order so `badges` reads top-to-bottom like the list.
+        appendBadge(.review, count: unreviewedCount) { count in
+            "\(count) \(count == 1 ? "item" : "items") to review"
+        }
+        appendBadge(.budgets, count: overBudgetCount) { count in
+            "\(count) \(count == 1 ? "category" : "categories") over budget"
+        }
+        appendBadge(.alerts, count: unacknowledgedAlertCount) { count in
+            "\(count) unacknowledged \(count == 1 ? "alert" : "alerts")"
+        }
+        appendBadge(.accounts, count: reconnectNeededCount) { count in
+            "\(count) \(count == 1 ? "account needs" : "accounts need") reconnecting"
+        }
+
+        return SidebarBadgeModel(badges: badges)
+    }
+}

--- a/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+// MARK: - SidebarBadgeModel (window-first sidebar count badges, AND-595)
+
+@Suite("Sidebar badge model")
+struct SidebarBadgeModelTests {
+    @Test("Each positive count yields a visible badge on the right destination")
+    func badgesForEachSource() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 4,
+            overBudgetCount: 2,
+            unacknowledgedAlertCount: 3,
+            reconnectNeededCount: 1
+        )
+
+        #expect(model.badge(for: .review)?.count == 4)
+        #expect(model.badge(for: .budgets)?.count == 2)
+        #expect(model.badge(for: .alerts)?.count == 3)
+        #expect(model.badge(for: .accounts)?.count == 1)
+        #expect(model.badges.count == 4)
+    }
+
+    @Test("Badge text is the count as a string")
+    func badgeTextIsCount() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 12,
+            overBudgetCount: 0,
+            unacknowledgedAlertCount: 0,
+            reconnectNeededCount: 0
+        )
+        #expect(model.badge(for: .review)?.text == "12")
+    }
+
+    @Test("A zero count hides the badge (hide-when-zero contract)")
+    func hidesWhenZero() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 0,
+            overBudgetCount: 5,
+            unacknowledgedAlertCount: 0,
+            reconnectNeededCount: 0
+        )
+        #expect(model.badge(for: .review) == nil)
+        #expect(model.badge(for: .alerts) == nil)
+        #expect(model.badge(for: .accounts) == nil)
+        #expect(model.badge(for: .budgets)?.count == 5)
+        #expect(model.badges.count == 1)
+    }
+
+    @Test("All-zero counts produce an empty model")
+    func allZeroIsEmpty() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 0,
+            overBudgetCount: 0,
+            unacknowledgedAlertCount: 0,
+            reconnectNeededCount: 0
+        )
+        #expect(model.badges.isEmpty)
+        #expect(model == .empty)
+    }
+
+    @Test("Negative inputs clamp to zero (no negative or phantom badges)")
+    func negativeClampsToZero() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: -3,
+            overBudgetCount: -1,
+            unacknowledgedAlertCount: -7,
+            reconnectNeededCount: -2
+        )
+        #expect(model.badges.isEmpty)
+    }
+
+    @Test("Only the four IA-specified destinations ever badge")
+    func onlyFourDestinationsBadge() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 1,
+            overBudgetCount: 1,
+            unacknowledgedAlertCount: 1,
+            reconnectNeededCount: 1
+        )
+        let badged = Set(model.badges.map(\.destination))
+        #expect(badged == [.review, .budgets, .alerts, .accounts])
+        // Destinations the IA gives no badge never appear.
+        for d in [RouteDestination.dashboard, .transactions, .planning, .goals, .insights, .settings] {
+            #expect(model.badge(for: d) == nil)
+        }
+    }
+
+    @Test("Badges are emitted in sidebar (allCases) order")
+    func badgeOrderMatchesSidebar() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 1,
+            overBudgetCount: 1,
+            unacknowledgedAlertCount: 1,
+            reconnectNeededCount: 1
+        )
+        // Review (band Workflows) → Budgets (Workflows) → Alerts (Insights) →
+        // Accounts (Money): the order they appear in RouteDestination.allCases.
+        #expect(model.badges.map(\.destination) == [.review, .budgets, .alerts, .accounts])
+    }
+
+    // MARK: Accessibility phrasing (singular vs plural; folded into the row label)
+
+    @Test("Review accessibility text pluralizes correctly")
+    func reviewAccessibilityPluralization() {
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 1, overBudgetCount: 0, unacknowledgedAlertCount: 0, reconnectNeededCount: 0)
+                .badge(for: .review)?.accessibilityText == "1 item to review"
+        )
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 5, overBudgetCount: 0, unacknowledgedAlertCount: 0, reconnectNeededCount: 0)
+                .badge(for: .review)?.accessibilityText == "5 items to review"
+        )
+    }
+
+    @Test("Budgets accessibility text pluralizes category/categories")
+    func budgetsAccessibilityPluralization() {
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 1, unacknowledgedAlertCount: 0, reconnectNeededCount: 0)
+                .badge(for: .budgets)?.accessibilityText == "1 category over budget"
+        )
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 3, unacknowledgedAlertCount: 0, reconnectNeededCount: 0)
+                .badge(for: .budgets)?.accessibilityText == "3 categories over budget"
+        )
+    }
+
+    @Test("Alerts accessibility text pluralizes alert/alerts")
+    func alertsAccessibilityPluralization() {
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 1, reconnectNeededCount: 0)
+                .badge(for: .alerts)?.accessibilityText == "1 unacknowledged alert"
+        )
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 2, reconnectNeededCount: 0)
+                .badge(for: .alerts)?.accessibilityText == "2 unacknowledged alerts"
+        )
+    }
+
+    @Test("Accounts accessibility text pluralizes account needs / accounts need")
+    func accountsAccessibilityPluralization() {
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 0, reconnectNeededCount: 1)
+                .badge(for: .accounts)?.accessibilityText == "1 account needs reconnecting"
+        )
+        #expect(
+            SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 0, reconnectNeededCount: 4)
+                .badge(for: .accounts)?.accessibilityText == "4 accounts need reconnecting"
+        )
+    }
+}
+
+// MARK: - Sidebar grouping & ordering (the model the sidebar renders)
+
+@Suite("Sidebar groups and ordering")
+struct SidebarGroupingTests {
+    @Test("Five bands in canonical IA order")
+    func fiveBandsInOrder() {
+        #expect(
+            RouteDestination.Band.allCases == [.overview, .workflows, .insights, .money, .system]
+        )
+    }
+
+    @Test("Bands map to the IA's 5 groups → 11 destinations")
+    func groupsToDestinations() {
+        func destinations(in band: RouteDestination.Band) -> [RouteDestination] {
+            RouteDestination.allCases.filter { $0.band == band }
+        }
+
+        #expect(destinations(in: .overview) == [.dashboard])
+        #expect(destinations(in: .workflows) == [.review, .transactions, .budgets, .planning, .goals])
+        #expect(destinations(in: .insights) == [.insights, .alerts])
+        #expect(destinations(in: .money) == [.accounts])
+        #expect(destinations(in: .system) == [.settings])
+    }
+
+    @Test("Every destination belongs to exactly one band; no destination is dropped")
+    func everyDestinationInExactlyOneBand() {
+        let regrouped = RouteDestination.Band.allCases.flatMap { band in
+            RouteDestination.allCases.filter { $0.band == band }
+        }
+        // Same set as allCases (nothing dropped or duplicated).
+        #expect(Set(regrouped) == Set(RouteDestination.allCases))
+        #expect(regrouped.count == RouteDestination.allCases.count)
+        #expect(regrouped.count == 10)
+    }
+
+    @Test("Settings is the only System destination (opens the native scene, not a pane)")
+    func settingsIsSystem() {
+        #expect(RouteDestination.settings.band == .system)
+        #expect(RouteDestination.allCases.filter { $0.band == .system } == [.settings])
+    }
+}


### PR DESCRIPTION
## Summary

Fills the `AppShellView` `NavigationSplitView` **sidebar** with the IA's **5 bands → 11 destinations**, driven by the per-window `NavigationModel` / typed `Route` (PlaidBarCore). Selecting a row sets the window's destination and routes the content column. This is the AND-595 step of Epic 2 (window-first migration, ADR-001).

- **Sidebar** — banded `List(selection:)` over `RouteDestination` (Overview · Workflows · Insights · Money · System), each row icon + label + optional textual badge. Both the bands and the rows are derived from `RouteDestination`/`Band`, so there is no second hand-maintained destination list.
- **Selection** — bound to the per-window `NavigationModel.destination` (R-10). **Settings** is excluded from the selectable set: its row triggers `openSettings()` (the native Settings scene, IA §5.10) rather than parking the split selection on a content-less destination.
- **Content column** — every routed destination shows a labeled `ContentUnavailableView` placeholder. The real workspaces are decomposed from the popover in **Epics 4–7**; this PR is scope-limited to the sidebar (no ⌘K, no deep-linking — those are AND-596/597).
- **Footer** — the existing `ConnectionHealthStripView` + a Demo/Sandbox/Production data-mode chip (reusing `AppState.statusModeText`). No new health/mode signals invented.

## Badge model

Textual count badges (per IA §3.2), assembled by a pure, `Sendable` `SidebarBadgeModel` in PlaidBarCore so the view stays thin and the policy is unit-tested:

| Destination | Live source | Hidden when |
|-------------|-------------|-------------|
| Review | `transactionReviewCount` (`TransactionReviewInboxSnapshot.totalCount`) | queue clear |
| Budgets | `categoryBudgetPresentation.overBudgetCount` | nothing over |
| Alerts | non-healthy `AttentionQueue` rows (see below) | none unacked |
| Accounts | `ConnectionHealthStrip` reconnect-needed bucket | all healthy |

`AppState.sidebarBadgeModel` feeds these live counts in; `SidebarBadgeModel.make` clamps negatives, hides zero counts, emits in sidebar order, and produces a pluralized accessibility phrase per badge.

## Accessibility (textual badges, never color)

Per `ACCESSIBILITY.md` (no meaning by color alone): each badge is a **monospaced number**, never a color dot, and is **folded into the row's VoiceOver label** ("Review, 4 items to review") rather than read as a bare number. The data-mode chip and health strip are also text+glyph. Badges hide at zero.

## Flag-off inert

Built **only** in the window-first surface. With `WindowFirstFeatureFlag` **OFF** (the shipping default) the `Window` scene is `.defaultLaunchBehavior(.suppressed)` and the only opener ("Open VaultPeek") is flag-gated, so the window never opens and behavior is **byte-identical** to the popover-first build. The menu-bar popover is untouched. Demoable via `swift run PlaidBar --window-first on`.

## IA ambiguity resolved

The IA's Alerts badge wants an "unacknowledged alert count", but the dedicated Alerts feed model lands in **Epic 6** — it does not exist yet. Mapped the Alerts badge to the count of **non-healthy `AttentionQueue` rows** — the canonical "do I need to act?" rollup the menu-bar glance and Dashboard already key off (IA §1.3) — so the badge stays truthful and consistent across surfaces until the real feed arrives. Documented inline.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — 1849 passed (baseline ~1834 + 15 new).
- New `SidebarBadgeModelTests` / `SidebarGroupingTests`: badge per source, hide-when-zero, negative clamp, only-the-four-destinations, sidebar ordering, singular/plural a11y phrasing, and the 5 bands → 11 destinations grouping (every destination in exactly one band, none dropped).

Refs **AND-595**, **AND-580** (Epic 2), **ADR-001** (window-first hybrid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)