### PR TITLE
refactor: extract Budgets hero detail copy → PlaidBarCore

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -132,7 +132,7 @@ struct BudgetsDestinationView: View {
             label: "Budgeted this month",
             value: heroCurrency(summary.totalLimit, masked: masked),
             systemImage: "slider.horizontal.3",
-            detail: budgetedDetail(summary),
+            detail: summary.budgetedDetail,
             accent: SemanticColors.brand
         )
 
@@ -141,7 +141,7 @@ struct BudgetsDestinationView: View {
             label: "Spent",
             value: heroCurrency(summary.totalSpent, masked: masked),
             systemImage: "creditcard",
-            detail: spentDetail(summary),
+            detail: summary.spentDetail,
             accent: .secondary
         )
 
@@ -154,7 +154,7 @@ struct BudgetsDestinationView: View {
                 label: summary.isAggregateOver ? "Over budget" : "Left this month",
                 value: heroCurrency(abs(remaining), masked: masked),
                 systemImage: summary.isAggregateOver ? "exclamationmark.triangle.fill" : "checkmark.circle",
-                detail: remainingDetail(summary),
+                detail: summary.remainingDetail,
                 accent: summary.isAggregateOver ? SemanticColors.negative : SemanticColors.positive
             )
         } else {
@@ -169,40 +169,6 @@ struct BudgetsDestinationView: View {
         }
 
         return [budgeted, spent, remainingTile]
-    }
-
-    private func budgetedDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
-        guard summary.budgetedCount > 0 else { return "No category budgets yet" }
-        return "Across \(summary.budgetedCount) of \(summary.trackedCount) categories"
-    }
-
-    /// Detail for the aggregate "Left / Over" tile. Describes the *aggregate*
-    /// position (the figure's own sense), not the per-category band, so the tile
-    /// never reads "Left this month … Over budget".
-    private func remainingDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
-        if summary.isAggregateOver {
-            return "Spending exceeds your budgeted total"
-        }
-        if summary.overBudgetCount > 0 {
-            return summary.overBudgetCount == 1
-                ? "Still room overall, but 1 category is over"
-                : "Still room overall, but \(summary.overBudgetCount) categories are over"
-        }
-        return "Remaining across your budgeted total"
-    }
-
-    private func spentDetail(_ summary: BudgetsStatusSummary.Summary) -> String {
-        if summary.overBudgetCount > 0 {
-            return summary.overBudgetCount == 1
-                ? "1 category over its limit"
-                : "\(summary.overBudgetCount) categories over their limit"
-        }
-        if summary.nearingCount > 0 {
-            return summary.nearingCount == 1
-                ? "1 category nearing its limit"
-                : "\(summary.nearingCount) categories nearing a limit"
-        }
-        return "This month, all categories"
     }
 
     /// Hero figures use the compact masked-aware currency the Dashboard hero row

--- a/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
@@ -82,6 +82,44 @@ public enum BudgetsStatusSummary {
             guard budgetedCount > 0, totalLimit > 0 else { return nil }
             return min(1, max(0, totalSpent / totalLimit))
         }
+
+        /// Detail line under the "Budgeted this month" hero tile: how many
+        /// categories carry a budget out of those tracked, or a first-run prompt.
+        public var budgetedDetail: String {
+            guard budgetedCount > 0 else { return "No category budgets yet" }
+            return "Across \(budgetedCount) of \(trackedCount) categories"
+        }
+
+        /// Detail line under the "Spent" hero tile: surfaces the worst per-category
+        /// band (over → nearing → none), with grammatically correct singular/plural.
+        public var spentDetail: String {
+            if overBudgetCount > 0 {
+                return overBudgetCount == 1
+                    ? "1 category over its limit"
+                    : "\(overBudgetCount) categories over their limit"
+            }
+            if nearingCount > 0 {
+                return nearingCount == 1
+                    ? "1 category nearing its limit"
+                    : "\(nearingCount) categories nearing a limit"
+            }
+            return "This month, all categories"
+        }
+
+        /// Detail line under the aggregate "Left / Over" hero tile. Describes the
+        /// *aggregate* position (the figure's own sense), not the per-category band,
+        /// so the tile never reads "Left this month … Over budget".
+        public var remainingDetail: String {
+            if isAggregateOver {
+                return "Spending exceeds your budgeted total"
+            }
+            if overBudgetCount > 0 {
+                return overBudgetCount == 1
+                    ? "Still room overall, but 1 category is over"
+                    : "Still room overall, but \(overBudgetCount) categories are over"
+            }
+            return "Remaining across your budgeted total"
+        }
     }
 
     /// Reduce a finished dashboard rollup into the status summary.

