### PR TITLE
feat(dashboard): window-first Dashboard destination 2-col composed canvas (AND-622)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -1,22 +1,170 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Dashboard** destination (2-column — IA §3.1/§5.1, `[⌘1]`).
+/// **Dashboard** destination (2-column composed canvas — IA §3.1/§5.1, `[⌘1]`) —
+/// AND-622 (ADR-001 window-first workspace).
 ///
-/// A composed overview canvas with no master→detail relationship, so the shell
-/// renders only this content column (no inspector). Drill-ins deep-link to other
-/// destinations rather than opening a local third column.
+/// The default / primary surface: a composed *overview* canvas with no
+/// master→detail relationship, so the shell renders only this content column (no
+/// inspector). It re-hosts the **same overview content the menu-bar popover and
+/// its detached desktop window show** (``MainPopover``), surfaced from the same
+/// reusable subviews + the same `PlaidBarCore` presentation engines — **no model
+/// or chart logic lives here** (surface only). The two surfaces can never diverge
+/// because they read the same `AppState` and the same Core.
 ///
-/// Scaffold for the parallel Epics 4–7: today it shows the shared
-/// `DestinationPlaceholder`; the real canvas (decomposed from `MainPopover`'s
-/// dashboard body) lands in its epic by replacing this `body`. Owning its own
-/// file means that epic never touches `AppShellView`.
+/// Layout (IA §5.1): a two-column canvas — a **Summary** column (the existing
+/// ``WealthSummaryFlyout``: net-worth hero, balance mix, 30-day cashflow) beside
+/// an **Overview** column (the change receipt, balance time-machine, weekly
+/// review, category dashboard, status readiness, the activity heatmap + account
+/// rows, and the local-insight receipt). On a narrow window the two columns stack.
+///
+/// **Drill-ins deep-link, they don't open a third column** (IA §3.1, §5.1): the
+/// 2-column dashboard has no inspector, so selecting an account routes to the
+/// **Accounts** destination via `\.openRoute` rather than opening a local
+/// inspector pane. With the window-first flag OFF the route handler is a no-op, so
+/// this view is never instantiated and the popover is byte-identical.
+///
+/// **Privacy Mask / App Lock:** the shell already paints the full
+/// ``AppLockedGateView`` over the whole window while content is *locked* (ADR-001
+/// Epic 10 / AND-588), so this canvas never double-gates; it only honors Privacy
+/// *Mask* the same way the re-hosted subviews already do (they read
+/// `AppState.shouldMaskFinancialValues`), so masked values stay dotted and are
+/// never leaked here.
+///
+/// **Empty / loading / error states** match the popover: the re-hosted cards each
+/// carry their own loading redaction and empty copy, the overview block shows the
+/// shared fallback banner before setup completes, and a sync error surfaces in the
+/// inline ``DashboardErrorBanner`` at the top of the overview column — the same
+/// signals the popover renders.
+///
+/// **Flag-OFF inert:** reached only when the window-first `Window` opens
+/// (`WindowFirstFeatureFlag` ON). This file is never instantiated in the
+/// flag-OFF popover build.
 struct DashboardDestinationView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openRoute) private var openRoute
