### PR TITLE
feat(ux): chrome-only Liquid Glass + cross-window App-Lock/Privacy-Mask a11y parity (AND-588)

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -478,11 +478,15 @@ struct PlaidBarApp: App {
                 // the window-first flag), so flag-OFF behavior is unchanged.
                 .onAppear { windowActivationPolicy.onWindowAppear() }
                 .onDisappear { windowActivationPolicy.onWindowDisappear() }
-                // Liquid Glass on chrome only (ADR-001): the window background is
-                // the ultra-thin material; data surfaces inside stay opaque. This
-                // is a content modifier (it walks up to the window), so it lives on
-                // the scene's root view, not on the `Window` scene itself.
-                .containerBackground(.ultraThinMaterial, for: .window)
+                // Liquid Glass on chrome only (ADR-001, R-08): the window
+                // background is the ultra-thin material; data surfaces inside stay
+                // opaque. Under Reduce Transparency (system setting or the reduced
+                // decorative-effects preference) it falls back to a fully solid
+                // window background — custom translucency self-manages its a11y
+                // degradation rather than relying on the framework to thin the
+                // material (AND-588). The glass-vs-solid decision is the pure,
+                // unit-tested `WindowChromeGlass.chromeBackground(reduceTransparency:)`.
+                .appliesWindowChromeBackground()
         }
         // Do not steal launch/activation: the window only appears when opened.
         .defaultLaunchBehavior(.suppressed)
@@ -770,6 +774,47 @@ struct AppTextSizeApplier: ViewModifier {
     }
 }
 
+/// Applies the window-first shell's **chrome** background (ADR-001 Epic 10 /
+/// AND-588, R-08). Liquid Glass is for the navigation layer only — the window
+/// container behind the sidebar / toolbar / nav bars — never lists, tables,
+/// charts, or dense data, which stay opaque inside.
+///
+/// Custom translucency must self-manage its accessibility degradation rather
+/// than rely on the framework to thin the material: when **Reduce Transparency**
+/// is on (the system accessibility setting always wins, or the user's reduced
+/// decorative-effects preference), this falls back to a fully solid window
+/// background so the chrome stays legible in light and dark. The glass-vs-solid
+/// choice is the pure, unit-tested `WindowChromeGlass.chromeBackground(reduceTransparency:)`.
+struct WindowChromeBackgroundModifier: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var systemReduceTransparency
+    @AppStorage(DecorativeEffectsPreference.storageKey) private var decorativeEffectsRaw = DecorativeEffectsPreference.defaultValue.rawValue
+
+    /// `true` when transparency must be reduced: the system setting wins, and the
+    /// user's "Reduced" decorative-effects preference also suppresses it. Mirrors
+    /// the popover's `ResolvedDecorativeEffects.allowsTexture` gate so the window
+    /// and popover degrade identically.
+    private var reduceTransparency: Bool {
+        let preference = DecorativeEffectsPreference(rawValue: decorativeEffectsRaw) ?? .followSystem
+        let effects = preference.resolved(
+            systemReduceMotion: false,
+            systemReduceTransparency: systemReduceTransparency
+        )
+        return !effects.allowsTexture
+    }
+
+    func body(content: Content) -> some View {
+        switch WindowChromeGlass.chromeBackground(reduceTransparency: reduceTransparency) {
+        case .glass:
+            content.containerBackground(.ultraThinMaterial, for: .window)
+        case .solid:
+            // Solid fallback: the opaque window background color reads correctly
+            // in both light and dark and carries no translucency for the chrome
+            // to sample (AND-588).
+            content.containerBackground(Color(nsColor: .windowBackgroundColor), for: .window)
+        }
+    }
+}
+
 /// Bridges the SwiftUI-free Core `ForcedDynamicTypeSize` to SwiftUI's
 /// `DynamicTypeSize`. The Core enum keeps the case → size decision testable
 /// without importing SwiftUI; this 1:1 switch is the only place the two enums
