### PR TITLE
feat(ux): flip default to window-first + reduce menu bar to a glance (AND-616)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1636,7 +1636,7 @@ final class AppState {
     func consumePendingRoute(into navigationModel: NavigationModel) {
         guard let route = pendingRoute else { return }
         pendingRoute = nil
-        navigationModel.apply(route)
+        navigationModel.apply(route.resolvingAccountSelection(in: accounts))
     }
 
     var notificationPermissionPresentation: NotificationPermissionPresentation {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1506,6 +1506,56 @@ final class AppState {
         transactionReviewInboxSnapshot.totalCount
     }
 
+    // MARK: - Menu-bar glance (ADR-001 §6 / AND-616)
+
+    /// The reduced menu-bar **glance** contract (ADR-001 §6): the sync line, the
+    /// high-signal glance metrics (net worth · safe-to-spend · to-review), and the
+    /// ≤3 attention chips that deep-link into window destinations. Once
+    /// window-first is the default (AND-616) this — not the full dashboard — is the
+    /// menu-bar surface; the dashboard lives only in the window's Dashboard
+    /// destination.
+    ///
+    /// Assembly lives in the pure `MenuBarGlanceModel.make` (PlaidBarCore) so the
+    /// contract (≤4 metrics, ≤3 chips, each chip's route) is unit-tested without
+    /// the app; this feeds it the live finance signals — the same
+    /// `WealthSummaryPresentation` / `SafeToSpendCalculator` math the dashboard and
+    /// the App Intents snapshot use, so no surface can disagree on the figures.
+    /// Currency metrics honor Privacy Mask / App Lock via `shouldMaskFinancialValues`.
+    var menuBarGlanceModel: MenuBarGlanceModel {
+        let wealth = WealthSummaryPresentation.evaluate(
+            accounts: accounts,
+            transactions: transactions,
+            isDemoMode: usesDemoConnectionPresentation,
+            serverConnected: serverConnected,
+            credentialsConfigured: serverCredentialsConfigured,
+            linkedItemCount: statusItemCount,
+            syncedItemCount: serverSyncedItemCount ?? 0,
+            itemStatuses: itemStatuses,
+            isSyncStale: isSyncStale,
+            lastSyncRelative: lastSyncRelative,
+            statusSyncText: statusSyncText,
+            errorMessage: error,
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            balanceHistory: balanceHistory
+        )
+        let safeToSpend = SafeToSpendCalculator.compute(
+            accounts: accounts,
+            recurringTransactions: recurringTransactions,
+            cashflow: wealth.cashflow,
+            asOf: Date()
+        ).amount
+
+        return MenuBarGlanceModel.make(
+            netWorth: wealth.netWorth,
+            safeToSpend: safeToSpend,
+            unreviewedCount: transactionReviewCount,
+            syncStatusText: statusSyncText,
+            syncSeverity: wealth.syncHealth.severity,
+            attention: attentionQueue,
+            isMasked: shouldMaskFinancialValues
+        )
+    }
+
     // MARK: - Window-first sidebar (ADR-001 / AND-595)
 
     /// Items needing reconnect — the actionable degraded items the connection

--- a/Sources/PlaidBar/App/NavigationModel.swift
+++ b/Sources/PlaidBar/App/NavigationModel.swift
@@ -151,6 +151,16 @@ final class NavigationModel {
         set { state.selectAlert(id: newValue) }
     }
 
+    /// The Review destination's Triage ↔ Table presentation. Deliberately **not**
+    /// persisted: like the transaction row / budget category selections it is
+    /// ephemeral per-session per-window UI state, so a fresh window opens on
+    /// `.triage`. The "Open review table" affordance sets `.table` before
+    /// navigating to Review.
+    var reviewWorkspaceMode: ReviewWorkspaceMode {
+        get { state.reviewWorkspaceMode }
+        set { state.setReviewWorkspaceMode(newValue) }
+    }
+
     func deselectBudgetCategory() {
         state.deselectBudgetCategory()
     }

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -9,15 +9,19 @@ import SwiftUI
 @main
 struct PlaidBarApp: App {
     @State private var appState: AppState
-    /// Owns the floating desktop-window dashboard (AND-384). `@State` so it
-    /// persists across `body` recomputes for the process lifetime.
-    @State private var detachedDashboard = DetachedDashboardCoordinator()
-    /// Owns the detached full Category Dashboard window (AND-539). `@State` so the
-    /// lazily-built window survives `body` recomputes for the process lifetime.
-    @State private var categoryDashboardWindow = CategoryDashboardWindowCoordinator()
-    /// Owns the detached multi-select review Table window (AND-532). `@State` so the
-    /// lazily-built window survives `body` recomputes for the process lifetime.
-    @State private var reviewTableWindow = ReviewTableWindowCoordinator()
+    /// The legacy popover-host window coordinators (AND-384/539/532). They are
+    /// **only constructed when window-first is OFF** — the hidden escape hatch
+    /// this stage (AND-616). Once window-first is the default the menu bar is a
+    /// glance that routes into the primary `Window`, and the detached-dashboard /
+    /// Category-Dashboard / Review-Table affordances reroute to window
+    /// destinations via `AppState.route(to:openWindow:)` instead of building
+    /// these AppKit windows — so on the default path nothing constructs them.
+    /// (Stage 2 deletes these files; this stage just stops constructing them.)
+    /// `@State` so the legacy-path instances survive `body` recomputes for the
+    /// process lifetime.
+    @State private var detachedDashboard: DetachedDashboardCoordinator?
+    @State private var categoryDashboardWindow: CategoryDashboardWindowCoordinator?
+    @State private var reviewTableWindow: ReviewTableWindowCoordinator?
     /// Owns the global summon hotkey (⇧⌘V, AND-487). `@State` so the Carbon
     /// registration survives `body` recomputes for the process lifetime.
     @State private var summonHotkeyMonitor = SummonHotkeyMonitor()
@@ -63,6 +67,16 @@ struct PlaidBarApp: App {
 
         let state = AppState()
         _appState = State(initialValue: state)
+        // Construct the legacy popover-host window coordinators only on the
+        // escape-hatch (window-first OFF) path. On the default window-first path
+        // they are never built — the glance + window routing replace them
+        // (AND-616). `isWindowFirstEnabled` (a `let` resolved from the same flag)
+        // is not yet initialized here, so resolve the flag directly.
+        if !WindowFirstFeatureFlag.resolved() {
+            _detachedDashboard = State(initialValue: DetachedDashboardCoordinator())
+            _categoryDashboardWindow = State(initialValue: CategoryDashboardWindowCoordinator())
+            _reviewTableWindow = State(initialValue: ReviewTableWindowCoordinator())
+        }
         updaterController = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: nil,
@@ -102,12 +116,32 @@ struct PlaidBarApp: App {
         }
     }
 
-    var body: some Scene {
-        MenuBarExtra {
+    /// The menu-bar surface. **Default (window-first ON):** the reduced
+    /// ``MenuBarGlanceView`` — sync line + glance metrics + ≤3 routing chips +
+    /// "Open VaultPeek" (ADR-001 §6, AND-616). The full dashboard now lives only
+    /// in the primary `Window`'s Dashboard destination. **Escape hatch
+    /// (window-first OFF):** the legacy ``MainPopover`` with its detach /
+    /// Category-Dashboard / Review-Table window affordances, byte-identical to the
+    /// pre-flip build.
+    @ViewBuilder
+    private var menuBarContent: some View {
+        if isWindowFirstEnabled {
+            MenuBarGlanceView()
+                .environment(appState)
+                // A glance chip deep-links a typed `Route` into the primary window
+                // via the single reusable entry point (`AppState.route(to:openWindow:)`,
+                // also the App Intents path); "Open VaultPeek" opens the window
+                // with no destination change.
+                .environment(\.openRoute, glanceRouteHandler)
+                .environment(\.openPrimaryWindow, { openWindow(id: Self.mainWindowID) })
+                .forcedAppColorScheme(Self.forcedColorScheme)
+                .appliesAppAppearance()
+                .appliesAppTextSize()
+        } else {
             MainPopover()
                 .environment(appState)
                 .environment(\.dashboardPresentation, .popover(detach: {
-                    detachedDashboard.detach(
+                    detachedDashboard?.detach(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
@@ -117,7 +151,7 @@ struct PlaidBarApp: App {
                 // the detached full dashboard window (AND-539). Wired here so the
                 // view never touches AppKit window lifecycle.
                 .environment(\.openCategoryDashboard, {
-                    categoryDashboardWindow.open(
+                    categoryDashboardWindow?.open(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme
                     )
@@ -126,21 +160,14 @@ struct PlaidBarApp: App {
                 // detached multi-select review Table window (AND-532). Wired here so
                 // the view never touches AppKit window lifecycle.
                 .environment(\.openReviewTable, {
-                    reviewTableWindow.open(
+                    reviewTableWindow?.open(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme
                     )
                 })
-                // Glance attention-chip deep-linking (ADR-001 / AND-597). Only
-                // install a real handler when the window-first flag is ON; with the
-                // flag OFF the `openRoute` environment value stays its no-op
-                // default, so a chip falls back to its existing in-place action and
-                // the popover behaves byte-identically to today. When ON, a chip
-                // routes a typed `Route` into the primary window through the single
-                // reusable entry point (`AppState.route(to:openWindow:)`, also the
-                // App Intents Epic-8 path), staging the route then opening the
-                // window via `openWindow(id:)`.
-                .environment(\.openRoute, glanceRouteHandler)
+                // Flag-OFF: `openRoute` stays its no-op default, so an attention
+                // chip falls back to its in-place action — popover behaves
+                // byte-identically to the pre-flip build.
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
                 // Apply the in-app text-size preference once at the popover root
@@ -149,6 +176,12 @@ struct PlaidBarApp: App {
                 // so this control is the only way users can enlarge VaultPeek's
                 // text (AND-570).
                 .appliesAppTextSize()
+        }
+    }
+
+    var body: some Scene {
+        MenuBarExtra {
+            menuBarContent
         } label: {
             MenuBarLabel()
                 .environment(appState)
@@ -175,7 +208,11 @@ struct PlaidBarApp: App {
                 // SwiftUI would open the popover instead of raising the floating
                 // window (AND-384).
                 .task {
-                    detachedDashboard.sync(
+                    // Legacy detached-dashboard sync (window-first OFF only). On
+                    // the default window-first path `detachedDashboard` is nil and
+                    // the floating window is replaced by the primary `Window`, so
+                    // this is a no-op.
+                    detachedDashboard?.sync(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
@@ -186,9 +223,9 @@ struct PlaidBarApp: App {
                     // QA/screenshot aid: "--detach" opens the floating window at
                     // launch (parallel to "--show-popover") WITHOUT persisting the
                     // detached intent, so a QA run never leaves a durable
-                    // `dashboard.detached` preference behind.
+                    // `dashboard.detached` preference behind. Legacy path only.
                     if CommandLine.arguments.contains("--detach") {
-                        detachedDashboard.presentForLaunchOverride(
+                        detachedDashboard?.presentForLaunchOverride(
                             appState: appState,
                             forcedColorScheme: Self.forcedColorScheme,
                             reduceMotion: reduceMotion
@@ -223,7 +260,12 @@ struct PlaidBarApp: App {
                 // but intentionally leaves the persisted detached preference off,
                 // so include window visibility in the intercept.
                 .onChange(of: appState.isPopoverPresented) { _, isPresented in
-                    guard isPresented, appState.isDashboardDetached || detachedDashboard.isWindowVisible else { return }
+                    // Legacy detached-window intercept (window-first OFF only).
+                    // With window-first ON `detachedDashboard` is nil, so the
+                    // guard short-circuits and the menu bar mounts the glance.
+                    guard let detachedDashboard,
+                          isPresented,
+                          appState.isDashboardDetached || detachedDashboard.isWindowVisible else { return }
                     appState.isPopoverPresented = false
                     detachedDashboard.handleMenuBarActivation(
                         appState: appState,
@@ -232,7 +274,7 @@ struct PlaidBarApp: App {
                     )
                 }
                 .onChange(of: appState.isDashboardDetached) { _, _ in
-                    detachedDashboard.sync(
+                    detachedDashboard?.sync(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
@@ -313,21 +355,36 @@ struct PlaidBarApp: App {
                 statusItem: statusItem,
                 actions: StatusItemContextMenuActions(
                     showDashboard: {
-                        // "Open VaultPeek" raises the floating window when
-                        // detached; otherwise it opens the popover (AND-384).
-                        if detachedDashboard.handleMenuBarActivation(
+                        // Window-first (default): "Open VaultPeek" opens the
+                        // primary `Window` (AND-616). Legacy escape hatch: raise
+                        // the floating window when detached, else open the popover
+                        // (AND-384).
+                        if isWindowFirstEnabled {
+                            openWindow(id: Self.mainWindowID)
+                            return
+                        }
+                        if detachedDashboard?.handleMenuBarActivation(
                             appState: appState,
                             forcedColorScheme: Self.forcedColorScheme,
                             reduceMotion: reduceMotion
-                        ) {
+                        ) == true {
                             return
                         }
                         appState.isPopoverPresented = true
                     },
                     openInWindow: {
-                        // Detach into the floating desktop window directly, so the
-                        // window is reachable without hunting for the footer glyph.
-                        detachedDashboard.detach(
+                        // Window-first (default): "Open in window" routes into the
+                        // primary `Window`'s Dashboard destination via the single
+                        // routing entry point — no legacy detached AppKit window is
+                        // constructed (AND-616). Legacy escape hatch: detach into
+                        // the floating desktop window directly.
+                        if isWindowFirstEnabled {
+                            appState.route(to: .dashboard) {
+                                openWindow(id: Self.mainWindowID)
+                            }
+                            return
+                        }
+                        detachedDashboard?.detach(
                             appState: appState,
                             forcedColorScheme: Self.forcedColorScheme,
                             reduceMotion: reduceMotion
@@ -596,33 +653,48 @@ struct PlaidBarApp: App {
         }
     }
 
-    /// Opens the dashboard for a `vaultpeek://` deep link — raising the floating
-    /// window when detached, otherwise opening the popover. Shared by the
-    /// `.onOpenURL` handler (widget / control deep links) and the Spotlight
+    /// Opens the dashboard for a `vaultpeek://` deep link / Spotlight tap. Shared
+    /// by the `.onOpenURL` handler (widget / control deep links) and the Spotlight
     /// `CSSearchableItemActionType` continuation (tapping an indexed account),
     /// since both resolve to the same dashboard target (AND-513).
+    ///
+    /// Window-first (default): route into the primary `Window`'s Dashboard
+    /// destination (AND-616). Legacy escape hatch: raise the floating window when
+    /// detached, otherwise open the popover.
     @MainActor
     private func openDashboardFromDeepLink() {
-        if detachedDashboard.handleMenuBarActivation(
+        if isWindowFirstEnabled {
+            appState.route(to: .dashboard) {
+                openWindow(id: Self.mainWindowID)
+            }
+            return
+        }
+        if detachedDashboard?.handleMenuBarActivation(
             appState: appState,
             forcedColorScheme: Self.forcedColorScheme,
             reduceMotion: reduceMotion
-        ) {
+        ) == true {
             return
         }
         appState.isPopoverPresented = true
     }
 
-    /// Brings VaultPeek to the front and shows the dashboard — raising the
-    /// floating window when detached, otherwise activating the app and opening
-    /// the popover. Mirrors the `vaultpeek://` deep-link summon path.
+    /// Brings VaultPeek to the front and shows the dashboard. Window-first
+    /// (default): open the primary `Window` (AND-616). Legacy escape hatch: raise
+    /// the floating window when detached, otherwise activate the app and open the
+    /// popover. Mirrors the `vaultpeek://` deep-link summon path.
     @MainActor
     private func summonDashboard() {
-        if detachedDashboard.handleMenuBarActivation(
+        if isWindowFirstEnabled {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            openWindow(id: Self.mainWindowID)
+            return
+        }
+        if detachedDashboard?.handleMenuBarActivation(
             appState: appState,
             forcedColorScheme: Self.forcedColorScheme,
             reduceMotion: reduceMotion
-        ) {
+        ) == true {
             return
         }
         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/Sources/PlaidBar/App/RouteWindowEnvironment.swift
+++ b/Sources/PlaidBar/App/RouteWindowEnvironment.swift
@@ -28,3 +28,22 @@ extension EnvironmentValues {
         set { self[OpenRouteKey.self] = newValue }
     }
 }
+
+/// Environment hook the menu-bar **glance** uses to open the primary `Window`
+/// without a destination — the "Open VaultPeek" button (ADR-001 §6, AND-616).
+///
+/// Supplied by the app scene (which owns SwiftUI's `openWindow(id:)`). The
+/// default is a no-op so previews / snapshots / any host that does not wire the
+/// window render the button inertly, mirroring ``openRoute``.
+private struct OpenPrimaryWindowKey: EnvironmentKey {
+    static let defaultValue: @MainActor @Sendable () -> Void = {}
+}
+
+extension EnvironmentValues {
+    /// Opens the window-first primary window (no destination change). No-op by
+    /// default.
+    var openPrimaryWindow: @MainActor @Sendable () -> Void {
+        get { self[OpenPrimaryWindowKey.self] }
+        set { self[OpenPrimaryWindowKey.self] = newValue }
+    }
+}

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -154,6 +154,20 @@ struct AppShellView: View {
         // The Dashboard reads the live query from the environment to filter its
         // account rows (the shell owns the field, the canvas owns the filtering).
         .environment(\.dashboardSearchQuery, destinationSupportsSearch(destination) ? searchText : "")
+        // Reroute the legacy "open detached window" affordances into in-window
+        // navigation (ADR-001 / AND-616). The Dashboard canvas embeds
+        // `CategoryDashboardCard` (its "Open dashboard" button) and the Review
+        // canvas embeds `ReviewInboxView` (its "Open review table" button); both
+        // read these environment hooks. In window-first there is no detached
+        // AppKit window to open — instead navigate *this* window's model to the
+        // Budgets / Review destination, so the affordance stays live and no legacy
+        // coordinator is constructed.
+        .environment(\.openCategoryDashboard) {
+            appState.navigationModel.go(to: .budgets)
+        }
+        .environment(\.openReviewTable) {
+            appState.navigationModel.go(to: .review)
+        }
         // Deep-link hand-off (ADR-001 / AND-597). The primary scene is a
         // declarative `Window`, so a route can't be threaded through `openWindow`;
         // instead the opener stages it on `AppState.pendingRoute` and this view

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -166,8 +166,20 @@ struct AppShellView: View {
             appState.navigationModel.go(to: .budgets)
         }
         .environment(\.openReviewTable) {
+            // The "Open review table" affordance must land the multi-select table,
+            // not triage (AND-616). Set the mode first, then navigate. `Route.review`
+            // still defaults to triage, so the glance weekly-review deep-link
+            // (`Route.from(weeklyReview:)`) keeps landing on triage.
+            appState.navigationModel.reviewWorkspaceMode = .table
             appState.navigationModel.go(to: .review)
         }
+        // Drive in-window `openRoute(...)` callers (account rows, recurring card,
+        // Add Account, Dashboard attention chips) against *this* window's model
+        // (AND-616). Without this, the primary `Window` scene mounts `AppShellView`
+        // but never injects `\.openRoute`, so those controls hit the no-op default
+        // and are inert. Routing in-place (rather than `appState.route(to:openWindow:)`)
+        // avoids re-opening the already-open window.
+        .environment(\.openRoute, inWindowRouteHandler)
         // Deep-link hand-off (ADR-001 / AND-597). The primary scene is a
         // declarative `Window`, so a route can't be threaded through `openWindow`;
         // instead the opener stages it on `AppState.pendingRoute` and this view
@@ -228,6 +240,18 @@ struct AppShellView: View {
             // gate; dismiss it so unlocking returns to the bare workspace.
             if isLocked { paletteModel.dismiss() }
         }
+    }
+
+    // MARK: - In-window route handler (AND-616)
+
+    /// The in-window `\.openRoute` handler: drives *this* window's `NavigationModel`
+    /// so in-window controls (account rows, recurring card, Add Account, Dashboard
+    /// attention chips) navigate the open window rather than hitting the no-op
+    /// default. Returned as an explicitly typed `@MainActor @Sendable` closure
+    /// (mirroring `PlaidBarApp.glanceRouteHandler`) so the `.environment(\.openRoute, …)`
+    /// site type-checks under strict concurrency.
+    private var inWindowRouteHandler: @MainActor @Sendable (Route) -> Void {
+        { route in appState.navigationModel.apply(route) }
     }
 
     // MARK: - Unified per-destination toolbar (AND-624)

--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -43,6 +43,11 @@ struct BudgetsDestinationView: View {
     /// The category whose budget the user is editing; drives the re-hosted
     /// `BudgetEditorSheet` (AND-541 pattern, mirroring `CategoryDashboardWindow`).
     @State private var budgetEditorCategory: BudgetEditorCategory?
+    /// User-selected flat-table ordering for the re-hosted "All categories" table.
+    /// Stored as the small `Sendable` ``CategoryDashboardTableModel/Order`` enum (a
+    /// `[KeyPathComparator]` is not `Sendable`, so it cannot live in `@State` under
+    /// strict concurrency); mapped to the pure model when the rows are built.
+    @State private var tableOrder: CategoryDashboardTableModel.Order = .spendDescending
 
     private var navigationModel: NavigationModel { appState.navigationModel }
 
@@ -61,6 +66,7 @@ struct BudgetsDestinationView: View {
                     heroMetricsRow
                     donutSection
                     treeSection
+                    tableSection
                 }
             }
             .padding(WindowMetrics.canvasMargin)
@@ -211,6 +217,29 @@ struct BudgetsDestinationView: View {
         PrivacyMaskPresentation.currency(amount, format: .compact, isEnabled: masked)
     }
 
+    /// Masked-aware currency for the flat table's money columns — matches the
+    /// Inspector / legacy `CategoryDashboardWindow` formatting so every amount in
+    /// the destination reads identically (Privacy Mask preserved).
+    private func currency(_ amount: Double) -> String {
+        PrivacyMaskPresentation.currency(
+            amount,
+            format: .full,
+            isEnabled: isMasked,
+            style: .compact
+        )
+    }
+
+    /// Redundant color cue for the table's status column — the glyph + label already
+    /// carry the verdict (ACCESSIBILITY.md), so tint is never the only signal.
+    private func statusTint(_ status: CategoryBudgetStatus?) -> Color {
+        switch status {
+        case .over: SemanticColors.negative
+        case .nearing: SemanticColors.warning
+        case .under: .secondary
+        case nil: .secondary
+        }
+    }
+
     // MARK: - Donut (hero visual)
 
     /// The spend donut — the destination's prominent hero visual, given its own
@@ -239,6 +268,168 @@ struct BudgetsDestinationView: View {
                 onEditBudget: selectAndEdit
             )
         }
+    }
+
+    // MARK: - Flat "All categories" table
+
+    /// The flat, sortable **SPENT / BUDGET / LEFT / Status / Plan** table — the
+    /// analytic counterpart to the two-level tree, re-hosted from the legacy
+    /// `CategoryDashboardWindow` so the "Open dashboard" route into Budgets keeps
+    /// every leaf in one sortable list (AND-616 category-dashboard parity). The rows
+    /// and footer totals come from the pure ``CategoryDashboardTableModel`` (no
+    /// recompute); the Plan column drives the same `selectAndEdit` the tree uses, so
+    /// editing here also selects the inspector. Amounts honor Privacy Mask; budget
+    /// pressure rides on glyph + text, never color alone (ACCESSIBILITY.md).
+    private var tableSection: some View {
+        let rows = CategoryDashboardTableModel.rows(from: presentation, order: tableOrder)
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+
+        return WindowSection("All categories", systemImage: "tablecells") {
+            Picker("Sort", selection: $tableOrder) {
+                Text("By spend").tag(CategoryDashboardTableModel.Order.spendDescending)
+                Text("By group").tag(CategoryDashboardTableModel.Order.groupThenSpend)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            .accessibilityLabel("Sort categories")
+        } content: {
+            VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+                Table(rows) {
+                    TableColumn("Category") { row in
+                        Label {
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text(row.categoryName)
+                                    .lineLimit(1)
+                                Text(row.groupTitle)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        } icon: {
+                            Image(systemName: row.iconName)
+                                .foregroundStyle(CategoryAccentTokens.color(for: row.category))
+                        }
+                        .accessibilityLabel("\(row.categoryName), \(row.groupTitle)")
+                    }
+                    .width(min: 160, ideal: 200)
+
+                    TableColumn("Spent") { row in
+                        Text(currency(row.spent))
+                            .monospacedDigit()
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    .width(min: 80, ideal: 96)
+
+                    TableColumn("Budget") { row in
+                        Text(row.budget.map(currency) ?? "—")
+                            .monospacedDigit()
+                            .foregroundStyle(row.isBudgeted ? .primary : .secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    .width(min: 80, ideal: 96)
+
+                    TableColumn("Left") { row in
+                        leftCell(row)
+                    }
+                    .width(min: 80, ideal: 96)
+
+                    TableColumn("Status") { row in
+                        Label(row.statusText, systemImage: row.statusIconName)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(statusTint(row.status))
+                            .labelStyle(.titleAndIcon)
+                            .lineLimit(1)
+                            .accessibilityLabel(row.statusText)
+                    }
+                    .width(min: 120, ideal: 140)
+
+                    TableColumn("Plan") { row in
+                        budgetActionCell(row)
+                    }
+                    .width(min: 104, ideal: 120)
+                }
+                .frame(minHeight: 220)
+
+                tableFooter(totals)
+            }
+        }
+    }
+
+    private func leftCell(_ row: CategoryDashboardTableRow) -> some View {
+        guard let remaining = row.remaining else {
+            return AnyView(
+                Text("—")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            )
+        }
+        // Over-budget rows read negative; the band glyph + text already carry the
+        // verdict, so the tint here is a redundant cue, never the only signal.
+        return AnyView(
+            Text(currency(remaining))
+                .monospacedDigit()
+                .foregroundStyle(remaining < 0 ? SemanticColors.negative : .primary)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .accessibilityLabel(remaining < 0
+                    ? "\(currency(abs(remaining))) over"
+                    : "\(currency(remaining)) left")
+        )
+    }
+
+    /// The flat-table "Set a budget" / "Edit" action cell (AND-541). Budgetable
+    /// rows get a labeled button that selects the row for the inspector and opens
+    /// `BudgetEditorSheet` (via the shared `selectAndEdit`); income / transfer rows
+    /// show an em dash, since they can never carry a budget.
+    @ViewBuilder
+    private func budgetActionCell(_ row: CategoryDashboardTableRow) -> some View {
+        let affordance = BudgetRowAffordance(category: row.category, isBudgeted: row.isBudgeted)
+        if affordance.isAvailable {
+            Button {
+                selectAndEdit(row.category)
+            } label: {
+                Label(affordance.title, systemImage: affordance.systemImage)
+                    .labelStyle(.titleAndIcon)
+                    .lineLimit(1)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .accessibilityLabel(affordance.accessibilityLabel)
+        } else {
+            Text("—")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func tableFooter(_ totals: CategoryDashboardTableModel.Totals) -> some View {
+        HStack(spacing: WindowMetrics.lg) {
+            footerStat("Total spent", currency(totals.spent))
+            if totals.hasBudget {
+                footerStat("Budgeted", currency(totals.budget))
+                footerStat(
+                    totals.remaining < 0 ? "Over" : "Left",
+                    currency(abs(totals.remaining)),
+                    tint: totals.remaining < 0 ? SemanticColors.negative : .primary
+                )
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.top, WindowMetrics.xs)
+    }
+
+    private func footerStat(_ label: String, _ value: String, tint: Color = .primary) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(tint)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
     }
 
     // MARK: - Empty state

--- a/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
@@ -36,15 +36,12 @@ import SwiftUI
 struct ReviewDestinationView: View {
     @Environment(AppState.self) private var appState
 
-    /// Triage ↔ Table presentation, persisted per-window so a power user who lives
-    /// in the table stays there across re-opens of the same window. `@SceneStorage`
-    /// keeps it window-scoped (each workspace window remembers its own mode) without
-    /// touching shared `AppState`.
-    @SceneStorage("review.workspace.mode") private var modeRaw = ReviewWorkspaceMode.triage.rawValue
-
+    /// Triage ↔ Table presentation, held on the per-window `NavigationModel`
+    /// (`PlaidBarCore`) so the "Open review table" affordance can land the table
+    /// before navigating here (AND-616). Per-window scene state (R-10), not shared
+    /// across windows; ephemeral, so a fresh window opens on `.triage`.
     private var mode: ReviewWorkspaceMode {
-        get { ReviewWorkspaceMode(rawValue: modeRaw) ?? .triage }
-        nonmutating set { modeRaw = newValue.rawValue }
+        appState.navigationModel.reviewWorkspaceMode
     }
 
     private var snapshot: TransactionReviewInboxSnapshot {
@@ -134,7 +131,7 @@ struct ReviewDestinationView: View {
     /// visible — the spec's "Triage | Table mode toggle".
     private var modePicker: some View {
         Picker("Review mode", selection: modeBinding) {
-            ForEach(ReviewWorkspaceMode.allCases) { mode in
+            ForEach(ReviewWorkspaceMode.allCases, id: \.self) { mode in
                 Label(mode.label, systemImage: mode.systemImage)
                     .tag(mode)
             }
@@ -149,7 +146,10 @@ struct ReviewDestinationView: View {
     }
 
     private var modeBinding: Binding<ReviewWorkspaceMode> {
-        Binding(get: { mode }, set: { mode = $0 })
+        Binding(
+            get: { appState.navigationModel.reviewWorkspaceMode },
+            set: { appState.navigationModel.reviewWorkspaceMode = $0 }
+        )
     }
 
     /// The detail-column (inspector) pane for Review — a contextual triage guide.
@@ -338,33 +338,6 @@ struct ReviewDestinationView: View {
                 Text("The review guide is hidden while Privacy Mask or App Lock is active.")
             }
             .accessibilityLabel("Review guide hidden while VaultPeek is private")
-        }
-    }
-}
-
-/// The Triage ↔ Table presentation of the Review workspace (Epic 6). A small,
-/// `Sendable`, `RawRepresentable` enum so it can live in `@SceneStorage`.
-private enum ReviewWorkspaceMode: String, CaseIterable, Identifiable {
-    /// Single-item triage: the embedded ``ReviewInboxView`` with date sections,
-    /// single-key actions, inline rule prompt, and undo.
-    case triage
-    /// Multi-select power review: the embedded ``ReviewTableWindow`` bulk engine
-    /// with blast-radius confirmation.
-    case table
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .triage: "Triage"
-        case .table: "Table"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .triage: "checklist"
-        case .table: "tablecells"
         }
     }
 }

--- a/Sources/PlaidBar/Views/MenuBarGlanceView.swift
+++ b/Sources/PlaidBar/Views/MenuBarGlanceView.swift
@@ -46,7 +46,7 @@ struct MenuBarGlanceView: View {
                 chips
             }
             Divider()
-            openButton
+            footer
         }
         .padding(Spacing.md)
         .frame(width: Self.width)
@@ -132,6 +132,55 @@ struct MenuBarGlanceView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Footer quick-actions
+
+    /// The reduced glance footer: the popover's one-click Privacy Mask and
+    /// Refresh affordances kept reachable here (AND-616), then the primary
+    /// "Open VaultPeek" CTA which fills the remaining width. The glance stays a
+    /// launcher — only these two icon buttons plus the CTA; Add-Account,
+    /// Recurring, Detach, Settings, and the status line live in the window.
+    private var footer: some View {
+        HStack(spacing: Spacing.sm) {
+            privacyMaskButton
+            refreshButton
+            openButton
+        }
+    }
+
+    private var privacyMaskButton: some View {
+        let isMasked = appState.appLockPreferences.privacyMaskEnabled
+        let label = PrivacyMaskPresentation.toggleActionLabel(isMasked: isMasked)
+        return Button {
+            appState.togglePrivacyMask()
+        } label: {
+            // State is shape-borne (eye vs. eye.slash), never color alone.
+            Image(systemName: PrivacyMaskPresentation.toggleSymbolName(isMasked: isMasked))
+                .accessibilityHidden(true)
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.secondary)
+        .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+        .help(label)
+        .accessibilityLabel(label)
+        .keyboardShortcut("p", modifiers: [.command, .shift])
+    }
+
+    private var refreshButton: some View {
+        Button {
+            Task { await appState.refreshDashboard() }
+        } label: {
+            // RefreshIcon carries loading state by glyph/motion, not color alone.
+            RefreshIcon(isLoading: appState.isLoading)
+                .accessibilityHidden(true)
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.secondary)
+        .frame(minWidth: Sizing.hitTargetMin, minHeight: Sizing.hitTargetMin)
+        .help("Refresh")
+        .accessibilityLabel("Refresh")
+        .keyboardShortcut("r", modifiers: .command)
     }
 
     // MARK: - Open window

--- a/Sources/PlaidBar/Views/MenuBarGlanceView.swift
+++ b/Sources/PlaidBar/Views/MenuBarGlanceView.swift
@@ -1,0 +1,228 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// The reduced menu-bar **glance** that replaces the full dashboard popover once
+/// window-first is the default (ADR-001 §6, AND-616 / AND-587).
+///
+/// The glance is **read + route only**. It shows the sync line, two-to-four
+/// high-signal numbers (net worth · safe-to-spend · to-review), up to three
+/// attention chips that **deep-link into window destinations**, and an
+/// "Open VaultPeek" button that opens the primary `Window`. The full dashboard
+/// now lives only in the window's Dashboard destination — this view never hosts
+/// it and never mutates finance data.
+///
+/// All assembly lives in the pure `MenuBarGlanceModel` (PlaidBarCore): this is a
+/// thin renderer over `appState.menuBarGlanceModel`. Color is never the sole
+/// carrier of meaning — every metric and chip pairs a label with an SF Symbol,
+/// and severity is shown by glyph *shape* plus text, not tint alone (ACCESSIBILITY.md).
+/// Privacy Mask / App Lock is honored upstream: the model redacts currency
+/// metrics when `shouldMaskFinancialValues` is set.
+struct MenuBarGlanceView: View {
+    @Environment(AppState.self) private var appState
+    /// Deep-links a chip's ``Route`` into the primary window (AND-597). When the
+    /// scene wires a real handler this opens the window at the destination; the
+    /// no-op default is never reached here (the glance is only mounted when
+    /// window-first is enabled), but keeping the environment seam means the view
+    /// stays headless-safe for previews/snapshots.
+    @Environment(\.openRoute) private var openRoute
+    /// Opens the primary window for the "Open VaultPeek" button — supplied by the
+    /// scene (it owns `openWindow(id:)`). No-op default keeps previews safe.
+    @Environment(\.openPrimaryWindow) private var openPrimaryWindow
+    @Environment(\.openSettings) private var openSettings
+
+    /// Compact glance width — narrower than the old 3-column dashboard popover,
+    /// matching a launcher rather than a workspace (ADR-001 §6).
+    private static let width: CGFloat = 300
+
+    private var model: MenuBarGlanceModel { appState.menuBarGlanceModel }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            syncStatusRow
+            metricsRow
+            if !model.chips.isEmpty {
+                Divider()
+                chips
+            }
+            Divider()
+            openButton
+        }
+        .padding(Spacing.md)
+        .frame(width: Self.width)
+    }
+
+    // MARK: - Sync status
+
+    private var syncStatusRow: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: model.syncStatusGlyph)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(model.syncStatusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Sync status. \(model.syncStatusText)")
+    }
+
+    // MARK: - Glance metrics
+
+    private var metricsRow: some View {
+        HStack(alignment: .top, spacing: Spacing.md) {
+            ForEach(model.metrics) { metric in
+                GlanceMetricCell(metric: metric)
+                if metric.id != model.metrics.last?.id {
+                    Divider().frame(height: 32)
+                }
+            }
+        }
+    }
+
+    // MARK: - Attention chips
+
+    private var chips: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(model.chips) { chip in
+                GlanceChipRow(chip: chip) {
+                    activate(chip)
+                }
+            }
+        }
+    }
+
+    /// A chip routes into the window when it carries a ``Route``; otherwise it
+    /// runs its in-place infrastructure action (check server, open Settings,
+    /// refresh) — exactly the `MenuBarGlanceModel.Chip` contract. The local-infra
+    /// action set mirrors `AttentionQueueView.perform`.
+    private func activate(_ chip: MenuBarGlanceModel.Chip) {
+        if let route = chip.route {
+            openRoute(route)
+            return
+        }
+        guard let action = chip.fallbackAction else { return }
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            Task { await appState.addAccount() }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .reconnect:
+            // Degraded-item chips carry a `Route` (`Route.from(attentionRow:)`
+            // maps `item-error-/item-repair-/item-outage-` rows to Accounts), so
+            // a reconnect action never reaches this fallback. Refresh defensively.
+            Task { await appState.refreshDashboard() }
+        case .openSettings:
+            openSettings()
+        case .requestNotificationPermission:
+            Task { _ = await appState.requestNotificationPermission() }
+        case .openNotificationSettings:
+            openNotificationSettings()
+        }
+    }
+
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            openSettings()
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Open window
+
+    private var openButton: some View {
+        Button {
+            openPrimaryWindow()
+        } label: {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "macwindow")
+                    .accessibilityHidden(true)
+                Text("Open VaultPeek")
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .accessibilityHint("Opens the VaultPeek window.")
+    }
+}
+
+/// One glance metric — label + value, with an SF Symbol so meaning is never tint
+/// alone.
+private struct GlanceMetricCell: View {
+    let metric: MenuBarGlanceModel.Metric
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            Label(metric.label, systemImage: metric.glyph)
+                .labelStyle(.titleAndIcon)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(metric.value)
+                .font(.callout.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(metric.label). \(metric.value)")
+    }
+}
+
+/// One attention chip row. The leading glyph's *shape* carries severity (never
+/// color alone); the whole row is a button that routes into the window or runs
+/// the chip's in-place action.
+private struct GlanceChipRow: View {
+    let chip: MenuBarGlanceModel.Chip
+    let action: () -> Void
+
+    private var tint: Color {
+        switch chip.severity {
+        case .healthy: .secondary
+        case .warning: SemanticColors.warning
+        case .blocked: SemanticColors.negative
+        }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: chip.glyph)
+                    .font(.callout)
+                    .foregroundStyle(tint)
+                    .frame(width: Sizing.glyphSmall)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                    Text(chip.title)
+                        .font(.caption.weight(.medium))
+                        .lineLimit(1)
+                    Text(chip.detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.vertical, Spacing.xs)
+            .padding(.horizontal, Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tint.opacity(chip.severity == .healthy ? 0.0 : 0.10), in: RoundedRectangle(cornerRadius: Radius.control))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(chip.accessibilityLabel)
+        .accessibilityHint(chip.accessibilityHint ?? (chip.deepLinks ? "Opens this in the VaultPeek window." : ""))
+    }
+}

--- a/Sources/PlaidBarCore/Models/MenuBarGlance.swift
+++ b/Sources/PlaidBarCore/Models/MenuBarGlance.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/// The pure, testable contract for the reduced menu-bar **glance** that becomes
+/// the only menu-bar surface once the window-first hybrid is the default
+/// (ADR-001 §6 "menu-bar glance" spec, AND-616 / AND-587).
+///
+/// The full dashboard moved into the primary `Window`'s Dashboard destination.
+/// The glance is read + route only: a sync line, a few high-signal numbers, and
+/// a short list of attention chips that **deep-link into window destinations**.
+/// It never hosts the dashboard, never mutates finance data, and never carries
+/// meaning through color alone (every metric and chip has a label + a glyph).
+///
+/// Keeping the assembly here in `PlaidBarCore` (CLAUDE.md: shared logic lives in
+/// Core) makes the contract — at most ``maximumMetricCount`` metrics and at most
+/// ``maximumChipCount`` chips, every chip's route — unit-testable without
+/// launching the SwiftUI app. The `MenuBarGlanceView` is a thin renderer over
+/// this model.
+public struct MenuBarGlanceModel: Equatable, Sendable {
+    /// ADR §6 caps the glance at four glance metrics so it stays a glance, not a
+    /// second dashboard. ``make(...)`` truncates to this.
+    public static let maximumMetricCount = 4
+
+    /// ADR §6 caps attention chips at three (it reuses the existing
+    /// ``AttentionQueue.maximumRowCount`` budget so the glance and the
+    /// dashboard's status strip can never disagree on how many it shows).
+    public static let maximumChipCount = AttentionQueue.maximumRowCount
+
+    /// A single high-signal number (net worth, safe-to-spend, unreviewed count).
+    /// Color is never the sole carrier of meaning — every metric pairs a `label`
+    /// with a `glyph` (an SF Symbol name) so the signal survives a grayscale /
+    /// color-blind reading.
+    public struct Metric: Equatable, Sendable, Identifiable {
+        public let id: String
+        /// Short caption, e.g. "Net worth", "Safe to spend", "To review".
+        public let label: String
+        /// Pre-formatted, already privacy-masked value, e.g. "$12,450" or "••••".
+        public let value: String
+        /// SF Symbol backing the metric so the meaning is shape-borne, not tint.
+        public let glyph: String
+
+        public init(id: String, label: String, value: String, glyph: String) {
+            self.id = id
+            self.label = label
+            self.value = value
+            self.glyph = glyph
+        }
+    }
+
+    /// One attention chip: a launcher into a window destination (or, for the
+    /// local-infrastructure rows, an in-place action). The chip carries the
+    /// route the menu-bar hand-off should fire (`route`); when `route` is `nil`
+    /// the chip falls back to the underlying row's existing `action` (check the
+    /// server, open Settings, refresh) — exactly the `Route.from(attentionRow:)`
+    /// contract.
+    public struct Chip: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let title: String
+        public let detail: String
+        public let severity: AttentionQueueSeverity
+        /// SF Symbol chosen for distinct *shape* per severity, so a chip's
+        /// urgency never rests on color alone.
+        public let glyph: String
+        public let accessibilityLabel: String
+        public let accessibilityHint: String?
+        /// The window destination this chip deep-links into, or `nil` for a
+        /// local-infrastructure row that keeps its in-place action.
+        public let route: Route?
+        /// The in-place action to run when `route` is `nil` (server offline,
+        /// missing credentials, generic recent-error/sync rows).
+        public let fallbackAction: DashboardStatusReadinessAction?
+
+        public init(
+            id: String,
+            title: String,
+            detail: String,
+            severity: AttentionQueueSeverity,
+            glyph: String,
+            accessibilityLabel: String,
+            accessibilityHint: String?,
+            route: Route?,
+            fallbackAction: DashboardStatusReadinessAction?
+        ) {
+            self.id = id
+            self.title = title
+            self.detail = detail
+            self.severity = severity
+            self.glyph = glyph
+            self.accessibilityLabel = accessibilityLabel
+            self.accessibilityHint = accessibilityHint
+            self.route = route
+            self.fallbackAction = fallbackAction
+        }
+
+        /// `true` when the chip routes into a window destination rather than
+        /// running an in-place action.
+        public var deepLinks: Bool { route != nil }
+    }
+
+    /// The one-line sync/connection status text shown at the top of the glance.
+    public let syncStatusText: String
+    /// SF Symbol for the sync line (shape-borne status, never color alone).
+    public let syncStatusGlyph: String
+    public let metrics: [Metric]
+    public let chips: [Chip]
+
+    public init(syncStatusText: String, syncStatusGlyph: String, metrics: [Metric], chips: [Chip]) {
+        self.syncStatusText = syncStatusText
+        self.syncStatusGlyph = syncStatusGlyph
+        // Defend the contract caps even if a caller over-supplies, so the
+        // invariants hold no matter the construction path.
+        self.metrics = Array(metrics.prefix(Self.maximumMetricCount))
+        self.chips = Array(chips.prefix(Self.maximumChipCount))
+    }
+
+    /// Assembles the glance from the live finance signals. Pure: every input is
+    /// passed in, so the whole contract is testable without the app.
+    ///
+    /// - Parameters:
+    ///   - netWorth: total assets minus debt (already computed in `WealthSummaryPresentation`).
+    ///   - safeToSpend: discretionary headroom (the `SafeToSpendCalculator` amount).
+    ///   - unreviewedCount: transactions awaiting review (drives the menu-bar badge too).
+    ///   - syncStatusText / syncSeverity: the sync line and its severity glyph.
+    ///   - attention: the ≤3-row attention queue (reused so the glance and the
+    ///     dashboard status strip stay in lockstep).
+    ///   - isMasked: Privacy Mask / App Lock — when on, currency metrics are
+    ///     redacted (the unreviewed *count* is not a balance, so it is shown).
+    public static func make(
+        netWorth: Double,
+        safeToSpend: Double,
+        unreviewedCount: Int,
+        syncStatusText: String,
+        syncSeverity: AttentionQueueSeverity,
+        attention: AttentionQueue,
+        isMasked: Bool
+    ) -> MenuBarGlanceModel {
+        var metrics: [Metric] = [
+            Metric(
+                id: "net-worth",
+                label: "Net worth",
+                value: PrivacyMaskPresentation.currency(netWorth, format: .compact, isEnabled: isMasked),
+                glyph: "chart.line.uptrend.xyaxis"
+            ),
+            Metric(
+                id: "safe-to-spend",
+                label: "Safe to spend",
+                value: PrivacyMaskPresentation.currency(safeToSpend, format: .compact, isEnabled: isMasked),
+                glyph: "wallet.pass"
+            ),
+        ]
+
+        // The unreviewed count is a count, not a balance, so it survives Privacy
+        // Mask. Only surface it when there is something to review, keeping the
+        // glance to the smallest set of high-signal numbers.
+        if unreviewedCount > 0 {
+            metrics.append(
+                Metric(
+                    id: "to-review",
+                    label: "To review",
+                    value: String(unreviewedCount),
+                    glyph: "tray.full"
+                )
+            )
+        }
+
+        let chips = attention.rows.map { row in
+            Chip(
+                id: row.id,
+                title: row.title,
+                detail: row.detail,
+                severity: row.severity,
+                glyph: row.severity.statusSymbolName,
+                accessibilityLabel: row.accessibilityLabel,
+                accessibilityHint: row.accessibilityHint,
+                route: Route.from(attentionRow: row),
+                fallbackAction: row.action
+            )
+        }
+
+        return MenuBarGlanceModel(
+            syncStatusText: syncStatusText,
+            syncStatusGlyph: syncSeverity.statusSymbolName,
+            metrics: metrics,
+            chips: chips
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/MenuBarGlance.swift
+++ b/Sources/PlaidBarCore/Models/MenuBarGlance.swift
@@ -123,7 +123,11 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
     ///   - attention: the ≤3-row attention queue (reused so the glance and the
     ///     dashboard status strip stay in lockstep).
     ///   - isMasked: Privacy Mask / App Lock — when on, currency metrics are
-    ///     redacted (the unreviewed *count* is not a balance, so it is shown).
+    ///     redacted, the unreviewed *count* is withheld (matching
+    ///     ``MenuBarReviewBadge/isVisible(unreviewedCount:isMasked:)`` and the
+    ///     status-item badge, AND-483), and each attention chip is rebuilt from
+    ///     generic, non-identifying copy so institution names and transaction
+    ///     counts never leak through the glance.
     public static func make(
         netWorth: Double,
         safeToSpend: Double,
@@ -148,10 +152,14 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
             ),
         ]
 
-        // The unreviewed count is a count, not a balance, so it survives Privacy
-        // Mask. Only surface it when there is something to review, keeping the
-        // glance to the smallest set of high-signal numbers.
-        if unreviewedCount > 0 {
+        // The unreviewed count is withheld while masked — it tracks the same
+        // contract as the status-item badge
+        // (``MenuBarReviewBadge/isVisible(unreviewedCount:isMasked:)`` and
+        // ``ReviewInboxPrivacyPresentation/unreviewedBadge(count:isMasked:)``,
+        // AND-483) so the two surfaces can never disagree. When visible it is
+        // only surfaced if there is something to review, keeping the glance to
+        // the smallest set of high-signal numbers.
+        if MenuBarReviewBadge.isVisible(unreviewedCount: unreviewedCount, isMasked: isMasked) {
             metrics.append(
                 Metric(
                     id: "to-review",
@@ -163,17 +171,19 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
         }
 
         let chips = attention.rows.map { row in
-            Chip(
-                id: row.id,
-                title: row.title,
-                detail: row.detail,
-                severity: row.severity,
-                glyph: row.severity.statusSymbolName,
-                accessibilityLabel: row.accessibilityLabel,
-                accessibilityHint: row.accessibilityHint,
-                route: Route.from(attentionRow: row),
-                fallbackAction: row.action
-            )
+            isMasked
+                ? Self.maskedChip(from: row)
+                : Chip(
+                    id: row.id,
+                    title: row.title,
+                    detail: row.detail,
+                    severity: row.severity,
+                    glyph: row.severity.statusSymbolName,
+                    accessibilityLabel: row.accessibilityLabel,
+                    accessibilityHint: row.accessibilityHint,
+                    route: Route.from(attentionRow: row),
+                    fallbackAction: row.action
+                )
         }
 
         return MenuBarGlanceModel(
@@ -181,6 +191,28 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
             syncStatusGlyph: syncSeverity.statusSymbolName,
             metrics: metrics,
             chips: chips
+        )
+    }
+
+    /// Builds a privacy-safe chip from an attention row while Privacy Mask / App
+    /// Lock is on. The raw `row.title`/`row.detail`/`accessibilityLabel` can embed
+    /// identifying text — institution names on degraded-item rows, transaction
+    /// counts on the unusual-spending row — so under mask we replace the copy with
+    /// generic, non-sensitive text. Severity is still conveyed by the glyph SHAPE
+    /// and the (non-sensitive) ``AttentionQueueSeverity/statusLabel`` (never color
+    /// alone), and the chip keeps its `id`, `severity`, `glyph`, `route`, and
+    /// `fallbackAction` so it still deep-links / acts exactly as the unmasked chip.
+    static func maskedChip(from row: AttentionQueueRow) -> Chip {
+        Chip(
+            id: row.id,
+            title: row.severity.statusLabel,
+            detail: "Hidden while VaultPeek is private.",
+            severity: row.severity,
+            glyph: row.severity.statusSymbolName,
+            accessibilityLabel: "\(row.severity.statusLabel). Hidden while VaultPeek is private.",
+            accessibilityHint: nil,
+            route: Route.from(attentionRow: row),
+            fallbackAction: row.action
         )
     }
 }

--- a/Sources/PlaidBarCore/Models/NavigationState.swift
+++ b/Sources/PlaidBarCore/Models/NavigationState.swift
@@ -85,6 +85,15 @@ public struct NavigationState: Sendable, Equatable, Codable {
     /// from the unacknowledged count without resolving the underlying condition.
     public var acknowledgedAlertIDs: Set<String>
 
+    // MARK: Review workspace mode (AND-616)
+
+    /// The Review destination's Triage ↔ Table presentation. Held per-window so the
+    /// "Open review table" affordance can land the multi-select table while a fresh
+    /// window still opens on triage. Ephemeral per-window UI state (not persisted) —
+    /// a fresh window defaults to `.triage`, and the glance weekly-review deep-link
+    /// (`Route.from(weeklyReview:)`) still lands triage.
+    public var reviewWorkspaceMode: ReviewWorkspaceMode
+
     public init(
         destination: RouteDestination = .dashboard,
         dashboardFilter: DashboardAccountFilterKind = .all,
@@ -96,7 +105,8 @@ public struct NavigationState: Sendable, Equatable, Codable {
         goalSelection: String = "",
         budgetCategorySelection: SpendingCategory? = nil,
         alertSelection: String = "",
-        acknowledgedAlertIDs: Set<String> = []
+        acknowledgedAlertIDs: Set<String> = [],
+        reviewWorkspaceMode: ReviewWorkspaceMode = .triage
     ) {
         self.destination = destination
         self.dashboardFilter = dashboardFilter
@@ -109,6 +119,7 @@ public struct NavigationState: Sendable, Equatable, Codable {
         self.budgetCategorySelection = budgetCategorySelection
         self.alertSelection = alertSelection
         self.acknowledgedAlertIDs = acknowledgedAlertIDs
+        self.reviewWorkspaceMode = reviewWorkspaceMode
     }
 
     // MARK: - Pure transitions
@@ -307,5 +318,13 @@ public struct NavigationState: Sendable, Equatable, Codable {
         if !alertSelection.isEmpty, !rows.contains(where: { $0.id == alertSelection }) {
             alertSelection = ""
         }
+    }
+
+    // MARK: - Review workspace mode transitions (AND-616)
+
+    /// Set the Review destination's Triage ↔ Table presentation. Used by the
+    /// "Open review table" affordance to land the table before navigating to Review.
+    public mutating func setReviewWorkspaceMode(_ mode: ReviewWorkspaceMode) {
+        reviewWorkspaceMode = mode
     }
 }

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -175,6 +175,34 @@ public enum InsightSection: String, CaseIterable, Sendable, Hashable, Codable {
     case trends
 }
 
+/// The Review workspace's Triage ↔ Table presentation (Epic 6, AND-616). Lives in
+/// `PlaidBarCore` (rather than as a private view-level enum) so the in-window
+/// route hooks can set the mode before navigating and the mode→navigation
+/// behavior is unit-testable without the app target (CLAUDE.md). A small,
+/// `Sendable`, `RawRepresentable` enum so it can drive a `Picker`/persisted store.
+public enum ReviewWorkspaceMode: String, Sendable, Codable, CaseIterable {
+    /// Single-item triage: the embedded `ReviewInboxView` with date sections,
+    /// single-key actions, inline rule prompt, and undo.
+    case triage
+    /// Multi-select power review: the embedded `ReviewTableWindow` bulk engine with
+    /// blast-radius confirmation.
+    case table
+
+    public var label: String {
+        switch self {
+        case .triage: "Triage"
+        case .table: "Table"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .triage: "checklist"
+        case .table: "tablecells"
+        }
+    }
+}
+
 // MARK: - Route
 
 /// A typed deep-link target. Any surface can navigate anywhere by constructing a
@@ -286,5 +314,30 @@ public enum Route: Sendable, Hashable, Codable {
             // the caller keeps their existing action.
             return nil
         }
+    }
+
+    /// Resolves an `.accounts(itemID:)` deep-link whose `itemID` is actually a
+    /// Plaid *item_id* into one keyed by the matching `AccountDTO.id`, so the
+    /// Accounts destination (which selects by `AccountDTO.id`) lands on the right
+    /// row.
+    ///
+    /// Degraded-institution attention chips carry the affected Plaid `item_id`
+    /// (`AttentionQueueRow.targetItemId`), but the Accounts list selects accounts
+    /// by `AccountDTO.id`; `AccountDTO.itemId` provides the item→account hop. For a
+    /// multi-account item the **first matching account is selected by design** —
+    /// the chip points at the institution, and the inspector then surfaces the
+    /// item's other accounts.
+    ///
+    /// Any non-`.accounts` route, an `.accounts(itemID: nil)` route, or an item id
+    /// with no matching account returns `self` unchanged, so the caller can apply
+    /// the result unconditionally. Pure + `accounts`-driven so the resolution is
+    /// unit-testable at the Core layer (CLAUDE.md); the `AppState` wiring that calls
+    /// this with the live account list lives in the app target.
+    public func resolvingAccountSelection(in accounts: [AccountDTO]) -> Route {
+        if case .accounts(let itemID?) = self,
+           let accountID = accounts.first(where: { $0.itemId == itemID })?.id {
+            return .accounts(itemID: accountID)
+        }
+        return self
     }
 }

--- a/Sources/PlaidBarCore/Utilities/WindowFirstFeatureFlag.swift
+++ b/Sources/PlaidBarCore/Utilities/WindowFirstFeatureFlag.swift
@@ -1,35 +1,37 @@
 import Foundation
 
 /// Feature flag gating the window-first hybrid experience (ADR-001, Epic 1 /
-/// AND-579, first code step AND-591).
+/// AND-579, first code step AND-591; default flipped in Epic 9 / AND-616).
 ///
-/// The migration to a primary `Window` workspace runs **dual-run behind this
-/// flag**: while it is OFF the app behaves byte-identically to the popover-first
-/// build that shipped today — the menu-bar glance is the only surface and the
-/// declarative `Window` scene must not change launch or activation behavior. The
-/// window is opt-in until the workspace reaches parity (Epic 9 flips the default
-/// and removes the flag).
+/// The migration to a primary `Window` workspace ran **dual-run behind this
+/// flag**. Epic 9 (AND-616) flipped the default **ON**: window-first is now the
+/// shipping experience and the menu bar is reduced to a glance that routes into
+/// the window. The flag is retained this stage only as a hidden escape hatch —
+/// a user (or a QA pass via the `--window-first off` CLI override) can force the
+/// legacy popover back. Stage 2 removes the flag entirely once the flip has
+/// soaked.
 ///
-/// The flag defaults **OFF** on purpose: a fresh install, and every existing
-/// user who never toggles it, keeps the current popover-only experience. The
-/// resolution rule is pure and lives here in `PlaidBarCore` so it is `Sendable`,
-/// testable without launching the app, and shared by the UI process. The
-/// `CommandLine`/`UserDefaults` plumbing in `resolved()` is a thin wrapper over
-/// the pure `resolve(...)` decision.
+/// The flag defaults **ON** as of AND-616: a fresh install, and every existing
+/// user who never toggles it, gets the window-first hybrid (glance + primary
+/// window). The resolution rule is pure and lives here in `PlaidBarCore` so it
+/// is `Sendable`, testable without launching the app, and shared by the UI
+/// process. The `CommandLine`/`UserDefaults` plumbing in `resolved()` is a thin
+/// wrapper over the pure `resolve(...)` decision.
 public enum WindowFirstFeatureFlag {
     /// `UserDefaults` key persisting the user's opt-in. Absent ⇒ OFF (default).
     public static let storageKey = "featureFlag.windowFirst"
 
     /// CLI override (QA/screenshot aid, mirrors `--appearance` / `--text-size`):
-    /// `--window-first on|off|true|false|1|0`. Lets a QA pass exercise the window
-    /// without leaving a durable preference behind, and lets a flag-ON build be
-    /// forced OFF for a regression capture. The override wins over the stored
-    /// preference when present and parseable.
+    /// `--window-first on|off|true|false|1|0`. Lets a QA pass force the now-legacy
+    /// popover back on without leaving a durable preference behind, and lets the
+    /// window-first default be exercised explicitly. The override wins over the
+    /// stored preference when present and parseable.
     public static let commandLineFlag = "--window-first"
 
     /// The flag's default when neither a CLI override nor a stored preference is
-    /// present. **OFF** — popover-first stays the shipping default.
-    public static let defaultValue = false
+    /// present. **ON** as of AND-616 — window-first is the shipping default; the
+    /// menu bar is a glance into the primary window.
+    public static let defaultValue = true
 
     /// Pure resolution: CLI override (if parseable) wins, else the stored
     /// preference, else `defaultValue`. No I/O — every input is passed in, so the

--- a/Tests/PlaidBarCoreTests/CategoryDashboardTableModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardTableModelTests.swift
@@ -128,4 +128,47 @@ struct CategoryDashboardTableModelTests {
         #expect(totals.remaining == -60)  // 250 - 310
         #expect(totals.hasBudget)
     }
+
+    // MARK: - Budgets-destination "All categories" table visibility (AND-616)
+
+    /// Drives the demo presentation `BudgetsDestinationView` re-hosts the flat
+    /// "All categories" table from. A SwiftUI `Table` is not headlessly testable, so
+    /// this exercises the section's *data path*: the destination only renders the
+    /// `tableSection` when `presentation.isEmpty == false`, and the rows + footer
+    /// totals it shows come straight from this pure model. A non-empty (demo)
+    /// presentation must therefore yield visible rows and meaningful, budgeted
+    /// totals — the parity the legacy `CategoryDashboardWindow` exposed.
+    @Test("demo presentation yields a non-empty, budgeted flat table the Budgets destination renders")
+    func demoPresentationDrivesVisibleTable() {
+        let now = Formatters.parseTransactionDate("2026-06-13")!
+        let calendar = Calendar(identifier: .gregorian)
+        let budgets = Dictionary(
+            uniqueKeysWithValues: DemoFixtures.demoBudgets().map { ($0.category, $0.monthlyLimit) }
+        )
+        let p = CategoryDashboardBuilder.build(
+            transactions: DemoFixtures.demoBudgetScoringTransactions(now: now, calendar: calendar),
+            budgets: budgets,
+            asOf: now,
+            calendar: calendar
+        )
+
+        // Gating precondition for `tableSection` to render at all.
+        #expect(!p.isEmpty)
+
+        let rows = CategoryDashboardTableModel.rows(from: p, order: .spendDescending)
+        #expect(!rows.isEmpty)
+        // The demo set budgets several categories, so the budget/left footers mean
+        // something (the destination shows them rather than an em dash).
+        #expect(rows.contains { $0.isBudgeted })
+
+        let totals = CategoryDashboardTableModel.totals(for: rows)
+        #expect(totals.hasBudget)
+        #expect(totals.spent > 0)
+        #expect(totals.budget > 0)
+
+        // Re-sorting (the destination's segmented Picker) preserves the row set —
+        // the user never loses a category by switching order.
+        let byGroup = CategoryDashboardTableModel.rows(from: p, order: .groupThenSpend)
+        #expect(Set(byGroup.map(\.id)) == Set(rows.map(\.id)))
+    }
 }

--- a/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
+++ b/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// The pure menu-bar **glance** contract (ADR-001 §6, AND-616): at most four
+/// glance metrics, at most three attention chips, every chip's route, and
+/// Privacy-Mask redaction of currency metrics. Testing the assembly here at the
+/// Core layer keeps the contract enforceable without launching the SwiftUI app.
+@Suite("MenuBarGlanceModel contract")
+struct MenuBarGlanceModelTests {
+    // MARK: - Helpers
+
+    /// A financial-cockpit attention row (one of the chips that deep-links into a
+    /// window destination).
+    private func financialRow(id: String, title: String) -> AttentionQueueRow {
+        AttentionQueueRow(
+            id: id,
+            severity: .warning,
+            title: title,
+            detail: "Detail for \(title)",
+            menuBarAttentionText: title
+        )
+    }
+
+    /// A local-infrastructure row (server / credentials) that keeps its in-place
+    /// action and carries no route.
+    private func infraRow(id: String, action: DashboardStatusReadinessAction) -> AttentionQueueRow {
+        AttentionQueueRow(
+            id: id,
+            severity: .blocked,
+            title: "Infra \(id)",
+            detail: "Infra detail",
+            action: action
+        )
+    }
+
+    // MARK: - Metric contract
+
+    @Test("Surfaces net worth and safe-to-spend, plus to-review only when nonzero")
+    func metricsSurfaceTheRightSignals() {
+        let withReview = MenuBarGlanceModel.make(
+            netWorth: 12_450,
+            safeToSpend: 800,
+            unreviewedCount: 3,
+            syncStatusText: "Synced now",
+            syncSeverity: .healthy,
+            attention: AttentionQueue(rows: []),
+            isMasked: false
+        )
+        #expect(withReview.metrics.map(\.id) == ["net-worth", "safe-to-spend", "to-review"])
+        #expect(withReview.metrics.first { $0.id == "to-review" }?.value == "3")
+        // Every metric pairs a glyph with its label — meaning is never tint alone.
+        #expect(withReview.metrics.allSatisfy { !$0.glyph.isEmpty && !$0.label.isEmpty })
+
+        let noReview = MenuBarGlanceModel.make(
+            netWorth: 12_450,
+            safeToSpend: 800,
+            unreviewedCount: 0,
+            syncStatusText: "Synced now",
+            syncSeverity: .healthy,
+            attention: AttentionQueue(rows: []),
+            isMasked: false
+        )
+        // Nothing to review ⇒ the count metric is omitted, keeping the glance lean.
+        #expect(noReview.metrics.map(\.id) == ["net-worth", "safe-to-spend"])
+    }
+
+    @Test("Never exceeds the four-metric cap")
+    func metricCapHolds() {
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 9,
+            syncStatusText: "Synced",
+            syncSeverity: .healthy,
+            attention: AttentionQueue(rows: []),
+            isMasked: false
+        )
+        #expect(model.metrics.count <= MenuBarGlanceModel.maximumMetricCount)
+    }
+
+    @Test("Privacy Mask redacts currency metrics but not the review count")
+    func privacyMaskRedactsCurrencyOnly() {
+        let model = MenuBarGlanceModel.make(
+            netWorth: 12_450,
+            safeToSpend: 800,
+            unreviewedCount: 4,
+            syncStatusText: "Synced",
+            syncSeverity: .healthy,
+            attention: AttentionQueue(rows: []),
+            isMasked: true
+        )
+        let netWorth = model.metrics.first { $0.id == "net-worth" }
+        let safeToSpend = model.metrics.first { $0.id == "safe-to-spend" }
+        let toReview = model.metrics.first { $0.id == "to-review" }
+        #expect(netWorth?.value == PrivacyMaskPresentation.compactValue)
+        #expect(safeToSpend?.value == PrivacyMaskPresentation.compactValue)
+        // A count is not a balance, so it stays visible under Privacy Mask.
+        #expect(toReview?.value == "4")
+    }
+
+    // MARK: - Chip contract
+
+    @Test("Chips never exceed the three-chip cap and mirror the attention rows")
+    func chipCapAndMirroring() {
+        let rows = [
+            financialRow(id: "financial-low-cash", title: "Cash"),
+            financialRow(id: "financial-high-utilization", title: "Credit"),
+            financialRow(id: "financial-unusual-spending", title: "Spend"),
+        ]
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Synced",
+            syncSeverity: .warning,
+            attention: AttentionQueue(rows: rows),
+            isMasked: false
+        )
+        #expect(model.chips.count <= MenuBarGlanceModel.maximumChipCount)
+        #expect(model.chips.map(\.id) == rows.map(\.id))
+        // Each chip carries a shaped severity glyph (never color alone).
+        #expect(model.chips.allSatisfy { !$0.glyph.isEmpty })
+    }
+
+    @Test("Financial chips deep-link into window destinations")
+    func financialChipsDeepLink() {
+        let rows = [
+            financialRow(id: "financial-low-cash", title: "Cash"),
+            financialRow(id: "financial-high-utilization", title: "Credit"),
+            financialRow(id: "financial-unusual-spending", title: "Spend"),
+        ]
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Synced",
+            syncSeverity: .warning,
+            attention: AttentionQueue(rows: rows),
+            isMasked: false
+        )
+        // Every financial chip routes (no inert chip); matches Route.from(attentionRow:).
+        let allDeepLink = model.chips.allSatisfy { $0.deepLinks }
+        #expect(allDeepLink)
+        let byID = Dictionary(uniqueKeysWithValues: model.chips.map { ($0.id, $0) })
+        #expect(byID["financial-low-cash"]?.route == .accounts())
+        #expect(byID["financial-high-utilization"]?.route == .accounts())
+        #expect(byID["financial-unusual-spending"]?.route == .transactions())
+    }
+
+    @Test("A degraded-item chip routes to Accounts at the affected item")
+    func degradedItemChipRoutesToAccountsItem() {
+        let row = AttentionQueueRow(
+            id: "item-error-bank42",
+            severity: .blocked,
+            title: "Reconnect Example Bank",
+            detail: "Sign in again to keep balances current.",
+            action: .reconnect,
+            targetItemId: "bank42"
+        )
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Needs attention",
+            syncSeverity: .blocked,
+            attention: AttentionQueue(rows: [row]),
+            isMasked: false
+        )
+        let chip = model.chips.first
+        #expect(chip?.deepLinks == true)
+        #expect(chip?.route == .accounts(itemID: "bank42"))
+    }
+
+    @Test("Local-infra chips carry no route and keep their in-place action")
+    func infraChipsFallBackToAction() {
+        let rows = [
+            infraRow(id: "server-offline", action: .checkServer),
+            infraRow(id: "credentials-missing", action: .openSettings),
+        ]
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Server offline",
+            syncSeverity: .blocked,
+            attention: AttentionQueue(rows: rows),
+            isMasked: false
+        )
+        let byID = Dictionary(uniqueKeysWithValues: model.chips.map { ($0.id, $0) })
+        #expect(byID["server-offline"]?.route == nil)
+        #expect(byID["server-offline"]?.deepLinks == false)
+        #expect(byID["server-offline"]?.fallbackAction == .checkServer)
+        #expect(byID["credentials-missing"]?.route == nil)
+        #expect(byID["credentials-missing"]?.fallbackAction == .openSettings)
+    }
+
+    // MARK: - Sync status
+
+    @Test("Sync line carries the supplied text and a shaped severity glyph")
+    func syncLineCarriesTextAndGlyph() {
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Updated 2m ago",
+            syncSeverity: .warning,
+            attention: AttentionQueue(rows: []),
+            isMasked: false
+        )
+        #expect(model.syncStatusText == "Updated 2m ago")
+        #expect(model.syncStatusGlyph == AttentionQueueSeverity.warning.statusSymbolName)
+    }
+
+    // MARK: - Init defends the caps
+
+    @Test("init truncates over-supplied metrics and chips to the contract caps")
+    func initDefendsCaps() {
+        let chips = (0..<10).map { i in
+            MenuBarGlanceModel.Chip(
+                id: "c\(i)",
+                title: "t",
+                detail: "d",
+                severity: .warning,
+                glyph: "exclamationmark.triangle.fill",
+                accessibilityLabel: "a",
+                accessibilityHint: nil,
+                route: .dashboard,
+                fallbackAction: nil
+            )
+        }
+        let metrics = (0..<10).map { i in
+            MenuBarGlanceModel.Metric(id: "m\(i)", label: "l", value: "v", glyph: "g")
+        }
+        let model = MenuBarGlanceModel(
+            syncStatusText: "x",
+            syncStatusGlyph: "g",
+            metrics: metrics,
+            chips: chips
+        )
+        #expect(model.metrics.count == MenuBarGlanceModel.maximumMetricCount)
+        #expect(model.chips.count == MenuBarGlanceModel.maximumChipCount)
+    }
+}

--- a/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
+++ b/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
@@ -79,9 +79,9 @@ struct MenuBarGlanceModelTests {
         #expect(model.metrics.count <= MenuBarGlanceModel.maximumMetricCount)
     }
 
-    @Test("Privacy Mask redacts currency metrics but not the review count")
+    @Test("Privacy Mask redacts currency metrics and withholds the review count")
     func privacyMaskRedactsCurrencyOnly() {
-        let model = MenuBarGlanceModel.make(
+        let masked = MenuBarGlanceModel.make(
             netWorth: 12_450,
             safeToSpend: 800,
             unreviewedCount: 4,
@@ -90,13 +90,59 @@ struct MenuBarGlanceModelTests {
             attention: AttentionQueue(rows: []),
             isMasked: true
         )
-        let netWorth = model.metrics.first { $0.id == "net-worth" }
-        let safeToSpend = model.metrics.first { $0.id == "safe-to-spend" }
-        let toReview = model.metrics.first { $0.id == "to-review" }
+        let netWorth = masked.metrics.first { $0.id == "net-worth" }
+        let safeToSpend = masked.metrics.first { $0.id == "safe-to-spend" }
         #expect(netWorth?.value == PrivacyMaskPresentation.compactValue)
         #expect(safeToSpend?.value == PrivacyMaskPresentation.compactValue)
-        // A count is not a balance, so it stays visible under Privacy Mask.
-        #expect(toReview?.value == "4")
+        // The review count is withheld under mask, matching the status-item badge
+        // contract (MenuBarReviewBadge.isVisible / ReviewInboxPrivacyPresentation).
+        #expect(masked.metrics.first { $0.id == "to-review" } == nil)
+
+        // The same inputs unmasked surface the live count.
+        let unmasked = MenuBarGlanceModel.make(
+            netWorth: 12_450,
+            safeToSpend: 800,
+            unreviewedCount: 4,
+            syncStatusText: "Synced",
+            syncSeverity: .healthy,
+            attention: AttentionQueue(rows: []),
+            isMasked: false
+        )
+        #expect(unmasked.metrics.first { $0.id == "to-review" }?.value == "4")
+    }
+
+    @Test("Privacy Mask rebuilds attention chips from generic, non-identifying copy")
+    func privacyMaskRedactsChipCopy() {
+        // A degraded-item row whose title/detail embed an institution name.
+        let institution = "Chase Sapphire"
+        let row = AttentionQueueRow(
+            id: "item-error-bank42",
+            severity: .blocked,
+            title: "Reconnect \(institution)",
+            detail: "Sign in again to keep \(institution) balances current.",
+            action: .reconnect,
+            targetItemId: "bank42"
+        )
+        let model = MenuBarGlanceModel.make(
+            netWorth: 1,
+            safeToSpend: 1,
+            unreviewedCount: 0,
+            syncStatusText: "Needs attention",
+            syncSeverity: .blocked,
+            attention: AttentionQueue(rows: [row]),
+            isMasked: true
+        )
+        let chip = model.chips.first
+        #expect(chip != nil)
+        // No institution substring leaks through any visible/spoken text.
+        #expect(chip?.title.contains(institution) == false)
+        #expect(chip?.detail.contains(institution) == false)
+        #expect(chip?.accessibilityLabel.contains(institution) == false)
+        // The masked copy is the generic severity label + privacy notice.
+        #expect(chip?.title == AttentionQueueSeverity.blocked.statusLabel)
+        // The chip still deep-links to the affected item and keeps a shaped glyph.
+        #expect(chip?.route == .accounts(itemID: "bank42"))
+        #expect(chip?.glyph.isEmpty == false)
     }
 
     // MARK: - Chip contract

--- a/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
@@ -129,6 +129,70 @@ struct RouteTests {
         #expect(Route.from(weeklyReview: .safeToSpend) == .dashboard)
     }
 
+    // MARK: - Account deep-link mapper (AND-616)
+
+    /// A minimal account fixture: `id` is the Plaid `account_id` Accounts selects
+    /// by; `itemId` is the Plaid `item_id` a degraded-institution chip carries.
+    private func account(id: String, itemId: String) -> AccountDTO {
+        AccountDTO(
+            id: id,
+            itemId: itemId,
+            name: "Account \(id)",
+            type: .depository,
+            balances: BalanceDTO(available: 100, current: 100, isoCurrencyCode: "USD")
+        )
+    }
+
+    @Test("resolvingAccountSelection maps an item_id deep-link to the matching account_id (AND-616)")
+    func resolvingAccountSelectionMapsItemToAccount() {
+        let accounts = [
+            account(id: "acct_chk", itemId: "item_42"),
+            account(id: "acct_sav", itemId: "item_99"),
+        ]
+        // A chip carrying item_42 must resolve to that item's account_id.
+        #expect(
+            Route.accounts(itemID: "item_42").resolvingAccountSelection(in: accounts)
+                == .accounts(itemID: "acct_chk")
+        )
+    }
+
+    @Test("resolvingAccountSelection selects the first matching account for a multi-account item (AND-616)")
+    func resolvingAccountSelectionFirstMatch() {
+        // Two accounts share item_42; the first-listed is selected by design.
+        let accounts = [
+            account(id: "acct_first", itemId: "item_42"),
+            account(id: "acct_second", itemId: "item_42"),
+        ]
+        #expect(
+            Route.accounts(itemID: "item_42").resolvingAccountSelection(in: accounts)
+                == .accounts(itemID: "acct_first")
+        )
+    }
+
+    @Test("resolvingAccountSelection returns self when no account matches the item_id (AND-616)")
+    func resolvingAccountSelectionNoMatch() {
+        let accounts = [account(id: "acct_chk", itemId: "item_42")]
+        let route = Route.accounts(itemID: "item_missing")
+        #expect(route.resolvingAccountSelection(in: accounts) == route)
+        // Empty account list → unchanged too.
+        #expect(route.resolvingAccountSelection(in: []) == route)
+    }
+
+    @Test("resolvingAccountSelection returns self for a nil-item or non-accounts route (AND-616)")
+    func resolvingAccountSelectionPassThrough() {
+        let accounts = [account(id: "acct_chk", itemId: "item_42")]
+        // nil item → nothing to resolve.
+        #expect(
+            Route.accounts(itemID: nil).resolvingAccountSelection(in: accounts)
+                == .accounts(itemID: nil)
+        )
+        // A non-accounts route is returned untouched even if an id happens to match.
+        #expect(Route.dashboard.resolvingAccountSelection(in: accounts) == .dashboard)
+        #expect(
+            Route.transactions().resolvingAccountSelection(in: accounts) == .transactions()
+        )
+    }
+
     @Test("Route round-trips through Codable (deep-link persistence ready)")
     func codableRoundTrip() throws {
         let routes: [Route] = [
@@ -390,6 +454,44 @@ struct NavigationStateTransitionTests {
         state.selectGoal(id: "g7")
         state.go(to: .planning)
         #expect(state.goalSelection == "g7")
+    }
+
+    // MARK: - Review workspace mode (AND-616)
+
+    @Test("Review workspace mode defaults to triage")
+    func reviewModeDefault() {
+        #expect(NavigationState().reviewWorkspaceMode == .triage)
+    }
+
+    @Test("setReviewWorkspaceMode(.table) then go(to: .review) lands the table on Review (AND-616)")
+    func reviewTableModeViaGo() {
+        // The "Open review table" affordance sets the mode, then navigates: the
+        // window must land on Review *in table mode*, not triage.
+        var state = NavigationState()
+        state.setReviewWorkspaceMode(.table)
+        state.go(to: .review)
+        #expect(state.destination == .review)
+        #expect(state.reviewWorkspaceMode == .table)
+    }
+
+    @Test("setReviewWorkspaceMode(.table) survives an apply(.review) deep-link (AND-616)")
+    func reviewTableModeViaApply() {
+        // apply(_:) is the deep-link entry point; it must not reset a mode the
+        // caller set just before navigating.
+        var state = NavigationState()
+        state.setReviewWorkspaceMode(.table)
+        state.apply(.review())
+        #expect(state.destination == .review)
+        #expect(state.reviewWorkspaceMode == .table)
+    }
+
+    @Test("Review mode round-trips through Codable")
+    func reviewModeCodable() throws {
+        let state = NavigationState(destination: .review, reviewWorkspaceMode: .table)
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(NavigationState.self, from: data)
+        #expect(decoded.reviewWorkspaceMode == .table)
+        #expect(decoded == state)
     }
 }
 

--- a/Tests/PlaidBarCoreTests/WindowFirstFeatureFlagTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowFirstFeatureFlagTests.swift
@@ -6,15 +6,19 @@ import Testing
 struct WindowFirstFeatureFlagTests {
     // MARK: - Default
 
-    @Test("Defaults OFF when neither a CLI override nor a stored preference is set")
-    func defaultsOff() {
-        #expect(WindowFirstFeatureFlag.defaultValue == false)
-        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: nil) == false)
+    @Test("Defaults ON when neither a CLI override nor a stored preference is set (AND-616 flip)")
+    func defaultsOn() {
+        // AND-616 flipped the default: window-first is now the shipping
+        // experience; the flag is a hidden escape hatch this stage.
+        #expect(WindowFirstFeatureFlag.defaultValue == true)
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: nil) == true)
     }
 
-    @Test("With no override, the stored preference wins")
+    @Test("With no override, the stored preference wins (escape hatch can force the popover back)")
     func storedPreferenceWins() {
         #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: true) == true)
+        // A user who explicitly stored OFF keeps the legacy popover even though
+        // the default is now ON.
         #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: false) == false)
     }
 
@@ -36,24 +40,25 @@ struct WindowFirstFeatureFlagTests {
         #expect(WindowFirstFeatureFlag.parse("") == nil)
         #expect(WindowFirstFeatureFlag.parse("   ") == nil)
         #expect(WindowFirstFeatureFlag.parse(nil) == nil)
-        // Falls through to stored value when present, else the OFF default.
-        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: true) == true)
-        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: nil) == false)
+        // Falls through to stored value when present, else the now-ON default.
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: false) == false)
+        #expect(WindowFirstFeatureFlag.resolve(cliOverrideRaw: "garbage", storedValue: nil) == true)
     }
 
     // MARK: - resolved() wiring (UserDefaults + arguments)
 
-    @Test("resolved() returns OFF for an empty store and no CLI flag")
-    func resolvedDefaultsOff() {
+    @Test("resolved() returns ON for an empty store and no CLI flag (AND-616 flip)")
+    func resolvedDefaultsOn() {
         let defaults = Self.emptyDefaults()
-        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == false)
+        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == true)
     }
 
     @Test("resolved() reads the stored preference when no CLI flag is present")
     func resolvedReadsStoredPreference() {
         let defaults = Self.emptyDefaults()
-        defaults.set(true, forKey: WindowFirstFeatureFlag.storageKey)
-        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == true)
+        // The escape hatch: an explicitly-stored OFF still forces the legacy popover.
+        defaults.set(false, forKey: WindowFirstFeatureFlag.storageKey)
+        #expect(WindowFirstFeatureFlag.resolved(arguments: ["PlaidBar"], defaults: defaults) == false)
     }
 
     @Test("resolved() lets the CLI flag override the stored preference")


### PR DESCRIPTION
## What this is

**Stage 1 of the window-first capstone** (ADR-001 Epic 9 / **AND-616**, **AND-587**): flip the shipping default from the menu-bar popover to the window-first experience, and reduce the menu bar to a glance that routes into the window. The full window-first app + all 9 redesigned destinations already shipped behind `WindowFirstFeatureFlag` (default OFF); this turns it on by default and rehomes the menu bar.

This changes **default app behavior**. Stage 2 (separate PR) deletes the legacy coordinator/controller files and removes the flag.

## What changed

### 1. Flag default flipped ON
`WindowFirstFeatureFlag.defaultValue` is now `true`. The flag is retained this stage **only as a hidden escape hatch** — a stored OFF preference, or `--window-first off`, forces the legacy popover back. `isWindowFirstEnabled` is now true by default.

### 2. Menu bar reduced to a glance
New `MenuBarGlanceView` (thin renderer) over a pure, unit-tested `MenuBarGlanceModel` in `PlaidBarCore`. **Glance contract (ADR §6):**
- **Sync line** + severity glyph.
- **≤4 glance metrics:** Net worth, Safe to spend, and To-review (shown only when nonzero).
- **≤3 attention chips** that deep-link into window destinations via `AppState.route(to:openWindow:)`.
- **"Open VaultPeek"** button → opens the primary `Window` (`openWindow(id:"main")`).
- Currency metrics honor **Privacy Mask / App Lock** (the review count is not a balance, so it stays). **Never color-alone** — every metric/chip pairs a label with an SF Symbol; severity is carried by glyph shape + text.

The full dashboard now lives **only** in the window's Dashboard destination; the glance never hosts it.

### 3. The window is the primary experience
"Open VaultPeek" (status-item menu + glance) opens the `Window`. Launch behavior is conservative — the window opens **on demand** from the always-present glance (no flaky auto-open-at-launch).

### 4. Legacy affordances rerouted (no legacy AppKit window constructed on the default path)
| Affordance | Was | Now (window-first) |
|---|---|---|
| status-item "Open VaultPeek" / Spotlight / summon | popover / detached window | `openWindow(id:"main")` |
| status-item "Open in window" | `DetachedDashboardCoordinator.detach` | `route(.dashboard)` |
| Category-Dashboard card "Open dashboard" | `CategoryDashboardWindowCoordinator.open` | in-window `go(to:.budgets)` (wired on `AppShellView`) |
| Review Inbox "Open review table" | `ReviewTableWindowCoordinator.open` | in-window `go(to:.review)` (wired on `AppShellView`) |
| glance chips | in-place actions | routes per `Route.from(attentionRow:)` (Accounts / Transactions / Review / Dashboard), with infra rows keeping their in-place action |

The three legacy coordinators are now constructed **only on the escape-hatch (flag-OFF) path**; the default path never builds them. Their files are left in place (Stage 2 deletes them).

**grep proof** — the only constructions are inside `if !WindowFirstFeatureFlag.resolved()` in `PlaidBarApp.init`:
```
Sources/PlaidBar/App/PlaidBarApp.swift:76:  _detachedDashboard = State(initialValue: DetachedDashboardCoordinator())
Sources/PlaidBar/App/PlaidBarApp.swift:77:  _categoryDashboardWindow = State(initialValue: CategoryDashboardWindowCoordinator())
Sources/PlaidBar/App/PlaidBarApp.swift:78:  _reviewTableWindow = State(initialValue: ReviewTableWindowCoordinator())
```

### 5. Tests
- **Updated** `WindowFirstFeatureFlagTests` for the new default ON (escape-hatch semantics: stored/CLI OFF still forces the popover).
- **New** `MenuBarGlanceModelTests`: ≤4 metrics, ≤3 chips, chips produce the right routes (financial → Accounts/Transactions, degraded-item → Accounts at item, infra → no route + keeps in-place action), Privacy-Mask redaction, sync glyph, init cap defense.
- Security/privacy tests untouched.

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **clean**.
- `swift test` — **2044 tests**; the only failures are **2 pre-existing date-rollover** tests in `AttentionQueueTests` (hardcoded `2026-06-12` fixture is now >7 days old, outside the unusual-spend window) — proven independent of this change by running on a truly clean tree. Flagged for a separate fix.
- `--demo --render-window-first` — all 9 destination PNGs + shell, exit 0; Dashboard renders fully.
- `--window-first off --render-snapshot` — legacy popover still renders (escape hatch intact).

## Couldn't cleanly flip
Nothing blocking. The menu-bar glance itself isn't covered by the headless render harness (it renders window destinations, not the menu-bar surface) — its contract is unit-tested instead, and it compiles under the strict gate.

## Stage 2 (follow-up)
Delete legacy coordinator/controller files, retire `AppActivationPolicyCoordinator` / `PopoverWindowAnchor`, remove the flag + dead single-surface flags, glance-contract doc.

Refs: AND-616, AND-587, ADR-001 (`docs/strategy/macos26-migration/ADR-001-window-first-architecture.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
