### PR TITLE
chore(dist): gate widget .appex packaging + verify App Group entitlement (AND-586)

### DIFF
--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -122,6 +122,25 @@ codesign --force --options runtime --timestamp \
 echo "==> Verifying signature before submission..."
 codesign --verify --deep --strict --verbose=2 "$APP_DIR"
 
+# The widget extension only appears in the widget gallery and only reads the
+# shared App Group snapshot when the signed .appex actually carries the
+# group.com.ftchvs.PlaidBar entitlement. codesign silently drops --entitlements
+# if the file path is wrong, so confirm the entitlement survived the signing
+# pass before spending a notarization round-trip (AND-586 distribution).
+if [ -e "$WIDGET_APPEX" ]; then
+    echo "==> Verifying widget extension carries the App Group entitlement..."
+    if ! codesign -d --entitlements :- "$WIDGET_APPEX" 2>/dev/null \
+        | grep -q "group.com.ftchvs.PlaidBar"; then
+        {
+            echo "Signed widget extension is missing the App Group entitlement."
+            echo "Expected group.com.ftchvs.PlaidBar from $WIDGET_ENTITLEMENTS."
+            echo "Without it the widget cannot read the shared snapshot and shows"
+            echo "the setup state, and Control Center controls cannot toggle state."
+        } >&2
+        exit 1
+    fi
+fi
+
 echo "==> Notarizing the app bundle..."
 rm -f "$ZIP_PATH"
 ditto -c -k --keepParent "$APP_DIR" "$ZIP_PATH"

--- a/Scripts/validate-app-bundle.sh
+++ b/Scripts/validate-app-bundle.sh
@@ -17,6 +17,9 @@ SERVER_BINARY="$APP_DIR/Contents/MacOS/PlaidBarServer"
 SPARKLE_FRAMEWORK="$APP_DIR/Contents/Frameworks/Sparkle.framework"
 INFO_PLIST="$APP_DIR/Contents/Info.plist"
 APP_ICON="$APP_DIR/Contents/Resources/AppIcon.icns"
+WIDGET_APPEX="$APP_DIR/Contents/PlugIns/PlaidBarWidgetExtension.appex"
+WIDGET_INFO_PLIST="$WIDGET_APPEX/Contents/Info.plist"
+WIDGET_BINARY="$WIDGET_APPEX/Contents/MacOS/PlaidBarWidgetExtension"
 
 if [ ! -f "$INFO_PLIST" ]; then
     echo "Missing Info.plist at $INFO_PLIST" >&2
@@ -65,10 +68,56 @@ if ! otool -l "$APP_BINARY" | grep -q "@executable_path/../Frameworks"; then
     exit 1
 fi
 
+# Widget extension (.appex) — embedded under Contents/PlugIns so the WidgetKit
+# widgets, Control Center controls, and the Spotlight/Shortcuts App Intents
+# install with the app (AND-586 distribution). The extension only loads when it
+# is present with a valid WidgetKit extension point and a verifiable signature.
+# Entitlements (App Group / sandbox) are intentionally NOT asserted here: the
+# ad-hoc package omits them so the local/DMG build stays launchable (see
+# package-app.sh and PR #476); the App Group entitlement is applied and verified
+# only on the Developer ID + notarized path in Scripts/notarize.sh.
+if [ ! -d "$WIDGET_APPEX" ]; then
+    echo "Missing widget extension at $WIDGET_APPEX" >&2
+    echo "package-app.sh must embed PlaidBarWidgetExtension.appex under Contents/PlugIns." >&2
+    exit 1
+fi
+
+if [ ! -f "$WIDGET_INFO_PLIST" ]; then
+    echo "Missing widget Info.plist at $WIDGET_INFO_PLIST" >&2
+    exit 1
+fi
+
+if [ ! -x "$WIDGET_BINARY" ]; then
+    echo "Missing executable widget binary at $WIDGET_BINARY" >&2
+    exit 1
+fi
+
+WIDGET_EXTENSION_POINT="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionPointIdentifier' "$WIDGET_INFO_PLIST" 2>/dev/null || true)"
+if [ "$WIDGET_EXTENSION_POINT" != "com.apple.widgetkit-extension" ]; then
+    echo "Widget Info.plist NSExtensionPointIdentifier must be com.apple.widgetkit-extension (got: ${WIDGET_EXTENSION_POINT:-<missing>})" >&2
+    exit 1
+fi
+
+if [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$WIDGET_INFO_PLIST" 2>/dev/null || true)" != "com.ftchvs.PlaidBar.WidgetExtension" ]; then
+    echo "Widget Info.plist CFBundleIdentifier must be com.ftchvs.PlaidBar.WidgetExtension" >&2
+    exit 1
+fi
+
+if [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$WIDGET_INFO_PLIST" 2>/dev/null || true)" != "PlaidBarWidgetExtension" ]; then
+    echo "Widget Info.plist CFBundleExecutable must be PlaidBarWidgetExtension" >&2
+    exit 1
+fi
+
+if ! codesign --verify --strict "$WIDGET_APPEX" >/dev/null 2>&1; then
+    echo "Widget extension signature failed to verify for $WIDGET_APPEX (ad-hoc or Developer ID)" >&2
+    codesign --verify --strict --verbose=2 "$WIDGET_APPEX" >&2 || true
+    exit 1
+fi
+
 if ! codesign --verify --deep --strict "$APP_DIR" >/dev/null 2>&1; then
     echo "Code signature failed to verify for $APP_DIR (ad-hoc or Developer ID)" >&2
     codesign --verify --deep --strict --verbose=2 "$APP_DIR" >&2 || true
     exit 1
 fi
 