@@ -822,5 +867,12 @@ extension View {
     /// in `App/` can share the one definition.
     func appliesAppTextSize() -> some View {
         modifier(AppTextSizeApplier())
+    }
+
+    /// Applies the window-first shell's chrome background (Liquid Glass on chrome
+    /// only, with an explicit solid Reduce Transparency fallback — ADR-001 Epic
+    /// 10 / AND-588, R-08). Used on the primary `Window` scene root.
+    func appliesWindowChromeBackground() -> some View {
+        modifier(WindowChromeBackgroundModifier())
     }
 }

--- a/Sources/PlaidBar/Views/AppLockedGateView.swift
+++ b/Sources/PlaidBar/Views/AppLockedGateView.swift
@@ -1,0 +1,68 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Full-surface gate shown when App Lock is engaged (LOCKED, not just masked).
+/// It paints an opaque material over the entire surface so no real value,
+/// account, or institution name behind it can be read, and offers a single
+/// Unlock action that re-prompts for authentication. Distinct from Privacy
+/// Mask, which only dots currency and leaves content visible (AND-462).
+///
+/// Shared by **both** local UI surfaces so App Lock gating is identical across
+/// them (ADR-001 Epic 10 / AND-588 security parity):
+/// - the menu-bar popover + its detached host (`MainPopover`), and
+/// - the window-first primary workspace (`AppShellView`).
+///
+/// Because the host window can render a clear/non-opaque root (the popover's
+/// detached host and the window-first shell both paint glass chrome), the gate
+/// must obscure on its own rather than rely on the host being opaque.
+struct AppLockedGateView: View {
+    let message: String
+    let reduceMotion: Bool
+    let onUnlock: () -> Void
+
+    var body: some View {
+        ZStack {
+            // Opaque backdrop: the detached window renders a clear root, so the
+            // gate cannot rely on the host being opaque — it must obscure on its
+            // own. `.bar` material over the window background fully hides content.
+            Rectangle()
+                .fill(.background)
+                .overlay(.bar)
+                .ignoresSafeArea()
+
+            VStack(spacing: Spacing.md) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+
+                Text("VaultPeek Locked")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(AppearanceTextColors.primary)
+
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 320)
+
+                Button(action: onUnlock) {
+                    Label("Unlock", systemImage: "lock.open.fill")
+                        .frame(minWidth: 120)
+                }
+                // The primary unlock CTA uses prominent Liquid Glass (AND-511):
+                // it is the highest-signal action on the lock surface and reads
+                // as a tinted glass capsule consistent with the glass chrome.
+                .buttonStyle(.glassProminent)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(Spacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("VaultPeek is locked. \(message)")
+        .accessibilityAddTraits(.isModal)
+    }
+}

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -26,11 +26,22 @@ import SwiftUI
 /// is zero behavior change.
 ///
 /// Liquid Glass on chrome is applied at the scene level via
-/// `.containerBackground(.ultraThinMaterial, for: .window)` in `PlaidBarApp`, not
-/// here — per ADR-001 glass goes on chrome only, never on data.
+/// `.containerBackground(.ultraThinMaterial, for: .window)` in `PlaidBarApp`
+/// (with an explicit solid Reduce Transparency fallback), not here — per ADR-001
+/// glass goes on chrome only, never on data.
+///
+/// **App Lock parity (ADR-001 Epic 10 / AND-588):** when content is LOCKED (not
+/// merely masked), this shell paints the shared `AppLockedGateView` over the
+/// entire window — identical to the popover and its detached host — so the
+/// window-first surface can never show balances, account, or institution names
+/// while App Lock is engaged. The gate sits above every other overlay (including
+/// the ⌘K palette), and the palette is force-dismissed while locked.
 struct AppShellView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
+    /// Reduce Motion gates the App-Lock gate's enter/exit transition so locking
+    /// the window does not animate when the user has asked for less motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The ⌘K command-palette state for this window. Owned by the scene
     /// (`PlaidBarApp`) so the ⌘K menu command and this overlay share one source
     /// of truth, and injected here. Defaults to a fresh model so the `#Preview`
@@ -140,6 +151,33 @@ struct AppShellView: View {
             }
         }
         .animation(.easeOut(duration: 0.15), value: paletteModel.isPresented)
