### PR TITLE
fix(ux): solid category card surface + actionable recurring empty-state (AND-629 F2/F3)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1721,6 +1721,46 @@ final class AppState {
         RecurringSummary.estimatedMonthlyTotal(from: recurringTransactions, asOf: Date())
     }
 
+    /// The shared, contextual recurring **empty/unavailable** state — the single
+    /// source the window-first Dashboard and Planning recurring cards both render
+    /// when nothing is detected, so the two surfaces stay identical. The Core
+    /// engine (``SecondaryContentUnavailableState/recurring(isDemoMode:isInitialLoad:serverConnected:linkedItemCount:accountCount:syncedItemCount:transactionCount:errorMessage:)``)
+    /// decides the contextual copy + next-step action from the live load signals;
+    /// the views never branch on the inputs themselves.
+    var recurringUnavailableState: SecondaryContentUnavailableState {
+        SecondaryContentUnavailableState.recurring(
+            isDemoMode: usesDemoConnectionPresentation,
+            isInitialLoad: loadState(for: .recurring).isInitialLoad,
+            serverConnected: serverConnected,
+            linkedItemCount: statusItemCount,
+            accountCount: accounts.count,
+            syncedItemCount: serverSyncedItemCount ?? 0,
+            transactionCount: transactions.count,
+            errorMessage: error
+        )
+    }
+
+    /// Dispatches the recovery action carried by ``recurringUnavailableState`` to
+    /// the matching `AppState` method, mirroring the established mapping used by the
+    /// accounts empty state in Settings so behavior stays consistent. Keeps the
+    /// Dashboard and Planning recurring cards' action wiring identical.
+    func performRecurringUnavailableAction(_ action: SecondaryContentUnavailableAction) {
+        switch action {
+        case .checkServer:
+            Task { await checkServerConnection() }
+        case .refreshAccounts:
+            Task { await refreshAccounts() }
+        case .syncTransactions:
+            Task { await syncTransactions() }
+        case .refresh:
+            Task { await refreshDashboard() }
+        case .addAccount:
+            navigationModel.go(to: .accounts)
+        case .clearFilters, .showWiderPeriod:
+            break
+        }
+    }
+
     var localAIAvailability: LocalAIAvailability {
         if let probeAvailability = localAIProbeAvailability {
             return probeAvailability

--- a/Sources/PlaidBar/Views/CategoryDashboardCard.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardCard.swift
@@ -21,6 +21,12 @@ struct CategoryDashboardCard: View {
     /// no-op in previews / headless renders.
     @Environment(\.openCategoryDashboard) private var openCategoryDashboard
 
+    /// Mounts the shared card on the **window** workspace rather than the popover.
+    /// In the window the card backs onto the solid window surface
+    /// (`windowCardSurface()` — HIG Materials / ADR-001 "glass on chrome, not
+    /// data"); in the popover (default) it keeps the raised glass surface.
+    var inWindow: Bool = false
+
     private var presentation: CategoryDashboardPresentation {
         appState.categoryDashboardPresentation
     }
@@ -34,25 +40,42 @@ struct CategoryDashboardCard: View {
     var body: some View {
         let model = model
 
-        VStack(alignment: .leading, spacing: Spacing.sm) {
-            header(model)
+        surfaced {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                header(model)
 
-            if model.isEmpty {
-                emptyState
-            } else {
-                SpendDonutChart(model: model.donut, isPrivacyMasked: isMasked)
+                if model.isEmpty {
+                    emptyState
+                } else {
+                    SpendDonutChart(model: model.donut, isPrivacyMasked: isMasked)
 
-                if !model.topGroups.isEmpty {
-                    topGroups(model)
+                    if !model.topGroups.isEmpty {
+                        topGroups(model)
+                    }
                 }
-            }
 
-            openDashboardButton(model)
+                openDashboardButton(model)
+            }
         }
-        .padding(Spacing.sm)
-        .glassSurface(.raised)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilitySummary(model))
+    }
+
+    /// Wraps the card content in the surface appropriate to where it is mounted:
+    /// the solid window card surface in the window (data stays solid — ADR-001
+    /// "glass on chrome, not data"), the raised glass surface in the popover.
+    /// `windowCardSurface()` does not self-pad, so window padding is applied here.
+    @ViewBuilder
+    private func surfaced(@ViewBuilder _ content: () -> some View) -> some View {
+        if inWindow {
+            content()
+                .padding(WindowMetrics.md)
+                .windowCardSurface()
+        } else {
+            content()
+                .padding(Spacing.sm)
+                .glassSurface(.raised)
+        }
     }
 
     // MARK: - Header

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -170,7 +170,7 @@ struct DashboardDestinationView: View {
 
             DashboardRecurringCard(onOpen: { openRoute(.planning(section: .recurring)) })
 
-            CategoryDashboardCard()
+            CategoryDashboardCard(inWindow: true)
 
             if let presentation = appState.firstRunSnapshotPresentation {
                 FirstRunSnapshotView(

--- a/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
@@ -9,8 +9,10 @@ import SwiftUI
 /// the streams; this view never detects). It is meant to sit *inside* a
 /// ``WindowSection`` (which supplies the title + card chrome), so unlike the
 /// popover's self-carding section it renders only the rows — and, when nothing is
-/// detected, a quiet empty line instead of self-hiding, so the dashboard grid
-/// keeps a uniform card rather than a hole.
+/// detected, the shared contextual, actionable empty state (the same
+/// ``SecondaryContentUnavailableState`` recurring engine + action dispatch
+/// Planning uses, sourced from `AppState`) instead of self-hiding, so the
+/// dashboard grid keeps a uniform card rather than a hole and offers a next step.
 ///
 /// Honors Privacy Mask the same way the re-hosted rows do (amounts and the
 /// monthly total run through `PrivacyMaskPresentation`). The "open" affordance
@@ -34,12 +36,11 @@ struct DashboardRecurringCard: View {
             WindowSection("Recurring", systemImage: "repeat") {
                 EmptyView()
             } content: {
-                Label("No recurring charges detected yet.", systemImage: "repeat")
-                    .windowBodyText()
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                SecondaryUnavailableView(presentation: appState.recurringUnavailableState) {
+                    appState.performRecurringUnavailableAction(appState.recurringUnavailableState.action)
+                }
             }
-            .accessibilityElement(children: .combine)
+            .accessibilityElement(children: .contain)
         } else {
             RecurringObligationsSection(
                 presentation: presentation,

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -256,8 +256,11 @@ struct PlanningDestinationView: View {
     /// self-carding ``RecurringObligationsSection`` directly under the column banner
     /// (no card-in-card), exactly as the Dashboard does. The "open" affordance is
     /// dropped (`onOpenSubscriptions: nil`) because this *is* the recurring surface.
-    /// When nothing is detected it shows a quiet uniform ``WindowSection`` empty
-    /// card rather than self-hiding, so the grid keeps an even rhythm.
+    /// When nothing is detected it shows the shared contextual, actionable empty
+    /// state (the same ``SecondaryContentUnavailableState`` recurring engine +
+    /// action dispatch the Dashboard uses, sourced from `AppState`) in a uniform
+    /// ``WindowSection`` card rather than self-hiding, so the grid keeps an even
+    /// rhythm and both surfaces match.
     @ViewBuilder
     private var recurringCard: some View {
         let presentation = RecurringObligationsPresentation.make(
@@ -268,12 +271,11 @@ struct PlanningDestinationView: View {
             WindowSection("Recurring", systemImage: "repeat") {
                 EmptyView()
             } content: {
-                Label("No recurring charges detected yet.", systemImage: "repeat")
-                    .windowBodyText()
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                SecondaryUnavailableView(presentation: appState.recurringUnavailableState) {
+                    appState.performRecurringUnavailableAction(appState.recurringUnavailableState.action)
+                }
             }
-            .accessibilityElement(children: .combine)
+            .accessibilityElement(children: .contain)
         } else {
             RecurringObligationsSection(
                 presentation: presentation,


### PR DESCRIPTION
Apple-quality iteration 4 — dashboard card polish. Strict build clean, 2067 tests + 25 SecondaryContentUnavailable engine tests, dashboard render-eyeballed (F2).

- **F2** — `CategoryDashboardCard` gets an `inWindow` flag: in the window it uses the solid `windowCardSurface()` (HIG Materials / ADR-001 "glass on chrome, not data"); the legacy popover keeps glass. Verified `WindowCardSurface` doesn't self-pad (no double-padding).
- **F3** — both the Dashboard recurring card *and* Planning's recurring card replace the flat hardcoded "No recurring charges detected yet." with the shared, contextual, **actionable** empty state via `SecondaryContentUnavailableState` + `SecondaryUnavailableView`. Wiring is centralized on `AppState` (`recurringUnavailableState` + `performRecurringUnavailableAction`) so the two surfaces are provably identical and dispatch matches the established Settings pattern.

Context: AND-627's heavy "one readiness verdict" is **not** pursued — the AQ-1 audit found the per-surface load model is intentional and the worst incoherence was already fixed by the demo-teardown change. These F2/F3 card improvements are the tangible remainder.

@codex please review — focus on the AppState action dispatch (matches SettingsView.performEmptyAction) and that both recurring cards render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)