### PR TITLE
feat(dashboard): macOS 26 desk-distance design foundation + Dashboard reference exemplar (AND-624)

### DIFF
--- a/Sources/PlaidBar/Theme/WindowMetrics.swift
+++ b/Sources/PlaidBar/Theme/WindowMetrics.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+// MARK: - Window-Scale Design Foundation (AND-624)
+//
+// The menu-bar popover is a *compact*, arm's-length surface: its spacing
+// (``Spacing``) and type roles (``Typography``) are tuned for a dense, ~360pt
+// glance read at close range. The window-first workspace (ADR-001) is a
+// *desk-distance* surface — a resizable `Window` the user works in like Mail or
+// Finder — so it wants more generous spacing, a taller type ramp, and section
+// heads that the popover's caption-scale titles cannot carry.
+//
+// `WindowMetrics` / `WindowTypography` are the **additive** window-scale layer.
+// They live alongside the popover tokens and never replace them: the popover
+// keeps reading ``Spacing`` / ``Typography`` byte-for-byte (flag-OFF parity),
+// while the window-first surfaces read these. Apple's *Designing for macOS*
+// guidance — "more content, fewer nested levels, less modality, comfortable
+// density" — maps directly onto this split: comfortable density at the window,
+// compact density at the glance.
+//
+// Never-color-alone (ACCESSIBILITY.md): like ``Typography``, this file controls
+// only size, weight, and tabular alignment. It never encodes financial meaning
+// (balance / risk / utilization / trend) through color — direction and severity
+// always carry a text or glyph backup at the call site.
+
+// MARK: - Window-scale spacing
+
+/// Desk-distance spacing for the window-first workspace. A coarser step than the
+/// popover's compact 8pt grid (``Spacing``): the window has room to breathe, so
+/// section gaps and card padding are larger and the rhythm reads as "comfortable
+/// density" (Apple HIG) rather than the glance's tight pack.
+///
+/// Kept deliberately separate from ``Spacing`` so tuning the window never risks
+/// shifting the popover. Values stay on the 4pt sub-grid so they compose cleanly
+/// with the popover tokens where the two meet (e.g. a re-hosted popover card
+/// inside a window section).
+enum WindowMetrics {
+    // MARK: Spacing scale (4pt sub-grid, coarser steps than Spacing)
+
+    /// Tight inner spacing — label↔value, icon↔text within a metric tile.
+    static let xs: CGFloat = 6
+    /// Within-card spacing — rows inside a card, header↔body.
+    static let sm: CGFloat = 12
+    /// Card content padding and intra-section spacing.
+    static let md: CGFloat = 16
+    /// Between cards within a grid, and section header↔content.
+    static let lg: CGFloat = 20
+    /// Between major sections of a canvas.
+    static let xl: CGFloat = 28
+    /// Outer canvas margin — the window's content inset from its chrome.
+    static let canvasMargin: CGFloat = 24
+
+    // MARK: Layout
+
+    /// Corner radius for window-scale cards. Larger than the popover's
+    /// ``Radius/panel`` (8) so cards read as comfortable desk-distance surfaces.
+    static let cardCornerRadius: CGFloat = 12
+
+    /// The minimum width a metric/content card may shrink to before the grid
+    /// reflows to fewer columns. Tuned so a hero tile keeps its large figure
+    /// readable and a content card keeps its section header on one line.
+    static let cardMinWidth: CGFloat = 260
+
+    /// The content width below which a two-column canvas stacks into one column
+    /// (a narrow window). Mirrors the popover's behavior of dropping its side
+    /// rail when space is tight, at the window's larger scale.
+    static let twoColumnBreakpoint: CGFloat = 820
+
+    /// The hero metrics row's minimum tile width before it wraps. Below this the
+    /// hero figures lose their tabular legibility, so the row reflows.
+    static let heroTileMinWidth: CGFloat = 220
+}
+
+// MARK: - Window-scale type ramp
+
+// The window type ramp is taller than the popover's caption-scale roles: a
+// `largeTitle` page identity, `title2`/`title3` section heads, and a dedicated
+// hero-metric role for the dashboard's big figures. Each role is built on a
+// semantic SwiftUI text style so it scales with Dynamic Type automatically
+// (AND-515), except the hero-metric figure, which scales its fixed base point
+// size via `@ScaledMetric(relativeTo:)` exactly like ``DisplayBalance`` so the
+// big number grows with the user's text-size setting instead of staying pinned.
+// Numeric roles apply `.monospacedDigit()` on the font value so tabular columns
+// stay aligned at every Dynamic Type size and under Liquid Glass.
+
+/// Window page identity — the workspace/section title at desk distance.
+/// `largeTitle`, bold. Used for a canvas's lead heading where one is shown.
+struct WindowLargeTitle: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.largeTitle.weight(.bold))
+    }
+}
+
+/// Primary section head inside a window canvas (`title2`, semibold). One step
+/// down from the page identity; groups several cards under one banner.
+struct WindowSectionTitle: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.title2.weight(.semibold))
+    }
+}
+
+/// Card / sub-section head (`title3`, semibold). The workhorse heading for a
+/// single card in the dashboard grid ("Accounts", "Recent activity").
+struct WindowCardTitle: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.title3.weight(.semibold))
+    }
+}
+
+/// Body text at window scale (`.body`). The reading size for descriptions and
+/// list rows inside a window card — larger than the popover's `.callout`/`.caption`.
+struct WindowBodyText: ViewModifier {
+    func body(content: Content) -> some View {
+        content.font(.body)
+    }
+}
+
+/// Secondary / supporting label at window scale (`.subheadline`, secondary).
+/// Captions, metric labels, and supporting detail inside a card.
+struct WindowSupportingText: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+    }
+}
+
+/// The dashboard's hero metric figure — the big tabular number in a metric tile
+/// (net worth, safe-to-spend, this-month spend). Scales its 34pt base with the
+/// user's text-size / accessibility setting via `@ScaledMetric(relativeTo:
+/// .largeTitle)` (a plain `.system(size:)` font would not), with tabular digits
+/// so multiple tiles' figures align, and the same `.xSmall ... .accessibility3`
+/// clamp as ``DisplayBalance`` to stop before the layout-breaking AX4/AX5 steps.
+struct WindowHeroMetric: ViewModifier {
+    @ScaledMetric(relativeTo: .largeTitle) private var size: CGFloat = 34
+
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: size, weight: .semibold, design: .default).monospacedDigit())
+            .dynamicTypeSize(.xSmall ... .accessibility3)
+    }
+}
+
+extension View {
+    /// Window page identity (`largeTitle`, bold).
+    func windowLargeTitle() -> some View { modifier(WindowLargeTitle()) }
+
+    /// Primary window section head (`title2`, semibold).
+    func windowSectionTitle() -> some View { modifier(WindowSectionTitle()) }
+
+    /// Window card / sub-section head (`title3`, semibold).
+    func windowCardTitle() -> some View { modifier(WindowCardTitle()) }
+
+    /// Window-scale body text (`.body`).
+    func windowBodyText() -> some View { modifier(WindowBodyText()) }
+
+    /// Window-scale secondary / supporting label (`.subheadline`, secondary).
+    func windowSupportingText() -> some View { modifier(WindowSupportingText()) }
+
+    /// The dashboard hero metric figure (scaled, tabular). See ``WindowHeroMetric``.
+    func windowHeroMetric() -> some View { modifier(WindowHeroMetric()) }
+}

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -54,6 +54,21 @@ struct AppShellView: View {
     /// injected from the scene. No-op until per-destination search lands.
     private let focusSearch: () -> Void
 
+    /// The window's unified `.searchable` query (AND-624). The shell owns one
+    /// search field in the toolbar; it is threaded into the destination that
+    /// supports search (currently the Dashboard, via `\.dashboardSearchQuery`).
+    /// Window-scoped `@State` so each window searches independently, and reset on
+    /// a destination switch so a stale query never leaks across surfaces.
+    @State private var searchText = ""
+
+    /// Whether the third (inspector) column is shown for a 3-column destination
+    /// (AND-624). The shell now hosts the detail pane via the native
+    /// `.inspector(isPresented:)` API with a toolbar toggle, instead of a fixed
+    /// `NavigationSplitView` `detail:` column, so the user can collapse it. Per
+    /// window, defaults open so a 3-column destination still lands on its full
+    /// layout (IA §3.1: the inspector is content-gated, not hidden).
+    @State private var isInspectorPresented = true
+
     /// `paletteModel` is optional so the default is constructed inside this
     /// `@MainActor` init body (a `@MainActor`-isolated default *argument* would be
     /// evaluated in the caller's nonisolated context and fail strict concurrency).
@@ -93,31 +108,52 @@ struct AppShellView: View {
         // Column policy per destination (IA §3.1, driven by the pure
         // `RouteDestination.prefersThreeColumnLayout` in PlaidBarCore). 3-column
         // destinations (Review, Transactions, Budgets, Goals, Alerts, Accounts)
-        // get sidebar + content + inspector; 2-column destinations (Dashboard,
-        // Planning, Insights) get sidebar + content only. Settings is never routed
-        // here — it opens the native Settings scene. Both branches share the same
-        // sidebar; the difference is whether a detail (inspector) column is
-        // mounted, so the column count tracks the selected destination's policy.
-        Group {
-            if destination.prefersThreeColumnLayout {
-                NavigationSplitView {
-                    SidebarView(selection: selection)
-                } content: {
-                    DestinationContentView(destination: destination)
-                } detail: {
+        // get sidebar + content + a native **inspector**; 2-column destinations
+        // (Dashboard, Planning, Insights) get sidebar + content only. Settings is
+        // never routed here — it opens the native Settings scene.
+        //
+        // The shell is a two-column `NavigationSplitView` (sidebar + content); the
+        // third column is the native `.inspector(isPresented:)` API (AND-624) with
+        // a toolbar toggle, rather than a fixed `NavigationSplitView` `detail:`
+        // column — so the detail pane can be collapsed at window scale per Apple's
+        // *Inspectors* guidance, and the unified per-destination `.toolbar` carries
+        // the title, primary actions, and the inspector toggle.
+        NavigationSplitView {
+            SidebarView(selection: selection)
+        } detail: {
+            DestinationContentView(destination: destination)
+                .inspector(isPresented: inspectorBinding(for: destination)) {
                     // Content-gated, not existence-gated (IA §3.1): the inspector
                     // always exists for a 3-column destination and shows its
                     // "Select a …" prompt when nothing is selected.
                     DestinationInspectorView(destination: destination)
+                        .inspectorColumnWidth(min: 280, ideal: 320, max: 420)
                 }
-            } else {
-                NavigationSplitView {
-                    SidebarView(selection: selection)
-                } detail: {
-                    DestinationContentView(destination: destination)
-                }
-            }
+                .toolbar { destinationToolbar(for: destination) }
+                // The shell owns ONE unified `.searchable` field, applied only to
+                // destinations that adopt it (currently the Dashboard). Destinations
+                // with their own inline search (e.g. Transactions' filter bar) are
+                // left untouched so there is never a competing second field — the
+                // propagation pass migrates those to the shell field one at a time.
+                .modifier(
+                    ShellSearchable(
+                        isEnabled: destinationSupportsSearch(destination),
+                        text: $searchText,
+                        prompt: searchPrompt(for: destination)
+                    )
+                )
         }
+        // Reset the search query and restore the inspector when the destination
+        // changes, so a query typed on one surface never leaks to another and a
+        // collapsed inspector does not persist into a destination where it is the
+        // primary detail view.
+        .onChange(of: destination) { _, _ in
+            searchText = ""
+            isInspectorPresented = true
+        }
+        // The Dashboard reads the live query from the environment to filter its
+        // account rows (the shell owns the field, the canvas owns the filtering).
+        .environment(\.dashboardSearchQuery, destinationSupportsSearch(destination) ? searchText : "")
         // Deep-link hand-off (ADR-001 / AND-597). The primary scene is a
         // declarative `Window`, so a route can't be threaded through `openWindow`;
         // instead the opener stages it on `AppState.pendingRoute` and this view
@@ -179,6 +215,106 @@ struct AppShellView: View {
             if isLocked { paletteModel.dismiss() }
         }
     }
+
+    // MARK: - Unified per-destination toolbar (AND-624)
+
+    /// The window's unified `.toolbar` for the current destination: shared primary
+    /// actions (refresh, Privacy Mask toggle) on every destination, plus a native
+    /// inspector toggle for the 3-column destinations. The destination *title* is
+    /// carried by each destination's `.navigationTitle`, which the split view
+    /// promotes into the toolbar — so the toolbar here adds actions, not a
+    /// duplicate title.
+    @ToolbarContentBuilder
+    private func destinationToolbar(for destination: RouteDestination) -> some ToolbarContent {
+        ToolbarItemGroup(placement: .primaryAction) {
+            // Privacy Mask toggle — shape carries the state (struck-through eye when
+            // masked), never color alone (ACCESSIBILITY.md). Disabled under App Lock
+            // (the gate already hides everything).
+            Button {
+                appState.togglePrivacyMask()
+            } label: {
+                Label(
+                    appState.shouldMaskFinancialValues ? "Show values" : "Hide values",
+                    systemImage: PrivacyMaskPresentation.toggleSymbolName(
+                        isMasked: appState.shouldMaskFinancialValues
+                    )
+                )
+            }
+            .disabled(appState.isContentLocked)
+            .help(appState.shouldMaskFinancialValues
+                ? "Show financial values"
+                : "Hide financial values (Privacy Mask)")
+
+            // Refresh — the same dashboard refresh the popover triggers; the symbol
+            // spins via the shared Reduce-Motion-aware `RefreshIcon`.
+            Button {
+                Task { await appState.refreshDashboard(force: true) }
+            } label: {
+                RefreshIcon(isLoading: appState.isLoading)
+            }
+            .disabled(appState.isLoading)
+            .help("Refresh")
+
+            // Inspector toggle — only for 3-column destinations, whose detail pane
+            // is now the native collapsible `.inspector`. Native API placement so it
+            // reads as the standard macOS inspector control.
+            if destination.prefersThreeColumnLayout {
+                Button {
+                    isInspectorPresented.toggle()
+                } label: {
+                    Label("Toggle Inspector", systemImage: "sidebar.trailing")
+                }
+                .help(isInspectorPresented ? "Hide Inspector" : "Show Inspector")
+            }
+        }
+    }
+
+    // MARK: - Inspector + search wiring (AND-624)
+
+    /// The inspector-presented binding for a destination. 3-column destinations
+    /// bind to the shell's `isInspectorPresented` state (toggleable); 2-column
+    /// destinations have no inspector, so they bind to a constant `false` and the
+    /// `.inspector` never mounts a pane.
+    private func inspectorBinding(for destination: RouteDestination) -> Binding<Bool> {
+        guard destination.prefersThreeColumnLayout else { return .constant(false) }
+        return Binding(get: { isInspectorPresented }, set: { isInspectorPresented = $0 })
+    }
+
+    /// Whether a destination adopts the shell's unified `.searchable` field. Only
+    /// the Dashboard does today (it filters its account rows via
+    /// `\.dashboardSearchQuery`); destinations with their own inline search keep it
+    /// until the propagation pass migrates them, so there is never a second field.
+    private func destinationSupportsSearch(_ destination: RouteDestination) -> Bool {
+        destination == .dashboard
+    }
+
+    /// The search-field prompt for a search-adopting destination.
+    private func searchPrompt(for destination: RouteDestination) -> String {
+        switch destination {
+        case .dashboard: "Search accounts"
+        default: "Search"
+        }
+    }
+}
+
+// MARK: - Conditional searchable
+
+/// Applies `.searchable` only when the destination adopts the shell search field,
+/// so destinations with their own inline search never get a competing second one.
+/// A `ViewModifier` (rather than an inline `if`) keeps the view-type stable across
+/// destination switches.
+private struct ShellSearchable: ViewModifier {
+    let isEnabled: Bool
+    @Binding var text: String
+    let prompt: String
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.searchable(text: $text, placement: .toolbar, prompt: Text(prompt))
+        } else {
+            content
+        }
+    }
 }
 
 // MARK: - Sidebar