+        // Full App Lock gate (security parity with the popover + detached host —
+        // ADR-001 Epic 10 / AND-588). When content is LOCKED (not merely masked)
+        // the entire window must be hidden behind the shared `AppLockedGateView`:
+        // account and institution names, the sidebar badges, and every
+        // destination would otherwise leak even though balances are dotted
+        // (AND-462). This overlay is declared *after* the palette overlay so it
+        // renders on top of it, and the palette is force-dismissed while locked
+        // so unlocking never reveals a stale ⌘K surface.
+        .overlay {
+            if appState.isContentLocked {
+                AppLockedGateView(
+                    message: appState.lockedSurfaceCopy,
+                    reduceMotion: reduceMotion,
+                    onUnlock: { Task { await appState.unlockApp() } }
+                )
+                .transition(.opacity)
+            }
+        }
+        .animation(
+            MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion),
+            value: appState.isContentLocked
+        )
+        .onChange(of: appState.isContentLocked) { _, isLocked in
+            // A locked window must not keep the ⌘K palette mounted underneath the
+            // gate; dismiss it so unlocking returns to the bare workspace.
+            if isLocked { paletteModel.dismiss() }
+        }
     }
 }
 

--- a/Sources/PlaidBar/Views/Charts/ProjectedBalanceChart.swift
+++ b/Sources/PlaidBar/Views/Charts/ProjectedBalanceChart.swift
@@ -78,6 +78,11 @@ struct ProjectedBalanceChart: View {
                     revealFraction = 1
                 }
             }
+            // Scrubbable audio graph (AND-569/AND-588): the analogue of the spoken
+            // `accessibilitySummary` below — VoiceOver's "Play Audio Graph" rotor
+            // plays the projected balance tone-by-tone, with the projected-low day
+            // called out. No-op when the series has too few points to sonify.
+            .audioGraph(ChartAudioGraph.projection(projection))
 
             // Confidence cue: text + icon, never color alone.
             Label(confidenceText, systemImage: projection.confidence.iconName)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -742,62 +742,12 @@ private struct InspectorGlassMorphSurface: ViewModifier {
     }
 }
 
-/// Full-surface gate shown when App Lock is engaged (LOCKED, not just masked).
-/// It paints an opaque material over the entire dashboard so no real value,
-/// account, or institution name behind it can be read, and offers a single
-/// Unlock action that re-prompts for authentication. Distinct from Privacy
-/// Mask, which only dots currency and leaves the dashboard visible (AND-462).
-private struct AppLockedGateView: View {
-    let message: String
-    let reduceMotion: Bool
-    let onUnlock: () -> Void
-
-    var body: some View {
-        ZStack {
-            // Opaque backdrop: the detached window renders a clear root, so the
-            // gate cannot rely on the host being opaque — it must obscure on its
-            // own. `.bar` material over the window background fully hides content.
-            Rectangle()
-                .fill(.background)
-                .overlay(.bar)
-                .ignoresSafeArea()
-
-            VStack(spacing: Spacing.md) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 34, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
-
-                Text("VaultPeek Locked")
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(AppearanceTextColors.primary)
-
-                Text(message)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 320)
-
-                Button(action: onUnlock) {
-                    Label("Unlock", systemImage: "lock.open.fill")
-                        .frame(minWidth: 120)
-                }
-                // The primary unlock CTA uses prominent Liquid Glass (AND-511):
-                // it is the highest-signal action on the lock surface and reads
-                // as a tinted glass capsule consistent with the glass chrome.
-                .buttonStyle(.glassProminent)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
-            }
-            .padding(Spacing.xl)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("VaultPeek is locked. \(message)")
-        .accessibilityAddTraits(.isModal)
-    }
-}
+// `AppLockedGateView` — the full-surface App Lock gate — was moved to its own
+// file (`Views/AppLockedGateView.swift`) so the window-first shell (`AppShellView`)
+// can reuse the *same* gate for App Lock parity (ADR-001 Epic 10 / AND-588). The
+// popover's `.overlay { if appState.isContentLocked { AppLockedGateView(...) } }`
+// usage above is unchanged — same view, same behavior, just relocated to module
+// scope.
 
 private struct DashboardChangeReceiptStrip: View {
     @Environment(AppState.self) private var appState

--- a/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
+++ b/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
@@ -194,6 +194,71 @@ public enum ChartAudioGraph {
         )
     }
 
