### PR TITLE
fix(accounts): window-first Add Account / Plaid Link action (AND-631)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -67,6 +67,24 @@ struct AccountsDestinationView: View {
     var body: some View {
         content
             .navigationTitle(RouteDestination.accounts.title)
+            // The window-first Add Account entry point (AND-631): the destination
+            // every add-account affordance (Dashboard attention chip, readiness
+            // panel, recurring empty state) routes to. Invokes the shared
+            // `AppState.addAccount()` flow — which opens Plaid Hosted Link in the
+            // browser (no in-app sheet) — so those affordances resolve here instead
+            // of dead-ending. In demo it no-ops (keeps demo); with no server it
+            // surfaces the actionable error; with credentials it opens Link.
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await appState.addAccount() }
+                    } label: {
+                        Label("Add Account", systemImage: "plus")
+                    }
+                    .help("Connect a bank with Plaid Link")
+                    .disabled(appState.isLoading)
+                }
+            }
             // Self-heal: if the selected account falls out of the list (removed /
             // disconnected), clear it so the inspector returns to its prompt instead
             // of pointing at a vanished account. Mirrors the popover's reconcile.
@@ -243,6 +261,17 @@ struct AccountsDestinationView: View {
             Label("No accounts yet", systemImage: RouteDestination.accounts.systemImage)
         } description: {
             Text("Connect an institution to see its accounts here.")
+        } actions: {
+            // The primary recovery action for the no-accounts dead-end (AND-631):
+            // start Plaid Link via the shared flow rather than leaving the user on
+            // an explanation with no next step.
+            Button {
+                Task { await appState.addAccount() }
+            } label: {
+                Label("Add Account", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(appState.isLoading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -65,7 +65,20 @@ struct AccountsDestinationView: View {
     }
 
     var body: some View {
-        content
+        VStack(spacing: 0) {
+            // Surface add-account (and any app) failures on this destination too:
+            // routing here from a Dashboard affordance leaves the Dashboard's own
+            // error banner behind, so without this a failed `addAccount()` (no
+            // server / missing credentials) would strand the user on "No accounts
+            // yet" with no actionable error — recreating the dead end this entry
+            // point closes (AND-631, codex #623). Reuses the shared error banner.
+            if let error = appState.error {
+                DashboardErrorBanner(error: error) { appState.error = nil }
+                    .padding(.horizontal, WindowMetrics.canvasMargin)
+                    .padding(.top, WindowMetrics.md)
+            }
+            content
+        }
             .navigationTitle(RouteDestination.accounts.title)
             // The window-first Add Account entry point (AND-631): the destination
             // every add-account affordance (Dashboard attention chip, readiness
@@ -73,7 +86,8 @@ struct AccountsDestinationView: View {
             // `AppState.addAccount()` flow — which opens Plaid Hosted Link in the
             // browser (no in-app sheet) — so those affordances resolve here instead
             // of dead-ending. In demo it no-ops (keeps demo); with no server it
-            // surfaces the actionable error; with credentials it opens Link.
+            // surfaces the actionable error in the banner above; with credentials
+            // it opens Link.
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -82,7 +96,12 @@ struct AccountsDestinationView: View {
                         Label("Add Account", systemImage: "plus")
                     }
                     .help("Connect a bank with Plaid Link")
-                    .disabled(appState.isLoading)
+                    // App Lock is a hard interaction boundary. This toolbar item
+                    // lives in window chrome *outside* AppShellView's lock overlay,
+                    // so gate it explicitly like the shell's Privacy Mask toolbar
+                    // item — otherwise a locked window could still open Plaid Link
+                    // (codex #623).
+                    .disabled(appState.isLoading || appState.isContentLocked)
                 }
             }
             // Self-heal: if the selected account falls out of the list (removed /
@@ -271,7 +290,7 @@ struct AccountsDestinationView: View {
                 Label("Add Account", systemImage: "plus")
             }
             .buttonStyle(.borderedProminent)
-            .disabled(appState.isLoading)
+            .disabled(appState.isLoading || appState.isContentLocked)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }


### PR DESCRIPTION
Closes the window-first add-account dead-end surfaced by codex on #622. Strict build clean, 2067 tests.

**The gap:** every window-first "Add Account / Link Bank" affordance (Dashboard attention chip, readiness panel, recurring empty state) routes to the **Accounts** destination — but that destination had no action, so users hit a dead end.

**The fix:** the Accounts destination now hosts the Add Account action — a toolbar `+` button (primary action) and a prominent button in the no-accounts empty state — both invoking the shared `AppState.addAccount()` flow. No sheet hosting needed: `addAccount()` presents Plaid **Hosted Link in the browser** (`NSWorkspace.shared.open(url)`), and OAuth returns via the server's `/oauth/callback`. In demo it no-ops (keeps demo); with no server it surfaces the actionable error; with credentials it opens Link. Now every routing affordance resolves here.

**Verification:** strict build + 2067 tests; populated Accounts render unchanged. The toolbar button and empty-state action aren't capturable by the headless render harness (no window chrome; demo has accounts so the empty state doesn't show), and the full Link round-trip needs sandbox creds / on-hardware QA (ties into AND-615).

@codex please review the addAccount() dispatch + that this is the right window-first entry point (Hosted Link via browser, no in-app sheet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)