@@ -210,6 +346,7 @@ private struct SidebarView: View {
                 }
             }
         }
+        .listStyle(.sidebar)
         .navigationTitle("VaultPeek")
         .navigationSplitViewColumnWidth(min: 220, ideal: 248, max: 320)
         .safeAreaInset(edge: .bottom) {

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -1,77 +1,83 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Dashboard** destination (2-column composed canvas — IA §3.1/§5.1, `[⌘1]`) —
-/// AND-622 (ADR-001 window-first workspace).
+/// **Dashboard** destination — the window-first *reference* surface (AND-624,
+/// building on AND-622; ADR-001 window-first workspace, IA §3.1/§5.1, `[⌘1]`).
 ///
-/// The default / primary surface: a composed *overview* canvas with no
-/// master→detail relationship, so the shell renders only this content column (no
-/// inspector). It re-hosts the **same overview content the menu-bar popover and
-/// its detached desktop window show** (``MainPopover``), surfaced from the same
-/// reusable subviews + the same `PlaidBarCore` presentation engines — **no model
-/// or chart logic lives here** (surface only). The two surfaces can never diverge
-/// because they read the same `AppState` and the same Core.
+/// This is the design exemplar that sets the bar for the propagation pass across
+/// the other destinations: a **composed 2-column canvas that uses the window's
+/// width** rather than a re-hosted popover rail. It reads from the *same*
+/// `AppState` + `PlaidBarCore` presentation engines the menu-bar popover and the
+/// detached desktop window use — **no model or chart logic lives here** (surface
+/// only) — but it re-*hosts the data in a desktop layout*, it does not clone the
+/// popover's compact arrangement. The data can never diverge from the popover
+/// because both read the same Core; only the layout differs.
 ///
-/// Layout (IA §5.1): a two-column canvas — a **Summary** column (the existing
-/// ``WealthSummaryFlyout``: net-worth hero, balance mix, 30-day cashflow) beside
-/// an **Overview** column (the change receipt, balance time-machine, weekly
-/// review, category dashboard, status readiness, the activity heatmap + account
-/// rows, and the local-insight receipt). On a narrow window the two columns stack.
+/// Layout (desk-distance, ``WindowMetrics`` / ``WindowTypography``):
+/// 1. a **hero metrics row** — net worth, safe-to-spend, and last-30-day spend as
+///    large tabular figures with labels (the dashboard's headline numbers,
+///    surfaced from `WealthSummaryPresentation` + `SafeToSpendCalculator`, the
+///    same engines the rail/weekly-review use);
+/// 2. a **two-column card grid** below it — a generous left column (the 365-day
+///    activity heatmap + account rows, balance time-machine, weekly review) beside
+///    a right column (recurring obligations, the category dashboard, and the
+///    local-insight teaser), each card a ``WindowSection`` with a `title3` header
+///    and progressive disclosure. On a narrow window the two columns stack.
 ///
 /// **Drill-ins deep-link, they don't open a third column** (IA §3.1, §5.1): the
 /// 2-column dashboard has no inspector, so selecting an account routes to the
-/// **Accounts** destination via `\.openRoute` rather than opening a local
-/// inspector pane. With the window-first flag OFF the route handler is a no-op, so
-/// this view is never instantiated and the popover is byte-identical.
+/// **Accounts** destination via `\.openRoute`. With the window-first flag OFF the
+/// route handler is a no-op and this view is never instantiated, so the popover
+/// stays byte-identical.
 ///
-/// **Privacy Mask / App Lock:** the shell already paints the full
-/// ``AppLockedGateView`` over the whole window while content is *locked* (ADR-001
-/// Epic 10 / AND-588), so this canvas never double-gates; it only honors Privacy
-/// *Mask* the same way the re-hosted subviews already do (they read
-/// `AppState.shouldMaskFinancialValues`), so masked values stay dotted and are
-/// never leaked here.
+/// **Privacy Mask / App Lock:** the shell paints the full ``AppLockedGateView``
+/// over the whole window while content is *locked* (ADR-001 Epic 10 / AND-588),
+/// so this canvas never double-gates; it only honors Privacy *Mask* the way the
+/// re-hosted subviews and the hero figures do (every value runs through
+/// `PrivacyMaskPresentation` / `shouldMaskFinancialValues`), so masked figures
+/// stay dotted and are never leaked here.
 ///
 /// **Empty / loading / error states** match the popover: the re-hosted cards each
 /// carry their own loading redaction and empty copy, the overview block shows the
-/// shared fallback banner before setup completes, and a sync error surfaces in the
-/// inline ``DashboardErrorBanner`` at the top of the overview column — the same
-/// signals the popover renders.
+/// shared fallback banner before setup completes, the hero tiles read as
+/// dashes/“Private” before data lands, and a sync error surfaces in the inline
+/// ``DashboardErrorBanner`` at the top of the canvas.
 ///
 /// **Flag-OFF inert:** reached only when the window-first `Window` opens
-/// (`WindowFirstFeatureFlag` ON). This file is never instantiated in the
-/// flag-OFF popover build.
+/// (`WindowFirstFeatureFlag` ON). Never instantiated in the flag-OFF popover build.
 struct DashboardDestinationView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openRoute) private var openRoute
