### PR TITLE
fix(privacy): mask goal progress ratios

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
@@ -101,7 +101,7 @@ struct GoalsDestinationView: View {
                 )
                 WindowHeroMetricTile(
                     label: "Overall progress",
-                    value: "\(summary.overallPercent)%",
+                    value: percent(summary.overallPercent),
                     systemImage: "chart.bar.fill",
                     detail: remainingDetail(summary),
                     accent: SemanticColors.positive,
@@ -111,7 +111,11 @@ struct GoalsDestinationView: View {
             .accessibilityElement(children: .contain)
             .accessibilityLabel(summaryAccessibilityLabel(summary))
 
-            GoalsOverallProgressBar(fraction: summary.overallFraction, isComplete: false)
+            GoalsOverallProgressBar(
+                fraction: summary.overallFraction,
+                isComplete: false,
+                isMasked: isMasked
+            )
         }
     }
 
@@ -136,7 +140,7 @@ struct GoalsDestinationView: View {
     }
 
     private func summaryAccessibilityLabel(_ summary: GoalsSummary) -> String {
-        var parts = ["Goals summary", "\(summary.overallPercent) percent overall"]
+        var parts = ["Goals summary", "\(percent(summary.overallPercent)) overall"]
         parts.append("\(currency(summary.totalSaved)) saved of \(currency(summary.totalTarget)) target")
         if summary.fundedCount > 0 { parts.append("\(summary.fundedCount) funded") }
         if summary.behindCount > 0 { parts.append("\(summary.behindCount) behind pace") }
@@ -205,6 +209,10 @@ struct GoalsDestinationView: View {
 
     private func currency(_ amount: Double) -> String {
         PrivacyMaskPresentation.currency(amount, format: .compact, isEnabled: isMasked)
+    }
+
+    private func percent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
     }
 
     /// The detail-column (inspector) pane for Goals — the selected goal's detail,
@@ -296,12 +304,12 @@ private struct GoalListRow: View {
 
                     Spacer(minLength: WindowMetrics.sm)
 
-                    Text("\(goal.percentComplete)%")
+                    Text(percent(goal.percentComplete))
                         .font(.title3.weight(.semibold).monospacedDigit())
                         .foregroundStyle(.primary)
                 }
 
-                GoalProgressBar(goal: goal)
+                GoalProgressBar(goal: goal, isMasked: isMasked)
 
                 paceLabel
             }
@@ -338,7 +346,7 @@ private struct GoalListRow: View {
     }
 
     private var accessibilityLabel: String {
-        var parts = ["\(goal.name), \(goal.percentComplete) percent funded"]
+        var parts = ["\(goal.name), \(percent(goal.percentComplete)) funded"]
         parts.append("\(currency(goal.contributedAmount)) of \(currency(goal.targetAmount))")
         if goal.isComplete {
             parts.append("Funded")
@@ -352,6 +360,10 @@ private struct GoalListRow: View {
     private func currency(_ amount: Double) -> String {
         PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: isMasked, style: .compact)
     }
+
+    private func percent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
+    }
 }
 
 // MARK: - Progress bars