--- a/Tests/PlaidBarCoreTests/BudgetsStatusSummaryDetailTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetsStatusSummaryDetailTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Pins the exact hero-tile detail copy derived by ``BudgetsStatusSummary/Summary``
+/// (extracted from `BudgetsDestinationView`'s inline `budgetedDetail` /
+/// `spentDetail` / `remainingDetail` helpers — AND-583 window-first Budgets).
+///
+/// These are golden-string tests: the strings are user-visible hero copy with
+/// singular/plural agreement, so every branch is pinned literally to guard the
+/// grammar against regression.
+@Suite("Budgets status summary detail copy")
+struct BudgetsStatusSummaryDetailTests {
+    /// Build a `Summary` with overridable fields; defaults describe an empty,
+    /// budget-free month so each test only sets the fields its branch depends on.
+    private func summary(
+        health: BudgetsStatusSummary.Health = .noBudgets,
+        overBudgetCount: Int = 0,
+        nearingCount: Int = 0,
+        budgetedCount: Int = 0,
+        trackedCount: Int = 0,
+        totalSpent: Double = 0,
+        totalLimit: Double = 0
+    ) -> BudgetsStatusSummary.Summary {
+        BudgetsStatusSummary.Summary(
+            health: health,
+            overBudgetCount: overBudgetCount,
+            nearingCount: nearingCount,
+            budgetedCount: budgetedCount,
+            trackedCount: trackedCount,
+            totalSpent: totalSpent,
+            totalLimit: totalLimit
+        )
+    }
+
+    // MARK: - budgetedDetail
+
+    @Test("budgetedDetail: no budgets yet")
+    func budgetedDetailNoBudgets() {
+        #expect(summary(budgetedCount: 0, trackedCount: 4).budgetedDetail == "No category budgets yet")
+    }
+
+    @Test("budgetedDetail: across N of M categories")
+    func budgetedDetailCounts() {
+        #expect(summary(budgetedCount: 3, trackedCount: 7).budgetedDetail == "Across 3 of 7 categories")
+        // budgetedCount == 1 is not specially pluralized here — pin the literal.
+        #expect(summary(budgetedCount: 1, trackedCount: 1).budgetedDetail == "Across 1 of 1 categories")
+    }
+
+    // MARK: - spentDetail
+
+    @Test("spentDetail: over-budget wins, singular vs plural")
+    func spentDetailOver() {
+        #expect(summary(overBudgetCount: 1, nearingCount: 2).spentDetail == "1 category over its limit")
+        #expect(summary(overBudgetCount: 3, nearingCount: 2).spentDetail == "3 categories over their limit")
+    }
+
+    @Test("spentDetail: nearing when none over, singular vs plural")
+    func spentDetailNearing() {
+        #expect(summary(overBudgetCount: 0, nearingCount: 1).spentDetail == "1 category nearing its limit")
+        #expect(summary(overBudgetCount: 0, nearingCount: 4).spentDetail == "4 categories nearing a limit")
+    }
+
+    @Test("spentDetail: all clear")
+    func spentDetailAllClear() {
+        #expect(summary(overBudgetCount: 0, nearingCount: 0).spentDetail == "This month, all categories")
+    }
+
+    // MARK: - remainingDetail
+
+    @Test("remainingDetail: aggregate over wins regardless of per-category counts")
+    func remainingDetailAggregateOver() {
+        // remaining = 100 - 150 = -50 < 0 → isAggregateOver.
+        let over = summary(overBudgetCount: 2, budgetedCount: 1, totalSpent: 150, totalLimit: 100)
+        #expect(over.isAggregateOver)
+        #expect(over.remainingDetail == "Spending exceeds your budgeted total")
+    }
+
+    @Test("remainingDetail: room overall but some categories over, singular vs plural")
+    func remainingDetailRoomButOver() {
+        // remaining = 200 - 50 = +150 → not aggregate-over.
+        let one = summary(overBudgetCount: 1, budgetedCount: 2, totalSpent: 50, totalLimit: 200)
+        #expect(!one.isAggregateOver)
+        #expect(one.remainingDetail == "Still room overall, but 1 category is over")
+
+        let many = summary(overBudgetCount: 3, budgetedCount: 4, totalSpent: 50, totalLimit: 200)
+        #expect(many.remainingDetail == "Still room overall, but 3 categories are over")
+    }
+
+    @Test("remainingDetail: clean remainder")
+    func remainingDetailClean() {
+        let clean = summary(overBudgetCount: 0, budgetedCount: 2, totalSpent: 50, totalLimit: 200)
+        #expect(!clean.isAggregateOver)
+        #expect(clean.remainingDetail == "Remaining across your budgeted total")
+    }
+}


