### PR TITLE
feat(budgets): re-host Budgets to window-first desk-distance design (AND-624)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -1,34 +1,45 @@
 import PlaidBarCore
 import SwiftUI
 
-/// **Budgets** destination (3-column — IA §3.1/§5.4, `[⌘3]`).
+/// **Budgets** destination — window-first 3-column surface (AND-624; ADR-001
+/// window-first workspace, IA §3.1/§5.4, `[⌘3]`).
 ///
-/// Epic 5 / AND-583 (ADR-001 window-first workspace). The content column is the
-/// override-aware **category tree** (donut + two-level status-bar tree); the
-/// inspector column shows the **selected category's detail/editor** — re-hosting
-/// `BudgetEditorSheet` — plus an overall month **status** rollup.
+/// Re-hosted to the **desk-distance design language** the Dashboard reference set
+/// (``WindowMetrics`` / ``WindowTypography`` / ``WindowSection`` /
+/// ``WindowHeroMetricTile``): a calm content canvas — a **hero metric row**
+/// (total budget / spent / left) above two generous ``WindowSection`` cards (the
+/// **spend donut** as the prominent hero visual, then the override-aware
+/// **category tree**) — paired with a window-scale **inspector** (overall month
+/// status rollup + the selected category's detail/editor).
 ///
-/// Everything is surfaced from existing engines — no new aggregation lives here:
+/// **Data is re-hosted, not recomputed** — every figure comes from the same Core
+/// engines the popover uses; only the layout differs (R: re-host data, redesign
+/// layout):
 /// - `AppState.categoryDashboardPresentation` (built by `CategoryDashboardBuilder`
 ///   over `CategoryBudgetPlanner.netSpendByCategory`, override-aware) drives the
 ///   donut + tree.
-/// - `CategoryTreeView` / `SpendDonutChart` / `CategoryStatusBar` render it.
+/// - `CategoryTreeView` / `SpendDonutChart` / `CategoryStatusBar` render it unchanged.
 /// - `BudgetEditorSheet` is re-hosted for inline-editable category budgets.
-/// - `BudgetsStatusSummary` (new pure Core, unit-tested) reduces the rollup into
-///   the status pane.
+/// - `BudgetsStatusSummary` reduces the rollup into the hero row + status pane.
 ///
-/// Budget pressure (over/nearing) is always carried by **text + SF Symbol**, never
-/// color alone (ACCESSIBILITY.md). The content and inspector columns are separate
-/// split-view views, so they share selection through the per-window
-/// ``NavigationModel`` (`appState.navigationModel.budgetCategorySelection`) — a
-/// per-window value, never a singleton, so two windows hold independent Budgets
-/// selection (AND-621, R-10).
+/// **Never color alone (ACCESSIBILITY.md):** budget pressure (over / nearing) is
+/// always carried by **text + SF Symbol**; tint is layered redundantly on top.
+/// **Privacy Mask:** every figure runs through `PrivacyMaskPresentation`, so
+/// masked values stay dotted. **App Lock** is shell-gated (ADR-001 Epic 10), so
+/// this canvas never double-gates. Data/charts stay solid (R-08, glass on chrome
+/// only) via ``WindowSection``'s quiet card surface.
 ///
-/// Window-first surface only: reached solely when `AppShellView` mounts (behind
+/// The content and inspector columns are separate split-view views that share
+/// selection through the per-window ``NavigationModel``
+/// (`appState.navigationModel.budgetCategorySelection`) — a per-window value, never
+/// a singleton, so two windows hold independent Budgets selection (AND-621, R-10).
+///
+/// **Flag-OFF inert:** reached solely when `AppShellView` mounts (behind
 /// `WindowFirstFeatureFlag`, default OFF). With the flag off none of this is
-/// instantiated and the popover is byte-identical.
+/// instantiated and the popover stays byte-identical.
 struct BudgetsDestinationView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The category whose budget the user is editing; drives the re-hosted
     /// `BudgetEditorSheet` (AND-541 pattern, mirroring `CategoryDashboardWindow`).
     @State private var budgetEditorCategory: BudgetEditorCategory?
