### PR TITLE
fix(ux): window chip padding tokens + token-relative icon sizing (AND-629 DS-5/DS-6)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -358,7 +358,7 @@ private struct AccountListRow: View {
         Button(action: onSelect) {
             HStack(spacing: WindowMetrics.sm) {
                 Image(systemName: AccountPresentation.iconName(for: account))
-                    .font(.system(size: 18, weight: .medium))
+                    .font(.title3.weight(.medium))
                     .foregroundStyle(.secondary)
                     .frame(width: 40, height: 40)
                     .background(.quinary, in: RoundedRectangle(cornerRadius: Radius.control))

--- a/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
@@ -464,8 +464,8 @@ private struct AlertDetailView: View {
                     Label("Acknowledged", systemImage: "bell.slash")
                         .windowFigureCaption()
                         .foregroundStyle(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
+                        .padding(.horizontal, Spacing.sm)
+                        .padding(.vertical, Spacing.chipVertical)
                         .background(Color.primary.opacity(0.06), in: Capsule())
                 }
                 Spacer()
@@ -542,8 +542,8 @@ private struct AlertSeverityBadge: View {
                 .lineLimit(1)
         }
         .foregroundStyle(tint)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
         .background(tint.opacity(0.11), in: Capsule())
         .overlay { Capsule().stroke(tint.opacity(0.22), lineWidth: 1) }
         .accessibilityHidden(true)

--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -142,8 +142,8 @@ struct InsightsAIInsightView: View {
                 .lineLimit(1)
         }
         .foregroundStyle(phaseTint)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.chipVertical)
         .background(phaseTint.opacity(0.12), in: Capsule())
         .overlay { Capsule().stroke(phaseTint.opacity(0.20), lineWidth: 1) }
         .help(phaseHelpText)
@@ -269,9 +269,9 @@ struct InsightsAIInsightView: View {
         VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             ForEach(Array(provenanceLines.enumerated()), id: \.offset) { _, line in
                 HStack(alignment: .top, spacing: WindowMetrics.sm) {
-                    Image(systemName: "circle.fill")
-                        .font(.system(size: 5))
-                        .foregroundStyle(.secondary)
+                    Circle()
+                        .fill(.secondary)
+                        .frame(width: 4, height: 4)
                         .padding(.top, 7)
                         .accessibilityHidden(true)
                     Text(line)
@@ -349,8 +349,8 @@ struct InsightsEvidenceChipView: View {
             Text(chip.value)
                 .windowDataText()
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
         .background(Color.primary.opacity(0.05), in: Capsule())
         .overlay { Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 1) }
         .accessibilityElement(children: .ignore)


### PR DESCRIPTION
Apple-quality iteration 3 — low-risk consistency polish (AND-629 subset). Strict build clean, 2067 tests.

- **DS-5** — window chip/badge padding snapped to spacing tokens (was literal 7/8/10/3/5pt): Insights phase pill + evidence chip, Alerts acknowledged + severity badges → `Spacing.sm`/`Spacing.chipVertical`/`Spacing.xs`. All chips now share one inset.
- **DS-6** — token/text-style-relative icon sizing: Accounts row glyph `.system(size: 18)` → `.title3.weight(.medium)` (weight-matches the row title); Insights provenance bullet `.system(size: 5)` symbol → a 4pt `Circle` shape (matches the local-insight card).

Deferred from AND-629 to the AND-627 dashboard iteration (shared-component / non-trivial): F2 (CategoryDashboardCard glass→windowCardSurface, needs a popover/window conditional), F3 (recurring empty-state via SecondaryContentUnavailableState, needs a renderer + action wiring), AI-UX-4 (deeper messaging collapse). DS-7 dropped (invalid — @ScaledMetric is load-bearing for the Text Size feature).

@codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)