### PR TITLE
feat(dashboard): comfortable desk-distance density polish for window-first Dashboard (AND-624)

### DIFF
--- a/Sources/PlaidBar/Theme/WindowMetrics.swift
+++ b/Sources/PlaidBar/Theme/WindowMetrics.swift
@@ -34,26 +34,38 @@ import SwiftUI
 /// with the popover tokens where the two meet (e.g. a re-hosted popover card
 /// inside a window section).
 enum WindowMetrics {
-    // MARK: Spacing scale (4pt sub-grid, coarser steps than Spacing)
+    // MARK: Spacing scale (8pt grid, coarser steps than the popover's Spacing)
+    //
+    // Tuned up for desk-distance "comfortable density" (AND-624): a calm,
+    // spacious macOS 26 desktop dashboard reads as breathing room first, dense
+    // figures second. Steps sit on the 8pt grid (with one 4pt half-step for the
+    // tightest inner spacing) so cards align to a single even rhythm — the gap
+    // *between* cards is never smaller than the gap *inside* a card, which is
+    // what makes a grid read as separated rather than crammed.
 
     /// Tight inner spacing — label↔value, icon↔text within a metric tile.
-    static let xs: CGFloat = 6
-    /// Within-card spacing — rows inside a card, header↔body.
+    static let xs: CGFloat = 8
+    /// Within-card spacing — rows inside a card, label↔figure clusters.
     static let sm: CGFloat = 12
-    /// Card content padding and intra-section spacing.
-    static let md: CGFloat = 16
-    /// Between cards within a grid, and section header↔content.
+    /// Card content padding and header↔body spacing (≥20pt: generous interior
+    /// breathing room so figures don't crowd the card edge).
+    static let md: CGFloat = 20
+    /// Between cards within a column, and section header↔content (≥20pt: cards
+    /// read as distinctly separated surfaces, not a stuck-together stack).
     static let lg: CGFloat = 20
-    /// Between major sections of a canvas.
-    static let xl: CGFloat = 28
+    /// Between major sections of a canvas (hero row ↔ the column grid).
+    static let xl: CGFloat = 32
+    /// The gap between the two canvas columns. Wider than the inter-card gap so
+    /// the two columns read as two distinct regions, not one run-on grid (≥24pt).
+    static let columnGap: CGFloat = 28
     /// Outer canvas margin — the window's content inset from its chrome.
-    static let canvasMargin: CGFloat = 24
+    static let canvasMargin: CGFloat = 28
 
     // MARK: Layout
 
     /// Corner radius for window-scale cards. Larger than the popover's
     /// ``Radius/panel`` (8) so cards read as comfortable desk-distance surfaces.
-    static let cardCornerRadius: CGFloat = 12
+    static let cardCornerRadius: CGFloat = 14
 
     /// The minimum width a metric/content card may shrink to before the grid
     /// reflows to fewer columns. Tuned so a hero tile keeps its large figure
@@ -67,7 +79,12 @@ enum WindowMetrics {
 
     /// The hero metrics row's minimum tile width before it wraps. Below this the
     /// hero figures lose their tabular legibility, so the row reflows.
-    static let heroTileMinWidth: CGFloat = 220
+    static let heroTileMinWidth: CGFloat = 240
+
+    /// The minimum height the hero activity heatmap card reserves for its grid,
+    /// so the signature year-scale instrument reads as a prominent, full-width
+    /// hero at the top of the Activity column rather than a small lost strip.
+    static let heatmapHeroMinHeight: CGFloat = 132
 }
 
 // MARK: - Window-scale type ramp
@@ -131,7 +148,7 @@ struct WindowSupportingText: ViewModifier {
 /// so multiple tiles' figures align, and the same `.xSmall ... .accessibility3`
 /// clamp as ``DisplayBalance`` to stop before the layout-breaking AX4/AX5 steps.
 struct WindowHeroMetric: ViewModifier {
-    @ScaledMetric(relativeTo: .largeTitle) private var size: CGFloat = 34
+    @ScaledMetric(relativeTo: .largeTitle) private var size: CGFloat = 38
 
     func body(content: Content) -> some View {
         content

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -13,16 +13,25 @@ import SwiftUI
 /// popover's compact arrangement. The data can never diverge from the popover
 /// because both read the same Core; only the layout differs.
 ///
-/// Layout (desk-distance, ``WindowMetrics`` / ``WindowTypography``):
+/// Layout (desk-distance, ``WindowMetrics`` / ``WindowTypography``) — tuned for
+/// "comfortable density" (AND-624): a calm, spacious canvas of a few generous
+/// cards per column rather than a tight stack of small ones.
 /// 1. a **hero metrics row** — net worth, safe-to-spend, and last-30-day spend as
 ///    large tabular figures with labels (the dashboard's headline numbers,
 ///    surfaced from `WealthSummaryPresentation` + `SafeToSpendCalculator`, the
 ///    same engines the rail/weekly-review use);
-/// 2. a **two-column card grid** below it — a generous left column (the 365-day
-///    activity heatmap + account rows, balance time-machine, weekly review) beside
-///    a right column (recurring obligations, the category dashboard, and the
-///    local-insight teaser), each card a ``WindowSection`` with a `title3` header
-///    and progressive disclosure. On a narrow window the two columns stack.
+/// 2. a **two-column card grid** below it, **at most three cards per column** under
+///    a `title2` column banner:
+///    - left **Activity** column — the year-scale activity **heatmap hero** (the
+///      signature instrument, a prominent near-full-width card at the top), the
+///      consolidated **Accounts** card (filter segments + account rows + the "what
+///      the bank said" balances merged into one card), and either the
+///      **status-readiness** group (while setup needs attention) or the **weekly
+///      review** card;
+///    - right **Money & insights** column — recurring obligations, the category
+///      dashboard, and the local-insight teaser.
+///    Each card self-cards (a ``WindowSection`` or its own chrome) with a `title3`
+///    header. On a narrow window the two columns stack.
 ///
 /// **Drill-ins deep-link, they don't open a third column** (IA §3.1, §5.1): the
 /// 2-column dashboard has no inspector, so selecting an account routes to the
@@ -64,7 +73,7 @@ struct DashboardDestinationView: View {
                     heroMetricsRow
 
                     if isWide {
-                        HStack(alignment: .top, spacing: WindowMetrics.lg) {
+                        HStack(alignment: .top, spacing: WindowMetrics.columnGap) {
                             primaryColumn
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
                             secondaryColumn
@@ -119,38 +128,45 @@ struct DashboardDestinationView: View {
 
     // MARK: - Columns
 
-    /// The left/primary column: the year-scale activity heatmap + account rows
-    /// (the dashboard's core instrument), the balance time-machine, and the weekly
-    /// review. These re-host the existing reusable subviews unchanged — they each
-    /// carry their own card chrome and section header, so they are mounted directly
-    /// (not nested in a ``WindowSection``, which would card-in-a-card). The layout
-    /// gives them desk-distance room at ``WindowMetrics`` spacing; the data is
-    /// identical to the popover.
+    /// The left/primary **Activity** column — at most three generous cards so the
+    /// column reads as calm, comfortable density rather than a tight stack of small
+    /// cards (AND-624):
+    /// 1. the year-scale activity **heatmap hero** (the signature instrument), given
+    ///    a prominent near-full-column-width card at the top;
+    /// 2. the consolidated **Accounts** card (filter segments + account rows + the
+    ///    "what the bank said" bank-reported balances, all merged into one card);
+    /// 3. the **status-readiness** card *when setup needs attention*, otherwise the
+    ///    **weekly review** card — never both, so the column stays at three cards.
+    ///
+    /// Each card self-cards (it is a ``WindowSection`` or carries its own chrome);
+    /// the column banner above them is a `title2` region header. The data is
+    /// identical to the popover — these re-host the same Core engines.
     private var primaryColumn: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.lg) {
-            sectionHeader("Activity", systemImage: "square.grid.3x3.fill")
+            columnHeader("Activity", systemImage: "square.grid.3x3.fill")
+
+            DashboardActivityHeatmapCard()
 
             DashboardOverviewColumn(onSelectAccount: { account in
                 openRoute(.accounts(itemID: account.itemId))
             })
 
-            BalanceTimeMachineView()
-
-            WeeklyReviewCard()
-
             if shouldShowStatusReadiness {
-                statusReadinessCluster
+                statusReadinessCard
+            } else {
+                WeeklyReviewCard()
             }
         }
         .accessibilityElement(children: .contain)
     }
 
-    /// The right/secondary column: recurring obligations, the category dashboard,
-    /// the first-run snapshot (when present), and the local-insight teaser. Like the
-    /// primary column, each re-hosted card self-cards, so they are mounted directly.
+    /// The right/secondary **Money & insights** column — three cards: recurring
+    /// obligations, the category dashboard, and the local-insight teaser (plus the
+    /// first-run snapshot when present, which is transient). Each re-hosted card
+    /// self-cards, so they are mounted directly under the column banner.
     private var secondaryColumn: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.lg) {
-            sectionHeader("Money & insights", systemImage: "chart.pie")
+            columnHeader("Money & insights", systemImage: "chart.pie")
 
             DashboardRecurringCard(onOpen: { openRoute(.planning(section: .recurring)) })
 
@@ -168,13 +184,13 @@ struct DashboardDestinationView: View {
         .accessibilityElement(children: .contain)
     }
 
-    /// A window-scale column section header (`title3` via ``WindowCardTitle``) — the
-    /// reference pattern for grouping cards in a desktop canvas (the deliverable's
-    /// "section headers (title3)"). It is a heading, not a card, so it sits cleanly
-    /// above the self-carding cards below it without nesting a card in a card.
-    private func sectionHeader(_ title: String, systemImage: String) -> some View {
+    /// A window-scale **column** region header (`title2` via ``WindowSectionTitle``)
+    /// — one step up from a card's `title3` title, so the column reads as a region
+    /// grouping its cards. It is a heading, not a card, so it sits cleanly above the
+    /// self-carding cards below without nesting a card in a card.
+    private func columnHeader(_ title: String, systemImage: String) -> some View {
         Label {
-            Text(title).windowCardTitle()
+            Text(title).windowSectionTitle()
         } icon: {
             Image(systemName: systemImage).foregroundStyle(.secondary)
         }
@@ -193,8 +209,24 @@ struct DashboardDestinationView: View {
         return !appState.isSetupComplete || level == .warning || level == .blocked
     }
 
-    private var statusReadinessCluster: some View {
+    /// The status-readiness group: connection health + attention queue + the
+    /// readiness panel under a single `title3` "Status" header. The three pieces
+    /// each carry their own glass chrome (they are shared popover views), so they
+    /// are grouped by a header + tight spacing rather than re-wrapped in another
+    /// card — that would card-in-a-card. They occupy the column's third slot in
+    /// place of the weekly review while setup needs attention. Tighter
+    /// intra-group spacing (`sm`) reads them as one cluster, distinct from the
+    /// `lg` gaps between the column's top-level cards.
+    private var statusReadinessCard: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            Label {
+                Text("Status").windowCardTitle()
+            } icon: {
+                Image(systemName: "checklist").foregroundStyle(.secondary)
+            }
+            .labelStyle(.titleAndIcon)
+            .accessibilityAddTraits(.isHeader)
+
             ConnectionHealthStripView()
             AttentionQueueView(title: "Attention", onAddAccount: { openRoute(.accounts()) })
             DashboardReadinessPanel(

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -1,23 +1,92 @@
 import PlaidBarCore
 import SwiftUI
 
-/// The overview block of the window-first **Dashboard** destination (AND-622): the
-/// activity heatmap + the primary account filter + the account rows — the same
-/// instrument the menu-bar popover renders via its private `DashboardOverviewStack`.
+/// The signature **Activity heatmap hero** of the window-first Dashboard
+/// (AND-622/AND-624): the read-only 365-day year-scale activity grid, given a
+/// prominent near-full-column-width card at the *top* of the Activity column so
+/// it reads as the dashboard's headline instrument rather than a small lost
+/// strip buried in a list of cards.
+///
+/// **Surface only — no model logic here.** It reads the *same*
+/// ``SpendingHeatmapLayout`` Core engine the popover and the Insights destination
+/// compute (`SpendingHeatmap.cellIntensity`, `ChartAudioGraph.heatmap`) — the
+/// data is never recomputed or divergent. It renders that layout at a
+/// **desk-distance scale** (``DashboardYearHeatmapGrid``: larger cells, month
+/// markers, more height) rather than re-hosting the popover/Insights
+/// ``InsightsActivityHeatmapGrid``, whose cells are capped at a glance-scale 9pt
+/// and read small/lost on a desktop hero. Privacy Mask / Reduce Transparency swap
+/// in a text alternative, since the grid leans on tinted, translucent cells
+/// (ACCESSIBILITY.md — never color/translucency alone).
+struct DashboardActivityHeatmapCard: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private var layout: SpendingHeatmapLayout {
+        let calendar = Calendar.current
+        let end = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -364, to: end) ?? end
+        return SpendingHeatmapLayout.compute(
+            from: appState.transactions,
+            startDate: start,
+            endDate: end,
+            mode: appState.dashboardHeatmapMode,
+            calendar: calendar
+        )
+    }
+
+    var body: some View {
+        let layout = layout
+        WindowSection("Activity", systemImage: "square.grid.3x3.fill") {
+            Text(layout.mode.summaryTitle)
+                .windowSupportingText()
+        } content: {
+            if appState.shouldMaskFinancialValues || reduceTransparency {
+                heatmapTextAlternative(layout: layout)
+            } else {
+                DashboardYearHeatmapGrid(layout: layout)
+            }
+        }
+        .loadingRedaction(appState.loadState(for: .activityHeatmap))
+    }
+
+    private func heatmapTextAlternative(layout: SpendingHeatmapLayout) -> some View {
+        let masked = appState.shouldMaskFinancialValues
+        let total = masked
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(layout.totalValue, format: .compact)
+        return VStack(alignment: .leading, spacing: WindowMetrics.xs) {
+            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
+                .windowBodyText()
+            Text(masked
+                ? "Activity totals are hidden while VaultPeek is private."
+                : "\(total) across active days. \(layout.mode.semanticDescription)")
+                .windowSupportingText()
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, minHeight: WindowMetrics.heatmapHeroMinHeight, alignment: .topLeading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// The consolidated **Accounts** card of the window-first Dashboard
+/// (AND-622/AND-624): the primary account filter, the account rows, and the
+/// "what the bank said" bank-reported balances — merged into one card so the
+/// Activity column reads as a few generous cards rather than a tight stack of
+/// small ones. The filter segments live *inside* this card's header area (they
+/// scope its rows) rather than as a separate strip above it.
 ///
 /// **Surface only — no model logic here.** It composes existing reusable pieces
 /// over `PlaidBarCore`:
 /// - the **filter bar** is the existing ``DashboardFilterBar``, bound to the same
 ///   `AppState.dashboardFilter` the popover persists;
-/// - the **activity heatmap** is the existing read-only ``InsightsActivityHeatmapGrid``
-///   (already factored out for the Insights destination, AND-585) over the same
-///   ``SpendingHeatmapLayout`` Core engine — *the heatmap is not rebuilt here*;
 /// - the **account rows** render from the same ``AccountPresentation`` Core helpers
-///   the popover row uses, honoring Privacy Mask.
+///   the popover row uses, honoring Privacy Mask, at window (desk-distance) type;
+/// - the **"what the bank said" balances** re-host the same Core ledger the popover
+///   strip reads (``BalanceTimeMachineView``), folded in as a footer detail.
 ///
-/// **Drill-ins deep-link, not a third column** (IA §3.1, §5.1): the 2-column
-/// dashboard has no inspector, so selecting a row calls `onSelectAccount`, which
-/// the destination routes to the **Accounts** destination via `\.openRoute`.
+/// **Drill-ins deep-link, not a third column** (IA §3.1, §5.1): selecting a row
+/// calls `onSelectAccount`, which the destination routes to the **Accounts**
+/// destination via `\.openRoute`.
 ///
 /// Empty / loading states mirror the popover: a pre-setup install shows the Core
 /// ``DashboardOverviewFallbackState`` banner instead of an empty grid; the
@@ -63,79 +132,25 @@ struct DashboardOverviewColumn: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
+        WindowSection("Accounts", systemImage: "building.columns") {
+            Text("\(filteredAccounts.count)")
+                .windowCardTitle()
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+                .opacity(accountsLoadState.showsSkeleton ? 0 : 1)
+                .accessibilityLabel("\(filteredAccounts.count) accounts")
+        } content: {
             if let fallbackState {
                 DashboardOverviewFallback(presentation: fallbackState)
             } else {
-                activityHeatmap
-            }
-
-            VStack(alignment: .leading, spacing: Spacing.sm) {
-                DashboardFilterBar(selection: filterBinding, hasSelectedAccount: false)
-                accountsSection
-            }
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Overview with activity heatmap, account filters, and account rows.")
-    }
-
-    // MARK: - Heatmap
-
-    /// The read-only year heatmap, reusing the existing ``InsightsActivityHeatmapGrid``
-    /// over the same Core layout the popover computes. Privacy Mask / Reduce
-    /// Transparency swap in a text alternative, since the grid leans on tinted,
-    /// translucent cells (ACCESSIBILITY.md — never color/translucency alone).
-    @ViewBuilder
-    private var activityHeatmap: some View {
-        let layout = heatmapLayout()
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            Label(layout.mode.summaryTitle, systemImage: "square.grid.3x3.fill")
-                .sectionTitle()
-                .foregroundStyle(.secondary)
-
-            if appState.shouldMaskFinancialValues || reduceTransparency {
-                heatmapTextAlternative(layout: layout)
-            } else {
-                InsightsActivityHeatmapGrid(layout: layout)
+                VStack(alignment: .leading, spacing: WindowMetrics.md) {
+                    DashboardFilterBar(selection: filterBinding, hasSelectedAccount: false)
+                    accountsSection
+                    bankSaidFooter
+                }
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Spacing.md)
-        .glassSurface(.raised)
-        .loadingRedaction(appState.loadState(for: .activityHeatmap))
-        .accessibilityElement(children: .contain)
-    }
-
-    private func heatmapLayout() -> SpendingHeatmapLayout {
-        let calendar = Calendar.current
-        let end = calendar.startOfDay(for: Date())
-        let start = calendar.date(byAdding: .day, value: -364, to: end) ?? end
-        return SpendingHeatmapLayout.compute(
-            from: appState.transactions,
-            startDate: start,
-            endDate: end,
-            mode: appState.dashboardHeatmapMode,
-            calendar: calendar
-        )
-    }
-
-    private func heatmapTextAlternative(layout: SpendingHeatmapLayout) -> some View {
-        let masked = appState.shouldMaskFinancialValues
-        let total = masked
-            ? PrivacyMaskPresentation.compactValue
-            : Formatters.currency(layout.totalValue, format: .compact)
-        return VStack(alignment: .leading, spacing: Spacing.xs) {
-            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
-                .font(.subheadline.weight(.medium))
-            Text(masked
-                ? "Activity totals are hidden while VaultPeek is private."
-                : "\(total) across active days. \(layout.mode.semanticDescription)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Accounts with filters, account rows, and bank-reported balances.")
     }
 
     // MARK: - Accounts
@@ -145,20 +160,7 @@ struct DashboardOverviewColumn: View {
     }
 
     private var accountsSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text("Accounts")
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text("\(filteredAccounts.count)")
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
-                    .opacity(accountsLoadState.showsSkeleton ? 0 : 1)
-            }
-            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-            .padding(.bottom, Spacing.xs)
-
+        Group {
             if filteredAccounts.isEmpty {
                 if accountsLoadState.showsSkeleton {
                     DashboardAccountRowSkeletonList(loadState: accountsLoadState)
@@ -185,6 +187,22 @@ struct DashboardOverviewColumn: View {
         }
     }
 
+    // MARK: - "What the bank said" (folded-in footer)
+
+    /// The bank-reported balance ledger, folded into the Accounts card rather
+    /// than carried as its own small card. ``BalanceTimeMachineView`` self-hides
+    /// when there is nothing to show, so a divider only appears when there is a
+    /// footer to separate.
+    @ViewBuilder
+    private var bankSaidFooter: some View {
+        if appState.accountBalanceLedger.latestEntriesByAccount().contains(where: { entry in
+            appState.accounts.contains { $0.id == entry.accountId }
+        }) {
+            Divider().opacity(0.4)
+            BalanceTimeMachineView()
+        }
+    }
+
     private var filterBinding: Binding<DashboardAccountFilter> {
         Binding(
             get: { appState.dashboardFilter },
@@ -197,8 +215,11 @@ struct DashboardOverviewColumn: View {
 
 /// A single account row for the window-first dashboard overview. Drives off the
 /// shared ``AccountPresentation`` Core helpers (the same source the popover row
-/// uses), so name, subtitle, amount, and the VoiceOver label match. Selection
-/// deep-links to the Accounts destination rather than opening a local inspector.
+/// uses), so name, subtitle, amount, and the VoiceOver label match. Rendered at
+/// window (desk-distance) type — the account name and amount read at `.body`, the
+/// subtitle at `.subheadline` — so the primary figures never drop to caption
+/// scale on the larger surface. Selection deep-links to the Accounts destination
+/// rather than opening a local inspector.
 private struct DashboardAccountRowButton: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -210,26 +231,29 @@ private struct DashboardAccountRowButton: View {
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(spacing: Spacing.compactRowContentSpacing) {
+            HStack(spacing: WindowMetrics.sm) {
                 Image(systemName: AccountPresentation.iconName(for: account))
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.body.weight(.medium))
                     .foregroundStyle(.secondary)
                     .frame(width: Sizing.iconChip, height: Sizing.iconChip)
                     .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))
 
-                VStack(alignment: .leading, spacing: Spacing.compactRowTextSpacing) {
+                VStack(alignment: .leading, spacing: 2) {
                     Text(account.name)
-                        .font(.callout.weight(.medium))
+                        .windowBodyText()
+                        .fontWeight(.medium)
                         .lineLimit(1)
                     Text(subtitle)
-                        .detailText()
+                        .windowSupportingText()
                         .lineLimit(1)
                 }
 
-                Spacer(minLength: Spacing.compactRowContentSpacing)
+                Spacer(minLength: WindowMetrics.sm)
 
                 Text(amountText)
-                    .dataText()
+                    .windowBodyText()
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
                     .rollingTabularNumber(amountText, reduceMotion: reduceMotion)
                     .foregroundStyle(AppearanceTextColors.primary)
                     .lineLimit(1)
@@ -237,11 +261,11 @@ private struct DashboardAccountRowButton: View {
                 // The drill-in opens the Accounts destination; chevron.forward
                 // flips correctly under RTL and carries the affordance by shape.
                 Image(systemName: "chevron.forward")
-                    .font(.caption.weight(.medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(.tertiary)
             }
-            .padding(.horizontal, Spacing.compactRowHorizontalPadding)
-            .padding(.vertical, Spacing.compactRowVerticalPadding)
+            .padding(.horizontal, WindowMetrics.sm)
+            .padding(.vertical, WindowMetrics.sm)
             .contentShape(Rectangle())
             .overlay(alignment: .bottom) {
                 Divider().opacity(0.4)
@@ -329,8 +353,8 @@ private struct DashboardAccountEmpty: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 9) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            HStack(spacing: WindowMetrics.sm) {
                 Image(systemName: presentation.iconName)
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(tint)
@@ -339,9 +363,10 @@ private struct DashboardAccountEmpty: View {
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(presentation.title)
-                        .font(.callout.weight(.semibold))
+                        .windowBodyText()
+                        .fontWeight(.semibold)
                     Text(presentation.detail)
-                        .detailText()
+                        .windowSupportingText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -354,9 +379,7 @@ private struct DashboardAccountEmpty: View {
                 .controlSize(.small)
             }
         }
-        .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(emphasizedTint.map { SurfaceRank.emphasized($0) } ?? .raised)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(presentation.title). \(presentation.detail)")
     }
@@ -366,13 +389,6 @@ private struct DashboardAccountEmpty: View {
         case .brand: SemanticColors.brand
         case .warning: SemanticColors.warning
         case .healthy, .loading, .offline, .secondary: .secondary
-        }
-    }
-
-    private var emphasizedTint: Color? {
-        switch presentation.tone {
-        case .brand, .warning: tint
-        case .healthy, .loading, .offline, .secondary: nil
         }
     }
 }
@@ -385,8 +401,8 @@ private struct DashboardOverviewFallback: View {
     let presentation: DashboardOverviewFallbackState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 10) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            HStack(alignment: .top, spacing: WindowMetrics.sm) {
                 Image(systemName: presentation.iconName)
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(SemanticColors.brandSecondary)
@@ -398,9 +414,10 @@ private struct DashboardOverviewFallback: View {
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(presentation.title)
-                        .font(.callout.weight(.semibold))
+                        .windowBodyText()
+                        .fontWeight(.semibold)
                     Text(presentation.detail)
-                        .detailText()
+                        .windowSupportingText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -413,8 +430,138 @@ private struct DashboardOverviewFallback: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
         }
-        .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.emphasized(SemanticColors.brandSecondary))
+    }
+}
+
+// MARK: - Year heatmap (desk-distance scale)
+
+/// The 365-day activity heatmap rendered at **desk-distance scale** for the
+/// Dashboard hero (AND-624). It reads the exact same ``SpendingHeatmapLayout``
+/// the popover/Insights compute and the exact same `SpendingHeatmap.cellIntensity`
+/// mapping — only the *render size* differs from the glance-scale
+/// ``InsightsActivityHeatmapGrid`` (whose cells cap at 9pt): cells here grow to
+/// fill the hero card's width (clamped to a comfortable desk range) and the grid
+/// carries month markers, so the signature year view reads as a prominent hero
+/// rather than a small lost strip.
+///
+/// Meaning never rides on cell color alone (ACCESSIBILITY.md): the card's title +
+/// the legend + the active-day count + the VoiceOver label and audio graph carry
+/// the same information in text and sound. Callers swap in a text alternative
+/// under Privacy Mask / Reduce Transparency before reaching this view.
+struct DashboardYearHeatmapGrid: View {
+    let layout: SpendingHeatmapLayout
+
+    /// Gap between cells. A touch wider than the glance grid's 2pt so the larger
+    /// cells read as a clean lattice at desk distance.
+    private let cellSpacing: CGFloat = 3
+    /// Desk-distance cell-size clamp: never smaller than the glance cap (so it is
+    /// always at least as legible as the popover), never so large the year grid
+    /// dominates the column. The actual size fills the available width between.
+    private let minCell: CGFloat = 9
+    private let maxCell: CGFloat = 15
+
+    private var weekCount: Int { max(layout.weekColumns.count, 1) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            GeometryReader { proxy in
+                let cell = clampedCell(forWidth: proxy.size.width)
+                VStack(alignment: .leading, spacing: cellSpacing) {
+                    monthMarkers(cell: cell)
+                    grid(cell: cell)
+                }
+            }
+            .frame(height: gridHeight)
+
+            legend
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
+        )
+        // VoiceOver audio graph over the active days (AND-569) — same Core source.
+        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
+    }
+
+    /// Largest cell that lets all weeks fit the available width, clamped to the
+    /// desk-distance range so the hero never collapses to a glance strip or blows
+    /// the column out.
+    private func clampedCell(forWidth width: CGFloat) -> CGFloat {
+        let usable = width - CGFloat(weekCount - 1) * cellSpacing
+        let fit = floor(usable / CGFloat(weekCount))
+        return min(maxCell, max(minCell, fit))
+    }
+
+    /// Reserve height for seven day-rows at the max cell size plus the month-marker
+    /// row, so the card lays out at a stable, prominent height regardless of the
+    /// resolved cell size.
+    private var gridHeight: CGFloat {
+        let markerRow: CGFloat = 16
+        return markerRow + 7 * maxCell + 6 * cellSpacing
+    }
+
+    private func grid(cell: CGFloat) -> some View {
+        HStack(alignment: .top, spacing: cellSpacing) {
+            ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { _, week in
+                VStack(spacing: cellSpacing) {
+                    ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                        cellView(for: day, size: cell)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func cellView(for day: SpendingHeatmapDay?, size: CGFloat) -> some View {
+        if let day {
+            let intensity = SpendingHeatmap.cellIntensity(for: day, peakValue: layout.peakValue)
+            RoundedRectangle(cornerRadius: Radius.control)
+                .fill(Color.primary.opacity(0.10 + 0.62 * intensity))
+                .frame(width: size, height: size)
+        } else {
+            RoundedRectangle(cornerRadius: Radius.control)
+                .fill(.clear)
+                .frame(width: size, height: size)
+        }
+    }
+
+    /// Month labels above the grid, positioned by their week index. Hidden from
+    /// accessibility (the VoiceOver label already names the span).
+    private func monthMarkers(cell: CGFloat) -> some View {
+        let step = cell + cellSpacing
+        return ZStack(alignment: .topLeading) {
+            ForEach(layout.monthMarkers) { marker in
+                Text(marker.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize()
+                    .offset(x: CGFloat(marker.weekIndex) * step)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 14, alignment: .topLeading)
+        .accessibilityHidden(true)
+    }
+
+    private var legend: some View {
+        HStack(spacing: WindowMetrics.xs) {
+            Text("Less")
+                .windowSupportingText()
+            ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
+                RoundedRectangle(cornerRadius: Radius.control)
+                    .fill(Color.primary.opacity(0.10 + 0.62 * intensity))
+                    .frame(width: 12, height: 12)
+            }
+            Text("More")
+                .windowSupportingText()
+
+            Spacer()
+
+            Text("\(layout.activeDayCount) active days")
+                .windowSupportingText()
+        }
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
@@ -31,10 +31,15 @@ struct DashboardRecurringCard: View {
     var body: some View {
         let presentation = presentation
         if presentation.isEmpty {
-            Label("No recurring charges detected yet.", systemImage: "repeat")
-                .windowSupportingText()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .accessibilityElement(children: .combine)
+            WindowSection("Recurring", systemImage: "repeat") {
+                EmptyView()
+            } content: {
+                Label("No recurring charges detected yet.", systemImage: "repeat")
+                    .windowBodyText()
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .accessibilityElement(children: .combine)
         } else {
             RecurringObligationsSection(
                 presentation: presentation,


### PR DESCRIPTION
## What & why

The window-first Dashboard (the AND-624 reference surface) read slightly **busy/cramped** — a tight vertical stack of small cards with a 365-day heatmap that got lost mid-column. This loosens it into a **calm, spacious macOS 26 desktop dashboard** ("more content, fewer nested levels, comfortable density that doesn't make people strain" — Apple's *Designing for macOS*), **without losing information** and **without touching the popover**.

This is the exemplar the other 8 destinations will copy, so the goal was an unmistakably calmer, more deliberate rhythm.

## Before → after (concrete density changes)

### Spacing (`WindowMetrics`, on the 8pt grid)
| Token | Before | After | Effect |
|------|--------|-------|--------|
| card interior padding (`md`) | 16 | **20** | figures stop crowding the card edge |
| column gap | 20 (shared `lg`) | **28** (new `columnGap`) | the two columns read as two regions, not one run-on grid |
| major-section gap (`xl`) | 28 | **32** | hero row breathes away from the grid |
| canvas margin | 24 | **28** | window content insets further from chrome |
| card radius | 12 | **14** | softer desk-distance surfaces |
| inner (`xs`) | 6 | **8** | even rhythm; on-grid |
| hero figure base pt | 34 | **38** | headline numbers get slightly more presence |

Inter-card gap stays 20pt — deliberately **not** smaller than the 20pt intra-card padding, so the grid reads separated rather than crammed.

### Fewer, larger cards (≤3 per column)
**Left "Activity" column** went from ~5 small blocks → **3 cards**:
1. **Activity heatmap hero** (see below)
2. **Accounts** — one card that folds the **filter segments** and the **"what the bank said"** bank-reported balances *in with* the account rows (was three separate strips/cards)
3. the **status-readiness** group *or* the **weekly review** card — never both, so the column holds at three

The status-readiness cluster is now grouped under a single `title3` "Status" header with tight intra-group spacing, instead of fanning out as separate cards. Column banners stepped up to **title2** (`WindowSectionTitle`); cards keep **title3**.

### Heatmap = hero
New `DashboardYearHeatmapGrid` renders the **same** `SpendingHeatmapLayout` Core output (same `SpendingHeatmap.cellIntensity`, same `ChartAudioGraph.heatmap` audio graph) at **desk-distance scale**: larger cells (**9–15pt** vs the glance grid's 9pt cap), **month markers**, more height, in a **full-column-width card at the top** of the Activity column. The shared glance-scale `InsightsActivityHeatmapGrid` (used by the Insights destination) is left **untouched** — no recompute, no divergence, just a desk-distance render.

### Type step-up
Account rows now render at window **body / subheadline** (were `callout` / `caption`); empty + fallback states use `windowBodyText`. All figures keep tabular numerics.

## Preserved
2-column composed canvas · never color-alone (glyph + text) · Privacy Mask · App Lock (shell-gated) · Reduce Transparency text-alternative for the heatmap · same Core engines throughout (no recompute) · no popover or model logic touched.

## Flag-OFF parity
All changes live only in `Dashboard*` destination files + `WindowMetrics.swift`, which the **flag-OFF popover never reads or instantiates** (verified: no non-destination view references the window-scale tokens). The popover stays **byte-identical**.

## Scope
Touched only: `WindowMetrics.swift`, `DashboardDestinationView.swift`, `DashboardOverviewColumn.swift`, `DashboardRecurringCard.swift`. No other destination, `AppShellView`, `DestinationRouter`, `SnapshotRenderer`, or popover file changed.

## Testing
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green (exit 0)
- `swift test` — **2035 tests pass** (baseline)
- Rendered `window-dashboard.png` via the #602 headless harness and confirmed: prominent heatmap hero with month markers, ≤3 cards/column, larger card-body type, visibly looser rhythm.

Ref: AND-624