@@ -43,18 +54,17 @@ struct BudgetsDestinationView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.lg) {
-                header
-
+            VStack(alignment: .leading, spacing: WindowMetrics.xl) {
                 if presentation.isEmpty {
                     emptyState
                 } else {
+                    heroMetricsRow
                     donutSection
                     treeSection
                 }
             }
-            .padding(Spacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(WindowMetrics.canvasMargin)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .scrollContentBackground(.hidden)
         .navigationTitle(RouteDestination.budgets.title)
@@ -72,69 +82,194 @@ struct BudgetsDestinationView: View {
         budgetEditorCategory = BudgetEditorCategory(category)
     }
 
-    // MARK: - Header
+    // MARK: - Hero metrics row
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: Spacing.xxs) {
-            Text("Budgets")
-                .font(.title2.weight(.bold))
-            Text("Set monthly limits and track this month's spending by category.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+    /// The headline month figures across the top of the canvas — budgeted total,
+    /// spent, and what's left (or over) — as large tabular ``WindowHeroMetricTile``
+    /// figures. Reflows to wrap on a narrow window so each figure keeps its tabular
+    /// legibility (`heroTileMinWidth`). Reduces a finished `BudgetsStatusSummary`,
+    /// no new aggregation. None rely on color for meaning (the label names the
+    /// figure; the "Left/Over" tile carries its sense in the label + glyph).
+    private var heroMetricsRow: some View {
+        let metrics = heroMetrics
+        return LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: WindowMetrics.heroTileMinWidth), spacing: WindowMetrics.lg)],
+            alignment: .leading,
+            spacing: WindowMetrics.lg
+        ) {
+            ForEach(metrics) { metric in
+                WindowHeroMetricTile(
+                    label: metric.label,
+                    value: metric.value,
+                    systemImage: metric.systemImage,
+                    detail: metric.detail,
+                    accent: metric.accent,
+                    reduceMotion: reduceMotion
+                )
+            }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Budget headline figures")
     }
 
-    // MARK: - Donut
+    /// One headline figure for the hero row. Pure presentation data derived from
+    /// the same `BudgetsStatusSummary` the inspector status pane uses.
+    private struct HeroMetric: Identifiable {
+        let id: String
+        let label: String
+        let value: String
+        let systemImage: String
+        let detail: String?
+        let accent: Color
+    }
 
