### PR TITLE
test: fix wall-clock time-bomb in AttentionQueue spend-window tests (nightly QA 2026-06-20)

### DIFF
--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -244,7 +244,8 @@ struct AttentionQueueTests {
             ],
             lowCashThreshold: 100,
             largeTransactionThreshold: 500,
-            creditUtilizationThreshold: 30
+            creditUtilizationThreshold: 30,
+            now: Formatters.parseTransactionDate("2026-06-14")!
         )
 
         #expect(queue.rows.map(\.id) == [
@@ -338,7 +339,8 @@ struct AttentionQueueTests {
             ],
             lowCashThreshold: 100,
             largeTransactionThreshold: 500,
-            creditUtilizationThreshold: 30
+            creditUtilizationThreshold: 30,
+            now: Formatters.parseTransactionDate("2026-06-14")!
         )
         let belowWarnings = AttentionQueue.evaluate(
             isDemoMode: false,
@@ -360,7 +362,8 @@ struct AttentionQueueTests {
             ],
             lowCashThreshold: 100,
             largeTransactionThreshold: 500,
-            creditUtilizationThreshold: 30
+            creditUtilizationThreshold: 30,
+            now: Formatters.parseTransactionDate("2026-06-14")!
         )
 
         #expect(atThreshold.rows.map(\.id) == [

