### PR TITLE
feat(nav): content-column destination router + per-destination view scaffold (AND-600)

### DIFF
--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -7,11 +7,18 @@ import SwiftUI
 /// A `NavigationSplitView` whose sidebar lists the IA's **5 bands → 11
 /// destinations** (`05-information-architecture.md` §2), driven by the
 /// per-window `NavigationModel` / typed `Route` (`PlaidBarCore`). Selecting a row
-/// sets the window's destination and routes the content column; destinations
-/// whose real workspaces land in later epics (4–7) show a labeled
-/// `ContentUnavailableView` placeholder. **Settings** is the native macOS
-/// `Settings` scene, so its sidebar row triggers `openSettings()` rather than an
-/// in-split pane (IA §5.10).
+/// sets the window's destination and routes the content column via
+/// `DestinationContentView` (and, for 3-column destinations, a detail/inspector
+/// column via `DestinationInspectorView`) — see
+/// `Views/Destinations/DestinationRouter.swift`. The column count tracks each
+/// destination's **2-col vs 3-col policy** (IA §3.1, pure
+/// `RouteDestination.prefersThreeColumnLayout`): 2-column for Dashboard /
+/// Planning / Insights, 3-column for Review / Transactions / Budgets / Goals /
+/// Alerts / Accounts. Destinations whose real workspaces land in later epics
+/// (4–7) show a labeled `ContentUnavailableView` placeholder in their own
+/// per-destination view file. **Settings** is the native macOS `Settings` scene,
+/// so its sidebar row triggers `openSettings()` rather than an in-split pane
+/// (IA §5.10).
 ///
 /// This is built **only** in the window-first surface — the menu-bar popover is
 /// untouched. The window never opens unless `WindowFirstFeatureFlag` is ON
@@ -70,10 +77,35 @@ struct AppShellView: View {
             }
         )
 
-        NavigationSplitView {
-            SidebarView(selection: selection)
-        } detail: {
-            ShellContentColumn(destination: appState.navigationModel.destination)
+        let destination = appState.navigationModel.destination
+
+        // Column policy per destination (IA §3.1, driven by the pure
+        // `RouteDestination.prefersThreeColumnLayout` in PlaidBarCore). 3-column
+        // destinations (Review, Transactions, Budgets, Goals, Alerts, Accounts)
+        // get sidebar + content + inspector; 2-column destinations (Dashboard,
+        // Planning, Insights) get sidebar + content only. Settings is never routed
+        // here — it opens the native Settings scene. Both branches share the same
+        // sidebar; the difference is whether a detail (inspector) column is
+        // mounted, so the column count tracks the selected destination's policy.
+        Group {
+            if destination.prefersThreeColumnLayout {
+                NavigationSplitView {
+                    SidebarView(selection: selection)
+                } content: {
+                    DestinationContentView(destination: destination)
+                } detail: {
+                    // Content-gated, not existence-gated (IA §3.1): the inspector
+                    // always exists for a 3-column destination and shows its
+                    // "Select a …" prompt when nothing is selected.
+                    DestinationInspectorView(destination: destination)
+                }
+            } else {
+                NavigationSplitView {
+                    SidebarView(selection: selection)
+                } detail: {
+                    DestinationContentView(destination: destination)
+                }
+            }
         }
         // Deep-link hand-off (ADR-001 / AND-597). The primary scene is a
         // declarative `Window`, so a route can't be threaded through `openWindow`;
@@ -241,29 +273,14 @@ private struct DataModeChip: View {
 }
 
 // MARK: - Content column
-
-/// The detail (content) column. For now every destination shows a labeled
-/// `ContentUnavailableView` placeholder — the real workspaces are decomposed from
-/// the popover in Epics 4–7 (AND-595 is scope-limited to the sidebar). Settings
-/// is never routed here: its sidebar row opens the native Settings scene instead.
-private struct ShellContentColumn: View {
-    let destination: RouteDestination
-
-    var body: some View {
-        ContentUnavailableView {
-            Label(destination.title, systemImage: destination.systemImage)
-        } description: {
-            Text(placeholderDescription)
-        }
-        .navigationTitle(destination.title)
-    }
-
-    /// Honest "under construction" copy naming the destination, so the shell is
-    /// demoable (via `--window-first on`) without pretending the workspaces exist.
-    private var placeholderDescription: String {
-        "The \(destination.title) workspace is coming soon."
-    }
-}
+//
+// The content / inspector columns are now routed per destination by
+// `DestinationContentView` / `DestinationInspectorView` (see
+// `Views/Destinations/DestinationRouter.swift`), each backed by a
+// per-destination `…DestinationView` file so Epics 4–7 fill their own files in
+// parallel without colliding here. Each still renders the same labeled
+// placeholder it showed inline before (`DestinationPlaceholder`), preserving
+// current behavior; the 2-col vs 3-col policy is applied in `body` above.
 
 #Preview {
     AppShellView()

--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -1,0 +1,34 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Accounts** destination (3-column — IA §3.1/§5.9, `[⌘8]`).
+///
+/// Institution/account list → `AccountDetailFlyout` inspector (the existing,
+/// proven master→detail). The shell renders this content column plus `Inspector`
+/// in the detail column, which is content-gated and shows "Select an account"
+/// when nothing is selected (IA §3.1).
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real institution/account list and `AccountDetailFlyout` inspector
+/// land in this destination's epic by replacing the two bodies, never touching
+/// `AppShellView`.
+struct AccountsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .accounts)
+    }
+
+    /// The detail-column (inspector) pane for Accounts.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .accounts)
+        }
+    }
+}
+
+#Preview("Content") {
+    AccountsDestinationView()
+}
+
+#Preview("Inspector") {
+    AccountsDestinationView.Inspector()
+}

