### PR TITLE
feat(intents): Core AppIntentsPackage, Route deep-links, widget families + Spotlight snippet (AND-586)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3773,6 +3773,9 @@ final class AppState {
             recurringTransactions: recurringTransactions,
             cashflow: cashflow,
             isMasked: shouldMaskFinancialValues,
+            transactions: transactions,
+            reviewMetadata: transactionReviewMetadata,
+            transactionRules: transactionRules,
             creditUtilizationThreshold: creditUtilizationThreshold,
             generatedAt: updatedAt
         )

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -243,8 +243,8 @@ struct PlaidBarApp: App {
                     applySummonHotkeyState()
                 }
                 .onOpenURL { url in
-                    guard url.scheme == "vaultpeek" else { return }
-                    openDashboardFromDeepLink()
+                    guard url.scheme == RouteDeepLink.scheme else { return }
+                    handleDeepLink(url)
                 }
                 // Selecting an indexed account in Spotlight does NOT arrive via
                 // `.onOpenURL` even though the searchable item carries a
@@ -569,6 +569,25 @@ struct PlaidBarApp: App {
             summonHotkeyMonitor.start { summonDashboard() }
         } else {
             summonHotkeyMonitor.stop()
+        }
+    }
+
+    /// Handles a `vaultpeek://` deep link (AND-586). App Intents, widgets, and
+    /// Control Center hand the app a typed `RouteDeepLink` URL; when the
+    /// window-first shell is enabled this parses it into a `Route` and routes the
+    /// primary window there via the single reusable entry point
+    /// (`AppState.route(to:openWindow:)`) — so "Show Spending" lands on Budgets,
+    /// "Review Transactions" lands on Review, etc. When the flag is OFF (or the URL
+    /// carries no recognizable route) it falls back to the existing
+    /// open-the-dashboard behavior, so installed widgets keep working unchanged.
+    @MainActor
+    private func handleDeepLink(_ url: URL) {
+        guard isWindowFirstEnabled, let route = RouteDeepLink.route(from: url) else {
+            openDashboardFromDeepLink()
+            return
+        }
+        appState.route(to: route) {
+            openWindow(id: Self.mainWindowID)
         }
     }
 

--- a/Sources/PlaidBar/Intents/FinanceAppIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceAppIntents.swift
@@ -1,137 +1,35 @@
 import AppIntents
 import PlaidBarCore
 
-// MARK: - Finance App Intents (AND-512, Epic D)
+// MARK: - App Intents registration (AND-586, Epic 8)
 //
-// These intents are the macOS 26 "Tahoe spine": Spotlight / Siri / Shortcuts can
-// answer finance questions straight from the shared App Group snapshot
-// (`FinanceSnapshot`) without launching the UI, hitting the local server, or
-// touching Plaid. They are deliberately thin — every numeric/textual decision and
-// the privacy/withholding rule lives in `FinanceIntentQueries` (PlaidBarCore), so
-// it is unit-tested without the AppIntents runtime.
+// The finance App Intents themselves — "safe to spend", "show spending", "review
+// transactions", "total balance", "next bills", "credit utilization" — now live
+// in `PlaidBarCore` (`FinanceAppIntentsPackage.swift`) as an `AppIntentsPackage`,
+// so the app, the widget extension, Siri, Spotlight, and Shortcuts all reuse one
+// `Sendable` source of truth instead of each target redefining them (AND-586).
 //
-// Privacy (D3): when the snapshot is masked (App Lock / Privacy Mask active) the
-// query returns `.withheld`, and the intent surfaces a value-free dialog instead
-// of leaking the figure.
+// AppIntents metadata extraction runs against the *main app target*. This file is
+// the app's hook:
+//   1. `PlaidBarAppIntentsPackage.includedPackages` pulls Core's package in so the
+//      extractor records every shared Core intent against the VaultPeek app.
+//   2. `PlaidBarShortcutsProvider` is the single `AppShortcutsProvider` — it lives
+//      here (not Core) so it can list both the Core query/navigation intents and
+//      the app-only `FinanceDashboardSnippetIntent` (a SwiftUI `SnippetIntent`
+//      that can't live in the UI-free Core package).
 
-/// Reads the current shared snapshot, or `nil` when none has been written yet.
-@MainActor
-private func currentFinanceSnapshot() -> FinanceSnapshot? {
-    AppGroupSnapshotStore.loadIfAvailable()
-}
-
-/// Maps a value-bearing ``FinanceIntentResolution`` to an AppIntents result, or
-/// throws a user-facing error for the withheld / unavailable cases so Siri reads
-/// the safe dialog without a number.
-private func valueResult(
-    from resolution: FinanceIntentResolution
-) throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
-    switch resolution {
-    case let .value(value, spokenDialog):
-        return .result(value: value, dialog: IntentDialog(stringLiteral: spokenDialog))
-    case let .message(text):
-        // A value intent received a non-numeric answer (e.g. "no credit cards").
-        // Throw `unavailable` rather than returning a fabricated 0: Shortcuts
-        // automations would otherwise see a real-looking 0% / $0 and act on it.
-        throw FinanceIntentError.unavailable(text)
-    case let .withheld(spokenDialog):
-        throw FinanceIntentError.locked(spokenDialog)
-    case let .unavailable(spokenDialog):
-        throw FinanceIntentError.unavailable(spokenDialog)
+/// The app's `AppIntentsPackage`. Declaring `includedPackages` here makes the
+/// AppIntents extractor walk into Core's package, so the shared finance intents are
+/// registered against the app without being duplicated in this target.
+struct PlaidBarAppIntentsPackage: AppIntentsPackage {
+    static var includedPackages: [any AppIntentsPackage.Type] {
+        [PlaidBarCoreAppIntentsPackage.self]
     }
 }
-
-/// Maps a textual ``FinanceIntentResolution`` (bills list) to a dialog-only
-/// result, throwing for withheld / unavailable.
-private func messageResult(
-    from resolution: FinanceIntentResolution
-) throws -> some IntentResult & ProvidesDialog {
-    switch resolution {
-    case let .value(_, spokenDialog):
-        return .result(dialog: IntentDialog(stringLiteral: spokenDialog))
-    case let .message(text):
-        return .result(dialog: IntentDialog(stringLiteral: text))
-    case let .withheld(spokenDialog):
-        throw FinanceIntentError.locked(spokenDialog)
-    case let .unavailable(spokenDialog):
-        throw FinanceIntentError.unavailable(spokenDialog)
-    }
-}
-
-/// User-facing intent errors. `CustomLocalizedStringResourceConvertible` lets Siri
-/// speak the safe message for the locked / unavailable states.
-enum FinanceIntentError: Error, CustomLocalizedStringResourceConvertible {
-    case locked(String)
-    case unavailable(String)
-
-    var localizedStringResource: LocalizedStringResource {
-        switch self {
-        case let .locked(message), let .unavailable(message):
-            return LocalizedStringResource(stringLiteral: message)
-        }
-    }
-}
-
-// MARK: - Get Safe to Spend
-
-struct GetSafeToSpendIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Safe to Spend"
-    static let description = IntentDescription(
-        "How much you can safely spend through the current window, from local VaultPeek data."
-    )
-
-    @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
-        try valueResult(from: FinanceIntentQueries.safeToSpend(from: currentFinanceSnapshot()))
-    }
-}
-
-// MARK: - Get Balance
-
-struct GetBalanceIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Total Balance"
-    static let description = IntentDescription(
-        "Your total spendable balance across linked accounts, from local VaultPeek data."
-    )
-
-    @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
-        try valueResult(from: FinanceIntentQueries.totalBalance(from: currentFinanceSnapshot()))
-    }
-}
-
-// MARK: - Next Recurring Bills
-
-struct NextRecurringBillsIntent: AppIntent {
-    static let title: LocalizedStringResource = "Next Recurring Bills"
-    static let description = IntentDescription(
-        "Your upcoming recurring bills, from local VaultPeek data."
-    )
-
-    @MainActor
-    func perform() async throws -> some IntentResult & ProvidesDialog {
-        try messageResult(from: FinanceIntentQueries.nextRecurringBills(from: currentFinanceSnapshot()))
-    }
-}
-
-// MARK: - Get Credit Utilization
-
-struct GetCreditUtilizationIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Credit Utilization"
-    static let description = IntentDescription(
-        "Your aggregate credit-card utilization percentage, from local VaultPeek data."
-    )
-
-    @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
-        try valueResult(from: FinanceIntentQueries.creditUtilization(from: currentFinanceSnapshot()))
-    }
-}
-
-// MARK: - App Shortcuts
 
 /// Exposes the finance intents to Spotlight, Siri, and the Shortcuts app. Phrases