--- a/docs/qa-nightly/2026-06-20.md
+++ b/docs/qa-nightly/2026-06-20.md
@@ -1,0 +1,136 @@
+# Nightly Capability QA — 2026-06-20
+
+Automated nightly QA pass on VaultPeek (formerly PlaidBar). One realistic
+scenario per major capability, run under identical conditions, root-causing every
+failure until the quality bar is met.
+
+- **Branch:** `qa/nightly-capability-2026-06-20` (off `origin/main` @ `224417e`)
+- **Toolchain / conditions:** `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors --disable-keychain` then `swift test --skip-update --disable-keychain`; demo via `.build/debug/PlaidBar --demo --render-snapshot`; server via a credential-less `PlaidBarServer --sandbox` boot. Synthetic/demo data only — no real Plaid credentials, tokens, account IDs, or balances.
+- **App version under test:** 1.0.0
+
+## Quality bar (defined before running)
+
+> 100% of capability scenarios pass with zero strict-concurrency build warnings.
+
+**Evaluation method (one consistent method for the whole set):** deterministic
+pass/fail assertions. Each unit-level capability scenario passes only if its
+representative Swift Testing suite passes inside a single identical-conditions
+full `swift test` run (185 suites / 2035 tests). The two process-level scenarios
+(server surface, demo launch) pass only if every explicit assertion in their
+runner holds (HTTP codes, file permissions, allowed-key set, rendered output).
+
+## Result summary
+
+| Gate | Result |
+|------|--------|
+| Strict-concurrency build (`-warnings-as-errors`) | **PASS** — `Build complete! (20.71s)`, exit 0, **zero compiler warnings** |
+| Full test suite (`swift test`) | **PASS** — 2035 tests, 185 suites, **0 issues** (after fix) |
+| Capability scenarios | **13 / 13 PASS** |
+
+> Note on the lone manifest line: SwiftPM emits one cosmetic note —
+> `dependency 'async-http-client' is not used by any target`. This is **not** a
+> strict-concurrency compiler warning and is **intentional**: `async-http-client`
+> is pinned `exact: "1.33.1"` in `Package.swift` to hold the transitive resolution
+> on the Swift 6.0 baseline (1.34.0 dropped `Package@swift-6.0.swift`). The pin is
+> load-bearing; removing it would float the transitive graph and break resolution.
+> Left as-is. Compiler-warning count under the strict gate is zero.
+
+## Capabilities → scenarios → evidence
+
+N = 13 major capabilities derived from the current code (Core utilities/models,
+the `PlaidBarCache` target, the server surface, and the demo app process).
+
+| # | Capability | Scenario (expected outcome) | Representative suite / runner | Result |
+|---|------------|-----------------------------|-------------------------------|--------|
+| C1 | Account & balance summaries | Demo accounts reduce to correct net worth + balance mix; menu-bar summary text is derived, not raw | `Wealth summary presentation`, `MenuBarAnnouncement Tests` | PASS |
+| C2 | Transaction sync + cursor reduction | `added`+`modified` upsert by id, `removed` drop, and pending→posted dedupe yield a correct ordered set; staleness derived from last-sync | `Sync response payloads`, `Sync History Diff Tests`, `SyncStaleness Tests` | PASS |
+| C3 | Recurring-charge detection | Periodic merchants roll up to recurring commitments; insufficient history yields the empty state | `Recurring detector helpers`, `Recurring commitment rollup (AND-559)` | PASS |
+| C4 | Category/budget rollups & spend math | Override-aware (persisted-only) spend math; exclude/transfer decisions move SPENT/LEFT; suggested vs explicit budgets resolve correctly | `Override-aware spend math (AND-526)`, `Effective Category Resolver Tests`, `Category budget presentation` | PASS |
+| C5 | AI / local insights | Local insight receipt + Foundation Models structured insight + NL/FM merchant categorization stay local-only and deterministic | `Foundation Models Structured Insight Tests`, `NL Merchant Categorizer Tests`, `FM Merchant Categorizer Tests` | PASS |
+| C6 | Number / currency / date formatters | Currency, percent, relative-date, and transaction-date parsing format deterministically | `Formatters` | PASS |
+| C7 | Presentation & state mapping | Typed `Route` navigation + deep-link contract + status-readiness/connection presentation map correctly | `Route`, `Route destinations`, `StatusPanelText Tests`, `Dashboard status readiness` | PASS |
+| C8 | Attention-queue state surfacing | Recovery/sync/financial attention rows surface in deterministic priority order, threshold edges inclusive, spend window bounded; copy stays amount-free | `AttentionQueue Tests` | PASS *(fixed — see below)* |
+| C9 | Server surface (live) | `/health` open (200); `/api/status` fails closed without/with-wrong token (401) and returns metadata-only with a valid token; Plaid routes 503 naming missing creds; `auth-token` 0600, data dir 0700 | credential-less `PlaidBarServer --sandbox` runner | PASS |
+| C10 | Privacy & security (mask/lock) | Strong-mask formatter + privacy-mask presentation + App-Lock/Privacy-Mask window parity hide values without leaking figures | `Strong mask formatter`, `Privacy Mask Presentation Tests`, `Window-first App Lock / Privacy Mask parity (AND-588)` | PASS |
+| C11 | Goals (local-first) | Goal progress math, editor input validation, summary rollup, and local-first persistence behave deterministically | `Goal progress math (AND-606)`, `Goals local-first persistence (AND-606)`, `Goals summary rollup (AND-606)` | PASS |
+| C12 | SwiftData read-model cache (`PlaidBarCache`) | Disposable read-model + per-transaction cache store upsert/dedup and survive the clear-wins cold-start race | `Disposable SwiftData read-model cache store (AND-566)`, `Disposable per-transaction cache store (AND-567)`, `Read-model cache clear-wins race` | PASS |
+| C13 | Demo fixtures / app boot (live) | `--demo` boots with no Plaid/server/credentials and renders populated dashboard, three-column flyout, and settings surfaces | `--demo --render-snapshot` + `Demo Review / Budget Fixtures` | PASS |
+
+### C9 server-surface evidence (credential-less `--sandbox`, port 18585, isolated data dir)
+
+```
+S1 /health (unauth)                         -> HTTP 200
+S2 /api/status (no token)                   -> HTTP 401   (fails closed)
+S3 /api/status (wrong bearer)               -> HTTP 401   (rejected)
+auth-token perms -rw-------  data dir drwx------   (0600 / 0700)
+S4 /api/status (valid token)                -> HTTP 200, metadata only:
+   keys = [credentialsConfigured, environment, itemCount, storagePath,
+           syncReady, syncedItemCount, version]   credentialsConfigured=false
+S5 /api/accounts (valid token)              -> HTTP 503, body names PLAID_CLIENT_ID + PLAID_SECRET
+S6 forbidden-field scan of status JSON      -> FORBIDDEN KEYS: NONE
+```
+
+No tokens, account IDs, balances, or transactions are exposed by `/api/status`.
+
+### C13 demo-launch evidence
+
+```
+.build/debug/PlaidBar --demo --render-snapshot <dir>   -> exit 0
+  wrote render-dashboard.png            (2244x1988)
+  wrote render-flyout.png               (2244x1988)
+  wrote render-settings-appearance.png  (1120x1280)
+```
+
+Visual confirmation: the flyout render shows fully populated fixtures — net
+worth $17,604.24, balance mix, safe-to-spend, projected balance, recurring
+obligations, spending-by-category donut ($4,122.21) with budget rollups, spend
+heatmap, and the Review Inbox — i.e. a populated three-column workspace, not an
+empty state.
+
+## Root-cause fixes applied
+
+| File | Fix | One-line rationale |
+|------|-----|--------------------|
+| `Tests/PlaidBarCoreTests/AttentionQueueTests.swift` | Pin `now:` to `Formatters.parseTransactionDate("2026-06-14")!` at the three `AttentionQueue.evaluate(...)` call sites in `representsFinancialAttentionStatesInPriorityOrder` and `financialThresholdEdgesAreInclusiveWhereConfigured` | Remove a latent wall-clock dependency that made two tests time-bombs. |
+
+### Diagnosis (C8)
+
+On the first identical-conditions run, 3 of 2035 tests failed — all in
+`AttentionQueue Tests`:
+
+- `representsFinancialAttentionStatesInPriorityOrder` expected rows
+  `[financial-low-cash, financial-high-utilization, financial-unusual-spending]`
+  / menu-bar text `[Cash, Credit, Spend]` but got only the first two of each.
+- `financialThresholdEdgesAreInclusiveWhereConfigured` expected the at-threshold
+  case to include `financial-unusual-spending` but got only
+  `financial-high-utilization`.
+
+**Root cause — not a product bug.** The product code is correct and deterministic:
+`AttentionQueue.evaluate` bounds the "unusual spending" signal to a 7-day window
+(`unusualSpendingWindowDays = 7`) measured from `now` (default `Date()`). The
+test fixture `transaction(...)` is hardcoded to date `2026-06-12`. The two
+failing tests were the only spend-path tests that **omitted** the `now:` pin that
+their date-sensitive siblings already use (e.g. `now = parseTransactionDate("2026-06-14")`
+at lines 375/405/435). Run on **2026-06-20**, the window start was `2026-06-13`,
+so the `2026-06-12` fixture aged *out* of the window and the `Spend` row
+correctly disappeared — failing the (time-dependent) assertions.
+
+The fix pins `now` to a fixed clock so the fixture sits inside the window
+deterministically, exactly matching the established sibling-test pattern. No
+assertion was weakened or removed — the `Spend` row and its priority/menu-bar
+text remain fully asserted; the change only removes the wall-clock dependency
+that made the tests non-deterministic. This is consistent with the repo's
+"deterministic testing via injectable dependencies (no wall-clock deps)"
+convention.
+
+## Final state
+
+- **All green.** Strict-concurrency build: 0 compiler warnings. Full suite:
+  2035 tests / 185 suites / 0 issues. 13/13 capability scenarios pass.
+- One pre-existing latent defect found and fixed (C8 wall-clock time-bomb in two
+  `AttentionQueueTests`). No product-code changes were required; the product
+  behavior was already correct.
+- Working tree clean except the single intended test fix on the QA branch.
+- No blockers remaining.
+</content>
+</invoke>