+    // MARK: - Projected balance (cash-flow forecast)
+
+    /// Audio graph for the forward cash-flow projection line
+    /// (``BalanceProjection`` / `ProjectedBalanceChart`, AND-498). The x axis is a
+    /// day index over the forecast horizon (each point also labeled with its
+    /// date); the y axis is the projected balance. Continuous, since the chart is
+    /// a (dashed) line — the dash conveys "forecast" visually, but the audio graph
+    /// scrubs it like any other line, with the projected low spoken on its day.
+    ///
+    /// This is the audio-graph analogue of the chart's existing
+    /// `accessibilitySummary`: it closes the AND-588 gap where the projected-balance
+    /// chart in the window-first shell carried a spoken summary but no scrubbable
+    /// audio graph (the net-worth trend and spend donut both already had one).
+    ///
+    /// Returns a descriptor with no points when the series has fewer than two
+    /// snapshots — there is nothing to sonify for a single anchor point.
+    public static func projection(_ projection: BalanceProjection, currencyCode: String = "USD") -> Descriptor {
+        let series = projection.series
+        guard series.count >= 2 else {
+            return Descriptor(
+                title: "Projected balance",
+                summary: projection.accessibilitySummary,
+                xAxis: NumericAxis(title: "Day", lowerBound: 0, upperBound: 0),
+                yAxis: NumericAxis(title: "Projected balance", lowerBound: 0, upperBound: 0),
+                seriesName: "Projected balance",
+                isContinuous: true,
+                points: []
+            )
+        }
+
+        let lowDate = projection.projectedLow.date
+        let points = series.enumerated().map { index, snapshot -> Point in
+            let dateText = Formatters.displayDate(snapshot.date)
+            let amountText = Formatters.currency(snapshot.balance, format: .full, currencyCode: currencyCode)
+            // Call out the projected-low day so the audio graph speaks the dip.
+            let isLow = snapshot.date == lowDate
+            let label = isLow
+                ? "\(dateText), \(amountText), projected low"
+                : "\(dateText), \(amountText)"
+            return Point(xValue: Double(index), xLabel: dateText, yValue: snapshot.balance, label: label)
+        }
+
+        let balances = series.map(\.balance)
+        let yAxis = NumericAxis(
+            title: "Projected balance",
+            lowerBound: balances.min() ?? 0,
+            upperBound: balances.max() ?? 0
+        )
+        let xAxis = NumericAxis(
+            title: "Day",
+            lowerBound: 0,
+            upperBound: Double(max(points.count - 1, 0))
+        )
+
+        return Descriptor(
+            title: "Projected balance",
+            summary: projection.accessibilitySummary,
+            xAxis: xAxis,
+            yAxis: yAxis,
+            seriesName: "Projected balance",
+            isContinuous: true,
+            points: points
+        )
+    }
+
     // MARK: - Spend donut
 
     /// Audio graph for the spend-by-category donut. Each slice becomes one