-/// must include `\(.applicationName)` so Siri can disambiguate VaultPeek.
+/// must include `\(.applicationName)` so Siri can disambiguate VaultPeek. The
+/// intents are Core types; the snippet entry is the app-only `SnippetIntent`.
 struct PlaidBarShortcutsProvider: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
@@ -144,7 +42,25 @@ struct PlaidBarShortcutsProvider: AppShortcutsProvider {
             systemImageName: "wallet.pass"
         )
         AppShortcut(
-            intent: GetBalanceIntent(),
+            intent: ShowSpendingIntent(),
+            phrases: [
+                "Show my spending in \(.applicationName)",
+                "How much have I spent in \(.applicationName)",
+            ],
+            shortTitle: "Show Spending",
+            systemImageName: "chart.bar"
+        )
+        AppShortcut(
+            intent: ReviewTransactionsIntent(),
+            phrases: [
+                "Review transactions in \(.applicationName)",
+                "Open my review inbox in \(.applicationName)",
+            ],
+            shortTitle: "Review Transactions",
+            systemImageName: "tray.full"
+        )
+        AppShortcut(
+            intent: GetTotalBalanceIntent(),
             phrases: [
                 "What's my balance in \(.applicationName)",
                 "Show my total balance in \(.applicationName)",

--- a/Sources/PlaidBar/Intents/FinanceDashboardSnippetIntent.swift
+++ b/Sources/PlaidBar/Intents/FinanceDashboardSnippetIntent.swift
@@ -1,0 +1,133 @@
+import AppIntents
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Spotlight mini-dashboard SnippetIntent (AND-586, Epic 8)
+//
+// `SnippetIntent` (macOS 26+) lets an intent render a small SwiftUI view inline in
+// Spotlight / Siri results — a "mini-dashboard" the user sees without opening the
+// app. This one reads the shared `FinanceSnapshot` from the App Group and renders
+// it through `SnippetDashboardPresentation` (the pure PlaidBarCore model that owns
+// row selection, formatting, and the masked/unavailable decision), so the snippet
+// never leaks a figure past App Lock / Privacy Mask and the layout logic stays
+// unit-tested at the Core layer.
+//
+// It lives in the app target (not Core / the widget extension) because the snippet
+// view is SwiftUI and is extracted against the app. Tapping the snippet's footer
+// deep-links into the window via the shared `RouteDeepLink` dashboard URL.
+
+@available(macOS 26.0, *)
+struct FinanceDashboardSnippetIntent: SnippetIntent {
+    static let title: LocalizedStringResource = "VaultPeek Dashboard"
+    static let description = IntentDescription(
+        "A glance at your balance, safe-to-spend, and spending — inline in Spotlight."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ShowsSnippetView {
+        let model = SnippetDashboardPresentation.model(from: AppGroupSnapshotStore.loadIfAvailable())
+        return .result(view: FinanceDashboardSnippetView(model: model))
+    }
+}
+
+// MARK: - Snippet view
+
+@available(macOS 26.0, *)
+private struct FinanceDashboardSnippetView: View {
+    let model: SnippetDashboardPresentation.Model
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if model.isWithheld {
+                withheldRow
+            } else {
+                metrics
+                if !model.categories.isEmpty {
+                    Divider()
+                    categoriesSection
+                }
+            }
+
+            footer
+        }
+        .padding(14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(model.accessibilityLabel)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "lock.shield")
+                .imageScale(.small)
+            Text("VaultPeek")
+                .font(.caption.weight(.semibold))
+            Spacer(minLength: 0)
+            Text(model.headline)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var metrics: some View {
+        HStack(alignment: .top, spacing: 16) {
+            ForEach(model.rows) { row in
+                VStack(alignment: .leading, spacing: 3) {
+                    Label(row.title, systemImage: row.systemImage)
+                        .labelStyle(.iconOnly)
+                        .imageScale(.medium)
+                        .foregroundStyle(.secondary)
+                    Text(row.value)
+                        .font(.headline.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                    Text(row.title)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var categoriesSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Top categories")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(model.categories) { category in
+                HStack(spacing: 8) {
+                    Label(category.title, systemImage: category.systemImage)
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    Text(category.value)
+                        .font(.caption.weight(.medium))
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    private var withheldRow: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "eye.slash")
+                .imageScale(.small)
+            Text(model.headline)
+                .font(.callout.weight(.medium))
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    private var footer: some View {
+        Text("Updated \(model.updatedAt, style: .time)")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift
+++ b/Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift
@@ -1,0 +1,223 @@
+import AppIntents
+import Foundation
+
+// MARK: - Finance App Intents package (AND-586, Epic 8)
+//
+// The macOS 26 `AppIntentsPackage` lets a *library* (here `PlaidBarCore`) export
+// App Intents that the app, the widget extension, Siri, Spotlight, and Shortcuts
+// all reuse — instead of every target redefining its own. Housing them in Core
+// also keeps them `Sendable` and lets their decision logic stay unit-testable via
+// `FinanceIntentQueries` / `RouteDeepLink`, which import no AppIntents runtime.
+//
+// Two kinds of intent live here:
+//   1. Query intents (`GetSafeToSpendIntent`, `ShowSpendingIntent`,
+//      `GetTotalBalanceIntent`, `GetCreditUtilizationIntent`,
+//      `NextRecurringBillsIntent`) — answer from the shared `FinanceSnapshot`
+//      without launching the UI. Privacy: a masked snapshot yields `.withheld`,
+//      surfaced as a value-free error so Siri never speaks a number past the lock.
+//   2. Navigation intents (`ShowSpendingIntent`, `ReviewTransactionsIntent`,
+//      `OpenDashboardIntent`) — additionally deep-link into the window via an
+//      `OpenURLIntent` carrying a `RouteDeepLink` URL, which the app's `onOpenURL`
+//      parses back into a `Route` and feeds to `AppState.route(to:)` (ADR-001).
+//
+// These supersede the app-target `FinanceAppIntents.swift` definitions: the app's
+// `AppShortcutsProvider` now points at these Core intents (single source of
+// truth). The widget extension links Core and so reaches the same intents.
+
+// MARK: - Snapshot access
+
+/// Reads the current shared snapshot, or `nil` when none has been written yet.
+/// `nonisolated` so it is callable from any intent actor context; the store is a
+/// stateless enum performing a single atomic file read.
+private func currentFinanceSnapshot() -> FinanceSnapshot? {
+    AppGroupSnapshotStore.loadIfAvailable()
+}
+
+// MARK: - Result mapping
+
+/// Maps a value-bearing ``FinanceIntentResolution`` to an AppIntents result, or
+/// throws a user-facing error for the withheld / unavailable cases so Siri reads
+/// the safe dialog without a number.
+private func valueResult(
+    from resolution: FinanceIntentResolution
+) throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+    switch resolution {
+    case let .value(value, spokenDialog):
+        return .result(value: value, dialog: IntentDialog(stringLiteral: spokenDialog))
+    case let .message(text):
+        // A value intent received a non-numeric answer (e.g. "no credit cards").
+        // Throw `unavailable` rather than returning a fabricated 0: Shortcuts
+        // automations would otherwise see a real-looking 0% / $0 and act on it.
+        throw FinanceAppIntentError.unavailable(text)
+    case let .withheld(spokenDialog):
+        throw FinanceAppIntentError.locked(spokenDialog)
+    case let .unavailable(spokenDialog):
+        throw FinanceAppIntentError.unavailable(spokenDialog)
+    }
+}
+
+/// Maps a textual ``FinanceIntentResolution`` (bills list) to a dialog-only
+/// result, throwing for withheld / unavailable.
+private func messageResult(
+    from resolution: FinanceIntentResolution
+) throws -> some IntentResult & ProvidesDialog {
+    switch resolution {
+    case let .value(_, spokenDialog):
+        return .result(dialog: IntentDialog(stringLiteral: spokenDialog))
+    case let .message(text):
+        return .result(dialog: IntentDialog(stringLiteral: text))
+    case let .withheld(spokenDialog):
+        throw FinanceAppIntentError.locked(spokenDialog)
+    case let .unavailable(spokenDialog):
+        throw FinanceAppIntentError.unavailable(spokenDialog)
+    }
+}
+
+/// User-facing intent errors. `CustomLocalizedStringResourceConvertible` lets Siri
+/// speak the safe message for the locked / unavailable states.
+public enum FinanceAppIntentError: Error, CustomLocalizedStringResourceConvertible {
+    case locked(String)
+    case unavailable(String)
+
+    public var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case let .locked(message), let .unavailable(message):
+            return LocalizedStringResource(stringLiteral: message)
+        }
+    }
+}
+
+/// Builds the `OpenURLIntent` that deep-links the window to a destination via the
+/// shared `RouteDeepLink` contract. The URL is a compile-time-safe string; the
+/// fallback only satisfies the non-optional initializer and is unreachable.
+private func openRouteIntent(_ destination: RouteDestination) -> OpenURLIntent {
+    OpenURLIntent(RouteDeepLink.url(for: destination) ?? URL(fileURLWithPath: "/"))
+}
+
+// MARK: - Query intents
+
+/// "What's safe to spend" — answers from the snapshot without launching the UI.
+public struct GetSafeToSpendIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Get Safe to Spend"
+    public static let description = IntentDescription(
+        "How much you can safely spend through the current window, from local VaultPeek data."
+    )
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.safeToSpend(from: currentFinanceSnapshot()))
+    }
+}
+
+/// "What's my balance" — total spendable balance across linked accounts.
+public struct GetTotalBalanceIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Get Total Balance"
+    public static let description = IntentDescription(
+        "Your total spendable balance across linked accounts, from local VaultPeek data."
+    )
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.totalBalance(from: currentFinanceSnapshot()))
+    }
+}
+
+/// "What are my next bills" — upcoming recurring obligations, spoken as a list.
+public struct NextRecurringBillsIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Next Recurring Bills"
+    public static let description = IntentDescription(
+        "Your upcoming recurring bills, from local VaultPeek data."
+    )
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        try messageResult(from: FinanceIntentQueries.nextRecurringBills(from: currentFinanceSnapshot()))
+    }
+}
+
+/// "What's my credit utilization" — aggregate credit-card utilization percent.
+public struct GetCreditUtilizationIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Get Credit Utilization"
+    public static let description = IntentDescription(
+        "Your aggregate credit-card utilization percentage, from local VaultPeek data."
+    )
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog {
+        try valueResult(from: FinanceIntentQueries.creditUtilization(from: currentFinanceSnapshot()))
+    }
+}
+
+// MARK: - Navigation intents
+
+/// "Show spending" — speaks this period's spend + top categories AND opens the
+/// window on the Budgets destination so the user can dig in. Returns the period
+/// total so a Shortcut can chain on the number.
+public struct ShowSpendingIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Show Spending"
+    public static let description = IntentDescription(
+        "Show how much you've spent this period and open VaultPeek to your budgets."
+    )
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<Double> & ProvidesDialog & OpensIntent {
+        let resolution = FinanceIntentQueries.showSpending(from: currentFinanceSnapshot())
+        switch resolution {
+        case let .value(value, spokenDialog):
+            return .result(
+                value: value,
+                opensIntent: openRouteIntent(.budgets),
+                dialog: IntentDialog(stringLiteral: spokenDialog)
+            )
+        case let .message(text):
+            throw FinanceAppIntentError.unavailable(text)
+        case let .withheld(spokenDialog):
+            throw FinanceAppIntentError.locked(spokenDialog)
+        case let .unavailable(spokenDialog):
+            throw FinanceAppIntentError.unavailable(spokenDialog)
+        }
+    }
+}
+
+/// "Review transactions" — opens the window straight to the Review inbox. Pure
+/// navigation; no figure is read, so it works even while masked.
+public struct ReviewTransactionsIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Review Transactions"
+    public static let description = IntentDescription(
+        "Open VaultPeek to review and categorize recent transactions."
+    )
+    public static let openAppWhenRun = true
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: openRouteIntent(.review))
+    }
+}
+
+/// "Open VaultPeek" — opens the window on the Dashboard. The neutral entry point
+/// also used by the glance widget / Control Center deep links.
+public struct OpenDashboardIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Open Dashboard"
+    public static let description = IntentDescription("Open VaultPeek to your dashboard.")
+    public static let openAppWhenRun = true
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: openRouteIntent(.dashboard))
+    }
+}
+
+// MARK: - AppIntentsPackage
+
+/// The `AppIntentsPackage` that exports this library's intents so the app and the
+/// widget extension can both declare `static var includedPackages` pointing here,
+/// extracting the metadata once from Core instead of redefining intents per target
+/// (AND-586). The app target adds its UI-bound `SnippetIntent` on top of this.
+public struct PlaidBarCoreAppIntentsPackage: AppIntentsPackage {}

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -53,6 +53,35 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         }
     }
 
