### PR TITLE
feat(transactions): window-first Transaction Workspace (AND-582)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4036,6 +4036,19 @@ final class AppState {
         }
     }
 
+    /// Attach (or clear) a free-text note on a transaction from the Transaction
+    /// Workspace inspector (AND-582). Routes through the SAME undoable
+    /// `updateReviewMetadata` path as every other override, so the note persists on
+    /// the existing review-metadata storage and is covered by ⌘Z. A note is a
+    /// display-only annotation — it does NOT mark the row reviewed and never feeds
+    /// budget/category/export totals. An empty/whitespace note clears it.
+    func updateReviewNote(_ id: String, note: String) {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        updateReviewMetadata(id: id) { metadata, _ in
+            metadata.userNote = trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
     func createRule(
         from item: TransactionReviewItem,
         category: SpendingCategory? = nil,

--- a/Sources/PlaidBar/App/NavigationModel.swift
+++ b/Sources/PlaidBar/App/NavigationModel.swift
@@ -32,6 +32,13 @@ final class NavigationModel {
         /// destination the user left off (IA §2.1 selection persistence). Absent ⇒
         /// Dashboard, so an upgrading user (and the flag-OFF popover) is unchanged.
         static let destination = "navigation.destination"
+        /// The Transaction Workspace filter/search, JSON-encoded (AND-582). New in
+        /// Epic 4: the popover never had this surface, so the key is absent for an
+        /// upgrading user (and the flag-OFF popover) ⇒ the default empty filter.
+        static let transactionFilter = "navigation.transactionFilter"
+        /// The Transaction Workspace sort order's raw value (AND-582). Absent ⇒
+        /// the default newest-first sort.
+        static let transactionSort = "navigation.transactionSort"
     }
 
     /// The pure state. Mutations route through the typed accessors below (which
@@ -89,6 +96,45 @@ final class NavigationModel {
             state.heatmapMode = newValue
             persistHeatmapMode()
         }
+    }
+
+    // MARK: - Transaction Workspace façade (AND-582)
+
+    var transactionFilter: TransactionWorkspace.Filter {
+        get { state.transactionFilter }
+        set {
+            state.setTransactionFilter(newValue)
+            persistTransactionFilter()
+            // setTransactionFilter clears the row selection on a real change; this
+            // selection is window-only (not persisted), so nothing else to mirror.
+        }
+    }
+
+    var transactionSort: TransactionWorkspace.Sort {
+        get { state.transactionSort }
+        set {
+            state.setTransactionSort(newValue)
+            persistTransactionSort()
+        }
+    }
+
+    /// The selected transaction row id, or empty when none. Deliberately **not**
+    /// persisted: a row selection is ephemeral per-session window state (unlike the
+    /// dashboard account selection, which restored a drill-in), so a relaunch lands
+    /// on the unselected inspector prompt.
+    var selectedTransactionID: String {
+        get { state.selectedTransactionID }
+        set { state.selectTransaction(id: newValue) }
+    }
+
+    func deselectTransaction() {
+        state.deselectTransaction()
+    }
+
+    /// Self-heal: drop a selected transaction id no longer in the filtered rows.
+    @discardableResult
+    func reconcileTransactionSelection(visibleTransactionIDs: [String]) -> Bool {
+        state.reconcileTransactionSelection(visibleTransactionIDs: visibleTransactionIDs)
     }
 
     // MARK: - Navigation
@@ -156,6 +202,18 @@ final class NavigationModel {
            let mode = SpendingHeatmapMode(rawValue: rawMode) {
             restored.heatmapMode = mode
         }
+        // Transaction Workspace filter/sort (AND-582). Absent ⇒ defaults, so the
+        // flag-OFF popover (which never reads these) is unchanged. A filter that
+        // fails to decode (e.g. a removed category) falls back to the default
+        // rather than throwing.
+        if let data = defaults.data(forKey: Keys.transactionFilter),
+           let filter = try? JSONDecoder().decode(TransactionWorkspace.Filter.self, from: data) {
+            restored.transactionFilter = filter
+        }
+        if let rawSort = defaults.string(forKey: Keys.transactionSort),
+           let sort = TransactionWorkspace.Sort(rawValue: rawSort) {
+            restored.transactionSort = sort
+        }
         state = restored
     }
 
@@ -177,5 +235,17 @@ final class NavigationModel {
     private func persistHeatmapMode() {
         guard !isHydrating else { return }
         defaults.set(state.heatmapMode.rawValue, forKey: Keys.heatmapMode)
+    }
+
+    private func persistTransactionFilter() {
+        guard !isHydrating else { return }
+        if let data = try? JSONEncoder().encode(state.transactionFilter) {
+            defaults.set(data, forKey: Keys.transactionFilter)
+        }
+    }
+
+    private func persistTransactionSort() {
+        guard !isHydrating else { return }
+        defaults.set(state.transactionSort.rawValue, forKey: Keys.transactionSort)
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
@@ -1,0 +1,330 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The Transaction Workspace detail-column inspector (AND-582).
+///
+/// Reads the selected transaction id from the shared ``NavigationModel`` and
+/// resolves it (override-aware) against `AppState`. Content-gated: shows the
+/// "Select a transaction" prompt when nothing is selected (IA §3.1). All edits —
+/// recategorize, add/clear note, mark / un-mark transfer, "always categorize"
+/// rule, mark reviewed — route through the existing `AppState` review path, so the
+/// inspector, the table, and the Review Inbox stay in lockstep and every edit is
+/// undoable and reflected in dependent surfaces (budgets, category dashboard).
+///
+/// Under Privacy Mask / App Lock the inspector withholds merchant + amount.
+struct TransactionInspectorView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Local draft of the note so typing doesn't write per-keystroke to the
+    /// persisted store; committed on submit / focus-loss. Re-seeded when the
+    /// selected row changes.
+    @State private var noteDraft = ""
+    @FocusState private var noteFocused: Bool
+
+    private var navigationModel: NavigationModel { appState.navigationModel }
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    /// The selected row, resolved through the pure Core builder so its category /
+    /// transfer / status match the table exactly. `nil` when nothing is selected or
+    /// the selection no longer exists.
+    private var selectedRow: TransactionWorkspace.Row? {
+        let id = navigationModel.selectedTransactionID
+        guard !id.isEmpty else { return nil }
+        return TransactionWorkspace.rows(
+            transactions: appState.transactions,
+            metadata: appState.transactionReviewMetadata,
+            rules: appState.transactionRules
+        ).first { $0.id == id }
+    }
+
+    var body: some View {
+        Group {
+            if let row = selectedRow {
+                if isMasked {
+                    maskedPlaceholder
+                } else {
+                    detail(for: row)
+                }
+            } else {
+                emptyPrompt
+            }
+        }
+        .onChange(of: navigationModel.selectedTransactionID) { _, _ in
+            noteDraft = selectedRow?.note ?? ""
+        }
+        .onAppear { noteDraft = selectedRow?.note ?? "" }
+    }
+
+    // MARK: - Detail
+
+    private func detail(for row: TransactionWorkspace.Row) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                header(row)
+                amountSection(row)
+                categorySection(row)
+                noteSection(row)
+                actionsSection(row)
+            }
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func header(_ row: TransactionWorkspace.Row) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: Spacing.sm) {
+                MerchantLogoView(
+                    logoURL: row.transaction.logoURL,
+                    fallbackTint: row.transaction.isIncome ? SemanticColors.positive : Color.secondary.opacity(0.55)
+                )
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text(row.merchantName)
+                        .font(.title3.weight(.semibold))
+                        .lineLimit(2)
+                    Text(Formatters.displayTransactionDate(row.transaction.date))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            statusBadges(row)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func statusBadges(_ row: TransactionWorkspace.Row) -> some View {
+        HStack(spacing: Spacing.xs) {
+            badge(statusTitle(row.status), systemImage: statusGlyph(row.status), tint: statusColor(row.status))
+            if row.transaction.pending {
+                badge("Pending", systemImage: "clock", tint: SemanticColors.pending)
+            }
+            if row.isTransfer {
+                badge("Transfer", systemImage: "arrow.left.arrow.right", tint: .secondary)
+            }
+        }
+    }
+
+    private func badge(_ title: String, systemImage: String, tint: Color) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption.weight(.medium))
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(tint)
+            .padding(.horizontal, Spacing.xs)
+            .padding(.vertical, Spacing.xxs)
+            .background(tint.opacity(0.12), in: Capsule())
+            .accessibilityLabel(title)
+    }
+
+    private func amountSection(_ row: TransactionWorkspace.Row) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Text(row.transaction.isIncome ? "Received" : "Spent")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(amountText(row))
+                .font(.title.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(row.transaction.isIncome ? SemanticColors.positive : AppearanceTextColors.primary)
+            if row.transaction.name != row.merchantName {
+                Text("Statement: \(row.transaction.name)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            if row.excludedFromBudgets {
+                Label("Excluded from budgets", systemImage: "minus.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func categorySection(_ row: TransactionWorkspace.Row) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            sectionTitle("Category")
+            Picker("Category", selection: categoryBinding(row)) {
+                Text("Uncategorized").tag(SpendingCategory?.none)
+                ForEach(SpendingCategory.allCases, id: \.self) { category in
+                    Label(category.displayName, systemImage: category.iconName)
+                        .tag(SpendingCategory?.some(category))
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            if row.isCategorySuggested, let suggested = row.suggestedCategory {
+                Label("Suggested on device: \(suggested.displayName)", systemImage: "sparkles")
+                    .font(.caption)
+                    .foregroundStyle(SemanticColors.brand)
+            }
+        }
+    }
+
+    private func noteSection(_ row: TransactionWorkspace.Row) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            sectionTitle("Note")
+            TextEditor(text: $noteDraft)
+                .frame(minHeight: 60, maxHeight: 120)
+                .focused($noteFocused)
+                .padding(Spacing.xxs)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.control)
+                        .stroke(.quaternary, lineWidth: 1)
+                )
+                .accessibilityLabel("Transaction note")
+                .onChange(of: noteFocused) { _, focused in
+                    // Commit on focus-loss so the persisted store isn't written per
+                    // keystroke. (The note is display-only; it never marks reviewed.)
+                    if !focused { commitNote(row.id) }
+                }
+            HStack {
+                Spacer()
+                Button("Save note") { commitNote(row.id) }
+                    .controlSize(.small)
+                    .disabled(noteDraft == (row.note ?? ""))
+            }
+        }
+    }
+
+    private func actionsSection(_ row: TransactionWorkspace.Row) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            sectionTitle("Actions")
+
+            if row.isTransfer {
+                Button {
+                    edit { appState.markReviewItemTransfer(row.id, isTransfer: false) }
+                } label: {
+                    Label("Mark not a transfer", systemImage: "arrow.uturn.left")
+                }
+                .help("Restore this row to spend and clear its budget exclusion")
+            } else {
+                Button {
+                    edit { appState.markReviewItemTransfer(row.id, isTransfer: true) }
+                } label: {
+                    Label("Mark as transfer", systemImage: "arrow.left.arrow.right")
+                }
+                .help("Exclude this row from budgets as an account transfer")
+            }
+
+            // Inline rule affordance: "always categorize this merchant" reusing the
+            // existing createRule path. Offered only when there's an effective
+            // category to bind the rule to.
+            if let category = row.effectiveCategory {
+                Button {
+                    edit { appState.createRule(from: reviewItem(for: row), category: category) }
+                } label: {
+                    Label("Always categorize “\(row.merchantName)” as \(category.displayName)", systemImage: "wand.and.stars")
+                }
+                .help("Create a rule so future transactions from this merchant categorize automatically")
+            }
+
+            if row.status != .reviewed {
+                Button {
+                    edit { appState.approveReviewItem(row.id) }
+                } label: {
+                    Label("Mark reviewed", systemImage: "checkmark.circle")
+                }
+            }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.regular)
+    }
+
+    // MARK: - Bindings + edits
+
+    private func categoryBinding(_ row: TransactionWorkspace.Row) -> Binding<SpendingCategory?> {
+        Binding(
+            get: { row.effectiveCategory },
+            set: { newValue in
+                guard let newValue, newValue != row.effectiveCategory else { return }
+                edit { appState.updateReviewCategory(row.id, category: newValue) }
+            }
+        )
+    }
+
+    private func commitNote(_ id: String) {
+        appState.updateReviewNote(id, note: noteDraft)
+    }
+
+    /// Build a `TransactionReviewItem` from the resolved row so the existing
+    /// `createRule(from:)` path can read merchant + category + transfer state. The
+    /// rule matcher keys on the effective merchant name, exactly as the inbox does.
+    private func reviewItem(for row: TransactionWorkspace.Row) -> TransactionReviewItem {
+        TransactionReviewItem(
+            transaction: row.transaction,
+            status: row.status,
+            reasonCodes: [],
+            effectiveCategory: row.effectiveCategory,
+            effectiveMerchantName: row.merchantName,
+            isTransfer: row.isTransfer,
+            excludedFromBudgets: row.excludedFromBudgets,
+            matchedRuleIds: []
+        )
+    }
+
+    private func edit(_ change: () -> Void) {
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            change()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+    }
+
+    private var emptyPrompt: some View {
+        ContentUnavailableView {
+            Label(
+                RouteDestination.transactions.detailColumnEmptyPrompt ?? "Select a transaction",
+                systemImage: RouteDestination.transactions.systemImage
+            )
+        } description: {
+            Text("Choose a transaction from the list to see its details and edit it here.")
+        }
+    }
+
+    private var maskedPlaceholder: some View {
+        ContentUnavailableView {
+            Label("Transaction hidden", systemImage: "eye.slash")
+        } description: {
+            Text("Details are hidden while Privacy Mask or App Lock is active.")
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func amountText(_ row: TransactionWorkspace.Row) -> String {
+        let prefix = row.transaction.isIncome ? "+" : ""
+        return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
+    }
+
+    private func statusTitle(_ status: TransactionReviewStatus) -> String {
+        switch status {
+        case .needsReview: "Needs review"
+        case .reviewed: "Reviewed"
+        case .ignored: "Ignored"
+        }
+    }
+
+    private func statusGlyph(_ status: TransactionReviewStatus) -> String {
+        switch status {
+        case .needsReview: "exclamationmark.circle"
+        case .reviewed: "checkmark.circle"
+        case .ignored: "minus.circle"
+        }
+    }
+
+    private func statusColor(_ status: TransactionReviewStatus) -> Color {
+        switch status {
+        case .needsReview: SemanticColors.warning
+        case .reviewed: SemanticColors.positive
+        case .ignored: .secondary
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -1,34 +1,272 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Transactions** destination (3-column — IA §3.1/§5.2).
+/// **Transactions** destination (3-column — IA §3.1/§5.2, AND-582 / Epic 4).
 ///
-/// The ledger: a table (list) → transaction inspector (detail). The shell
-/// renders this content (table) column plus `Inspector` in the detail column,
-/// which is content-gated and shows "Select a transaction" when nothing is
-/// selected (IA §3.1).
+/// The ledger: a sortable, keyboard-navigable `Table` (content column) → a
+/// transaction inspector (detail column). The shell renders this content column
+/// plus ``Inspector`` in the detail column, which is content-gated and shows
+/// "Select a transaction" when nothing is selected (IA §3.1).
 ///
-/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
-/// today; the real `ReviewTableWindow` table engine and `TransactionDetailView`
-/// inspector land in this destination's epic by replacing the two bodies, never
-/// touching `AppShellView`.
+/// ## Reused engines (nothing rebuilt)
+/// - **Filter / search / sort math** is the pure, unit-tested
+///   ``TransactionWorkspace`` (PlaidBarCore): build override-aware rows → filter
+///   (AND of every facet) → search → sort. Filter + sort + selection live in
+///   ``NavigationModel`` (the prompt's "filter/search state lives in
+///   NavigationModel"), so the table and the inspector share one source of truth
+///   and the window restores its last query.
+/// - **Override-aware spend attributes** (effective category, transfer, exclusion)
+///   come from ``EffectiveCategoryResolver`` — no spend re-derivation here.
+/// - **Edits** (recategorize, mark / un-mark transfer, create rule, add note)
+///   route through the existing `AppState` review path (`updateReviewCategory`,
+///   `markReviewItemTransfer`, `createRule`, `updateReviewNote`), so the workspace
+///   and the Review Inbox can never diverge in what an action means, and every
+///   edit is undoable (⌘Z) and reflected in dependent surfaces.
+///
+/// ## Privacy
+/// Under Privacy Mask / App Lock the table withholds merchant + amount figures
+/// (a placeholder replaces the rows), and every status/category cue rides on
+/// glyph + text, never color alone (ACCESSIBILITY.md / SECURITY.md).
+///
+/// Window-first surface only: built solely behind `WindowFirstFeatureFlag`
+/// (default OFF), so with the flag off none of this is instantiated and the
+/// popover is byte-identical.
 struct TransactionsDestinationView: View {
-    var body: some View {
-        DestinationPlaceholder(destination: .transactions)
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Focuses the search field for the ⌘F / find affordance.
+    @FocusState private var isSearchFocused: Bool
+
+    /// Large-history paging engine (AND-567), reused verbatim: page 0 loads on
+    /// appear, the next page loads as the table nears the end of the loaded rows.
+    /// When the disposable SwiftData cache is unavailable/disabled the source stays
+    /// on the in-memory `appState.transactions` fallback, so a small history (or a
+    /// cache-less environment) renders exactly today's rows — no regression. The
+    /// source's `rows` are the *input* to the pure ``TransactionWorkspace`` pipeline
+    /// (filter → search → sort), so a 10k+-row history materializes a page at a time
+    /// rather than all at once.
+    @State private var pagedSource: PagedTransactionSource
+
+    @MainActor
+    init() {
+        // A placeholder source until `.task` rebuilds it against the live AppState
+        // store/cache. `inMemory([])` stays on the fallback path with no rows; the
+        // real source is built in `body`'s `.task` once `appState` is available.
+        _pagedSource = State(initialValue: .inMemory([]))
     }
 
-    /// The detail-column (inspector) pane for Transactions.
+    private var navigationModel: NavigationModel { appState.navigationModel }
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    /// The transactions feeding the pipeline: the paged source's current rows
+    /// (paged from cache, or the in-memory fallback when paging is unavailable).
+    private var sourceTransactions: [TransactionDTO] { pagedSource.rows }
+
+    /// The fully composed rows: page → build → filter → search → sort (pure Core).
+    private var rows: [TransactionWorkspace.Row] {
+        TransactionWorkspace.resolve(
+            transactions: sourceTransactions,
+            metadata: appState.transactionReviewMetadata,
+            rules: appState.transactionRules,
+            filter: navigationModel.transactionFilter,
+            sort: navigationModel.transactionSort,
+            now: Date()
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            TransactionsFilterBar(
+                filter: filterBinding,
+                sort: sortBinding,
+                accounts: appState.accounts,
+                resultCount: rows.count,
+                isSearchFocused: $isSearchFocused
+            )
+            .padding(.horizontal, Spacing.lg)
+            .padding(.top, Spacing.md)
+
+            Divider().opacity(0.4)
+
+            content
+        }
+        .navigationTitle(RouteDestination.transactions.title)
+        // Build the paged source against the live AppState cache once, then load the
+        // first page. Best-effort: any failure leaves it on the in-memory fallback.
+        .task {
+            pagedSource = appState.makePagedTransactionSource(fallback: appState.transactions)
+            await pagedSource.loadFirstPageIfNeeded()
+        }
+        // Keep the fallback rows fresh when a refresh replaces the in-memory array,
+        // so the list reflects new data even before/without a cache page.
+        .onChange(of: appState.transactions) { _, latest in
+            pagedSource.updateFallback(latest)
+        }
+        // While a filter or search is active, drain remaining pages so the facet
+        // applies to the WHOLE history, not just the pages scrolled so far —
+        // otherwise filtering a partially-paged 10k history would silently omit
+        // matches in unloaded pages. Re-runs whenever the active filter changes;
+        // the source's in-flight guard keeps this from over-fetching.
+        .task(id: navigationModel.transactionFilter) {
+            guard navigationModel.transactionFilter.isActive else { return }
+            while pagedSource.hasMore {
+                await pagedSource.loadNextPageIfNeeded()
+            }
+        }
+        // Self-heal: if the selected row falls out of the filtered set, clear it so
+        // the inspector returns to its prompt instead of pointing at a hidden row.
+        .onChange(of: rows.map(\.id)) { _, ids in
+            navigationModel.reconcileTransactionSelection(visibleTransactionIDs: ids)
+        }
+    }
+
+    // MARK: - Content states
+
+    @ViewBuilder
+    private var content: some View {
+        if appState.isBootLoadInFlight {
+            TransactionsLoadingSkeleton()
+        } else if let error = appState.error, appState.transactions.isEmpty {
+            errorState(error)
+        } else if isMasked {
+            maskedPlaceholder
+        } else if appState.transactions.isEmpty {
+            emptyState
+        } else if rows.isEmpty {
+            filteredEmptyState
+        } else {
+            table
+        }
+    }
+
+    private var table: some View {
+        TransactionsTable(
+            rows: rows,
+            selection: selectionBinding,
+            isMasked: isMasked,
+            hasMorePages: pagedSource.hasMore,
+            onReachEnd: {
+                // The table is near the end of the currently-loaded page — fetch the
+                // next page from the cache (no-op outside the paged path / when one
+                // is already in flight, guarded inside the source).
+                if pagedSource.hasMore {
+                    Task { await pagedSource.loadNextPageIfNeeded() }
+                }
+            },
+            onRecategorize: { id, category in
+                animate { appState.updateReviewCategory(id, category: category) }
+            },
+            onMarkTransfer: { id, isTransfer in
+                animate { appState.markReviewItemTransfer(id, isTransfer: isTransfer) }
+            },
+            onApprove: { id in
+                animate { appState.approveReviewItem(id) }
+            }
+        )
+    }
+
+    // MARK: - Bindings to the shared NavigationModel state
+
+    private var filterBinding: Binding<TransactionWorkspace.Filter> {
+        Binding(
+            get: { navigationModel.transactionFilter },
+            set: { navigationModel.transactionFilter = $0 }
+        )
+    }
+
+    private var sortBinding: Binding<TransactionWorkspace.Sort> {
+        Binding(
+            get: { navigationModel.transactionSort },
+            set: { navigationModel.transactionSort = $0 }
+        )
+    }
+
+    /// The `Table`'s single-selection binding, bridged to the model's `""` sentinel.
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: {
+                let id = navigationModel.selectedTransactionID
+                return id.isEmpty ? nil : id
+            },
+            set: { navigationModel.selectedTransactionID = $0 ?? "" }
+        )
+    }
+
+    private func animate(_ change: () -> Void) {
+        withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+            change()
+        }
+    }
+
+    // MARK: - Empty / loading / error states
+
+    private var maskedPlaceholder: some View {
+        ContentUnavailableView {
+            Label("Transactions hidden", systemImage: "eye.slash")
+        } description: {
+            Text("Merchants and amounts are hidden while Privacy Mask or App Lock is active.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel("Transactions hidden while VaultPeek is private")
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No transactions yet", systemImage: "list.bullet.rectangle")
+        } description: {
+            Text("Connected accounts will show their transaction history here.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var filteredEmptyState: some View {
+        ContentUnavailableView {
+            Label("No matching transactions", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text("No transactions match the current filters or search.")
+        } actions: {
+            Button("Clear filters") {
+                animate {
+                    navigationModel.transactionFilter = navigationModel.transactionFilter.cleared()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("Couldn’t load transactions", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel("Could not load transactions. \(message)")
+    }
+
+    /// The detail-column (inspector) pane for Transactions — the selected row's full
+    /// detail + inline edit. Content-gated: shows "Select a transaction" when
+    /// nothing is selected (IA §3.1). A separate `View` because the shell mounts the
+    /// content and inspector columns independently; both read the shared selection
+    /// from `AppState.navigationModel`.
     struct Inspector: View {
+        @Environment(AppState.self) private var appState
+
         var body: some View {
-            DestinationInspectorPlaceholder(destination: .transactions)
+            TransactionInspectorView()
+                .environment(appState)
         }
     }
 }
 
 #Preview("Content") {
     TransactionsDestinationView()
+        .environment(AppState())
+        .frame(width: 640, height: 480)
 }
 
 #Preview("Inspector") {
     TransactionsDestinationView.Inspector()
+        .environment(AppState())
+        .frame(width: 320, height: 480)
 }

--- a/Sources/PlaidBar/Views/Destinations/TransactionsFilterBar.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsFilterBar.swift
@@ -1,0 +1,168 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The Transaction Workspace's filter + search + sort bar (AND-582).
+///
+/// Every control writes the shared ``TransactionWorkspace/Filter`` /
+/// ``TransactionWorkspace/Sort`` held in ``NavigationModel``, so the query
+/// persists per window and the table re-resolves through the pure Core pipeline.
+/// Facets compose (AND); the search field also composes with them. A result count
+/// and a "Clear" affordance round out the bar.
+struct TransactionsFilterBar: View {
+    @Binding var filter: TransactionWorkspace.Filter
+    @Binding var sort: TransactionWorkspace.Sort
+    let accounts: [AccountDTO]
+    let resultCount: Int
+    var isSearchFocused: FocusState<Bool>.Binding
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            searchRow
+            facetRow
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Search row
+
+    private var searchRow: some View {
+        HStack(spacing: Spacing.sm) {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search merchant or note", text: $filter.searchText)
+                    .textFieldStyle(.plain)
+                    .focused(isSearchFocused)
+                if !filter.searchText.isEmpty {
+                    Button {
+                        filter.searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: Radius.control))
+            .frame(maxWidth: 360)
+
+            Spacer(minLength: Spacing.sm)
+
+            Text(resultCountText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+                .accessibilityLabel(resultCountText)
+
+            if filter.isActive {
+                Button {
+                    filter = filter.cleared()
+                } label: {
+                    Label("Clear filters", systemImage: "xmark.circle")
+                }
+                .controlSize(.small)
+                .help("Reset every filter and the search")
+            }
+        }
+    }
+
+    private var resultCountText: String {
+        resultCount == 1 ? "1 transaction" : "\(resultCount) transactions"
+    }
+
+    // MARK: - Facet row
+
+    private var facetRow: some View {
+        HStack(spacing: Spacing.sm) {
+            accountPicker
+            categoryPicker
+            dateRangePicker
+            amountPicker
+            statusPicker
+
+            Spacer(minLength: Spacing.sm)
+
+            sortPicker
+        }
+        .controlSize(.small)
+    }
+
+    private var accountPicker: some View {
+        Picker("Account", selection: $filter.accountID) {
+            Text("All accounts").tag("")
+            ForEach(accounts) { account in
+                Text(accountLabel(account)).tag(account.id)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Filter by account")
+    }
+
+    private var categoryPicker: some View {
+        Picker("Category", selection: $filter.category) {
+            Text("All categories").tag(SpendingCategory?.none)
+            ForEach(SpendingCategory.allCases, id: \.self) { category in
+                Label(category.displayName, systemImage: category.iconName)
+                    .tag(SpendingCategory?.some(category))
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Filter by category")
+    }
+
+    private var dateRangePicker: some View {
+        Picker("Date", selection: $filter.dateRange) {
+            ForEach(TransactionWorkspace.DateRange.allCases, id: \.self) { range in
+                Text(range.label).tag(range)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Filter by date range")
+    }
+
+    private var amountPicker: some View {
+        Picker("Amount", selection: $filter.amountBand) {
+            ForEach(TransactionWorkspace.AmountBand.allCases, id: \.self) { band in
+                Text(band.label).tag(band)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Filter by amount")
+    }
+
+    private var statusPicker: some View {
+        Picker("Status", selection: $filter.status) {
+            ForEach(TransactionWorkspace.StatusFilter.allCases, id: \.self) { status in
+                Text(status.label).tag(status)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Filter by review status")
+    }
+
+    private var sortPicker: some View {
+        Picker("Sort", selection: $sort) {
+            ForEach(TransactionWorkspace.Sort.allCases, id: \.self) { option in
+                Text(option.label).tag(option)
+            }
+        }
+        .pickerStyle(.menu)
+        .fixedSize()
+        .accessibilityLabel("Sort transactions")
+    }
+
+    private func accountLabel(_ account: AccountDTO) -> String {
+        if let mask = account.mask, !mask.isEmpty {
+            return "\(account.name) ••\(mask)"
+        }
+        return account.name
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/TransactionsLoadingSkeleton.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsLoadingSkeleton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// A lightweight placeholder shown while the launch handshake is still loading
+/// transactions (AND-582). Redacted rows convey "content is coming" without
+/// implying real data; the rows are decorative and hidden from VoiceOver, which
+/// reads the single status label instead.
+struct TransactionsLoadingSkeleton: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var shimmer = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.rowVertical) {
+            ForEach(0..<8, id: \.self) { _ in
+                skeletonRow
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.lg)
+        .padding(.vertical, Spacing.sm)
+        .opacity(reduceMotion ? 0.6 : (shimmer ? 0.4 : 0.7))
+        .animation(
+            reduceMotion ? nil : .easeInOut(duration: 0.9).repeatForever(autoreverses: true),
+            value: shimmer
+        )
+        .onAppear { shimmer = true }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Loading transactions")
+    }
+
+    private var skeletonRow: some View {
+        HStack(spacing: Spacing.sm) {
+            Circle()
+                .fill(.quaternary)
+                .frame(width: Sizing.iconInline + 8, height: Sizing.iconInline + 8)
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                RoundedRectangle(cornerRadius: Radius.control)
+                    .fill(.quaternary)
+                    .frame(width: 180, height: 10)
+                RoundedRectangle(cornerRadius: Radius.control)
+                    .fill(.quinary)
+                    .frame(width: 90, height: 8)
+            }
+            Spacer()
+            RoundedRectangle(cornerRadius: Radius.control)
+                .fill(.quaternary)
+                .frame(width: 64, height: 10)
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
@@ -1,0 +1,225 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The Transaction Workspace's sortable, keyboard-navigable `Table` (AND-582).
+///
+/// Single-selection (the inspector follows the selected row). `Table` gives arrow
+/// navigation, Return/double-click activation, and type-to-search over the visible
+/// cell text for free; the selection binding into ``NavigationModel`` means moving
+/// the highlight updates the inspector live. Rows are the pure
+/// ``TransactionWorkspace/Row`` view-models (already filtered + sorted by Core), so
+/// this view owns only layout, the per-row context menu, and the selection.
+///
+/// Sorting is driven by the parent's ``TransactionWorkspace/Sort`` picker (not
+/// `Table`'s `sortOrder:`) because `[KeyPathComparator]` is not `Sendable` and
+/// cannot live in strict-concurrency `@State` — the same constraint
+/// `ReviewTableWindow` documents.
+///
+/// Every status/category cue pairs color with a glyph + text, never color alone
+/// (ACCESSIBILITY.md); amounts/merchants are withheld under Privacy Mask.
+struct TransactionsTable: View {
+    let rows: [TransactionWorkspace.Row]
+    @Binding var selection: String?
+    let isMasked: Bool
+    /// Whether the paged source has more pages to load (AND-567). When true, the
+    /// last row's appearance triggers `onReachEnd` to page on demand.
+    var hasMorePages: Bool = false
+    var onReachEnd: () -> Void = {}
+    let onRecategorize: (String, SpendingCategory) -> Void
+    let onMarkTransfer: (String, Bool) -> Void
+    let onApprove: (String) -> Void
+
+    var body: some View {
+        Table(rows, selection: $selection) {
+            TableColumn("Merchant") { row in
+                merchantCell(row)
+                    // Page-on-demand: when the last loaded row is rendered and more
+                    // pages remain, ask the source for the next page. `Table` itself
+                    // virtualizes row rendering, so this fires only as the user
+                    // scrolls near the end of the loaded window.
+                    .onAppear {
+                        if hasMorePages, row.id == rows.last?.id {
+                            onReachEnd()
+                        }
+                    }
+            }
+            .width(min: 180, ideal: 240)
+
+            TableColumn("Date") { row in
+                Text(Formatters.displayTransactionDate(row.transaction.date))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .width(min: 90, ideal: 110)
+
+            TableColumn("Category") { row in
+                categoryCell(row)
+            }
+            .width(min: 150, ideal: 180)
+
+            TableColumn("Status") { row in
+                statusCell(row)
+            }
+            .width(min: 110, ideal: 130)
+
+            TableColumn("Amount") { row in
+                Text(amountText(row))
+                    .monospacedDigit()
+                    .foregroundStyle(amountColor(row))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .width(min: 90, ideal: 110)
+        }
+        .contextMenu(forSelectionType: String.self) { ids in
+            contextMenu(for: ids)
+        }
+        .accessibilityLabel("Transactions table")
+    }
+
+    // MARK: - Cells
+
+    private func merchantCell(_ row: TransactionWorkspace.Row) -> some View {
+        HStack(spacing: Spacing.xs) {
+            Text(isMasked ? "•••••" : row.merchantName)
+                .lineLimit(1)
+            if row.transaction.pending {
+                Image(systemName: "clock")
+                    .font(.caption2)
+                    .foregroundStyle(SemanticColors.pending)
+                    .help("Pending")
+                    .accessibilityLabel("Pending")
+            }
+            if row.isTransfer {
+                Image(systemName: "arrow.left.arrow.right")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .help("Transfer — excluded from budgets")
+                    .accessibilityLabel("Transfer")
+            }
+            if row.hasNote {
+                Image(systemName: "note.text")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .help("Has a note")
+                    .accessibilityLabel("Has a note")
+            }
+        }
+    }
+
+    /// Category pill — glyph + text + a redundant accent (never color alone).
+    /// Mirrors the inbox/review-table pill so the surfaces match.
+    private func categoryCell(_ row: TransactionWorkspace.Row) -> some View {
+        let category = row.effectiveCategory ?? row.suggestedCategory
+        let accent = category.map(CategoryAccentTokens.color(for:)) ?? .secondary
+        return HStack(spacing: Spacing.xxs) {
+            Label(categoryTitle(row), systemImage: category?.iconName ?? "tag")
+                .font(.caption.weight(.medium))
+                .labelStyle(.titleAndIcon)
+                .foregroundStyle(accent)
+                .lineLimit(1)
+            if row.isCategorySuggested {
+                Image(systemName: "sparkles")
+                    .font(.caption2)
+                    .foregroundStyle(SemanticColors.brand)
+                    .help("Category suggested on device")
+                    .accessibilityLabel("suggested")
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Category: \(categoryTitle(row))\(row.isCategorySuggested ? ", suggested" : "")")
+    }
+
+    /// Review status — glyph + text, never color alone.
+    private func statusCell(_ row: TransactionWorkspace.Row) -> some View {
+        Label(statusTitle(row.status), systemImage: statusGlyph(row.status))
+            .font(.caption.weight(.medium))
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(statusColor(row.status))
+            .lineLimit(1)
+            .accessibilityLabel("Status: \(statusTitle(row.status))")
+    }
+
+    // MARK: - Context menu (single-row, via the existing review path)
+
+    @ViewBuilder
+    private func contextMenu(for ids: Set<String>) -> some View {
+        if let id = ids.first, let row = rows.first(where: { $0.id == id }) {
+            Menu("Recategorize") {
+                ForEach(SpendingCategory.allCases, id: \.self) { category in
+                    Button {
+                        onRecategorize(id, category)
+                    } label: {
+                        Label(category.displayName, systemImage: category.iconName)
+                    }
+                }
+            }
+
+            if row.isTransfer {
+                Button {
+                    onMarkTransfer(id, false)
+                } label: {
+                    Label("Mark not transfer", systemImage: "arrow.uturn.left")
+                }
+            } else {
+                Button {
+                    onMarkTransfer(id, true)
+                } label: {
+                    Label("Mark transfer", systemImage: "arrow.left.arrow.right")
+                }
+            }
+
+            Divider()
+
+            if row.status != .reviewed {
+                Button {
+                    onApprove(id)
+                } label: {
+                    Label("Mark reviewed", systemImage: "checkmark")
+                }
+            }
+        } else {
+            Text("No transaction selected")
+        }
+    }
+
+    // MARK: - Formatting helpers
+
+    private func amountText(_ row: TransactionWorkspace.Row) -> String {
+        if isMasked { return "••••" }
+        let prefix = row.transaction.isIncome ? "+" : ""
+        return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
+    }
+
+    private func amountColor(_ row: TransactionWorkspace.Row) -> Color {
+        if isMasked { return .secondary }
+        return row.transaction.isIncome ? SemanticColors.positive : AppearanceTextColors.primary
+    }
+
+    private func categoryTitle(_ row: TransactionWorkspace.Row) -> String {
+        (row.effectiveCategory ?? row.suggestedCategory)?.displayName ?? "Uncategorized"
+    }
+
+    private func statusTitle(_ status: TransactionReviewStatus) -> String {
+        switch status {
+        case .needsReview: "Needs review"
+        case .reviewed: "Reviewed"
+        case .ignored: "Ignored"
+        }
+    }
+
+    private func statusGlyph(_ status: TransactionReviewStatus) -> String {
+        switch status {
+        case .needsReview: "exclamationmark.circle"
+        case .reviewed: "checkmark.circle"
+        case .ignored: "minus.circle"
+        }
+    }
+
+    private func statusColor(_ status: TransactionReviewStatus) -> Color {
+        switch status {
+        case .needsReview: SemanticColors.warning
+        case .reviewed: SemanticColors.positive
+        case .ignored: .secondary
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/NavigationState.swift
+++ b/Sources/PlaidBarCore/Models/NavigationState.swift
@@ -35,16 +35,38 @@ public struct NavigationState: Sendable, Equatable, Codable {
     /// `@AppStorage("dashboard.heatmapMode")` on the heatmap subview.
     public var heatmapMode: SpendingHeatmapMode
 
+    // MARK: Transaction Workspace state (AND-582, Epic 4)
+
+    /// The Transaction Workspace ledger's composed filter + search. Held here (not
+    /// view-level) so the window restores its last query and the table + inspector
+    /// share one source of truth (the prompt's "filter/search state lives in
+    /// NavigationModel"). All facets compose; the default passes everything.
+    public var transactionFilter: TransactionWorkspace.Filter
+
+    /// The Transaction Workspace table sort order.
+    public var transactionSort: TransactionWorkspace.Sort
+
+    /// The selected transaction id in the workspace, or empty when none. Empty
+    /// string (not `nil`) mirrors the `selectedAccountID` "" sentinel so the
+    /// content-gated inspector shows its "Select a transaction" prompt.
+    public var selectedTransactionID: String
+
     public init(
         destination: RouteDestination = .dashboard,
         dashboardFilter: DashboardAccountFilterKind = .all,
         selectedAccountID: String = "",
-        heatmapMode: SpendingHeatmapMode = .spending
+        heatmapMode: SpendingHeatmapMode = .spending,
+        transactionFilter: TransactionWorkspace.Filter = TransactionWorkspace.Filter(),
+        transactionSort: TransactionWorkspace.Sort = .dateDescending,
+        selectedTransactionID: String = ""
     ) {
         self.destination = destination
         self.dashboardFilter = dashboardFilter
         self.selectedAccountID = selectedAccountID
         self.heatmapMode = heatmapMode
+        self.transactionFilter = transactionFilter
+        self.transactionSort = transactionSort
+        self.selectedTransactionID = selectedTransactionID
     }
 
     // MARK: - Pure transitions
@@ -125,5 +147,44 @@ public struct NavigationState: Sendable, Equatable, Codable {
             selectedAccountID,
             visibleAccountIds: visibleAccountIDs
         )
+    }
+
+    // MARK: - Transaction Workspace transitions (AND-582)
+
+    /// Replace the workspace filter/search. Changing the filter clears the row
+    /// selection (the selected row may no longer be listed), mirroring the
+    /// dashboard filter→deselect rule. No-op (and no deselect) when unchanged.
+    public mutating func setTransactionFilter(_ filter: TransactionWorkspace.Filter) {
+        guard filter != transactionFilter else { return }
+        transactionFilter = filter
+        selectedTransactionID = ""
+    }
+
+    /// Change the workspace sort order (does not affect the selection).
+    public mutating func setTransactionSort(_ sort: TransactionWorkspace.Sort) {
+        transactionSort = sort
+    }
+
+    /// Select a transaction row in the workspace.
+    public mutating func selectTransaction(id: String) {
+        selectedTransactionID = id
+    }
+
+    /// Clear the workspace row selection.
+    public mutating func deselectTransaction() {
+        selectedTransactionID = ""
+    }
+
+    /// Drop a selected transaction id that is no longer among the visible (filtered)
+    /// rows — the same self-heal the dashboard does for accounts. Returns `true`
+    /// when a stale selection was cleared.
+    @discardableResult
+    public mutating func reconcileTransactionSelection(visibleTransactionIDs: [String]) -> Bool {
+        guard !selectedTransactionID.isEmpty,
+              !visibleTransactionIDs.contains(selectedTransactionID) else {
+            return false
+        }
+        selectedTransactionID = ""
+        return true
     }
 }

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -52,6 +52,14 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
     public var lastSeenAmount: Double?
     public var lastSeenName: String?
     public var lastSeenPending: Bool?
+    /// A free-text note the user attached to this transaction from the
+    /// Transaction Workspace inspector (AND-582). Display-only annotation: it is
+    /// never fed to budget/category/export totals and never bypasses the
+    /// review/override flow, so it cannot mis-attribute spend. Persisted on the
+    /// same review-metadata storage path as every other override. `nil` (and
+    /// decoded as `nil` when absent) so records written before AND-582 still
+    /// decode and behave identically.
+    public var userNote: String?
 
     public init(
         id: String,
@@ -64,7 +72,8 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
         reviewReasonCodes: [TransactionReviewReason] = [],
         lastSeenAmount: Double? = nil,
         lastSeenName: String? = nil,
-        lastSeenPending: Bool? = nil
+        lastSeenPending: Bool? = nil,
+        userNote: String? = nil
     ) {
         self.id = id
         self.status = status
@@ -77,6 +86,26 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
         self.lastSeenAmount = lastSeenAmount
         self.lastSeenName = lastSeenName
         self.lastSeenPending = lastSeenPending
+        self.userNote = userNote
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        status = try container.decode(TransactionReviewStatus.self, forKey: .status)
+        userCategory = try container.decodeIfPresent(SpendingCategory.self, forKey: .userCategory)
+        userMerchantName = try container.decodeIfPresent(String.self, forKey: .userMerchantName)
+        isTransferOverride = try container.decodeIfPresent(Bool.self, forKey: .isTransferOverride)
+        excludedFromBudgets = try container.decodeIfPresent(Bool.self, forKey: .excludedFromBudgets) ?? false
+        reviewedAt = try container.decodeIfPresent(Date.self, forKey: .reviewedAt)
+        reviewReasonCodes = try container.decodeIfPresent([TransactionReviewReason].self, forKey: .reviewReasonCodes) ?? []
+        lastSeenAmount = try container.decodeIfPresent(Double.self, forKey: .lastSeenAmount)
+        lastSeenName = try container.decodeIfPresent(String.self, forKey: .lastSeenName)
+        lastSeenPending = try container.decodeIfPresent(Bool.self, forKey: .lastSeenPending)
+        // New field (AND-582) — absent in records written before it existed, so
+        // default to nil. Matches the forward-compatible decode used for
+        // `TransactionDTO.isLowConfidenceCategory`.
+        userNote = try container.decodeIfPresent(String.self, forKey: .userNote)
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/TransactionWorkspace.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionWorkspace.swift
@@ -1,0 +1,391 @@
+import Foundation
+
+/// Pure, value-type model for the **Transaction Workspace** (AND-582, Epic 4) —
+/// the window-first ledger's filter/search/sort state and the row view-model its
+/// `Table` renders.
+///
+/// All of this lives in PlaidBarCore (CLAUDE.md: shared logic out of views) so the
+/// compose pipeline — filter, then search, then sort — is unit-testable without
+/// SwiftUI and shared by both the table column rendering and the inspector. The
+/// override-aware spend attributes (effective category, transfer, exclusion) come
+/// from the existing ``EffectiveCategoryResolver``; nothing here re-derives spend
+/// math. The note/category/transfer *edits* persist through the existing AppState
+/// review path — this file only reads the resolved state.
+public enum TransactionWorkspace {}
+
+// MARK: - Filter
+
+public extension TransactionWorkspace {
+    /// A relative date window for the ledger. Resolved to a concrete lower-bound
+    /// `yyyy-MM-dd` key against a supplied "today", so the comparison is a cheap
+    /// string compare on the canonical transaction date (no `DateFormatter` per
+    /// row). `allTime` imposes no lower bound.
+    enum DateRange: String, CaseIterable, Sendable, Codable, Hashable {
+        case allTime
+        case last7Days
+        case last30Days
+        case last90Days
+        case thisYear
+
+        public var label: String {
+            switch self {
+            case .allTime: "All time"
+            case .last7Days: "Last 7 days"
+            case .last30Days: "Last 30 days"
+            case .last90Days: "Last 90 days"
+            case .thisYear: "This year"
+            }
+        }
+
+        /// The inclusive lower-bound transaction-date key for this range relative to
+        /// `now`, or `nil` for `allTime`. A transaction passes when its date key is
+        /// `>=` this value.
+        public func lowerBoundKey(now: Date, calendar: Calendar = .current) -> String? {
+            switch self {
+            case .allTime:
+                return nil
+            case .last7Days:
+                return Self.key(daysAgo: 7, from: now, calendar: calendar)
+            case .last30Days:
+                return Self.key(daysAgo: 30, from: now, calendar: calendar)
+            case .last90Days:
+                return Self.key(daysAgo: 90, from: now, calendar: calendar)
+            case .thisYear:
+                let year = calendar.component(.year, from: now)
+                return String(format: "%04d-01-01", year)
+            }
+        }
+
+        private static func key(daysAgo days: Int, from now: Date, calendar: Calendar) -> String? {
+            guard let date = calendar.date(byAdding: .day, value: -days, to: now) else { return nil }
+            return Formatters.transactionDateString(date)
+        }
+    }
+
+    /// The amount-magnitude band a row must fall in (absolute value, in dollars).
+    /// All thresholds compare against `TransactionDTO.displayAmount`.
+    enum AmountBand: String, CaseIterable, Sendable, Codable, Hashable {
+        case any
+        case under25
+        case from25to100
+        case from100to500
+        case over500
+
+        public var label: String {
+            switch self {
+            case .any: "Any amount"
+            case .under25: "Under $25"
+            case .from25to100: "$25 – $100"
+            case .from100to500: "$100 – $500"
+            case .over500: "Over $500"
+            }
+        }
+
+        public func contains(_ displayAmount: Double) -> Bool {
+            switch self {
+            case .any: true
+            case .under25: displayAmount < 25
+            case .from25to100: displayAmount >= 25 && displayAmount < 100
+            case .from100to500: displayAmount >= 100 && displayAmount < 500
+            case .over500: displayAmount >= 500
+            }
+        }
+    }
+
+    /// The review-status facet a row must match. Mirrors the inbox's three states
+    /// plus "any" and a derived "flagged" (still needs review) facet.
+    enum StatusFilter: String, CaseIterable, Sendable, Codable, Hashable {
+        case any
+        case needsReview
+        case reviewed
+        case ignored
+
+        public var label: String {
+            switch self {
+            case .any: "Any status"
+            case .needsReview: "Needs review"
+            case .reviewed: "Reviewed"
+            case .ignored: "Ignored"
+            }
+        }
+
+        public func matches(_ status: TransactionReviewStatus) -> Bool {
+            switch self {
+            case .any: true
+            case .needsReview: status == .needsReview
+            case .reviewed: status == .reviewed
+            case .ignored: status == .ignored
+            }
+        }
+    }
+
+    /// The composable filter + search state for the ledger. Persisted in
+    /// `NavigationState` so the window restores its last query. All facets compose
+    /// (AND); empty/`any` facets are no-ops, so the default value passes everything.
+    struct Filter: Sendable, Codable, Hashable {
+        /// Empty string ⇒ all accounts (matches the dashboard "" sentinel).
+        public var accountID: String
+        /// `nil` ⇒ all categories. Matches the row's *effective* category.
+        public var category: SpendingCategory?
+        public var dateRange: DateRange
+        public var amountBand: AmountBand
+        public var status: StatusFilter
+        /// Free-text search; matched case-insensitively against merchant + raw name.
+        public var searchText: String
+
+        public init(
+            accountID: String = "",
+            category: SpendingCategory? = nil,
+            dateRange: DateRange = .allTime,
+            amountBand: AmountBand = .any,
+            status: StatusFilter = .any,
+            searchText: String = ""
+        ) {
+            self.accountID = accountID
+            self.category = category
+            self.dateRange = dateRange
+            self.amountBand = amountBand
+            self.status = status
+            self.searchText = searchText
+        }
+
+        /// Whether any facet narrows the result set (drives the "Clear filters"
+        /// affordance and the filtered empty state).
+        public var isActive: Bool {
+            !accountID.isEmpty
+                || category != nil
+                || dateRange != .allTime
+                || amountBand != .any
+                || status != .any
+                || !trimmedSearch.isEmpty
+        }
+
+        /// The trimmed search term (so leading/trailing whitespace never blanks the
+        /// list or counts as an active filter).
+        public var trimmedSearch: String {
+            searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        public func cleared() -> Filter { Filter() }
+    }
+}
+
+// MARK: - Sort
+
+public extension TransactionWorkspace {
+    /// The table sort order, stored as a small `Sendable` enum because
+    /// `[KeyPathComparator]` is not `Sendable` and cannot live in `@State` under
+    /// strict concurrency (the same constraint `ReviewTableWindow` documents). The
+    /// table sorts via ``sorted(_:)`` rather than `Table`'s `sortOrder:` binding.
+    enum Sort: String, CaseIterable, Sendable, Codable, Hashable {
+        case dateDescending
+        case dateAscending
+        case amountDescending
+        case amountAscending
+        case merchantAscending
+
+        public var label: String {
+            switch self {
+            case .dateDescending: "Newest first"
+            case .dateAscending: "Oldest first"
+            case .amountDescending: "Largest amount"
+            case .amountAscending: "Smallest amount"
+            case .merchantAscending: "Merchant A–Z"
+            }
+        }
+
+        public func sorted(_ rows: [Row]) -> [Row] {
+            switch self {
+            case .dateDescending:
+                rows.sorted { lhs, rhs in
+                    if lhs.transaction.date != rhs.transaction.date {
+                        return lhs.transaction.date > rhs.transaction.date
+                    }
+                    return lhs.id < rhs.id
+                }
+            case .dateAscending:
+                rows.sorted { lhs, rhs in
+                    if lhs.transaction.date != rhs.transaction.date {
+                        return lhs.transaction.date < rhs.transaction.date
+                    }
+                    return lhs.id < rhs.id
+                }
+            case .amountDescending:
+                rows.sorted { lhs, rhs in
+                    if lhs.transaction.displayAmount != rhs.transaction.displayAmount {
+                        return lhs.transaction.displayAmount > rhs.transaction.displayAmount
+                    }
+                    return lhs.id < rhs.id
+                }
+            case .amountAscending:
+                rows.sorted { lhs, rhs in
+                    if lhs.transaction.displayAmount != rhs.transaction.displayAmount {
+                        return lhs.transaction.displayAmount < rhs.transaction.displayAmount
+                    }
+                    return lhs.id < rhs.id
+                }
+            case .merchantAscending:
+                rows.sorted { lhs, rhs in
+                    let lk = lhs.merchantName.localizedLowercase
+                    let rk = rhs.merchantName.localizedLowercase
+                    if lk != rk { return lk < rk }
+                    return lhs.id < rhs.id
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Row view-model
+
+public extension TransactionWorkspace {
+    /// One ledger row: the raw transaction plus its override-aware resolved spend
+    /// attributes (from ``EffectiveCategoryResolver``) and review status. Pure and
+    /// `Sendable` so the `Table` renders it directly and tests assert against it
+    /// without SwiftUI.
+    struct Row: Sendable, Identifiable, Hashable {
+        public let transaction: TransactionDTO
+        /// Effective merchant display name: user rename → cleaned → raw.
+        public let merchantName: String
+        /// The override-aware effective (budget) category — user override → rule →
+        /// confident Plaid → uncategorized. May be `nil` (genuinely uncategorized).
+        public let effectiveCategory: SpendingCategory?
+        /// Display-only on-device NL suggestion (the "Suggested" badge), when the
+        /// category came from neither the user nor a rule.
+        public let suggestedCategory: SpendingCategory?
+        public let isTransfer: Bool
+        public let excludedFromBudgets: Bool
+        public let status: TransactionReviewStatus
+        /// The user's free-text note, if any (display-only).
+        public let note: String?
+
+        public var id: String { transaction.id }
+
+        public init(
+            transaction: TransactionDTO,
+            merchantName: String,
+            effectiveCategory: SpendingCategory?,
+            suggestedCategory: SpendingCategory?,
+            isTransfer: Bool,
+            excludedFromBudgets: Bool,
+            status: TransactionReviewStatus,
+            note: String?
+        ) {
+            self.transaction = transaction
+            self.merchantName = merchantName
+            self.effectiveCategory = effectiveCategory
+            self.suggestedCategory = suggestedCategory
+            self.isTransfer = isTransfer
+            self.excludedFromBudgets = excludedFromBudgets
+            self.status = status
+            self.note = note
+        }
+
+        /// Whether this row's effective category was filled by the on-device NL
+        /// tier rather than the user / Plaid — drives the "Suggested" badge.
+        public var isCategorySuggested: Bool {
+            effectiveCategory == nil && suggestedCategory != nil
+        }
+
+        /// Whether a free-text note is attached (drives a glyph in the table).
+        public var hasNote: Bool {
+            !(note?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        }
+    }
+}
+
+// MARK: - Pipeline (build → filter → search → sort)
+
+public extension TransactionWorkspace {
+    /// Builds the override-aware row view-models for every transaction, reusing the
+    /// existing ``EffectiveCategoryResolver`` (no spend re-derivation) and the
+    /// persisted review metadata. NL inference is intentionally **not** run here
+    /// (it is async / expensive); the resolver's `suggestedCategory` is consulted
+    /// only via the metadata path, so the table stays synchronous and cheap. The
+    /// caller supplies the same `metadata`/`rules` AppState already holds.
+    static func rows(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata],
+        rules: [TransactionRule]
+    ) -> [Row] {
+        let metadataByID = Dictionary(uniqueKeysWithValues: metadata.map { ($0.id, $0) })
+        return transactions.map { transaction in
+            let own = metadataByID[transaction.id]
+            let resolution = EffectiveCategoryResolver.resolve(
+                transaction: transaction,
+                metadata: own,
+                rules: rules
+            )
+            let merchant = trimmedNonEmpty(own?.userMerchantName)
+                ?? trimmedNonEmpty(transaction.merchantName)
+                ?? transaction.name
+            return Row(
+                transaction: transaction,
+                merchantName: merchant,
+                effectiveCategory: resolution.category,
+                suggestedCategory: resolution.suggestedCategory,
+                isTransfer: resolution.isTransfer,
+                excludedFromBudgets: resolution.excludedFromBudgets,
+                status: own?.status ?? .needsReview,
+                note: trimmedNonEmpty(own?.userNote)
+            )
+        }
+    }
+
+    /// Applies the filter (AND of every facet) + search to the rows. `now` resolves
+    /// any relative date range; injecting it keeps the date facet deterministic in
+    /// tests.
+    static func filtered(_ rows: [Row], by filter: Filter, now: Date) -> [Row] {
+        let lowerBound = filter.dateRange.lowerBoundKey(now: now)
+        let search = filter.trimmedSearch.localizedLowercase
+        return rows.filter { row in
+            if !filter.accountID.isEmpty, row.transaction.accountId != filter.accountID {
+                return false
+            }
+            if let category = filter.category {
+                // Match against the *effective* (override-aware) category so a
+                // recategorized row filters where the user expects it.
+                guard row.effectiveCategory == category else { return false }
+            }
+            if let lowerBound, row.transaction.date < lowerBound {
+                return false
+            }
+            if !filter.amountBand.contains(row.transaction.displayAmount) {
+                return false
+            }
+            if !filter.status.matches(row.status) {
+                return false
+            }
+            if !search.isEmpty {
+                let merchant = row.merchantName.localizedLowercase
+                let raw = row.transaction.name.localizedLowercase
+                let note = row.note?.localizedLowercase ?? ""
+                guard merchant.contains(search) || raw.contains(search) || note.contains(search) else {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+
+    /// The full pipeline: build rows, filter + search, then sort. The single entry
+    /// point the view calls.
+    static func resolve(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata],
+        rules: [TransactionRule],
+        filter: Filter,
+        sort: Sort,
+        now: Date
+    ) -> [Row] {
+        let built = rows(transactions: transactions, metadata: metadata, rules: rules)
+        let narrowed = filtered(built, by: filter, now: now)
+        return sort.sorted(narrowed)
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionWorkspaceTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionWorkspaceTests.swift
@@ -1,0 +1,318 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+/// Unit coverage for the pure Transaction Workspace pipeline (AND-582, Epic 4):
+/// filter facets, search, sort, override-aware row building, the NavigationState
+/// transitions, and the `userNote` Codable round-trip.
+@Suite("Transaction Workspace")
+struct TransactionWorkspaceTests {
+    // MARK: - Fixtures
+
+    private func tx(
+        _ id: String,
+        account: String = "acc1",
+        amount: Double = 50,
+        date: String = "2026-06-10",
+        name: String = "Coffee Shop",
+        merchant: String? = "Coffee Shop",
+        category: SpendingCategory? = .foodAndDrink,
+        pending: Bool = false
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: account,
+            amount: amount,
+            date: date,
+            name: name,
+            merchantName: merchant,
+            category: category,
+            pending: pending
+        )
+    }
+
+    private let now = Formatters.parseTransactionDate("2026-06-15")!
+
+    // MARK: - Row building (override-aware)
+
+    @Test("Rows surface the override-aware effective category and merchant rename")
+    func rowsAreOverrideAware() {
+        let transactions = [tx("a", category: .other)]
+        let metadata = [
+            TransactionReviewMetadata(
+                id: "a",
+                status: .reviewed,
+                userCategory: .shopping,
+                userMerchantName: "Renamed Co"
+            ),
+        ]
+        let rows = TransactionWorkspace.rows(transactions: transactions, metadata: metadata, rules: [])
+        #expect(rows.count == 1)
+        #expect(rows[0].effectiveCategory == .shopping)
+        #expect(rows[0].merchantName == "Renamed Co")
+        #expect(rows[0].status == .reviewed)
+    }
+
+    @Test("A transfer override marks the row as transfer + excluded from budgets")
+    func transferOverrideReflected() {
+        let metadata = [TransactionReviewMetadata(id: "a", isTransferOverride: true)]
+        let rows = TransactionWorkspace.rows(transactions: [tx("a")], metadata: metadata, rules: [])
+        #expect(rows[0].isTransfer)
+        #expect(rows[0].excludedFromBudgets)
+    }
+
+    @Test("A row with no metadata defaults to needsReview and no note")
+    func defaultStatus() {
+        let rows = TransactionWorkspace.rows(transactions: [tx("a")], metadata: [], rules: [])
+        #expect(rows[0].status == .needsReview)
+        #expect(rows[0].note == nil)
+        #expect(!rows[0].hasNote)
+    }
+
+    @Test("A note is surfaced and drives hasNote")
+    func noteSurfaced() {
+        let metadata = [TransactionReviewMetadata(id: "a", userNote: "  trip reimbursement  ")]
+        let rows = TransactionWorkspace.rows(transactions: [tx("a")], metadata: metadata, rules: [])
+        #expect(rows[0].note == "trip reimbursement")
+        #expect(rows[0].hasNote)
+    }
+
+    // MARK: - Filtering (each facet, and composition)
+
+    private func rows() -> [TransactionWorkspace.Row] {
+        let transactions = [
+            tx("food", account: "acc1", amount: 12, date: "2026-06-14", merchant: "Cafe", category: .foodAndDrink),
+            tx("shop", account: "acc2", amount: 240, date: "2026-06-01", merchant: "Big Store", category: .shopping),
+            tx("old", account: "acc1", amount: 800, date: "2026-01-02", merchant: "Flight", category: .travel),
+        ]
+        let metadata = [
+            TransactionReviewMetadata(id: "food", status: .needsReview),
+            TransactionReviewMetadata(id: "shop", status: .reviewed),
+            TransactionReviewMetadata(id: "old", status: .ignored),
+        ]
+        return TransactionWorkspace.rows(transactions: transactions, metadata: metadata, rules: [])
+    }
+
+    @Test("Account facet narrows to one account")
+    func accountFacet() {
+        let filter = TransactionWorkspace.Filter(accountID: "acc2")
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["shop"])
+    }
+
+    @Test("Category facet matches the effective category")
+    func categoryFacet() {
+        let filter = TransactionWorkspace.Filter(category: .travel)
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["old"])
+    }
+
+    @Test("Date range facet drops rows older than the window")
+    func dateFacet() {
+        let filter = TransactionWorkspace.Filter(dateRange: .last30Days)
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        // "old" (2026-01-02) is older than 30 days before 2026-06-15.
+        #expect(Set(out.map(\.id)) == ["food", "shop"])
+    }
+
+    @Test("Amount band facet filters by magnitude")
+    func amountFacet() {
+        let filter = TransactionWorkspace.Filter(amountBand: .over500)
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["old"])
+    }
+
+    @Test("Status facet filters by review status")
+    func statusFacet() {
+        let filter = TransactionWorkspace.Filter(status: .reviewed)
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["shop"])
+    }
+
+    @Test("Search matches merchant case-insensitively")
+    func searchFacet() {
+        let filter = TransactionWorkspace.Filter(searchText: "big")
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["shop"])
+    }
+
+    @Test("Search also matches the note text")
+    func searchMatchesNote() {
+        let transactions = [tx("a", merchant: "Generic")]
+        let metadata = [TransactionReviewMetadata(id: "a", userNote: "vacation flight")]
+        let built = TransactionWorkspace.rows(transactions: transactions, metadata: metadata, rules: [])
+        let filter = TransactionWorkspace.Filter(searchText: "vacation")
+        #expect(TransactionWorkspace.filtered(built, by: filter, now: now).map(\.id) == ["a"])
+    }
+
+    @Test("Facets compose with AND semantics")
+    func facetsCompose() {
+        let filter = TransactionWorkspace.Filter(accountID: "acc1", amountBand: .over500)
+        let out = TransactionWorkspace.filtered(rows(), by: filter, now: now)
+        #expect(out.map(\.id) == ["old"])
+    }
+
+    @Test("The default filter passes everything and is inactive")
+    func defaultFilterPassesAll() {
+        let filter = TransactionWorkspace.Filter()
+        #expect(!filter.isActive)
+        #expect(TransactionWorkspace.filtered(rows(), by: filter, now: now).count == 3)
+    }
+
+    @Test("Whitespace-only search is not active and does not blank the list")
+    func whitespaceSearchInert() {
+        let filter = TransactionWorkspace.Filter(searchText: "   ")
+        #expect(!filter.isActive)
+        #expect(TransactionWorkspace.filtered(rows(), by: filter, now: now).count == 3)
+    }
+
+    // MARK: - Sorting
+
+    @Test("Date descending then ascending sort")
+    func dateSorts() {
+        let r = rows()
+        #expect(TransactionWorkspace.Sort.dateDescending.sorted(r).map(\.id) == ["food", "shop", "old"])
+        #expect(TransactionWorkspace.Sort.dateAscending.sorted(r).map(\.id) == ["old", "shop", "food"])
+    }
+
+    @Test("Amount descending then ascending sort")
+    func amountSorts() {
+        let r = rows()
+        #expect(TransactionWorkspace.Sort.amountDescending.sorted(r).map(\.id) == ["old", "shop", "food"])
+        #expect(TransactionWorkspace.Sort.amountAscending.sorted(r).map(\.id) == ["food", "shop", "old"])
+    }
+
+    @Test("Merchant A–Z sort")
+    func merchantSort() {
+        let r = rows()
+        // Big Store, Cafe, Flight
+        #expect(TransactionWorkspace.Sort.merchantAscending.sorted(r).map(\.id) == ["shop", "food", "old"])
+    }
+
+    @Test("Full resolve pipeline filters then sorts")
+    func fullPipeline() {
+        let transactions = [
+            tx("a", amount: 10, date: "2026-06-14", category: .foodAndDrink),
+            tx("b", amount: 30, date: "2026-06-13", category: .foodAndDrink),
+            tx("c", amount: 20, date: "2026-06-12", category: .shopping),
+        ]
+        let out = TransactionWorkspace.resolve(
+            transactions: transactions,
+            metadata: [],
+            rules: [],
+            filter: TransactionWorkspace.Filter(category: .foodAndDrink),
+            sort: .amountDescending,
+            now: now
+        )
+        #expect(out.map(\.id) == ["b", "a"])
+    }
+
+    // MARK: - AmountBand / DateRange boundaries
+
+    @Test("Amount bands cover contiguous magnitude ranges")
+    func amountBandBoundaries() {
+        #expect(TransactionWorkspace.AmountBand.under25.contains(24.99))
+        #expect(!TransactionWorkspace.AmountBand.under25.contains(25))
+        #expect(TransactionWorkspace.AmountBand.from25to100.contains(25))
+        #expect(TransactionWorkspace.AmountBand.from25to100.contains(99.99))
+        #expect(TransactionWorkspace.AmountBand.from100to500.contains(100))
+        #expect(TransactionWorkspace.AmountBand.over500.contains(500))
+        #expect(TransactionWorkspace.AmountBand.any.contains(0))
+    }
+
+    @Test("All-time range imposes no lower bound; this-year starts Jan 1")
+    func dateRangeBounds() {
+        #expect(TransactionWorkspace.DateRange.allTime.lowerBoundKey(now: now) == nil)
+        #expect(TransactionWorkspace.DateRange.thisYear.lowerBoundKey(now: now) == "2026-01-01")
+    }
+}
+
+// MARK: - NavigationState transitions
+
+@Suite("NavigationState transaction workspace")
+struct NavigationStateTransactionTests {
+    @Test("Setting a different filter clears the row selection")
+    func filterChangeClearsSelection() {
+        var state = NavigationState()
+        state.selectTransaction(id: "tx1")
+        state.setTransactionFilter(TransactionWorkspace.Filter(category: .travel))
+        #expect(state.selectedTransactionID == "")
+        #expect(state.transactionFilter.category == .travel)
+    }
+
+    @Test("Setting the same filter is a no-op and keeps the selection")
+    func sameFilterKeepsSelection() {
+        var state = NavigationState()
+        state.selectTransaction(id: "tx1")
+        state.setTransactionFilter(TransactionWorkspace.Filter())
+        #expect(state.selectedTransactionID == "tx1")
+    }
+
+    @Test("Sort changes do not clear the selection")
+    func sortKeepsSelection() {
+        var state = NavigationState()
+        state.selectTransaction(id: "tx1")
+        state.setTransactionSort(.amountDescending)
+        #expect(state.selectedTransactionID == "tx1")
+        #expect(state.transactionSort == .amountDescending)
+    }
+
+    @Test("Deselect clears the row selection")
+    func deselect() {
+        var state = NavigationState()
+        state.selectTransaction(id: "tx1")
+        state.deselectTransaction()
+        #expect(state.selectedTransactionID == "")
+    }
+
+    @Test("Reconcile drops a selection no longer visible")
+    func reconcile() {
+        var state = NavigationState()
+        state.selectTransaction(id: "gone")
+        let didClear = state.reconcileTransactionSelection(visibleTransactionIDs: ["a", "b"])
+        #expect(didClear)
+        #expect(state.selectedTransactionID == "")
+        // A still-visible selection survives.
+        state.selectTransaction(id: "a")
+        let didClearVisible = state.reconcileTransactionSelection(visibleTransactionIDs: ["a", "b"])
+        #expect(!didClearVisible)
+        #expect(state.selectedTransactionID == "a")
+    }
+
+    @Test("Two states hold independent transaction selection (per-window)")
+    func independentWindows() {
+        var one = NavigationState()
+        var two = NavigationState()
+        one.selectTransaction(id: "tx1")
+        two.selectTransaction(id: "tx2")
+        #expect(one.selectedTransactionID == "tx1")
+        #expect(two.selectedTransactionID == "tx2")
+    }
+}
+
+// MARK: - userNote Codable compatibility
+
+@Suite("TransactionReviewMetadata userNote")
+struct TransactionReviewMetadataNoteTests {
+    @Test("userNote round-trips through Codable")
+    func roundTrip() throws {
+        let original = TransactionReviewMetadata(id: "a", status: .reviewed, userNote: "remember this")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TransactionReviewMetadata.self, from: data)
+        #expect(decoded.userNote == "remember this")
+        #expect(decoded == original)
+    }
+
+    @Test("Records written before userNote existed still decode (nil note)")
+    func forwardCompatibleDecode() throws {
+        // Simulate an older payload with no `userNote` key.
+        let json = """
+        {"id":"a","status":"reviewed","excludedFromBudgets":false,"reviewReasonCodes":[]}
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(TransactionReviewMetadata.self, from: data)
+        #expect(decoded.id == "a")
+        #expect(decoded.status == .reviewed)
+        #expect(decoded.userNote == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fills `TransactionsDestinationView` for the window-first shell — a 3-column ledger: a sortable, keyboard-navigable transaction **Table** (content column) → a transaction **inspector** (detail column). Epic 4 of the window-first workspace.

**Epic:** AND-582 — Transaction Workspace · **ADR-001** (window-first macOS 26 destination).

## Flag-off note

Everything here is reached **only** when the window-first `Window` opens (`WindowFirstFeatureFlag` ON). With the flag OFF the popover/legacy surfaces are byte-identical — no popover/legacy code was touched. I did not edit `AppShellView`, `DestinationRouter`, `PlaidBarApp`, or any other epic's destination file.

## What's in it

- **Sortable, keyboard-navigable Table** — columns Merchant / Date / Category / Status / Amount. Arrow navigation, Return/double-click activation, and type-to-search are native to SwiftUI `Table`; single-selection drives the inspector live.
- **Faceted filters + ⌘F search** — account, category (override-aware), date range, amount band, review status — all compose (AND), plus a search field (matches merchant, raw name, note). **Filter / sort / selection live in `NavigationModel`** (extends the existing dashboard filter) and persist per window.
- **AND-567 large-history paging wired in** — `PagedTransactionSource` / `PagedTransactionFeed` feed the table; page-on-demand as the table nears the end, and the remaining pages drain while a filter is active so facets apply to the **whole** history (not just scrolled pages). Stays on the in-memory fallback when the cache is unavailable/disabled → no regression.
- **Inspector** — full detail + inline edit: recategorize, add/clear **note**, mark / **un-mark** transfer, inline **"always categorize this merchant"** rule, mark reviewed. Every edit routes through the **existing** `AppState` review path, so the workspace, the Review Inbox, budgets, and the category dashboard never diverge and every edit is **undoable** (⌘Z).
- **Empty / loading / error / masked states** — `ContentUnavailableView` + a redacted skeleton; Privacy Mask / App Lock withholds merchant + amount.

## Reused components (nothing rebuilt)

- `EffectiveCategoryResolver` (override-aware effective category / transfer / exclusion — no spend re-derivation)
- `PagedTransactionSource` / `PagedTransactionFeed` / `TransactionCacheStore` (AND-567 paging)
- `AppState` review path: `updateReviewCategory`, `markReviewItemTransfer`, `createRule`, `approveReviewItem` (+ new additive `updateReviewNote`)
- `MerchantLogoView`, `TransactionMiniRow` visual system, `CategoryAccentTokens`, `DesignTokens` / `Spacing` / `Typography` / `SemanticColors`

## New Core (pure, unit-tested)

- `TransactionWorkspace` — filter / search / sort enums + the override-aware row builder and the build→filter→search→sort pipeline.
- `NavigationState` — transaction filter/sort/selection fields + transitions (per-window, value-type).
- `TransactionReviewMetadata.userNote` — additive, forward-compatible Codable (older records decode with `nil`).

## Accessibility

Status and category are always conveyed with **glyph + text**, never color alone (ACCESSIBILITY.md). Amounts/merchants are withheld under Privacy Mask.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — **1916 passed** (+28 new Core tests over the ~1888 baseline): filter facets, search (incl. note), sort, override-aware row building, NavigationState transitions, `userNote` round-trip + forward-compat decode.

## Deferred follow-ups

- Bulk multi-select actions in the workspace table (single-row context-menu edits only here; the detached `ReviewTableWindow` already covers bulk triage).
- Row selection is intentionally **not** persisted across relaunch (ephemeral per-session window state); revisit if deep-link-to-row restoration is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)