### PR TITLE
feat(window): Budgets + Planning workspace destinations (AND-583)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -3,32 +3,341 @@ import SwiftUI
 
 /// **Budgets** destination (3-column — IA §3.1/§5.4, `[⌘3]`).
 ///
-/// Category tree/table (list) → budget editor inspector (detail). The shell
-/// renders this content column plus `Inspector` in the detail column, which is
-/// content-gated and shows "Select a category" when nothing is selected
-/// (IA §3.1).
+/// Epic 5 / AND-583 (ADR-001 window-first workspace). The content column is the
+/// override-aware **category tree** (donut + two-level status-bar tree); the
+/// inspector column shows the **selected category's detail/editor** — re-hosting
+/// `BudgetEditorSheet` — plus an overall month **status** rollup.
 ///
-/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
-/// today; the real `CategoryTreeView` list and budget-editor inspector land in
-/// this destination's epic by replacing the two bodies, never touching
-/// `AppShellView`.
+/// Everything is surfaced from existing engines — no new aggregation lives here:
+/// - `AppState.categoryDashboardPresentation` (built by `CategoryDashboardBuilder`
+///   over `CategoryBudgetPlanner.netSpendByCategory`, override-aware) drives the
+///   donut + tree.
+/// - `CategoryTreeView` / `SpendDonutChart` / `CategoryStatusBar` render it.
+/// - `BudgetEditorSheet` is re-hosted for inline-editable category budgets.
+/// - `BudgetsStatusSummary` (new pure Core, unit-tested) reduces the rollup into
+///   the status pane.
+///
+/// Budget pressure (over/nearing) is always carried by **text + SF Symbol**, never
+/// color alone (ACCESSIBILITY.md). The content and inspector columns are separate
+/// split-view views, so they share selection through `BudgetsSelectionModel.shared`.
+///
+/// Window-first surface only: reached solely when `AppShellView` mounts (behind
+/// `WindowFirstFeatureFlag`, default OFF). With the flag off none of this is
+/// instantiated and the popover is byte-identical.
 struct BudgetsDestinationView: View {
-    var body: some View {
-        DestinationPlaceholder(destination: .budgets)
+    @Environment(AppState.self) private var appState
+    @State private var selection = BudgetsSelectionModel.shared
+    /// The category whose budget the user is editing; drives the re-hosted
+    /// `BudgetEditorSheet` (AND-541 pattern, mirroring `CategoryDashboardWindow`).
+    @State private var budgetEditorCategory: BudgetEditorCategory?
+
+    private var presentation: CategoryDashboardPresentation {
+        appState.categoryDashboardPresentation
     }
 
-    /// The detail-column (inspector) pane for Budgets.
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                header
+
+                if presentation.isEmpty {
+                    emptyState
+                } else {
+                    donutSection
+                    treeSection
+                }
+            }
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .navigationTitle(RouteDestination.budgets.title)
+        .loadingRedaction(appState.loadState(for: .summaryCards))
+        .sheet(item: $budgetEditorCategory) { item in
+            BudgetEditorSheet(category: item.category)
+                .environment(appState)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    /// Select a category (drives the inspector) and open its budget editor.
+    private func selectAndEdit(_ category: SpendingCategory) {
+        selection.selectedCategory = category
+        budgetEditorCategory = BudgetEditorCategory(category)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("Budgets")
+                .font(.title2.weight(.bold))
+            Text("Set monthly limits and track this month's spending by category.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Donut
+
+    private var donutSection: some View {
+        let donut = SpendDonutModel(presentation: presentation)
+        return VStack(alignment: .leading, spacing: Spacing.sm) {
+            SpendDonutChart(model: donut, isPrivacyMasked: isMasked)
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    // MARK: - Tree
+
+    private var treeSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label("By group", systemImage: "list.bullet.indent")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+            // Tapping a leaf's budget affordance selects it for the inspector and
+            // opens the editor; the inspector reflects the selection independently.
+            CategoryTreeView(
+                presentation: presentation,
+                privacyMaskEnabled: isMasked,
+                onEditBudget: selectAndEdit
+            )
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Label("No category spending yet", systemImage: "chart.pie")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("Budgets and spending appear here once this month's transactions arrive.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
+        .multilineTextAlignment(.center)
+        .padding(Spacing.lg)
+        .glassSurface(.raised)
+    }
+
+    /// The detail-column (inspector) pane for Budgets: the selected category's
+    /// detail/editor plus the overall month status rollup. Content-gated — shows
+    /// the "Select a category" prompt when nothing is selected (IA §3.1).
     struct Inspector: View {
+        @Environment(AppState.self) private var appState
+        @State private var selection = BudgetsSelectionModel.shared
+        @State private var budgetEditorCategory: BudgetEditorCategory?
+
+        private var presentation: CategoryDashboardPresentation {
+            appState.categoryDashboardPresentation
+        }
+
+        private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
         var body: some View {
-            DestinationInspectorPlaceholder(destination: .budgets)
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    statusSection
+
+                    if let category = selection.selectedCategory {
+                        categoryDetail(category)
+                    } else {
+                        selectionPrompt
+                    }
+                }
+                .padding(Spacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollContentBackground(.hidden)
+            .sheet(item: $budgetEditorCategory) { item in
+                BudgetEditorSheet(category: item.category)
+                    .environment(appState)
+            }
+            .accessibilityElement(children: .contain)
+        }
+
+        // MARK: - Status rollup
+
+        private var statusSection: some View {
+            let summary = BudgetsStatusSummary.summarize(presentation)
+            return VStack(alignment: .leading, spacing: Spacing.sm) {
+                Label("Status", systemImage: "gauge.with.dots.needle.33percent")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                // Headline verdict: glyph + label, tint redundant (ACCESSIBILITY.md).
+                Label(summary.health.label, systemImage: summary.health.iconName)
+                    .font(.headline)
+                    .foregroundStyle(healthTint(summary.health))
+                    .accessibilityLabel("Budget status: \(summary.health.label)")
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    statusStat(
+                        "Over budget",
+                        "\(summary.overBudgetCount)",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    statusStat(
+                        "Nearing a limit",
+                        "\(summary.nearingCount)",
+                        systemImage: "exclamationmark.circle"
+                    )
+                    statusStat(
+                        "Budgeted categories",
+                        "\(summary.budgetedCount) of \(summary.trackedCount)",
+                        systemImage: "slider.horizontal.3"
+                    )
+                }
+
+                if let remaining = summary.remaining {
+                    Divider().opacity(0.4)
+                    HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                        Label(
+                            summary.isAggregateOver ? "Over by" : "Left this month",
+                            systemImage: summary.isAggregateOver ? "minus.circle" : "plus.circle"
+                        )
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        Spacer(minLength: Spacing.sm)
+                        Text(currency(abs(remaining)))
+                            .font(.callout.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(summary.isAggregateOver ? SemanticColors.negative : .primary)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+            }
+            .padding(Spacing.md)
+            .glassSurface(.raised)
+        }
+
+        private func statusStat(_ label: String, _ value: String, systemImage: String) -> some View {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Label(label, systemImage: systemImage)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: Spacing.sm)
+                Text(value)
+                    .font(.callout.weight(.semibold))
+                    .monospacedDigit()
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(label): \(value)")
+        }
+
+        // MARK: - Selected category detail/editor
+
+        private func categoryDetail(_ category: SpendingCategory) -> some View {
+            let leaf = presentation.leaf(category)
+            return VStack(alignment: .leading, spacing: Spacing.sm) {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: category.iconName)
+                        .font(.title3)
+                        .foregroundStyle(CategoryAccentTokens.color(for: category))
+                        .frame(width: 28)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(category.displayName)
+                            .font(.headline)
+                        Text(category.group.title)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: Spacing.sm)
+                }
+                .accessibilityElement(children: .combine)
+
+                if let leaf {
+                    CategoryStatusBar(
+                        model: CategoryStatusBarModel(leaf: leaf),
+                        spentText: currency(leaf.spent),
+                        limitText: leaf.monthlyLimit.map(currency),
+                        accent: CategoryAccentTokens.color(for: category)
+                    )
+                } else {
+                    Label("No spending or budget yet this month", systemImage: "tray")
+                        .microText()
+                        .foregroundStyle(.secondary)
+                }
+
+                editBudgetButton(for: category)
+            }
+            .padding(Spacing.md)
+            .glassSurface(.raised)
+        }
+
+        @ViewBuilder
+        private func editBudgetButton(for category: SpendingCategory) -> some View {
+            let isBudgeted = presentation.leaf(category)?.isBudgeted ?? false
+            let affordance = BudgetRowAffordance(category: category, isBudgeted: isBudgeted)
+            if affordance.isAvailable {
+                Button {
+                    budgetEditorCategory = BudgetEditorCategory(category)
+                } label: {
+                    Label(affordance.title, systemImage: affordance.systemImage)
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .accessibilityLabel(affordance.accessibilityLabel)
+            } else {
+                Label(
+                    "Income and transfer categories can't have a budget.",
+                    systemImage: "info.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+
+        private var selectionPrompt: some View {
+            ContentUnavailableView {
+                Label(
+                    RouteDestination.budgets.detailColumnEmptyPrompt ?? "Select a category",
+                    systemImage: RouteDestination.budgets.systemImage
+                )
+            } description: {
+                Text("Choose a category from the list to edit its budget and see its detail here.")
+            }
+        }
+
+        // MARK: - Helpers
+
+        private func currency(_ amount: Double) -> String {
+            PrivacyMaskPresentation.currency(
+                amount,
+                format: .full,
+                isEnabled: isMasked,
+                style: .compact
+            )
+        }
+
+        /// Redundant color cue — the glyph + label already carry the verdict.
+        private func healthTint(_ health: BudgetsStatusSummary.Health) -> Color {
+            switch health {
+            case .over: SemanticColors.negative
+            case .nearing: SemanticColors.warning
+            case .onTrack: SemanticColors.positive
+            case .noBudgets: .secondary
+            }
         }
     }
 }
 
 #Preview("Content") {
     BudgetsDestinationView()
+        .environment(AppState())
 }
 
 #Preview("Inspector") {
     BudgetsDestinationView.Inspector()
+        .environment(AppState())
 }

--- a/Sources/PlaidBar/Views/Destinations/BudgetsSelectionModel.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsSelectionModel.swift
@@ -1,0 +1,34 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Shared selection state for the 3-column **Budgets** destination (Epic 5 /
+/// AND-583).
+///
+/// `AppShellView` mounts `BudgetsDestinationView` (content) and
+/// `BudgetsDestinationView.Inspector` (detail) as **separate** views in different
+/// columns of a `NavigationSplitView`, so they cannot share `@State`. This tiny
+/// `@MainActor @Observable` singleton is the bridge: the content column writes the
+/// tapped category; the inspector column reads it to show that category's
+/// detail/editor. Selection is ephemeral UI state — no persistence schema — so a
+/// shared in-memory model is exactly the right scope.
+///
+/// Window-first surface only: it is referenced solely from the Budgets
+/// destination, which is built behind `WindowFirstFeatureFlag` via `AppShellView`.
+/// With the flag OFF the workspace never mounts, so this is never instantiated and
+/// the popover is byte-identical.
+@MainActor
+@Observable
+final class BudgetsSelectionModel {
+    /// Process-wide shared instance — the only way the two split-view columns can
+    /// observe the same selection (they have no common SwiftUI parent to inject an
+    /// environment object through). Mirrors the app's existing singleton pattern
+    /// (e.g. `ServerProcessService.shared`).
+    static let shared = BudgetsSelectionModel()
+
+    /// The category whose detail/editor the inspector shows. `nil` means the
+    /// inspector is content-gated — it renders the "Select a category" prompt
+    /// (IA §3.1), never collapsing.
+    var selectedCategory: SpendingCategory?
+
+    private init() {}
+}

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -3,19 +3,176 @@ import SwiftUI
 
 /// **Planning** destination (2-column — IA §3.1/§5.5, `[⌘4]`).
 ///
-/// A composed analytical canvas (forecast + recurring + income flow); its
-/// sub-sections switch via a segmented control, not a master list, so the shell
-/// renders only this content column (no inspector).
+/// Epic 5 / AND-583 (ADR-001 window-first workspace). A composed analytical
+/// canvas — no master list, so the shell renders only this content column (no
+/// inspector). It stacks the forward-looking planning surfaces, every one driven
+/// by an existing engine (no new aggregation here):
 ///
-/// Scaffold for the parallel Epics 4–7: today it shows the shared
-/// `DestinationPlaceholder`; the real canvas lands in its epic by replacing this
-/// `body`, without touching `AppShellView`.
+/// - **Safe to spend** — `SafeToSpendCard` over `SafeToSpendCalculator.compute`,
+///   the exact Core computation the popover uses, so the two surfaces can never
+///   disagree. It recomputes from live `transactions` / `recurringTransactions` /
+///   cashflow, so it updates whenever a transaction is edited.
+/// - **Cashflow projection** — `ProjectedBalanceChart` over
+///   `ProjectedBalancePresentation.evaluate`; self-hides until there is enough
+///   recorded balance history to anchor a line.
+/// - **Upcoming recurring** — `RecurringObligationsSection` over
+///   `RecurringObligationsPresentation.make`, the same read-only recurring
+///   presentation the flyout shows; self-hides when nothing is detected.
+/// - **Goals** — a read-only summary placeholder. The full Goals destination is a
+///   separate net-new sub (AND-606) and is **deferred**; Planning only previews it.
+///
+/// Confidence / pressure cues ride on text + SF Symbol, never color alone
+/// (ACCESSIBILITY.md — the reused cards already enforce this). Window-first surface
+/// only: reached solely when `AppShellView` mounts (behind `WindowFirstFeatureFlag`,
+/// default OFF), so the flag-off popover is byte-identical.
 struct PlanningDestinationView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// The wealth summary supplies the cashflow window the safe-to-spend card needs;
+    /// built from the same inputs the flyout uses so the number matches everywhere.
+    private var wealthPresentation: WealthSummaryPresentation {
+        WealthSummaryPresentation.evaluate(
+            accounts: appState.accounts,
+            transactions: appState.transactions,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
+            linkedItemCount: appState.statusItemCount,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            itemStatuses: appState.itemStatuses,
+            isSyncStale: appState.isSyncStale,
+            lastSyncRelative: appState.lastSyncRelative,
+            statusSyncText: appState.statusSyncText,
+            errorMessage: appState.error,
+            creditUtilizationThreshold: appState.creditUtilizationThreshold,
+            lowCashThreshold: appState.lowBalanceThreshold,
+            largeTransactionThreshold: appState.largeTransactionThreshold,
+            balanceHistory: appState.balanceHistory
+        )
+    }
+
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
     var body: some View {
-        DestinationPlaceholder(destination: .planning)
+        let presentation = wealthPresentation
+        let privacyMaskEnabled = isMasked
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                header
+
+                // Safe to spend — must match the Core computation (AND-401).
+                SafeToSpendCard(
+                    result: SafeToSpendCalculator.compute(
+                        accounts: appState.accounts,
+                        recurringTransactions: appState.recurringTransactions,
+                        cashflow: presentation.cashflow,
+                        asOf: Date()
+                    ),
+                    lastUpdatedRelative: appState.lastSyncRelative,
+                    privacyMaskEnabled: privacyMaskEnabled
+                )
+                .loadingRedaction(appState.loadState(for: .summaryCards))
+
+                // Forward cashflow projection (AND-498). Self-hides until there is
+                // enough recorded balance history to anchor a line.
+                cashflowProjectionSection(privacyMaskEnabled: privacyMaskEnabled)
+
+                // Upcoming recurring obligations (AND-400), read-only. Self-hides
+                // when no recurring series are detected.
+                RecurringObligationsSection(
+                    presentation: RecurringObligationsPresentation.make(
+                        from: appState.recurringTransactions,
+                        asOf: Date()
+                    ),
+                    privacyMaskEnabled: privacyMaskEnabled
+                )
+                .loadingRedaction(appState.loadState(for: .recurring))
+
+                // Goals contributions — read-only summary placeholder. The full
+                // Goals destination is the separate net-new AND-606 (deferred).
+                goalsSummarySection
+            }
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .navigationTitle(RouteDestination.planning.title)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text("Planning")
+                .font(.title2.weight(.bold))
+            Text("Look ahead: what's safe to spend, where the balance is heading, and what's already committed.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Cashflow projection
+
+    @ViewBuilder
+    private func cashflowProjectionSection(privacyMaskEnabled: Bool) -> some View {
+        let projection = ProjectedBalancePresentation.evaluate(
+            history: appState.balanceHistory,
+            recurring: appState.recurringTransactions,
+            now: Date()
+        )
+        switch projection {
+        case let .available(balanceProjection):
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                Label("Projected balance", systemImage: "chart.xyaxis.line")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                if privacyMaskEnabled {
+                    Label("Forecast hidden while VaultPeek is private", systemImage: "eye.slash")
+                        .detailText()
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+                } else {
+                    ProjectedBalanceChart(projection: balanceProjection)
+                }
+            }
+            .padding(Spacing.md)
+            .glassSurface(.raised)
+            .loadingRedaction(appState.loadState(for: .summaryCards))
+            .accessibilityElement(children: .contain)
+        case .insufficientHistory:
+            // Stay quiet until there is enough history — no empty placeholder.
+            EmptyView()
+        }
+    }
+
+    // MARK: - Goals summary (deferred destination — AND-606)
+
+    private var goalsSummarySection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label("Goals", systemImage: RouteDestination.goals.systemImage)
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            ContentUnavailableView {
+                Label("Savings goals are coming soon", systemImage: "flag.checkered")
+            } description: {
+                Text("Set targets and track contributions in the dedicated Goals workspace.")
+            }
+            .frame(maxWidth: .infinity, minHeight: 140)
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Goals: savings goals are coming soon.")
     }
 }
 
 #Preview {
     PlanningDestinationView()
+        .environment(AppState())
 }

--- a/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Pure, deterministic rollup for the **Budgets** workspace status column
+/// (Epic 5 / AND-583, ADR-001 window-first surface).
+///
+/// The 3-column Budgets destination shows a category tree (content) → category
+/// detail/editor (inspector). Its third pane needs a compact, glance-able health
+/// summary for the whole month's budgets. Rather than recomputing anything in the
+/// view, this enum reduces a finished ``CategoryDashboardPresentation`` (already
+/// override-aware — it comes from ``CategoryDashboardBuilder`` /
+/// ``CategoryBudgetPlanner/netSpendByCategory(from:startKey:endKey:metadata:rules:)``)
+/// into a small `Sendable` ``Summary`` the status pane renders directly.
+///
+/// Every verdict carries text **and** an SF Symbol so budget pressure is never
+/// communicated by color alone (ACCESSIBILITY.md). The view layers a redundant
+/// tint on top; this model never encodes color.
+public enum BudgetsStatusSummary {
+    /// The overall budget-health band for the month, ordered worst-first so the
+    /// view can pick a headline glyph/label without re-deriving precedence.
+    public enum Health: String, Sendable, Hashable {
+        /// At least one category is over its limit.
+        case over
+        /// No category is over, but at least one is nearing its limit.
+        case nearing
+        /// Budgets exist and everything is comfortably under.
+        case onTrack
+        /// No category carries a budget yet (first-run / never configured).
+        case noBudgets
+
+        /// Short verdict text — always paired with ``iconName`` (never color alone).
+        public var label: String {
+            switch self {
+            case .over: "Over budget"
+            case .nearing: "Nearing a limit"
+            case .onTrack: "On track"
+            case .noBudgets: "No budgets set"
+            }
+        }
+
+        /// SF Symbol carrying the verdict without color.
+        public var iconName: String {
+            switch self {
+            case .over: "exclamationmark.triangle.fill"
+            case .nearing: "exclamationmark.circle"
+            case .onTrack: "checkmark.circle"
+            case .noBudgets: "slider.horizontal.3"
+            }
+        }
+    }
+
+    /// A finished, `Sendable` view-model the status pane renders directly.
+    public struct Summary: Sendable, Hashable {
+        /// Overall month band, worst-first precedence already applied.
+        public let health: Health
+        /// Number of leaf categories over their individual limit.
+        public let overBudgetCount: Int
+        /// Number of leaf categories in the nearing band (not yet over).
+        public let nearingCount: Int
+        /// Number of leaf categories that carry a positive budget.
+        public let budgetedCount: Int
+        /// Total leaf categories with spend or a budget in the rollup.
+        public let trackedCount: Int
+        /// Sum of every leaf's spend across all groups.
+        public let totalSpent: Double
+        /// Sum of every budgeted leaf's limit.
+        public let totalLimit: Double
+
+        /// `totalLimit - totalSpent` across budgeted categories; `nil` when no
+        /// budget exists (so the view shows no "left/over" line at all).
+        public var remaining: Double? {
+            budgetedCount > 0 ? totalLimit - totalSpent : nil
+        }
+
+        /// True when the budgeted total has been exceeded in aggregate.
+        public var isAggregateOver: Bool {
+            (remaining ?? 0) < 0
+        }
+
+        /// Fraction of the budgeted total already spent, clamped to `0...1` for a
+        /// progress affordance; `nil` when there is no budget.
+        public var fractionUsed: Double? {
+            guard budgetedCount > 0, totalLimit > 0 else { return nil }
+            return min(1, max(0, totalSpent / totalLimit))
+        }
+    }
+
+    /// Reduce a finished dashboard rollup into the status summary.
+    ///
+    /// - Parameter presentation: the override-aware month rollup the tree renders.
+    public static func summarize(
+        _ presentation: CategoryDashboardPresentation
+    ) -> Summary {
+        let leaves = presentation.leaves
+        let budgetedCount = leaves.reduce(0) { $0 + ($1.isBudgeted ? 1 : 0) }
+
+        let health: Health
+        if presentation.overBudgetCount > 0 {
+            health = .over
+        } else if presentation.nearingCount > 0 {
+            health = .nearing
+        } else if budgetedCount > 0 {
+            health = .onTrack
+        } else {
+            health = .noBudgets
+        }
+
+        return Summary(
+            health: health,
+            overBudgetCount: presentation.overBudgetCount,
+            nearingCount: presentation.nearingCount,
+            budgetedCount: budgetedCount,
+            trackedCount: leaves.count,
+            totalSpent: presentation.totalSpent,
+            totalLimit: presentation.totalLimit
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetsStatusSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetsStatusSummaryTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Tests for the Epic 5 / AND-583 Budgets status rollup. The summary must:
+/// - pick the worst-first overall health band (over > nearing > onTrack > noBudgets),
+/// - count over / nearing leaves and budgeted vs. tracked categories,
+/// - compute the aggregate remaining only when a budget exists, and
+/// - be a pure reduction of a finished dashboard presentation (no `Date()`).
+@Suite("Budgets status summary (AND-583)")
+struct BudgetsStatusSummaryTests {
+    // June 13, 2026 — current month is June (matches the builder fixtures).
+    private let now = Formatters.parseTransactionDate("2026-06-13")!
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func tx(
+        _ amount: Double,
+        _ date: String,
+        _ category: SpendingCategory?,
+        name: String = "Merchant"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: "\(name)-\(date)-\(amount)",
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: name,
+            merchantName: name,
+            category: category,
+            pending: false,
+            pendingTransactionId: nil,
+            isLowConfidenceCategory: false
+        )
+    }
+
+    private func presentation(
+        transactions: [TransactionDTO],
+        budgets: [SpendingCategory: Double]
+    ) -> CategoryDashboardPresentation {
+        CategoryDashboardBuilder.build(
+            transactions: transactions,
+            budgets: budgets,
+            asOf: now,
+            calendar: calendar
+        )
+    }
+
+    // MARK: - Health band precedence
+
+    @Test("No budgets → noBudgets health, no remaining")
+    func noBudgets() {
+        let result = presentation(
+            transactions: [tx(100, "2026-06-02", .foodAndDrink)],
+            budgets: [:]
+        )
+        let summary = BudgetsStatusSummary.summarize(result)
+
+        #expect(summary.health == .noBudgets)
+        #expect(summary.budgetedCount == 0)
+        #expect(summary.trackedCount == 1)
+        #expect(summary.remaining == nil)
+        #expect(summary.fractionUsed == nil)
+        #expect(summary.isAggregateOver == false)
+    }
+
+    @Test("All comfortably under a budget → onTrack")
+    func onTrack() {
+        let result = presentation(
+            transactions: [tx(20, "2026-06-02", .foodAndDrink)],
+            budgets: [.foodAndDrink: 200]
+        )
+        let summary = BudgetsStatusSummary.summarize(result)
+
+        #expect(summary.health == .onTrack)
+        #expect(summary.overBudgetCount == 0)
+        #expect(summary.nearingCount == 0)
+        #expect(summary.budgetedCount == 1)
+        #expect(summary.remaining == 180)
+        #expect(summary.isAggregateOver == false)
+    }
+
+    @Test("A nearing leaf (no over) → nearing health")
+    func nearing() {
+        // 190 of a 200 budget is in the nearing band (>= ~75%, < 100%).
+        let result = presentation(
+            transactions: [tx(190, "2026-06-02", .foodAndDrink)],
+            budgets: [.foodAndDrink: 200]
+        )
+        let summary = BudgetsStatusSummary.summarize(result)
+
+        #expect(summary.health == .nearing)
+        #expect(summary.overBudgetCount == 0)
+        #expect(summary.nearingCount == 1)
+    }
+
+    @Test("Any over-budget leaf wins precedence → over health")
+    func overWinsPrecedence() {
+        let result = presentation(
+            transactions: [
+                tx(300, "2026-06-02", .foodAndDrink),  // over its 200 limit
+                tx(190, "2026-06-03", .shopping),      // nearing its 200 limit
+            ],
+            budgets: [.foodAndDrink: 200, .shopping: 200]
+        )
+        let summary = BudgetsStatusSummary.summarize(result)
+
+        #expect(summary.health == .over)
+        #expect(summary.overBudgetCount == 1)
+        #expect(summary.nearingCount == 1)
+        #expect(summary.budgetedCount == 2)
+    }
+
+    // MARK: - Aggregate remaining
+
+    @Test("Aggregate remaining sums budgeted limits minus spend; over reads negative")
+    func aggregateRemaining() {
+        let result = presentation(
+            transactions: [
+                tx(300, "2026-06-02", .foodAndDrink),  // spent 300 of 200
+                tx(50, "2026-06-03", .shopping),       // spent 50 of 200
+            ],
+            budgets: [.foodAndDrink: 200, .shopping: 200]
+        )
+        let summary = BudgetsStatusSummary.summarize(result)
+
+        // totalLimit 400, totalSpent 350 → +50 remaining overall, not over.
+        #expect(summary.totalLimit == 400)
+        #expect(summary.totalSpent == 350)
+        #expect(summary.remaining == 50)
+        #expect(summary.isAggregateOver == false)
+    }
+
+    @Test("Empty presentation → noBudgets, zero counts")
+    func emptyPresentation() {
+        let summary = BudgetsStatusSummary.summarize(.empty)
+
+        #expect(summary.health == .noBudgets)
+        #expect(summary.trackedCount == 0)
+        #expect(summary.budgetedCount == 0)
+        #expect(summary.totalSpent == 0)
+        #expect(summary.totalLimit == 0)
+        #expect(summary.remaining == nil)
+    }
+
+    // MARK: - Health labels carry text + glyph (ACCESSIBILITY.md)
+
+    @Test("Every health band has non-empty text and an SF Symbol")
+    func healthLabelsArePopulated() {
+        for health in [
+            BudgetsStatusSummary.Health.over,
+            .nearing,
+            .onTrack,
+            .noBudgets,
+        ] {
+            #expect(!health.label.isEmpty)
+            #expect(!health.iconName.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Epic 5 — Planning & Budgeting Workspace (AND-583, ADR-001 window-first surface). Fills the two assigned destination views; the shell, nav, and `DestinationRouter` are untouched.

- **Budgets (3-col)** — `BudgetsDestinationView` + `.Inspector`:
  - Content: override-aware spend donut + two-level `CategoryTreeView` (group rollups over leaves), each row's budget affordance opens the editor and selects the category for the inspector.
  - Inspector: month **status** rollup (overall health + over/nearing counts + aggregate remaining) and the **selected category's detail/editor**, re-hosting `BudgetEditorSheet` for inline-editable budgets. Content-gated "Select a category" prompt when nothing is selected (IA §3.1).
  - Over-budget / nearing badges are **text + SF Symbol**, never color alone (ACCESSIBILITY.md).
- **Planning (2-col composed canvas)** — `PlanningDestinationView`:
  - `SafeToSpendCard` over `SafeToSpendCalculator.compute` (matches the Core computation the popover uses; recomputes from live transactions/recurring/cashflow so it updates on transaction edits).
  - Projected-balance cashflow chart (`ProjectedBalanceChart` / `ProjectedBalancePresentation.evaluate`), self-hiding until enough history.
  - Read-only `RecurringObligationsSection` (upcoming recurring), self-hiding when none detected.
  - Read-only **Goals** summary placeholder — the full Goals destination is the separate net-new **AND-606**, deferred here.
- New pure Core `BudgetsStatusSummary` (namespaced, unit-tested) reduces the dashboard rollup into the status pane. No new persistence schema.

## Flag-off note

Everything is reached only when the window-first `Window` opens via `AppShellView` (behind `WindowFirstFeatureFlag`, default OFF). With the flag off none of this is instantiated and the popover is byte-identical. The shared `BudgetsSelectionModel.shared` singleton is only referenced from the Budgets destination, so it is never constructed in the flag-off build.

## Reused components (no rebuild)

`CategoryDashboardBuilder`, `CategoryBudgetPlanner.netSpendByCategory` (override-aware), `CategoryDashboardPresentation`, `CategoryTreeView`, `SpendDonutChart` / `SpendDonutModel`, `CategoryStatusBar` / `CategoryStatusBarModel`, `BudgetEditorSheet` / `BudgetEditorCategory`, `BudgetRowAffordance`, `SafeToSpendCard` / `SafeToSpendCalculator`, `ProjectedBalanceChart` / `ProjectedBalancePresentation`, `RecurringObligationsSection` / `RecurringObligationsPresentation`, `WealthSummaryPresentation` (cashflow window). Validated against the Copilot category-dashboard spec (`docs/superpowers/specs/2026-06-18-copilot-review-category-dashboard-design.md`).

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — 1895 tests pass (baseline ~1888 + 7 new `BudgetsStatusSummaryTests`: health-band precedence, counts, aggregate remaining, empty/no-budget, text+glyph labels).

## Deferred follow-ups

- Full **Goals** destination + contributions (AND-606) — Planning shows a read-only summary placeholder only.
- Per-month budget series / rollover (v2, AND-524) — out of scope (Option A: one monthly limit per category).

🤖 Generated with [Claude Code](https://claude.com/claude-code)