### PR DESCRIPTION
## Nightly capability QA — 2026-06-20

Autonomous nightly QA pass: one realistic scenario per major VaultPeek capability, run under the CI gate (`swift build -strict-concurrency=complete -warnings-as-errors` + `swift test`), with every failure root-caused.

### Outcome
- **Strict-concurrency build:** clean, **0 compiler warnings**.
- **Full suite:** 2035 tests / 185 suites / **0 issues** (after the fix below).
- **13/13 capability scenarios pass** (account/balance summaries, sync+cursor reduction, recurring detection, override-aware budget/spend math, local AI insights, formatters, presentation/routing, attention-queue surfacing, live server surface, privacy/mask/lock, goals, SwiftData read-model cache, demo app boot).

Full report: `docs/qa-nightly/2026-06-20.md`.

### Root-cause fix
The initial gate run failed 3/2035 tests, all in `AttentionQueue Tests`. **Not a product bug** — `AttentionQueue.evaluate` bounds the "unusual spending" signal to a 7-day window from `now` (default `Date()`), and two tests exercised that path with a hardcoded `2026-06-12` fixture while omitting the `now:` pin their date-sensitive siblings already use. Run on 2026-06-20, the fixture aged out of the window and the `Spend` row correctly disappeared, failing the time-dependent assertions.

Fix: pin `now:` to `Formatters.parseTransactionDate("2026-06-14")!` at the three `evaluate(...)` call sites — matching the established sibling pattern and the repo's "no wall-clock deps" testing convention. Product code unchanged; no assertion weakened (the `Spend` row stays fully asserted).

### Live scenario evidence
- **Server surface** (credential-less `--sandbox`): `/health` 200; `/api/status` 401 without/with-wrong token; 200 + metadata-only with a valid token (zero forbidden keys, `credentialsConfigured=false`); `/api/accounts` 503 naming both missing creds; `auth-token` 0600, data dir 0700.
- **Demo launch**: `--demo --render-snapshot` exits 0 and renders a populated dashboard / three-column flyout / settings, no Plaid or credentials.

Synthetic/demo data only — no real Plaid credentials, tokens, account IDs, or balances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)