--- a/Sources/PlaidBarCore/Utilities/WindowChromeGlass.swift
+++ b/Sources/PlaidBarCore/Utilities/WindowChromeGlass.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Pure decision for the **window-first shell's chrome background** (ADR-001
+/// Epic 10 / AND-588, risk R-08).
+///
+/// VaultPeek's Liquid Glass is applied to the navigation layer only — the window
+/// container background behind the sidebar / toolbar / nav bars — and **never**
+/// to lists, tables, charts, or dense data (R-08). The window container
+/// background is *custom* translucency (`.containerBackground(.ultraThinMaterial,
+/// for: .window)`), and per the Epic 10 contract custom translucency must
+/// self-manage its accessibility degradation rather than rely on the framework
+/// to thin the material: when the user has **Reduce Transparency** on, the chrome
+/// must fall back to a fully solid window background so it stays legible in light
+/// and dark.
+///
+/// This is the SwiftUI-free decision the scene consults, so the rule is
+/// unit-tested independently of AppKit/SwiftUI. The view layer maps
+/// ``WindowChromeBackground/glass`` to the ultra-thin material and
+/// ``WindowChromeBackground/solid`` to the opaque window background color.
+public enum WindowChromeBackground: Sendable, Equatable {
+    /// Liquid Glass: the ultra-thin material behind the navigation chrome.
+    case glass
+    /// Opaque, fully solid window background (the Reduce Transparency fallback).
+    case solid
+}
+
+public enum WindowChromeGlass {
+    /// Resolve the window-first shell's chrome background.
+    ///
+    /// - Parameter reduceTransparency: the resolved Reduce Transparency state —
+    ///   `true` when the system accessibility setting is on **or** the user chose
+    ///   reduced decorative effects (the system setting always wins; see
+    ///   ``DecorativeEffectsPreference``). When `true` the chrome must be solid.
+    /// - Returns: ``WindowChromeBackground/solid`` when transparency is reduced,
+    ///   otherwise ``WindowChromeBackground/glass``.
+    public static func chromeBackground(reduceTransparency: Bool) -> WindowChromeBackground {
+        reduceTransparency ? .solid : .glass
+    }
+
+    /// Whether a given surface in the window-first shell is allowed to carry a
+    /// Liquid Glass material. Glass is for the **navigation layer** only; **data**
+    /// surfaces (lists, tables, charts, dense rows) always stay solid so values
+    /// never sample a translucent backdrop (R-08).
+    ///
+    /// This encodes the chrome-vs-data policy as a pure, testable rule: the view
+    /// layer classifies each surface as ``WindowSurfaceKind`` and this decides
+    /// whether glass may be applied. It is intentionally independent of Reduce
+    /// Transparency — that gates *how* glass degrades
+    /// (``chromeBackground(reduceTransparency:)``), whereas this gates *whether* a
+    /// surface is eligible for glass at all.
+    public static func allowsGlass(on surface: WindowSurfaceKind) -> Bool {
+        switch surface {
+        case .chrome:
+            return true
+        case .data:
+            return false
+        }
+    }
+}
+
+/// Classifies a window-first surface for the glass-on-chrome-only policy (R-08).
+public enum WindowSurfaceKind: Sendable, Equatable {
+    /// Navigation chrome — sidebar, toolbar, nav bars, window container. May use
+    /// Liquid Glass.
+    case chrome
+    /// Data — lists, tables, charts, dense rows / values. Always solid; never
+    /// glass.
+    case data
+}

--- a/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
+++ b/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
@@ -356,4 +356,60 @@ struct ChartAudioGraphTests {
             #expect(!line.contains("75"))
         }
     }
+
+    // MARK: - Projected balance (AND-588 chart-parity gap fix)
+
+    private func projection(_ balances: [Double], lowIndex: Int, now: Date = Date()) -> BalanceProjection {
+        let calendar = Calendar.current
+        let day0 = calendar.startOfDay(for: now)
+        let series = balances.enumerated().map { index, balance in
+            BalanceSnapshot(
+                date: calendar.date(byAdding: .day, value: index, to: day0) ?? day0,
+                balance: balance
+            )
+        }
+        return BalanceProjection(
+            series: series,
+            projectedLow: series[lowIndex],
+            confidence: .ok,
+            accessibilitySummary: "Projected to dip then recover."
+        )
+    }
+
+    @Test("projection maps every forward snapshot to an ordered continuous point")
+    func projectionMapsPoints() {
+        let descriptor = ChartAudioGraph.projection(projection([1000, 800, 600, 900], lowIndex: 2))
+
+        #expect(!descriptor.isEmpty)
+        #expect(descriptor.points.count == 4)
+        #expect(descriptor.isContinuous)
+        #expect(descriptor.title == "Projected balance")
+        #expect(descriptor.summary == "Projected to dip then recover.")
+        // X axis is the day index 0…count-1; Y axis spans the balance range.
+        #expect(descriptor.xAxis.lowerBound == 0)
+        #expect(descriptor.xAxis.upperBound == 3)
+        #expect(descriptor.yAxis.lowerBound == 600)
+        #expect(descriptor.yAxis.upperBound == 1000)
+        // Points scrub left-to-right by ascending x index.
+        #expect(descriptor.points.map(\.xValue) == [0, 1, 2, 3])
+    }
+
+    @Test("projection calls out the projected-low day in its spoken label")
+    func projectionAnnouncesProjectedLow() {
+        let descriptor = ChartAudioGraph.projection(projection([1000, 800, 600, 900], lowIndex: 2))
+        let lowLabels = descriptor.points.filter { $0.label.contains("projected low") }
+        #expect(lowLabels.count == 1)
+        // Exactly the low snapshot's point carries the call-out.
+        #expect(lowLabels.first?.yValue == 600)
+    }
+
+    @Test("projection with a single anchor point has nothing to sonify")
+    func projectionTooFewPointsIsEmpty() {
+        let descriptor = ChartAudioGraph.projection(projection([1000], lowIndex: 0))
+        #expect(descriptor.isEmpty)
+        #expect(descriptor.points.isEmpty)
+        // A non-empty, non-inverted axis range is still guaranteed.
+        #expect(descriptor.xAxis.lowerBound <= descriptor.xAxis.upperBound)
+        #expect(descriptor.yAxis.lowerBound <= descriptor.yAxis.upperBound)
+    }
 }

