### PR TITLE
fix: 3 reachable bugs from bug-hunt round 2 (widget privacy leak, Spotlight race, ⌘K a11y)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -494,12 +494,13 @@ final class AppState {
         guard !isContentLocked else { return true }
         if appLockPreferences.privacyMaskEnabled != command.maskEnabled {
             appLockPreferences.privacyMaskEnabled = command.maskEnabled
-            // Re-emit both App Group snapshots so the new mask state takes effect on
-            // disk immediately — enabling overwrites real figures with value-free
-            // snapshots, disabling restores the real values — instead of waiting for
-            // the next data refresh. Mirrors `togglePrivacyMask`.
-            writeGlanceSnapshot()
         }
+        // Re-emit both App Group snapshots after every consumed command, even when
+        // the in-app preference already matches. A background Control Center/Focus
+        // ON→OFF sequence can leave the persisted files masked while the app still
+        // has `privacyMaskEnabled == false`; the queued OFF command must restore the
+        // real App Group snapshots instead of being skipped as a state no-op.
+        writeGlanceSnapshot()
         return true
     }
 
@@ -2532,7 +2533,6 @@ final class AppState {
     }
 
     func startDemoMode() {
-        isDemoMode = true
         loadDemoData()
     }
 
@@ -4019,6 +4019,16 @@ final class AppState {
         WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
     }
 
+    private func clearPublishedSystemSnapshotsForDemoEntry() {
+        glanceSnapshotWriteGeneration += 1
+        let debouncer = glanceSnapshotWriteDebouncer
+        Task { await debouncer.cancel() }
+        try? GlanceSnapshotStore.clear()
+        try? AppGroupSnapshotStore.clear()
+        AccountSpotlightIndexer.clear()
+        WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
+    }
+
     /// Consume a pending widget/control command (e.g. the "Refresh balances"
     /// control) and run it. Reached from `loadInitialData()` and
     /// `refreshDashboard()`, and — because the control opens the app via its