+    /// One spending category's period total, reduced to a stable category-key, a
+    /// user-facing label, and the amount spent. The `categoryKey` is the
+    /// ``SpendingCategory`` raw value so a reader (the "show spending" intent, the
+    /// Spotlight snippet, a `systemLarge` widget) can recover the icon/colour from
+    /// `SpendingCategory(rawValue:)` without the snapshot carrying UI concerns.
+    public struct CategorySpend: Codable, Sendable, Equatable, Identifiable {
+        public let categoryKey: String
+        public let displayName: String
+        public let amount: Double
+
+        public var id: String { categoryKey }
+
+        /// The ``SpendingCategory`` this row maps to, or `nil` for an unknown key
+        /// (forward-compat if a future build adds a category this one can't decode).
+        public var category: SpendingCategory? { SpendingCategory(rawValue: categoryKey) }
+
+        public init(categoryKey: String, displayName: String, amount: Double) {
+            self.categoryKey = categoryKey
+            self.displayName = displayName
+            self.amount = amount
+        }
+
+        public init(category: SpendingCategory, amount: Double) {
+            self.categoryKey = category.rawValue
+            self.displayName = category.displayName
+            self.amount = amount
+        }
+    }
+
     /// Conservative discretionary balance through the look-ahead horizon
     /// (`SafeToSpendResult.amount`). May be negative — reported honestly.
     public let safeToSpend: Double
@@ -72,6 +101,12 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
     /// True when App Lock / Privacy Mask is active. Intents must withhold values
     /// while this is set.
     public let isMasked: Bool
+    /// Total spend across the current period (month-to-date), used by the
+    /// "show spending" intent and the Spotlight snippet. Zero when unknown.
+    public let periodSpending: Double
+    /// Top spending categories this period, largest first, already truncated to a
+    /// small count (the writer keeps only the leaders). Empty when unknown.
+    public let topSpendingCategories: [CategorySpend]
 
     public init(
         safeToSpend: Double,
@@ -81,7 +116,9 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         creditUtilization: Double?,
         isoCurrencyCode: String = "USD",
         generatedAt: Date,
-        isMasked: Bool
+        isMasked: Bool,
+        periodSpending: Double = 0,
+        topSpendingCategories: [CategorySpend] = []
     ) {
         self.safeToSpend = safeToSpend
         self.totalBalance = totalBalance
@@ -91,6 +128,31 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         self.isoCurrencyCode = isoCurrencyCode
         self.generatedAt = generatedAt
         self.isMasked = isMasked
+        self.periodSpending = periodSpending
+        self.topSpendingCategories = topSpendingCategories
+    }
+
+    // Decode the spending fields defensively: a snapshot written by an older build
+    // (no `periodSpending` / `topSpendingCategories` keys) decodes them as their
+    // empty defaults, so an upgrade never fails to read a pre-AND-586 snapshot.
+    private enum CodingKeys: String, CodingKey {
+        case safeToSpend, totalBalance, accountBalances, nextRecurringBills
+        case creditUtilization, isoCurrencyCode, generatedAt, isMasked
+        case periodSpending, topSpendingCategories
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        safeToSpend = try container.decode(Double.self, forKey: .safeToSpend)
+        totalBalance = try container.decode(Double.self, forKey: .totalBalance)
+        accountBalances = try container.decode([AccountBalance].self, forKey: .accountBalances)
+        nextRecurringBills = try container.decode([UpcomingBill].self, forKey: .nextRecurringBills)
+        creditUtilization = try container.decodeIfPresent(Double.self, forKey: .creditUtilization)
+        isoCurrencyCode = try container.decodeIfPresent(String.self, forKey: .isoCurrencyCode) ?? "USD"
+        generatedAt = try container.decode(Date.self, forKey: .generatedAt)
+        isMasked = try container.decode(Bool.self, forKey: .isMasked)
+        periodSpending = try container.decodeIfPresent(Double.self, forKey: .periodSpending) ?? 0
+        topSpendingCategories = try container.decodeIfPresent([CategorySpend].self, forKey: .topSpendingCategories) ?? []
     }
 
     /// Empty placeholder used before the first real snapshot exists. Treated as