### PR DESCRIPTION
## Summary

- Move the window-first **Budgets** destination's three hero-tile detail-string builders (`budgetedDetail` / `spentDetail` / `remainingDetail`) out of `BudgetsDestinationView` and onto `BudgetsStatusSummary.Summary` in **PlaidBarCore**, beside its existing `remaining` / `isAggregateOver` / `fractionUsed` derivations.
- Behavior-preserving: the moved bodies are character-identical save `summary.X` → implicit-`self` `X`. Follows the codebase idiom (pure presentation copy lives in Core — `Health.label`, `AlertsSummary.title` — and views delegate), making the copy unit-testable by both processes.
- Adds `BudgetsStatusSummaryDetailTests` (9 golden-string tests) pinning every branch, including both singular and plural arms and the `isAggregateOver`-wins precedence.

## Autonomous task IDs

- Task ID(s): autonomous architecture-refactor pass (Step 7)
- Backlog slice: AppState/view → PlaidBarCore pure-logic extraction loop
- Scope note: one focused, behavior-preserving extraction; no product behavior change.

## Agent coordination

- Builder agent: Claude (scheduled `vaultpeek-architecture-refactor`)
- Builder branch/worktree: `refactor/auto-2026-06-20` (throwaway worktree off `origin/main`)
- Reviewer/merge steward: Otto
- Coordination note: review only — no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift` — add `budgetedDetail` / `spentDetail` / `remainingDetail` computed properties on `Summary`.
- `Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift` — delegate to the new properties; delete the three private helpers.
- `Tests/PlaidBarCoreTests/BudgetsStatusSummaryDetailTests.swift` — new golden-string tests.

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean (the CI gate).
- [x] Server target compiles under the same strict build (no server code changed).
- [x] `swift test --filter BudgetsStatusSummary` 15/15; full `swift test` green except the pre-existing `AttentionQueueTests` wall-clock time-bomb (the 7-day "unusual spending" window aging out on 2026-06-20 — fixed by the still-open #612, in a file this PR does not touch; verified failing on clean `origin/main` with this diff stashed).
- [x] Secret scan completed over the diff — no secrets/PII; detail copy is count-only and amount-free.

## Privacy and safety impact

- [x] Only synthetic/in-memory data in tests.
- [x] No real Plaid credentials, tokens, IDs, balances, or financial screenshots.
- [x] Preserves the local-first boundary (no backend/telemetry/cloud).
- [x] User-facing copy unchanged (byte-identical strings).

## UI and accessibility checks

- [x] No visual/layout change — only the source location of the detail strings moved; rendered output is identical.
- [x] Detail copy stays amount-free (counts only), consistent with the no-color-alone / no-balances-in-copy rules.
- [x] No screenshots needed (no user-facing behavior change).

## Merge safety

- [x] Final diff reviewed for secrets, private data, scope creep, destructive behavior — clean.
- [x] One focused behavior-preserving extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)