@@ -4109,7 +4119,11 @@ final class AppState {
     // MARK: - Demo Data
 
     func loadDemoData() {
+        let wasDemoMode = isDemoMode
         isDemoMode = true
+        if !wasDemoMode {
+            clearPublishedSystemSnapshotsForDemoEntry()
+        }
         // Demo fixtures load synchronously: there is no boot handshake to wait for.
         isBooting = false
         isDemoStatusRecoveryScenario = CommandLine.arguments.contains("--screenshot-status-recovery")

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -474,6 +474,35 @@ final class AppState {
         writeGlanceSnapshot()
     }
 
+    /// Applies a pending Control Center / Focus-filter privacy-mask command, if
+    /// any. Drives the same `appLockPreferences.privacyMaskEnabled` path as the
+    /// in-app eye toggle so persistence, the masked snapshot rewrite, and control
+    /// reload all happen through the existing flow. A no-op (returns `false`) when
+    /// no command is pending. Skipped while fully locked — App Lock already masks
+    /// everything and owns reveal (mirrors `togglePrivacyMask`).
+    ///
+    /// Lives here (not in `PrivacyMaskControlCommandReader`) so it can re-emit both
+    /// App Group snapshots via the file-private `writeGlanceSnapshot()`, exactly
+    /// like `togglePrivacyMask` / `lockApp` / `unlockApp`. The extension that drops
+    /// the command (Control Center toggle) already re-redacts the on-disk snapshot
+    /// when enabling the mask; this makes the *activation* path deterministic too,
+    /// so the snapshot is re-redacted the moment the app applies the command rather
+    /// than at a later refresh (bug-hunt R2).
+    @discardableResult
+    func applyPendingPrivacyMaskControlCommand() -> Bool {
+        guard let command = try? PrivacyMaskControlCommandReader.consume() else { return false }
+        guard !isContentLocked else { return true }
+        if appLockPreferences.privacyMaskEnabled != command.maskEnabled {
+            appLockPreferences.privacyMaskEnabled = command.maskEnabled
+            // Re-emit both App Group snapshots so the new mask state takes effect on
+            // disk immediately — enabling overwrites real figures with value-free
+            // snapshots, disabling restores the real values — instead of waiting for
+            // the next data refresh. Mirrors `togglePrivacyMask`.
+            writeGlanceSnapshot()
+        }
+        return true
+    }
+
     /// True only in full App Lock (`.locked`) — distinct from
     /// `shouldMaskFinancialValues`, which is also true for the lighter Privacy
     /// Mask (`.masked`). When this is true the dashboard must be gated behind the
@@ -2425,6 +2454,13 @@ final class AppState {
             // only; restore the user's real saved watchlist (or empty) so demo
             // Starbucks/Shopping targets never fire against real data.
             loadWatchlistTargets(defaults: .standard)
+            // Demo fixtures may have been published to the shared App Group before
+            // the demo guards landed, or by an older build; wipe both the glance and
+            // finance snapshots (and the Spotlight account index) on demo exit so a
+            // prior demo's unlabeled figures never linger on the widget / Control
+            // Center / Siri / Spotlight surfaces (bug-hunt R2). `clearGlanceSnapshot`
+            // clears both stores + the index and reloads the widget timeline.
+            await clearGlanceSnapshot()
             // Fall through into the real add-account flow: the demo readiness
             // card advertises "Connect Bank", so the first click must continue
             // into the server check + Plaid Link handoff (or surface the precise
@@ -3810,6 +3846,14 @@ final class AppState {
     }
 
     private func writeGlanceSnapshot(updatedAt: Date = Date()) {
+        // Demo-mode fixtures must never reach the shared App Group container: a
+        // glance/finance snapshot there is shown UNLABELED on Control Center / Siri
+        // / Spotlight / the widget and would PERSIST after demo exit. Skip the
+        // publish entirely while in demo. The tradeoff: demo mode loses widget /
+        // Control Center coverage — acceptable for a screenshot/preview mode, and it
+        // removes the leak. The demo-exit teardown clears any lingering snapshot
+        // (see `addAccount`'s `isDemoMode = false` path and `resetLocalData`).
+        guard !isDemoMode else { return }
         // With no accounts (e.g. the user just disconnected their last
         // institution), clear the app-group snapshot instead of leaving the
         // previous balances on disk — otherwise the widget would keep showing
@@ -3903,6 +3947,10 @@ final class AppState {
     /// When App Lock / Privacy Mask is active the snapshot is written with
     /// `isMasked == true` so the intents withhold the figures past the lock.
     private func writeFinanceSnapshot(updatedAt: Date = Date()) {
+        // Defense in depth alongside `writeGlanceSnapshot`'s guard: never publish
+        // demo fixtures to the shared App Group `FinanceSnapshot` that backs the
+        // unlabeled Control Center value controls / Siri / Spotlight / Shortcuts.
+        guard !isDemoMode else { return }
         let cashflow = WealthSummaryPresentation.evaluate(
             accounts: accounts,
             transactions: transactions,

--- a/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
+++ b/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
@@ -91,6 +91,20 @@ enum PrivacyMaskControlCommandReader {
         try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         #endif
     }
+
+    /// Redacts every App Group payload that can be read by system surfaces while
+    /// the app is backgrounded. Used by Control Center / Focus privacy-mask
+    /// writers before they reload widgets or controls.
+    static func redactPublishedSnapshots(
+        directory: URL = directory(),
+        fileManager: FileManager = .default
+    ) {
+        if let snapshot = AppGroupSnapshotStore.loadIfAvailable(directory: directory, fileManager: fileManager),
+           !snapshot.isMasked {
+            try? AppGroupSnapshotStore.save(snapshot.masked(), directory: directory, fileManager: fileManager)
+        }
+        try? GlanceSnapshotStore.redactIfAvailable(directory: directory, fileManager: fileManager)
+    }
 }
 
 // MARK: - AppState integration

--- a/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
+++ b/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
@@ -95,29 +95,14 @@ enum PrivacyMaskControlCommandReader {
 
 // MARK: - AppState integration
 //
-// `applyPendingPrivacyMaskControlCommand()` is wired into the app's activation
-// hook (`PlaidBarApp`'s `didBecomeActive` handler, alongside
+// `AppState.applyPendingPrivacyMaskControlCommand()` (defined in `AppState.swift`,
+// next to `togglePrivacyMask`) is wired into the app's activation hook
+// (`PlaidBarApp`'s `didBecomeActive` handler, alongside
 // `consumePendingGlanceCommand()`), so the Control Center toggle takes effect the
-// next time VaultPeek activates. The privacy control deliberately does NOT open
-// the app (silent masking), so it relies on the next natural activation — opening
-// the popover, summoning the window, or any focus change — to consume the pending
-// command. The reader is consume-and-delete, so a stale file never lingers and
-// re-running on every activation is a cheap no-op when nothing is pending.
-
-extension AppState {
-    /// Applies a pending Control Center privacy-mask command, if any. Drives the
-    /// same `appLockPreferences.privacyMaskEnabled` path as the in-app eye toggle
-    /// so persistence, the masked snapshot rewrite, and control reload all happen
-    /// through the existing flow. A no-op (returns `false`) when no command is
-    /// pending. Skipped while fully locked — App Lock already masks everything and
-    /// owns reveal (mirrors `togglePrivacyMask`).
-    @discardableResult
-    func applyPendingPrivacyMaskControlCommand() -> Bool {
-        guard let command = try? PrivacyMaskControlCommandReader.consume() else { return false }
-        guard !isContentLocked else { return true }
-        if appLockPreferences.privacyMaskEnabled != command.maskEnabled {
-            appLockPreferences.privacyMaskEnabled = command.maskEnabled
-        }
-        return true
-    }
-}
+// next time VaultPeek activates. It consumes the pending command via
+// `PrivacyMaskControlCommandReader.consume()` above. The privacy control
+// deliberately does NOT open the app (silent masking), so it relies on the next
+// natural activation — opening the popover, summoning the window, or any focus
+// change — to consume the pending command. The reader is consume-and-delete, so a
+// stale file never lingers and re-running on every activation is a cheap no-op
+// when nothing is pending.

--- a/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
+++ b/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
@@ -83,10 +83,8 @@ struct FocusPrivacyFilterIntent: SetFocusFilterIntent {
             // shared FinanceSnapshot in place so every system surface reads
             // value-free figures now. Un-mask still defers to the app: revealing is
             // the non-leaking direction, and only the app holds the real numbers.
-            if outcome.desiredMaskEnabled,
-               let snapshot = AppGroupSnapshotStore.loadIfAvailable(),
-               !snapshot.isMasked {
-                try? AppGroupSnapshotStore.save(snapshot.masked())
+            if outcome.desiredMaskEnabled {
+                PrivacyMaskControlCommandReader.redactPublishedSnapshots()
             }
             // Reload the Control Center toggle + widgets so the "Privacy Mask"
             // control reflects the new state even before the app applies it.

--- a/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
+++ b/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
@@ -76,6 +76,18 @@ struct FocusPrivacyFilterIntent: SetFocusFilterIntent {
             try PrivacyMaskControlCommandReader.write(
                 PrivacyMaskControlCommand(maskEnabled: outcome.desiredMaskEnabled, requestedAt: Date())
             )
+            // Enabling the mask must take effect on disk immediately, not wait for
+            // the app to foreground and apply the command — otherwise the widget and
+            // the Safe-to-Spend / Credit-Utilization value controls keep rendering
+            // the real balances from the already-persisted snapshot. Re-redact the
+            // shared FinanceSnapshot in place so every system surface reads
+            // value-free figures now. Un-mask still defers to the app: revealing is
+            // the non-leaking direction, and only the app holds the real numbers.
+            if outcome.desiredMaskEnabled,
+               let snapshot = AppGroupSnapshotStore.loadIfAvailable(),
+               !snapshot.isMasked {
+                try? AppGroupSnapshotStore.save(snapshot.masked())
+            }
             // Reload the Control Center toggle + widgets so the "Privacy Mask"
             // control reflects the new state even before the app applies it.
             ControlCenter.shared.reloadAllControls()

--- a/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
+++ b/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
@@ -77,6 +77,28 @@ enum AccountSpotlightIndexer {
     /// Deep link selecting a result opens — the shared dashboard URL.
     nonisolated static let deepLinkURL = GlanceSnapshot.deepLinkURL
 
+    /// Serializes every index/clear mutation through a single in-flight chain so a
+    /// later op never overtakes an earlier one. `index()` and `clear()` each spawn
+    /// an independent `Task` that suspends at its own `await`s, so without ordering
+    /// a `clear()` issued *after* an `index()` could finish *before* it — leaving
+    /// real account names re-indexed in Spotlight *after* the Privacy Mask cleared
+    /// them. Each enqueued op awaits the previous one's completion, so the final
+    /// state always reflects the last call (refresh-then-mask ⇒ "cleared").
+    @MainActor private static var pending: Task<Void, Never>?
+
+    /// Appends `work` to the in-flight chain: it runs only after the previously
+    /// enqueued op finishes. `work` is a `@MainActor`-isolated closure, so the
+    /// non-Sendable `CSSearchableIndex` it captures stays on the main actor and
+    /// never crosses an isolation boundary (Swift 6-clean).
+    @MainActor
+    private static func enqueue(_ work: @escaping @MainActor () async -> Void) {
+        let previous = pending
+        pending = Task { @MainActor in
+            await previous?.value
+            await work()
+        }
+    }
+
     /// Replaces the indexed account set with `entries`. When `entries` is empty
     /// (no accounts) the domain is cleared. Safe to call repeatedly — it replaces
     /// the whole domain, so removed accounts drop out of search.
@@ -93,7 +115,10 @@ enum AccountSpotlightIndexer {
         // Replace the whole domain atomically via the async API so the delete and
         // re-index stay ordered without nesting non-Sendable captures across a
         // `@Sendable` completion-handler boundary (Swift 6 strict concurrency).
-        Task { @MainActor in
+        // Routed through `enqueue` so this reindex can't be overtaken by — or
+        // overtake — a concurrent clear(); the `@MainActor` closure keeps the
+        // non-Sendable `index`/`items` on the main actor.
+        enqueue {
             try? await index.deleteSearchableItems(withDomainIdentifiers: [domainIdentifier])
             try? await index.indexSearchableItems(items)
         }
@@ -101,10 +126,12 @@ enum AccountSpotlightIndexer {
 
     /// Removes every VaultPeek account from Spotlight. Called when Privacy Mask /
     /// App Lock engages or all accounts are unlinked so names never linger in
-    /// system search.
+    /// system search. Routed through `enqueue` so a mask's clear() is strictly
+    /// ordered after any in-flight refresh's index() — a later clear can't be
+    /// beaten by an earlier reindex, so the masked end state is always "cleared".
     static func clear(index: CSSearchableIndex = .default()) {
         guard CSSearchableIndex.isIndexingAvailable() else { return }
-        Task { @MainActor in
+        enqueue {
             try? await index.deleteSearchableItems(withDomainIdentifiers: [domainIdentifier])
         }
     }

--- a/Sources/PlaidBar/Views/CommandPalette.swift
+++ b/Sources/PlaidBar/Views/CommandPalette.swift
@@ -99,6 +99,12 @@ struct CommandPalette: View {
                             .id(index)
                             .contentShape(Rectangle())
                             .onTapGesture { execute(command) }
+                            // The row carries the `.isButton` trait, so VoiceOver
+                            // announces it as a button and its activate gesture must
+                            // run the command — `.onTapGesture` alone is invisible to
+                            // VoiceOver (matches the `.accessibilityAction` pattern in
+                            // MainPopover.swift account rows).
+                            .accessibilityAction { execute(command) }
                             .onHover { hovering in
                                 if hovering { highlightedIndex = index }
                             }

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -169,6 +169,29 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         )
     }
 
+    /// Returns the value-free, `isMasked == true` form of this snapshot: every
+    /// figure zeroed, every list emptied, only the timestamp and currency code
+    /// preserved. Mirrors the inline masked construction in
+    /// ``FinanceSnapshotBuilder`` so the app and the widget extension can re-redact
+    /// an already-persisted snapshot the instant Privacy Mask is enabled (from the
+    /// Control Center control / Focus filter) instead of leaking real balances
+    /// until the app is next foregrounded.
+    ///
+    /// Idempotent: calling `masked()` on an already-masked snapshot returns an
+    /// equivalent value-free snapshot.
+    public func masked() -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: 0,
+            totalBalance: 0,
+            accountBalances: [],
+            nextRecurringBills: [],
+            creditUtilization: nil,
+            isoCurrencyCode: isoCurrencyCode,
+            generatedAt: generatedAt,
+            isMasked: true
+        )
+    }
+
     /// True when the snapshot carries no usable figures. Used to drive a
     /// setup/unavailable intent response. A credit-only user (paid-off cards, no
     /// cash accounts, no bills) still has a usable `creditUtilization`, so a

--- a/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/GlanceSnapshot.swift
@@ -316,6 +316,24 @@ public enum GlanceSnapshotStore {
         }
     }
 
+    /// Rewrites an already-persisted glance snapshot into its value-free form.
+    ///
+    /// Control Center / Focus-filter privacy-mask intents can run while the app is
+    /// backgrounded, so they cannot rebuild the real widget snapshot from app
+    /// state. They can, however, make the existing on-disk snapshot safe by
+    /// zeroing every figure before WidgetKit reloads its timelines. Missing files
+    /// are a no-op so first-run/setup systems can call this defensively.
+    public static func redactIfAvailable(
+        directory: URL = snapshotDirectory(),
+        fileManager: FileManager = .default
+    ) throws {
+        let url = snapshotURL(directory: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        let snapshot = try load(directory: directory, fileManager: fileManager)
+        guard !snapshot.isRedacted else { return }
+        try save(snapshot.redacted(), directory: directory, fileManager: fileManager)
+    }
+
     public static func saveCommand(
         _ request: GlanceCommandRequest,
         directory: URL = snapshotDirectory(),

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -89,7 +89,9 @@ public enum FinanceSnapshotBuilder {
         // Defense in depth: a masked snapshot must be value-free *on disk*, not
         // merely withheld at read time. If anyone bypasses the read-time gate
         // (`FinanceIntentQueries`) the file itself carries no real figures — only
-        // the flag, timestamp, and currency code survive.
+        // the flag, timestamp, and currency code survive. Reuses
+        // ``FinanceSnapshot/masked()`` so this builder and the app/extension
+        // re-redaction path share one value-free shape.
         if isMasked {
             return FinanceSnapshot(
                 safeToSpend: 0,
@@ -99,8 +101,8 @@ public enum FinanceSnapshotBuilder {
                 creditUtilization: nil,
                 isoCurrencyCode: currencyCode,
                 generatedAt: generatedAt,
-                isMasked: true
-            )
+                isMasked: false
+            ).masked()
         }
 
         return FinanceSnapshot(

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -423,8 +423,11 @@ struct SetPrivacyMaskIntent: SetValueIntent {
         // FinanceSnapshot in place so every system surface reads value-free figures
         // now. Un-mask (value == false) still defers to the app: revealing is the
         // non-leaking direction, and only the app holds the real numbers to restore.
-        if value, let snapshot = AppGroupSnapshotStore.loadIfAvailable(), !snapshot.isMasked {
-            try? AppGroupSnapshotStore.save(snapshot.masked())
+        if value {
+            if let snapshot = AppGroupSnapshotStore.loadIfAvailable(), !snapshot.isMasked {
+                try? AppGroupSnapshotStore.save(snapshot.masked())
+            }
+            try? GlanceSnapshotStore.redactIfAvailable()
         }
         // Reload the widgets + controls so the toggle and every figure reflect the
         // new state even before the app has applied the command and rewritten the

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -416,8 +416,21 @@ struct SetPrivacyMaskIntent: SetValueIntent {
         try WidgetControlCommandStore.savePrivacyCommand(
             PrivacyMaskCommandRequest(maskEnabled: value, requestedAt: Date())
         )
-        // Reload the controls so the toggle reflects its new state even before the
-        // app has applied the command and rewritten the snapshot.
+        // Enabling the mask must take effect on disk immediately, not wait for the
+        // app to foreground and apply the command — otherwise the widget and the
+        // Safe-to-Spend / Credit-Utilization value controls keep rendering the real
+        // balances from the already-persisted snapshot. Re-redact the shared
+        // FinanceSnapshot in place so every system surface reads value-free figures
+        // now. Un-mask (value == false) still defers to the app: revealing is the
+        // non-leaking direction, and only the app holds the real numbers to restore.
+        if value, let snapshot = AppGroupSnapshotStore.loadIfAvailable(), !snapshot.isMasked {
+            try? AppGroupSnapshotStore.save(snapshot.masked())
+        }
+        // Reload the widgets + controls so the toggle and every figure reflect the
+        // new state even before the app has applied the command and rewritten the
+        // snapshot. `reloadAllTimelines` was previously missing here, so the glance
+        // widget kept showing real balances until the next 15-minute reload.
+        WidgetCenter.shared.reloadAllTimelines()
         ControlCenter.shared.reloadAllControls()
         return .result()
     }

--- a/Tests/PlaidBarCoreTests/AppGroupSnapshotStoreTests.swift
+++ b/Tests/PlaidBarCoreTests/AppGroupSnapshotStoreTests.swift
@@ -63,6 +63,76 @@ struct AppGroupSnapshotStoreTests {
         #expect(FinanceSnapshot.filename != GlanceSnapshot.filename)
     }
 
+    // MARK: - Privacy-command re-redaction (bug-hunt R2)
+    //
+    // When Privacy Mask is enabled from the Control Center control / Focus filter
+    // (or applied on app activation), the privacy-command path re-redacts the
+    // already-persisted snapshot in place with `AppGroupSnapshotStore.save(s.masked())`
+    // — so the widget + Safe-to-Spend / Credit-Utilization value controls stop
+    // reading real balances immediately, without waiting for the app to foreground.
+    // These tests lock in that the persisted snapshot is value-free and `isMasked`.
+
+    @Test("masked() zeroes every figure and empties every list, keeping isMasked true")
+    func maskedIsValueFree() {
+        let masked = sampleSnapshot().masked()
+
+        #expect(masked.isMasked)
+        #expect(masked.safeToSpend == 0)
+        #expect(masked.totalBalance == 0)
+        #expect(masked.creditUtilization == nil)
+        #expect(masked.periodSpending == 0)
+        #expect(masked.accountBalances.isEmpty)
+        #expect(masked.nextRecurringBills.isEmpty)
+        #expect(masked.topSpendingCategories.isEmpty)
+        // Non-value metadata is preserved so the masked surface still timestamps.
+        #expect(masked.isoCurrencyCode == sampleSnapshot().isoCurrencyCode)
+        #expect(masked.generatedAt == sampleSnapshot().generatedAt)
+    }
+
+    @Test("masked() is idempotent on an already-masked snapshot")
+    func maskedIsIdempotent() {
+        let once = sampleSnapshot().masked()
+        let twice = once.masked()
+        #expect(twice == once)
+        #expect(twice.isMasked)
+    }
+
+    @Test("Privacy-command path leaves the persisted FinanceSnapshot value-free and masked")
+    func privacyCommandPathPersistsMaskedSnapshot() throws {
+        let directory = temporaryDirectory()
+        // A real, value-bearing snapshot is already on disk (last app write).
+        let real = sampleSnapshot()
+        try AppGroupSnapshotStore.save(real, directory: directory)
+
+        // Enabling Privacy Mask re-redacts in place — mirrors
+        // SetPrivacyMaskIntent.perform() / FocusPrivacyFilterIntent.perform() /
+        // AppState.applyPendingPrivacyMaskControlCommand().
+        let onDisk = try #require(AppGroupSnapshotStore.loadIfAvailable(directory: directory))
+        #expect(!onDisk.isMasked)
+        try AppGroupSnapshotStore.save(onDisk.masked(), directory: directory)
+
+        // The reader surfaces (widget, value controls) now see no real figures.
+        let reread = try AppGroupSnapshotStore.load(directory: directory)
+        #expect(reread.isMasked)
+        #expect(reread.safeToSpend == 0)
+        #expect(reread.totalBalance == 0)
+        #expect(reread.creditUtilization == nil)
+        #expect(reread.accountBalances.isEmpty)
+        #expect(reread.nextRecurringBills.isEmpty)
+
+        // And the bytes on disk carry none of the real figures either.
+        let json = try String(
+            contentsOf: AppGroupSnapshotStore.snapshotURL(directory: directory),
+            encoding: .utf8
+        )
+        #expect(!json.contains("1234.56"))
+        #expect(!json.contains("9876.54"))
+        #expect(!json.contains("Everyday Checking"))
+        #expect(!json.contains("Vacation Savings"))
+        #expect(!json.contains("Rent"))
+        #expect(!json.contains("27.5"))
+    }
+
     // MARK: - Helpers
 
     private func sampleSnapshot(isMasked: Bool = false) -> FinanceSnapshot {

--- a/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
+++ b/Tests/PlaidBarCoreTests/GlanceSnapshotTests.swift
@@ -198,23 +198,22 @@ struct GlanceSnapshotTests {
         #expect(try GlanceSnapshotStore.saveIfChanged(real, directory: directory))
         #expect(try GlanceSnapshotStore.load(directory: directory).netWorth == 1_250)
 
-        // 2. Mask turns on — the writer rebuilds and the persisted file is
-        // rewritten value-free (the change in `isRedacted`/figures defeats the
-        // saveIfChanged short-circuit).
-        let masked = GlanceSnapshot.make(
-            netWorth: 1_250,
-            balanceHistory: history,
-            updatedAt: now,
-            isDemo: false,
-            isMasked: true
-        )
-        #expect(try GlanceSnapshotStore.saveIfChanged(masked, directory: directory))
+        // 2. Mask turns on from a background control/focus intent — the existing
+        // persisted file is rewritten value-free before the app can foreground.
+        try GlanceSnapshotStore.redactIfAvailable(directory: directory)
 
         let onDisk = try GlanceSnapshotStore.load(directory: directory)
         #expect(onDisk.isRedacted)
         #expect(onDisk.netWorth == 0)
         #expect(onDisk.todayChange == 0)
         #expect(onDisk.sparkline.isEmpty)
+    }
+
+    @Test("Redacting a missing persisted snapshot is a no-op")
+    func redactingMissingPersistedSnapshotIsNoop() throws {
+        let directory = temporaryDirectory()
+        try GlanceSnapshotStore.redactIfAvailable(directory: directory)
+        #expect((try? GlanceSnapshotStore.load(directory: directory)) == nil)
     }
 
     @Test("Legacy snapshot without isRedacted decodes as not redacted")

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -112,6 +112,28 @@ struct PlaidBarTests {
         #expect(planningSource.contains("ProgressView(value: summary.overallFraction)"))
     }
 
+    @Test("Control and Focus privacy mask paths redact both App Group snapshots")
+    func privacyMaskControlPathsRedactEveryPublishedSnapshot() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let widgetSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift"),
+            encoding: .utf8
+        )
+        let focusSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift"),
+            encoding: .utf8
+        )
+        let appStateSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/AppState.swift"),
+            encoding: .utf8
+        )
+
+        #expect(widgetSource.contains("GlanceSnapshotStore.redactIfAvailable()"))
+        #expect(focusSource.contains("PrivacyMaskControlCommandReader.redactPublishedSnapshots()"))
+        #expect(appStateSource.contains("queued OFF command must restore the"))
+        #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
+    }
+
     // MARK: - Account Type Categorization
 
     @Test("AccountDTO types correctly categorized")

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -809,6 +809,44 @@ struct PlaidBarTests {
         #expect(restored.selectedAccountID == "demo_visa")
     }
 
+    // MARK: - Spotlight index/clear serialization (mirrors AccountSpotlightIndexer, bug-hunt R2)
+    //
+    // BUG #5 (privacy race): `index()` (a refresh's delete+reindex) and `clear()`
+    // (a mask's delete) each spawned an independent `Task { @MainActor in … }`.
+    // Independent Tasks suspend at their own `await`s with no ordering guarantee,
+    // so a `clear()` issued *after* an `index()` could finish *before* it — leaving
+    // real account names re-indexed in Spotlight *after* the Privacy Mask cleared
+    // them. The fix funnels BOTH ops through a single in-flight chain (`pending` +
+    // `enqueue`) so each awaits the previous, making refresh-then-mask strictly
+    // ordered. AccountSpotlightIndexer is in the app target (not @testable here,
+    // and `CSSearchableIndex` can't run in CI), so — like the window-first masking
+    // test above — this pins the fix as a source-level invariant.
+
+    @Test("AccountSpotlightIndexer serializes index/clear through a single in-flight Task chain")
+    func spotlightIndexClearSerialized() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let source = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift"),
+            encoding: .utf8
+        )
+
+        // The serialization primitives exist: one in-flight slot + an enqueue that
+        // chains each op after the previous one's completion.
+        #expect(source.contains("private static var pending: Task<Void, Never>?"))
+        #expect(source.contains("private static func enqueue("))
+        #expect(source.contains("let previous = pending"))
+        #expect(source.contains("await previous?.value"))
+
+        // Both mutating ops route through enqueue rather than spawning their own
+        // unordered Task. The only remaining `Task { @MainActor in … }` is the
+        // single chained one INSIDE enqueue — index()/clear() must not spawn their
+        // own. (The bug was two independent `Task { @MainActor in … }`, one per op.)
+        let enqueueCallSites = source.components(separatedBy: "enqueue {").count - 1
+        #expect(enqueueCallSites == 2, "expected index() and clear() to each route through enqueue")
+        let chainedTasks = source.components(separatedBy: "Task { @MainActor in").count - 1
+        #expect(chainedTasks == 1, "only enqueue's single chained Task should exist")
+    }
+
     // MARK: - Foundation Models categorization tier (mirrors AppState.refreshFoundationModelsCategorySuggestions)
 
     @Test("FM categorizer produces a foundationModels suggestion when Apple Intelligence is available")


### PR DESCRIPTION
Bug-hunt round 2 (server/storage/widget/a11y, 6 finders → refute-by-default verify): **6 confirmed, 1 rejected.** This PR ships the 3 **reachable** fixes; the 2 dormant webhook defects → AND-634, demo/full-isDemo polish considered. Strict build clean, **2077 tests** (+regression).

### P2 — Control Center / Focus Privacy-Mask leaves real balances on the widget
Toggling Privacy Mask via the Control Center control / Focus filter wrote a command file but didn't re-redact the on-disk `FinanceSnapshot`, so the widget + Safe-to-Spend / Credit-Utilization value controls kept showing **real balances** until the app next foregrounded. **Fix:** added `FinanceSnapshot.masked()` (value-free, isMasked:true; shared by app+extension+builder); the privacy intents now rewrite the persisted snapshot value-free + `reloadAllTimelines()`/`reloadAllControls()` immediately; activation re-redacts deterministically via `writeGlanceSnapshot()`. + tests asserting the on-disk JSON carries no figures.

### P3 — Demo fixtures leaked to system surfaces + persisted after demo exit
Demo balances were published unlabeled to Control Center/Siri/Spotlight/widget and lingered after exit. **Fix (minimal):** guard `writeFinanceSnapshot`/`writeGlanceSnapshot` with `!isDemoMode`, and clear both App Group stores on the demo→real exit. (Tradeoff: demo loses widget coverage — acceptable for a screenshot mode; full labeled-demo is a possible follow-up.)

### P3 — Spotlight index/clear race re-indexed real account names after a mask clear
`index()` and `clear()` ran as independent unordered Tasks. **Fix:** serialize both through a single `@MainActor` in-flight Task chain, so a mask `clear()` can never be overtaken by an earlier `index()`. + invariant test.

### P3 — ⌘K command-palette rows not VoiceOver-activatable
Rows carried `.isButton` but only `.onTapGesture` (no Button/accessibilityAction), so VoiceOver announced buttons that did nothing. **Fix:** added `.accessibilityAction { execute(command) }`.

@codex please review — esp. the snapshot re-redaction (no figure leaks in the persisted bytes) and the Spotlight Task-chain ordering under strict concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)