### PR TITLE
fix(core): propagate local insight cancellation

### DIFF
--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelRuntime.swift
@@ -416,25 +416,34 @@ public enum LocalInsightModelRuntime {
         nanoseconds: UInt64,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            let race = LocalInsightModelTimeoutRace(continuation: continuation)
-            let operationTask = Task {
-                do {
-                    let result = try await operation()
-                    race.complete(.success(result))
-                } catch {
-                    race.complete(.failure(error))
+        let race = LocalInsightModelTimeoutRace<T>()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let operationTask = Task {
+                    do {
+                        let result = try await operation()
+                        race.complete(.success(result))
+                    } catch {
+                        race.complete(.failure(error))
+                    }
                 }
-            }
-            let timeoutTask = Task {
-                do {
-                    try await Task.sleep(nanoseconds: nanoseconds)
-                    race.complete(.failure(LocalInsightModelTimeoutError()))
-                } catch {
-                    race.cancelTimeout()
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(nanoseconds: nanoseconds)
+                        race.complete(.failure(LocalInsightModelTimeoutError()))
+                    } catch {
+                        race.cancelTimeout()
+                    }
                 }
+                race.start(
+                    continuation: continuation,
+                    operationTask: operationTask,
+                    timeoutTask: timeoutTask
+                )
             }
-            race.setTasks(operationTask: operationTask, timeoutTask: timeoutTask)
+        } onCancel: {
+            race.complete(.failure(CancellationError()))
         }
     }
 }
@@ -444,26 +453,31 @@ private final class LocalInsightModelTimeoutRace<T: Sendable>: @unchecked Sendab
     private var continuation: CheckedContinuation<T, Error>?
     private var operationTask: Task<Void, Never>?
     private var timeoutTask: Task<Void, Never>?
+    private var completedResult: Result<T, Error>?
 
-    init(continuation: CheckedContinuation<T, Error>) {
-        self.continuation = continuation
-    }
+    func start(
+        continuation: CheckedContinuation<T, Error>,
+        operationTask: Task<Void, Never>,
+        timeoutTask: Task<Void, Never>
+    ) {
+        let resultToResume: Result<T, Error>?
 
-    func setTasks(operationTask: Task<Void, Never>, timeoutTask: Task<Void, Never>) {
-        var shouldCancel = false
         lock.lock()
-        if continuation == nil {
-            shouldCancel = true
-        } else {
+        resultToResume = completedResult
+        if resultToResume == nil {
+            self.continuation = continuation
             self.operationTask = operationTask
             self.timeoutTask = timeoutTask
         }
         lock.unlock()
 
-        if shouldCancel {
-            operationTask.cancel()
-            timeoutTask.cancel()
+        guard let resultToResume else {
+            return
         }
+
+        operationTask.cancel()
+        timeoutTask.cancel()
+        resume(continuation, with: resultToResume)
     }
 
     func complete(_ result: Result<T, Error>) {
@@ -472,6 +486,11 @@ private final class LocalInsightModelTimeoutRace<T: Sendable>: @unchecked Sendab
         let timeoutTaskToCancel: Task<Void, Never>?
 
         lock.lock()
+        guard completedResult == nil else {
+            lock.unlock()
+            return
+        }
+        completedResult = result
         continuationToResume = continuation
         continuation = nil
         operationTaskToCancel = operationTask
@@ -480,18 +499,11 @@ private final class LocalInsightModelTimeoutRace<T: Sendable>: @unchecked Sendab
         timeoutTask = nil
         lock.unlock()
 
-        guard let continuationToResume else {
-            return
-        }
-
         operationTaskToCancel?.cancel()
         timeoutTaskToCancel?.cancel()
 
-        switch result {
-        case .success(let value):
-            continuationToResume.resume(returning: value)
-        case .failure(let error):
-            continuationToResume.resume(throwing: error)
+        if let continuationToResume {
+            resume(continuationToResume, with: result)
         }
     }
 
@@ -504,6 +516,15 @@ private final class LocalInsightModelTimeoutRace<T: Sendable>: @unchecked Sendab
         lock.unlock()
 
         timeoutTaskToCancel?.cancel()
+    }
+
+    private func resume(_ continuation: CheckedContinuation<T, Error>, with result: Result<T, Error>) {
+        switch result {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
     }
 }
 

--- a/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelRuntimeTests.swift
@@ -205,6 +205,38 @@ struct LocalInsightModelRuntimeTests {
         #expect(result.fallbackReason == .timeout)
     }
 
+    @Test("Runtime outer cancellation returns before the timeout elapses")
+    func runtimeOuterCancellationReturnsBeforeTimeoutElapses() async {
+        let state = BlockingCancellationIgnoringLocalInsightModel.State()
+        let model = BlockingCancellationIgnoringLocalInsightModel(
+            output: "Food spending was the largest driver this month.",
+            state: state
+        )
+        let timeoutNanoseconds: UInt64 = 200_000_000
+
+        let runtimeTask = Task {
+            await LocalInsightModelRuntime.generateSummary(
+                input: input(),
+                model: model,
+                fallbackSummary: { _ in "deterministic fallback" },
+                configuration: LocalInsightModelGenerationConfiguration(timeoutNanoseconds: timeoutNanoseconds)
+            )
+        }
+
+        await state.waitUntilStarted()
+        let startedAt = ContinuousClock.now
+        runtimeTask.cancel()
+        let result = await runtimeTask.value
+        let elapsed = startedAt.duration(to: .now)
+        #expect(!state.wasReleased)
+        state.release()
+
+        #expect(elapsed < .milliseconds(100))
+        #expect(result.summary == "deterministic fallback")
+        #expect(result.usedModelOutput == false)
+        #expect(result.fallbackReason == .modelError)
+    }
+
     private func input() -> LocalAIActivitySummaryInput {
         let current = LocalAIActivityMetrics(
             transactionCount: 4,


### PR DESCRIPTION
## Summary

- propagates outer task cancellation into `LocalInsightModelRuntime.withTimeout`
- preserves the existing timeout fast-return behavior for cancellation-ignoring model operations
- adds a regression test for superseded local insight generation returning before the timeout elapses

Fixes #585
Linear: AND-619

## Verification

- `git diff --check` — pass
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — pass
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by pre-existing unrelated strict-concurrency errors in `Tests/PlaidBarCoreTests/FMMerchantCategorizerTests.swift:43`/`:45` (`NSLock.lock`/`unlock` unavailable from async context); the touched `LocalInsightModelRuntimeTests.swift` did compile before the failure
- `swift test --filter 'Local Insight Model Runtime Tests/Runtime outer cancellation returns before the timeout elapses' --skip PlaidBarCacheTests` — blocked by pre-existing SwiftData macro plugin failure in `Sources/PlaidBarCache/*` (`SwiftDataMacros.PersistentModelMacro` / `PersistentModelActorMacro` plugin not found)

## Privacy/security

This change stays inside the local Core timeout/cancellation utility. It does not move Plaid credentials, tokens, account IDs, transaction IDs, balances, prompts, raw model responses, SQLite data, logs, or screenshots into the app/docs/tests/artifacts.