--- a/Tests/PlaidBarCoreTests/WindowChromeGlassTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowChromeGlassTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Window chrome glass decision (AND-588 / R-08)")
+struct WindowChromeGlassTests {
+    // MARK: - chromeBackground(reduceTransparency:)
+
+    @Test("Chrome uses Liquid Glass when transparency is not reduced")
+    func usesGlassByDefault() {
+        #expect(WindowChromeGlass.chromeBackground(reduceTransparency: false) == .glass)
+    }
+
+    @Test("Chrome falls back to a solid background when Reduce Transparency is on")
+    func solidUnderReduceTransparency() {
+        #expect(WindowChromeGlass.chromeBackground(reduceTransparency: true) == .solid)
+    }
+
+    // MARK: - allowsGlass(on:) — chrome-only policy (R-08)
+
+    @Test("Glass is allowed on chrome surfaces")
+    func glassAllowedOnChrome() {
+        #expect(WindowChromeGlass.allowsGlass(on: .chrome) == true)
+    }
+
+    @Test("Glass is never allowed on data surfaces (lists, tables, charts) — R-08")
+    func glassForbiddenOnData() {
+        #expect(WindowChromeGlass.allowsGlass(on: .data) == false)
+    }
+
+    // MARK: - Cross-check against the decorative-effects resolution
+
+    @Test("Reduced decorative-effects preference forces the solid fallback even when the system setting is off")
+    func reducedPreferenceForcesSolid() {
+        // Mirrors the popover: when the user picks "Reduced" decorative effects,
+        // `allowsTexture` is false, which the window modifier maps to
+        // reduceTransparency == true → solid chrome.
+        let effects = DecorativeEffectsPreference.reduced.resolved(
+            systemReduceMotion: false,
+            systemReduceTransparency: false
+        )
+        let reduceTransparency = !effects.allowsTexture
+        #expect(reduceTransparency == true)
+        #expect(WindowChromeGlass.chromeBackground(reduceTransparency: reduceTransparency) == .solid)
+    }
+
+    @Test("System Reduce Transparency forces solid regardless of the app preference")
+    func systemSettingWins() {
+        for preference in DecorativeEffectsPreference.allCases {
+            let effects = preference.resolved(systemReduceMotion: false, systemReduceTransparency: true)
+            let reduceTransparency = !effects.allowsTexture
+            #expect(reduceTransparency == true)
+            #expect(WindowChromeGlass.chromeBackground(reduceTransparency: reduceTransparency) == .solid)
+        }
+    }
+
+    @Test("With the system setting off and effects allowed (follow-system / on), chrome is glass")
+    func glassWhenEffectsAllowed() {
+        for preference in [DecorativeEffectsPreference.followSystem, .on] {
+            let effects = preference.resolved(systemReduceMotion: false, systemReduceTransparency: false)
+            let reduceTransparency = !effects.allowsTexture
+            #expect(reduceTransparency == false)
+            #expect(WindowChromeGlass.chromeBackground(reduceTransparency: reduceTransparency) == .glass)
+        }
+    }
+}