+
+    /// Below this content width the two columns stack into one (a narrow window),
+    /// matching the popover's behavior of dropping the side rail when space is
+    /// tight. Tuned to the same ballpark as the popover's three-column floor.
+    private let twoColumnBreakpoint: CGFloat = 760
+
     var body: some View {
-        DestinationPlaceholder(destination: .dashboard)
+        GeometryReader { proxy in
+            let isWide = proxy.size.width >= twoColumnBreakpoint
+
+            ScrollView {
+                Group {
+                    if isWide {
+                        HStack(alignment: .top, spacing: Spacing.lg) {
+                            summaryColumn
+                                .frame(width: PopoverGeometry.railWidth, alignment: .topLeading)
+
+                            overviewColumn
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                        }
+                    } else {
+                        VStack(alignment: .leading, spacing: Spacing.lg) {
+                            summaryColumn
+                            overviewColumn
+                        }
+                    }
+                }
+                .padding(Spacing.lg)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle(RouteDestination.dashboard.title)
+        .accessibilityElement(children: .contain)
+        .task { await appState.loadInitialData() }
+    }
+
+    // MARK: - Summary column
+
+    /// The left **Summary** column: the existing ``WealthSummaryFlyout`` the
+    /// popover mounts as its rail (net-worth hero, balance mix, 30-day cashflow),
+    /// re-hosted unchanged. Its "Add account" / "Recurring" / "Income flow"
+    /// affordances deep-link to the relevant destinations so the 2-column canvas
+    /// never needs a local inspector.
+    private var summaryColumn: some View {
+        WealthSummaryFlyout(
+            onAddAccount: { openRoute(.accounts()) },
+            onOpenSubscriptions: { openRoute(.planning(section: .recurring)) },
+            onOpenFlow: { openRoute(.planning(section: .incomeFlow)) }
+        )
+        .leftPanelSurface()
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Overview column
+
+    /// The right **Overview** column: the same center-column stack the popover
+    /// renders, top to bottom, each item an existing reusable subview driven by
+    /// the same `AppState` + Core. Order and content mirror ``MainPopover``'s
+    /// `dashboardColumn` so the two surfaces stay in lockstep.
+    private var overviewColumn: some View {
+        VStack(alignment: .leading, spacing: Spacing.lg) {
+            if let error = appState.error {
+                DashboardErrorBanner(error: error) { appState.error = nil }
+            }
+
+            BalanceTimeMachineView()
+
+            WeeklyReviewCard()
+
+            CategoryDashboardCard()
+
+            if let presentation = appState.firstRunSnapshotPresentation {
+                FirstRunSnapshotView(
+                    presentation: presentation,
+                    onDismiss: appState.dismissFirstRunSnapshot
+                )
+            }
+
+            if shouldShowStatusReadiness {
+                statusReadinessCluster
+            }
+
+            // The activity heatmap + filter bar + account rows — the overview's
+            // core instrument. Account drill-ins deep-link to Accounts (no local
+            // inspector on a 2-column canvas).
+            DashboardOverviewColumn(onSelectAccount: { account in
+                openRoute(.accounts(itemID: account.itemId))
+            })
+
+            DashboardLocalInsightCard()
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Dashboard overview")
+    }
+
+    /// The status-readiness cluster (connection health + attention queue +
+    /// readiness panel) is shown when setup is incomplete or the readiness verdict
+    /// needs attention — the same gate the popover uses to elevate it. A healthy,
+    /// fully-set-up dashboard keeps it quiet.
+    private var shouldShowStatusReadiness: Bool {
+        let level = appState.dashboardStatusReadiness.level
+        return !appState.isSetupComplete || level == .warning || level == .blocked
+    }
+
+    private var statusReadinessCluster: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            ConnectionHealthStripView()
+
+            AttentionQueueView(title: "Attention", onAddAccount: { openRoute(.accounts()) })
+
+            DashboardReadinessPanel(
+                openSettings: { openSettings() },
+                onAddAccount: { openRoute(.accounts()) }
+            )
+        }
+        .accessibilityElement(children: .contain)
     }
 }
 
 #Preview {
     DashboardDestinationView()
+        .environment(AppState())
 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
@@ -1,0 +1,154 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The local-only insight receipt for the window-first **Dashboard** destination
+/// (AND-622), surfaced from the same Core ``LocalAIInsightReceipt`` the menu-bar
+/// popover renders (its `LocalInsightsCard` is private to `MainPopover`). It shows
+/// the on-device summary headline, the evidence chips, the confidence /
+/// limitations lines, and the local-only provenance badge — all computed from the
+/// same `AppState.localAIActivitySummaries` + availability.
+///
+/// **Surface only — no AI/model logic here.** The receipt, its chips, and the
+/// availability state come from Core. On-device AI is **off by default with a
+/// visible status** (AND-564); the availability label carries the current state so
+/// the user always sees whether anything ran locally. Honors Privacy Mask via the
+/// receipt's `privacyMaskEnabled` input, and never carries meaning by color alone.
+struct DashboardLocalInsightCard: View {
+    @Environment(AppState.self) private var appState
+
+    private var summaries: [LocalAIActivitySummary] {
+        appState.localAIActivitySummaries
+    }
+
+    private var primarySummary: LocalAIActivitySummary? {
+        summaries.first { $0.window == .lastMonth } ?? summaries.first
+    }
+
+    private var availability: LocalAIAvailability {
+        primarySummary?.availability ?? appState.localAIAvailability
+    }
+
+    private var receipt: LocalAIInsightReceipt {
+        LocalAIInsightReceipt.make(
+            summary: primarySummary,
+            availability: availability,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
+        )
+    }
+
+    var body: some View {
+        let receipt = receipt
+
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 8) {
+                Text(receipt.title)
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                availabilityLabel
+            }
+
+            Text(receipt.headline)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.86)
+
+            HStack(spacing: 6) {
+                ForEach(receipt.evidenceChips) { chip in
+                    evidenceChip(chip)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(Array(detailLines(receipt).enumerated()), id: \.offset) { _, detail in
+                    HStack(alignment: .top, spacing: 6) {
+                        Circle()
+                            .fill(Color.secondary.opacity(0.58))
+                            .frame(width: 4, height: 4)
+                            .padding(.top, 6)
+                        Text(detail)
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
+            HStack(spacing: 5) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text("\(receipt.localOnlyBadge). \(receipt.reversibleActionCopy)")
+                    .microText()
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 4)
+            }
+        }
+        .padding(Spacing.sm)
+        .glassSurface(.inset)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(receipt.accessibilitySummary)
+    }
+
+    private var availabilityLabel: some View {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: LocalAIAvailabilityPresentation.iconName(for: availability.state))
+                .font(.caption2.weight(.medium))
+            Text(LocalAIAvailabilityPresentation.popoverLabel(for: availability))
+                .font(.caption.weight(.medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(availabilityTint)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
+        .background(.quinary, in: Capsule())
+        .help(LocalAIAvailabilityPresentation.helpText(for: availability))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(LocalAIAvailabilityPresentation.popoverLabel(for: availability))
+    }
+
+    private var availabilityTint: Color {
+        switch availability.state {
+        case .available: SemanticColors.positive
+        case .disabled, .checking: AppearanceTextColors.secondary
+        case .unavailable: SemanticColors.warning
+        }
+    }
+
+    private func detailLines(_ receipt: LocalAIInsightReceipt) -> [String] {
+        var lines = [receipt.confidence]
+        if let unavailableState = receipt.unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: receipt.limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
+    private func evidenceChip(_ chip: LocalAIInsightReceipt.EvidenceChip) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Image(systemName: chip.systemImage)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(chip.label)
+                    .lineLimit(1)
+            }
+            .microText()
+            .foregroundStyle(.secondary)
+
+            Text(chip.value)
+                .font(.caption.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.76)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.rowVertical)
+        .glassSurface(.inset, cornerRadius: Radius.control)
+        .help("\(chip.label): \(chip.value)")
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -1,0 +1,400 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The overview block of the window-first **Dashboard** destination (AND-622): the
+/// activity heatmap + the primary account filter + the account rows — the same
+/// instrument the menu-bar popover renders via its private `DashboardOverviewStack`.
+///
+/// **Surface only — no model logic here.** It composes existing reusable pieces
+/// over `PlaidBarCore`:
+/// - the **filter bar** is the existing ``DashboardFilterBar``, bound to the same
+///   `AppState.dashboardFilter` the popover persists;
+/// - the **activity heatmap** is the existing read-only ``InsightsActivityHeatmapGrid``
+///   (already factored out for the Insights destination, AND-585) over the same
+///   ``SpendingHeatmapLayout`` Core engine — *the heatmap is not rebuilt here*;
+/// - the **account rows** render from the same ``AccountPresentation`` Core helpers
+///   the popover row uses, honoring Privacy Mask.
+///
+/// **Drill-ins deep-link, not a third column** (IA §3.1, §5.1): the 2-column
+/// dashboard has no inspector, so selecting a row calls `onSelectAccount`, which
+/// the destination routes to the **Accounts** destination via `\.openRoute`.
+///
+/// Empty / loading states mirror the popover: a pre-setup install shows the Core
+/// ``DashboardOverviewFallbackState`` banner instead of an empty grid; the
+/// accounts section shows the skeleton while the first fetch is in flight and the
+/// Core ``DashboardAccountEmptyState`` copy when a filter resolves to no rows.
+struct DashboardOverviewColumn: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    /// Routed by the destination to the Accounts destination (no local inspector
+    /// on a 2-column canvas).
+    let onSelectAccount: (AccountDTO) -> Void
+
+    private var filter: DashboardAccountFilter { appState.dashboardFilter }
+
+    private var filteredAccounts: [AccountDTO] {
+        appState.accounts.filter { filter.includes($0, appState: appState) }
+    }
+
+    private var fallbackState: DashboardOverviewFallbackState? {
+        DashboardOverviewFallbackState.evaluate(
+            isSetupComplete: appState.isSetupComplete,
+            isDemoMode: appState.isDemoMode,
+            accountCount: appState.accounts.count,
+            transactionCount: appState.transactions.count
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            if let fallbackState {
+                DashboardOverviewFallback(presentation: fallbackState)
+            } else {
+                activityHeatmap
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                DashboardFilterBar(selection: filterBinding, hasSelectedAccount: false)
+                accountsSection
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Overview with activity heatmap, account filters, and account rows.")
+    }
+
+    // MARK: - Heatmap
+
+    /// The read-only year heatmap, reusing the existing ``InsightsActivityHeatmapGrid``
+    /// over the same Core layout the popover computes. Privacy Mask / Reduce
+    /// Transparency swap in a text alternative, since the grid leans on tinted,
+    /// translucent cells (ACCESSIBILITY.md — never color/translucency alone).
+    @ViewBuilder
+    private var activityHeatmap: some View {
+        let layout = heatmapLayout()
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Label(layout.mode.summaryTitle, systemImage: "square.grid.3x3.fill")
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+
+            if appState.shouldMaskFinancialValues || reduceTransparency {
+                heatmapTextAlternative(layout: layout)
+            } else {
+                InsightsActivityHeatmapGrid(layout: layout)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .glassSurface(.raised)
+        .loadingRedaction(appState.loadState(for: .activityHeatmap))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func heatmapLayout() -> SpendingHeatmapLayout {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -364, to: end) ?? end
+        return SpendingHeatmapLayout.compute(
+            from: appState.transactions,
+            startDate: start,
+            endDate: end,
+            mode: appState.dashboardHeatmapMode,
+            calendar: calendar
+        )
+    }
+
+    private func heatmapTextAlternative(layout: SpendingHeatmapLayout) -> some View {
+        let masked = appState.shouldMaskFinancialValues
+        let total = masked
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(layout.totalValue, format: .compact)
+        return VStack(alignment: .leading, spacing: Spacing.xs) {
+            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
+                .font(.subheadline.weight(.medium))
+            Text(masked
+                ? "Activity totals are hidden while VaultPeek is private."
+                : "\(total) across active days. \(layout.mode.semanticDescription)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Accounts
+
+    private var accountsLoadState: DashboardLoadState {
+        appState.loadState(for: .accounts)
+    }
+
+    private var accountsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Accounts")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(filteredAccounts.count)")
+                    .sectionTitle()
+                    .foregroundStyle(.secondary)
+                    .opacity(accountsLoadState.showsSkeleton ? 0 : 1)
+            }
+            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+            .padding(.bottom, Spacing.xs)
+
+            if filteredAccounts.isEmpty {
+                if accountsLoadState.showsSkeleton {
+                    DashboardAccountRowSkeletonList(loadState: accountsLoadState)
+                } else {
+                    DashboardAccountEmpty(filter: filter)
+                }
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(filteredAccounts) { account in
+                        DashboardAccountRowButton(
+                            account: account,
+                            isStatusFilter: filter == .status,
+                            onSelect: { onSelectAccount(account) }
+                        )
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: Radius.panel))
+            }
+        }
+    }
+
+    private var filterBinding: Binding<DashboardAccountFilter> {
+        Binding(
+            get: { appState.dashboardFilter },
+            set: { appState.dashboardFilter = $0 }
+        )
+    }
+}
+
+// MARK: - Account row
+
+/// A single account row for the window-first dashboard overview. Drives off the
+/// shared ``AccountPresentation`` Core helpers (the same source the popover row
+/// uses), so name, subtitle, amount, and the VoiceOver label match. Selection
+/// deep-links to the Accounts destination rather than opening a local inspector.
+private struct DashboardAccountRowButton: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let account: AccountDTO
+    let isStatusFilter: Bool
+    let onSelect: () -> Void
+
+    private var privacyMaskEnabled: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: Spacing.compactRowContentSpacing) {
+                Image(systemName: AccountPresentation.iconName(for: account))
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: Sizing.iconChip, height: Sizing.iconChip)
+                    .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
+
+                VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
+                    Text(account.name)
+                        .font(.callout.weight(.medium))
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .detailText()
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: Spacing.compactRowContentSpacing)
+
+                Text(amountText)
+                    .dataText()
+                    .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
+                    .foregroundStyle(AppearanceTextColors.primary)
+                    .lineLimit(1)
+
+                // The drill-in opens the Accounts destination; chevron.forward
+                // flips correctly under RTL and carries the affordance by shape.
+                Image(systemName: "chevron.forward")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
+            .padding(.vertical, Spacing.compactRowVerticalPadding)
+            .contentShape(Rectangle())
+            .overlay(alignment: .bottom) {
+                Divider().opacity(0.4)
+            }
+        }
+        .buttonStyle(.plain)
+        .hoverHighlight()
+        .help("Open \(AccountPresentation.displayName(for: account)) in Accounts")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Opens this account in the Accounts destination.")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var subtitle: String {
+        AccountPresentation.dashboardRowSubtitle(
+            for: account,
+            connectionLabel: statusText,
+            pendingCount: pendingCount,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+    }
+
+    private var amountText: String {
+        AccountPresentation.rowAmountText(for: account, privacyMaskEnabled: privacyMaskEnabled)
+    }
+
+    private var pendingCount: Int {
+        appState.transactionsForAccount(account.id).count(where: \.pending)
+    }
+
+    private var accessibilityLabel: String {
+        AccountPresentation.rowAccessibilityLabel(
+            for: account,
+            amountText: amountText,
+            connectionLabel: statusText,
+            pendingCount: pendingCount,
+            isSelected: false,
+            utilizationThreshold: appState.creditUtilizationThreshold,
+            privacyMaskEnabled: privacyMaskEnabled,
+            liability: appState.liabilities.first { $0.accountId == account.id }
+        )
+    }
+
+    private var itemConnectionStatus: ItemStatus? {
+        appState.itemStatuses.first { $0.id == account.itemId }
+    }
+
+    private var statusText: String {
+        AccountConnectionPresentation.evaluate(
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            isSyncStale: appState.isSyncStale,
+            statusSyncText: appState.statusSyncText,
+            itemStatus: itemConnectionStatus?.status,
+            institutionName: itemConnectionStatus?.institutionName,
+            itemLastSyncRelative: itemConnectionStatus?.lastSync.map(Formatters.relativeDate)
+        ).rowLabel
+    }
+}
+
+// MARK: - Empty / fallback
+
+/// The dashboard accounts empty state, surfaced from the same Core
+/// ``DashboardAccountEmptyState`` engine the popover uses. The "Add account"
+/// affordance deep-links to the Accounts destination via the parent's route.
+private struct DashboardAccountEmpty: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openRoute) private var openRoute
+    let filter: DashboardAccountFilter
+
+    private var presentation: DashboardAccountEmptyState {
+        DashboardAccountEmptyState.evaluate(
+            filter: filter,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            isInitialLoad: appState.loadState(for: .accounts).isInitialLoad,
+            serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
+            linkedItemCount: appState.statusItemCount,
+            accountCount: appState.accounts.count,
+            degradedItemCount: appState.needsLoginItemCount + appState.erroredItemCount,
+            degradedItemRecoveryTitle: ItemRecoveryTarget.actionTitle(from: appState.itemStatuses),
+            degradedItemRecoveryDetail: ItemRecoveryTarget.recoveryDetail(from: appState.itemStatuses)
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Image(systemName: presentation.iconName)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 28, height: 28)
+                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: Radius.panel))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(presentation.title)
+                        .font(.callout.weight(.semibold))
+                    Text(presentation.detail)
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            if !presentation.isLoading, presentation.showsAddAccount {
+                Button { openRoute(.accounts()) } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(emphasizedTint.map { SurfaceRank.emphasized($0) } ?? .raised)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(presentation.title). \(presentation.detail)")
+    }
+
+    private var tint: Color {
+        switch presentation.tone {
+        case .brand: SemanticColors.brand
+        case .warning: SemanticColors.warning
+        case .healthy, .loading, .offline, .secondary: .secondary
+        }
+    }
+
+    private var emphasizedTint: Color? {
+        switch presentation.tone {
+        case .brand, .warning: tint
+        case .healthy, .loading, .offline, .secondary: nil
+        }
+    }
+}
+
+/// The pre-setup overview fallback banner, surfaced from the Core
+/// ``DashboardOverviewFallbackState`` (shown when no demo or synced data can yet
+/// provide a meaningful first glance). The action deep-links to Accounts.
+private struct DashboardOverviewFallback: View {
+    @Environment(\.openRoute) private var openRoute
+    let presentation: DashboardOverviewFallbackState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: presentation.iconName)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(SemanticColors.brandSecondary)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        SemanticColors.brandSecondary.opacity(0.14),
+                        in: RoundedRectangle(cornerRadius: Radius.panel)
+                    )
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(presentation.title)
+                        .font(.callout.weight(.semibold))
+                    Text(presentation.detail)
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(presentation.title). \(presentation.detail)")
+
+            Button { openRoute(.accounts()) } label: {
+                Label(presentation.actionTitle, systemImage: presentation.actionIconName)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.emphasized(SemanticColors.brandSecondary))
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
@@ -1,0 +1,220 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// The dashboard's status-readiness panel for the window-first **Dashboard**
+/// destination (AND-622), surfaced from the same Core ``DashboardStatusReadiness``
+/// verdict the menu-bar popover renders. It carries the readiness title/detail,
+/// the status metric grid, and the primary recovery action — dispatched through
+/// the same `AppState` methods the popover uses, so the two surfaces drive
+/// identical recovery behavior.
+///
+/// **Surface only — no verdict logic here.** The verdict, its tone, and the
+/// action set all come from `AppState.dashboardStatusReadiness` (Core). Meaning is
+/// carried by glyph + text, never color alone (ACCESSIBILITY.md).
+struct DashboardReadinessPanel: View {
+    @Environment(AppState.self) private var appState
+    let openSettings: () -> Void
+    let onAddAccount: () -> Void
+
+    private var readiness: DashboardStatusReadiness {
+        appState.dashboardStatusReadiness
+    }
+
+    private var needsAttention: Bool {
+        readiness.level == .warning || readiness.level == .blocked
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 9) {
+                Image(systemName: icon)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 28, height: 28)
+                    .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: Radius.panel))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(readiness.title)
+                        .font(.callout.weight(.semibold))
+                    Text(readiness.detail)
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+            }
+
+            DashboardStatusMetricGrid()
+
+            if let primaryAction = readiness.primaryAction {
+                Button {
+                    perform(primaryAction)
+                } label: {
+                    Label(
+                        primaryActionLabel(for: primaryAction),
+                        systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                    )
+                }
+                .buttonStyle(needsAttention ? AnyButtonStyle(.borderedProminent) : AnyButtonStyle(.bordered))
+                .controlSize(.small)
+                .tint(tint)
+                .disabled(appState.isLoading)
+            }
+        }
+        .padding(Spacing.md)
+        .glassSurface(needsAttention ? .emphasized(tint) : .raised)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var icon: String {
+        switch readiness.level {
+        case .healthy: "checkmark.circle.fill"
+        case .loading: "arrow.triangle.2.circlepath"
+        case .warning: "exclamationmark.triangle.fill"
+        case .blocked: "xmark.octagon.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch readiness.level {
+        case .healthy, .loading: AppearanceTextColors.secondary
+        case .warning: SemanticColors.warning
+        case .blocked: SemanticColors.negative
+        }
+    }
+
+    private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {
+        if action == .reconnect,
+           let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
+            return title
+        }
+        return readiness.primaryActionTitle ?? action.defaultTitle
+    }
+
+    /// Dispatches a readiness action through the same `AppState` entry points the
+    /// popover's panel uses, so window-first recovery matches the popover exactly.
+    private func perform(_ action: DashboardStatusReadinessAction) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            onAddAccount()
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .reconnect:
+            guard let itemId = ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
+                Task { await appState.refreshAccounts() }
+                return
+            }
+            Task { await appState.reconnectItem(itemId: itemId) }
+        case .openSettings:
+            openSettings()
+        case .requestNotificationPermission:
+            Task { _ = await appState.requestNotificationPermission() }
+        case .openNotificationSettings:
+            openNotificationSettings()
+        }
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            openSettings()
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+/// The readiness status metric grid (Mode / Server / Items / Synced / Credentials
+/// / Last Sync / Data Path), reading the same `AppState` status accessors the
+/// popover grid reads. Surface only.
+private struct DashboardStatusMetricGrid: View {
+    @Environment(AppState.self) private var appState
+
+    private let columns = [
+        GridItem(.flexible(minimum: 112), spacing: 6),
+        GridItem(.flexible(minimum: 112), spacing: 6),
+        GridItem(.flexible(minimum: 112), spacing: 6),
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 6) {
+            metric("Mode", appState.statusModeText)
+            metric("Server", appState.statusServerText)
+            metric("Items", "\(appState.statusItemCount) linked")
+            metric("Synced", "\(appState.serverSyncedItemCount ?? 0) of \(appState.statusItemCount)")
+            metric("Credentials", appState.serverCredentialsText)
+            metric("Last Sync", appState.lastSyncRelative ?? "Never")
+            metric("Data Path", appState.activeStorageDirectoryDisplayText)
+        }
+    }
+
+    private func metric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .microText()
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title): \(value)")
+    }
+}
+
+/// An inline error banner for the window-first dashboard overview, mirroring the
+/// popover's `ErrorBanner` (which is private to `MainPopover`). Same shape +
+/// dismiss + VoiceOver announcement so a sync error reads the same on both
+/// surfaces. Meaning is carried by glyph + text, never color alone.
+struct DashboardErrorBanner: View {
+    let error: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(SemanticColors.negative)
+                .accessibilityHidden(true)
+            Text(error)
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.borderless)
+            .help("Dismiss error")
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .background(SemanticColors.negative.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Error: \(error)")
+        .task(id: error) {
+            await Task.yield()
+            AccessibilityNotification.Announcement("Error: \(error)").post()
+        }
+    }
+}
+
+/// Type-erased button style so the readiness primary action can pick prominent vs
+/// bordered without the two branches producing different `some View` body types.
+private struct AnyButtonStyle: PrimitiveButtonStyle {
+    private let makeBody: (Configuration) -> AnyView
+
+    init(_ style: some PrimitiveButtonStyle) {
+        makeBody = { configuration in
+            AnyView(style.makeBody(configuration: configuration))
+        }
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        makeBody(configuration)
+    }
+}


