### PR TITLE
feat(ux): ⌘K command palette + global keymap behind window-first flag (AND-596)

### DIFF
--- a/Sources/PlaidBar/App/CommandPaletteModel.swift
+++ b/Sources/PlaidBar/App/CommandPaletteModel.swift
@@ -1,0 +1,96 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Present/dismiss state + the command registry for the ⌘K palette (AND-596).
+///
+/// `@Observable @MainActor` so the `AppShellView` overlay and the ⌘K command
+/// share one source of truth. It is per-window scene state (one per
+/// `AppShellView`), mirroring `NavigationModel`'s per-window ownership (R-10) —
+/// the palette in one window does not present in another.
+///
+/// Holds the pure ``CommandRegistry`` (the searchable command set); the search /
+/// ranking is the registry's own pure method, so this wrapper only carries the
+/// `isPresented` flag and the registry instance.
+@Observable
+@MainActor
+final class CommandPaletteModel {
+    /// Whether the palette overlay is showing. Toggled by the ⌘K command and the
+    /// palette's own dismiss paths (Esc, scrim tap, after executing a command).
+    var isPresented = false
+
+    /// The command set the palette searches. The default registry (every
+    /// destination + the four global verbs + find) is the complete AND-596 set.
+    let registry: CommandRegistry
+
+    init(registry: CommandRegistry = .makeDefault()) {
+        self.registry = registry
+    }
+
+    func present() { isPresented = true }
+    func dismiss() { isPresented = false }
+    func toggle() { isPresented.toggle() }
+}
+
+/// Executes a chosen palette command's `Kind` against the **existing** app
+/// actions (AND-596). The palette never reimplements behavior — it routes the
+/// command back to the same paths the menu-bar / global shortcuts use:
+///
+/// - **navigate** → `NavigationModel.go(to:)` (sets the window's destination).
+/// - **act(.refresh)** → `AppState.refreshDashboard()`.
+/// - **act(.togglePrivacyMask)** → `AppState.togglePrivacyMask()`.
+/// - **act(.openSettings)** → the scene's `openSettings` closure.
+/// - **act(.summon)** → the scene's summon closure.
+/// - **find** → the scene's focus-search closure (the ⌘F path).
+///
+/// `openSettings` / `summon` / `focusSearch` are owned by the SwiftUI scene
+/// (`PlaidBarApp`), so they are injected as closures rather than reached through
+/// `AppState`. `@MainActor`; a value type holding `@MainActor` closures, so it is
+/// cheap to construct per `body`.
+@MainActor
+struct CommandDispatcher {
+    let appState: AppState
+    let navigationModel: NavigationModel
+    /// Opens the native Settings scene (`openSettings()` environment action).
+    let openSettings: () -> Void
+    /// Brings VaultPeek to the front (the summon-hotkey path).
+    let summon: () -> Void
+    /// Focuses the current destination's search field (the ⌘F path). The
+    /// per-destination search surfaces land in later epics; today this is a hook
+    /// the find command and ⌘F share.
+    let focusSearch: () -> Void
+
+    func run(_ kind: CommandRegistry.Kind) {
+        switch kind {
+        case .navigate(let destination):
+            navigate(to: destination)
+        case .act(let action):
+            perform(action)
+        case .find:
+            focusSearch()
+        }
+    }
+
+    /// Navigates the window to a destination. Settings is the native scene, so it
+    /// opens that window rather than parking the split-view on a content-less
+    /// destination (mirrors `AppShellView`'s sidebar binding).
+    func navigate(to destination: RouteDestination) {
+        if destination == .settings {
+            openSettings()
+        } else {
+            navigationModel.go(to: destination)
+        }
+    }
+
+    func perform(_ action: CommandRegistry.Action) {
+        switch action {
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .togglePrivacyMask:
+            appState.togglePrivacyMask()
+        case .openSettings:
+            openSettings()
+        case .summon:
+            summon()
+        }
+    }
+}

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -29,6 +29,12 @@ struct PlaidBarApp: App {
     /// the `Window` actually opens, which only happens behind the window-first flag,
     /// so flag-OFF activation behavior is unchanged.
     @State private var windowActivationPolicy = WindowActivationPolicy()
+    /// The window-first ⌘K command-palette state (ADR-001, IA §3.3, AND-596).
+    /// Owned at the scene level so the ⌘K `CommandMenu` and the `AppShellView`
+    /// overlay share one source of truth. `@State` so it survives `body`
+    /// recomputes. Inert unless the window-first surface is shown, which only
+    /// happens behind the flag — so flag-OFF behavior is unchanged.
+    @State private var commandPalette = CommandPaletteModel()
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -354,6 +360,64 @@ struct PlaidBarApp: App {
                     }
                     .keyboardShortcut("0", modifiers: .command)
                 }
+
+                // The window-first global keyboard map (ADR-001, IA §3.4,
+                // AND-596). All gated by the same flag as "Open VaultPeek" — with
+                // the flag OFF none of these menus/shortcuts are added, so the
+                // menu bar and the whole app are byte-identical to today. Each
+                // command drives the shared per-window models / the existing
+                // action paths; none reimplements behavior. (`⌘,` Settings stays
+                // the native Settings scene shortcut; it is not redeclared here.)
+
+                // Go menu — ⌘K palette, ⌘1–8 destinations, ⌘F find.
+                CommandMenu("Go") {
+                    Button("Command Palette…") {
+                        ensureWindowOpen()
+                        commandPalette.present()
+                    }
+                    .keyboardShortcut("k", modifiers: .command)
+
+                    Divider()
+
+                    // ⌘1…⌘8 jump to a destination, matching
+                    // `RouteDestination.commandShortcutNumber` (Dashboard…Accounts).
+                    ForEach(destinationsWithShortcut, id: \.self) { destination in
+                        Button(destination.title) {
+                            goToDestination(destination)
+                        }
+                        .keyboardShortcut(
+                            shortcutKey(for: destination.commandShortcutNumber),
+                            modifiers: .command
+                        )
+                    }
+
+                    Divider()
+
+                    Button("Find Transaction…") {
+                        ensureWindowOpen()
+                        commandPalette.dismiss()
+                        runFindCommand()
+                    }
+                    .keyboardShortcut("f", modifiers: .command)
+                }
+
+                // Account/Actions menu — ⌘R refresh, ⌘⇧P Privacy Mask, ⇧⌘V summon.
+                CommandMenu("Actions") {
+                    Button("Refresh") {
+                        Task { await appState.refreshDashboard() }
+                    }
+                    .keyboardShortcut("r", modifiers: .command)
+
+                    Button(privacyMaskMenuTitle) {
+                        appState.togglePrivacyMask()
+                    }
+                    .keyboardShortcut("p", modifiers: [.command, .shift])
+
+                    Button("Summon VaultPeek") {
+                        summonDashboard()
+                    }
+                    .keyboardShortcut("v", modifiers: [.command, .shift])
+                }
             }
         }
 