-
-    /// Below this content width the two columns stack into one (a narrow window),
-    /// matching the popover's behavior of dropping the side rail when space is
-    /// tight. Tuned to the same ballpark as the popover's three-column floor.
-    private let twoColumnBreakpoint: CGFloat = 760
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { proxy in
-            let isWide = proxy.size.width >= twoColumnBreakpoint
+            let isWide = proxy.size.width >= WindowMetrics.twoColumnBreakpoint
 
             ScrollView {
-                Group {
-                    if isWide {
-                        HStack(alignment: .top, spacing: Spacing.lg) {
-                            summaryColumn
-                                .frame(width: PopoverGeometry.railWidth, alignment: .topLeading)
+                VStack(alignment: .leading, spacing: WindowMetrics.xl) {
+                    if let error = appState.error {
+                        DashboardErrorBanner(error: error) { appState.error = nil }
+                    }
 
-                            overviewColumn
+                    heroMetricsRow
+
+                    if isWide {
+                        HStack(alignment: .top, spacing: WindowMetrics.lg) {
+                            primaryColumn
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                            secondaryColumn
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
                         }
                     } else {
-                        VStack(alignment: .leading, spacing: Spacing.lg) {
-                            summaryColumn
-                            overviewColumn
+                        VStack(alignment: .leading, spacing: WindowMetrics.xl) {
+                            primaryColumn
+                            secondaryColumn
                         }
                     }
                 }
-                .padding(Spacing.lg)
+                .padding(WindowMetrics.canvasMargin)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .scrollContentBackground(.hidden)
@@ -81,38 +87,72 @@ struct DashboardDestinationView: View {
         .task { await appState.loadInitialData() }
     }
 
-    // MARK: - Summary column
+    // MARK: - Hero metrics row
 
-    /// The left **Summary** column: the existing ``WealthSummaryFlyout`` the
-    /// popover mounts as its rail (net-worth hero, balance mix, 30-day cashflow),
-    /// re-hosted unchanged. Its "Add account" / "Recurring" / "Income flow"
-    /// affordances deep-link to the relevant destinations so the 2-column canvas
-    /// never needs a local inspector.
-    private var summaryColumn: some View {
-        WealthSummaryFlyout(
-            onAddAccount: { openRoute(.accounts()) },
-            onOpenSubscriptions: { openRoute(.planning(section: .recurring)) },
-            onOpenFlow: { openRoute(.planning(section: .incomeFlow)) }
-        )
-        .leftPanelSurface()
+    /// The headline figures across the top of the canvas. Reflows to wrap on a
+    /// narrow window so each figure keeps its tabular legibility (``WindowMetrics``
+    /// `heroTileMinWidth`). Every value runs through `PrivacyMaskPresentation`, so
+    /// masked figures show the dotted placeholder; none rely on color for meaning
+    /// (the label names the figure).
+    private var heroMetricsRow: some View {
+        let metrics = heroMetrics
+        return LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: WindowMetrics.heroTileMinWidth), spacing: WindowMetrics.lg)],
+            alignment: .leading,
+            spacing: WindowMetrics.lg
+        ) {
+            ForEach(metrics) { metric in
+                WindowHeroMetricTile(
+                    label: metric.label,
+                    value: metric.value,
+                    systemImage: metric.systemImage,
+                    detail: metric.detail,
+                    accent: metric.accent,
+                    reduceMotion: reduceMotion
+                )
+            }
+        }
+        .loadingRedaction(appState.loadState(for: .summaryCards))
         .accessibilityElement(children: .contain)
+        .accessibilityLabel("Headline metrics")
     }
 
-    // MARK: - Overview column
+    // MARK: - Columns
 
-    /// The right **Overview** column: the same center-column stack the popover
-    /// renders, top to bottom, each item an existing reusable subview driven by
-    /// the same `AppState` + Core. Order and content mirror ``MainPopover``'s
-    /// `dashboardColumn` so the two surfaces stay in lockstep.
-    private var overviewColumn: some View {
-        VStack(alignment: .leading, spacing: Spacing.lg) {
-            if let error = appState.error {
-                DashboardErrorBanner(error: error) { appState.error = nil }
-            }
+    /// The left/primary column: the year-scale activity heatmap + account rows
+    /// (the dashboard's core instrument), the balance time-machine, and the weekly
+    /// review. These re-host the existing reusable subviews unchanged — they each
+    /// carry their own card chrome and section header, so they are mounted directly
+    /// (not nested in a ``WindowSection``, which would card-in-a-card). The layout
+    /// gives them desk-distance room at ``WindowMetrics`` spacing; the data is
+    /// identical to the popover.
+    private var primaryColumn: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.lg) {
+            sectionHeader("Activity", systemImage: "square.grid.3x3.fill")
+
+            DashboardOverviewColumn(onSelectAccount: { account in
+                openRoute(.accounts(itemID: account.itemId))
+            })
 
             BalanceTimeMachineView()
 
             WeeklyReviewCard()
+
+            if shouldShowStatusReadiness {
+                statusReadinessCluster
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    /// The right/secondary column: recurring obligations, the category dashboard,
+    /// the first-run snapshot (when present), and the local-insight teaser. Like the
+    /// primary column, each re-hosted card self-cards, so they are mounted directly.
+    private var secondaryColumn: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.lg) {
+            sectionHeader("Money & insights", systemImage: "chart.pie")
+
+            DashboardRecurringCard(onOpen: { openRoute(.planning(section: .recurring)) })
 
             CategoryDashboardCard()
 
@@ -123,22 +163,26 @@ struct DashboardDestinationView: View {
                 )
             }
 
-            if shouldShowStatusReadiness {
-                statusReadinessCluster
-            }
-
-            // The activity heatmap + filter bar + account rows — the overview's
-            // core instrument. Account drill-ins deep-link to Accounts (no local
-            // inspector on a 2-column canvas).
-            DashboardOverviewColumn(onSelectAccount: { account in
-                openRoute(.accounts(itemID: account.itemId))
-            })
-
             DashboardLocalInsightCard()
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Dashboard overview")
     }
+
+    /// A window-scale column section header (`title3` via ``WindowCardTitle``) — the
+    /// reference pattern for grouping cards in a desktop canvas (the deliverable's
+    /// "section headers (title3)"). It is a heading, not a card, so it sits cleanly
+    /// above the self-carding cards below it without nesting a card in a card.
+    private func sectionHeader(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title).windowCardTitle()
+        } icon: {
+            Image(systemName: systemImage).foregroundStyle(.secondary)
+        }
+        .labelStyle(.titleAndIcon)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Status readiness
 
     /// The status-readiness cluster (connection health + attention queue +
     /// readiness panel) is shown when setup is incomplete or the readiness verdict
@@ -150,17 +194,96 @@ struct DashboardDestinationView: View {
     }
 
     private var statusReadinessCluster: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             ConnectionHealthStripView()
-
             AttentionQueueView(title: "Attention", onAddAccount: { openRoute(.accounts()) })
-
             DashboardReadinessPanel(
                 openSettings: { openSettings() },
                 onAddAccount: { openRoute(.accounts()) }
             )
         }
         .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Hero metric data (surface-only; reuses Core engines)
+
+    /// One headline figure for the hero row. Pure presentation data, derived from
+    /// the same Core engines the rail/weekly-review use — no new model logic.
+    private struct HeroMetric: Identifiable {
+        let id: String
+        let label: String
+        let value: String
+        let systemImage: String
+        let detail: String?
+        let accent: Color
+    }
+
+    /// The wealth summary the rail also computes — the single source for net worth,
+    /// account count, and the 30-day cashflow used by the hero figures and the
+    /// safe-to-spend input.
+    private var wealthSummary: WealthSummaryPresentation {
+        WealthSummaryPresentation.evaluate(
+            accounts: appState.accounts,
+            transactions: appState.transactions,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
+            linkedItemCount: appState.statusItemCount,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            itemStatuses: appState.itemStatuses,
+            isSyncStale: appState.isSyncStale,
+            lastSyncRelative: appState.lastSyncRelative,
+            statusSyncText: appState.statusSyncText,
+            errorMessage: appState.error,
+            creditUtilizationThreshold: appState.creditUtilizationThreshold,
+            lowCashThreshold: appState.lowBalanceThreshold,
+            largeTransactionThreshold: appState.largeTransactionThreshold,
+            balanceHistory: appState.balanceHistory
+        )
+    }
+
+    private var heroMetrics: [HeroMetric] {
+        let masked = appState.shouldMaskFinancialValues
+        let summary = wealthSummary
+        let safeToSpend = SafeToSpendCalculator.compute(
+            accounts: appState.accounts,
+            recurringTransactions: appState.recurringTransactions,
+            cashflow: summary.cashflow,
+            asOf: Date()
+        )
+
+        let netWorth = HeroMetric(
+            id: "netWorth",
+            label: "Net worth",
+            value: PrivacyMaskPresentation.currency(summary.netWorth, format: .compact, isEnabled: masked),
+            systemImage: "chart.line.uptrend.xyaxis",
+            detail: accountCountDetail(summary.accountCount),
+            accent: SemanticColors.brand
+        )
+
+        let safe = HeroMetric(
+            id: "safeToSpend",
+            label: "Safe to spend",
+            value: PrivacyMaskPresentation.currency(safeToSpend.amount, format: .compact, isEnabled: masked),
+            systemImage: safeToSpend.confidence.iconName,
+            detail: "Through end of month · \(safeToSpend.confidence.label) confidence",
+            accent: safeToSpend.amount >= 0 ? SemanticColors.positive : SemanticColors.warning
+        )
+
+        let spend = HeroMetric(
+            id: "spend30",
+            label: "Last 30-day spend",
+            value: PrivacyMaskPresentation.currency(summary.cashflow.spending, format: .compact, isEnabled: masked),
+            systemImage: "creditcard",
+            detail: "Across \(summary.cashflow.transactionCount) transactions",
+            accent: .secondary
+        )
+
+        return [netWorth, safe, spend]
+    }
+
+    private func accountCountDetail(_ count: Int) -> String {
+        count == 1 ? "Across 1 account" : "Across \(count) accounts"
     }
 }
 

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -27,6 +27,9 @@ struct DashboardOverviewColumn: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    /// The shell's unified `.searchable` query (AND-624). Empty ⇒ no filter, so the
+    /// flag-OFF popover (which never injects it) is unchanged.
+    @Environment(\.dashboardSearchQuery) private var searchQuery
 
     /// Routed by the destination to the Accounts destination (no local inspector
     /// on a 2-column canvas).
@@ -34,8 +37,20 @@ struct DashboardOverviewColumn: View {
 
     private var filter: DashboardAccountFilter { appState.dashboardFilter }
 
+    private var trimmedQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var filteredAccounts: [AccountDTO] {
-        appState.accounts.filter { filter.includes($0, appState: appState) }
+        let byFilter = appState.accounts.filter { filter.includes($0, appState: appState) }
+        let query = trimmedQuery
+        guard !query.isEmpty else { return byFilter }
+        // Case-insensitive substring match on the displayed account name — the one
+        // field the user reads in the row. Honors the active filter (search refines
+        // within it) and never reveals masked values (it matches names, not amounts).
+        return byFilter.filter {
+            AccountPresentation.displayName(for: $0).localizedCaseInsensitiveContains(query)
+        }
     }
 
     private var fallbackState: DashboardOverviewFallbackState? {
@@ -147,6 +162,11 @@ struct DashboardOverviewColumn: View {
             if filteredAccounts.isEmpty {
                 if accountsLoadState.showsSkeleton {
                     DashboardAccountRowSkeletonList(loadState: accountsLoadState)
+                } else if !trimmedQuery.isEmpty {
+                    // A search that matched nothing reads differently from a filter
+                    // that resolved to no accounts — name the query, not the filter.
+                    ContentUnavailableView.search(text: trimmedQuery)
+                        .frame(maxWidth: .infinity, minHeight: 120)
                 } else {
                     DashboardAccountEmpty(filter: filter)
                 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
@@ -1,0 +1,53 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The window-first **Dashboard** recurring-obligations card content (AND-624).
+///
+/// Surface only — it re-hosts the same ``RecurringObligationsSection`` rows the
+/// popover's Wealth Summary flyout shows, over the same
+/// ``RecurringObligationsPresentation`` Core engine (`RecurringDetector` finds
+/// the streams; this view never detects). It is meant to sit *inside* a
+/// ``WindowSection`` (which supplies the title + card chrome), so unlike the
+/// popover's self-carding section it renders only the rows — and, when nothing is
+/// detected, a quiet empty line instead of self-hiding, so the dashboard grid
+/// keeps a uniform card rather than a hole.
+///
+/// Honors Privacy Mask the same way the re-hosted rows do (amounts and the
+/// monthly total run through `PrivacyMaskPresentation`). The "open" affordance
+/// deep-links to **Planning → Recurring** rather than opening a local inspector
+/// (the 2-column dashboard has none).
+struct DashboardRecurringCard: View {
+    @Environment(AppState.self) private var appState
+    /// Deep-links to the recurring workspace (Planning → Recurring).
+    let onOpen: () -> Void
+
+    private var presentation: RecurringObligationsPresentation {
+        RecurringObligationsPresentation.make(
+            from: appState.recurringTransactions,
+            asOf: Date()
+        )
+    }
+
+    var body: some View {
+        let presentation = presentation
+        if presentation.isEmpty {
+            Label("No recurring charges detected yet.", systemImage: "repeat")
+                .windowSupportingText()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityElement(children: .combine)
+        } else {
+            RecurringObligationsSection(
+                presentation: presentation,
+                onOpenSubscriptions: onOpen,
+                privacyMaskEnabled: appState.shouldMaskFinancialValues
+            )
+        }
+    }
+}
+
+#Preview {
+    DashboardRecurringCard(onOpen: {})
+        .environment(AppState())
+        .padding()
+        .frame(width: 360)
+}

--- a/Sources/PlaidBar/Views/Destinations/DashboardSearchQuery.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardSearchQuery.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// The window's Dashboard search query, threaded from the shell's `.searchable`
+/// toolbar field into the Dashboard canvas (AND-624).
+///
+/// The window-first shell owns the unified `.searchable` toolbar (so search lives
+/// in the window chrome, not inside the canvas), and the Dashboard reads the live
+/// query from the environment to filter its account rows. Routing it through the
+/// environment (rather than a threaded binding) keeps the content-column router
+/// (`DestinationContentView`) signature untouched, so the propagation pass can
+/// adopt the same pattern per destination without a shared plumbing change.
+///
+/// Empty string ⇒ no filter (the default), so the popover build — which never
+/// mounts the shell — is unaffected.
+private struct DashboardSearchQueryKey: EnvironmentKey {
+    static let defaultValue: String = ""
+}
+
+extension EnvironmentValues {
+    /// The live Dashboard search query from the shell's `.searchable` field.
+    /// Trimmed/empty means "no filter".
+    var dashboardSearchQuery: String {
+        get { self[DashboardSearchQueryKey.self] }
+        set { self[DashboardSearchQueryKey.self] = newValue }
+    }
+}

--- a/Sources/PlaidBar/Views/Destinations/WindowSection.swift
+++ b/Sources/PlaidBar/Views/Destinations/WindowSection.swift
@@ -1,0 +1,203 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Window-scale shared desktop components (AND-624)
+//
+// The reference-quality building blocks the window-first destinations compose
+// from: a titled section card and a hero metric tile, both at the window
+// (desk-distance) scale defined in ``WindowMetrics`` / ``WindowTypography``.
+// They set the design language the propagation pass (the other 8 destinations)
+// will follow.
+//
+// These are pure layout/presentation — they hold no model logic and read no
+// `AppState`; data and Core presentations are passed in by the call site. That
+// keeps them reusable across destinations and trivially previewable.
+//
+// Liquid Glass goes on *chrome*, not data (ADR-001): a `WindowSection`'s card
+// uses a quiet, solid hierarchical fill so the figures inside stay crisp and
+// legible. Section separation comes from spacing and the title, with a hairline
+// stroke for definition — never from a translucent wash behind the numbers.
+
+// MARK: - Window section card
+
+/// A titled content card for a window-first canvas: a `title3` section header
+/// (with an optional trailing accessory) above its content, on a quiet rounded
+/// surface at window scale.
+///
+/// The header is read as one VoiceOver element naming the section; the content
+/// stays separately navigable. Meaning is never color-only — the title text
+/// carries the section's identity, accessories carry their own labels.
+struct WindowSection<Content: View, Accessory: View>: View {
+    let title: String
+    /// Optional SF Symbol shown before the title (shape, not color, for meaning).
+    var systemImage: String?
+    /// A trailing header accessory (a count, a small control). Carries its own
+    /// accessibility; folded into nothing here so it stays separately reachable.
+    @ViewBuilder var accessory: () -> Accessory
+    @ViewBuilder var content: () -> Content
+
+    init(
+        _ title: String,
+        systemImage: String? = nil,
+        @ViewBuilder accessory: @escaping () -> Accessory = { EmptyView() },
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.accessory = accessory
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.md) {
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.xs) {
+                Label {
+                    Text(title)
+                        .windowCardTitle()
+                } icon: {
+                    if let systemImage {
+                        Image(systemName: systemImage)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .labelStyle(.titleAndIcon)
+                .accessibilityAddTraits(.isHeader)
+
+                Spacer(minLength: WindowMetrics.sm)
+
+                accessory()
+            }
+
+            content()
+        }
+        .padding(WindowMetrics.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .windowCardSurface()
+        .accessibilityElement(children: .contain)
+    }
+}
+
+// MARK: - Hero metric tile
+
+/// A single hero metric in the dashboard's top row: a large tabular figure with
+/// a label above it and optional supporting detail below. The figure uses the
+/// ``WindowHeroMetric`` role (scaled, monospaced); the label and detail give the
+/// number meaning in text, so the tile never relies on color or position alone
+/// to communicate (ACCESSIBILITY.md).
+struct WindowHeroMetricTile: View {
+    let label: String
+    /// The already-formatted, privacy-mask-aware value string the figure shows.
+    let value: String
+    var systemImage: String?
+    /// Optional supporting line under the figure (e.g. "across 6 accounts").
+    var detail: String?
+    /// Optional emphasis tint for the leading glyph only — never the figure, so
+    /// meaning is carried by the label/detail text, not the color.
+    var accent: Color = .secondary
+    /// Rolls the figure on change (disabled under Reduce Motion). Pass the live
+    /// `reduceMotion` environment value.
+    var reduceMotion: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.xs) {
+            Label {
+                Text(label)
+                    .windowSupportingText()
+                    .textCase(.uppercase)
+            } icon: {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(accent)
+                }
+            }
+            .labelStyle(.titleAndIcon)
+
+            Text(value)
+                .windowHeroMetric()
+                .rollingTabularNumber(value, reduceMotion: reduceMotion)
+                .foregroundStyle(AppearanceTextColors.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+
+            if let detail {
+                Text(detail)
+                    .windowSupportingText()
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(WindowMetrics.md)
+        .frame(maxWidth: .infinity, minHeight: 96, alignment: .leading)
+        .windowCardSurface()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        var parts = ["\(label): \(value)"]
+        if let detail { parts.append(detail) }
+        return parts.joined(separator: ". ")
+    }
+}
+
+// MARK: - Window card surface
+
+private struct WindowCardSurface: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: WindowMetrics.cardCornerRadius)
+        // Data stays solid (ADR-001 — glass on chrome, not data): a window card
+        // backs its figures with a quiet hierarchical `.quaternary` fill so the
+        // tabular numbers read crisply, rather than a translucent wash. Under
+        // Reduce Transparency the same solid fill is used (it is already solid),
+        // so no contrast regression. Separation is the hairline stroke + spacing.
+        content
+            .background(.quaternary.opacity(reduceTransparency ? 0.9 : 0.6), in: shape)
+            .overlay {
+                shape.stroke(Color.primary.opacity(0.07), lineWidth: 1)
+            }
+    }
+}
+
+extension View {
+    /// The quiet, solid window-scale card surface used by ``WindowSection`` and
+    /// ``WindowHeroMetricTile``. Data surfaces stay solid (ADR-001); glass is
+    /// reserved for the shell chrome applied at the scene/shell level.
+    func windowCardSurface() -> some View {
+        modifier(WindowCardSurface())
+    }
+}
+
+#Preview("Window section") {
+    VStack(spacing: WindowMetrics.lg) {
+        HStack(spacing: WindowMetrics.lg) {
+            WindowHeroMetricTile(
+                label: "Net worth",
+                value: "$48,250",
+                systemImage: "chart.line.uptrend.xyaxis",
+                detail: "across 6 accounts",
+                accent: SemanticColors.brand,
+                reduceMotion: false
+            )
+            WindowHeroMetricTile(
+                label: "Safe to spend",
+                value: "$1,240",
+                systemImage: "checkmark.shield",
+                detail: "through end of month",
+                accent: SemanticColors.positive,
+                reduceMotion: false
+            )
+        }
+        WindowSection("Accounts", systemImage: "building.columns") {
+            Text("3 accounts")
+                .windowSupportingText()
+        } content: {
+            Text("Account rows go here")
+                .windowBodyText()
+        }
+    }
+    .padding(WindowMetrics.canvasMargin)
+    .frame(width: 720)
+}


### PR DESCRIPTION
## Summary

Sets the **window-first design language** the other 8 destinations will follow (the propagation pass), and delivers the **Dashboard** as the reference-quality exemplar. Additive and **flag-OFF inert** — every new surface is reached only behind `WindowFirstFeatureFlag` (default OFF), so the menu-bar popover stays byte-identical.

## Window-scale design tokens (additive — popover tokens untouched)
- **`WindowMetrics`** — desk-distance spacing scale + layout constants (card radius, two-column breakpoint, hero-tile min width), separate from the popover's compact 8pt `Spacing`.
- **Window type ramp** (`WindowTypography` roles) — `largeTitle` page identity, `title2` section / `title3` card heads, body, supporting, and a scaled tabular **hero-metric** figure (`@ScaledMetric(relativeTo: .largeTitle)`, AX3 clamp like `DisplayBalance`). Every numeric role uses tabular digits.

## Shared desktop components (new — for the propagation pass)
- **`WindowSection`** — titled card container at window scale.
- **`WindowHeroMetricTile`** — large tabular figure + label + detail. Data stays **solid** (glass on chrome, not data); never color-alone (label/detail carry meaning).

## Shell chrome (`AppShellView`)
- **Unified per-destination `.toolbar`** — Privacy Mask toggle (shape-not-color), refresh (Reduce-Motion-aware `RefreshIcon`), and an inspector toggle for 3-column destinations. Title via `.navigationTitle`.
- **Native `.inspector(isPresented:)`** for the 3-column destinations with a toolbar toggle, replacing the fixed `NavigationSplitView` `detail:` column so the detail pane is collapsible at window scale (Apple *Inspectors* guidance). Content-gated, not existence-gated.
- **One unified `.searchable`** field, adopted only by destinations without an inline search (Dashboard today) so there is never a competing second field; query resets on destination switch.
- Native `.sidebar` list styling. Liquid Glass chrome + Reduce Transparency fallback stay scene-level (`WindowChromeGlass`). ⌘K palette + deep-link consume unchanged.

## Dashboard — full desktop redesign (the reference)
- **Hero metrics row** — net worth / safe-to-spend / last-30-day spend as large tabular figures with labels, surfaced from the *same* `WealthSummaryPresentation` + `SafeToSpendCalculator` engines the rail/weekly-review use (data re-hosted, **not** recomputed).
- **Two-column card grid** with `title3` section headers and generous `WindowMetrics` spacing. Re-hosts the existing self-carding cards (heatmap + accounts, balance time-machine, weekly review, recurring, categories, insights) **directly** — no card-in-a-card.
- Shell `.searchable` filters the account rows via `\.dashboardSearchQuery` (empty ⇒ no filter, so the popover is unchanged); dedicated search-empty state.

## Accessibility / safety
- Privacy Mask honored throughout (`PrivacyMaskPresentation`); App Lock gated by the shell overlay; **never color-alone** (labels/glyphs carry meaning).
- Did **not** touch `Route.swift`, `AppState`, `SnapshotRenderer`, or the other 8 destinations.

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green.
- `swift test` — **2032 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)