@@ -361,12 +373,21 @@ private struct GoalListRow: View {
 /// color-independent (ACCESSIBILITY.md).
 private struct GoalProgressBar: View {
     let goal: Goal
+    let isMasked: Bool
 
+    @ViewBuilder
     var body: some View {
-        ProgressView(value: goal.fractionComplete)
-            .progressViewStyle(.linear)
-            .tint(goal.isComplete ? SemanticColors.positive : SemanticColors.brand)
-            .accessibilityHidden(true)
+        if isMasked {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .tint(.secondary)
+                .accessibilityHidden(true)
+        } else {
+            ProgressView(value: goal.fractionComplete)
+                .progressViewStyle(.linear)
+                .tint(goal.isComplete ? SemanticColors.positive : SemanticColors.brand)
+                .accessibilityHidden(true)
+        }
     }
 }
 
@@ -375,12 +396,21 @@ private struct GoalProgressBar: View {
 private struct GoalsOverallProgressBar: View {
     let fraction: Double
     let isComplete: Bool
+    let isMasked: Bool
 
+    @ViewBuilder
     var body: some View {
-        ProgressView(value: fraction)
-            .progressViewStyle(.linear)
-            .tint(isComplete ? SemanticColors.positive : SemanticColors.brand)
-            .accessibilityHidden(true)
+        if isMasked {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .tint(.secondary)
+                .accessibilityHidden(true)
+        } else {
+            ProgressView(value: fraction)
+                .progressViewStyle(.linear)
+                .tint(isComplete ? SemanticColors.positive : SemanticColors.brand)
+                .accessibilityHidden(true)
+        }
     }
 }
 
@@ -441,10 +471,10 @@ private struct GoalDetailPane: View {
                 .minimumScaleFactor(0.6)
                 .accessibilityLabel("Saved \(currency(goal.contributedAmount))")
 
-            GoalProgressBar(goal: goal)
+            GoalProgressBar(goal: goal, isMasked: isMasked)
 
             HStack(alignment: .firstTextBaseline) {
-                Text("\(goal.percentComplete)% funded")
+                Text("\(percent(goal.percentComplete)) funded")
                     .windowBodyText()
                     .fontWeight(.semibold)
                     .monospacedDigit()
@@ -533,6 +563,10 @@ private struct GoalDetailPane: View {
 
     private func currency(_ amount: Double) -> String {
         PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: isMasked, style: .compact)
+    }
+
+    private func percent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
     }
 
     private static let dateFormatter: DateFormatter = {

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -315,13 +315,20 @@ struct PlanningDestinationView: View {
 
     private func goalsOverview(_ summary: GoalsSummary) -> some View {
         VStack(alignment: .leading, spacing: WindowMetrics.sm) {
-            ProgressView(value: summary.overallFraction)
-                .progressViewStyle(.linear)
-                .tint(SemanticColors.brand)
-                .accessibilityHidden(true)
+            if isMasked {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .tint(.secondary)
+                    .accessibilityHidden(true)
+            } else {
+                ProgressView(value: summary.overallFraction)
+                    .progressViewStyle(.linear)
+                    .tint(SemanticColors.brand)
+                    .accessibilityHidden(true)
+            }
 
             HStack(alignment: .firstTextBaseline) {
-                Text("\(summary.overallPercent)% of total")
+                Text("\(goalsPercent(summary.overallPercent)) of total")
                     .windowBodyText()
                     .fontWeight(.semibold)
                     .monospacedDigit()
@@ -348,7 +355,7 @@ struct PlanningDestinationView: View {
 
     private func goalsAccessibilityLabel(_ summary: GoalsSummary) -> String {
         guard !summary.isEmpty else { return "Goals: no goals yet." }
-        var parts = ["Goals: \(summary.overallPercent) percent of total saved across \(summary.goalCount) goal\(summary.goalCount == 1 ? "" : "s")"]
+        var parts = ["Goals: \(goalsPercent(summary.overallPercent)) of total saved across \(summary.goalCount) goal\(summary.goalCount == 1 ? "" : "s")"]
         if summary.fundedCount > 0 { parts.append("\(summary.fundedCount) funded") }
         if summary.behindCount > 0 { parts.append("\(summary.behindCount) behind") }
         return parts.joined(separator: ". ")
@@ -356,6 +363,10 @@ struct PlanningDestinationView: View {
 
     private func goalsCurrency(_ amount: Double) -> String {
         PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: isMasked, style: .compact)
+    }
+
+    private func goalsPercent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
     }
 
     // MARK: - Hero metric data (surface-only; reuses Core engines)

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -86,6 +86,32 @@ struct PlaidBarTests {
         #expect(Set(pngs) == expected, "got PNGs: \(pngs)")
     }
 
+    @Test("Window-first Goals and Planning mask amount-derived progress while Privacy Mask is active")
+    func windowFirstGoalsProgressUsesPrivacyMask() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let goalsSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift"),
+            encoding: .utf8
+        )
+        let planningSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift"),
+            encoding: .utf8
+        )
+
+        #expect(!goalsSource.contains(#"\(summary.overallPercent)%"#))
+        #expect(!goalsSource.contains(#"\(goal.percentComplete)%"#))
+        #expect(goalsSource.contains("percent(summary.overallPercent)"))
+        #expect(goalsSource.contains("percent(goal.percentComplete)"))
+        #expect(goalsSource.contains("GoalProgressBar(goal: goal, isMasked: isMasked)"))
+        #expect(goalsSource.contains("GoalsOverallProgressBar("))
+        #expect(goalsSource.contains("isMasked: isMasked"))
+
+        #expect(!planningSource.contains(#"\(summary.overallPercent)% of total"#))
+        #expect(planningSource.contains("goalsPercent(summary.overallPercent)"))
+        #expect(planningSource.contains("if isMasked"))
+        #expect(planningSource.contains("ProgressView(value: summary.overallFraction)"))
+    }
+
     // MARK: - Account Type Categorization
 
     @Test("AccountDTO types correctly categorized")


### PR DESCRIPTION
## Summary

Fixes #613 / AND-626.

- Masks amount-derived Goals progress percentages in the window-first Goals hero, rows, inspector, and accessibility labels.
- Masks the Planning goals overview percentage and accessibility label.
- Withholds exact determinate progress geometry while Privacy Mask / App Lock is active by rendering neutral/indeterminate progress indicators instead of exact goal fractions.
- Adds a source-level regression guard because the SwiftUI app executable target cannot be imported directly by tests.

## Privacy/Security

Local UI disclosure fix only. No Plaid credentials, provider tokens, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies are moved or printed. Counts remain visible; amount-derived ratios/fractions are masked.

## Verification

Passed:

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
root=Path.cwd()
goals=(root/'Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift').read_text()
planning=(root/'Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift').read_text()
checks={
 'goals no raw summary percent': r'\\(summary.overallPercent)%' not in goals,
 'goals no raw goal percent': r'\\(goal.percentComplete)%' not in goals,
 'goals masks summary percent': 'percent(summary.overallPercent)' in goals,
 'goals masks goal percent': 'percent(goal.percentComplete)' in goals,
 'goals progress receives mask': 'GoalProgressBar(goal: goal, isMasked: isMasked)' in goals,
 'planning no raw summary percent text': r'\\(summary.overallPercent)% of total' not in planning,
 'planning masks summary percent': 'goalsPercent(summary.overallPercent)' in planning,
 'planning has masked progress branch': 'if isMasked' in planning and 'ProgressView(value: summary.overallFraction)' in planning,
}
for k,v in checks.items(): print(f'{k}: {v}')
raise SystemExit(0 if all(checks.values()) else 1)
PY
swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
```

Blocked by local toolchain (unrelated existing SwiftData macro gate):

```bash
swift test --filter windowFirstGoalsProgressUsesPrivacyMask -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
```

The command fails before the focused test can run because this machine is selected to `/Library/Developer/CommandLineTools` and no `/Applications/Xcode.app` exists; SwiftPM compiles `PlaidBarCache` and reports `external macro implementation type 'SwiftDataMacros.PersistentModelMacro' could not be found for macro 'Model()'` in `Sources/PlaidBarCache/CachedDashboardReadModel.swift` / `TransactionCacheStore.swift`.