--- a/Tests/PlaidBarCoreTests/WindowFirstAppLockParityTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowFirstAppLockParityTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import PlaidBarCore
+
+/// Codifies the **App Lock + Privacy Mask cross-window parity** decision the
+/// window-first shell relies on (ADR-001 Epic 10 / AND-588). The popover, its
+/// detached host, and the window-first `AppShellView` all gate on the *same* pure
+/// `AppLockPreferences.effectiveDisplayMode(isAppLocked:)` decision via
+/// `AppState.isContentLocked` (== `effectiveDisplayMode == .locked`) and
+/// `AppState.shouldMaskFinancialValues` (== `effectiveDisplayMode != .normal`).
+///
+/// These tests pin the invariant that "locked withholds content, masked dots
+/// values" resolves identically regardless of which surface is showing — so the
+/// window-first window can never display balances/account names while App Lock is
+/// engaged, matching the popover.
+@Suite("Window-first App Lock / Privacy Mask parity (AND-588)")
+struct WindowFirstAppLockParityTests {
+    /// The view-level gate predicate the shell + popover share:
+    /// `AppState.isContentLocked`.
+    private func isContentLocked(_ preferences: AppLockPreferences, isAppLocked: Bool) -> Bool {
+        preferences.effectiveDisplayMode(isAppLocked: isAppLocked) == .locked
+    }
+
+    /// The view-level mask predicate the shell + popover share:
+    /// `AppState.shouldMaskFinancialValues`.
+    private func shouldMask(_ preferences: AppLockPreferences, isAppLocked: Bool) -> Bool {
+        preferences.effectiveDisplayMode(isAppLocked: isAppLocked) != .normal
+    }
+
+    @Test("When App Lock is enabled and engaged, content is withheld (gate shown) on every surface")
+    func lockedWithholdsContent() {
+        let preferences = AppLockPreferences(appLockEnabled: true)
+        // Engaged → locked: the window-first shell mounts AppLockedGateView, same
+        // as the popover.
+        #expect(isContentLocked(preferences, isAppLocked: true) == true)
+        // Not engaged → no gate.
+        #expect(isContentLocked(preferences, isAppLocked: false) == false)
+    }
+
+    @Test("App Lock disabled never withholds content even if the engaged flag flips")
+    func disabledLockNeverGates() {
+        let preferences = AppLockPreferences(appLockEnabled: false)
+        #expect(isContentLocked(preferences, isAppLocked: true) == false)
+        #expect(isContentLocked(preferences, isAppLocked: false) == false)
+    }
+
+    @Test("Locked supersedes Privacy Mask — a locked window withholds rather than just dotting values")
+    func lockedSupersedesMask() {
+        let preferences = AppLockPreferences(privacyMaskEnabled: true, appLockEnabled: true)
+        #expect(preferences.effectiveDisplayMode(isAppLocked: true) == .locked)
+        #expect(isContentLocked(preferences, isAppLocked: true) == true)
+        // Still considered "masking" (a superset), so amount call sites stay dotted
+        // underneath the gate too.
+        #expect(shouldMask(preferences, isAppLocked: true) == true)
+    }
+
+    @Test("Privacy Mask alone dots values on every surface without withholding content")
+    func maskDotsWithoutWithholding() {
+        let preferences = AppLockPreferences(privacyMaskEnabled: true, appLockEnabled: false)
+        #expect(isContentLocked(preferences, isAppLocked: false) == false)
+        #expect(shouldMask(preferences, isAppLocked: false) == true)
+    }
+
+    @Test("Normal mode shows content unmasked on every surface")
+    func normalShowsEverything() {
+        let preferences = AppLockPreferences()
+        #expect(isContentLocked(preferences, isAppLocked: false) == false)
+        #expect(shouldMask(preferences, isAppLocked: false) == false)
+    }
+}


### PR DESCRIPTION
## Summary

Epic 10 of the window-first migration (**ADR-001**, **AND-588**): Liquid Glass polish on **chrome only** plus cross-window accessibility finalization for the window-first shell. The flagship of this PR is the **App Lock security parity** fix — the window-first window previously could show data while App Lock was engaged; it now withholds content identically to the popover.

All changes live in the **window-first surface** (behind `WindowFirstFeatureFlag`, default **OFF**) or are behavior-preserving relocations, so the menu-bar popover is **byte-identical when the flag is OFF**.

## Chrome-only Liquid Glass (R-08)