-echo "Validated VaultPeek.app bundle at $APP_DIR"
+echo "Validated VaultPeek.app bundle (incl. widget extension) at $APP_DIR"

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -70,7 +70,14 @@ signing pass; sign nested code first:
    each `codesign --force --options runtime --timestamp`.
 2. `Sparkle.framework` itself.
 3. `Contents/MacOS/PlaidBarServer`.
-4. `VaultPeek.app` with `--entitlements PlaidBar.entitlements --options runtime --timestamp`.
+4. `Contents/PlugIns/PlaidBarWidgetExtension.appex` with
+   `--entitlements PlaidBarWidgetExtension.entitlements --options runtime --timestamp`.
+   `package-app.sh` only ad-hoc signs (no entitlements) this nested extension so
+   the local/DMG build stays launchable; the notarized build must re-sign it
+   here with its App Group + sandbox entitlements **before** the outer app, or
+   the widget never reaches the gallery (AND-385/AND-586). `notarize.sh` verifies
+   `group.com.ftchvs.PlaidBar` survived this pass before submitting.
+5. `VaultPeek.app` with `--entitlements PlaidBar.entitlements --options runtime --timestamp`.
 
 Then verify locally before submission:
 
@@ -110,6 +117,35 @@ Open workaround, menu bar item appears, demo mode renders, server starts, and
 `~/.vaultpeek/` is created with private permissions. Only after this passes
 may README/About/release-notes language change from "ad-hoc signed" to
 "notarized" (T084).
+
+### Widget, Control Center, and App Intents discovery (AND-586)
+
+The widget extension only loads from a **notarized, /Applications-installed**
+build — an ad-hoc local/DMG bundle embeds the `.appex` (gated by
+`validate-app-bundle.sh`) but macOS will not surface it in the gallery without a
+real signature. After the notarized install, on the same clean machine confirm:
+
+```bash
+# The host registered the embedded extension with the WidgetKit plugin host.
+pluginkit -m -v -i com.ftchvs.PlaidBar.WidgetExtension
+```
+
+Then, in the UI:
+
+- **Widget gallery** (Notification Center → Edit Widgets, or desktop
+  right-click → Edit Widgets): "VaultPeek" appears with the small/medium/large
+  families; adding one shows the redacted placeholder until the app writes a
+  snapshot.
+- **Control Center / menu bar** (System Settings → Control Center → add a
+  control): "Refresh balances", "Privacy Mask", "Safe to Spend", and "Credit
+  Utilization" controls are listed.
+- **Spotlight / Shortcuts**: searching "VaultPeek" surfaces the App Intents
+  (e.g. Refresh balances, Privacy Mask) and the Spotlight snippet; Shortcuts →
+  app actions lists the same intents.
+
+If the gallery is empty, the `.appex` signature lost its App Group/sandbox
+entitlements or was deep-signed away — re-run the inside-out signing order above
+and re-check `codesign -d --entitlements :- <appex>`.
 
 ## Sparkle Update Channel (decide before promising updates)
 