@@ -377,7 +441,14 @@ struct PlaidBarApp: App {
         // shell is an empty `NavigationSplitView` skeleton; routing/destinations
         // and the activation-policy/appearance wiring land in later Epic 1/2 PRs.
         Window("VaultPeek", id: Self.mainWindowID) {
-            AppShellView()
+            AppShellView(
+                paletteModel: commandPalette,
+                summon: { summonDashboard() },
+                // Per-destination search lands in later epics; ⌘F / the find
+                // command focus the window for now (the real search-field focus
+                // wires up when Transactions/Review land).
+                focusSearch: { NSApplication.shared.activate(ignoringOtherApps: true) }
+            )
                 .environment(appState)
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 // Fold the primary `Window` into the single `NSApp.appearance`
@@ -411,6 +482,55 @@ struct PlaidBarApp: App {
         // never collapses below a usable width.
         .windowResizability(.contentMinSize)
         .defaultSize(width: 1080, height: 720)
+    }
+
+    // MARK: - Window-first command map (AND-596)
+
+    /// Destinations that own a `⌘N` shortcut (Dashboard…Accounts), in shortcut
+    /// order. Drives the "Go" menu's numbered items off the single source of
+    /// truth in `RouteDestination`, so the menu and the keymap never drift.
+    private var destinationsWithShortcut: [RouteDestination] {
+        RouteDestination.allCases
+            .filter { $0.commandShortcutNumber != nil }
+            .sorted { ($0.commandShortcutNumber ?? 0) < ($1.commandShortcutNumber ?? 0) }
+    }
+
+    /// The `KeyEquivalent` for a destination's shortcut number (1…8). Falls back
+    /// to "1" defensively; `destinationsWithShortcut` only yields numbered ones.
+    private func shortcutKey(for number: Int?) -> KeyEquivalent {
+        guard let number, let scalar = Character(String(number)).unicodeScalars.first else {
+            return "1"
+        }
+        return KeyEquivalent(Character(scalar))
+    }
+
+    /// The Privacy Mask menu title reflects the current state so the menu reads
+    /// "Hide Balances" / "Show Balances" rather than a static label.
+    private var privacyMaskMenuTitle: String {
+        appState.shouldMaskFinancialValues ? "Show Balances" : "Hide Balances"
+    }
+
+    /// Opens the primary window if it is not already up, so a ⌘K / ⌘1–8 pressed
+    /// while only the menu bar is showing brings the workspace forward first.
+    @MainActor
+    private func ensureWindowOpen() {
+        openWindow(id: Self.mainWindowID)
+    }
+
+    /// Navigates the primary window to a destination (the ⌘1–8 path). Opens the
+    /// window first, then drives the shared per-window `NavigationModel`.
+    @MainActor
+    private func goToDestination(_ destination: RouteDestination) {
+        ensureWindowOpen()
+        appState.navigationModel.go(to: destination)
+    }
+
+    /// Runs the palette's "find" command (the ⌘F path): focus the current
+    /// destination's search. Per-destination search surfaces land in later epics;
+    /// today this brings the window forward so the user lands on the workspace.
+    @MainActor
+    private func runFindCommand() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
     /// Registers or unregisters the global summon hotkey to match the persisted

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -24,6 +24,33 @@ import SwiftUI
 struct AppShellView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    /// The ⌘K command-palette state for this window. Owned by the scene
+    /// (`PlaidBarApp`) so the ⌘K menu command and this overlay share one source
+    /// of truth, and injected here. Defaults to a fresh model so the `#Preview`
+    /// and any standalone use still work (AND-596).
+    @State private var paletteModel: CommandPaletteModel
+    /// Brings VaultPeek to the front (the summon-hotkey path); injected from the
+    /// scene since summon is a scene-level concern. No-op by default.
+    private let summon: () -> Void
+    /// Focuses the current destination's search field (the ⌘F / find path);
+    /// injected from the scene. No-op until per-destination search lands.
+    private let focusSearch: () -> Void
+
+    /// `paletteModel` is optional so the default is constructed inside this
+    /// `@MainActor` init body (a `@MainActor`-isolated default *argument* would be
+    /// evaluated in the caller's nonisolated context and fail strict concurrency).
+    /// The scene injects its shared model; the `#Preview` / standalone use gets a
+    /// fresh one.
+    @MainActor
+    init(
+        paletteModel: CommandPaletteModel? = nil,
+        summon: @escaping () -> Void = {},
+        focusSearch: @escaping () -> Void = {}
+    ) {
+        _paletteModel = State(initialValue: paletteModel ?? CommandPaletteModel())
+        self.summon = summon
+        self.focusSearch = focusSearch
+    }
 
     var body: some View {
         // The per-window navigation model owns the selected destination (R-10).
@@ -48,6 +75,26 @@ struct AppShellView: View {
         } detail: {
             ShellContentColumn(destination: appState.navigationModel.destination)
         }
+        // The ⌘K command palette is a window-level overlay (IA §3.3). It is only
+        // ever reachable in this window-first surface — `AppShellView` is built
+        // solely behind `WindowFirstFeatureFlag` — so the palette never exists in
+        // the flag-OFF popover build.
+        .overlay {
+            if paletteModel.isPresented {
+                CommandPalette(
+                    model: paletteModel,
+                    dispatcher: CommandDispatcher(
+                        appState: appState,
+                        navigationModel: appState.navigationModel,
+                        openSettings: { openSettings() },
+                        summon: summon,
+                        focusSearch: focusSearch
+                    )
+                )
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.15), value: paletteModel.isPresented)
     }
 }
 

--- a/Sources/PlaidBar/Views/CommandPalette.swift
+++ b/Sources/PlaidBar/Views/CommandPalette.swift
@@ -1,0 +1,199 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The ⌘K command palette overlay (ADR-001, IA §3.3, AND-596).
+///
+/// A spotlight-style overlay rendered at the `AppShellView` window level: a
+/// search field over the pure ``CommandRegistry``, with fuzzy filtering
+/// (``FuzzyMatcher``), `↑`/`↓` to move, `Return` to execute, and `Esc` to
+/// dismiss. It is **keyboard-first** — the field auto-focuses on present, and
+/// every command is reachable without the mouse (IA §1.4 "Keyboard-first").
+///
+/// Selecting a command dispatches its `Kind` through ``CommandDispatcher``, which
+/// calls the *existing* action paths (navigate → `NavigationModel.destination`;
+/// act → the real refresh / Privacy Mask / settings / summon paths) — the palette
+/// never reimplements behavior.
+///
+/// This view exists **only** in the window-first surface: it is presented from
+/// `AppShellView`, which is only ever instantiated behind `WindowFirstFeatureFlag`
+/// (default OFF). With the flag off the palette never appears, so flag-OFF
+/// behavior is byte-identical to today.
+struct CommandPalette: View {
+    /// Drives present/dismiss; owned by `AppShellView` so the ⌘K command and the
+    /// overlay share one source of truth.
+    @Bindable var model: CommandPaletteModel
+    /// Executes a chosen command against the live app actions.
+    let dispatcher: CommandDispatcher
+
+    @State private var query = ""
+    @State private var highlightedIndex = 0
+    @FocusState private var searchFieldFocused: Bool
+
+    /// The registry filtered by the current query, best match first. Empty query
+    /// shows the full command list (registry order).
+    private var results: [CommandRegistry.Command] {
+        model.registry.search(query)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            resultsList
+        }
+        .frame(width: 560)
+        .frame(maxHeight: 420)
+        .glassSurface(.raised, cornerRadius: Radius.panel)
+        .shadow(radius: 24, y: 8)
+        .padding(.top, Spacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(scrim)
+        .onAppear { searchFieldFocused = true }
+        .onChange(of: query) { _, _ in
+            // A new query reorders results — keep the highlight in range and on
+            // the new best match.
+            highlightedIndex = 0
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Command palette")
+        .accessibilityAddTraits(.isModal)
+    }
+
+    // MARK: - Search field
+
+    private var searchField: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            TextField("Search commands…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.title3)
+                .focused($searchFieldFocused)
+                .onSubmit(executeHighlighted)
+                .accessibilityLabel("Search commands")
+        }
+        .padding(.horizontal, Spacing.lg)
+        .padding(.vertical, Spacing.md)
+        // Keyboard-first navigation: arrow keys move the highlight, Esc dismisses.
+        // These attach to the field so they work while typing.
+        .onKeyPress(.downArrow) { moveHighlight(by: 1); return .handled }
+        .onKeyPress(.upArrow) { moveHighlight(by: -1); return .handled }
+        .onKeyPress(.escape) { model.dismiss(); return .handled }
+    }
+
+    // MARK: - Results
+
+    private var resultsList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if results.isEmpty {
+                        emptyState
+                    } else {
+                        ForEach(Array(results.enumerated()), id: \.element.id) { index, command in
+                            CommandPaletteRow(
+                                command: command,
+                                isHighlighted: index == highlightedIndex
+                            )
+                            .id(index)
+                            .contentShape(Rectangle())
+                            .onTapGesture { execute(command) }
+                            .onHover { hovering in
+                                if hovering { highlightedIndex = index }
+                            }
+                        }
+                    }
+                }
+                .padding(Spacing.xs)
+            }
+            .onChange(of: highlightedIndex) { _, index in
+                withAnimation(.easeOut(duration: 0.12)) {
+                    proxy.scrollTo(index, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text("No commands match “\(query)”.")
+            .detailText()
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var scrim: some View {
+        // A dim scrim catches clicks outside the panel to dismiss, and darkens the
+        // shell behind the overlay. Decorative, so hidden from VoiceOver.
+        Color.black.opacity(0.18)
+            .ignoresSafeArea()
+            .onTapGesture { model.dismiss() }
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Keyboard handling
+
+    private func moveHighlight(by delta: Int) {
+        guard !results.isEmpty else { return }
+        let count = results.count
+        highlightedIndex = (highlightedIndex + delta + count) % count
+    }
+
+    private func executeHighlighted() {
+        guard results.indices.contains(highlightedIndex) else { return }
+        execute(results[highlightedIndex])
+    }
+
+    private func execute(_ command: CommandRegistry.Command) {
+        model.dismiss()
+        dispatcher.run(command.kind)
+    }
+}
+
+// MARK: - Row
+
+/// One palette result row: icon + title + optional subtitle/shortcut. The title
+/// carries the meaning; the icon is chrome and the highlight uses the native
+/// selection treatment (never color alone — ACCESSIBILITY.md).
+private struct CommandPaletteRow: View {
+    let command: CommandRegistry.Command
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: Spacing.md) {
+            Image(systemName: command.systemImage)
+                .frame(width: Sizing.iconNav)
+                .foregroundStyle(isHighlighted ? Color.white : .secondary)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(command.title)
+                    .font(.body)
+                    .foregroundStyle(isHighlighted ? Color.white : .primary)
+                if let subtitle = command.subtitle {
+                    Text(subtitle)
+                        .microText()
+                        .foregroundStyle(isHighlighted ? Color.white.opacity(0.8) : .secondary)
+                }
+            }
+            Spacer(minLength: Spacing.sm)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .background {
+            if isHighlighted {
+                RoundedRectangle(cornerRadius: Radius.control)
+                    .fill(Color.accentColor)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(isHighlighted ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var accessibilityLabel: String {
+        guard let subtitle = command.subtitle else { return command.title }
+        return "\(command.title), \(subtitle)"
+    }
+}

--- a/Sources/PlaidBarCore/Models/CommandRegistry.swift
+++ b/Sources/PlaidBarCore/Models/CommandRegistry.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// The pure, `Sendable` model of every command the ⌘K palette can run
+/// (ADR-001, IA §3.3 "Command palette", AND-596).
+///
+/// The IA calls the command palette "the single most important new piece": a
+/// spotlight-style overlay with fuzzy search across three action classes —
+/// **navigate**, **act**, **find**. This type is the registry of those commands
+/// as *data*. It deliberately carries **no closures**: a command describes
+/// *what* it does (a `Kind` + a stable `id` + display strings), and the app
+/// layer maps the chosen command's `Kind` onto the existing action path
+/// (navigate → `NavigationModel.destination`; act → the real refresh / Privacy
+/// Mask / settings / summon paths). Keeping the registry closure-free is what
+/// makes it `Sendable` and unit-testable without the SwiftUI app target
+/// (CLAUDE.md: shared, testable logic lives in `PlaidBarCore`).
+///
+/// The palette filters/ranks this set with ``FuzzyMatcher``; selecting a result
+/// hands the command's `Kind` back to the app to execute.
+public struct CommandRegistry: Sendable, Equatable {
+    /// The kind of thing a command does. Drives both how it is grouped in the
+    /// palette and how the app executes it.
+    public enum Kind: Sendable, Equatable, Hashable, Codable {
+        /// Jump to a destination (the canonical route for it). IA §3.3 class 1.
+        case navigate(RouteDestination)
+        /// A global verb that works from anywhere. IA §3.3 class 2.
+        case act(Action)
+        /// Enter "find" mode — search transactions and jump to the match. IA
+        /// §3.3 class 3. The query itself is typed in the palette; this command
+        /// is the entry point (it focuses the current destination's search, per
+        /// the ⌘F keymap row).
+        case find
+
+        /// The bare destination a `navigate` command targets, else `nil`.
+        public var navigationDestination: RouteDestination? {
+            if case .navigate(let destination) = self { return destination }
+            return nil
+        }
+    }
+
+    /// The global verbs the palette exposes (IA §3.3 class 2 + the keymap §3.4).
+    /// Each maps to an existing app action — the palette never invents behavior,
+    /// it surfaces the paths the menu-bar / shortcuts already drive.
+    public enum Action: String, Sendable, Equatable, Hashable, Codable, CaseIterable {
+        /// Refresh / sync now (`⌘R`) — `AppState.refreshDashboard()`.
+        case refresh
+        /// Toggle Privacy Mask (`⌘⇧P`) — `AppState.togglePrivacyMask()`.
+        case togglePrivacyMask
+        /// Open the native Settings scene (`⌘,`) — `openSettings()`.
+        case openSettings
+        /// Summon VaultPeek to the front (`⇧⌘V`) — the summon-hotkey path.
+        case summon
+    }
+
+    /// One palette command. Pure data: id + kind + the strings the palette shows
+    /// and searches.
+    public struct Command: Sendable, Equatable, Identifiable, Hashable {
+        /// Stable identifier, also the de-dupe / selection key. Derived from the
+        /// kind so it is deterministic (`navigate.dashboard`, `act.refresh`,
+        /// `find`).
+        public let id: String
+        public let kind: Kind
+        /// The primary label, fuzzy-searched with the highest weight.
+        public let title: String
+        /// Optional secondary line (e.g. the shortcut hint or a hint of scope).
+        public let subtitle: String?
+        /// Extra search terms (synonyms / verbs) so "sync" finds "Refresh" and
+        /// "hide balances" finds "Toggle Privacy Mask". Fuzzy-searched below the
+        /// title.
+        public let keywords: [String]
+        /// SF Symbol for the row (chrome only — the title always carries meaning).
+        public let systemImage: String
+
+        public init(
+            id: String,
+            kind: Kind,
+            title: String,
+            subtitle: String? = nil,
+            keywords: [String] = [],
+            systemImage: String
+        ) {
+            self.id = id
+            self.kind = kind
+            self.title = title
+            self.subtitle = subtitle
+            self.keywords = keywords
+            self.systemImage = systemImage
+        }
+    }
+
+    /// Every command, in a stable display order: navigate (sidebar order) →
+    /// act → find. The palette shows this order when the query is empty.
+    public let commands: [Command]
+
+    public init(commands: [Command]) {
+        self.commands = commands
+    }
+
+    /// Looks a command up by its stable id (the palette hands this back on
+    /// selection so the app can dispatch the `Kind`).
+    public func command(id: String) -> Command? {
+        commands.first { $0.id == id }
+    }
+
+    /// Fuzzy-searches the registry, best match first, using ``FuzzyMatcher``
+    /// over each command's title + keywords. An empty query returns every
+    /// command in registry order (so the palette lists everything before the
+    /// user types).
+    public func search(_ query: String) -> [Command] {
+        FuzzyMatcher.search(
+            query: query,
+            candidates: commands,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        ).map(\.element)
+    }
+
+    // MARK: - Construction
+
+    /// Builds the **default** registry: a navigate command for every
+    /// `RouteDestination`, the four global act verbs, and the find entry point.
+    /// This is the complete command set AND-596 ships; contextual per-destination
+    /// commands (IA §3.3) layer on in later epics.
+    ///
+    /// Order: navigate (sidebar / `allCases` order) → act (refresh, Privacy Mask,
+    /// settings, summon) → find.
+    public static func makeDefault() -> CommandRegistry {
+        var commands: [Command] = []
+
+        // 1. Navigate — one per destination, in sidebar order (IA §3.3 class 1).
+        for destination in RouteDestination.allCases {
+            commands.append(
+                Command(
+                    id: navigateID(destination),
+                    kind: .navigate(destination),
+                    title: "Go to \(destination.title)",
+                    subtitle: navigateSubtitle(destination),
+                    keywords: navigateKeywords(destination),
+                    systemImage: destination.systemImage
+                )
+            )
+        }
+
+        // 2. Act — the global verbs, each mapping to an existing action path.
+        commands.append(
+            Command(
+                id: actID(.refresh),
+                kind: .act(.refresh),
+                title: "Refresh",
+                subtitle: "Sync now",
+                keywords: ["sync", "reload", "update", "fetch"],
+                systemImage: "arrow.clockwise"
+            )
+        )
+        commands.append(
+            Command(
+                id: actID(.togglePrivacyMask),
+                kind: .act(.togglePrivacyMask),
+                title: "Toggle Privacy Mask",
+                subtitle: "Hide or show balances",
+                keywords: ["privacy", "hide", "mask", "balances", "amounts", "blur", "redact"],
+                systemImage: "eye.slash"
+            )
+        )
+        commands.append(
+            Command(
+                id: actID(.openSettings),
+                kind: .act(.openSettings),
+                title: "Open Settings",
+                subtitle: "Preferences",
+                keywords: ["settings", "preferences", "configuration", "options"],
+                systemImage: "gearshape"
+            )
+        )
+        commands.append(
+            Command(
+                id: actID(.summon),
+                kind: .act(.summon),
+                title: "Summon VaultPeek",
+                subtitle: "Bring to front",
+                keywords: ["summon", "front", "activate", "show", "bring", "focus"],
+                systemImage: "macwindow.on.rectangle"
+            )
+        )
+
+        // 3. Find — the search entry point (IA §3.3 class 3).
+        commands.append(
+            Command(
+                id: findID,
+                kind: .find,
+                title: "Find Transaction",
+                subtitle: "Search by merchant, amount, or category",
+                keywords: ["find", "search", "transaction", "merchant", "amount", "category", "filter"],
+                systemImage: "magnifyingglass"
+            )
+        )
+
+        return CommandRegistry(commands: commands)
+    }
+
+    // MARK: - Stable id derivation
+
+    public static func navigateID(_ destination: RouteDestination) -> String {
+        "navigate.\(destination.rawValue)"
+    }
+
+    public static func actID(_ action: Action) -> String {
+        "act.\(action.rawValue)"
+    }
+
+    public static let findID = "find"
+
+    // MARK: - Per-destination palette copy
+
+    private static func navigateSubtitle(_ destination: RouteDestination) -> String? {
+        guard let number = destination.commandShortcutNumber else { return nil }
+        return "⌘\(number)"
+    }
+
+    /// Search synonyms so a destination is reachable by its job, not just its
+    /// label (e.g. "spending" → Budgets, "subscriptions" → Planning).
+    private static func navigateKeywords(_ destination: RouteDestination) -> [String] {
+        switch destination {
+        case .dashboard: ["home", "overview", "net worth", "summary"]
+        case .review: ["inbox", "triage", "approve", "categorize", "unreviewed"]
+        case .transactions: ["ledger", "history", "spending", "payments"]
+        case .budgets: ["spending", "categories", "limits", "over budget"]
+        case .planning: ["forecast", "recurring", "subscriptions", "runway", "cashflow"]
+        case .goals: ["savings", "payoff", "targets", "progress"]
+        case .insights: ["receipts", "weekly review", "trends", "ai"]
+        case .alerts: ["notifications", "warnings", "watchlist"]
+        case .accounts: ["banks", "institutions", "balances", "connections"]
+        case .settings: ["preferences", "configuration", "options"]
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FuzzyMatcher.swift
+++ b/Sources/PlaidBarCore/Utilities/FuzzyMatcher.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// A pure, `Sendable` subsequence fuzzy matcher + ranker for the ⌘K command
+/// palette (ADR-001, IA §3.3, AND-596).
+///
+/// The palette needs the same "type a few letters, the right command floats to
+/// the top" behavior every spotlight-style launcher has. Keeping the matcher
+/// here in `PlaidBarCore` (not in the SwiftUI palette) makes the ranking policy
+/// pure, `Sendable`, and unit-testable without the app target — CLAUDE.md's "put
+/// shared logic in Core" rule. The palette view becomes a thin renderer over
+/// `FuzzyMatcher.search(...)`.
+///
+/// The algorithm is deliberately simple and predictable (not a full
+/// Smith-Waterman): a **case- and diacritic-insensitive ordered subsequence
+/// match** with a score that rewards the qualities users feel —
+///
+/// - an exact / prefix hit on the title beats a scattered subsequence,
+/// - consecutive matched characters beat gaps,
+/// - matches at word starts (after a space / separator) beat mid-word matches,
+/// - an earlier first match beats a later one,
+/// - a title hit beats a keyword-only hit.
+///
+/// Ties break by the candidate's natural order (so a stable input order yields a
+/// stable output order). An empty query returns every candidate in input order
+/// with a neutral score, so the palette shows the full command list before the
+/// user types.
+public enum FuzzyMatcher {
+    /// One ranked search hit: the candidate's index in the input array plus its
+    /// score and the matched character positions (so a view can bold them).
+    public struct Match<Element>: Sendable where Element: Sendable {
+        /// The matched candidate.
+        public let element: Element
+        /// The candidate's position in the input array (stable tiebreak key).
+        public let index: Int
+        /// Higher is a better match. Comparable only within one `search` call.
+        public let score: Int
+        /// Indices (into the *matched field's* characters) that the query hit.
+        /// Empty for an empty query. Useful for highlighting the title.
+        public let matchedRanges: [Int]
+
+        public init(element: Element, index: Int, score: Int, matchedRanges: [Int]) {
+            self.element = element
+            self.index = index
+            self.score = score
+            self.matchedRanges = matchedRanges
+        }
+    }
+
+    // MARK: - Scoring weights (tuned for the palette; pure constants)
+
+    /// Base reward for each matched character.
+    private static let perCharacter = 8
+    /// Bonus when a matched character immediately follows a previous match
+    /// (a run of consecutive hits, e.g. "bud" in "Budgets").
+    private static let consecutiveBonus = 12
+    /// Bonus when a match lands at a word boundary (start, or after a separator).
+    private static let wordBoundaryBonus = 14
+    /// Bonus when the whole query is a prefix of the field ("bud" → "Budgets").
+    private static let prefixBonus = 40
+    /// Bonus when the query equals the field exactly.
+    private static let exactBonus = 60
+    /// Penalty per leading unmatched character before the first hit (rewards an
+    /// early first match), capped so a long title can't drown the signal.
+    private static let leadingGapPenalty = 2
+    private static let maxLeadingGapPenalty = 20
+    /// Keyword-only matches are real but rank below any title match.
+    private static let keywordFieldPenalty = 30
+
+    // MARK: - Public API
+
+    /// Scores a single `query` against one `field`. Returns `nil` when the query
+    /// is not an ordered subsequence of the field; returns a neutral
+    /// `(score: 0, ranges: [])` for an empty query. Diacritic- and
+    /// case-insensitive.
+    ///
+    /// `isKeywordField` applies the keyword penalty so a title hit always
+    /// outranks a keyword-only hit on the same candidate.
+    public static func score(
+        query: String,
+        in field: String,
+        isKeywordField: Bool = false
+    ) -> (score: Int, matchedRanges: [Int])? {
+        let normalizedQuery = normalize(query)
+        guard !normalizedQuery.isEmpty else { return (0, []) }
+
+        let fieldChars = Array(normalize(field))
+        let queryChars = Array(normalizedQuery)
+        guard !fieldChars.isEmpty else { return nil }
+
+        var total = 0
+        var matched: [Int] = []
+        var queryIdx = 0
+        var previousMatchIdx: Int? = nil
+
+        for (fieldIdx, char) in fieldChars.enumerated() where queryIdx < queryChars.count {
+            guard char == queryChars[queryIdx] else { continue }
+
+            total += perCharacter
+            if let previous = previousMatchIdx, previous == fieldIdx - 1 {
+                total += consecutiveBonus
+            }
+            if isWordBoundary(fieldChars, at: fieldIdx) {
+                total += wordBoundaryBonus
+            }
+            matched.append(fieldIdx)
+            previousMatchIdx = fieldIdx
+            queryIdx += 1
+        }
+
+        // Not all query characters were consumed ⇒ not a subsequence.
+        guard queryIdx == queryChars.count else { return nil }
+
+        if let first = matched.first {
+            total -= min(first * leadingGapPenalty, maxLeadingGapPenalty)
+        }
+        if fieldChars == queryChars {
+            total += exactBonus
+        } else if fieldChars.starts(with: queryChars) {
+            total += prefixBonus
+        }
+        if isKeywordField {
+            total -= keywordFieldPenalty
+        }
+
+        return (total, matched)
+    }
+
+    /// Ranks `candidates` against `query`, best first.
+    ///
+    /// Each candidate is scored against its `title` and, separately, every one of
+    /// its `keywords`; the candidate keeps its **best** field score (the title is
+    /// already favored by the keyword penalty). Candidates that match nowhere are
+    /// dropped. An empty/whitespace query returns *all* candidates in input order
+    /// (neutral score), so the palette lists everything before the user types.
+    ///
+    /// - Parameters:
+    ///   - query: the raw search text.
+    ///   - candidates: the items to rank.
+    ///   - title: the primary searchable string for a candidate.
+    ///   - keywords: additional searchable strings (subtitle words, synonyms).
+    public static func search<Element>(
+        query: String,
+        candidates: [Element],
+        title: (Element) -> String,
+        keywords: (Element) -> [String] = { _ in [] }
+    ) -> [Match<Element>] where Element: Sendable {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else {
+            return candidates.enumerated().map { index, element in
+                Match(element: element, index: index, score: 0, matchedRanges: [])
+            }
+        }
+
+        var matches: [Match<Element>] = []
+        for (index, element) in candidates.enumerated() {
+            var best: (score: Int, matchedRanges: [Int])? = nil
+
+            if let titleHit = score(query: trimmed, in: title(element)) {
+                best = titleHit
+            }
+            for keyword in keywords(element) {
+                guard let keywordHit = score(query: trimmed, in: keyword, isKeywordField: true) else {
+                    continue
+                }
+                if best == nil || keywordHit.score > best!.score {
+                    // Keep the title's ranges when the title also matched but a
+                    // keyword scored higher — highlight stays on the visible title.
+                    best = (keywordHit.score, best?.matchedRanges ?? [])
+                }
+            }
+
+            guard let best else { continue }
+            matches.append(
+                Match(element: element, index: index, score: best.score, matchedRanges: best.matchedRanges)
+            )
+        }
+
+        // Best score first; ties fall back to input order for a stable result.
+        return matches.sorted { lhs, rhs in
+            lhs.score != rhs.score ? lhs.score > rhs.score : lhs.index < rhs.index
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Lowercased + diacritic-folded so "Café" matches "cafe" and case never
+    /// matters. Folding to the current locale keeps it deterministic for tests.
+    private static func normalize(_ string: String) -> String {
+        string.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+    }
+
+    /// A field index is a word boundary when it is the first character or follows
+    /// a separator (space, hyphen, slash, or other non-alphanumeric).
+    private static func isWordBoundary(_ chars: [Character], at index: Int) -> Bool {
+        guard index > 0 else { return true }
+        let previous = chars[index - 1]
+        return !previous.isLetter && !previous.isNumber
+    }
+}

--- a/Tests/PlaidBarCoreTests/CommandRegistryTests.swift
+++ b/Tests/PlaidBarCoreTests/CommandRegistryTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+@Suite("CommandRegistry default set")
+struct CommandRegistryDefaultTests {
+    private let registry = CommandRegistry.makeDefault()
+
+    @Test("Has a navigate command for every destination, the 4 act verbs, and find")
+    func completeness() {
+        let commands = registry.commands
+
+        // Navigate: one per RouteDestination.
+        let navigateDestinations = commands.compactMap { $0.kind.navigationDestination }
+        #expect(Set(navigateDestinations) == Set(RouteDestination.allCases))
+        #expect(navigateDestinations.count == RouteDestination.allCases.count)
+
+        // Act: exactly the four global verbs.
+        let actions = commands.compactMap { command -> CommandRegistry.Action? in
+            if case .act(let action) = command.kind { return action }
+            return nil
+        }
+        #expect(Set(actions) == Set(CommandRegistry.Action.allCases))
+        #expect(actions.count == 4)
+
+        // Find: exactly one.
+        let findCount = commands.filter { $0.kind == .find }.count
+        #expect(findCount == 1)
+
+        // Total = 10 destinations + 4 acts + 1 find = 15.
+        #expect(commands.count == RouteDestination.allCases.count + 4 + 1)
+    }
+
+    @Test("All command ids are unique and stable")
+    func uniqueStableIDs() {
+        let ids = registry.commands.map(\.id)
+        #expect(Set(ids).count == ids.count, "ids must be unique")
+
+        // Stable derivation matches the documented scheme.
+        #expect(registry.command(id: "navigate.dashboard")?.kind == .navigate(.dashboard))
+        #expect(registry.command(id: "act.refresh")?.kind == .act(.refresh))
+        #expect(registry.command(id: "find")?.kind == .find)
+        #expect(CommandRegistry.navigateID(.budgets) == "navigate.budgets")
+        #expect(CommandRegistry.actID(.togglePrivacyMask) == "act.togglePrivacyMask")
+        #expect(CommandRegistry.findID == "find")
+    }
+
+    @Test("Every command has a non-empty title and SF Symbol")
+    func displayStrings() {
+        for command in registry.commands {
+            #expect(!command.title.isEmpty)
+            #expect(!command.systemImage.isEmpty)
+        }
+    }
+
+    @Test("Display order is navigate (sidebar order) → act → find")
+    func displayOrder() {
+        let kinds = registry.commands.map(\.kind)
+        let navigateCount = RouteDestination.allCases.count
+
+        // First N are navigate, in sidebar (allCases) order.
+        let navigatePrefix = kinds.prefix(navigateCount).compactMap(\.navigationDestination)
+        #expect(navigatePrefix == RouteDestination.allCases)
+
+        // Then the four acts, then find last.
+        #expect(kinds[navigateCount] == .act(.refresh))
+        #expect(kinds.last == .find)
+    }
+
+    @Test("Numbered destinations show their ⌘N shortcut as the subtitle")
+    func navigateSubtitleShortcut() {
+        // Dashboard = ⌘1, Accounts = ⌘8.
+        #expect(registry.command(id: "navigate.dashboard")?.subtitle == "⌘1")
+        #expect(registry.command(id: "navigate.accounts")?.subtitle == "⌘8")
+        // Transactions has no number → no ⌘N subtitle.
+        #expect(registry.command(id: "navigate.transactions")?.subtitle == nil)
+    }
+
+    @Test("Kind.navigationDestination extracts the destination only for navigate")
+    func navigationDestinationAccessor() {
+        #expect(CommandRegistry.Kind.navigate(.goals).navigationDestination == .goals)
+        #expect(CommandRegistry.Kind.act(.refresh).navigationDestination == nil)
+        #expect(CommandRegistry.Kind.find.navigationDestination == nil)
+    }
+}
+
+@Suite("CommandRegistry search")
+struct CommandRegistrySearchTests {
+    private let registry = CommandRegistry.makeDefault()
+
+    @Test("Empty query returns the full command set in registry order")
+    func emptyQuery() {
+        let results = registry.search("")
+        #expect(results.count == registry.commands.count)
+        #expect(results.map(\.id) == registry.commands.map(\.id))
+    }
+
+    @Test("Typing a destination name surfaces its navigate command first")
+    func navigateByName() {
+        #expect(registry.search("budgets").first?.kind == .navigate(.budgets))
+        #expect(registry.search("review").first?.kind == .navigate(.review))
+        #expect(registry.search("accounts").first?.kind == .navigate(.accounts))
+    }
+
+    @Test("Act verbs are reachable by title and by keyword synonyms")
+    func actByTitleAndKeyword() {
+        // By title.
+        #expect(registry.search("refresh").first?.kind == .act(.refresh))
+        #expect(registry.search("privacy").first?.kind == .act(.togglePrivacyMask))
+        // By keyword synonym: "sync" → Refresh, "hide" → Privacy Mask.
+        #expect(registry.search("sync").first?.kind == .act(.refresh))
+        #expect(registry.search("hide").first?.kind == .act(.togglePrivacyMask))
+    }
+
+    @Test("Find is reachable by 'search' / 'find' keywords")
+    func findReachable() {
+        #expect(registry.search("find").first?.kind == .find)
+    }
+
+    @Test("A no-match query returns an empty result set")
+    func noMatch() {
+        #expect(registry.search("zzqqxx").isEmpty)
+    }
+
+    @Test("Keyword-driven navigation: unique synonyms surface their destination")
+    func keywordNavigation() {
+        // "subscriptions" is unique to Planning; "limits" is unique to Budgets.
+        #expect(registry.search("subscriptions").first?.kind == .navigate(.planning))
+        #expect(registry.search("limits").first?.kind == .navigate(.budgets))
+        // "banks" is unique to Accounts.
+        #expect(registry.search("banks").first?.kind == .navigate(.accounts))
+    }
+}
+
+@Suite("CommandRegistry Codable kinds")
+struct CommandRegistryCodableTests {
+    @Test("Kind round-trips through Codable for every case shape")
+    func kindCodable() throws {
+        let kinds: [CommandRegistry.Kind] = [
+            .navigate(.dashboard),
+            .navigate(.settings),
+            .act(.refresh),
+            .act(.summon),
+            .find,
+        ]
+        for kind in kinds {
+            let data = try JSONEncoder().encode(kind)
+            let decoded = try JSONDecoder().decode(CommandRegistry.Kind.self, from: data)
+            #expect(decoded == kind)
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/FuzzyMatcherTests.swift
+++ b/Tests/PlaidBarCoreTests/FuzzyMatcherTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+@Suite("FuzzyMatcher")
+struct FuzzyMatcherTests {
+    // MARK: - Subsequence matching
+
+    @Test("Matches an ordered subsequence, rejects a non-subsequence")
+    func subsequence() {
+        // "bdg" is an ordered subsequence of "Budgets"; "gub" is not (wrong order).
+        #expect(FuzzyMatcher.score(query: "bdg", in: "Budgets") != nil)
+        #expect(FuzzyMatcher.score(query: "gub", in: "Budgets") == nil)
+        // A character not present at all fails.
+        #expect(FuzzyMatcher.score(query: "budz", in: "Budgets") == nil)
+    }
+
+    @Test("Matching is case- and diacritic-insensitive")
+    func caseAndDiacritics() {
+        #expect(FuzzyMatcher.score(query: "BUDGETS", in: "budgets") != nil)
+        #expect(FuzzyMatcher.score(query: "cafe", in: "Café") != nil)
+        #expect(FuzzyMatcher.score(query: "CAFÉ", in: "cafe") != nil)
+    }
+
+    @Test("Empty query returns a neutral (matchable) score, not nil")
+    func emptyQueryNeutral() {
+        let hit = FuzzyMatcher.score(query: "", in: "Anything")
+        #expect(hit != nil)
+        #expect(hit?.score == 0)
+        #expect(hit?.matchedRanges.isEmpty == true)
+    }
+
+    @Test("Matched ranges are the field indices the query hit")
+    func matchedRanges() {
+        // "bg" hits index 0 (B) and 3 (g) of "Budgets".
+        let hit = FuzzyMatcher.score(query: "bg", in: "Budgets")
+        #expect(hit?.matchedRanges == [0, 3])
+    }
+
+    // MARK: - Ranking quality
+
+    @Test("Exact match outranks prefix match outranks scattered subsequence")
+    func rankingTiers() {
+        let exact = FuzzyMatcher.score(query: "review", in: "Review")!.score
+        let prefix = FuzzyMatcher.score(query: "rev", in: "Review")!.score
+        let scattered = FuzzyMatcher.score(query: "rw", in: "Review")!.score
+        #expect(exact > prefix)
+        #expect(prefix > scattered)
+    }
+
+    @Test("A prefix hit beats the same query buried later in the field")
+    func earlierBeatsLater() {
+        // "go" as a prefix of "Goals" should beat "go" inside "Go to Settings"-style
+        // late placement.
+        let early = FuzzyMatcher.score(query: "goal", in: "Goals")!.score
+        let late = FuzzyMatcher.score(query: "goal", in: "Set a goal")!.score
+        #expect(early > late)
+    }
+
+    @Test("Word-boundary matches beat mid-word matches of equal length")
+    func wordBoundaryBonus() {
+        // "ns" — in "Net Spend" both hit word starts (N..., S...); in "Insights" they
+        // are mid-word. The boundary hits should score higher.
+        let boundary = FuzzyMatcher.score(query: "ns", in: "Net Spend")!.score
+        let midWord = FuzzyMatcher.score(query: "ns", in: "Insights")!.score
+        #expect(boundary > midWord)
+    }
+
+    @Test("Consecutive matches beat gapped matches")
+    func consecutiveBonus() {
+        // "rev" consecutive in "Review" beats "rvw"-style gapped match in the same word.
+        let consecutive = FuzzyMatcher.score(query: "rev", in: "Reverie")!.score
+        let gapped = FuzzyMatcher.score(query: "rvr", in: "Reverie")!.score
+        #expect(consecutive > gapped)
+    }
+
+    // MARK: - search() over candidates
+
+    private struct Item: Sendable, Equatable {
+        let title: String
+        let keywords: [String]
+    }
+
+    private let items = [
+        Item(title: "Dashboard", keywords: ["home", "overview"]),
+        Item(title: "Budgets", keywords: ["spending", "categories"]),
+        Item(title: "Review", keywords: ["inbox", "triage"]),
+        Item(title: "Accounts", keywords: ["banks", "balances"]),
+    ]
+
+    @Test("search() ranks the best title match first")
+    func searchRanksBest() {
+        let results = FuzzyMatcher.search(
+            query: "bud",
+            candidates: items,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        #expect(results.first?.element.title == "Budgets")
+    }
+
+    @Test("search() with an empty query returns all candidates in input order")
+    func searchEmptyQuery() {
+        let results = FuzzyMatcher.search(
+            query: "   ",
+            candidates: items,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        #expect(results.count == items.count)
+        #expect(results.map(\.element.title) == items.map(\.title))
+        #expect(results.allSatisfy { $0.score == 0 })
+    }
+
+    @Test("search() drops candidates that match nowhere")
+    func searchDropsNonMatches() {
+        let results = FuzzyMatcher.search(
+            query: "zzzz",
+            candidates: items,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        #expect(results.isEmpty)
+    }
+
+    @Test("A keyword match surfaces a candidate whose title does not match")
+    func keywordMatch() {
+        // "spend" is a keyword of Budgets but not in any title.
+        let results = FuzzyMatcher.search(
+            query: "spend",
+            candidates: items,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        #expect(results.first?.element.title == "Budgets")
+    }
+
+    @Test("A title hit outranks a keyword-only hit on a competing candidate")
+    func titleBeatsKeyword() {
+        // Query "ban": "Accounts" matches only via keyword "banks"; add a decoy whose
+        // title contains the letters at a word start.
+        let candidates = [
+            Item(title: "Accounts", keywords: ["banks"]),
+            Item(title: "Ban Hammer", keywords: []),
+        ]
+        let results = FuzzyMatcher.search(
+            query: "ban",
+            candidates: candidates,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        // The title match ("Ban Hammer", prefix) should beat the keyword-only match.
+        #expect(results.first?.element.title == "Ban Hammer")
+    }
+
+    @Test("Ties break by input order (stable result)")
+    func stableTiebreak() {
+        // Two identical titles: the earlier one must come first.
+        let candidates = [
+            Item(title: "Same", keywords: []),
+            Item(title: "Same", keywords: []),
+        ]
+        let results = FuzzyMatcher.search(
+            query: "same",
+            candidates: candidates,
+            title: { $0.title },
+            keywords: { $0.keywords }
+        )
+        #expect(results.map(\.index) == [0, 1])
+    }
+}

--- a/docs/strategy/macos26-migration/05-information-architecture.md
+++ b/docs/strategy/macos26-migration/05-information-architecture.md
@@ -354,6 +354,31 @@ Per-row triage keys inside **Review** (carried verbatim from `ReviewInboxView`):
 > safe). The `⌘1–8` navigation and `⌘K` palette take precedence at the shell
 > level.
 
+#### Keymap as shipped (AND-596)
+
+The first slice of this map ships behind `WindowFirstFeatureFlag` (default OFF):
+the `⌘K` palette + a `Go` and an `Actions` `CommandMenu` in `PlaidBarApp`. With
+the flag OFF none of these commands are added — the menu bar and the whole app are
+byte-identical to the popover-first build. Each command drives the existing action
+path (it never reimplements behavior). The palette (`CommandPalette` over the pure
+`CommandRegistry` + `FuzzyMatcher`, both in `PlaidBarCore`) lists every command;
+`↑/↓` move, `Return` executes, `Esc` dismisses.
+
+| Shortcut | Menu | Action | Wires to |
+|----------|------|--------|----------|
+| `⌘K` | Go → Command Palette… | Open the command palette | `CommandPaletteModel.present()` |
+| `⌘1`…`⌘8` | Go → (destination) | Go to destination N (Dashboard…Accounts) | `NavigationModel.go(to:)` |
+| `⌘F` | Go → Find Transaction… | Focus search / find | find command (per-destination search lands later) |
+| `⌘R` | Actions → Refresh | Refresh / sync now | `AppState.refreshDashboard()` |
+| `⌘⇧P` | Actions → Hide/Show Balances | Toggle Privacy Mask | `AppState.togglePrivacyMask()` |
+| `⇧⌘V` | Actions → Summon VaultPeek | Summon from any app | summon-hotkey path (`summonDashboard()`) |
+| `⌘,` | (native app menu) | Settings | native `Settings` scene (unchanged) |
+
+Command **kinds** in the registry: **navigate** (one per `RouteDestination`),
+**act** (`refresh`, `togglePrivacyMask`, `openSettings`, `summon`), and **find**.
+`⌘\` (toggle sidebar) is the native `NavigationSplitView` control; `⌘N`, `⌘Z/⇧⌘Z`,
+and the list/Review per-row keys land with their destinations in later epics.
+
 ### 3.5 Selection & focus behavior
 
 - Selecting a list row fills the detail column and shows the native accent


### PR DESCRIPTION
## Summary

Implements the command palette (IA §3.3) and the global keyboard map (IA §3.4)
for the window-first shell. Refs **AND-596** (Epic 2), **AND-580** (window-first
migration epic), **ADR-001** (window-first hybrid). Builds on the AND-591
`Window`/`AppShellView` foundation and the AND-594/595 `Route`/`NavigationModel`
nav stack.

The palette is the IA's "single most important new piece": one ⌘K-and-type away
from any action, so the keymap is a fast-path layer over it.

## Flag-OFF is byte-identical

Everything new is gated behind `WindowFirstFeatureFlag` (default **OFF**) exactly
like the existing "Open VaultPeek" command — the new `CommandMenu`s live inside
the same `if isWindowFirstEnabled { … }` block in `.commands`, and the palette
overlay only exists on `AppShellView`, which is only instantiated behind the flag.
With the flag OFF, no commands are added and the popover build is unchanged.
Verified: the `Go`/`Actions` menus and ⌘K only appear when the flag is ON.

## What landed

**Core (pure, `Sendable`, unit-tested — CLAUDE.md "logic in PlaidBarCore"):**
- `FuzzyMatcher` — case/diacritic-insensitive ordered-subsequence matcher + ranker
  (exact > prefix > word-boundary > consecutive; early-match bonus; keyword
  penalty; stable input-order tiebreak; empty query returns all in order).
- `CommandRegistry` — **closure-free** model of every command in three **kinds**:
  - **navigate** — one per `RouteDestination`
  - **act** — `refresh`, `togglePrivacyMask`, `openSettings`, `summon`
  - **find** — the search entry point
  Stable ids (`navigate.<dest>` / `act.<verb>` / `find`), keyword synonyms, and a
  `search()` over `FuzzyMatcher`. `makeDefault()` is the complete AND-596 set.

**App:**
- `CommandPalette` — window-level ⌘K overlay; type to fuzzy-search, ↑/↓ to move,
  Return to execute, Esc/scrim to dismiss; auto-focused field; keyboard-first;
  reuses `glassSurface`/`Spacing`/`Typography` tokens; accessible (modal, labeled
  rows, native selection highlight — no color-only meaning).
- `CommandPaletteModel` (per-window `@Observable`, R-10) + `CommandDispatcher` —
  maps a command `Kind` onto the **existing** action paths (navigate →
  `NavigationModel.go(to:)`; refresh → `AppState.refreshDashboard()`; Privacy Mask
  → `AppState.togglePrivacyMask()`; settings → `openSettings()`; summon →
  `summonDashboard()`). No behavior reimplemented.
- `PlaidBarApp` — `Go` + `Actions` `CommandMenu`s wired to those paths.

## Keymap as shipped

| Shortcut | Menu | Action | Wires to |
|----------|------|--------|----------|
| `⌘K` | Go → Command Palette… | Open the palette | `CommandPaletteModel.present()` |
| `⌘1`…`⌘8` | Go → (destination) | Go to destination N (Dashboard…Accounts) | `NavigationModel.go(to:)` |
| `⌘F` | Go → Find Transaction… | Focus search / find | find command (per-destination search lands later) |
| `⌘R` | Actions → Refresh | Refresh / sync now | `AppState.refreshDashboard()` |
| `⌘⇧P` | Actions → Hide/Show Balances | Toggle Privacy Mask | `AppState.togglePrivacyMask()` |
| `⇧⌘V` | Actions → Summon VaultPeek | Summon from any app | `summonDashboard()` |
| `⌘,` | (native app menu) | Settings | native `Settings` scene (unchanged) |

`⌘1–8` derive from `RouteDestination.commandShortcutNumber` (single source of
truth). `⌘\` (toggle sidebar) is the native `NavigationSplitView` control; `⌘N`,
`⌘Z/⇧⌘Z`, and the Review per-row keys land with their destinations in later epics.

Doc: keymap-as-shipped table added to `05-information-architecture.md` §3.4.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — **1876 passing** (1849 baseline + 27 new).
- New tests: `FuzzyMatcherTests` (subsequence, case/diacritic, ranking tiers,
  word-boundary/consecutive bonuses, keyword vs title, stable tiebreak) +
  `CommandRegistryTests` (command-set completeness, unique/stable ids, display
  order, ⌘N subtitles, search by name/keyword, Codable kinds).

## Deferred (per IA, later epics)

- Per-destination contextual commands + real ⌘F search-field focus (find currently
  brings the window forward; the search surfaces land with Transactions/Review).
- "Find" mode transaction search results in-palette; ⌘N add-account, ⌘Z/⇧⌘Z undo.
- AND-597 (deep-linking) builds on this `AppShellView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)