- Replaced the unconditional scene-level `.containerBackground(.ultraThinMaterial, for: .window)` with `WindowChromeBackgroundModifier`, which **self-manages its Reduce Transparency degradation** rather than relying on the framework to thin the material (per the Epic 10 contract: custom translucency requires explicit a11y handling):
  - Resolves glass vs solid via the new pure, unit-tested `WindowChromeGlass.chromeBackground(reduceTransparency:)` in `PlaidBarCore`.
  - Glass = `.ultraThinMaterial`; **solid fallback** = opaque `windowBackgroundColor` (legible in light + dark).
  - `reduceTransparency` is `true` when the **system** Reduce Transparency setting is on **or** the user's reduced decorative-effects preference applies — the system setting always wins, mirroring the popover's `ResolvedDecorativeEffects.allowsTexture` gate so the two surfaces degrade identically.
- **Glass is confined to the navigation layer.** Audit of the shell + destinations:
  - Glass surfaces: the window container background and the sidebar footer `DataModeChip` (`.glassSurface(.inset)`) — both chrome. Destination section/card containers use `.glassSurface(.raised)` as the established card-chrome pattern.
  - **No glass on data:** the Transactions table, Review table, and chart **plot areas** carry no material (charts render on a `.clear`-fill card; marks are solid). Verified `TransactionsTable` / `TransactionsDestinationView` have zero `glass*` usage.
  - Encoded the policy as the pure `WindowChromeGlass.allowsGlass(on:)` (`.chrome` → true, `.data` → false).

## App Lock parity (security — the important parity work)

- Extracted `AppLockedGateView` into its own file (`Views/AppLockedGateView.swift`) so the popover, its detached host, and the window-first shell all use **one** gate. The popover's call site is unchanged (pure relocation).
- Mounted the gate on `AppShellView` as the **topmost** overlay: when content is **LOCKED** (not merely masked), the entire window is obscured — no balances, account/institution names, or sidebar badges leak (AND-462). Verified the window-first window **cannot show data while App Lock is engaged**.
- Gate transition gates on **Reduce Motion**; the ⌘K palette is force-dismissed while locked so unlocking never reveals a stale surface.

## Privacy Mask, text size, motion

- **Privacy Mask:** all real destinations (Transactions, Budgets, Planning, Insights, Review, Alerts) already mask via `appState.shouldMaskFinancialValues`; the glance/widgets already redact. Pinned the cross-window parity invariant in tests.
- **Text size (AND-570):** the shell already applies `.appliesAppTextSize()` at the scene root — confirmed; no change needed.
- **Reduce Motion:** existing shell springs/matched-geometry (AND-577) already gate on Reduce Motion; the new App-Lock transition does too.

## Audio-graph coverage gap closed

The task asked to confirm no shell chart lacks an audio graph. `ProjectedBalanceChart` (Planning) was the one chart with a spoken `accessibilityLabel` but **no scrubbable audio graph** (the net-worth trend and spend donut both had one). Added `ChartAudioGraph.projection(_:)` (a continuous line series, projected-low day called out, privacy-aware via the shared value-description path) and wired `.audioGraph(...)` onto the chart.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **passes**.
- `swift test` — **1986 tests pass** (~1971 baseline + 15 new).
- New tests: `WindowChromeGlassTests` (glass-vs-solid decision + chrome-only policy + system-setting-wins), `WindowFirstAppLockParityTests` (locked withholds / masked dots / normal shows, on every surface), and `ChartAudioGraph.projection` builder tests.

## Parity gaps found (for the Epic 9 sign-off checklist)

- **[fixed in this PR]** Window-first window did not gate on App Lock — content was visible while locked. Now gated.
- **[fixed in this PR]** `ProjectedBalanceChart` lacked an audio graph. Now has one.
- **[note]** `.glassSurface(.raised)` is applied to destination *card containers* that hold dense data (e.g. Budgets `treeSection`, Insights/Budgets donut cards). This is the established card-as-chrome pattern from the popover (the chart/list marks themselves stay solid), consistent with how R-08 is interpreted in already-merged destinations. Flagging for explicit sign-off rather than silently changing merged patterns.

Refs: **AND-588**, **ADR-001**, risk **R-08**, AND-462, AND-570, AND-569, AND-577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