### PR DESCRIPTION
## Summary

- The `PlaidBarWidgetExtension.appex` is **already** built, wrapped, embedded under `Contents/PlugIns/`, and signed by `package-app.sh` (ad-hoc) and `notarize.sh` (Developer ID, entitled, inside-out) — the AND-586 "distribution follow-up" premise that it was unpackaged is stale. The real gap was **verification**: nothing asserted the embed, so CI's package+validate gate would stay green even if the appex silently disappeared, and a mis-pathed `--entitlements` would ship a widget that never reaches the gallery.
- `Scripts/validate-app-bundle.sh`: assert the embedded appex — presence, Info.plist (`NSExtensionPointIdentifier=com.apple.widgetkit-extension`, `CFBundleIdentifier`, `CFBundleExecutable`), executable binary, and signature. Entitlements are intentionally **not** asserted here — the ad-hoc/DMG build omits them on purpose so it stays launchable (PR #476). Since `package-app.sh` and CI both call this validator, the widget embed is now regression-proof.
- `Scripts/notarize.sh`: verify `group.com.ftchvs.PlaidBar` survived the appex signing pass before spending a notarization round-trip (`codesign` silently drops `--entitlements` on a bad path).
- `docs/distribution.md`: documented signing order now lists the appex step (was missing → drift from the real script); added a clean-machine widget gallery / Control Center / Shortcuts-Spotlight discovery checklist.

## Autonomous task IDs

- Task ID(s): AND-586 (distribution follow-up)
- Backlog slice: Widget/App-Intents distribution packaging verification
- Scope note: One focused slice — packaging **verification gates + docs** only; no behavior change to the app, server, or the embed/sign logic itself.

## Agent coordination

- Builder agent: Claude (Opus 4.8)
- Builder branch/worktree: `claude/magical-einstein-9c17ea` @ `.claude/worktrees/magical-einstein-9c17ea`
- Reviewer/merge steward: Otto
- Coordination note: Review only — no other agent should push to this branch.

## Changed files

- `Scripts/validate-app-bundle.sh` — assert embedded widget appex structure + signature
- `Scripts/notarize.sh` — verify App Group entitlement landed on the signed appex
- `docs/distribution.md` — appex signing-order step + clean-machine discovery checklist

## Local gates

- [x] `git diff --check` (clean)
- [x] `swift build --target PlaidBar ...` — N/A: no Swift sources changed. Verified instead via full `./Scripts/package-app.sh` (release build green end-to-end, prints `Validated VaultPeek.app bundle (incl. widget extension)`).
- [x] `swift build --target PlaidBarServer ...` — N/A: no server/DTO/package code changed.
- [x] Tests — N/A: shell/docs only. Verified with `bash -n` + `shellcheck -S warning` (clean), plus positive (validate exits 0 on a real bundle) and negative tests (exits 1 on missing appex and on a wrong `NSExtensionPointIdentifier`).
- [x] Secret scan completed — no credentials/tokens/IDs/balances in the diff.

## Privacy and safety impact

- [x] Used only synthetic/demo packaging artifacts; no real financial data.
- [x] No real Plaid credentials, tokens, account IDs, exports, balances, or screenshots.
- [x] Preserves the local-first boundary — packaging/verification scripts only; no backend, telemetry, or cloud surface added.
- [x] User-facing copy (docs) stays honest: widget gallery discovery is explicitly gated on a notarized `/Applications` install, which requires Apple Developer credentials not currently held; `notarize.sh` remains a never-run scaffold.

## UI and accessibility checks

- [x] No UI changes (build/packaging scripts + distribution docs only).

## Reviewer notes

- True widget-gallery / Shortcuts / Spotlight discovery cannot be verified without a notarized, `/Applications`-installed build (needs Apple Developer creds). The new `docs/distribution.md` section documents that manual procedure for when those exist.
- Out of scope but flagged: the unused `PLAIDBAR_CODESIGN_IDENTITY` branch in `package-app.sh` is a latent footgun (under-signs Sparkle) — left untouched; fails safe via the deep `codesign --verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)