### PR TITLE
feat(ux): window-first Insights composed 2-col canvas (AND-624)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -19,8 +19,11 @@ import SwiftUI
 ///   contract): with the toggle off no model is invoked and the surface shows only
 ///   the enable affordance.
 ///
-/// Liquid Glass never touches a chart; this is a text/receipt surface, so it uses
-/// the standard raised card chrome. Phase + provenance are carried by text + SF
+/// This is the Insights canvas **hero** (AND-624): a prominent full-width card at
+/// the top of the destination, at the window (desk-distance) scale —
+/// ``WindowMetrics`` / ``WindowTypography``. Data stays solid (ADR-001: glass on
+/// chrome, not data), so the receipt sits on the quiet ``windowCardSurface()``
+/// rather than a translucent wash. Phase + provenance are carried by text + SF
 /// Symbol, never color alone (ACCESSIBILITY.md).
 struct InsightsAIInsightView: View {
     @Environment(AppState.self) private var appState
@@ -69,7 +72,7 @@ struct InsightsAIInsightView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
+        VStack(alignment: .leading, spacing: WindowMetrics.md) {
             header
 
             if phase == .off {
@@ -78,8 +81,9 @@ struct InsightsAIInsightView: View {
                 insightBody
             }
         }
-        .padding(Spacing.md)
-        .glassSurface(.raised)
+        .padding(WindowMetrics.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .windowCardSurface()
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
         // Probe the on-device runtime when the surface appears so an enabled-but-
@@ -94,12 +98,16 @@ struct InsightsAIInsightView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
-            Label("Spending insights", systemImage: "sparkles")
-                .sectionTitle()
-                .foregroundStyle(.secondary)
+        HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
+            Label {
+                Text("Spending insights").windowCardTitle()
+            } icon: {
+                Image(systemName: "sparkles").foregroundStyle(.secondary)
+            }
+            .labelStyle(.titleAndIcon)
+            .accessibilityAddTraits(.isHeader)
 
-            Spacer(minLength: Spacing.sm)
+            Spacer(minLength: WindowMetrics.sm)
 
             phasePill
 
@@ -149,23 +157,22 @@ struct InsightsAIInsightView: View {
     // MARK: - Off state (consent)
 
     private var offState: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             Text("On-device spending summaries are off")
-                .font(.callout.weight(.semibold))
+                .font(.body.weight(.semibold))
 
             Text("Turn on Local AI to generate a short, factual summary of your spending on this Mac. Nothing leaves your device — there is no cloud fallback.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
                 .fixedSize(horizontal: false, vertical: true)
 
-            HStack(spacing: Spacing.sm) {
+            HStack(spacing: WindowMetrics.sm) {
                 Button {
                     appState.localAIEnabled = true
                 } label: {
                     Label("Enable Local AI", systemImage: "sparkles")
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.small)
+                .controlSize(.large)
                 .accessibilityHint("Enables on-device spending insights. Off by default.")
 
                 Button {
@@ -174,23 +181,25 @@ struct InsightsAIInsightView: View {
                     Label("Where your data lives", systemImage: "lock.shield")
                 }
                 .buttonStyle(.bordered)
-                .controlSize(.small)
+                .controlSize(.large)
                 .accessibilityHint("Opens Settings to the local data section.")
             }
         }
-        .padding(Spacing.sm)
+        .padding(WindowMetrics.sm)
         .nativeInsetSurface()
     }
 
     // MARK: - Insight body (generating / streamed / unavailable)
 
     private var insightBody: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             // Headline — the deterministic fallback while generating, replaced in
-            // place by the model-generated headline when it streams in.
-            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            // place by the model-generated headline when it streams in. The hero
+            // figure of the card, so it reads at window `title3` rather than the
+            // popover's callout scale.
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
                 Text(receipt.headline)
-                    .font(.callout.weight(.semibold))
+                    .windowCardTitle()
                     .fixedSize(horizontal: false, vertical: true)
                     .transition(.opacity)
                     .id(receipt.headline) // cross-fade as the streamed text lands
@@ -219,7 +228,7 @@ struct InsightsAIInsightView: View {
 
     private var evidenceChips: some View {
         // Wrap so chips reflow rather than clip on a narrow column.
-        InsightsFlowLayout(spacing: Spacing.xs) {
+        InsightsFlowLayout(spacing: WindowMetrics.xs) {
             ForEach(receipt.evidenceChips) { chip in
                 InsightsEvidenceChipView(chip: chip)
             }
@@ -231,17 +240,16 @@ struct InsightsAIInsightView: View {
     /// Provenance / consent receipt lines — confidence, runtime limitations, and
     /// the reversible-action note — each as a bulleted detail line.
     private var provenance: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
+        VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             ForEach(Array(provenanceLines.enumerated()), id: \.offset) { _, line in
-                HStack(alignment: .top, spacing: Spacing.sm) {
+                HStack(alignment: .top, spacing: WindowMetrics.sm) {
                     Image(systemName: "circle.fill")
-                        .font(.system(size: 4))
+                        .font(.system(size: 5))
                         .foregroundStyle(.secondary)
-                        .padding(.top, 6)
+                        .padding(.top, 7)
                         .accessibilityHidden(true)
                     Text(line)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .windowSupportingText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -259,33 +267,32 @@ struct InsightsAIInsightView: View {
 
     private var unavailableNote: some View {
         Label(availability.detail, systemImage: "exclamationmark.triangle")
-            .font(.caption.weight(.medium))
+            .font(.subheadline.weight(.medium))
             .foregroundStyle(SemanticColors.warning)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(Spacing.sm)
+            .padding(WindowMetrics.sm)
             .nativeInsetSurface(stroke: SemanticColors.warning.opacity(0.18))
             .accessibilityLabel("Runtime unavailable. \(availability.detail)")
     }
 
     private var footer: some View {
-        HStack(spacing: Spacing.xs) {
+        HStack(spacing: WindowMetrics.xs) {
             Image(systemName: "lock.shield.fill")
-                .font(.caption2.weight(.semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .accessibilityHidden(true)
             Text("\(receipt.localOnlyBadge). \(receipt.reversibleActionCopy)")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
                 .fixedSize(horizontal: false, vertical: true)
 
-            Spacer(minLength: Spacing.xs)
+            Spacer(minLength: WindowMetrics.xs)
 
             Button {
                 openSettings()
             } label: {
                 Label("Where your data lives", systemImage: "externaldrive.badge.questionmark")
                     .labelStyle(.titleAndIcon)
-                    .font(.caption2)
+                    .font(.subheadline)
             }
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
@@ -317,18 +324,18 @@ struct InsightsEvidenceChipView: View {
     var body: some View {
         HStack(spacing: Spacing.xxs) {
             Image(systemName: chip.systemImage)
-                .font(.caption2.weight(.semibold))
+                .font(.subheadline.weight(.semibold))
                 .foregroundStyle(accent)
                 .accessibilityHidden(true)
             Text(chip.label)
-                .font(.caption2)
+                .font(.subheadline)
                 .foregroundStyle(.secondary)
             Text(chip.value)
-                .font(.caption2.weight(.semibold))
+                .font(.subheadline.weight(.semibold))
                 .monospacedDigit()
         }
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
         .background(Color.primary.opacity(0.05), in: Capsule())
         .overlay { Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 1) }
         .accessibilityElement(children: .ignore)

--- a/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
@@ -1,30 +1,41 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Insights** destination (2-column composed canvas — IA §3.1/§5.7, `[⌘6]`) —
-/// Epic 7 / AND-585 (ADR-001 window-first workspace).
+/// **Insights** destination — a window-first **composed 2-column canvas** (AND-624,
+/// matching the Dashboard reference; ADR-001 window-first workspace, IA §3.1/§5.7,
+/// `[⌘6]`), Epic 7 / AND-585.
 ///
-/// A composed reading canvas — no master list, so the shell renders only this
-/// content column (no inspector). It stacks the three Insights bands (IA §5.7 —
-/// ``InsightSection``), every one surfaced from an existing engine; **no model or
-/// chart logic lives here** (surface only):
+/// This re-*hosts* the Insights data — the on-device Foundation Models summary, the
+/// weekly review, and the trend charts — in a desk-distance desktop layout rather
+/// than re-using the popover's compact stack. It reads the *same* `AppState` +
+/// `PlaidBarCore` engines as the popover and the menu-bar surfaces, so the two can
+/// never diverge; **no model or chart logic lives here** (surface only).
 ///
-/// - **Spending insights** (``InsightSection/receipts``) — the streaming
-///   Foundation Models `@Generable` insight + the on-device ``LocalAIInsightReceipt``
-///   (tier + provenance + consent), via ``InsightsAIInsightView``. AI is **off by
-///   default with a visible toggle** (AND-564); FM availability is detected with a
-///   graceful NaturalLanguage / deterministic fallback (AND-563).
-/// - **Weekly review** (``InsightSection/weeklyReview``) — the existing
-///   ``WeeklyReviewCard`` re-hosted unchanged, so the window-first surface and the
-///   menu-bar popover drive the same review state.
-/// - **Trends** (``InsightSection/trends``) — the chart canvas (``InsightsTrendsView``):
-///   net-worth trend, spend donut, and activity heatmap. Every chart ships its
-///   ``ChartAudioGraph`` audio graph (AND-569) + a `reduceTransparency` / Privacy
-///   Mask text alternative; **Liquid Glass never touches a chart**, and no meaning
-///   rides on color alone (ACCESSIBILITY.md).
+/// Layout (desk-distance, ``WindowMetrics`` / ``WindowTypography`` — "comfortable
+/// density", a calm canvas of a few generous cards):
+/// 1. a **hero**: the streaming FM spending-insight headline + the on-device
+///    ``LocalAIInsightReceipt`` (tier + provenance + consent), surfaced via
+///    ``InsightsAIInsightView`` as a prominent full-width hero card. AI is **off by
+///    default with a visible toggle** (AND-564); availability is detected with a
+///    graceful NaturalLanguage / deterministic fallback (AND-563);
+/// 2. a **two-column card grid** below it, **at most three cards per column** under a
+///    `title2` column banner:
+///    - left **Trends** column — the net-worth trend, the spend donut, and the
+///      activity heatmap, each its own ``WindowSection`` chart card
+///      (``InsightsTrendsView``). Every chart ships its ``ChartAudioGraph`` audio
+///      graph (AND-569) + a `reduceTransparency` / Privacy Mask text alternative;
+///      **Liquid Glass never touches a chart** and no meaning rides on color alone
+///      (ACCESSIBILITY.md);
+///    - right **Review** column — the existing ``WeeklyReviewCard`` re-hosted
+///      unchanged, so the window-first surface and the popover drive the same
+///      review state.
+///   On a narrow window the two columns stack.
 ///
-/// A segmented section picker jumps between the three bands (scroll-to-anchor),
-/// matching the IA's Insights sub-sections without splitting into a master list.
+/// **Privacy Mask / App Lock:** the shell paints the full lock gate over the whole
+/// window while *locked* (ADR-001 Epic 10), so this canvas never double-gates; it
+/// honors Privacy *Mask* the way the re-hosted subviews do (figures run through
+/// `PrivacyMaskPresentation` / `shouldMaskFinancialValues`), so masked figures stay
+/// hidden and are never leaked here.
 ///
 /// **Flag-OFF inert:** reached only when the window-first `Window` opens
 /// (`WindowFirstFeatureFlag` ON). With the flag off the popover is byte-identical —
@@ -32,108 +43,78 @@ import SwiftUI
 struct InsightsDestinationView: View {
     @Environment(AppState.self) private var appState
 
-    /// The section the picker last jumped to. `@SceneStorage` keeps it window-
-    /// scoped so each workspace window remembers its own focus without touching
-    /// shared `AppState`.
-    @SceneStorage("insights.section") private var sectionRaw = InsightSection.receipts.rawValue
-
-    private var section: InsightSection {
-        InsightSection(rawValue: sectionRaw) ?? .receipts
-    }
-
     var body: some View {
-        ScrollViewReader { scroll in
+        GeometryReader { proxy in
+            let isWide = proxy.size.width >= WindowMetrics.twoColumnBreakpoint
+
             ScrollView {
-                VStack(alignment: .leading, spacing: Spacing.lg) {
-                    header
-
+                VStack(alignment: .leading, spacing: WindowMetrics.xl) {
+                    // Hero — the on-device spending insight + receipt, given the
+                    // full canvas width so it reads as the destination's headline
+                    // instrument (like the Dashboard's heatmap hero).
                     InsightsAIInsightView()
-                        .id(InsightSection.receipts)
 
-                    weeklyReviewSection
-                        .id(InsightSection.weeklyReview)
-
-                    InsightsTrendsView()
-                        .id(InsightSection.trends)
+                    if isWide {
+                        HStack(alignment: .top, spacing: WindowMetrics.columnGap) {
+                            trendsColumn
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                            reviewColumn
+                                .frame(maxWidth: .infinity, alignment: .topLeading)
+                        }
+                    } else {
+                        VStack(alignment: .leading, spacing: WindowMetrics.xl) {
+                            trendsColumn
+                            reviewColumn
+                        }
+                    }
                 }
-                .padding(Spacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(WindowMetrics.canvasMargin)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .scrollContentBackground(.hidden)
-            .onChange(of: sectionRaw) { _, raw in
-                guard let target = InsightSection(rawValue: raw) else { return }
-                withAnimation { scroll.scrollTo(target, anchor: .top) }
-            }
         }
         .navigationTitle(RouteDestination.insights.title)
         .accessibilityElement(children: .contain)
+        .task { await appState.loadInitialData() }
     }
 
-    // MARK: - Header
+    // MARK: - Columns
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            VStack(alignment: .leading, spacing: Spacing.xxs) {
-                Text("Insights")
-                    .font(.title2.weight(.bold))
-                Text("On-device spending summaries, your weekly review, and the trends behind them — all computed locally on this Mac.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-            .accessibilityElement(children: .combine)
-
-            sectionPicker
+    /// The left/primary **Trends** column — the three trend chart cards (net-worth
+    /// trend, spend donut, activity heatmap). Each self-cards as a ``WindowSection``
+    /// inside ``InsightsTrendsView``; the column banner above them is a `title2`
+    /// region header. Charts stay solid (never glass) and re-host the same Core
+    /// engines as the popover.
+    private var trendsColumn: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.lg) {
+            columnHeader("Trends", systemImage: "chart.xyaxis.line")
+            InsightsTrendsView()
         }
+        .accessibilityElement(children: .contain)
     }
 
-    /// Jumps the canvas to a band. Each segment carries a glyph **and** a label so
-    /// the selection is never conveyed by tint alone (ACCESSIBILITY.md).
-    private var sectionPicker: some View {
-        Picker("Insights section", selection: sectionBinding) {
-            ForEach(InsightSection.allCases, id: \.self) { section in
-                Label(sectionLabel(section), systemImage: sectionGlyph(section))
-                    .tag(section)
-            }
-        }
-        .pickerStyle(.segmented)
-        .labelStyle(.titleAndIcon)
-        .fixedSize()
-        .accessibilityLabel("Insights section")
-        .accessibilityHint("Jump to spending insights, the weekly review, or trends.")
-    }
-
-    private var sectionBinding: Binding<InsightSection> {
-        Binding(get: { section }, set: { sectionRaw = $0.rawValue })
-    }
-
-    private func sectionLabel(_ section: InsightSection) -> String {
-        switch section {
-        case .receipts: "Insights"
-        case .weeklyReview: "Weekly review"
-        case .trends: "Trends"
-        }
-    }
-
-    private func sectionGlyph(_ section: InsightSection) -> String {
-        switch section {
-        case .receipts: "sparkles"
-        case .weeklyReview: "calendar.badge.checkmark"
-        case .trends: "chart.xyaxis.line"
-        }
-    }
-
-    // MARK: - Weekly review
-
-    private var weeklyReviewSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            Label("Weekly review", systemImage: "calendar.badge.checkmark")
-                .sectionTitle()
-                .foregroundStyle(.secondary)
-            // The existing card, re-hosted unchanged — same review state as the
-            // menu-bar popover, so the two surfaces can never diverge.
+    /// The right/secondary **Review** column — the weekly review, re-hosted
+    /// unchanged so this surface and the popover drive the same review state.
+    private var reviewColumn: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.lg) {
+            columnHeader("Review", systemImage: "calendar.badge.checkmark")
             WeeklyReviewCard()
         }
         .accessibilityElement(children: .contain)
+    }
+
+    /// A window-scale **column** region header (`title2` via ``WindowSectionTitle``)
+    /// — one step up from a card's `title3` title, so the column reads as a region
+    /// grouping its cards. A heading, not a card, so it sits cleanly above the
+    /// self-carding cards below without nesting a card in a card.
+    private func columnHeader(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title).windowSectionTitle()
+        } icon: {
+            Image(systemName: systemImage).foregroundStyle(.secondary)
+        }
+        .labelStyle(.titleAndIcon)
+        .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
@@ -1,12 +1,13 @@
 import PlaidBarCore
 import SwiftUI
 
-/// The **Trends** band of the Insights destination (Epic 7 / AND-585) — the
-/// chart canvas. It re-hosts the existing, unchanged chart components and gives
-/// each one its audio graph + a `reduceTransparency` text fallback + a non-color
-/// alternative (ACCESSIBILITY.md). **Liquid Glass never touches a chart** — the
-/// charts render on the standard raised card chrome (a `.clear`-fill surface), and
-/// the marks themselves carry no material.
+/// The **Trends** column of the Insights window canvas (Epic 7 / AND-585; AND-624) —
+/// the chart cards. It re-hosts the existing, unchanged chart components at the
+/// window (desk-distance) scale and gives each one its audio graph + a
+/// `reduceTransparency` text fallback + a non-color alternative (ACCESSIBILITY.md).
+/// **Liquid Glass never touches a chart** — each chart sits on a quiet, *solid*
+/// ``WindowSection`` card (ADR-001: data stays solid), and the marks carry no
+/// material.
 ///
 /// - **Net worth trend** — ``BalanceTrendChart`` over ``BalanceTrend/evaluate``,
 ///   self-hides until there is enough recorded history to draw a line.
@@ -15,6 +16,9 @@ import SwiftUI
 /// - **Activity heatmap** — a read-only year heatmap built from the existing
 ///   ``SpendingHeatmapLayout`` Core engine + ``ChartAudioGraph/heatmap`` audio
 ///   graph (AND-569), with a Reduce Transparency / Privacy Mask text alternative.
+///
+/// At most three cards, so the column reads as calm comfortable density rather than
+/// a tight stack (AND-624).
 struct InsightsTrendsView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -23,7 +27,7 @@ struct InsightsTrendsView: View {
     private var isMasked: Bool { appState.shouldMaskFinancialValues }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.lg) {
+        VStack(alignment: .leading, spacing: WindowMetrics.lg) {
             netWorthTrendSection
             spendingByCategorySection
             activityHeatmapSection
@@ -35,27 +39,23 @@ struct InsightsTrendsView: View {
     @ViewBuilder
     private var netWorthTrendSection: some View {
         if let trend = BalanceTrend.evaluate(history: appState.balanceHistory) {
-            chartCard(
-                title: "Net worth trend",
-                systemImage: "chart.xyaxis.line"
-            ) {
+            WindowSection("Net worth trend", systemImage: "chart.xyaxis.line") {
+                // Direction is carried by the signed delta text + the VoiceOver
+                // summary, never by line color alone (ACCESSIBILITY.md).
+                Label(trend.deltaText, systemImage: directionGlyph(trend.direction))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(directionTint(trend.direction))
+                    .monospacedDigit()
+                    .accessibilityHidden(true)
+            } content: {
                 if isMasked {
                     maskedChartFallback(
                         message: "Net worth trend hidden while VaultPeek is private.",
-                        minHeight: 120
+                        minHeight: 160
                     )
                 } else {
-                    VStack(alignment: .leading, spacing: Spacing.xs) {
-                        // Direction is carried by the signed delta text + the
-                        // VoiceOver summary, never by line color alone.
-                        Label(trend.deltaText, systemImage: directionGlyph(trend.direction))
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(directionTint(trend.direction))
-                            .accessibilityHidden(true)
-
-                        BalanceTrendChart(trend: trend)
-                            .frame(minHeight: 120)
-                    }
+                    BalanceTrendChart(trend: trend)
+                        .frame(minHeight: 160)
                 }
             }
             .loadingRedaction(appState.loadState(for: .summaryCards))
@@ -84,10 +84,7 @@ struct InsightsTrendsView: View {
     private var spendingByCategorySection: some View {
         let presentation = appState.categoryDashboardPresentation
         if !presentation.isEmpty {
-            chartCard(
-                title: "Spending by category",
-                systemImage: "chart.pie"
-            ) {
+            WindowSection("Spending by category", systemImage: "chart.pie") {
                 SpendDonutChart(
                     model: SpendDonutModel(presentation: presentation),
                     isPrivacyMasked: isMasked
@@ -103,10 +100,10 @@ struct InsightsTrendsView: View {
     private var activityHeatmapSection: some View {
         let layout = heatmapLayout()
         if layout.activeDayCount > 0 {
-            chartCard(
-                title: layout.mode.summaryTitle,
-                systemImage: "square.grid.3x3.fill"
-            ) {
+            WindowSection(layout.mode.summaryTitle, systemImage: "square.grid.3x3.fill") {
+                Text("Last 365 days")
+                    .windowSupportingText()
+            } content: {
                 if isMasked || reduceTransparency {
                     // Reduce Transparency / Privacy Mask text alternative: the
                     // heatmap leans on tinted, translucent cells, so when either
@@ -138,45 +135,22 @@ struct InsightsTrendsView: View {
         let total = isMasked
             ? PrivacyMaskPresentation.compactValue
             : Formatters.currency(layout.totalValue, format: .compact)
-        return VStack(alignment: .leading, spacing: Spacing.xs) {
+        return VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
-                .font(.subheadline.weight(.medium))
+                .windowBodyText()
             Text(isMasked
                 ? "Activity totals are hidden while VaultPeek is private."
                 : "\(total) spent across active days. \(layout.mode.semanticDescription)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: WindowMetrics.heatmapHeroMinHeight, alignment: .topLeading)
         .accessibilityElement(children: .combine)
-    }
-
-    // MARK: - Card chrome
-
-    /// Standard raised card chrome for a chart section. The chart marks never get
-    /// a glass treatment; the card surface uses `.glassSurface(.raised)`, whose
-    /// `.raised` rank is a `.clear` fill (no material on the chart).
-    private func chartCard(
-        title: String,
-        systemImage: String,
-        @ViewBuilder content: () -> some View
-    ) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            Label(title, systemImage: systemImage)
-                .sectionTitle()
-                .foregroundStyle(.secondary)
-            content()
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(Spacing.md)
-        .glassSurface(.raised)
-        .accessibilityElement(children: .contain)
     }
 
     private func maskedChartFallback(message: String, minHeight: CGFloat) -> some View {
         Label(message, systemImage: "eye.slash")
-            .font(.subheadline)
+            .windowBodyText()
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, minHeight: minHeight, alignment: .leading)
             .accessibilityLabel(message)
@@ -184,21 +158,30 @@ struct InsightsTrendsView: View {
 }
 
 /// A read-only year activity heatmap grid built from the existing
-/// ``SpendingHeatmapLayout`` Core engine. It carries the ``ChartAudioGraph/heatmap``
-/// audio graph (AND-569) and a full text alternative via its VoiceOver label, so
-/// meaning never rides on cell color alone. No glass — cells are plain tinted
-/// rounded rects. Privacy Mask / Reduce Transparency callers swap this for a text
-/// summary upstream; this view is shown only when neither is active.
+/// ``SpendingHeatmapLayout`` Core engine, rendered at **desk-distance scale**
+/// (larger cells than the popover's glance-scale grid) so it reads as a comfortable
+/// window instrument. It carries the ``ChartAudioGraph/heatmap`` audio graph
+/// (AND-569) and a full text alternative via its VoiceOver label, so meaning never
+/// rides on cell color alone. No glass — cells are plain tinted rounded rects.
+/// Privacy Mask / Reduce Transparency callers swap this for a text summary upstream;
+/// this view is shown only when neither is active.
 struct InsightsActivityHeatmapGrid: View {
     let layout: SpendingHeatmapLayout
 
-    private let spacing: CGFloat = 2
+    private let spacing: CGFloat = 3
+    /// Desk-distance cell bounds — larger than the popover's 5...9pt glance cells so
+    /// the year grid reads as a comfortable window instrument, not a tiny strip.
+    private let minCell: CGFloat = 9
+    private let maxCell: CGFloat = 15
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             GeometryReader { proxy in
                 let weeks = max(layout.weekColumns.count, 1)
-                let cell = max(5, min(9, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks))))
+                let cell = max(
+                    minCell,
+                    min(maxCell, floor((proxy.size.width - (CGFloat(weeks - 1) * spacing)) / CGFloat(weeks)))
+                )
                 HStack(alignment: .top, spacing: spacing) {
                     ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { _, week in
                         VStack(spacing: spacing) {
@@ -210,7 +193,7 @@ struct InsightsActivityHeatmapGrid: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(height: 7 * 9 + 6 * spacing)
+            .frame(height: 7 * maxCell + 6 * spacing)
 
             legend
         }
@@ -237,24 +220,21 @@ struct InsightsActivityHeatmapGrid: View {
     }
 
     private var legend: some View {
-        HStack(spacing: 5) {
+        HStack(spacing: WindowMetrics.xs) {
             Text("Less")
-                .microText()
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
             ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { intensity in
                 RoundedRectangle(cornerRadius: Radius.cell)
                     .fill(Color.primary.opacity(0.12 + 0.6 * intensity))
-                    .frame(width: 8, height: 8)
+                    .frame(width: 11, height: 11)
             }
             Text("More")
-                .microText()
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
 
             Spacer()
 
             Text("\(layout.activeDayCount) active days")
-                .microText()
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
         }
         .accessibilityHidden(true)
     }


### PR DESCRIPTION
## What

Redesigns the **Insights** destination into a window-first **composed 2-column canvas** that matches the locked **Dashboard** reference design language (AND-624 / ADR-001 window-first workspace, IA §5.7).

Before: a single-column popover-scale stack (`Spacing.*`, `.sectionTitle()`, `.glassSurface(.raised)` on chart cards) with a segmented section picker.
After: a composed window canvas at desk-distance scale.

## Design changes

- **Hero**: the streaming Foundation Models spending-insight headline + the on-device `LocalAIInsightReceipt` (tier + provenance + consent), promoted to a prominent **full-width hero card** at the top — like the Dashboard's heatmap hero. The **off-by-default consent toggle stays visible** (AND-564); FM availability keeps its NaturalLanguage / deterministic fallback (AND-563).
- **Two-column grid (≤3 cards/column)** under `title2` column banners:
  - **Trends** (3 cards): net-worth trend, spend donut, activity heatmap — each now a quiet **solid `WindowSection`** card. Data stays solid; **Liquid Glass is on chrome only** (R-08). Charts keep their `AXChartDescriptor`/`ChartAudioGraph` audio graphs (AND-569) + `reduceTransparency` / Privacy Mask text fallbacks. No meaning on color alone (glyph + text everywhere).
  - **Review**: `WeeklyReviewCard` re-hosted unchanged (same review state as the popover).
- **Window-scale spacing & type** via `WindowMetrics` / `WindowTypography` (REUSED, not edited): ~20pt card padding, 28pt column gap, 32pt section gap, 8pt grid; `title2` banners, `title3` card + headline, body+ figures, tabular numerics. Never caption-scale primary figures.
- Scaled the namespaced `InsightsActivityHeatmapGrid` up to **desk-distance cells (9…15pt)** so the year grid reads as a comfortable window instrument, not a glance-scale strip.

## Reuse / data integrity

Surface-only re-host: reuses `LocalAIInsightsService`, `LocalAIInsightReceipt`, the existing charts, and the same `PlaidBarCore` engines as the popover. **No model or chart logic added** — the window and popover surfaces read the same Core and can never diverge.

## Scope / flag-off

Only the three Insights destination files changed (`InsightsDestinationView`, `InsightsAIInsightView`, `InsightsTrendsView`). No edits to `WindowMetrics`, `WindowSection`, `AppShellView`, `DestinationRouter`, `SnapshotRenderer`, the popover, or other destinations. All three files are **flag-OFF inert** — instantiated only when the window-first `Window` opens (`WindowFirstFeatureFlag` ON), so the popover build stays **byte-identical**.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — **2035 tests pass** (matches baseline).
- Headless render `--demo --render-window-first` — `window-insights.png` exit 0.

## Render self-assessment

The rendered canvas reads **calm and on-language with the Dashboard**: identical card surface, column-header style ("Trends"/"Review" mirror "Activity"/"Money & insights"), generous 8pt-grid rhythm, `title3` card headers, and solid chart surfaces. The hero is a single prominent full-width card (appropriate — the streaming insight is the destination's headline figure), and the columns hold ≤3 cards each. Density and type match the reference.

AND-624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)