+    private var heroMetrics: [HeroMetric] {
+        let summary = BudgetsStatusSummary.summarize(presentation)
+        let masked = isMasked
+
+        let budgeted = HeroMetric(
+            id: "budgeted",
+            label: "Budgeted this month",
+            value: heroCurrency(summary.totalLimit, masked: masked),
+            systemImage: "slider.horizontal.3",
+            detail: budgetedDetail(summary),
+            accent: SemanticColors.brand
+        )
+
+        let spent = HeroMetric(
+            id: "spent",
+            label: "Spent",
+            value: heroCurrency(summary.totalSpent, masked: masked),
+            systemImage: "creditcard",
+            detail: spentDetail(summary),
+            accent: .secondary
+        )
+
+        // The third tile flips its identity (and glyph) with the verdict — never
+        // color alone: the label says "Left this month" vs "Over budget".
+        let remainingTile: HeroMetric
+        if let remaining = summary.remaining {
+            remainingTile = HeroMetric(
+                id: "remaining",
+                label: summary.isAggregateOver ? "Over budget" : "Left this month",
+                value: heroCurrency(abs(remaining), masked: masked),
+                systemImage: summary.isAggregateOver ? "exclamationmark.triangle.fill" : "checkmark.circle",
+                detail: remainingDetail(summary),
+                accent: summary.isAggregateOver ? SemanticColors.negative : SemanticColors.positive
+            )
+        } else {
+            remainingTile = HeroMetric(
+                id: "remaining",
+                label: "No budgets set",
+                value: "—",
+                systemImage: "slider.horizontal.3",
+                detail: "Add a limit to a category to start tracking",
+                accent: .secondary
+            )
+        }
+
+        return [budgeted, spent, remainingTile]
+    }
+
+    private func budgetedDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
+        guard summary.budgetedCount > 0 else { return "No category budgets yet" }
+        return "Across \(summary.budgetedCount) of \(summary.trackedCount) categories"
+    }
+
+    /// Detail for the aggregate "Left / Over" tile. Describes the *aggregate*
+    /// position (the figure's own sense), not the per-category band, so the tile
+    /// never reads "Left this month … Over budget".
+    private func remainingDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
+        if summary.isAggregateOver {
+            return "Spending exceeds your budgeted total"
+        }
+        if summary.overBudgetCount > 0 {
+            return summary.overBudgetCount == 1
+                ? "Still room overall, but 1 category is over"
+                : "Still room overall, but \(summary.overBudgetCount) categories are over"
+        }
+        return "Remaining across your budgeted total"
+    }
+
+    private func spentDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
+        if summary.overBudgetCount > 0 {
+            return summary.overBudgetCount == 1
+                ? "1 category over its limit"
+                : "\(summary.overBudgetCount) categories over their limit"
+        }
+        if summary.nearingCount > 0 {
+            return summary.nearingCount == 1
+                ? "1 category nearing its limit"
+                : "\(summary.nearingCount) categories nearing a limit"
+        }
+        return "This month, all categories"
+    }
+
+    /// Hero figures use the compact masked-aware currency the Dashboard hero row
+    /// uses, so the two destinations' headline numbers read identically.
+    private func heroCurrency(_ amount: Double, masked: Bool) -> String {
+        PrivacyMaskPresentation.currency(amount, format: .compact, isEnabled: masked)
+    }
+
+    // MARK: - Donut (hero visual)
+
+    /// The spend donut — the destination's prominent hero visual, given its own
+    /// titled ``WindowSection`` card so it reads as the signature instrument rather
+    /// than a small chart stuck to the tree.
     private var donutSection: some View {
         let donut = SpendDonutModel(presentation: presentation)
-        return VStack(alignment: .leading, spacing: Spacing.sm) {
+        return WindowSection("Spending by category", systemImage: "chart.pie") {
+            CategoryCountAccessory(count: presentation.leaves.count)
+        } content: {
             SpendDonutChart(model: donut, isPrivacyMasked: isMasked)
+                .frame(maxWidth: .infinity)
         }
-        .padding(Spacing.md)
-        .glassSurface(.raised)
     }
 
     // MARK: - Tree
 
+    /// The override-aware two-level category tree. Tapping a leaf's budget
+    /// affordance selects it for the inspector and opens the editor; the inspector
+    /// reflects the selection independently.
     private var treeSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            Label("By group", systemImage: "list.bullet.indent")
-                .sectionTitle()
-                .foregroundStyle(.secondary)
-            // Tapping a leaf's budget affordance selects it for the inspector and
-            // opens the editor; the inspector reflects the selection independently.
+        WindowSection("By group", systemImage: "list.bullet.indent") {
             CategoryTreeView(
                 presentation: presentation,
                 privacyMaskEnabled: isMasked,
                 onEditBudget: selectAndEdit
             )
         }
-        .padding(Spacing.md)
-        .glassSurface(.raised)
     }
 
     // MARK: - Empty state
 
     private var emptyState: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-            Label("No category spending yet", systemImage: "chart.pie")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("Budgets and spending appear here once this month's transactions arrive.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        WindowSection("Spending by category", systemImage: "chart.pie") {
+            ContentUnavailableView {
+                Label("No category spending yet", systemImage: "chart.pie")
+            } description: {
+                Text("Budgets and spending appear here once this month's transactions arrive.")
+            }
+            .frame(maxWidth: .infinity, minHeight: 220)
         }
-        .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
-        .multilineTextAlignment(.center)
-        .padding(Spacing.lg)
-        .glassSurface(.raised)
     }
 