--- a/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
@@ -1,0 +1,32 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Alerts** destination (3-column — IA §3.1/§5.8, `[⌘7]`).
+///
+/// Alert feed (list) → alert detail / rule editor (inspector). The shell renders
+/// this content column plus `Inspector` in the detail column, which is
+/// content-gated and shows "Select an alert" when nothing is selected (IA §3.1).
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real alert feed and detail/rule-editor inspector land in this
+/// destination's epic by replacing the two bodies, never touching `AppShellView`.
+struct AlertsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .alerts)
+    }
+
+    /// The detail-column (inspector) pane for Alerts.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .alerts)
+        }
+    }
+}
+
+#Preview("Content") {
+    AlertsDestinationView()
+}
+
+#Preview("Inspector") {
+    AlertsDestinationView.Inspector()
+}

--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -1,0 +1,34 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Budgets** destination (3-column — IA §3.1/§5.4, `[⌘3]`).
+///
+/// Category tree/table (list) → budget editor inspector (detail). The shell
+/// renders this content column plus `Inspector` in the detail column, which is
+/// content-gated and shows "Select a category" when nothing is selected
+/// (IA §3.1).
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real `CategoryTreeView` list and budget-editor inspector land in
+/// this destination's epic by replacing the two bodies, never touching
+/// `AppShellView`.
+struct BudgetsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .budgets)
+    }
+
+    /// The detail-column (inspector) pane for Budgets.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .budgets)
+        }
+    }
+}
+
+#Preview("Content") {
+    BudgetsDestinationView()
+}
+
+#Preview("Inspector") {
+    BudgetsDestinationView.Inspector()
+}

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -1,0 +1,22 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Dashboard** destination (2-column — IA §3.1/§5.1, `[⌘1]`).
+///
+/// A composed overview canvas with no master→detail relationship, so the shell
+/// renders only this content column (no inspector). Drill-ins deep-link to other
+/// destinations rather than opening a local third column.
+///
+/// Scaffold for the parallel Epics 4–7: today it shows the shared
+/// `DestinationPlaceholder`; the real canvas (decomposed from `MainPopover`'s
+/// dashboard body) lands in its epic by replacing this `body`. Owning its own
+/// file means that epic never touches `AppShellView`.
+struct DashboardDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .dashboard)
+    }
+}
+
+#Preview {
+    DashboardDestinationView()
+}