### PR DESCRIPTION
## Summary

Fills `DashboardDestinationView` — the default / primary surface of the window-first shell (IA §5.1, `⌘1`) — replacing the "coming soon" placeholder with a **2-column composed overview canvas** that re-hosts the same overview content the menu-bar popover and its detached desktop window render (`MainPopover`). Surface only: no model or chart logic is added here; everything reads the same `AppState` and `PlaidBarCore` presentation engines, so the two surfaces can never diverge.

**Layout (IA §5.1):** a two-column canvas — a **Summary** column (the existing `WealthSummaryFlyout`: net-worth hero, balance mix, 30-day cashflow) beside an **Overview** column (balance time-machine, weekly review, category dashboard, status readiness, the activity heatmap + account rows, and the local-only insight receipt). A narrow window stacks the two columns.

**Drill-ins deep-link, not a third column** (IA §3.1 — the 2-column dashboard has no inspector): selecting an account routes to the **Accounts** destination via `\.openRoute`; the summary column's add-account / recurring / income-flow affordances deep-link too.

## Refs
- Issue: **AND-622**
- **ADR-001** window-first migration (`docs/strategy/macos26-migration`)

## Flag-off note
Inert with the window-first flag OFF. The new views are only reachable through `DestinationContentView` inside `AppShellView`, which is built **solely** behind `WindowFirstFeatureFlag` (default OFF). `MainPopover`, `AppShellView`, `DestinationRouter`, and `NavigationModel`/`NavigationState` are **untouched** — the popover is byte-identical with the flag off. Only the assigned `DashboardDestinationView` was edited; everything else is new, destination-namespaced files.

