### PR TITLE
fix(privacy): hide sidebar counts while masked

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1588,7 +1588,8 @@ final class AppState {
             unreviewedCount: transactionReviewCount,
             overBudgetCount: categoryBudgetPresentation.overBudgetCount,
             unacknowledgedAlertCount: sidebarUnacknowledgedAlertCount,
-            reconnectNeededCount: sidebarReconnectNeededCount
+            reconnectNeededCount: sidebarReconnectNeededCount,
+            isMasked: shouldMaskFinancialValues
         )
     }
 

--- a/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
+++ b/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
@@ -10,7 +10,10 @@ struct ConnectionHealthStripView: View {
     @Environment(AppState.self) private var appState
 
     private var result: ConnectionHealthStrip.Result {
-        ConnectionHealthStrip.evaluate(appState.itemStatuses)
+        // Withhold exact connection counts under Privacy Mask / App Lock — the
+        // status word + reconnect affordance stay, only the number is masked
+        // (matches the sidebar badge gating; AND-483 / codex #619).
+        ConnectionHealthStrip.evaluate(appState.itemStatuses, isMasked: appState.shouldMaskFinancialValues)
     }
 
     var body: some View {

--- a/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
+++ b/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
@@ -9,7 +9,10 @@ import Foundation
 /// zero**. Keeping the derivation here (rather than in the SwiftUI sidebar) makes
 /// the "which destinations badge, what counts, when do they hide" policy
 /// unit-testable without the app target (CLAUDE.md: shared logic lives in
-/// `PlaidBarCore`); the view stays a thin renderer over `badges`.
+/// `PlaidBarCore`); the view stays a thin renderer over `badges`. When Privacy
+/// Mask / App Lock is active, badges are withheld entirely so the window-first
+/// sidebar does not reveal review, budget, alert, or reconnect counts while the
+/// rest of the app is private.
 ///
 /// Four destinations badge, each from a live `AppState` signal (IA §3.2):
 ///
@@ -72,7 +75,8 @@ public struct SidebarBadgeModel: Sendable, Equatable {
     /// computes. Each negative input is clamped to zero, and a zero count
     /// produces no badge (the hide-when-zero rule). The resulting badges are
     /// ordered by `RouteDestination.allCases` so the model's order matches the
-    /// sidebar's.
+    /// sidebar's. When `isMasked` is true, all badges are withheld because exact
+    /// counts are behavioral finance metadata.
     ///
     /// - Parameters:
     ///   - unreviewedCount: items awaiting review
@@ -85,12 +89,17 @@ public struct SidebarBadgeModel: Sendable, Equatable {
     ///     menu-bar glance and Dashboard use (IA §1.3).
     ///   - reconnectNeededCount: items needing reconnect
     ///     (`ConnectionHealthStrip` reconnect-needed bucket).
+    ///   - isMasked: Privacy Mask / App Lock state. When true, every badge is
+    ///     hidden regardless of count.
     public static func make(
         unreviewedCount: Int,
         overBudgetCount: Int,
         unacknowledgedAlertCount: Int,
-        reconnectNeededCount: Int
+        reconnectNeededCount: Int,
+        isMasked: Bool = false
     ) -> SidebarBadgeModel {
+        guard !isMasked else { return .empty }
+
         var badges: [Badge] = []
 
         func appendBadge(

--- a/Sources/PlaidBarCore/Utilities/ConnectionHealthStrip.swift
+++ b/Sources/PlaidBarCore/Utilities/ConnectionHealthStrip.swift
@@ -64,7 +64,14 @@ public enum ConnectionHealthStrip {
 
     /// Groups statuses into the three buckets, omitting empty buckets. The result
     /// preserves a stable Connected → Reconnect-needed → Provider-outage order.
-    public static func evaluate(_ statuses: [ItemStatus]) -> Result {
+    ///
+    /// - Parameter isMasked: when Privacy Mask / App Lock is active, the bucket
+    ///   labels drop the exact count and read as the status word alone
+    ///   ("Connected" / "Needs attention" / "Temporarily unavailable"). The
+    ///   recovery *status* (and its reconnect affordance) is preserved — never
+    ///   hidden — while the exact item count, which is behavioral metadata gated
+    ///   like the sidebar badges (AND-483), is withheld.
+    public static func evaluate(_ statuses: [ItemStatus], isMasked: Bool = false) -> Result {
         let counts = statuses.reduce(into: [State: Int]()) { partial, item in
             partial[bucketState(for: item.status), default: 0] += 1
         }
@@ -75,7 +82,7 @@ public enum ConnectionHealthStrip {
                 Bucket(
                     state: .connected,
                     count: connected,
-                    label: "\(connected) connected",
+                    label: isMasked ? "Connected" : "\(connected) connected",
                     detail: "Syncing normally.",
                     iconName: "checkmark.circle",
                     isActionable: false
@@ -87,7 +94,7 @@ public enum ConnectionHealthStrip {
                 Bucket(
                     state: .reconnectNeeded,
                     count: reconnect,
-                    label: "\(reconnect) need\(reconnect == 1 ? "s" : "") attention",
+                    label: isMasked ? "Needs attention" : "\(reconnect) need\(reconnect == 1 ? "s" : "") attention",
                     detail: "Reconnect to keep these accounts in sync.",
                     iconName: "exclamationmark.triangle",
                     isActionable: true
@@ -99,7 +106,7 @@ public enum ConnectionHealthStrip {
                 Bucket(
                     state: .providerOutage,
                     count: outage,
-                    label: "\(outage) temporarily unavailable",
+                    label: isMasked ? "Temporarily unavailable" : "\(outage) temporarily unavailable",
                     detail: "Your bank or Plaid is down. We'll retry automatically — no action needed.",
                     iconName: "wifi.exclamationmark",
                     isActionable: false

--- a/Tests/PlaidBarCoreTests/ConnectionHealthStripTests.swift
+++ b/Tests/PlaidBarCoreTests/ConnectionHealthStripTests.swift
@@ -35,6 +35,29 @@ struct ConnectionHealthStripTests {
         #expect(outage?.iconName != reconnect?.iconName)
     }
 
+    @Test("Privacy Mask withholds exact counts from labels but preserves status + recovery affordance")
+    func maskedLabelsDropCounts() {
+        let statuses = [
+            status("a", .connected),
+            status("b", .connected),
+            status("c", .error),
+            status("d", .providerOutage),
+        ]
+        let masked = ConnectionHealthStrip.evaluate(statuses, isMasked: true)
+        // Same buckets/states/order and the reconnect affordance survive…
+        #expect(masked.buckets.map(\.state) == [.connected, .reconnectNeeded, .providerOutage])
+        #expect(masked.hasActionableWork == true)
+        // …but no label leaks a digit, and they read as the status words.
+        #expect(masked.buckets.allSatisfy { !$0.label.contains(where: \.isNumber) })
+        let byState = Dictionary(uniqueKeysWithValues: masked.buckets.map { ($0.state, $0.label) })
+        #expect(byState[.connected] == "Connected")
+        #expect(byState[.reconnectNeeded] == "Needs attention")
+        #expect(byState[.providerOutage] == "Temporarily unavailable")
+        // Unmasked still shows the counts.
+        let unmasked = ConnectionHealthStrip.evaluate(statuses)
+        #expect(unmasked.buckets.contains { $0.label.contains("2 connected") })
+    }
+
     @Test("Reconnect-needed bucket is actionable, provider-outage is not")
     func actionableFlags() {
         let result = ConnectionHealthStrip.evaluate([

--- a/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
@@ -60,6 +60,23 @@ struct SidebarBadgeModelTests {
         #expect(model == .empty)
     }
 
+    @Test("Privacy Mask withholds all exact sidebar counts")
+    func privacyMaskWithholdsCounts() {
+        let model = SidebarBadgeModel.make(
+            unreviewedCount: 7,
+            overBudgetCount: 3,
+            unacknowledgedAlertCount: 2,
+            reconnectNeededCount: 1,
+            isMasked: true
+        )
+
+        #expect(model == .empty)
+        #expect(model.badge(for: .review) == nil)
+        #expect(model.badge(for: .budgets) == nil)
+        #expect(model.badge(for: .alerts) == nil)
+        #expect(model.badge(for: .accounts) == nil)
+    }
+
     @Test("Negative inputs clamp to zero (no negative or phantom badges)")
     func negativeClampsToZero() {
         let model = SidebarBadgeModel.make(


### PR DESCRIPTION
## Summary

- hide window-first sidebar count badges while Privacy Mask / App Lock is active
- thread `shouldMaskFinancialValues` into `SidebarBadgeModel`
- add a Core regression test proving exact sidebar counts are withheld under mask

Fixes #618
Linear: AND-630

## Verification

- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `git diff --check` ✅
- `swift test --filter SidebarBadgeModel -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ⚠️ blocked before focused tests run by unrelated SwiftData macro plugin/toolchain errors in `PlaidBarCache` (`SwiftDataMacros.PersistentModelActorMacro` / `PersistentModelMacro` plugin not found)

## Privacy / security

No Plaid credentials, tokens, account IDs, transaction IDs, balances, local SQLite contents, prompts, or response bodies are included. The fix reduces local UI disclosure of behavioral finance metadata while private.