--- a/Sources/PlaidBar/Views/Destinations/DestinationPlaceholder.swift
+++ b/Sources/PlaidBar/Views/Destinations/DestinationPlaceholder.swift
@@ -1,0 +1,61 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The shared "workspace coming soon" placeholder every window-first destination
+/// renders today (ADR-001, AND-580/581).
+///
+/// Each destination has its own `…DestinationView` file (so Epics 4–7 can fill
+/// them in parallel without colliding in `AppShellView`), but until that real
+/// content lands they all show this one labeled `ContentUnavailableView` — the
+/// exact placeholder `AppShellView` showed inline before the content-column
+/// router (AND-600). Centralizing the copy keeps every scaffold byte-identical
+/// and makes the eventual "replace the body" diff per destination trivial.
+///
+/// Window-first surface only: `AppShellView` is built solely behind
+/// `WindowFirstFeatureFlag` (default OFF), so with the flag off none of this is
+/// ever instantiated and the popover is unchanged.
+struct DestinationPlaceholder: View {
+    let destination: RouteDestination
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(destination.title, systemImage: destination.systemImage)
+        } description: {
+            Text("The \(destination.title) workspace is coming soon.")
+        }
+        .navigationTitle(destination.title)
+    }
+}
+
+/// The inspector (detail-column) empty state a 3-column destination shows when
+/// nothing is selected. The third column is **content-gated, not
+/// existence-gated** (IA §3.1): it always exists and shows this "Select a …"
+/// prompt rather than collapsing. The prompt copy is the pure
+/// `RouteDestination.detailColumnEmptyPrompt` (PlaidBarCore), so it stays in
+/// lockstep with the column policy and is unit-tested at the Core layer.
+struct DestinationInspectorPlaceholder: View {
+    let destination: RouteDestination
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(prompt, systemImage: destination.systemImage)
+        } description: {
+            Text("Choose an item from \(destination.title) to see its details here.")
+        }
+    }
+
+    /// Falls back to a generic prompt for the (unreachable) case of a 2-column
+    /// destination being rendered with an inspector — the router only mounts this
+    /// for destinations whose `detailColumnEmptyPrompt` is non-nil.
+    private var prompt: String {
+        destination.detailColumnEmptyPrompt ?? "Select an item"
+    }
+}
+
+#Preview("Content placeholder") {
+    DestinationPlaceholder(destination: .dashboard)
+}
+
+#Preview("Inspector placeholder") {
+    DestinationInspectorPlaceholder(destination: .review)
+}

--- a/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
+++ b/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
@@ -1,0 +1,70 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The content-column router for the window-first shell (ADR-001, AND-580/581).
+///
+/// Maps the window's selected `RouteDestination` to its per-destination content
+/// view. Each destination owns its own `…DestinationView` file under
+/// `Views/Destinations/`, so the parallel Epics 4–7 each fill their own file
+/// without ever colliding in `AppShellView` — this `switch` is the single point
+/// the shell touches.
+///
+/// **Settings is never routed here**: its sidebar row opens the native macOS
+/// `Settings` scene (IA §5.10), so the shell maps a Settings tap to
+/// `openSettings()` and the split-view selection never parks on `.settings`. The
+/// `.settings` arm falls back to the shared placeholder defensively, but it is
+/// unreachable in practice.
+///
+/// Window-first surface only: built solely behind `WindowFirstFeatureFlag`
+/// (default OFF), so with the flag off none of this is instantiated.
+struct DestinationContentView: View {
+    let destination: RouteDestination
+
+    var body: some View {
+        switch destination {
+        case .dashboard: DashboardDestinationView()
+        case .review: ReviewDestinationView()
+        case .transactions: TransactionsDestinationView()
+        case .budgets: BudgetsDestinationView()
+        case .planning: PlanningDestinationView()
+        case .goals: GoalsDestinationView()
+        case .insights: InsightsDestinationView()
+        case .alerts: AlertsDestinationView()
+        case .accounts: AccountsDestinationView()
+        case .settings:
+            // Unreachable — Settings opens the native scene, not an in-split pane.
+            DestinationPlaceholder(destination: .settings)
+        }
+    }
+}
+
+/// The detail-column (inspector) router for the window-first shell.
+///
+/// Only the **3-column** destinations (`RouteDestination.prefersThreeColumnLayout`
+/// — Review, Transactions, Budgets, Goals, Alerts, Accounts) have an inspector;
+/// for them this maps to the destination's `Inspector` pane. The 2-column
+/// destinations and Settings have no detail column and `AppShellView` never
+/// mounts this for them, so their arms fall back to the content-gated empty
+/// prompt defensively.
+///
+/// The third column is **content-gated, not existence-gated** (IA §3.1): each
+/// `Inspector` shows its "Select a …" prompt when nothing is selected rather than
+/// collapsing.
+struct DestinationInspectorView: View {
+    let destination: RouteDestination
+
+    var body: some View {
+        switch destination {
+        case .review: ReviewDestinationView.Inspector()
+        case .transactions: TransactionsDestinationView.Inspector()
+        case .budgets: BudgetsDestinationView.Inspector()
+        case .goals: GoalsDestinationView.Inspector()
+        case .alerts: AlertsDestinationView.Inspector()
+        case .accounts: AccountsDestinationView.Inspector()
+        case .dashboard, .planning, .insights, .settings:
+            // 2-column / native-Settings destinations have no inspector; not
+            // mounted by the shell, shown defensively only.
+            DestinationInspectorPlaceholder(destination: destination)
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
@@ -1,0 +1,32 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Goals** destination (3-column — IA §3.1/§5.6, `[⌘5]`).
+///
+/// Goal list → goal detail/progress (and new-goal editor) inspector. The shell
+/// renders this content column plus `Inspector` in the detail column, which is
+/// content-gated and shows "Select a goal" when nothing is selected (IA §3.1).
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real goal list and progress/editor inspector land in this
+/// destination's epic by replacing the two bodies, never touching `AppShellView`.
+struct GoalsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .goals)
+    }
+
+    /// The detail-column (inspector) pane for Goals.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .goals)
+        }
+    }
+}
+
+#Preview("Content") {
+    GoalsDestinationView()
+}
+
+#Preview("Inspector") {
+    GoalsDestinationView.Inspector()
+}