## Reused / re-hosted components
- **Unchanged reusable subviews:** `WealthSummaryFlyout`, `BalanceTimeMachineView`, `WeeklyReviewCard`, `CategoryDashboardCard`, `FirstRunSnapshotView`, `ConnectionHealthStripView`, `AttentionQueueView`, `DashboardFilterBar`.
- **`InsightsActivityHeatmapGrid`** (already factored out for the Insights destination, AND-585) over the same `SpendingHeatmapLayout` Core — *the heatmap is not rebuilt*.
- **New namespaced surface views over Core** (for content that is `private` to `MainPopover` and can't be imported across files):
  - `DashboardOverviewColumn` — heatmap + filter bar + account rows (rows from `AccountPresentation` Core; empty/fallback from `DashboardAccountEmptyState` / `DashboardOverviewFallbackState`).
  - `DashboardReadinessPanel` — `DashboardStatusReadiness` verdict + status metric grid + the same `AppState` recovery dispatch the popover uses.
  - `DashboardLocalInsightCard` — `LocalAIInsightReceipt` (on-device AI off-by-default status visible).
  - `DashboardErrorBanner` — mirrors the popover's private `ErrorBanner`.

## Accessibility / security
- **Privacy Mask** honored: re-hosted views read `shouldMaskFinancialValues`; the heatmap swaps to a text alternative under Privacy Mask / Reduce Transparency.
- **App Lock** is gated at the shell (`AppShellView` paints `AppLockedGateView` over the whole window) — no double-gating here, and nothing leaks.
- Meaning is never carried by color alone (glyph + text everywhere).

## Empty / loading / error parity
- Pre-setup: Core `DashboardOverviewFallbackState` banner instead of an empty grid.
- Accounts: skeleton while the first fetch is in flight, then `DashboardAccountEmptyState` copy when a filter resolves to no rows.
- Sync error: inline `DashboardErrorBanner` at the top of the overview column.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- `swift test` — **2026 tests pass**.
- No new pure logic added (surface-only re-host), so no new tests; the underlying Core engines are already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)