-    /// The detail-column (inspector) pane for Budgets: the selected category's
-    /// detail/editor plus the overall month status rollup. Content-gated — shows
-    /// the "Select a category" prompt when nothing is selected (IA §3.1).
+    /// A small trailing header count for a ``WindowSection``, naming the figure in
+    /// text (never count-by-position alone).
+    private struct CategoryCountAccessory: View {
+        let count: Int
+        var body: some View {
+            Text(count == 1 ? "1 category" : "\(count) categories")
+                .windowSupportingText()
+                .monospacedDigit()
+                .accessibilityLabel("\(count) categories tracked")
+        }
+    }
+
+    /// The detail-column (inspector) pane for Budgets at window scale: the overall
+    /// month **status** rollup, then the selected category's detail/editor. Content
+    /// -gated — shows the "Select a category" prompt when nothing is selected
+    /// (IA §3.1). Re-hosts the same Core engines as the content column.
     struct Inspector: View {
         @Environment(AppState.self) private var appState
         @State private var budgetEditorCategory: BudgetEditorCategory?
@@ -149,7 +284,7 @@ struct BudgetsDestinationView: View {
 
         var body: some View {
             ScrollView {
-                VStack(alignment: .leading, spacing: Spacing.lg) {
+                VStack(alignment: .leading, spacing: WindowMetrics.lg) {
                     statusSection
 
                     if let category = navigationModel.budgetCategorySelection {
@@ -158,8 +293,8 @@ struct BudgetsDestinationView: View {
                         selectionPrompt
                     }
                 }
-                .padding(Spacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(WindowMetrics.canvasMargin)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .scrollContentBackground(.hidden)
             .sheet(item: $budgetEditorCategory) { item in
@@ -173,18 +308,14 @@ struct BudgetsDestinationView: View {
 
         private var statusSection: some View {
             let summary = BudgetsStatusSummary.summarize(presentation)
-            return VStack(alignment: .leading, spacing: Spacing.sm) {
-                Label("Status", systemImage: "gauge.with.dots.needle.33percent")
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
+            return WindowSection("Status", systemImage: "gauge.with.dots.needle.33percent") {
+                VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+                    // Headline verdict: glyph + label, tint redundant (ACCESSIBILITY.md).
+                    Label(summary.health.label, systemImage: summary.health.iconName)
+                        .windowCardTitle()
+                        .foregroundStyle(healthTint(summary.health))
+                        .accessibilityLabel("Budget status: \(summary.health.label)")
 
-                // Headline verdict: glyph + label, tint redundant (ACCESSIBILITY.md).
-                Label(summary.health.label, systemImage: summary.health.iconName)
-                    .font(.headline)
-                    .foregroundStyle(healthTint(summary.health))
-                    .accessibilityLabel("Budget status: \(summary.health.label)")
-
-                VStack(alignment: .leading, spacing: Spacing.xs) {
                     statusStat(
                         "Over budget",
                         "\(summary.overBudgetCount)",
@@ -200,38 +331,36 @@ struct BudgetsDestinationView: View {
                         "\(summary.budgetedCount) of \(summary.trackedCount)",
                         systemImage: "slider.horizontal.3"
                     )
-                }
 
-                if let remaining = summary.remaining {
-                    Divider().opacity(0.4)
-                    HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
-                        Label(
-                            summary.isAggregateOver ? "Over by" : "Left this month",
-                            systemImage: summary.isAggregateOver ? "minus.circle" : "plus.circle"
-                        )
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        Spacer(minLength: Spacing.sm)
-                        Text(currency(abs(remaining)))
-                            .font(.callout.weight(.semibold))
-                            .monospacedDigit()
-                            .foregroundStyle(summary.isAggregateOver ? SemanticColors.negative : .primary)
+                    if let remaining = summary.remaining {
+                        Divider().opacity(0.4)
+                        HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
+                            Label(
+                                summary.isAggregateOver ? "Over by" : "Left this month",
+                                systemImage: summary.isAggregateOver ? "minus.circle" : "plus.circle"
+                            )
+                            .windowSupportingText()
+                            Spacer(minLength: WindowMetrics.sm)
+                            Text(currency(abs(remaining)))
+                                .windowBodyText()
+                                .fontWeight(.semibold)
+                                .monospacedDigit()
+                                .foregroundStyle(summary.isAggregateOver ? SemanticColors.negative : .primary)
+                        }
+                        .accessibilityElement(children: .combine)
                     }
-                    .accessibilityElement(children: .combine)
                 }
             }
-            .padding(Spacing.md)
-            .glassSurface(.raised)
         }
 
         private func statusStat(_ label: String, _ value: String, systemImage: String) -> some View {
-            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
                 Label(label, systemImage: systemImage)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: Spacing.sm)
+                    .windowSupportingText()
+                Spacer(minLength: WindowMetrics.sm)
                 Text(value)
-                    .font(.callout.weight(.semibold))
+                    .windowBodyText()
+                    .fontWeight(.semibold)
                     .monospacedDigit()
             }
             .accessibilityElement(children: .combine)
@@ -242,41 +371,27 @@ struct BudgetsDestinationView: View {
 
         private func categoryDetail(_ category: SpendingCategory) -> some View {
             let leaf = presentation.leaf(category)
-            return VStack(alignment: .leading, spacing: Spacing.sm) {
-                HStack(spacing: Spacing.sm) {
-                    Image(systemName: category.iconName)
-                        .font(.title3)
-                        .foregroundStyle(CategoryAccentTokens.color(for: category))
-                        .frame(width: 28)
-                        .accessibilityHidden(true)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(category.displayName)
-                            .font(.headline)
-                        Text(category.group.title)
-                            .font(.caption)
+            return WindowSection(category.displayName, systemImage: category.iconName) {
+                Text(category.group.title)
+                    .windowSupportingText()
+            } content: {
+                VStack(alignment: .leading, spacing: WindowMetrics.md) {
+                    if let leaf {
+                        CategoryStatusBar(
+                            model: CategoryStatusBarModel(leaf: leaf),
+                            spentText: currency(leaf.spent),
+                            limitText: leaf.monthlyLimit.map(currency),
+                            accent: CategoryAccentTokens.color(for: category)
+                        )
+                    } else {
+                        Label("No spending or budget yet this month", systemImage: "tray")
+                            .windowBodyText()
                             .foregroundStyle(.secondary)
                     }
-                    Spacer(minLength: Spacing.sm)
-                }
-                .accessibilityElement(children: .combine)
 
-                if let leaf {
-                    CategoryStatusBar(
-                        model: CategoryStatusBarModel(leaf: leaf),
-                        spentText: currency(leaf.spent),
-                        limitText: leaf.monthlyLimit.map(currency),
-                        accent: CategoryAccentTokens.color(for: category)
-                    )
-                } else {
-                    Label("No spending or budget yet this month", systemImage: "tray")
-                        .microText()
-                        .foregroundStyle(.secondary)
+                    editBudgetButton(for: category)
                 }
-
-                editBudgetButton(for: category)
             }
-            .padding(Spacing.md)
-            .glassSurface(.raised)
         }
 
         @ViewBuilder
@@ -291,15 +406,14 @@ struct BudgetsDestinationView: View {
                         .labelStyle(.titleAndIcon)
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
+                .controlSize(.large)
                 .accessibilityLabel(affordance.accessibilityLabel)
             } else {
                 Label(
                     "Income and transfer categories can't have a budget.",
                     systemImage: "info.circle"
                 )
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .windowSupportingText()
             }
         }
 


### PR DESCRIPTION
## What

Re-hosts the window-first **Budgets** destination (3-col list→inspector) into the locked macOS 26 **desk-distance design language** the Dashboard reference established (`WindowMetrics` / `WindowTypography` / `WindowSection` / `WindowHeroMetricTile`), replacing the prior popover-scale `Spacing` + `glassSurface` layout. AND-624.

## Design changes

**Content column** — calm composed canvas (≤3 elements, generous `WindowMetrics` 8pt-grid rhythm):
- **Hero metric row** — Budgeted this month / Spent / Left this month (flips to **Over budget** when aggregate is exceeded), large tabular `WindowHeroMetricTile` figures, reduced from the same `BudgetsStatusSummary` the inspector uses.
- **"Spending by category"** `WindowSection` — the spend donut as the prominent hero visual (its own titled card, not stuck to the tree).
- **"By group"** `WindowSection` — the override-aware `CategoryTreeView`.

**Inspector** — window scale:
- **"Status"** `WindowSection` — overall month rollup; over-budget verdict carried by **text + SF Symbol** (red tint redundant), `windowBodyText`/`windowSupportingText` stat rows.
- **Selected-category** `WindowSection` — `CategoryStatusBar` + re-hosted `BudgetEditorSheet`, or the "Select a category" prompt.

## Re-host, not recompute

All data comes from existing Core engines unchanged — only the layout differs: `CategoryDashboardBuilder` / `CategoryDashboardPresentation` / `BudgetsStatusSummary` / `CategoryTreeView` / `SpendDonutChart` / `CategoryStatusBar` / `BudgetEditorSheet`. Per-window `NavigationModel` selection preserved (AND-621, R-10). Privacy Mask honored on every figure; App Lock stays shell-gated (no double-gate). Never color alone (R: glyph+text). Data surfaces stay solid — glass on chrome only (R-08).

## Flag-OFF note

Reached only behind `WindowFirstFeatureFlag` (default OFF) via `AppShellView`. With the flag off none of this is instantiated and the popover stays byte-identical. Only `BudgetsDestinationView.swift` changed (no shared infra touched).

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean.
- `swift test` — 2035 passing (baseline).
- Rendered via `.build/debug/PlaidBar --demo --render-window-first` and inspected `window-budgets.png`.

## Render self-assessment

The canvas reads **calm and on-language**: hero metric row up top (Budgeted $4,370 / Spent $4,122 / Left $248), the donut as a prominent titled hero card, then the "By group" tree below — even `WindowMetrics` spacing throughout, body+ type, tabular figures. The inspector's Status card shows the **Over budget** verdict in text + triangle glyph (tint redundant) with the stat rows and "Left this month $247.79", above the selection prompt. Density and type match the Dashboard reference. The aggregate "Left/Over" tile's detail describes the aggregate position ("Still room overall, but 1 category is over") so it never contradicts the per-category band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)