--- a/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
@@ -1,0 +1,21 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Insights** destination (2-column — IA §3.1/§5.7, `[⌘6]`).
+///
+/// A reading feed of receipts + weekly review; selecting a receipt expands in
+/// place rather than filling a detail column, so the shell renders only this
+/// content column (no inspector).
+///
+/// Scaffold for the parallel Epics 4–7: today it shows the shared
+/// `DestinationPlaceholder`; the real feed lands in its epic by replacing this
+/// `body`, without touching `AppShellView`.
+struct InsightsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .insights)
+    }
+}
+
+#Preview {
+    InsightsDestinationView()
+}

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -1,0 +1,21 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Planning** destination (2-column — IA §3.1/§5.5, `[⌘4]`).
+///
+/// A composed analytical canvas (forecast + recurring + income flow); its
+/// sub-sections switch via a segmented control, not a master list, so the shell
+/// renders only this content column (no inspector).
+///
+/// Scaffold for the parallel Epics 4–7: today it shows the shared
+/// `DestinationPlaceholder`; the real canvas lands in its epic by replacing this
+/// `body`, without touching `AppShellView`.
+struct PlanningDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .planning)
+    }
+}
+
+#Preview {
+    PlanningDestinationView()
+}

--- a/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
@@ -1,0 +1,35 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Review** destination (3-column — IA §3.1/§5.3, `[⌘2]`, the marquee
+/// list ↔ detail triage flow).
+///
+/// The shell renders this content (list) column plus `Inspector` in the detail
+/// column. The detail column is **content-gated, not existence-gated** (IA §3.1):
+/// when nothing is selected the inspector shows the "Select an item to review"
+/// prompt rather than collapsing.
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real `ReviewInboxView(embedded:)` list and triage inspector land in
+/// this destination's epic by replacing the two bodies, never touching
+/// `AppShellView`.
+struct ReviewDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .review)
+    }
+
+    /// The detail-column (inspector) pane for Review.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .review)
+        }
+    }
+}
+
+#Preview("Content") {
+    ReviewDestinationView()
+}
+
+#Preview("Inspector") {
+    ReviewDestinationView.Inspector()
+}

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -1,0 +1,34 @@
+import PlaidBarCore
+import SwiftUI
+
+/// **Transactions** destination (3-column — IA §3.1/§5.2).
+///
+/// The ledger: a table (list) → transaction inspector (detail). The shell
+/// renders this content (table) column plus `Inspector` in the detail column,
+/// which is content-gated and shows "Select a transaction" when nothing is
+/// selected (IA §3.1).
+///
+/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
+/// today; the real `ReviewTableWindow` table engine and `TransactionDetailView`
+/// inspector land in this destination's epic by replacing the two bodies, never
+/// touching `AppShellView`.
+struct TransactionsDestinationView: View {
+    var body: some View {
+        DestinationPlaceholder(destination: .transactions)
+    }
+
+    /// The detail-column (inspector) pane for Transactions.
+    struct Inspector: View {
+        var body: some View {
+            DestinationInspectorPlaceholder(destination: .transactions)
+        }
+    }
+}
+
+#Preview("Content") {
+    TransactionsDestinationView()
+}
+
+#Preview("Inspector") {
+    TransactionsDestinationView.Inspector()
+}

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -121,6 +121,28 @@ public enum RouteDestination: String, CaseIterable, Sendable, Hashable, Codable 
             false
         }
     }