@@ -110,11 +172,14 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
     /// True when the snapshot carries no usable figures. Used to drive a
     /// setup/unavailable intent response. A credit-only user (paid-off cards, no
     /// cash accounts, no bills) still has a usable `creditUtilization`, so a
-    /// non-nil utilization keeps the snapshot non-empty.
+    /// non-nil utilization keeps the snapshot non-empty. Likewise a user with
+    /// recorded spend but no linked cash account stays non-empty.
     public var isEmpty: Bool {
         accountBalances.isEmpty
             && nextRecurringBills.isEmpty
             && totalBalance == 0
             && creditUtilization == nil
+            && periodSpending == 0
+            && topSpendingCategories.isEmpty
     }
 }

--- a/Sources/PlaidBarCore/Models/RouteDeepLink.swift
+++ b/Sources/PlaidBarCore/Models/RouteDeepLink.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// The shared `vaultpeek://` deep-link contract that maps a URL to a ``Route`` and
+/// back (AND-586 / ADR-001).
+///
+/// App Intents (Spotlight / Siri / Shortcuts), widgets, and Control Center
+/// controls cannot reach into the app's window directly — they hand the app a URL.
+/// This is the single, pure, `Sendable` place that decides what URL a deep link
+/// uses and how the app parses it back into a ``Route`` so it can call
+/// `AppState.route(to:)`. Keeping it in ``PlaidBarCore`` means both the producing
+/// side (intents in the widget/Core target) and the consuming side (`onOpenURL`
+/// in the app target) agree on one contract, unit-testable without the app.
+///
+/// Form: `vaultpeek://route/<destination>` where `<destination>` is the
+/// ``RouteDestination`` raw value (e.g. `vaultpeek://route/transactions`). The
+/// legacy `vaultpeek://dashboard` link (``GlanceSnapshot/deepLinkURL``) still
+/// resolves to the dashboard for backward compatibility with already-installed
+/// widgets and Spotlight items.
+///
+/// Only the *bare destination* travels in the URL — not per-row selection. A
+/// deep link lands the window on the right destination's canonical route; the
+/// inspector then shows its "Select a …" empty state. This keeps the contract
+/// small and avoids leaking identifiers (account ids, transaction ids) into a URL
+/// the system may log.
+public enum RouteDeepLink {
+    /// The custom URL scheme registered in the app's `Info.plist`.
+    public static let scheme = "vaultpeek"
+
+    /// The host segment that marks a typed route link, distinguishing it from the
+    /// legacy `vaultpeek://dashboard` form (which uses the destination as the host).
+    public static let routeHost = "route"
+
+    /// Builds the deep-link URL string for a bare destination.
+    /// e.g. `.transactions` → `"vaultpeek://route/transactions"`.
+    public static func urlString(for destination: RouteDestination) -> String {
+        "\(scheme)://\(routeHost)/\(destination.rawValue)"
+    }
+
+    /// Builds the deep-link URL for a bare destination, or `nil` if the string
+    /// cannot form a URL (unreachable in practice — the components are URL-safe).
+    public static func url(for destination: RouteDestination) -> URL? {
+        URL(string: urlString(for: destination))
+    }
+
+    /// The deep-link URL string for the destination a ``Route`` resolves to.
+    /// Selection is intentionally dropped (see type docs).
+    public static func urlString(for route: Route) -> String {
+        urlString(for: route.destination)
+    }
+
+    /// Parses a `vaultpeek://` URL into the destination's canonical ``Route``.
+    ///
+    /// Accepts three forms, returning `nil` for anything else (wrong scheme,
+    /// unknown destination):
+    /// - `vaultpeek://route/<destination>` — the typed route form.
+    /// - `vaultpeek://<destination>` — host-only form (e.g. the legacy
+    ///   `vaultpeek://dashboard`), so existing widget/Spotlight links keep working.
+    /// - `vaultpeek://route` with no path — resolves to the dashboard.
+    public static func route(from url: URL) -> Route? {
+        guard url.scheme == scheme else { return nil }
+
+        // `vaultpeek://route/<destination>`: host == "route", first path segment
+        // is the destination.
+        if url.host == routeHost {
+            let segments = url.pathComponents.filter { $0 != "/" }
+            guard let first = segments.first else {
+                // `vaultpeek://route` with no destination → dashboard.
+                return .dashboard
+            }
+            return destination(forRawValue: first).map(Route.canonical(for:))
+        }
+
+        // Legacy / host-only form `vaultpeek://<destination>` (covers
+        // `vaultpeek://dashboard`).
+        if let host = url.host, let destination = destination(forRawValue: host) {
+            return Route.canonical(for: destination)
+        }
+
+        return nil
+    }
+
+    /// Resolves a ``RouteDestination`` from its raw value, case-insensitively, so a
+    /// link is forgiving of casing differences across surfaces.
+    private static func destination(forRawValue raw: String) -> RouteDestination? {
+        let lowered = raw.lowercased()
+        return RouteDestination.allCases.first { $0.rawValue.lowercased() == lowered }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
@@ -91,6 +91,36 @@ public enum FinanceIntentQueries {
         return .message(sentence)
     }
 
+    // MARK: - Spending this period
+
+    /// How many top categories to read aloud / list in the "show spending" answer.
+    public static let maxSpokenSpendingCategories = 3
+
+    /// Answers "show spending" / "how much have I spent": the month-to-date total
+    /// plus the leading categories. Returns a `.value` carrying the period total so
+    /// a `ReturnsValue` intent can hand Shortcuts the number, with a spoken dialog
+    /// that names the top categories.
+    public static func showSpending(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {
+        if let blocked = gate(snapshot) { return blocked }
+        guard let snapshot else { return .unavailable(spokenDialog: unavailableDialog) }
+
+        let total = snapshot.periodSpending
+        let formattedTotal = Formatters.currency(total, format: .full, currencyCode: snapshot.isoCurrencyCode)
+
+        let categories = snapshot.topSpendingCategories
+        guard !categories.isEmpty else {
+            // Non-empty snapshot but no categorized spend yet — report the total
+            // honestly rather than withholding.
+            return .value(total, spokenDialog: "You've spent \(formattedTotal) so far this period.")
+        }
+
+        let spoken = categories.prefix(maxSpokenSpendingCategories).map { row in
+            "\(Formatters.currency(row.amount, format: .full, currencyCode: snapshot.isoCurrencyCode)) on \(row.displayName)"
+        }
+        let dialog = "You've spent \(formattedTotal) this period. Top categories: " + listSentence(spoken) + "."
+        return .value(total, spokenDialog: dialog)
+    }
+
     // MARK: - Credit utilization
 
     public static func creditUtilization(from snapshot: FinanceSnapshot?) -> FinanceIntentResolution {

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -18,6 +18,10 @@ public enum FinanceSnapshotBuilder {
     /// line with ``SafeToSpendCalculator/minimumObligationConfidence``.
     public static let minimumBillConfidence = SafeToSpendCalculator.minimumObligationConfidence
 
+    /// How many top spending categories the snapshot carries for the "show
+    /// spending" intent and the Spotlight snippet / `systemLarge` widget.
+    public static let maxSnapshotCategories = 4
+
     public static func make(
         accounts: [AccountDTO],
         recurringTransactions: [RecurringTransaction],
@@ -25,6 +29,9 @@ public enum FinanceSnapshotBuilder {
         safeToSpendInputs: SafeToSpendInputs = .default,
         pendingHolds: Double = 0,
         isMasked: Bool,
+        transactions: [TransactionDTO] = [],
+        reviewMetadata: [TransactionReviewMetadata]? = nil,
+        transactionRules: [TransactionRule]? = nil,
         creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
         generatedAt: Date = Date(),
         calendar: Calendar = .current
@@ -67,6 +74,14 @@ public enum FinanceSnapshotBuilder {
 
         let utilization = creditUtilizationPercent(from: accounts)
 
+        let spending = monthToDateSpending(
+            transactions: transactions,
+            metadata: reviewMetadata,
+            rules: transactionRules,
+            asOf: generatedAt,
+            calendar: calendar
+        )
+
         let currencyCode = accounts
             .compactMap { $0.balances.isoCurrencyCode }
             .first ?? "USD"
@@ -96,8 +111,48 @@ public enum FinanceSnapshotBuilder {
             creditUtilization: utilization,
             isoCurrencyCode: currencyCode,
             generatedAt: generatedAt,
-            isMasked: isMasked
+            isMasked: isMasked,
+            periodSpending: spending.total,
+            topSpendingCategories: spending.categories
         )
+    }
+
+    // MARK: - Spending this period
+
+    /// Month-to-date spend total + the leading categories, reusing
+    /// ``SpendingSummary/spendingByCategory(from:metadata:rules:)`` so the figures
+    /// match the override-aware dashboard. Returns zeros / empty when no
+    /// transactions are supplied (the server-less / demo path).
+    private static func monthToDateSpending(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata]?,
+        rules: [TransactionRule]?,
+        asOf date: Date,
+        calendar: Calendar
+    ) -> (total: Double, categories: [FinanceSnapshot.CategorySpend]) {
+        guard !transactions.isEmpty else { return (0, []) }
+
+        // Start of the current calendar month, formatted as the canonical
+        // `yyyy-MM-dd` transaction date string SpendingSummary compares against.
+        let monthStart = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: date)
+        ) ?? calendar.startOfDay(for: date)
+        let monthStartString = Formatters.transactionDateString(monthStart)
+
+        let monthExpenses = SpendingSummary.expenseTransactions(
+            from: transactions,
+            startingAt: monthStartString
+        )
+        let byCategory = SpendingSummary.spendingByCategory(
+            from: monthExpenses,
+            metadata: metadata,
+            rules: rules
+        )
+        let total = byCategory.reduce(0) { $0 + $1.1 }
+        let categories = byCategory
+            .prefix(maxSnapshotCategories)
+            .map { FinanceSnapshot.CategorySpend(category: $0.0, amount: $0.1) }
+        return (total, Array(categories))
     }
 
     // MARK: - Upcoming bills

--- a/Sources/PlaidBarCore/Utilities/SnippetDashboardPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/SnippetDashboardPresentation.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Pure presentation model for the Spotlight ``SnippetIntent`` mini-dashboard and
+/// the `systemLarge` widget (AND-586). Both surfaces show the same compact set of
+/// rows — net balance, safe-to-spend, this period's spend, top categories — so the
+/// row selection, masking, and formatting all live here in ``PlaidBarCore`` where
+/// they are `Sendable` and unit-tested without the SwiftUI snippet view.
+///
+/// Privacy mirrors ``FinanceIntentQueries`` and ``ControlValuePresentation``: when
+/// the snapshot is masked, missing, or empty, every figure is withheld (replaced
+/// with the shared dot placeholder) and the view shows a setup/locked state — a
+/// figure is never leaked past App Lock / Privacy Mask.
+public enum SnippetDashboardPresentation {
+    /// One labelled figure row in the mini-dashboard.
+    public struct MetricRow: Sendable, Equatable, Identifiable {
+        public let id: String
+        /// User-facing metric name (e.g. "Safe to spend").
+        public let title: String
+        /// The figure rendered to a display string, or the dot placeholder when masked.
+        public let value: String
+        /// SF Symbol whose SHAPE carries the metric identity (never colour alone).
+        public let systemImage: String
+
+        public init(id: String, title: String, value: String, systemImage: String) {
+            self.id = id
+            self.title = title
+            self.value = value
+            self.systemImage = systemImage
+        }
+    }
+
+    /// A rendered mini-dashboard ready to drop into a snippet or widget view.
+    public struct Model: Sendable, Equatable {
+        /// Headline overview line shown above the rows.
+        public let headline: String
+        /// The metric rows, in display order.
+        public let rows: [MetricRow]
+        /// Top spending categories, each as a ready-to-render label + value pair.
+        public let categories: [MetricRow]
+        /// When the underlying snapshot was produced (chrome, never sensitive).
+        public let updatedAt: Date
+        /// True when every figure is withheld (masked) or the snapshot is missing
+        /// / empty (setup). Drives the view's masked/setup affordance.
+        public let isWithheld: Bool
+        /// A self-contained accessibility sentence describing the whole snippet.
+        public let accessibilityLabel: String
+
+        public init(
+            headline: String,
+            rows: [MetricRow],
+            categories: [MetricRow],
+            updatedAt: Date,
+            isWithheld: Bool,
+            accessibilityLabel: String
+        ) {
+            self.headline = headline
+            self.rows = rows
+            self.categories = categories
+            self.updatedAt = updatedAt
+            self.isWithheld = isWithheld
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    /// How many top categories the mini-dashboard renders.
+    public static let maxCategories = 3
+
+    /// Builds the mini-dashboard model from the shared snapshot (or its absence).
+    public static func model(from snapshot: FinanceSnapshot?) -> Model {
+        guard let snapshot, !snapshot.isEmpty else {
+            return unavailableModel(updatedAt: snapshot?.generatedAt ?? Date())
+        }
+        if snapshot.isMasked {
+            return maskedModel(updatedAt: snapshot.generatedAt)
+        }
+
+        let currency = snapshot.isoCurrencyCode
+        let rows: [MetricRow] = [
+            MetricRow(
+                id: "total-balance",
+                title: "Balance",
+                value: Formatters.currency(snapshot.totalBalance, format: .compact, currencyCode: currency),
+                systemImage: "banknote"
+            ),
+            MetricRow(
+                id: "safe-to-spend",
+                title: "Safe to spend",
+                value: Formatters.currency(snapshot.safeToSpend, format: .compact, currencyCode: currency),
+                systemImage: "dollarsign.circle"
+            ),
+            MetricRow(
+                id: "period-spending",
+                title: "Spent this period",
+                value: Formatters.currency(snapshot.periodSpending, format: .compact, currencyCode: currency),
+                systemImage: "chart.bar"
+            ),
+        ]
+
+        let categories = snapshot.topSpendingCategories.prefix(maxCategories).map { row in
+            MetricRow(
+                id: "category-\(row.categoryKey)",
+                title: row.displayName,
+                value: Formatters.currency(row.amount, format: .compact, currencyCode: currency),
+                systemImage: row.category?.iconName ?? "circle"
+            )
+        }
+
+        let headline = snapshot.isDemoHeadline
+        let a11y = accessibilitySentence(rows: rows, categories: Array(categories))
+
+        return Model(
+            headline: headline,
+            rows: rows,
+            categories: Array(categories),
+            updatedAt: snapshot.generatedAt,
+            isWithheld: false,
+            accessibilityLabel: a11y
+        )
+    }
+
+    // MARK: - Withheld states
+
+    private static func maskedModel(updatedAt: Date) -> Model {
+        Model(
+            headline: "Figures hidden",
+            rows: withheldRows,
+            categories: [],
+            updatedAt: updatedAt,
+            isWithheld: true,
+            accessibilityLabel: "VaultPeek figures are hidden while Privacy Mask is on."
+        )
+    }
+
+    private static func unavailableModel(updatedAt: Date) -> Model {
+        Model(
+            headline: "Open VaultPeek",
+            rows: [],
+            categories: [],
+            updatedAt: updatedAt,
+            isWithheld: true,
+            accessibilityLabel: "VaultPeek hasn't synced yet. Open VaultPeek to connect an account."
+        )
+    }
+
+    private static var withheldRows: [MetricRow] {
+        let dot = PrivacyMaskPresentation.compactValue
+        return [
+            MetricRow(id: "total-balance", title: "Balance", value: dot, systemImage: "eye.slash"),
+            MetricRow(id: "safe-to-spend", title: "Safe to spend", value: dot, systemImage: "eye.slash"),
+            MetricRow(id: "period-spending", title: "Spent this period", value: dot, systemImage: "eye.slash"),
+        ]
+    }
+
+    private static func accessibilitySentence(rows: [MetricRow], categories: [MetricRow]) -> String {
+        let metrics = rows.map { "\($0.title) \($0.value)" }.joined(separator: ", ")
+        guard !categories.isEmpty else { return metrics + "." }
+        let cats = categories.map { "\($0.value) on \($0.title)" }.joined(separator: ", ")
+        return metrics + ". Top categories: " + cats + "."
+    }
+}
+
+private extension FinanceSnapshot {
+    /// A short overview headline for the mini-dashboard, leading with net balance.
+    var isDemoHeadline: String {
+        "Net balance \(Formatters.currency(totalBalance, format: .compact, currencyCode: isoCurrencyCode))"
+    }
+}

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -15,6 +15,12 @@ private struct GlanceEntry: TimelineEntry {
     /// out every figure so balances never leak onto a shared/visible desktop
     /// while the user has explicitly masked the app (AND-513 / AND-462).
     var isMasked = false
+    /// The richer multi-metric mini-dashboard model used by the `systemLarge`
+    /// family (AND-586). Built in Core from the shared `FinanceSnapshot`, it owns
+    /// the masking/formatting so the large widget matches the Spotlight snippet.
+    /// `nil` only for the redacted placeholder; the view falls back to the glance
+    /// layout when absent.
+    var dashboard: SnippetDashboardPresentation.Model?
 }
 
 private struct GlanceTimelineProvider: TimelineProvider {
@@ -55,9 +61,44 @@ private struct GlanceTimelineProvider: TimelineProvider {
         // means the widget stays masked even if the sibling FinanceSnapshot is
         // missing or stale — and a redacted glance file already holds no figures
         // (AND-517).
-        let financeMasked = AppGroupSnapshotStore.loadIfAvailable()?.isMasked ?? false
+        let financeSnapshot = AppGroupSnapshotStore.loadIfAvailable()
+        let financeMasked = financeSnapshot?.isMasked ?? false
         let isMasked = financeMasked || snapshot.isRedacted
-        return GlanceEntry(date: snapshot.updatedAt, snapshot: snapshot, isMasked: isMasked)
+        // Build the richer mini-dashboard model for the systemLarge family. When
+        // the glance snapshot is redacted but the finance snapshot is missing,
+        // pass a masked finance snapshot so the large widget self-masks too.
+        let dashboardModel = SnippetDashboardPresentation.model(
+            from: dashboardSource(financeSnapshot: financeSnapshot, glanceRedacted: snapshot.isRedacted)
+        )
+        return GlanceEntry(
+            date: snapshot.updatedAt,
+            snapshot: snapshot,
+            isMasked: isMasked,
+            dashboard: dashboardModel
+        )
+    }
+
+    /// Resolves the `FinanceSnapshot` the large-widget mini-dashboard renders. If
+    /// the glance snapshot is redacted (app wrote it while masked) but the finance
+    /// snapshot is missing/unmasked, force a masked snapshot so the large widget
+    /// can never out-resolve the lock the glance file already honored (AND-517).
+    private func dashboardSource(
+        financeSnapshot: FinanceSnapshot?,
+        glanceRedacted: Bool
+    ) -> FinanceSnapshot? {
+        guard glanceRedacted, let financeSnapshot, !financeSnapshot.isMasked else {
+            return financeSnapshot
+        }
+        return FinanceSnapshot(
+            safeToSpend: 0,
+            totalBalance: 0,
+            accountBalances: [],
+            nextRecurringBills: [],
+            creditUtilization: nil,
+            isoCurrencyCode: financeSnapshot.isoCurrencyCode,
+            generatedAt: financeSnapshot.generatedAt,
+            isMasked: true
+        )
     }
 }
 
@@ -85,7 +126,7 @@ private struct PlaidBarGlanceWidget: Widget {
         }
         .configurationDisplayName("VaultPeek")
         .description("Glance at net worth and today's change from local VaultPeek data.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
 
@@ -96,6 +137,8 @@ private struct GlanceWidgetView: View {
     var body: some View {
         if entry.isUnavailable {
             unavailableState
+        } else if family == .systemLarge, let dashboard = entry.dashboard {
+            LargeDashboardView(model: dashboard, isMasked: entry.isMasked)
         } else {
             dataState
         }
@@ -194,6 +237,91 @@ private struct GlanceWidgetView: View {
             return "\(source)Figures hidden while Privacy Mask is on." + updated
         }
         return entry.snapshot.accessibilitySummary + updated
+    }
+}
+
+// MARK: - systemLarge mini-dashboard (AND-586)
+
+/// The `systemLarge` glance layout: a multi-metric mini-dashboard (balance,
+/// safe-to-spend, spent-this-period) plus the top spending categories, rendered
+/// from the Core ``SnippetDashboardPresentation/Model`` so it stays in lockstep
+/// with the Spotlight snippet and honors App Lock / Privacy Mask.
+private struct LargeDashboardView: View {
+    let model: SnippetDashboardPresentation.Model
+    let isMasked: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Image(systemName: isMasked ? "eye.slash" : "lock.shield")
+                    .imageScale(.small)
+                Text("VaultPeek")
+                    .font(.caption.weight(.semibold))
+                Spacer(minLength: 0)
+                Text("Updated \(model.updatedAt, style: .time)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if model.isWithheld {
+                Spacer(minLength: 0)
+                HStack(spacing: 6) {
+                    Image(systemName: "eye.slash")
+                    Text(model.headline)
+                        .font(.callout.weight(.semibold))
+                }
+                .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            } else {
+                metricsRow
+                if !model.categories.isEmpty {
+                    Divider()
+                    categoriesSection
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(model.accessibilityLabel)
+    }
+
+    private var metricsRow: some View {
+        HStack(alignment: .top, spacing: 14) {
+            ForEach(model.rows) { row in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.value)
+                        .font(.title3.weight(.bold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                    Text(row.title)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var categoriesSection: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Top categories")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(model.categories) { category in
+                HStack(spacing: 8) {
+                    Label(category.title, systemImage: category.systemImage)
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    Text(category.value)
+                        .font(.caption.weight(.medium))
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
+            }
+        }
     }
 }
 

--- a/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
@@ -144,6 +144,58 @@ struct FinanceIntentQueriesTests {
         #expect(text.lowercased().contains("no upcoming bills"))
     }
 
+    // MARK: - Show spending (AND-586)
+
+    @Test("Show spending returns the period total and names top categories")
+    func showSpendingReturnsValue() {
+        let categories = [
+            FinanceSnapshot.CategorySpend(category: .foodAndDrink, amount: 320),
+            FinanceSnapshot.CategorySpend(category: .shopping, amount: 180),
+        ]
+        guard case let .value(value, dialog) = FinanceIntentQueries.showSpending(
+            from: snapshot(periodSpending: 500, categories: categories)
+        ) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 500)
+        #expect(dialog.contains("Food & Drink"))
+        #expect(dialog.lowercased().contains("top categories"))
+    }
+
+    @Test("Show spending reports the total even with no categorized spend")
+    func showSpendingWithoutCategories() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.showSpending(
+            from: snapshot(periodSpending: 120, categories: [])
+        ) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 120)
+        #expect(dialog.contains("120") || dialog.lowercased().contains("spent"))
+    }
+
+    @Test("Masked snapshot withholds show-spending without leaking a figure")
+    func showSpendingMaskedWithholds() {
+        let categories = [FinanceSnapshot.CategorySpend(category: .travel, amount: 999)]
+        guard case let .withheld(dialog) = FinanceIntentQueries.showSpending(
+            from: snapshot(isMasked: true, periodSpending: 999, categories: categories)
+        ) else {
+            Issue.record("Expected .withheld")
+            return
+        }
+        #expect(!dialog.contains("999"))
+        #expect(!dialog.contains("Travel"))
+    }
+
+    @Test("Nil snapshot reports unavailable for show-spending")
+    func showSpendingNilUnavailable() {
+        guard case .unavailable = FinanceIntentQueries.showSpending(from: nil) else {
+            Issue.record("Expected .unavailable")
+            return
+        }
+    }
+
     // MARK: - Helpers
 
     private func snapshot(
@@ -151,7 +203,9 @@ struct FinanceIntentQueriesTests {
         totalBalance: Double = 5_000,
         bills: [FinanceSnapshot.UpcomingBill] = [],
         creditUtilization: Double? = 20,
-        isMasked: Bool = false
+        isMasked: Bool = false,
+        periodSpending: Double = 0,
+        categories: [FinanceSnapshot.CategorySpend] = []
     ) -> FinanceSnapshot {
         FinanceSnapshot(
             safeToSpend: safeToSpend,
@@ -162,7 +216,9 @@ struct FinanceIntentQueriesTests {
             nextRecurringBills: bills,
             creditUtilization: creditUtilization,
             generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
-            isMasked: isMasked
+            isMasked: isMasked,
+            periodSpending: periodSpending,
+            topSpendingCategories: categories
         )
     }
 }

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
@@ -139,7 +139,78 @@ struct FinanceSnapshotBuilderTests {
         #expect(snapshot.nextRecurringBills.map(\.merchantName) == ["Soon", "Later"])
     }
 
+    // MARK: - Spending this period (AND-586)
+
+    @Test("Builder computes month-to-date spend + top categories from transactions")
+    func builderComputesMonthToDateSpending() {
+        // asOf is 2026-05-28; month-to-date covers 2026-05-01 onward.
+        let transactions = [
+            expense("a", amount: 120, date: "2026-05-03", category: .foodAndDrink),
+            expense("b", amount: 80, date: "2026-05-10", category: .foodAndDrink),
+            expense("c", amount: 150, date: "2026-05-20", category: .shopping),
+            // Income (negative) must not count as spend.
+            income("d", amount: 5_000, date: "2026-05-15"),
+            // Prior-month expense must be excluded from the month-to-date total.
+            expense("e", amount: 999, date: "2026-04-29", category: .travel),
+        ]
+
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 4_000)],
+            recurringTransactions: [],
+            isMasked: false,
+            transactions: transactions,
+            generatedAt: asOf
+        )
+
+        // 120 + 80 + 150 = 350; the prior-month 999 and the income are excluded.
+        #expect(snapshot.periodSpending == 350)
+        // Food & Drink (200) leads Shopping (150).
+        #expect(snapshot.topSpendingCategories.first?.category == .foodAndDrink)
+        #expect(snapshot.topSpendingCategories.first?.amount == 200)
+        #expect(snapshot.topSpendingCategories.count == 2)
+    }
+
+    @Test("Masked snapshot carries no spending figures (defense in depth)")
+    func maskedSnapshotHasNoSpending() {
+        let transactions = [expense("a", amount: 500, date: "2026-05-03", category: .shopping)]
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 4_000)],
+            recurringTransactions: [],
+            isMasked: true,
+            transactions: transactions,
+            generatedAt: asOf
+        )
+        #expect(snapshot.periodSpending == 0)
+        #expect(snapshot.topSpendingCategories.isEmpty)
+    }
+
+    @Test("No transactions yields zero spend (server-less / demo path)")
+    func noTransactionsYieldsZeroSpend() {
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [depository(name: "Checking", available: 4_000)],
+            recurringTransactions: [],
+            isMasked: false,
+            generatedAt: asOf
+        )
+        #expect(snapshot.periodSpending == 0)
+        #expect(snapshot.topSpendingCategories.isEmpty)
+    }
+
     // MARK: - Helpers
+
+    private func expense(
+        _ id: String,
+        amount: Double,
+        date: String,
+        category: SpendingCategory
+    ) -> TransactionDTO {
+        TransactionDTO(id: id, accountId: "checking", amount: amount, date: date, name: id, category: category)
+    }
+
+    private func income(_ id: String, amount: Double, date: String) -> TransactionDTO {
+        TransactionDTO(id: id, accountId: "checking", amount: -amount, date: date, name: id, category: .income)
+    }
+
 
     private func depository(name: String, available: Double) -> AccountDTO {
         AccountDTO(

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotSpendingTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotSpendingTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("FinanceSnapshot spending fields (AND-586)")
+struct FinanceSnapshotSpendingTests {
+    private let asOf = Date(timeIntervalSince1970: 1_780_000_000)
+
+    @Test("A pre-AND-586 snapshot (no spending keys) decodes with empty defaults")
+    func decodesLegacySnapshotWithoutSpendingKeys() throws {
+        // A snapshot JSON written by an older build had no `periodSpending` /
+        // `topSpendingCategories` keys. It must still decode, defaulting them.
+        let legacyJSON = """
+        {
+          "safeToSpend": 1000,
+          "totalBalance": 5000,
+          "accountBalances": [],
+          "nextRecurringBills": [],
+          "isoCurrencyCode": "USD",
+          "generatedAt": "2026-05-28T00:00:00Z",
+          "isMasked": false
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(FinanceSnapshot.self, from: Data(legacyJSON.utf8))
+        #expect(snapshot.periodSpending == 0)
+        #expect(snapshot.topSpendingCategories.isEmpty)
+        #expect(snapshot.totalBalance == 5_000)
+    }
+
+    @Test("Spending fields round-trip through Codable")
+    func spendingFieldsRoundTrip() throws {
+        let snapshot = FinanceSnapshot(
+            safeToSpend: 1_000,
+            totalBalance: 5_000,
+            accountBalances: [],
+            nextRecurringBills: [],
+            creditUtilization: nil,
+            generatedAt: asOf,
+            isMasked: false,
+            periodSpending: 640,
+            topSpendingCategories: [
+                FinanceSnapshot.CategorySpend(category: .foodAndDrink, amount: 400),
+            ]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(FinanceSnapshot.self, from: encoder.encode(snapshot))
+        #expect(decoded == snapshot)
+        #expect(decoded.topSpendingCategories.first?.category == .foodAndDrink)
+    }
+
+    @Test("A spending-only snapshot is non-empty so intents answer it")
+    func spendingOnlySnapshotIsNonEmpty() {
+        let snapshot = FinanceSnapshot(
+            safeToSpend: 0,
+            totalBalance: 0,
+            accountBalances: [],
+            nextRecurringBills: [],
+            creditUtilization: nil,
+            generatedAt: asOf,
+            isMasked: false,
+            periodSpending: 250,
+            topSpendingCategories: [FinanceSnapshot.CategorySpend(category: .travel, amount: 250)]
+        )
+        #expect(!snapshot.isEmpty)
+    }
+
+    @Test("CategorySpend recovers its SpendingCategory from the stored key")
+    func categorySpendRecoversCategory() {
+        let row = FinanceSnapshot.CategorySpend(category: .billsAndUtilities, amount: 100)
+        #expect(row.categoryKey == SpendingCategory.billsAndUtilities.rawValue)
+        #expect(row.category == .billsAndUtilities)
+        // An unknown key decodes to a nil category (forward-compat), not a crash.
+        let unknown = FinanceSnapshot.CategorySpend(categoryKey: "FUTURE_CATEGORY", displayName: "Future", amount: 5)
+        #expect(unknown.category == nil)
+    }
+}

--- a/Tests/PlaidBarCoreTests/RouteDeepLinkTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteDeepLinkTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Route deep-link contract (AND-586)")
+struct RouteDeepLinkTests {
+    @Test("Every destination round-trips through the typed route URL")
+    func everyDestinationRoundTrips() throws {
+        for destination in RouteDestination.allCases {
+            let urlString = RouteDeepLink.urlString(for: destination)
+            let url = try #require(URL(string: urlString))
+            let route = try #require(RouteDeepLink.route(from: url))
+            #expect(route.destination == destination)
+            // The canonical route for the destination is what a bare deep link
+            // resolves to (no per-row selection carried).
+            #expect(route == Route.canonical(for: destination))
+        }
+    }
+
+    @Test("Typed route URL uses the vaultpeek://route/<destination> form")
+    func typedRouteURLForm() {
+        #expect(RouteDeepLink.urlString(for: .transactions) == "vaultpeek://route/transactions")
+        #expect(RouteDeepLink.urlString(for: .budgets) == "vaultpeek://route/budgets")
+        #expect(RouteDeepLink.urlString(for: .review) == "vaultpeek://route/review")
+    }
+
+    @Test("Legacy host-only vaultpeek://dashboard still resolves to the dashboard")
+    func legacyDashboardLinkResolves() throws {
+        let url = try #require(URL(string: GlanceSnapshot.deepLinkURL))
+        let route = try #require(RouteDeepLink.route(from: url))
+        #expect(route == .dashboard)
+    }
+
+    @Test("Host-only form resolves any destination (e.g. vaultpeek://accounts)")
+    func hostOnlyFormResolves() throws {
+        let url = try #require(URL(string: "vaultpeek://accounts"))
+        #expect(RouteDeepLink.route(from: url) == .accounts())
+    }
+
+    @Test("vaultpeek://route with no destination resolves to the dashboard")
+    func bareRouteHostResolvesToDashboard() throws {
+        let url = try #require(URL(string: "vaultpeek://route"))
+        #expect(RouteDeepLink.route(from: url) == .dashboard)
+    }
+
+    @Test("Casing is forgiven when parsing a destination")
+    func casingForgiven() throws {
+        let url = try #require(URL(string: "vaultpeek://route/Transactions"))
+        #expect(RouteDeepLink.route(from: url) == .transactions())
+    }
+
+    @Test("Wrong scheme returns nil")
+    func wrongSchemeReturnsNil() throws {
+        let url = try #require(URL(string: "https://route/dashboard"))
+        #expect(RouteDeepLink.route(from: url) == nil)
+    }
+
+    @Test("Unknown destination returns nil")
+    func unknownDestinationReturnsNil() throws {
+        let url = try #require(URL(string: "vaultpeek://route/nonsense"))
+        #expect(RouteDeepLink.route(from: url) == nil)
+    }
+
+    @Test("urlString(for: route) drops selection, keeping the destination")
+    func routeURLDropsSelection() {
+        let route = Route.transactions(filter: nil, focus: "abc-123")
+        #expect(RouteDeepLink.urlString(for: route) == "vaultpeek://route/transactions")
+    }
+}

--- a/Tests/PlaidBarCoreTests/SnippetDashboardPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/SnippetDashboardPresentationTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Snippet / large-widget mini-dashboard (AND-586)")
+struct SnippetDashboardPresentationTests {
+    private let asOf = Date(timeIntervalSince1970: 1_780_000_000)
+
+    @Test("Data snapshot yields the three headline metric rows + categories")
+    func dataSnapshotRows() {
+        let model = SnippetDashboardPresentation.model(from: dataSnapshot())
+        #expect(!model.isWithheld)
+        #expect(model.rows.count == 3)
+        #expect(model.rows.map(\.id) == ["total-balance", "safe-to-spend", "period-spending"])
+        #expect(model.categories.count == 2)
+        // The headline leads with net balance.
+        #expect(model.headline.lowercased().contains("balance"))
+    }
+
+    @Test("Categories are truncated to the documented maximum")
+    func categoriesTruncated() {
+        let many = (0..<6).map { index in
+            FinanceSnapshot.CategorySpend(categoryKey: "K\(index)", displayName: "Cat\(index)", amount: Double(index))
+        }
+        let model = SnippetDashboardPresentation.model(from: dataSnapshot(categories: many))
+        #expect(model.categories.count == SnippetDashboardPresentation.maxCategories)
+    }
+
+    @Test("Masked snapshot withholds every figure with the dot placeholder")
+    func maskedWithholds() {
+        let model = SnippetDashboardPresentation.model(from: dataSnapshot(isMasked: true))
+        #expect(model.isWithheld)
+        // No real figure leaks: every row value is the masked dot placeholder, and
+        // no category rows are emitted.
+        for row in model.rows {
+            #expect(row.value == PrivacyMaskPresentation.compactValue)
+        }
+        #expect(model.categories.isEmpty)
+        #expect(!model.accessibilityLabel.contains("8,000"))
+    }
+
+    @Test("Nil snapshot shows the setup/unavailable state")
+    func nilSnapshotUnavailable() {
+        let model = SnippetDashboardPresentation.model(from: nil)
+        #expect(model.isWithheld)
+        #expect(model.rows.isEmpty)
+        #expect(model.headline.lowercased().contains("open vaultpeek"))
+    }
+
+    @Test("Empty snapshot shows the setup state, not a misleading $0 dashboard")
+    func emptySnapshotUnavailable() {
+        let model = SnippetDashboardPresentation.model(from: .placeholder(generatedAt: asOf))
+        #expect(model.isWithheld)
+        #expect(model.rows.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func dataSnapshot(
+        isMasked: Bool = false,
+        categories: [FinanceSnapshot.CategorySpend]? = nil
+    ) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: 1_200,
+            totalBalance: 8_000,
+            accountBalances: [FinanceSnapshot.AccountBalance(displayName: "Checking", balance: 8_000)],
+            nextRecurringBills: [],
+            creditUtilization: 22,
+            generatedAt: asOf,
+            isMasked: isMasked,
+            periodSpending: 540,
+            topSpendingCategories: categories ?? [
+                FinanceSnapshot.CategorySpend(category: .foodAndDrink, amount: 320),
+                FinanceSnapshot.CategorySpend(category: .shopping, amount: 180),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Epic 8 — Widgets & App Intents (**AND-586**) of the window-first migration (**ADR-001**). Expands the existing widget / App-Intents infrastructure rather than recreating it.

### 1. `AppIntentsPackage` in PlaidBarCore
The finance intents now live in Core (`Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift`) as `PlaidBarCoreAppIntentsPackage`, `Sendable` and reused by the app, widget extension, Siri, Spotlight, and Shortcuts. The app target includes it via `PlaidBarAppIntentsPackage.includedPackages` and owns the single `AppShortcutsProvider`. The previously-duplicated app-target intent definitions are removed — Core is the single source of truth.

**Intents exposed via Core:**
- `GetSafeToSpendIntent` — "what's safe to spend" (value + dialog)
- `ShowSpendingIntent` — "show spending" (period total + top categories; **also navigates to Budgets**)
- `ReviewTransactionsIntent` — "review transactions" (navigates to Review)
- `OpenDashboardIntent` — neutral entry point (navigates to Dashboard)
- `GetTotalBalanceIntent`, `NextRecurringBillsIntent`, `GetCreditUtilizationIntent`

All decision logic stays in `FinanceIntentQueries` (no AppIntents runtime) so it's unit-testable.

### 2. Deep-link routing via the AND-597 `Route` API
New pure `RouteDeepLink` (Core) maps `vaultpeek://route/<destination>` ⇄ `Route`. Navigation intents open the window via `OpenURLIntent`; the app's `.onOpenURL` parses the URL with `RouteDeepLink.route(from:)` and calls `AppState.route(to:)`. The legacy host-only `vaultpeek://dashboard` link still resolves, so installed widgets/Spotlight items keep working. When the window-first flag is OFF the handler falls back to the existing open-dashboard behavior.

### 3. WidgetKit families expanded
The glance widget gains `.systemLarge` — a multi-metric mini-dashboard (balance / safe-to-spend / spent-this-period + top categories) rendered from the Core `SnippetDashboardPresentation` model, in lockstep with the Spotlight snippet. (`.systemSmall`/`.systemMedium` unchanged; Control Center controls — Refresh, Privacy Mask, Safe-to-Spend, Credit-Utilization — already shipped in Epic E and are retained.)

### 4. SnippetIntent Spotlight mini-dashboard
`FinanceDashboardSnippetIntent` (macOS 26+) renders the mini-dashboard inline in Spotlight / Siri via `.result(view:)`.

## App-Group write-ownership (R-11)

The widget reads a **read-only snapshot** and never races app writes:

- **Sole writer:** the app (`AppState.writeFinanceSnapshot` → `AppGroupSnapshotStore.save(...)`), on the same path that recomputes summaries for the glance widget. Writes are atomic (`.atomic`) and owner-only (`0o600`).
- **Readers only:** widget timeline provider, App Intents, Control Center value providers, the SnippetIntent — all via `AppGroupSnapshotStore.loadIfAvailable()` / `GlanceSnapshotStore.load()`. None write the live store.
- **No SwiftData store sharing across the App Group.** The widget reads the small JSON `FinanceSnapshot` (values only — never tokens, account ids, or transaction payloads), so there is no SwiftData contention to begin with; the disposable read-model cache stays app-process-local. This satisfies R-11's "read-only widget access to a snapshot" mitigation directly.
- `FinanceSnapshot` gains `periodSpending` + `topSpendingCategories` with **backward-compatible decoding** (older snapshots decode the new keys to empty defaults).

## ControlWidget availability finding (R-07)

Verified against the **Xcode 26.5 / macOS 26.5 SDK**:
- `ControlWidget`, `StaticControlConfiguration`, `ControlWidgetButton`, `ControlWidgetToggle`, `ControlValueProvider` — **available on the macOS 26 floor** (shipped macOS 15 / iOS 18). They already compile in the existing widget bundle.
- `SnippetIntent` — `@available(macOS 26.0, *)` (at the floor).
- `.systemLarge` (macOS 11+) and `.systemExtraLarge` (macOS 14+) widget families — available.

**No macOS-27-only symbol is used by this epic**, so no `if #available(macOS 27, *)` gate is required. If a future ControlWidget feature reaches for a macOS 27 beta symbol, it must be gated per R-07; that's flagged but not needed here.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **passes** (builds the widget target).
- `swift test` — **1948 tests pass** (~1923 baseline + 25 new).
- New Core tests: `RouteDeepLinkTests` (round-trip + legacy/host-only + invalid), `showSpending` query (value / masked-withheld / unavailable), `SnippetDashboardPresentationTests` (rows / truncation / masked / setup), `FinanceSnapshotSpendingTests` (legacy decode + Codable round-trip + isEmpty + category-key recovery), and `FinanceSnapshotBuilder` month-to-date spend (income excluded, prior-month excluded, masked value-free).
- Masking preserved end-to-end: masked/missing/empty snapshots withhold every figure across intents, snippet, and large widget.

## Deferred follow-ups

- **`.appex` bundling for real install** (packaging / Felipe concern): the widget builds green under `swift build`, but SwiftPM does not produce a code-signed `.appex` embedded in the app bundle. Wiring the widget extension into the distributable app (and signing it with the App Group entitlement) is a packaging step outside this code change.
- Per-row deep-link selection: deep links currently land on a destination's canonical route (inspector shows its empty state); carrying a specific transaction/account id in the URL is a later enhancement (and intentionally avoids leaking identifiers into URLs the system may log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
