### PR TITLE
feat(insights): window-first Insights & Alerts destinations (AND-585)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
@@ -1,32 +1,454 @@
+import AppKit
 import PlaidBarCore
 import SwiftUI
 
-/// **Alerts** destination (3-column — IA §3.1/§5.8, `[⌘7]`).
+/// **Alerts** destination (3-column — IA §3.1/§5.8, `[⌘7]`) — Epic 7 / AND-585
+/// (ADR-001 window-first workspace).
 ///
-/// Alert feed (list) → alert detail / rule editor (inspector). The shell renders
-/// this content column plus `Inspector` in the detail column, which is
-/// content-gated and shows "Select an alert" when nothing is selected (IA §3.1).
+/// Content column = the alert **list** (severity-sorted, with inline acknowledge +
+/// "Acknowledge all"); detail column = the selected alert's **detail** with its
+/// recovery action and acknowledge toggle. The detail column is **content-gated,
+/// not existence-gated** (IA §3.1): with nothing selected it shows the "Select an
+/// alert" prompt rather than collapsing.
 ///
-/// Scaffold for the parallel Epics 4–7: both panes show the shared placeholders
-/// today; the real alert feed and detail/rule-editor inspector land in this
-/// destination's epic by replacing the two bodies, never touching `AppShellView`.
+/// **Surfaces existing engines, adds no alert source:**
+/// - The alerts are the live ``AttentionQueue`` rows (``AppState/attentionQueue``)
+///   — the same "do I need to act?" rollup the menu-bar glance and Dashboard key
+///   off (IA §1.3), so the feed stays truthful and consistent across surfaces.
+/// - ``AlertsInbox`` (new pure Core, unit-tested) reduces those rows + the
+///   acknowledged-id set into a sorted feed and the unacknowledged count. The rows
+///   are stateless (recomputed each render), so acknowledgement is layered on top
+///   as session-scoped per-window state in ``AlertsSelectionModel`` — the rows and
+///   the queue are never mutated.
+/// - Each alert's recovery action runs through the same dispatch the existing
+///   ``AttentionQueueView`` uses, so an action means the same thing on every
+///   surface.
+///
+/// The sidebar's unacked badge (`AppState.sidebarUnacknowledgedAlertCount`) already
+/// exists; it counts live non-healthy rows. Acknowledging mutes an alert from
+/// *this destination's* unacknowledged count (session state) without resolving the
+/// underlying condition — the badge keeps reflecting the live rows.
+///
+/// Severity is always carried by text + SF Symbol, never color alone
+/// (ACCESSIBILITY.md). **Flag-OFF inert:** reached only when the window-first
+/// `Window` opens (`WindowFirstFeatureFlag` ON); with the flag off this file is
+/// never instantiated and the popover is byte-identical.
 struct AlertsDestinationView: View {
-    var body: some View {
-        DestinationPlaceholder(destination: .alerts)
+    @Environment(AppState.self) private var appState
+    @State private var selection = AlertsSelectionModel.shared
+
+    private var rows: [AttentionQueueRow] {
+        appState.attentionQueue.rows
     }
 
-    /// The detail-column (inspector) pane for Alerts.
-    struct Inspector: View {
-        var body: some View {
-            DestinationInspectorPlaceholder(destination: .alerts)
+    private var inbox: AlertsInbox {
+        AlertsInbox.make(rows: rows, acknowledgedIDs: selection.acknowledgedIDs)
+    }
+
+    private var summary: AlertsSummary {
+        AlertsSummary.make(from: inbox)
+    }
+
+    var body: some View {
+        let inbox = inbox
+
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            header(inbox)
+
+            if inbox.isEmpty {
+                emptyState
+            } else {
+                alertsList(inbox)
+            }
         }
+        .padding(Spacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .navigationTitle(RouteDestination.alerts.title)
+        // Keep the acknowledged set + selection bounded to the live rows so a
+        // resolved condition never lingers acknowledged or selected.
+        .onChange(of: rows.map(\.id)) { _, _ in
+            selection.prune(toRowsIn: rows)
+        }
+        .onAppear { selection.prune(toRowsIn: rows) }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Header
+
+    private func header(_ inbox: AlertsInbox) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+                    Text("Alerts")
+                        .font(.title2.weight(.bold))
+
+                    // Unacked-count chip. Meaning rides the number + the VoiceOver
+                    // label, never color alone (ACCESSIBILITY.md). Hidden at zero.
+                    if let badge = summary.unacknowledgedBadge {
+                        Text(badge)
+                            .font(.caption.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(SemanticColors.warning)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(SemanticColors.warning.opacity(0.12), in: Capsule())
+                            .overlay { Capsule().stroke(SemanticColors.warning.opacity(0.20), lineWidth: 1) }
+                            .accessibilityLabel("\(inbox.unacknowledgedCount) unacknowledged")
+                    }
+                }
+
+                Text(summary.title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(summary.accessibilityLabel)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            if inbox.unacknowledgedCount > 0 {
+                Button {
+                    selection.acknowledgeAll(in: inbox)
+                } label: {
+                    Label("Acknowledge all", systemImage: "checkmark.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Acknowledge every listed alert")
+                .accessibilityHint("Marks all listed alerts acknowledged.")
+            }
+        }
+    }
+
+    // MARK: - List
+
+    private func alertsList(_ inbox: AlertsInbox) -> some View {
+        ScrollView {
+            LazyVStack(spacing: Spacing.xs) {
+                ForEach(inbox.entries) { entry in
+                    AlertsRowView(
+                        entry: entry,
+                        isSelected: selection.selectedAlertID == entry.id,
+                        onSelect: { selection.selectedAlertID = entry.id },
+                        onToggleAcknowledged: { toggleAcknowledged(entry) }
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .accessibilityLabel("Alerts list, \(inbox.totalCount) item\(inbox.totalCount == 1 ? "" : "s")")
+    }
+
+    private func toggleAcknowledged(_ entry: AlertsInbox.Entry) {
+        if entry.isAcknowledged {
+            selection.unacknowledge(entry.id)
+        } else {
+            selection.acknowledge(entry.id)
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("All clear", systemImage: "checkmark.circle")
+        } description: {
+            Text("Nothing needs your attention right now. Connection, sync, and spending alerts show up here when something changes.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityLabel("Alerts. All clear, nothing needs attention.")
+    }
+
+    /// The detail-column (inspector) pane for Alerts — the selected alert's
+    /// detail, recovery action, and acknowledge toggle. Content-gated: shows the
+    /// "Select an alert" prompt when nothing is selected (IA §3.1).
+    struct Inspector: View {
+        @Environment(AppState.self) private var appState
+        @Environment(\.openSettings) private var openSettings
+        @State private var selection = AlertsSelectionModel.shared
+
+        private var inbox: AlertsInbox {
+            AlertsInbox.make(
+                rows: appState.attentionQueue.rows,
+                acknowledgedIDs: selection.acknowledgedIDs
+            )
+        }
+
+        private var selectedEntry: AlertsInbox.Entry? {
+            inbox.entry(id: selection.selectedAlertID)
+        }
+
+        var body: some View {
+            if let entry = selectedEntry {
+                AlertDetailView(
+                    entry: entry,
+                    onToggleAcknowledged: { toggleAcknowledged(entry) },
+                    onAction: { perform(entry.row) }
+                )
+            } else {
+                emptyPrompt
+            }
+        }
+
+        private var emptyPrompt: some View {
+            ContentUnavailableView {
+                Label(RouteDestination.alerts.detailColumnEmptyPrompt ?? "Select an alert", systemImage: "bell")
+            } description: {
+                Text("Pick an alert to see what changed and how to resolve it.")
+            }
+            .accessibilityLabel("Select an alert to see its detail.")
+        }
+
+        private func toggleAcknowledged(_ entry: AlertsInbox.Entry) {
+            if entry.isAcknowledged {
+                selection.unacknowledge(entry.id)
+            } else {
+                selection.acknowledge(entry.id)
+            }
+        }
+
+        /// Dispatch the alert's recovery action — the same paths
+        /// ``AttentionQueueView`` runs, so an action means the same thing here as
+        /// on the menu-bar glance.
+        private func perform(_ row: AttentionQueueRow) {
+            guard let action = row.action else { return }
+            switch action {
+            case .checkServer:
+                Task { await appState.checkServerConnection() }
+            case .addAccount:
+                Task { await appState.addAccount() }
+            case .refresh:
+                Task { await appState.refreshDashboard() }
+            case .reconnect:
+                guard let itemId = row.targetItemId ?? ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
+                    Task { await appState.refreshDashboard() }
+                    return
+                }
+                Task { await appState.reconnectItem(itemId: itemId) }
+            case .openSettings:
+                openSettings()
+            case .requestNotificationPermission:
+                Task { _ = await appState.requestNotificationPermission() }
+            case .openNotificationSettings:
+                openNotificationSettings()
+            }
+        }
+
+        private func openNotificationSettings() {
+            guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+                openSettings()
+                return
+            }
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+// MARK: - Row
+
+/// A single alert row in the list. Severity is carried by a status badge (glyph +
+/// label) and the acknowledged state by a strikethrough title + a labeled toggle —
+/// never tint alone.
+private struct AlertsRowView: View {
+    let entry: AlertsInbox.Entry
+    let isSelected: Bool
+    let onSelect: () -> Void
+    let onToggleAcknowledged: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(alignment: .top, spacing: Spacing.sm) {
+                Image(systemName: entry.severity.statusSymbolName)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: Sizing.glyphSmall, height: Sizing.glyphSmall)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    HStack(spacing: Spacing.xs) {
+                        AlertSeverityBadge(severity: entry.severity, tint: tint)
+                        Text(entry.title)
+                            .font(.caption.weight(.semibold))
+                            .strikethrough(entry.isAcknowledged)
+                            .foregroundStyle(entry.isAcknowledged ? .secondary : .primary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                    }
+                    Text(entry.detail)
+                        .microText()
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: Spacing.xs)
+
+                Button(action: onToggleAcknowledged) {
+                    Image(systemName: entry.isAcknowledged ? "bell.slash.fill" : "bell.fill")
+                        .font(.callout)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(entry.isAcknowledged ? .secondary : tint)
+                .help(entry.isAcknowledged ? "Un-acknowledge" : "Acknowledge")
+                .accessibilityLabel(entry.isAcknowledged ? "Un-acknowledge alert" : "Acknowledge alert")
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.rowVertical)
+        }
+        .buttonStyle(.plain)
+        .background(
+            isSelected ? SemanticColors.brand.opacity(0.10) : Color.clear,
+            in: RoundedRectangle(cornerRadius: Radius.control)
+        )
+        .nativeInsetSurface(stroke: panelStroke)
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityLabel(entry.accessibilityLabel)
+        .accessibilityHint("Opens the alert detail.")
+    }
+
+    private var tint: Color {
+        switch entry.severity {
+        case .healthy: .secondary
+        case .warning: SemanticColors.warning
+        case .blocked: SemanticColors.negative
+        }
+    }
+
+    private var panelStroke: Color {
+        if isSelected { return SemanticColors.brand.opacity(0.28) }
+        return entry.isAcknowledged ? Color.primary.opacity(0.06) : tint.opacity(0.16)
+    }
+}
+
+// MARK: - Detail (inspector)
+
+/// The selected alert's detail pane: title, severity, full message, an acknowledge
+/// toggle, and the recovery action (when the alert carries one).
+private struct AlertDetailView: View {
+    let entry: AlertsInbox.Entry
+    let onToggleAcknowledged: () -> Void
+    let onAction: () -> Void
+
+    private var row: AttentionQueueRow { entry.row }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.lg) {
+                headerCard
+                if row.action != nil || row.actionTitle != nil {
+                    actionCard
+                }
+            }
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollContentBackground(.hidden)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Alert detail. \(entry.accessibilityLabel)")
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                AlertSeverityBadge(severity: entry.severity, tint: tint)
+                if entry.isAcknowledged {
+                    Label("Acknowledged", systemImage: "bell.slash")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.primary.opacity(0.06), in: Capsule())
+                }
+                Spacer()
+            }
+
+            Text(row.title)
+                .font(.headline)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(row.detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Toggle(isOn: Binding(get: { entry.isAcknowledged }, set: { _ in onToggleAcknowledged() })) {
+                Text(entry.isAcknowledged ? "Acknowledged" : "Acknowledge")
+                    .font(.caption.weight(.medium))
+            }
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .accessibilityHint("Mutes this alert from the unacknowledged count without resolving the underlying condition.")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    private var actionCard: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Resolve")
+                .font(.headline)
+            Text("Run the suggested step to clear this alert.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button(action: onAction) {
+                Label(row.actionTitle ?? "Resolve", systemImage: row.actionIconName ?? "arrow.right")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .accessibilityLabel(row.actionTitle ?? "Resolve")
+            .accessibilityHint(row.accessibilityHint ?? row.detail)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+    }
+
+    private var tint: Color {
+        switch entry.severity {
+        case .healthy: .secondary
+        case .warning: SemanticColors.warning
+        case .blocked: SemanticColors.negative
+        }
+    }
+}
+
+// MARK: - Severity badge
+
+/// Severity badge — glyph + label, color-independent meaning carrier
+/// (ACCESSIBILITY.md). Mirrors the popover's attention badge without depending on
+/// its private view.
+private struct AlertSeverityBadge: View {
+    let severity: AttentionQueueSeverity
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: Spacing.xxs) {
+            Image(systemName: severity.statusSymbolName)
+                .font(.caption2.weight(.semibold))
+                .accessibilityHidden(true)
+            Text(severity.statusLabel)
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(tint.opacity(0.11), in: Capsule())
+        .overlay { Capsule().stroke(tint.opacity(0.22), lineWidth: 1) }
+        .accessibilityHidden(true)
     }
 }
 
 #Preview("Content") {
     AlertsDestinationView()
+        .environment(AppState())
 }
 
 #Preview("Inspector") {
     AlertsDestinationView.Inspector()
+        .environment(AppState())
 }

--- a/Sources/PlaidBar/Views/Destinations/AlertsSelectionModel.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsSelectionModel.swift
@@ -1,0 +1,77 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Shared selection + acknowledgement state for the 3-column **Alerts**
+/// destination (Epic 7 / AND-585, ADR-001 window-first).
+///
+/// `AppShellView` mounts ``AlertsDestinationView`` (content, the alert list) and
+/// ``AlertsDestinationView/Inspector`` (detail, the selected alert) as **separate**
+/// views in different columns of a `NavigationSplitView`, so they cannot share
+/// `@State`. This tiny `@MainActor @Observable` singleton is the bridge: the list
+/// writes the tapped alert id and toggles acknowledgement; the inspector reads the
+/// selected id to show that alert's detail and reflects the acknowledged bit.
+///
+/// **Scope note:** ideally alert selection would live on a *per-window*
+/// `NavigationModel` (so two open windows keep independent selections), but Epic 7
+/// owns only the destination files and must not edit `NavigationModel`. This
+/// mirrors the established ``BudgetsSelectionModel`` shared-singleton bridge for
+/// the same split-column constraint. The acknowledged-id set is ephemeral, session-
+/// scoped UI state (muting an alert from the unacknowledged count without resolving
+/// the underlying condition) — no persistence schema — so a shared in-memory model
+/// is the right scope. It is pruned to the live rows on every list render via
+/// ``AlertsInbox/pruneAcknowledgedIDs(_:toRowsIn:)`` so it never accumulates ids for
+/// conditions that have since resolved.
+///
+/// Window-first surface only: referenced solely from the Alerts destination, built
+/// behind `WindowFirstFeatureFlag` via `AppShellView`. With the flag OFF the
+/// workspace never mounts, so this is never instantiated and the popover is
+/// byte-identical.
+@MainActor
+@Observable
+final class AlertsSelectionModel {
+    /// Process-wide shared instance — the only way the two split-view columns can
+    /// observe the same state (they have no common SwiftUI parent to inject an
+    /// environment object through). Mirrors ``BudgetsSelectionModel/shared``.
+    static let shared = AlertsSelectionModel()
+
+    /// The id of the alert whose detail the inspector shows. `nil` means the
+    /// inspector is content-gated — it renders the "Select an alert" prompt
+    /// (IA §3.1), never collapsing.
+    var selectedAlertID: String?
+
+    /// Ids the user has acknowledged this session. Acknowledging mutes an alert
+    /// from the unacknowledged count; it does not resolve the underlying condition
+    /// (that clears on its own when the fact changes).
+    var acknowledgedIDs: Set<String> = []
+
+    private init() {}
+
+    /// Acknowledge a single alert.
+    func acknowledge(_ id: String) {
+        acknowledgedIDs.insert(id)
+    }
+
+    /// Un-acknowledge a single alert (re-surface it in the count).
+    func unacknowledge(_ id: String) {
+        acknowledgedIDs.remove(id)
+    }
+
+    /// Acknowledge every currently-listed alert ("acknowledge all"/"clear").
+    func acknowledgeAll(in inbox: AlertsInbox) {
+        for entry in inbox.entries {
+            acknowledgedIDs.insert(entry.id)
+        }
+    }
+
+    /// Drop acknowledged ids for conditions no longer present in the live rows, so
+    /// the set stays bounded and a re-occurring condition surfaces again.
+    func prune(toRowsIn rows: [AttentionQueueRow]) {
+        let pruned = AlertsInbox.pruneAcknowledgedIDs(acknowledgedIDs, toRowsIn: rows)
+        if pruned != acknowledgedIDs {
+            acknowledgedIDs = pruned
+        }
+        if let selectedAlertID, !rows.contains(where: { $0.id == selectedAlertID }) {
+            self.selectedAlertID = nil
+        }
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -1,0 +1,400 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The streaming Foundation Models spending-insight surface for the **Insights**
+/// destination (Epic 7 / AND-585). A thin renderer over the existing AI engine —
+/// it adds no model logic:
+///
+/// - The headline + evidence + provenance come from ``LocalAIInsightReceipt.make``
+///   (the same builder the popover's insight card uses), so the two surfaces can
+///   never disagree.
+/// - The incremental Foundation Models `@Generable` stream is surfaced reactively:
+///   ``AppState/localAIActivitySummaries`` returns the deterministic on-device
+///   headline immediately and is replaced in place when the model-generated
+///   headline streams in (the cache is `@Observable`), so this view re-renders
+///   from "generating on-device" into the streamed result without any extra
+///   plumbing. FM availability is detected with a graceful NaturalLanguage /
+///   deterministic fallback (AND-563).
+/// - AI stays **off by default** behind a visible toggle (the AND-564 consent
+///   contract): with the toggle off no model is invoked and the surface shows only
+///   the enable affordance.
+///
+/// Liquid Glass never touches a chart; this is a text/receipt surface, so it uses
+/// the standard raised card chrome. Phase + provenance are carried by text + SF
+/// Symbol, never color alone (ACCESSIBILITY.md).
+struct InsightsAIInsightView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var summaries: [LocalAIActivitySummary] {
+        appState.localAIActivitySummaries
+    }
+
+    private var primarySummary: LocalAIActivitySummary? {
+        summaries.first { $0.window == .lastMonth } ?? summaries.first
+    }
+
+    private var availability: LocalAIAvailability {
+        primarySummary?.availability ?? appState.localAIAvailability
+    }
+
+    private var receipt: LocalAIInsightReceipt {
+        LocalAIInsightReceipt.make(
+            summary: primarySummary,
+            availability: availability,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
+        )
+    }
+
+    /// Whether a model produced the headline yet (non-empty `generatedSummary`),
+    /// vs. the deterministic fallback. Drives the generating → streamed phase.
+    private var hasModelGeneratedHeadline: Bool {
+        !(primarySummary?.generatedSummary.isEmpty ?? true)
+    }
+
+    private var phase: InsightsStreamingPhase {
+        InsightsStreamingPhase.resolve(
+            isEnabled: appState.localAIEnabled,
+            availabilityState: availability.state,
+            hasModelGeneratedHeadline: hasModelGeneratedHeadline
+        )
+    }
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { appState.localAIEnabled },
+            set: { appState.localAIEnabled = $0 }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            header
+
+            if phase == .off {
+                offState
+            } else {
+                insightBody
+            }
+        }
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+        // Probe the on-device runtime when the surface appears so an enabled-but-
+        // unprobed state resolves to a truthful availability without waiting for a
+        // data change. A no-op while disabled or already checking.
+        .task(id: appState.localAIEnabled) {
+            guard appState.localAIEnabled else { return }
+            await appState.checkLocalAIAvailability()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label("Spending insights", systemImage: "sparkles")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            phasePill
+
+            // The off-by-default consent toggle, always visible (AND-564).
+            Toggle("Local AI", isOn: enabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+                .help(appState.localAIEnabled ? "Turn off on-device AI insights" : "Turn on on-device AI insights")
+                .accessibilityLabel("Local AI insights")
+                .accessibilityValue(appState.localAIEnabled ? "On" : "Off")
+                .accessibilityHint("Generates spending insights on this Mac. Off by default.")
+        }
+    }
+
+    /// Phase status pill — glyph + text so the state never rides on tint alone.
+    /// The generating phase animates a non-looping shimmer, suppressed under
+    /// Reduce Motion.
+    private var phasePill: some View {
+        HStack(spacing: Spacing.xxs) {
+            Image(systemName: phase.systemImage)
+                .font(.caption2.weight(.semibold))
+                .symbolEffect(.pulse, options: .repeating, isActive: phase.isWorking && !reduceMotion)
+                .accessibilityHidden(true)
+            Text(phase.statusLabel)
+                .font(.caption2.weight(.semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(phaseTint)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(phaseTint.opacity(0.12), in: Capsule())
+        .overlay { Capsule().stroke(phaseTint.opacity(0.20), lineWidth: 1) }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(phase.accessibilityLabel)
+    }
+
+    private var phaseTint: Color {
+        switch phase {
+        case .off: .secondary
+        case .unavailable: SemanticColors.warning
+        case .generating: SemanticColors.brand
+        case .streamed: SemanticColors.positive
+        }
+    }
+
+    // MARK: - Off state (consent)
+
+    private var offState: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("On-device spending summaries are off")
+                .font(.callout.weight(.semibold))
+
+            Text("Turn on Local AI to generate a short, factual summary of your spending on this Mac. Nothing leaves your device — there is no cloud fallback.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: Spacing.sm) {
+                Button {
+                    appState.localAIEnabled = true
+                } label: {
+                    Label("Enable Local AI", systemImage: "sparkles")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityHint("Enables on-device spending insights. Off by default.")
+
+                Button {
+                    openSettings()
+                } label: {
+                    Label("Where your data lives", systemImage: "lock.shield")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityHint("Opens Settings to the local data section.")
+            }
+        }
+        .padding(Spacing.sm)
+        .nativeInsetSurface()
+    }
+
+    // MARK: - Insight body (generating / streamed / unavailable)
+
+    private var insightBody: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            // Headline — the deterministic fallback while generating, replaced in
+            // place by the model-generated headline when it streams in.
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Text(receipt.headline)
+                    .font(.callout.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .transition(.opacity)
+                    .id(receipt.headline) // cross-fade as the streamed text lands
+                    .animation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion), value: receipt.headline)
+
+                if phase.isWorking {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Generating on-device")
+                }
+            }
+
+            if !receipt.evidenceChips.isEmpty {
+                evidenceChips
+            }
+
+            provenance
+
+            if phase == .unavailable {
+                unavailableNote
+            }
+
+            footer
+        }
+    }
+
+    private var evidenceChips: some View {
+        // Wrap so chips reflow rather than clip on a narrow column.
+        InsightsFlowLayout(spacing: Spacing.xs) {
+            ForEach(receipt.evidenceChips) { chip in
+                InsightsEvidenceChipView(chip: chip)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Evidence")
+    }
+
+    /// Provenance / consent receipt lines — confidence, runtime limitations, and
+    /// the reversible-action note — each as a bulleted detail line.
+    private var provenance: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(Array(provenanceLines.enumerated()), id: \.offset) { _, line in
+                HStack(alignment: .top, spacing: Spacing.sm) {
+                    Image(systemName: "circle.fill")
+                        .font(.system(size: 4))
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 6)
+                        .accessibilityHidden(true)
+                    Text(line)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private var provenanceLines: [String] {
+        var lines: [String] = [receipt.confidence]
+        if let unavailableState = receipt.unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: receipt.limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
+    private var unavailableNote: some View {
+        Label(availability.detail, systemImage: "exclamationmark.triangle")
+            .font(.caption.weight(.medium))
+            .foregroundStyle(SemanticColors.warning)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(Spacing.sm)
+            .nativeInsetSurface(stroke: SemanticColors.warning.opacity(0.18))
+            .accessibilityLabel("Runtime unavailable. \(availability.detail)")
+    }
+
+    private var footer: some View {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: "lock.shield.fill")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("\(receipt.localOnlyBadge). \(receipt.reversibleActionCopy)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: Spacing.xs)
+
+            Button {
+                openSettings()
+            } label: {
+                Label("Where your data lives", systemImage: "externaldrive.badge.questionmark")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption2)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Open Settings to see where VaultPeek stores your data on this Mac.")
+            .accessibilityLabel("Where your data lives")
+            .accessibilityHint("Opens Settings to the local data section.")
+        }
+    }
+
+    private var accessibilityLabel: String {
+        if phase == .off {
+            return "Spending insights. \(phase.accessibilityLabel)"
+        }
+        return "Spending insights. \(phase.accessibilityLabel) \(receipt.accessibilitySummary)"
+    }
+}
+
+/// A single evidence chip — glyph + label + value, color-independent (the accent
+/// is supplementary; the glyph and text carry the meaning). Mirrors the popover's
+/// chip presentation without depending on its private view.
+struct InsightsEvidenceChipView: View {
+    let chip: LocalAIInsightReceipt.EvidenceChip
+
+    private var accent: Color {
+        guard let category = chip.accentCategory else { return .secondary }
+        return CategoryAccentTokens.color(for: category)
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.xxs) {
+            Image(systemName: chip.systemImage)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(accent)
+                .accessibilityHidden(true)
+            Text(chip.label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(chip.value)
+                .font(.caption2.weight(.semibold))
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Color.primary.opacity(0.05), in: Capsule())
+        .overlay { Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 1) }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(chip.label): \(chip.value)")
+    }
+}
+
+/// A minimal left-to-right wrapping layout for the evidence chips, so they reflow
+/// onto a new row instead of clipping on a narrow content column. Pure geometry —
+/// no animation or state.
+struct InsightsFlowLayout: Layout {
+    var spacing: CGFloat = Spacing.xs
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = computeRows(maxWidth: maxWidth, subviews: subviews)
+        guard !rows.isEmpty else { return .zero }
+        let rowsHeight = rows.reduce(CGFloat.zero) { $0 + $1.height }
+        let interRowSpacing = spacing * CGFloat(rows.count - 1)
+        let width = rows.map(\.width).max() ?? 0
+        return CGSize(width: min(width, maxWidth), height: rowsHeight + interRowSpacing)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let rows = computeRows(maxWidth: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + spacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func computeRows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let projected = current.width == 0 ? size.width : current.width + spacing + size.width
+            if projected > maxWidth, !current.indices.isEmpty {
+                rows.append(current)
+                current = Row()
+                current.indices = [index]
+                current.width = size.width
+                current.height = size.height
+            } else {
+                current.indices.append(index)
+                current.width = projected
+                current.height = max(current.height, size.height)
+            }
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
@@ -1,21 +1,143 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Insights** destination (2-column — IA §3.1/§5.7, `[⌘6]`).
+/// **Insights** destination (2-column composed canvas — IA §3.1/§5.7, `[⌘6]`) —
+/// Epic 7 / AND-585 (ADR-001 window-first workspace).
 ///
-/// A reading feed of receipts + weekly review; selecting a receipt expands in
-/// place rather than filling a detail column, so the shell renders only this
-/// content column (no inspector).
+/// A composed reading canvas — no master list, so the shell renders only this
+/// content column (no inspector). It stacks the three Insights bands (IA §5.7 —
+/// ``InsightSection``), every one surfaced from an existing engine; **no model or
+/// chart logic lives here** (surface only):
 ///
-/// Scaffold for the parallel Epics 4–7: today it shows the shared
-/// `DestinationPlaceholder`; the real feed lands in its epic by replacing this
-/// `body`, without touching `AppShellView`.
+/// - **Spending insights** (``InsightSection/receipts``) — the streaming
+///   Foundation Models `@Generable` insight + the on-device ``LocalAIInsightReceipt``
+///   (tier + provenance + consent), via ``InsightsAIInsightView``. AI is **off by
+///   default with a visible toggle** (AND-564); FM availability is detected with a
+///   graceful NaturalLanguage / deterministic fallback (AND-563).
+/// - **Weekly review** (``InsightSection/weeklyReview``) — the existing
+///   ``WeeklyReviewCard`` re-hosted unchanged, so the window-first surface and the
+///   menu-bar popover drive the same review state.
+/// - **Trends** (``InsightSection/trends``) — the chart canvas (``InsightsTrendsView``):
+///   net-worth trend, spend donut, and activity heatmap. Every chart ships its
+///   ``ChartAudioGraph`` audio graph (AND-569) + a `reduceTransparency` / Privacy
+///   Mask text alternative; **Liquid Glass never touches a chart**, and no meaning
+///   rides on color alone (ACCESSIBILITY.md).
+///
+/// A segmented section picker jumps between the three bands (scroll-to-anchor),
+/// matching the IA's Insights sub-sections without splitting into a master list.
+///
+/// **Flag-OFF inert:** reached only when the window-first `Window` opens
+/// (`WindowFirstFeatureFlag` ON). With the flag off the popover is byte-identical —
+/// this file is never instantiated.
 struct InsightsDestinationView: View {
+    @Environment(AppState.self) private var appState
+
+    /// The section the picker last jumped to. `@SceneStorage` keeps it window-
+    /// scoped so each workspace window remembers its own focus without touching
+    /// shared `AppState`.
+    @SceneStorage("insights.section") private var sectionRaw = InsightSection.receipts.rawValue
+
+    private var section: InsightSection {
+        InsightSection(rawValue: sectionRaw) ?? .receipts
+    }
+
     var body: some View {
-        DestinationPlaceholder(destination: .insights)
+        ScrollViewReader { scroll in
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    header
+
+                    InsightsAIInsightView()
+                        .id(InsightSection.receipts)
+
+                    weeklyReviewSection
+                        .id(InsightSection.weeklyReview)
+
+                    InsightsTrendsView()
+                        .id(InsightSection.trends)
+                }
+                .padding(Spacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollContentBackground(.hidden)
+            .onChange(of: sectionRaw) { _, raw in
+                guard let target = InsightSection(rawValue: raw) else { return }
+                withAnimation { scroll.scrollTo(target, anchor: .top) }
+            }
+        }
+        .navigationTitle(RouteDestination.insights.title)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text("Insights")
+                    .font(.title2.weight(.bold))
+                Text("On-device spending summaries, your weekly review, and the trends behind them — all computed locally on this Mac.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+
+            sectionPicker
+        }
+    }
+
+    /// Jumps the canvas to a band. Each segment carries a glyph **and** a label so
+    /// the selection is never conveyed by tint alone (ACCESSIBILITY.md).
+    private var sectionPicker: some View {
+        Picker("Insights section", selection: sectionBinding) {
+            ForEach(InsightSection.allCases, id: \.self) { section in
+                Label(sectionLabel(section), systemImage: sectionGlyph(section))
+                    .tag(section)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelStyle(.titleAndIcon)
+        .fixedSize()
+        .accessibilityLabel("Insights section")
+        .accessibilityHint("Jump to spending insights, the weekly review, or trends.")
+    }
+
+    private var sectionBinding: Binding<InsightSection> {
+        Binding(get: { section }, set: { sectionRaw = $0.rawValue })
+    }
+
+    private func sectionLabel(_ section: InsightSection) -> String {
+        switch section {
+        case .receipts: "Insights"
+        case .weeklyReview: "Weekly review"
+        case .trends: "Trends"
+        }
+    }
+
+    private func sectionGlyph(_ section: InsightSection) -> String {
+        switch section {
+        case .receipts: "sparkles"
+        case .weeklyReview: "calendar.badge.checkmark"
+        case .trends: "chart.xyaxis.line"
+        }
+    }
+
+    // MARK: - Weekly review
+
+    private var weeklyReviewSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label("Weekly review", systemImage: "calendar.badge.checkmark")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+            // The existing card, re-hosted unchanged — same review state as the
+            // menu-bar popover, so the two surfaces can never diverge.
+            WeeklyReviewCard()
+        }
+        .accessibilityElement(children: .contain)
     }
 }
 
 #Preview {
     InsightsDestinationView()
+        .environment(AppState())
 }

--- a/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
@@ -1,0 +1,261 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The **Trends** band of the Insights destination (Epic 7 / AND-585) — the
+/// chart canvas. It re-hosts the existing, unchanged chart components and gives
+/// each one its audio graph + a `reduceTransparency` text fallback + a non-color
+/// alternative (ACCESSIBILITY.md). **Liquid Glass never touches a chart** — the
+/// charts render on the standard raised card chrome (a `.clear`-fill surface), and
+/// the marks themselves carry no material.
+///
+/// - **Net worth trend** — ``BalanceTrendChart`` over ``BalanceTrend/evaluate``,
+///   self-hides until there is enough recorded history to draw a line.
+/// - **Spending by category** — ``SpendDonutChart`` over the override-aware
+///   ``SpendDonutModel`` built from ``AppState/categoryDashboardPresentation``.
+/// - **Activity heatmap** — a read-only year heatmap built from the existing
+///   ``SpendingHeatmapLayout`` Core engine + ``ChartAudioGraph/heatmap`` audio
+///   graph (AND-569), with a Reduce Transparency / Privacy Mask text alternative.
+struct InsightsTrendsView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.lg) {
+            netWorthTrendSection
+            spendingByCategorySection
+            activityHeatmapSection
+        }
+    }
+
+    // MARK: - Net worth trend
+
+    @ViewBuilder
+    private var netWorthTrendSection: some View {
+        if let trend = BalanceTrend.evaluate(history: appState.balanceHistory) {
+            chartCard(
+                title: "Net worth trend",
+                systemImage: "chart.xyaxis.line"
+            ) {
+                if isMasked {
+                    maskedChartFallback(
+                        message: "Net worth trend hidden while VaultPeek is private.",
+                        minHeight: 120
+                    )
+                } else {
+                    VStack(alignment: .leading, spacing: Spacing.xs) {
+                        // Direction is carried by the signed delta text + the
+                        // VoiceOver summary, never by line color alone.
+                        Label(trend.deltaText, systemImage: directionGlyph(trend.direction))
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(directionTint(trend.direction))
+                            .accessibilityHidden(true)
+
+                        BalanceTrendChart(trend: trend)
+                            .frame(minHeight: 120)
+                    }
+                }
+            }
+            .loadingRedaction(appState.loadState(for: .summaryCards))
+        }
+    }
+
+    private func directionGlyph(_ direction: BalanceTrend.Direction) -> String {
+        switch direction {
+        case .up: "arrow.up.right"
+        case .down: "arrow.down.right"
+        case .flat: "arrow.right"
+        }
+    }
+
+    private func directionTint(_ direction: BalanceTrend.Direction) -> Color {
+        switch direction {
+        case .up: SemanticColors.positive
+        case .down: SemanticColors.negative
+        case .flat: .secondary
+        }
+    }
+
+    // MARK: - Spending by category (donut)
+
+    @ViewBuilder
+    private var spendingByCategorySection: some View {
+        let presentation = appState.categoryDashboardPresentation
+        if !presentation.isEmpty {
+            chartCard(
+                title: "Spending by category",
+                systemImage: "chart.pie"
+            ) {
+                SpendDonutChart(
+                    model: SpendDonutModel(presentation: presentation),
+                    isPrivacyMasked: isMasked
+                )
+            }
+            .loadingRedaction(appState.loadState(for: .summaryCards))
+        }
+    }
+
+    // MARK: - Activity heatmap
+
+    @ViewBuilder
+    private var activityHeatmapSection: some View {
+        let layout = heatmapLayout()
+        if layout.activeDayCount > 0 {
+            chartCard(
+                title: layout.mode.summaryTitle,
+                systemImage: "square.grid.3x3.fill"
+            ) {
+                if isMasked || reduceTransparency {
+                    // Reduce Transparency / Privacy Mask text alternative: the
+                    // heatmap leans on tinted, translucent cells, so when either
+                    // is on we drop to a plain text summary that carries the same
+                    // information without relying on color or translucency.
+                    heatmapTextAlternative(layout: layout)
+                } else {
+                    InsightsActivityHeatmapGrid(layout: layout)
+                }
+            }
+            .loadingRedaction(appState.loadState(for: .activityHeatmap))
+        }
+    }
+
+    private func heatmapLayout() -> SpendingHeatmapLayout {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -364, to: end) ?? end
+        return SpendingHeatmapLayout.compute(
+            from: appState.transactions,
+            startDate: start,
+            endDate: end,
+            mode: .spending,
+            calendar: calendar
+        )
+    }
+
+    private func heatmapTextAlternative(layout: SpendingHeatmapLayout) -> some View {
+        let total = isMasked
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(layout.totalValue, format: .compact)
+        return VStack(alignment: .leading, spacing: Spacing.xs) {
+            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
+                .font(.subheadline.weight(.medium))
+            Text(isMasked
+                ? "Activity totals are hidden while VaultPeek is private."
+                : "\(total) spent across active days. \(layout.mode.semanticDescription)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Card chrome
+
+    /// Standard raised card chrome for a chart section. The chart marks never get
+    /// a glass treatment; the card surface uses `.glassSurface(.raised)`, whose
+    /// `.raised` rank is a `.clear` fill (no material on the chart).
+    private func chartCard(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label(title, systemImage: systemImage)
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+        .accessibilityElement(children: .contain)
+    }
+
+    private func maskedChartFallback(message: String, minHeight: CGFloat) -> some View {
+        Label(message, systemImage: "eye.slash")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: minHeight, alignment: .leading)
+            .accessibilityLabel(message)
+    }
+}
+
+/// A read-only year activity heatmap grid built from the existing
+/// ``SpendingHeatmapLayout`` Core engine. It carries the ``ChartAudioGraph/heatmap``
+/// audio graph (AND-569) and a full text alternative via its VoiceOver label, so
+/// meaning never rides on cell color alone. No glass — cells are plain tinted
+/// rounded rects. Privacy Mask / Reduce Transparency callers swap this for a text
+/// summary upstream; this view is shown only when neither is active.
+struct InsightsActivityHeatmapGrid: View {
+    let layout: SpendingHeatmapLayout
+
+    private let spacing: CGFloat = 2
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            GeometryReader { proxy in
+                let weeks = max(layout.weekColumns.count, 1)
+                let cell = max(5, min(9, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks))))
+                HStack(alignment: .top, spacing: spacing) {
+                    ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { _, week in
+                        VStack(spacing: spacing) {
+                            ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                                cellView(for: day, size: cell)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: 7 * 9 + 6 * spacing)
+
+            legend
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
+        )
+        // VoiceOver audio graph over the active days (AND-569).
+        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
+    }
+
+    @ViewBuilder
+    private func cellView(for day: SpendingHeatmapDay?, size: CGFloat) -> some View {
+        if let day {
+            let intensity = SpendingHeatmap.cellIntensity(for: day, peakValue: layout.peakValue)
+            RoundedRectangle(cornerRadius: Radius.cell)
+                .fill(Color.primary.opacity(0.12 + 0.6 * intensity))
+                .frame(width: size, height: size)
+        } else {
+            RoundedRectangle(cornerRadius: Radius.cell)
+                .fill(.clear)
+                .frame(width: size, height: size)
+        }
+    }
+
+    private var legend: some View {
+        HStack(spacing: 5) {
+            Text("Less")
+                .microText()
+                .foregroundStyle(.secondary)
+            ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                RoundedRectangle(cornerRadius: Radius.cell)
+                    .fill(Color.primary.opacity(0.12 + 0.6 * intensity))
+                    .frame(width: 8, height: 8)
+            }
+            Text("More")
+                .microText()
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Text("\(layout.activeDayCount) active days")
+                .microText()
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/PlaidBarCore/Models/AlertsInbox.swift
+++ b/Sources/PlaidBarCore/Models/AlertsInbox.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Pure reduction of the live ``AttentionQueue`` rows into the **Alerts**
+/// destination's list → detail feed (Epic 7 / AND-585, ADR-001 window-first).
+///
+/// The ``AttentionQueue`` rows are *stateless* — they are recomputed every render
+/// from the current connection/sync/financial facts, so they carry no
+/// acknowledged/cleared bit. The Alerts destination needs exactly that: a user
+/// can acknowledge an alert (mute it from the unacknowledged count without making
+/// the underlying condition disappear) and the feed must reflect how many remain
+/// unacknowledged. ``AlertsInbox`` layers that per-window acknowledgement state on
+/// top of the live rows **without mutating the rows or the queue** — the
+/// acknowledged-id set is owned by the view (per-window `@State`), passed in here,
+/// and reduced into a sorted, display-safe list.
+///
+/// This stays in `PlaidBarCore` (pure, `Sendable`, unit-tested) so the destination
+/// view is a thin renderer and the sort/acknowledge/count policy is verifiable
+/// without the app target (CLAUDE.md).
+///
+/// Meaning never rides on color alone: every entry exposes a severity label +
+/// SF Symbol the view pairs with its tint (ACCESSIBILITY.md).
+public struct AlertsInbox: Sendable, Equatable {
+    /// One alert in the feed — a live ``AttentionQueueRow`` plus its
+    /// acknowledged bit. Identifiable by the row id so SwiftUI selection and the
+    /// acknowledged set key off the same stable identity.
+    public struct Entry: Sendable, Equatable, Identifiable {
+        public let row: AttentionQueueRow
+        public let isAcknowledged: Bool
+
+        public var id: String { row.id }
+        public var severity: AttentionQueueSeverity { row.severity }
+        public var title: String { row.title }
+        public var detail: String { row.detail }
+
+        public init(row: AttentionQueueRow, isAcknowledged: Bool) {
+            self.row = row
+            self.isAcknowledged = isAcknowledged
+        }
+
+        /// VoiceOver label for the row, folding in the acknowledged state so the
+        /// status is spoken, never carried by tint alone.
+        public var accessibilityLabel: String {
+            let base = row.accessibilityLabel
+            return isAcknowledged ? "\(base) Acknowledged." : base
+        }
+    }
+
+    /// All alerts, most-urgent first (blocked → warning), acknowledged entries
+    /// sinking below unacknowledged ones of the same severity so the list reads
+    /// as a work queue. Healthy rows are excluded — they are not alerts.
+    public let entries: [Entry]
+
+    public init(entries: [Entry]) {
+        self.entries = entries
+    }
+
+    /// Reduce the live attention rows + the acknowledged-id set into a sorted
+    /// feed. Healthy rows are dropped (they are not alerts to act on); the
+    /// remainder are ordered blocked-before-warning, then unacknowledged before
+    /// acknowledged, then by the queue's own order (stable) so the list never
+    /// reshuffles spuriously between renders.
+    public static func make(
+        rows: [AttentionQueueRow],
+        acknowledgedIDs: Set<String>
+    ) -> AlertsInbox {
+        let actionable = rows.filter { $0.severity != .healthy }
+        let entries = actionable
+            .enumerated()
+            .map { index, row in
+                (index: index, entry: Entry(row: row, isAcknowledged: acknowledgedIDs.contains(row.id)))
+            }
+            .sorted { lhs, rhs in
+                let leftRank = severityRank(lhs.entry.severity)
+                let rightRank = severityRank(rhs.entry.severity)
+                if leftRank != rightRank { return leftRank < rightRank }
+                if lhs.entry.isAcknowledged != rhs.entry.isAcknowledged {
+                    return !lhs.entry.isAcknowledged // unacknowledged first
+                }
+                return lhs.index < rhs.index // stable: preserve queue order
+            }
+            .map(\.entry)
+        return AlertsInbox(entries: entries)
+    }
+
+    /// `true` when there are no actionable alerts (every condition is healthy).
+    public var isEmpty: Bool { entries.isEmpty }
+
+    /// Total actionable alerts, regardless of acknowledgement.
+    public var totalCount: Int { entries.count }
+
+    /// Alerts the user has not yet acknowledged — the number the feed surfaces as
+    /// "needs you". This is the same "do I need to act?" rollup the sidebar badge
+    /// keys off, minus the ones the user has muted.
+    public var unacknowledgedCount: Int {
+        entries.lazy.filter { !$0.isAcknowledged }.count
+    }
+
+    /// Highest severity across unacknowledged alerts; `nil` when none remain.
+    /// Chrome that escalates only on hard failures keys off `.blocked`.
+    public var highestUnacknowledgedSeverity: AttentionQueueSeverity? {
+        entries
+            .lazy
+            .filter { !$0.isAcknowledged }
+            .map(\.severity)
+            .max { Self.severityRank($0) > Self.severityRank($1) }
+    }
+
+    /// The entry for a given id, if it is still in the live feed. Used by the
+    /// detail column to resolve a selection that may have aged out (the
+    /// underlying condition resolved between renders).
+    public func entry(id: String?) -> Entry? {
+        guard let id else { return nil }
+        return entries.first { $0.id == id }
+    }
+
+    /// Restrict an acknowledged-id set to ids still present in the feed, so the
+    /// set never accumulates ids for conditions that have since resolved. The
+    /// view calls this when it observes new rows, keeping its `@State` bounded.
+    public static func pruneAcknowledgedIDs(
+        _ acknowledgedIDs: Set<String>,
+        toRowsIn rows: [AttentionQueueRow]
+    ) -> Set<String> {
+        let liveIDs = Set(rows.map(\.id))
+        return acknowledgedIDs.intersection(liveIDs)
+    }
+
+    // MARK: - Sort policy
+
+    /// Lower rank = more urgent, so the natural ascending sort lists blocked
+    /// before warning. Healthy is ranked last but never appears (filtered out).
+    private static func severityRank(_ severity: AttentionQueueSeverity) -> Int {
+        switch severity {
+        case .blocked: 0
+        case .warning: 1
+        case .healthy: 2
+        }
+    }
+}
+
+// MARK: - Alerts summary
+
+/// One-line, display-safe header summary for the Alerts destination: how many
+/// alerts there are and how many still need acknowledgement, phrased for both the
+/// visible header chip and VoiceOver. Pure so the wording is unit-tested.
+public struct AlertsSummary: Sendable, Equatable {
+    public let title: String
+    public let accessibilityLabel: String
+    /// Discrete count chip text for the header, or `nil` when nothing is
+    /// unacknowledged (the chip hides at zero rather than showing "0").
+    public let unacknowledgedBadge: String?
+
+    public init(title: String, accessibilityLabel: String, unacknowledgedBadge: String?) {
+        self.title = title
+        self.accessibilityLabel = accessibilityLabel
+        self.unacknowledgedBadge = unacknowledgedBadge
+    }
+
+    public static func make(from inbox: AlertsInbox) -> AlertsSummary {
+        let total = inbox.totalCount
+        let unacked = inbox.unacknowledgedCount
+
+        if total == 0 {
+            return AlertsSummary(
+                title: "All clear",
+                accessibilityLabel: "Alerts. All clear, nothing needs attention.",
+                unacknowledgedBadge: nil
+            )
+        }
+
+        let title: String
+        if unacked == 0 {
+            let alertWord = total == 1 ? "alert" : "alerts"
+            title = "\(total) \(alertWord), all acknowledged"
+        } else if unacked == total {
+            // Grammatically agree with the count: "1 alert needs" / "2 alerts need".
+            let verb = unacked == 1 ? "needs" : "need"
+            let alertWord = unacked == 1 ? "alert" : "alerts"
+            title = "\(unacked) \(alertWord) \(verb) attention"
+        } else {
+            title = "\(unacked) of \(total) alerts need attention"
+        }
+
+        return AlertsSummary(
+            title: title,
+            accessibilityLabel: "Alerts. \(title).",
+            unacknowledgedBadge: unacked == 0 ? nil : "\(unacked)"
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/InsightsStreamingPhase.swift
+++ b/Sources/PlaidBarCore/Models/InsightsStreamingPhase.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// The display phase for the **Insights** destination's streaming spending-insight
+/// surface (Epic 7 / AND-585, ADR-001 window-first).
+///
+/// The Foundation Models `@Generable` insight is produced asynchronously: the
+/// service first returns a deterministic, on-device fallback headline (so the
+/// surface is never blank), then — when the FM/Ollama runtime is engaged — streams
+/// a model-generated headline that replaces it. This pure enum reduces the three
+/// observable inputs (the AI toggle, the runtime availability, and whether a
+/// model-generated headline has landed yet) into the single state the view
+/// renders, so the "off-by-default / generating / streamed" UX policy is
+/// unit-testable without the app target (CLAUDE.md) and the view stays a thin
+/// renderer.
+///
+/// AI is **off by default**: with the toggle off the phase is ``off`` and the
+/// surface shows only the visible enable affordance — no model is ever invoked
+/// (the consent contract, AND-564). Every phase is conveyed by text + SF Symbol,
+/// never color alone (ACCESSIBILITY.md).
+public enum InsightsStreamingPhase: String, Sendable, Equatable, CaseIterable {
+    /// AI is disabled (the default). Nothing is generated; the view offers to
+    /// enable it and explains that everything stays on-device.
+    case off
+    /// AI is enabled but the local runtime is not usable (no model installed /
+    /// Apple Intelligence not enabled / runtime offline). The view shows the
+    /// deterministic local summary and the remediation hint — there is no cloud
+    /// fallback.
+    case unavailable
+    /// AI is enabled and the runtime is reachable, but a model-generated headline
+    /// has not arrived yet — the on-device model is still producing it. The view
+    /// shows the deterministic headline with a "generating on-device" indicator
+    /// that resolves into the streamed result.
+    case generating
+    /// A model-generated headline has streamed in. The view shows it as the
+    /// finished insight.
+    case streamed
+
+    /// Derive the phase from the live observable inputs.
+    ///
+    /// - Parameters:
+    ///   - isEnabled: the AI toggle (`AppState.localAIEnabled`). Off ⇒ ``off``.
+    ///   - availabilityState: the resolved local-AI availability state.
+    ///   - hasModelGeneratedHeadline: whether the primary summary's
+    ///     `generatedSummary` is non-empty, i.e. a model (not the deterministic
+    ///     fallback) produced it.
+    public static func resolve(
+        isEnabled: Bool,
+        availabilityState: LocalAIAvailabilityState,
+        hasModelGeneratedHeadline: Bool
+    ) -> InsightsStreamingPhase {
+        guard isEnabled else { return .off }
+
+        switch availabilityState {
+        case .disabled:
+            // Enabled toggle but the service reports disabled (e.g. preference
+            // race during a rebuild) — treat as off-equivalent for the surface.
+            return .off
+        case .unavailable:
+            return .unavailable
+        case .available, .checking:
+            return hasModelGeneratedHeadline ? .streamed : .generating
+        }
+    }
+
+    /// Whether the on-device model is actively working — the cue the view animates
+    /// (a non-looping, Reduce-Motion-aware indicator).
+    public var isWorking: Bool { self == .generating }
+
+    /// Whether a finished, model-generated insight is being shown.
+    public var hasStreamedResult: Bool { self == .streamed }
+
+    /// SF Symbol for the phase's status pill (shape distinguishes it, not just
+    /// tint — ACCESSIBILITY.md).
+    public var systemImage: String {
+        switch self {
+        case .off: "sparkles"
+        case .unavailable: "exclamationmark.triangle"
+        case .generating: "wand.and.stars"
+        case .streamed: "checkmark.seal"
+        }
+    }
+
+    /// Short visible status label that backs up the icon and tint.
+    public var statusLabel: String {
+        switch self {
+        case .off: "AI off"
+        case .unavailable: "Runtime unavailable"
+        case .generating: "Generating on-device"
+        case .streamed: "On-device summary"
+        }
+    }
+
+    /// VoiceOver-friendly sentence describing the phase, so the state is spoken
+    /// rather than implied by the indicator.
+    public var accessibilityLabel: String {
+        switch self {
+        case .off:
+            "Local AI insights are off. Everything stays on this Mac when enabled."
+        case .unavailable:
+            "Local AI is enabled but the on-device runtime is unavailable. Showing the deterministic local summary."
+        case .generating:
+            "Generating a spending insight on-device."
+        case .streamed:
+            "On-device spending insight ready."
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/AlertsInboxTests.swift
+++ b/Tests/PlaidBarCoreTests/AlertsInboxTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("AlertsInbox Tests")
+struct AlertsInboxTests {
+    private func row(
+        _ id: String,
+        severity: AttentionQueueSeverity,
+        title: String = "Title",
+        detail: String = "Detail"
+    ) -> AttentionQueueRow {
+        AttentionQueueRow(id: id, severity: severity, title: title, detail: detail)
+    }
+
+    @Test("Healthy rows are excluded from the alerts feed")
+    func healthyRowsExcluded() {
+        let inbox = AlertsInbox.make(
+            rows: [
+                row("a", severity: .healthy),
+                row("b", severity: .warning),
+                row("c", severity: .blocked),
+            ],
+            acknowledgedIDs: []
+        )
+        #expect(inbox.totalCount == 2)
+        #expect(!inbox.entries.contains { $0.id == "a" })
+    }
+
+    @Test("Empty when every row is healthy")
+    func emptyWhenAllHealthy() {
+        let inbox = AlertsInbox.make(rows: [row("a", severity: .healthy)], acknowledgedIDs: [])
+        #expect(inbox.isEmpty)
+        #expect(inbox.totalCount == 0)
+        #expect(inbox.unacknowledgedCount == 0)
+        #expect(inbox.highestUnacknowledgedSeverity == nil)
+    }
+
+    @Test("Blocked sorts before warning")
+    func blockedBeforeWarning() {
+        let inbox = AlertsInbox.make(
+            rows: [
+                row("warn", severity: .warning),
+                row("block", severity: .blocked),
+            ],
+            acknowledgedIDs: []
+        )
+        #expect(inbox.entries.map(\.id) == ["block", "warn"])
+    }
+
+    @Test("Unacknowledged sort before acknowledged within a severity")
+    func unacknowledgedBeforeAcknowledged() {
+        let inbox = AlertsInbox.make(
+            rows: [
+                row("w1", severity: .warning),
+                row("w2", severity: .warning),
+                row("w3", severity: .warning),
+            ],
+            acknowledgedIDs: ["w1"]
+        )
+        // w1 is acknowledged → sinks below w2, w3 (which keep queue order).
+        #expect(inbox.entries.map(\.id) == ["w2", "w3", "w1"])
+        #expect(inbox.entries.first { $0.id == "w1" }?.isAcknowledged == true)
+    }
+
+    @Test("Sort is stable within the same severity + acknowledged state")
+    func stableSortPreservesQueueOrder() {
+        let inbox = AlertsInbox.make(
+            rows: [
+                row("first", severity: .blocked),
+                row("second", severity: .blocked),
+                row("third", severity: .blocked),
+            ],
+            acknowledgedIDs: []
+        )
+        #expect(inbox.entries.map(\.id) == ["first", "second", "third"])
+    }
+
+    @Test("Unacknowledged count reflects the acknowledged set")
+    func unacknowledgedCount() {
+        let rows = [
+            row("a", severity: .blocked),
+            row("b", severity: .warning),
+            row("c", severity: .warning),
+        ]
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: []).unacknowledgedCount == 3)
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: ["a"]).unacknowledgedCount == 2)
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: ["a", "b", "c"]).unacknowledgedCount == 0)
+    }
+
+    @Test("Highest unacknowledged severity ignores acknowledged blocked rows")
+    func highestUnacknowledgedSeverity() {
+        let rows = [
+            row("block", severity: .blocked),
+            row("warn", severity: .warning),
+        ]
+        // Nothing acknowledged → blocked is highest.
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: []).highestUnacknowledgedSeverity == .blocked)
+        // Acknowledge the blocked row → highest unacknowledged is now warning.
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: ["block"]).highestUnacknowledgedSeverity == .warning)
+        // Acknowledge everything → nil.
+        #expect(AlertsInbox.make(rows: rows, acknowledgedIDs: ["block", "warn"]).highestUnacknowledgedSeverity == nil)
+    }
+
+    @Test("entry(id:) resolves a live id and returns nil otherwise")
+    func entryLookup() {
+        let inbox = AlertsInbox.make(rows: [row("a", severity: .warning)], acknowledgedIDs: [])
+        #expect(inbox.entry(id: "a")?.id == "a")
+        #expect(inbox.entry(id: "missing") == nil)
+        #expect(inbox.entry(id: nil) == nil)
+    }
+
+    @Test("Acknowledged entry accessibility label folds in the acknowledged status")
+    func entryAccessibilityLabel() {
+        let inbox = AlertsInbox.make(
+            rows: [row("a", severity: .warning, title: "Sync stale", detail: "Refresh")],
+            acknowledgedIDs: ["a"]
+        )
+        let label = inbox.entry(id: "a")?.accessibilityLabel ?? ""
+        #expect(label.contains("Acknowledged."))
+    }
+
+    @Test("pruneAcknowledgedIDs drops ids no longer in the live rows")
+    func pruneAcknowledged() {
+        let rows = [row("live", severity: .warning)]
+        let pruned = AlertsInbox.pruneAcknowledgedIDs(["live", "stale"], toRowsIn: rows)
+        #expect(pruned == ["live"])
+    }
+}
+
+@Suite("AlertsSummary Tests")
+struct AlertsSummaryTests {
+    private func inbox(rows: [(String, AttentionQueueSeverity)], acked: Set<String> = []) -> AlertsInbox {
+        AlertsInbox.make(
+            rows: rows.map { AttentionQueueRow(id: $0.0, severity: $0.1, title: "T", detail: "D") },
+            acknowledgedIDs: acked
+        )
+    }
+
+    @Test("All-clear when there are no alerts")
+    func allClear() {
+        let summary = AlertsSummary.make(from: inbox(rows: []))
+        #expect(summary.title == "All clear")
+        #expect(summary.unacknowledgedBadge == nil)
+        #expect(summary.accessibilityLabel.contains("All clear"))
+    }
+
+    @Test("All alerts need attention when none acknowledged")
+    func allNeedAttention() {
+        let summary = AlertsSummary.make(from: inbox(rows: [("a", .blocked), ("b", .warning)]))
+        #expect(summary.title == "2 alerts need attention")
+        #expect(summary.unacknowledgedBadge == "2")
+    }
+
+    @Test("Partial acknowledgement reads as N of M")
+    func partialAcknowledged() {
+        let summary = AlertsSummary.make(from: inbox(rows: [("a", .blocked), ("b", .warning)], acked: ["a"]))
+        #expect(summary.title == "1 of 2 alerts need attention")
+        #expect(summary.unacknowledgedBadge == "1")
+    }
+
+    @Test("All acknowledged hides the badge")
+    func allAcknowledged() {
+        let summary = AlertsSummary.make(from: inbox(rows: [("a", .blocked)], acked: ["a"]))
+        #expect(summary.title == "1 alert, all acknowledged")
+        #expect(summary.unacknowledgedBadge == nil)
+    }
+
+    @Test("Singular wording for a single alert")
+    func singularWording() {
+        let summary = AlertsSummary.make(from: inbox(rows: [("a", .warning)]))
+        // A single unacknowledged alert uses the singular noun + verb agreement.
+        #expect(summary.title == "1 alert needs attention")
+        #expect(!summary.title.contains("alerts"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/InsightsStreamingPhaseTests.swift
+++ b/Tests/PlaidBarCoreTests/InsightsStreamingPhaseTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("InsightsStreamingPhase Tests")
+struct InsightsStreamingPhaseTests {
+    @Test("Disabled toggle is always off, regardless of availability")
+    func disabledIsOff() {
+        for state in [LocalAIAvailabilityState.available, .checking, .unavailable, .disabled] {
+            for hasHeadline in [true, false] {
+                let phase = InsightsStreamingPhase.resolve(
+                    isEnabled: false,
+                    availabilityState: state,
+                    hasModelGeneratedHeadline: hasHeadline
+                )
+                #expect(phase == .off)
+            }
+        }
+    }
+
+    @Test("Enabled but service-disabled resolves to off")
+    func enabledButServiceDisabled() {
+        let phase = InsightsStreamingPhase.resolve(
+            isEnabled: true,
+            availabilityState: .disabled,
+            hasModelGeneratedHeadline: false
+        )
+        #expect(phase == .off)
+    }
+
+    @Test("Enabled but runtime unavailable resolves to unavailable")
+    func enabledUnavailable() {
+        let phase = InsightsStreamingPhase.resolve(
+            isEnabled: true,
+            availabilityState: .unavailable,
+            hasModelGeneratedHeadline: false
+        )
+        #expect(phase == .unavailable)
+    }
+
+    @Test("Available without a model headline is generating")
+    func availableGenerating() {
+        let phase = InsightsStreamingPhase.resolve(
+            isEnabled: true,
+            availabilityState: .available,
+            hasModelGeneratedHeadline: false
+        )
+        #expect(phase == .generating)
+        #expect(phase.isWorking)
+        #expect(!phase.hasStreamedResult)
+    }
+
+    @Test("Checking without a model headline is generating")
+    func checkingGenerating() {
+        let phase = InsightsStreamingPhase.resolve(
+            isEnabled: true,
+            availabilityState: .checking,
+            hasModelGeneratedHeadline: false
+        )
+        #expect(phase == .generating)
+    }
+
+    @Test("Available with a model headline is streamed")
+    func availableStreamed() {
+        let phase = InsightsStreamingPhase.resolve(
+            isEnabled: true,
+            availabilityState: .available,
+            hasModelGeneratedHeadline: true
+        )
+        #expect(phase == .streamed)
+        #expect(phase.hasStreamedResult)
+        #expect(!phase.isWorking)
+    }
+
+    @Test("Every phase carries distinct text + symbol (never color alone)")
+    func phasesCarryTextAndSymbol() {
+        let phases = InsightsStreamingPhase.allCases
+        let labels = Set(phases.map(\.statusLabel))
+        let symbols = Set(phases.map(\.systemImage))
+        let a11y = Set(phases.map(\.accessibilityLabel))
+        // Distinct, non-empty text/symbol/a11y for each phase.
+        #expect(labels.count == phases.count)
+        #expect(symbols.count == phases.count)
+        #expect(a11y.count == phases.count)
+        #expect(phases.allSatisfy { !$0.statusLabel.isEmpty })
+        #expect(phases.allSatisfy { !$0.systemImage.isEmpty })
+        #expect(phases.allSatisfy { !$0.accessibilityLabel.isEmpty })
+    }
+
+    @Test("Only the generating phase reports working")
+    func onlyGeneratingIsWorking() {
+        #expect(InsightsStreamingPhase.generating.isWorking)
+        #expect(!InsightsStreamingPhase.off.isWorking)
+        #expect(!InsightsStreamingPhase.unavailable.isWorking)
+        #expect(!InsightsStreamingPhase.streamed.isWorking)
+    }
+}


### PR DESCRIPTION
## Summary

Epic 7 — **Insights & Intelligence** (AND-585) of the window-first migration (ADR-001). Fills the two `.insights` / `.alerts` destinations that the content router already dispatches to (placeholders until now). **Surfaces existing engines only — no model or chart logic changed.**

### Insights destination (2-column composed canvas, `⌘6`)
- **Streaming spending insight + receipt** — the Foundation Models `@Generable` insight via the existing `LocalAIInsightsService`, with the on-device `LocalAIInsightReceipt` (tier + provenance + consent). The incremental stream is surfaced reactively: the deterministic on-device headline shows immediately and is replaced in place by the model-generated headline as it streams into the `@Observable` summary cache (a pure `InsightsStreamingPhase` drives the generating → streamed UI). **AI is off-by-default behind a visible toggle** (AND-564); FM availability is detected with a graceful NaturalLanguage / deterministic fallback (AND-563).
- **Weekly review** — re-hosts the existing `WeeklyReviewCard` unchanged, so the window and the popover drive the same review state.
- **Trends** — `BalanceTrendChart`, `SpendDonutChart`, and a self-contained activity heatmap over the existing `SpendingHeatmapLayout` Core engine. A segmented section picker jumps between the three IA bands (`InsightSection`).

### Alerts destination (3-column list → detail, `⌘7`)
- Live `AttentionQueue` rows reduced into a sorted feed via the new pure `AlertsInbox`. **Acknowledge / un-acknowledge / acknowledge-all**, with the unacknowledged count reflected in the header chip. The rows are stateless (recomputed each render), so acknowledgement is layered on as session-scoped per-window state (`AlertsSelectionModel`) — the rows and the queue are never mutated. The detail column shows the selected alert + its recovery action, which reuses the existing `AttentionQueueView` dispatch. The sidebar unacked badge already exists and continues to reflect live non-healthy rows.

## Reused services / charts (unchanged)
- AI: `LocalAIInsightsService`, `LocalAIInsightReceipt`, `LocalAIActivitySummary`, availability via `AppState.localAIAvailability` / `localAIPreferredTier` / `foundationModelsAvailability`; consent toggle via `AppState.localAIEnabled`.
- Charts: `BalanceTrendChart`, `SpendDonutChart` (over `SpendDonutModel` / `categoryDashboardPresentation`), `SpendingHeatmapLayout`, `ChartAudioGraph` (`.trend` / `.donut` / `.heatmap`).
- Surfaces: `WeeklyReviewCard`, `AttentionQueue` / `AttentionQueueRow`, design tokens, `glassSurface` / `nativeInsetSurface`, `loadingRedaction`.

## New pure logic (PlaidBarCore, unit-tested)
- `AlertsInbox` / `AlertsInbox.Entry` / `AlertsSummary` — severity-sorted feed (blocked → warning, unacknowledged → acknowledged, stable), unacked count, acknowledged-id pruning.
- `InsightsStreamingPhase` — off / unavailable / generating / streamed, derived from the toggle + availability + whether a model headline has landed.

## Accessibility (audio graphs + no color-only)
- Every chart attaches its `AXChartDescriptor` audio graph via the existing `.audioGraph(ChartAudioGraph...)` modifier (AND-569).
- Each chart has a `reduceTransparency` / Privacy Mask text alternative (the heatmap swaps to a text summary; trend/donut hide or mask figures), and meaning is never carried by color alone — severity, trend direction, and AI phase all pair a tint with an SF Symbol + text label.
- **Liquid Glass never touches a chart**: charts sit on the `.raised` card rank (a `.clear` fill); no `.glassEffect` is applied to any chart.

## AI off-by-default
The `localAIEnabled` toggle defaults OFF; with it off no model is invoked and the Insights surface shows only the enable affordance + "Where your data lives". No cloud fallback.

## Scope / flag-off note
Owns **only** `InsightsDestinationView.swift`, `AlertsDestinationView.swift`, and new `Insights*` / `Alerts*` files. Does **not** touch `AppShellView`, `DestinationRouter`, `PlaidBarApp`, `NavigationModel`, or other destinations. **Flag-OFF inert**: reached only when `AppShellView` mounts behind `WindowFirstFeatureFlag` (default OFF), so the menu-bar popover is byte-identical.

Alert selection is held in a shared `AlertsSelectionModel` (mirroring the established `BudgetsSelectionModel` split-column bridge) because the two split-view columns can't share `@State` and Epic 7 must not edit `NavigationModel`. Per-window `NavigationModel` alert-selection state is the cleaner long-term home — noted as a follow-up.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — 1946 tests pass (baseline ~1923 + 23 new for `AlertsInbox` / `AlertsSummary` / `InsightsStreamingPhase`).

## Deferred follow-ups
- Move alert selection onto a per-window `NavigationModel` field (would let two windows keep independent selections) once Epic 7's file-ownership boundary is lifted.
- Acknowledgement is session-scoped (intentional); persisting it across launches is out of scope.

Refs: AND-585, ADR-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)