+
+    /// The inspector (detail-column) empty-state prompt a 3-column destination
+    /// shows when nothing is selected. The third column is **content-gated, not
+    /// existence-gated** (IA §3.1): it always exists and shows a "Select a …"
+    /// `ContentUnavailableView` rather than collapsing. `nil` for 2-column
+    /// destinations and the native Settings scene, which have no inspector column.
+    ///
+    /// Pure copy in `PlaidBarCore` so the per-destination prompt — and the
+    /// "3-column ⇔ non-nil prompt" invariant — is unit-testable without the app
+    /// target (CLAUDE.md). The real per-row inspector content lands with each
+    /// destination's workspace in Epics 4–7.
+    public var detailColumnEmptyPrompt: String? {
+        switch self {
+        case .review: "Select an item to review"
+        case .transactions: "Select a transaction"
+        case .budgets: "Select a category"
+        case .goals: "Select a goal"
+        case .alerts: "Select an alert"
+        case .accounts: "Select an account"
+        case .dashboard, .planning, .insights, .settings: nil
+        }
+    }
 }
 
 // MARK: - Sub-section enums

--- a/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
@@ -60,6 +60,34 @@ struct RouteDestinationTests {
         }
     }
 
+    @Test("Detail-column prompt exists iff the destination is 3-column (content-gated, IA §3.1)")
+    func detailColumnPromptMatchesPolicy() {
+        for d in RouteDestination.allCases {
+            // The third column is content-gated, not existence-gated: every
+            // 3-column destination has a "Select a …" prompt; 2-column
+            // destinations and Settings have none.
+            #expect((d.detailColumnEmptyPrompt != nil) == d.prefersThreeColumnLayout)
+            if let prompt = d.detailColumnEmptyPrompt {
+                #expect(!prompt.isEmpty)
+            }
+        }
+    }
+
+    @Test("Detail-column prompts are the IA per-destination copy")
+    func detailColumnPromptCopy() {
+        #expect(RouteDestination.review.detailColumnEmptyPrompt == "Select an item to review")
+        #expect(RouteDestination.transactions.detailColumnEmptyPrompt == "Select a transaction")
+        #expect(RouteDestination.budgets.detailColumnEmptyPrompt == "Select a category")
+        #expect(RouteDestination.goals.detailColumnEmptyPrompt == "Select a goal")
+        #expect(RouteDestination.alerts.detailColumnEmptyPrompt == "Select an alert")
+        #expect(RouteDestination.accounts.detailColumnEmptyPrompt == "Select an account")
+        // 2-column destinations + Settings have no inspector column.
+        #expect(RouteDestination.dashboard.detailColumnEmptyPrompt == nil)
+        #expect(RouteDestination.planning.detailColumnEmptyPrompt == nil)
+        #expect(RouteDestination.insights.detailColumnEmptyPrompt == nil)
+        #expect(RouteDestination.settings.detailColumnEmptyPrompt == nil)
+    }
+
     @Test("Every destination has a non-empty title and SF Symbol")
     func titlesAndSymbols() {
         for d in RouteDestination.allCases {


### PR DESCRIPTION
## Summary

Foundational refactor for VaultPeek's window-first migration (**ADR-001**), unblocking parallel workspace development across Epics 4–7. Two things:

1. **Content-column destination router + per-destination view files** (AND-580 / AND-581) — each in-split destination now has its own view file, so each epic fills its own file without colliding in `AppShellView`.
2. **AND-600** — confirm/migrate remaining view-level UI-selection/filter `@AppStorage`/`@SceneStorage` into the per-window `NavigationModel`.

All of this lives in the **window-first surface only**. `WindowFirstFeatureFlag` is OFF by default → the window never opens → the menu-bar popover is untouched and behavior is byte-identical.

## Per-destination file scaffold (unblocks parallel Epics 4–7)

New `Sources/PlaidBar/Views/Destinations/` group, one file per in-split destination:

- 2-column: `DashboardDestinationView`, `PlanningDestinationView`, `InsightsDestinationView`
- 3-column: `ReviewDestinationView`, `TransactionsDestinationView`, `BudgetsDestinationView`, `GoalsDestinationView`, `AlertsDestinationView`, `AccountsDestinationView` — each exposes a content body plus a nested `Inspector` for the detail column
- Shared `DestinationPlaceholder` / `DestinationInspectorPlaceholder` so every scaffold renders the **same labeled `ContentUnavailableView`** it showed inline today (current behavior preserved exactly)
- `DestinationRouter` (`DestinationContentView` / `DestinationInspectorView`) — the single `switch destination` the shell touches

Each epic replaces its file's `body` with real content (decomposed from the popover) without ever editing `AppShellView`.

## Column-policy router (2-col vs 3-col, IA §3.1)

`AppShellView`'s detail column was a single inline `ContentUnavailableView`. It is now a router that drives `NavigationSplitView` column count off the pure `RouteDestination.prefersThreeColumnLayout`:

- **2-column** (Dashboard, Planning, Insights): `NavigationSplitView { sidebar } detail: { content }`
- **3-column** (Review, Transactions, Budgets, Goals, Alerts, Accounts): `NavigationSplitView { sidebar } content: { content } detail: { inspector }`

The inspector is **content-gated, not existence-gated** (IA §3.1): it always exists for a 3-column destination and shows a "Select a …" prompt when nothing is selected. That prompt copy is a new pure `RouteDestination.detailColumnEmptyPrompt` in `PlaidBarCore`, so the policy + copy stay testable at the Core layer.

`Settings` is never routed in-split — its sidebar row still calls `openSettings()` (native Settings scene, IA §5.10). The ⌘K palette overlay and the deep-link consume (`onAppear` / `onChange(of: pendingRoute)`) are preserved.

## AND-600 migration result

**No view-level UI-selection/filter `@AppStorage`/`@SceneStorage` keys remained beyond the three AND-594 already migrated** (`dashboard.accountFilter`, `dashboard.selectedAccountId`, `dashboard.heatmapMode`, now owned by `NavigationModel` behind the `AppState` façade).

Audited every remaining `@AppStorage` in `Sources/PlaidBar/`:
- Genuine **preferences**, correctly left alone: appearance mode / popover transparency / contrast / decorative effects / density / text size / haptic feedback / keep-dashboard-on-top / subscription plan.
- `settings.selectedTab` — the **native Settings scene's** own tab (a separate window, not a window-first split destination); already routable via `Route.settings(tab:)` / `SettingsRouteTab` against the same key. Not shell selection state — left in place.
- Satellite-window `sort` / `selection` / `tableOrder` are ephemeral **`@State`** (not persisted), so out of AND-600's scope; they migrate with their destinations in Epics 4–7.

## Flag-off note

Everything here is reached only when the window-first `Window` opens, which requires `WindowFirstFeatureFlag` ON. With the flag OFF (shipping default) the window never opens, `AppShellView` is never instantiated, and the popover path is unchanged.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — pass
- `swift test` — **1888 passed** (baseline ~1885). Added 2 Core tests: `detailColumnEmptyPrompt` per-destination copy + the "3-column ⇔ non-nil prompt" invariant. The existing `RouteNavigationTests.columnPolicy` already covers `prefersThreeColumnLayout`, which the router drives.

References: **AND-600**, AND-580 / AND-581, **ADR-001** (window-first migration), IA spec `docs/strategy/macos26-migration/05-information-architecture.md` §3.1 / §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)