### PR TITLE
fix(ux): Apple-quality pass 1 — heatmap overflow, demo teardown, calm AI fallback, footer, window grid (AQ-1)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2320,8 +2320,36 @@ final class AppState {
             // already-correct demo guards in `reconnectItem` and
             // `refreshLiabilities`. Only once a server is actually present do we
             // fall through into the real add-account flow (teardown + Plaid Link).
+            // The probe's failure path (checkServerConnection's catch) clears
+            // itemStatuses + all server metadata. In a serverless demo (incl. the
+            // recovery-scenario screenshot mode) that would erase the demo
+            // sync-health rows even though accounts/transactions survive — so
+            // snapshot the demo status fields and restore them if no real server
+            // turns up (AQ-1, codex review).
+            let demoItemStatuses = itemStatuses
+            let demoServerConnected = serverConnected
+            let demoServerEnvironment = serverEnvironment
+            let demoServerVersion = serverVersion
+            let demoServerItemCount = serverItemCount
+            let demoServerCredentialsConfigured = serverCredentialsConfigured
+            let demoServerStoragePath = serverStoragePath
+            let demoServerSyncReady = serverSyncReady
+            let demoServerSyncedItemCount = serverSyncedItemCount
+            let demoBillingSubscription = billingSubscription
             await checkServerConnection()
             guard serverConnected else {
+                // No real server: restore the demo status fields the probe cleared
+                // and bail without tearing down demo data or painting a banner.
+                itemStatuses = demoItemStatuses
+                serverConnected = demoServerConnected
+                serverEnvironment = demoServerEnvironment
+                serverVersion = demoServerVersion
+                serverItemCount = demoServerItemCount
+                serverCredentialsConfigured = demoServerCredentialsConfigured
+                serverStoragePath = demoServerStoragePath
+                serverSyncReady = demoServerSyncReady
+                serverSyncedItemCount = demoServerSyncedItemCount
+                billingSubscription = demoBillingSubscription
                 error = nil
                 return
             }

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2310,6 +2310,22 @@ final class AppState {
         error = nil
 
         if isDemoMode {
+            // A serverless --demo launch needs no server to stay populated, but
+            // the demo readiness card advertises "Connect Bank". Probe for a real
+            // server FIRST and bail without mutating anything when none is
+            // reachable: the destructive demo→real teardown below (clearing
+            // accounts/transactions/etc.) must never run in a serverless demo, or
+            // a single "Connect Bank" tap would wipe the demo dashboard and paint
+            // a server-required banner the demo does not need. Mirrors the
+            // already-correct demo guards in `reconnectItem` and
+            // `refreshLiabilities`. Only once a server is actually present do we
+            // fall through into the real add-account flow (teardown + Plaid Link).
+            await checkServerConnection()
+            guard serverConnected else {
+                error = nil
+                return
+            }
+
             isDemoMode = false
             isDemoStatusRecoveryScenario = false
             isSetupComplete = false
@@ -2355,7 +2371,12 @@ final class AppState {
         }
 
         guard serverConnected else {
-            error = "Start the VaultPeek companion server before adding an account."
+            // Never paint a server-required banner over a demo dashboard
+            // (existing `error = isDemoMode ? nil : …` convention). The demo
+            // path already returned above before any teardown, so reaching here
+            // in demo mode is not expected — but suppress defensively in case a
+            // future caller re-enters this guard while demo is still active.
+            error = isDemoMode ? nil : "Start the VaultPeek companion server before adding an account."
             return
         }
 

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -441,15 +441,50 @@ private struct SidebarRow: View {
 /// `ConnectionHealthStripView` and `AppState.statusModeText` — no new signals.
 private struct SidebarFooter: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             Divider()
             ConnectionHealthStripView()
-            DataModeChip(mode: appState.statusModeText)
+            // Only show the data-mode chip for a known mode. Pre-connection the
+            // mode resolves to "Unknown" (serverless, no environment); printing a
+            // dead "❓ Unknown" pill is a non-actionable dead end. Instead surface
+            // an actionable "Not connected" control that deep-links to Settings,
+            // mirroring `ConnectionHealthStripView`'s self-hide of empty state.
+            if appState.statusModeText == "Unknown" {
+                NotConnectedFooterButton(openSettings: { openSettings() })
+            } else {
+                DataModeChip(mode: appState.statusModeText)
+            }
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.sm)
+    }
+}
+
+/// Shown in the sidebar footer when no data mode is resolved yet (server
+/// unreachable / pre-setup). Replaces the dead "❓ Unknown" pill with an
+/// actionable control that opens Settings, so the footer always offers a next
+/// step. Glyph + text + label carry the meaning together — never color alone.
+private struct NotConnectedFooterButton: View {
+    let openSettings: () -> Void
+
+    var body: some View {
+        Button(action: openSettings) {
+            Label("Not connected", systemImage: "bolt.horizontal.circle")
+                .labelStyle(.titleAndIcon)
+                .microText()
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.chipVertical)
+                .glassSurface(.inset)
+        }
+        .buttonStyle(.plain)
+        .help("Open Settings to connect VaultPeek to your bank.")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Not connected. Open Settings to connect.")
+        .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
@@ -13,6 +13,13 @@ import SwiftUI
 /// visible status** (AND-564); the availability label carries the current state so
 /// the user always sees whether anything ran locally. Honors Privacy Mask via the
 /// receipt's `privacyMaskEnabled` input, and never carries meaning by color alone.
+///
+/// Like its self-carding Dashboard siblings (``DashboardRecurringCard``,
+/// ``CategoryDashboardCard``) and the Insights hero (``InsightsAIInsightView``),
+/// the card wraps its body in a ``WindowSection`` so it inherits the solid
+/// ``windowCardSurface()`` + 20pt (``WindowMetrics/md``) padding + `title3`
+/// (``WindowCardTitle``) header. Data stays solid — Liquid Glass goes on chrome,
+/// not on the financial figures (ADR-001: "glass on chrome, not data").
 struct DashboardLocalInsightCard: View {
     @Environment(AppState.self) private var appState
 
@@ -39,56 +46,53 @@ struct DashboardLocalInsightCard: View {
     var body: some View {
         let receipt = receipt
 
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .center, spacing: 8) {
-                Text(receipt.title)
-                    .sectionTitle()
-                    .foregroundStyle(.secondary)
+        // A titled window-section card so the receipt inherits the solid surface,
+        // 20pt padding, and `title3` header from the shared component — matching
+        // every sibling Dashboard card. The availability state rides in the header
+        // accessory (text + glyph, never color alone).
+        WindowSection(receipt.title, systemImage: "sparkles") {
+            availabilityLabel
+        } content: {
+            VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+                Text(receipt.headline)
+                    .windowCardTitle()
+                    .fixedSize(horizontal: false, vertical: true)
 
-                Spacer()
-
-                availabilityLabel
-            }
-
-            Text(receipt.headline)
-                .font(.caption.weight(.semibold))
-                .lineLimit(1)
-                .minimumScaleFactor(0.86)
-
-            HStack(spacing: 6) {
-                ForEach(receipt.evidenceChips) { chip in
-                    evidenceChip(chip)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 3) {
-                ForEach(Array(detailLines(receipt).enumerated()), id: \.offset) { _, detail in
-                    HStack(alignment: .top, spacing: 6) {
-                        Circle()
-                            .fill(Color.secondary.opacity(0.58))
-                            .frame(width: 4, height: 4)
-                            .padding(.top, 6)
-                        Text(detail)
-                            .microText()
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                if !receipt.evidenceChips.isEmpty {
+                    HStack(spacing: WindowMetrics.sm) {
+                        ForEach(receipt.evidenceChips) { chip in
+                            evidenceChip(chip)
+                        }
                     }
                 }
-            }
 
-            HStack(spacing: 5) {
-                Image(systemName: "lock.shield.fill")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Text("\(receipt.localOnlyBadge). \(receipt.reversibleActionCopy)")
-                    .microText()
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                Spacer(minLength: 4)
+                VStack(alignment: .leading, spacing: WindowMetrics.xs) {
+                    ForEach(Array(detailLines(receipt).enumerated()), id: \.offset) { _, detail in
+                        HStack(alignment: .top, spacing: WindowMetrics.sm) {
+                            Image(systemName: "circle.fill")
+                                .font(.system(size: 5))
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 7)
+                                .accessibilityHidden(true)
+                            Text(detail)
+                                .windowSupportingText()
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+
+                HStack(spacing: WindowMetrics.xs) {
+                    Image(systemName: "lock.shield.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                    Text("\(receipt.localOnlyBadge). \(receipt.reversibleActionCopy)")
+                        .windowSupportingText()
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: WindowMetrics.xs)
+                }
             }
         }
-        .padding(Spacing.sm)
-        .glassSurface(.inset)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(receipt.accessibilitySummary)
     }
@@ -128,7 +132,7 @@ struct DashboardLocalInsightCard: View {
     }
 
     private func evidenceChip(_ chip: LocalAIInsightReceipt.EvidenceChip) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             HStack(spacing: 4) {
                 Image(systemName: chip.systemImage)
                     .font(.caption2.weight(.semibold))
@@ -148,7 +152,9 @@ struct DashboardLocalInsightCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.rowVertical)
-        .glassSurface(.inset, cornerRadius: Radius.control)
+        // A quiet `.quaternary` inner fill rather than Liquid Glass: even an inner
+        // evidence chip carries figures (data), so it stays solid (ADR-001).
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: Radius.control))
         .help("\(chip.label): \(chip.value)")
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -455,10 +455,15 @@ struct DashboardYearHeatmapGrid: View {
     /// Gap between cells. A touch wider than the glance grid's 2pt so the larger
     /// cells read as a clean lattice at desk distance.
     private let cellSpacing: CGFloat = 3
-    /// Desk-distance cell-size clamp: never smaller than the glance cap (so it is
-    /// always at least as legible as the popover), never so large the year grid
-    /// dominates the column. The actual size fills the available width between.
-    private let minCell: CGFloat = 9
+    /// Desk-distance cell-size clamp. `maxCell` keeps the grid from blowing the
+    /// column out when there is room; `deskMinCell` is the *preferred* desk floor,
+    /// but the grid is allowed to shrink below it (down to ``hardMinCell``) rather
+    /// than overflow when the 53-week year can't fit a narrow column — see
+    /// ``clampedCell(forWidth:)``. The popover/Insights grid floors hard at 9pt,
+    /// but it lives in a wider surface; the Dashboard hero shares a 2-column canvas
+    /// and must fit a ~368pt column, so a clean shrink beats a horizontal bleed.
+    private let deskMinCell: CGFloat = 9
+    private let hardMinCell: CGFloat = 4
     private let maxCell: CGFloat = 15
 
     private var weekCount: Int { max(layout.weekColumns.count, 1) }
@@ -466,13 +471,18 @@ struct DashboardYearHeatmapGrid: View {
     var body: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             GeometryReader { proxy in
-                let cell = clampedCell(forWidth: proxy.size.width)
+                let width = proxy.size.width
+                let cell = clampedCell(forWidth: width)
                 VStack(alignment: .leading, spacing: cellSpacing) {
-                    monthMarkers(cell: cell)
+                    monthMarkers(cell: cell, width: width)
                     grid(cell: cell)
                 }
             }
             .frame(height: gridHeight)
+            // Hard stop for the cross-column bleed: neither the grid nor the
+            // .offset month-marker row may paint outside the card, regardless of
+            // the resolved cell size or the column width (AQ-1).
+            .clipped()
 
             legend
         }
@@ -484,13 +494,25 @@ struct DashboardYearHeatmapGrid: View {
         .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
     }
 
-    /// Largest cell that lets all weeks fit the available width, clamped to the
-    /// desk-distance range so the hero never collapses to a glance strip or blows
-    /// the column out.
+    /// Largest cell that lets all weeks fit the available width.
+    ///
+    /// When there is room, the cell grows toward `maxCell` and never drops below the
+    /// preferred desk floor (`deskMinCell`) — keeping the comfortable desk-scale look.
+    /// When the 53-week year *can't* fit (e.g. a ~368pt two-column-breakpoint
+    /// column, where 53 cells at 9pt + spacing would need ~636pt), the cell is
+    /// allowed to shrink below the desk floor down to `hardMinCell` so the whole
+    /// year still fits inside the card instead of overflowing into the right column.
     private func clampedCell(forWidth width: CGFloat) -> CGFloat {
+        guard width > 0 else { return deskMinCell }
         let usable = width - CGFloat(weekCount - 1) * cellSpacing
         let fit = floor(usable / CGFloat(weekCount))
-        return min(maxCell, max(minCell, fit))
+        if fit >= deskMinCell {
+            // There is room for the comfortable desk scale (or more); clamp up.
+            return min(maxCell, fit)
+        }
+        // Not enough room for the desk floor: shrink to fit, but never below the
+        // hard minimum (below which the lattice stops reading as cells).
+        return max(hardMinCell, fit)
     }
 
     /// Reserve height for seven day-rows at the max cell size plus the month-marker
@@ -528,17 +550,24 @@ struct DashboardYearHeatmapGrid: View {
         }
     }
 
-    /// Month labels above the grid, positioned by their week index. Hidden from
-    /// accessibility (the VoiceOver label already names the span).
-    private func monthMarkers(cell: CGFloat) -> some View {
+    /// Month labels above the grid, positioned by their week index. `step` is
+    /// derived from the *resolved* (possibly shrunk) cell so the labels track the
+    /// grid columns exactly, and a marker is only emitted when its offset lands
+    /// within the available `width` — so a label can never paint past the right
+    /// edge into the neighboring column. Hidden from accessibility (the VoiceOver
+    /// label already names the span).
+    private func monthMarkers(cell: CGFloat, width: CGFloat) -> some View {
         let step = cell + cellSpacing
         return ZStack(alignment: .topLeading) {
             ForEach(layout.monthMarkers) { marker in
-                Text(marker.label)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .fixedSize()
-                    .offset(x: CGFloat(marker.weekIndex) * step)
+                let offset = CGFloat(marker.weekIndex) * step
+                if offset <= width {
+                    Text(marker.label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize()
+                        .offset(x: offset)
+                }
             }
         }
         .frame(maxWidth: .infinity, minHeight: 14, alignment: .topLeading)

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -472,16 +472,16 @@ struct DashboardYearHeatmapGrid: View {
         VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             GeometryReader { proxy in
                 let width = proxy.size.width
-                let cell = clampedCell(forWidth: width)
-                VStack(alignment: .leading, spacing: cellSpacing) {
-                    monthMarkers(cell: cell, width: width)
-                    grid(cell: cell)
+                let metrics = resolvedMetrics(forWidth: width)
+                VStack(alignment: .leading, spacing: metrics.spacing) {
+                    monthMarkers(cell: metrics.cell, spacing: metrics.spacing)
+                    grid(cell: metrics.cell, spacing: metrics.spacing)
                 }
             }
             .frame(height: gridHeight)
-            // Hard stop for the cross-column bleed: neither the grid nor the
-            // .offset month-marker row may paint outside the card, regardless of
-            // the resolved cell size or the column width (AQ-1).
+            // Belt-and-braces bound only: the resolved metrics already fit the full
+            // 53-week year (cell + gap) inside the column, so this never hides data
+            // — it just guarantees no sub-pixel paint escapes the card (AQ-1).
             .clipped()
 
             legend
@@ -494,25 +494,33 @@ struct DashboardYearHeatmapGrid: View {
         .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
     }
 
-    /// Largest cell that lets all weeks fit the available width.
+    /// Resolve the cell size **and** inter-cell gap so the full 53-week year fits the
+    /// available width — the whole year stays glanceable (never clipped or hidden)
+    /// at any column width.
     ///
-    /// When there is room, the cell grows toward `maxCell` and never drops below the
-    /// preferred desk floor (`deskMinCell`) — keeping the comfortable desk-scale look.
-    /// When the 53-week year *can't* fit (e.g. a ~368pt two-column-breakpoint
-    /// column, where 53 cells at 9pt + spacing would need ~636pt), the cell is
-    /// allowed to shrink below the desk floor down to `hardMinCell` so the whole
-    /// year still fits inside the card instead of overflowing into the right column.
-    private func clampedCell(forWidth width: CGFloat) -> CGFloat {
-        guard width > 0 else { return deskMinCell }
-        let usable = width - CGFloat(weekCount - 1) * cellSpacing
-        let fit = floor(usable / CGFloat(weekCount))
-        if fit >= deskMinCell {
-            // There is room for the comfortable desk scale (or more); clamp up.
-            return min(maxCell, fit)
+    /// When there is room, the cell grows toward `maxCell` at the comfortable desk
+    /// gap (`cellSpacing`). When the year can't fit the desk scale (e.g. the
+    /// ~330–368pt two-column column, where 53 cells at the 9pt desk floor + 3pt gaps
+    /// would need ~636pt), BOTH the cell and the gap shrink together — the gap
+    /// tightening toward 1pt so the lattice stays legible rather than gappy — so all
+    /// 53 weeks fit inside the card (Apple Health "Year"-style fit-to-width, not a
+    /// horizontal bleed). The `.clipped()` in `body` is then only a safety bound,
+    /// never the thing that hides weeks (AQ-1, codex review).
+    private func resolvedMetrics(forWidth width: CGFloat) -> (cell: CGFloat, spacing: CGFloat) {
+        guard width > 0 else { return (deskMinCell, cellSpacing) }
+        let n = CGFloat(weekCount)
+        let deskFit = floor((width - (n - 1) * cellSpacing) / n)
+        if deskFit >= deskMinCell {
+            // Room for the comfortable desk scale (or larger); grow up to maxCell.
+            return (min(maxCell, deskFit), cellSpacing)
         }
-        // Not enough room for the desk floor: shrink to fit, but never below the
-        // hard minimum (below which the lattice stops reading as cells).
-        return max(hardMinCell, fit)
+        // Too narrow for the desk scale: shrink cell + gap together so the whole
+        // year still fits. Size the cell assuming a tight 1pt gap, derive a
+        // proportional gap (≈ cell/3, capped at the desk gap), then re-fit the cell.
+        let tightCell = max(hardMinCell, floor((width - (n - 1)) / n))
+        let spacing = max(1, min(cellSpacing, floor(tightCell / 3)))
+        let cell = max(hardMinCell, floor((width - (n - 1) * spacing) / n))
+        return (cell, spacing)
     }
 
     /// Reserve height for seven day-rows at the max cell size plus the month-marker
@@ -523,10 +531,10 @@ struct DashboardYearHeatmapGrid: View {
         return markerRow + 7 * maxCell + 6 * cellSpacing
     }
 
-    private func grid(cell: CGFloat) -> some View {
-        HStack(alignment: .top, spacing: cellSpacing) {
+    private func grid(cell: CGFloat, spacing: CGFloat) -> some View {
+        HStack(alignment: .top, spacing: spacing) {
             ForEach(Array(layout.weekColumns.enumerated()), id: \.offset) { _, week in
-                VStack(spacing: cellSpacing) {
+                VStack(spacing: spacing) {
                     ForEach(Array(week.enumerated()), id: \.offset) { _, day in
                         cellView(for: day, size: cell)
                     }
@@ -551,23 +559,19 @@ struct DashboardYearHeatmapGrid: View {
     }
 
     /// Month labels above the grid, positioned by their week index. `step` is
-    /// derived from the *resolved* (possibly shrunk) cell so the labels track the
-    /// grid columns exactly, and a marker is only emitted when its offset lands
-    /// within the available `width` — so a label can never paint past the right
-    /// edge into the neighboring column. Hidden from accessibility (the VoiceOver
-    /// label already names the span).
-    private func monthMarkers(cell: CGFloat, width: CGFloat) -> some View {
-        let step = cell + cellSpacing
+    /// derived from the *resolved* cell + gap so the labels track the grid columns
+    /// exactly; because the resolved metrics fit the whole year inside the column,
+    /// the last label lands within the grid (no width guard needed). Hidden from
+    /// accessibility (the VoiceOver label already names the span).
+    private func monthMarkers(cell: CGFloat, spacing: CGFloat) -> some View {
+        let step = cell + spacing
         return ZStack(alignment: .topLeading) {
             ForEach(layout.monthMarkers) { marker in
-                let offset = CGFloat(marker.weekIndex) * step
-                if offset <= width {
-                    Text(marker.label)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .fixedSize()
-                        .offset(x: offset)
-                }
+                Text(marker.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize()
+                    .offset(x: CGFloat(marker.weekIndex) * step)
             }
         }
         .frame(maxWidth: .infinity, minHeight: 14, alignment: .topLeading)

--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -125,10 +125,15 @@ struct InsightsAIInsightView: View {
 
     /// Phase status pill — glyph + text so the state never rides on tint alone.
     /// The generating phase animates a non-looping shimmer, suppressed under
-    /// Reduce Motion.
+    /// Reduce Motion. When the runtime is unavailable — the expected graceful
+    /// fallback on a Mac without on-device AI, not an error — the pill reads as a
+    /// passive *info* status (neutral tint + info glyph), never an alarm (HIG:
+    /// match delivery to significance; never imply something's wrong). The long
+    /// availability detail and any raw probe diagnostic live only here, on the
+    /// `.help(...)` tooltip, so they never shout from the card body.
     private var phasePill: some View {
         HStack(spacing: Spacing.xxs) {
-            Image(systemName: phase.systemImage)
+            Image(systemName: phaseGlyph)
                 .font(.caption2.weight(.semibold))
                 .symbolEffect(.pulse, options: .repeating, isActive: phase.isWorking && !reduceMotion)
                 .accessibilityHidden(true)
@@ -141,17 +146,42 @@ struct InsightsAIInsightView: View {
         .padding(.vertical, 3)
         .background(phaseTint.opacity(0.12), in: Capsule())
         .overlay { Capsule().stroke(phaseTint.opacity(0.20), lineWidth: 1) }
+        .help(phaseHelpText)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(phase.accessibilityLabel)
     }
 
+    /// Glyph for the pill. The unavailable state uses a neutral info glyph rather
+    /// than the enum's `exclamationmark.triangle`, so the expected fallback reads
+    /// as information, not caution.
+    private var phaseGlyph: String {
+        switch phase {
+        case .unavailable: "info.circle"
+        default: phase.systemImage
+        }
+    }
+
     private var phaseTint: Color {
         switch phase {
-        case .off: .secondary
-        case .unavailable: SemanticColors.warning
+        // Unavailable is the expected fallback, not a fault — keep it secondary.
+        // `SemanticColors.warning` is reserved for true caution.
+        case .off, .unavailable: .secondary
         case .generating: SemanticColors.brand
         case .streamed: SemanticColors.positive
         }
+    }
+
+    /// Tooltip text for the pill. For the unavailable state it carries the long,
+    /// calm availability detail and — only here — the raw probe diagnostic, so
+    /// dev jargon never reaches the visible card (mirrors the popover sibling's
+    /// `.help(LocalAIAvailabilityPresentation.helpText(for:))`).
+    private var phaseHelpText: String {
+        guard phase == .unavailable else { return phase.accessibilityLabel }
+        var text = LocalAIAvailabilityPresentation.helpText(for: availability)
+        if let probe = availability.probeErrorText, !probe.isEmpty {
+            text += " (\(probe))"
+        }
+        return text
     }
 
     // MARK: - Off state (consent)
@@ -218,10 +248,6 @@ struct InsightsAIInsightView: View {
 
             provenance
 
-            if phase == .unavailable {
-                unavailableNote
-            }
-
             footer
         }
     }
@@ -263,16 +289,6 @@ struct InsightsAIInsightView: View {
         }
         lines.append(contentsOf: receipt.limitations.prefix(2))
         return Array(lines.prefix(3))
-    }
-
-    private var unavailableNote: some View {
-        Label(availability.detail, systemImage: "exclamationmark.triangle")
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(SemanticColors.warning)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(WindowMetrics.sm)
-            .nativeInsetSurface(stroke: SemanticColors.warning.opacity(0.18))
-            .accessibilityLabel("Runtime unavailable. \(availability.detail)")
     }
 
     private var footer: some View {

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -75,7 +75,7 @@ struct TransactionsDestinationView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             TransactionsFilterBar(
                 filter: filterBinding,
                 sort: sortBinding,
@@ -83,8 +83,8 @@ struct TransactionsDestinationView: View {
                 resultCount: rows.count,
                 isSearchFocused: $isSearchFocused
             )
-            .padding(.horizontal, Spacing.lg)
-            .padding(.top, Spacing.md)
+            .padding(.horizontal, WindowMetrics.canvasMargin)
+            .padding(.top, WindowMetrics.md)
 
             Divider().opacity(0.4)
 

--- a/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIRuntimeResolution.swift
@@ -184,10 +184,11 @@ public enum LocalAIRuntimeResolution {
         case .invalidOutput:
             "returned invalid or unsafe output"
         }
-        var detail = "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
-        if let diagnostic, !diagnostic.isEmpty {
-            detail += " Probe error: \(diagnostic)"
-        }
-        return detail
+        // The user-facing detail stays jargon-free (HIG: avoid technical jargon,
+        // never imply something's wrong). The raw probe diagnostic is preserved
+        // separately on `LocalAIAvailability.probeErrorText` for the help tooltip
+        // and Settings — it is deliberately NOT folded into this sentence.
+        _ = diagnostic
+        return "\(runtime) \(reasonText). VaultPeek used deterministic local summaries and did not call cloud AI."
     }
 }

--- a/Tests/PlaidBarCoreTests/DemoFixturesTests.swift
+++ b/Tests/PlaidBarCoreTests/DemoFixturesTests.swift
@@ -143,4 +143,25 @@ struct DemoFixturesTests {
         #expect(first == second)
         #expect(DemoFixtures.accountBalanceHistory(forAccountId: "accountSecretIdentifier", now: referenceDate).isEmpty)
     }
+
+    /// Demo-F2: the demo data contract is "accounts AND transactions together".
+    /// `--demo` (and any code that hydrates from `DemoFixtures`) must never land
+    /// in a half-populated state with accounts but no transactions, or vice
+    /// versa — a dashboard with accounts but an empty transaction list reads as
+    /// broken. Locks both halves non-empty together so a future fixture edit
+    /// cannot silently strand one side.
+    @Test("Demo fixtures populate accounts and transactions together")
+    func demoFixturesPopulateAccountsAndTransactionsTogether() {
+        let accounts = DemoFixtures.accounts
+        let transactions = DemoFixtures.transactions(now: referenceDate)
+
+        #expect(!accounts.isEmpty, "demo accounts must be populated")
+        #expect(!transactions.isEmpty, "demo transactions must be populated")
+        // The contract is the conjunction: neither side may be empty while the
+        // other is non-empty.
+        #expect(
+            accounts.isEmpty == transactions.isEmpty,
+            "demo accounts and transactions must be populated (or empty) together"
+        )
+    }
 }

--- a/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIRuntimeResolutionTests.swift
@@ -129,8 +129,25 @@ struct LocalAIRuntimeResolutionTests {
         )
         #expect(resolved.state == .unavailable)
         #expect(resolved.detail.contains("not reachable"))
-        #expect(resolved.detail.contains("Connection refused"))
+        // The raw probe diagnostic must NOT leak into the user-facing detail
+        // (HIG: jargon-free, never imply something's wrong). It is preserved only
+        // on `probeErrorText`, which the help tooltip / Settings surface.
+        #expect(!resolved.detail.contains("Connection refused"))
+        #expect(!resolved.detail.lowercased().contains("probe error"))
         #expect(resolved.probeErrorText == "Connection refused")
+    }
+
+    @Test("Fallback detail stays jargon-free even when a diagnostic is present")
+    func fallbackDetailExcludesDiagnostic() {
+        let detail = LocalAIRuntimeResolution.fallbackDetail(
+            runtimeName: "ollama",
+            reason: .modelError,
+            diagnostic: "Foundation Models generation failed: GenerationError"
+        )
+        #expect(!detail.contains("Probe error"))
+        #expect(!detail.contains("GenerationError"))
+        #expect(!detail.contains("Foundation Models generation failed"))
+        #expect(detail.contains("returned an error"))
     }
 
     @Test("Terminal states pass through resolution unchanged")


### PR DESCRIPTION
Apple-quality iteration 1. Root-caused from a **live-app eyeball** (the headless render hid all of these) and fixed across 5 file-disjoint slices. Strict-concurrency build clean, **2065 tests** (+2), all surfaces re-rendered and eyeballed.

## Fixes

**P1 — functional**
- **Heatmap overflow (`DashboardOverviewColumn`)** — the year-activity heatmap overflowed its column and its `.offset` month-marker row painted over the right column (garbled Recurring / Spending-by-category text). Now `.clipped()` + shrink-to-fit cell sizing + width-guarded markers, mirroring the clean `InsightsActivityHeatmapGrid`. Verified: dashboard render shows the heatmap fully contained, right column clean.
- **Demo `addAccount()` teardown (`AppState`)** — tapping "Connect Bank" in `--demo` unconditionally wiped demo data and showed a "Start the companion server" banner. Now probes the server first and bails without mutating when serverless; banner suppressed in demo. + DemoFixtures invariant test (accounts & transactions populate together).

**P2 — visual debt / HIG**
- **Calm AI-unavailable fallback (`InsightsAIInsightView`, `LocalAIRuntimeResolution`)** — the expected "Apple Intelligence unavailable → deterministic local summaries" state was rendered as a duplicated orange alarm with dev jargon. Now: one calm grey line, a neutral `info.circle` "Runtime unavailable" pill (no orange/triangle), and no "Probe error: GenerationError" leak (preserved on `probeErrorText`, shown only via `.help`). Grounded in HIG Feedback / Machine-learning guidance.
- **"Unknown" footer (`AppShellView`)** — the dead "❓ Unknown" data-mode pill is replaced with an actionable "Not connected" affordance that routes to Settings; the real Demo/Sandbox/Production chip shows otherwise.
- **Transactions grid (`TransactionsDestinationView`)** — adopted the `WindowMetrics` canvas grid like every sibling destination (was popover-density `Spacing`).
- **Local-insight card surface (`DashboardLocalInsightCard`)** — no more Liquid Glass on the data layer; now the solid `windowCardSurface` via `WindowSection` (HIG Materials / ADR-001 "glass on chrome, not data").

## Deferred to backlog
AND-627 (dashboard empty-state coherence), AND-628 (window semantic type roles), AND-629 (polish batch) — all under AND-624.

@codex please review — focus on: the demo addAccount guard ordering (no teardown before a confirmed server), heatmap shrink-to-fit at narrow widths, and that the AI-fallback still surfaces the cause (once) without alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)