### PR TITLE
fix: 4 core-logic bugs from bug-hunt round 3 (budget math, notification flood + 2)

### DIFF
--- a/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardPresentation.swift
@@ -174,6 +174,16 @@ public struct CategoryDashboardPresentation: Sendable, Hashable {
     /// Every leaf across all groups, flattened (groups stay in display order).
     public var leaves: [Leaf] { groups.flatMap(\.leaves) }
 
+    /// Sum of spend across *budgeted* leaves only — the spend figure that pairs
+    /// with ``totalLimit`` (which is itself budgeted-leaves only). Unbudgeted leaves
+    /// have no limit, so folding their spend into a budget comparison would
+    /// understate "left" and overstate "used" (mirrors the budgeted-only footer in
+    /// ``CategoryDashboardTableModel/totals(for:)``). Use ``totalSpent`` for the
+    /// all-leaves "Spent" figure; use this for over-budget / fraction-used math.
+    public var budgetedSpent: Double {
+        leaves.reduce(0) { $0 + ($1.isBudgeted ? $1.spent : 0) }
+    }
+
     /// The rollup for `group`, or `nil` when that group has no spend / budget.
     public func group(_ group: CategoryGroup) -> GroupRollup? {
         groups.first { $0.group == group }

--- a/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetsStatusSummary.swift
@@ -60,15 +60,23 @@ public enum BudgetsStatusSummary {
         public let budgetedCount: Int
         /// Total leaf categories with spend or a budget in the rollup.
         public let trackedCount: Int
-        /// Sum of every leaf's spend across all groups.
+        /// Sum of every leaf's spend across all groups (budgeted *and* unbudgeted).
+        /// Drives the all-leaves "Spent" hero tile — never the over-budget math.
         public let totalSpent: Double
+        /// Sum of spend across *budgeted* leaves only — the spend figure that pairs
+        /// with ``totalLimit``. Unbudgeted leaves have no limit, so comparing their
+        /// spend against the budgeted limit produced a false "Over budget" and an
+        /// inflated fraction (bug-hunt R3); the aggregate over/left/used figures
+        /// below all derive from this, mirroring the budgeted-only table footer.
+        public let budgetedSpent: Double
         /// Sum of every budgeted leaf's limit.
         public let totalLimit: Double
 
-        /// `totalLimit - totalSpent` across budgeted categories; `nil` when no
-        /// budget exists (so the view shows no "left/over" line at all).
+        /// `totalLimit - budgetedSpent` across budgeted categories; `nil` when no
+        /// budget exists (so the view shows no "left/over" line at all). Uses the
+        /// budgeted-only spend so unbudgeted spend never eats into the budgeted left.
         public var remaining: Double? {
-            budgetedCount > 0 ? totalLimit - totalSpent : nil
+            budgetedCount > 0 ? totalLimit - budgetedSpent : nil
         }
 
         /// True when the budgeted total has been exceeded in aggregate.
@@ -77,10 +85,11 @@ public enum BudgetsStatusSummary {
         }
 
         /// Fraction of the budgeted total already spent, clamped to `0...1` for a
-        /// progress affordance; `nil` when there is no budget.
+        /// progress affordance; `nil` when there is no budget. Uses budgeted-only
+        /// spend so unbudgeted categories never inflate the bar.
         public var fractionUsed: Double? {
             guard budgetedCount > 0, totalLimit > 0 else { return nil }
-            return min(1, max(0, totalSpent / totalLimit))
+            return min(1, max(0, budgetedSpent / totalLimit))
         }
 
         /// Detail line under the "Budgeted this month" hero tile: how many
@@ -149,6 +158,7 @@ public enum BudgetsStatusSummary {
             budgetedCount: budgetedCount,
             trackedCount: leaves.count,
             totalSpent: presentation.totalSpent,
+            budgetedSpent: presentation.budgetedSpent,
             totalLimit: presentation.totalLimit
         )
     }

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -43,6 +43,12 @@ public enum PlaidBarConstants {
     public static let creditUtilizationWarningThreshold: Double = 30.0
     public static let maxRecentTransactions: Int = 50
 
+    /// Recency window (days) for large-transaction OS notifications. Without it, a
+    /// fresh install's ~90-day import would fire one alert per historical large
+    /// charge (the delivered-dedup set is empty on first sync). Mirrors
+    /// AttentionQueue's `unusualSpendingWindowDays`.
+    public static let largeTransactionNotificationWindowDays: Int = 7
+
     /// Page size for the virtualized large-history transaction list (AND-567).
     /// One page of rows is read at a time from the disposable per-transaction
     /// cache; the next page loads when the user scrolls near the end. Chosen large

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -207,9 +207,16 @@ public enum NotificationTriggerSelection {
         }
 
         if config.largeTransaction {
+            // Constrain OS notifications to the recent window so a fresh install's
+            // ~90-day import does not fire one alert per historical large charge
+            // (the delivered-dedup set is empty on first sync). Mirrors the
+            // AttentionQueue window.
             for transaction in largeTransactions(
                 from: transactions,
-                threshold: config.largeTransactionThreshold
+                threshold: config.largeTransactionThreshold,
+                now: now,
+                windowDays: PlaidBarConstants.largeTransactionNotificationWindowDays,
+                calendar: calendar
             ) {
                 append(largeTransactionDecision(for: transaction))
             }
@@ -229,7 +236,12 @@ public enum NotificationTriggerSelection {
         let decisions = activeDecisions.filter { !deliveredDedupKeys.contains($0.dedupKey) }
         let clearableDeliveredKeys = deliveredDedupKeys.filter { key in
             guard let kind = kind(forDedupKey: key) else { return false }
-            return kind.clearsWhenResolved
+            // Only resolve a delivered key when its family was actually evaluated
+            // this pass. If the family is disabled in config, its block was
+            // skipped, so the underlying condition was never re-checked —
+            // preserving the delivered key prevents a still-active stateful alert
+            // from re-firing when the family is toggled off and back on.
+            return kind.clearsWhenResolved && isEnabled(kind, in: config)
         }
         let resolvedDedupKeys = Set(clearableDeliveredKeys).subtracting(activeDedupKeys)
 
@@ -253,12 +265,35 @@ public enum NotificationTriggerSelection {
     public static func largeTransactions(
         from transactions: [TransactionDTO],
         threshold: Double,
-        excluding notifiedTransactionIds: Set<String> = []
+        excluding notifiedTransactionIds: Set<String> = [],
+        now: Date? = nil,
+        windowDays: Int? = nil,
+        calendar: Calendar = .current
     ) -> [TransactionDTO] {
-        transactions.filter {
-            !$0.isIncome &&
-                $0.displayAmount >= threshold &&
-                !notifiedTransactionIds.contains($0.id)
+        // Optional recency window: when both `now` and `windowDays` are supplied,
+        // also require the transaction date within [startOfDay(now) - windowDays,
+        // startOfDay(now)]. Unparseable dates are dropped. When either is nil the
+        // filter behaves exactly as before so windowless callers (AttentionQueue,
+        // FirstRunSnapshot) keep their existing behavior.
+        let window: (start: Date, end: Date)? = {
+            guard let now, let windowDays else { return nil }
+            let end = calendar.startOfDay(for: now)
+            guard let start = calendar.date(byAdding: .day, value: -windowDays, to: end) else {
+                return nil
+            }
+            return (start, end)
+        }()
+
+        return transactions.filter { transaction in
+            guard !transaction.isIncome,
+                  transaction.displayAmount >= threshold,
+                  !notifiedTransactionIds.contains(transaction.id)
+            else { return false }
+
+            guard let window else { return true }
+            guard let date = Formatters.parseTransactionDate(transaction.date) else { return false }
+            let day = calendar.startOfDay(for: date)
+            return day >= window.start && day <= window.end
         }
     }
 
@@ -276,7 +311,10 @@ public enum NotificationTriggerSelection {
         threshold: Double
     ) -> [AccountDTO] {
         accounts.filter {
-            $0.type == .credit && ($0.balances.utilizationPercent ?? 0) > threshold
+            // Inclusive (>=) so an account exactly at the threshold fires the OS
+            // notification too, matching every in-app surface (AttentionQueue,
+            // AccountPresentation, AccountsDestinationView, MainPopover).
+            $0.type == .credit && ($0.balances.utilizationPercent ?? 0) >= threshold
         }
     }
 
@@ -458,6 +496,38 @@ public enum NotificationTriggerSelection {
             body: body,
             severity: .informational
         )
+    }
+
+    /// Whether the given trigger family is enabled in `config`, i.e. whether its
+    /// block in `evaluate()` actually ran this pass. Mirrors the per-family
+    /// gating above so delivered-key resolution only happens for re-evaluated
+    /// families.
+    private static func isEnabled(
+        _ kind: NotificationTriggerKind,
+        in config: NotificationTriggers
+    ) -> Bool {
+        switch kind {
+        case .itemError, .providerOutage:
+            config.itemError
+        case .loginRequired:
+            config.loginRequired
+        case .syncStale:
+            config.staleSync
+        case .highUtilization:
+            config.highUtilization
+        case .lowBalance:
+            config.lowBalance
+        case .largeTransaction:
+            config.largeTransaction
+        case .recurringChargeDetected:
+            config.recurringChargeDetected
+        case .recurringChargeChanged:
+            config.recurringChargeChanged
+        case .recurringChargeDueSoon:
+            config.recurringChargeDueSoon
+        case .merchantWatch, .categoryWatch:
+            config.watchlist
+        }
     }
 
     private static func kind(forDedupKey dedupKey: String) -> NotificationTriggerKind? {

--- a/Tests/PlaidBarCoreTests/BudgetsStatusSummaryDetailTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetsStatusSummaryDetailTests.swift
@@ -20,6 +20,7 @@ struct BudgetsStatusSummaryDetailTests {
         budgetedCount: Int = 0,
         trackedCount: Int = 0,
         totalSpent: Double = 0,
+        budgetedSpent: Double? = nil,
         totalLimit: Double = 0
     ) -> BudgetsStatusSummary.Summary {
         BudgetsStatusSummary.Summary(
@@ -29,6 +30,10 @@ struct BudgetsStatusSummaryDetailTests {
             budgetedCount: budgetedCount,
             trackedCount: trackedCount,
             totalSpent: totalSpent,
+            // Default budgeted-only spend to the all-leaves spend so existing
+            // detail-copy cases (which assume all tracked spend is budgeted) are
+            // unchanged; the regression test below sets it explicitly.
+            budgetedSpent: budgetedSpent ?? totalSpent,
             totalLimit: totalLimit
         )
     }
@@ -92,5 +97,66 @@ struct BudgetsStatusSummaryDetailTests {
         let clean = summary(overBudgetCount: 0, budgetedCount: 2, totalSpent: 50, totalLimit: 200)
         #expect(!clean.isAggregateOver)
         #expect(clean.remainingDetail == "Remaining across your budgeted total")
+    }
+
+    // MARK: - summarize(): budgeted-only over/left/used math (bug-hunt R3)
+
+    private func tx(
+        _ amount: Double,
+        _ date: String,
+        _ category: SpendingCategory,
+        name: String = "Merchant"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: "\(name)-\(date)-\(amount)",
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: name,
+            merchantName: name,
+            category: category,
+            pending: false,
+            pendingTransactionId: nil,
+            isLowConfidenceCategory: false
+        )
+    }
+
+    /// Regression: unbudgeted spend must NOT be subtracted from the budgeted limit.
+    ///
+    /// Before the fix, `remaining`/`fractionUsed` compared all-leaves `totalSpent`
+    /// against the budgeted-only `totalLimit`, so $300 of unbudgeted shopping ate
+    /// into the $200 food budget — a false "Over budget" with `fractionUsed == 1.0`.
+    /// Now the aggregate math uses `budgetedSpent`, so the budgeted food category's
+    /// $50/$200 reads +$150 left / 0.25 used regardless of the unbudgeted spend.
+    @Test("summarize: unbudgeted spend never eats the budgeted left (bug-hunt R3)")
+    func unbudgetedSpendDoesNotConsumeBudgetedLeft() {
+        let now = Formatters.parseTransactionDate("2026-06-13")!
+        let calendar = Calendar(identifier: .gregorian)
+        let presentation = CategoryDashboardBuilder.build(
+            transactions: [
+                tx(50, "2026-06-02", .foodAndDrink),  // budgeted: 50 of 200
+                tx(300, "2026-06-03", .shopping),     // UNBUDGETED: must not touch the food budget
+            ],
+            budgets: [.foodAndDrink: 200],  // only food is budgeted
+            asOf: now,
+            calendar: calendar
+        )
+
+        // Sanity: the presentation itself separates the two spend figures.
+        #expect(presentation.totalLimit == 200)
+        #expect(presentation.totalSpent == 350)    // all leaves (food 50 + shopping 300)
+        #expect(presentation.budgetedSpent == 50)  // budgeted leaves only (food)
+
+        let result = BudgetsStatusSummary.summarize(presentation)
+
+        #expect(result.budgetedCount == 1)
+        #expect(result.totalSpent == 350)   // "Spent" tile keeps all-leaves spend
+        #expect(result.budgetedSpent == 50) // over/left/used math uses budgeted-only
+        #expect(result.totalLimit == 200)
+        // The bug produced remaining = 200 - 350 = -150 (false over) and 1.0 used.
+        #expect(result.remaining == 150)
+        #expect(result.isAggregateOver == false)
+        #expect(result.fractionUsed == 0.25)
+        #expect(result.health == .onTrack)
     }
 }

--- a/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
+++ b/Tests/PlaidBarCoreTests/NotificationTriggerEvaluationTests.swift
@@ -37,6 +37,10 @@ struct NotificationTriggerEvaluationTests {
             NotificationTriggerKind.itemError,
             NotificationTriggerKind.loginRequired,
             NotificationTriggerKind.syncStale,
+            // Two credit accounts cross the 30% utilization threshold: the 90%
+            // account and the exactly-at-threshold account (30%), since the
+            // notification path uses an inclusive (>=) comparison.
+            NotificationTriggerKind.highUtilization,
             NotificationTriggerKind.highUtilization,
             NotificationTriggerKind.lowBalance,
             NotificationTriggerKind.recurringChargeChanged,
@@ -49,6 +53,7 @@ struct NotificationTriggerEvaluationTests {
         let severities = evaluation.decisions.map(\NotificationTriggerDecision.severity)
         #expect(severities == [
             NotificationTriggerSeverity.blocking,
+            NotificationTriggerSeverity.warning,
             NotificationTriggerSeverity.warning,
             NotificationTriggerSeverity.warning,
             NotificationTriggerSeverity.warning,
@@ -335,6 +340,79 @@ struct NotificationTriggerEvaluationTests {
         #expect(evaluation.resolvedDedupKeys.isEmpty)
     }
 
+    @Test("Large-transaction notifications fire only inside the recency window")
+    func largeTransactionNotificationsHonorRecencyWindow() {
+        // A large transaction ~30 days before `now` is outside the 7-day window
+        // and must NOT produce a largeTransaction decision (prevents the
+        // first-sync ~90-day import from flooding the OS with notifications).
+        let stale = NotificationTriggerSelection.evaluate(
+            transactions: [
+                transaction(id: "tx-old-large", amount: 650, date: "2026-05-15"),
+            ],
+            now: fixedNow,
+            config: testConfig
+        )
+        #expect(stale.decisions.contains { $0.kind == .largeTransaction } == false)
+
+        // A large transaction inside the 7-day window still fires.
+        let recent = NotificationTriggerSelection.evaluate(
+            transactions: [
+                transaction(id: "tx-recent-large", amount: 650, date: "2026-06-12"),
+            ],
+            now: fixedNow,
+            config: testConfig
+        )
+        #expect(recent.decisions.contains { $0.kind == .largeTransaction })
+
+        // Windowless callers (no now/window) keep their original behavior:
+        // every qualifying large transaction is returned regardless of date.
+        let windowless = NotificationTriggerSelection.largeTransactions(
+            from: [
+                transaction(id: "tx-old-large", amount: 650, date: "2026-05-15"),
+                transaction(id: "tx-recent-large", amount: 650, date: "2026-06-12"),
+            ],
+            threshold: 500
+        )
+        #expect(windowless.count == 2)
+    }
+
+    @Test("A disabled family preserves delivered keys and does not re-fire on re-enable")
+    func disabledFamilyPreservesDeliveredKeysAcrossToggle() {
+        // Deliver a stateful highUtilization alert (family enabled).
+        let active = NotificationTriggerSelection.evaluate(
+            accounts: [credit(id: "acct-high-util", current: -4_500, limit: 5_000)],
+            now: fixedNow,
+            config: testConfig
+        )
+        let utilKey = NotificationTriggerSelection.dedupKey(
+            kind: .highUtilization,
+            sourceID: "acct-high-util"
+        )
+        #expect(active.activeDedupKeys.contains(utilKey))
+        let delivered = active.activeDedupKeys
+
+        // Family toggled OFF while its condition is still active: the delivered
+        // key must NOT be resolved (the block never ran, so the condition was
+        // never re-checked).
+        let disabled = NotificationTriggerSelection.evaluate(
+            accounts: [credit(id: "acct-high-util", current: -4_500, limit: 5_000)],
+            now: fixedNow,
+            config: NotificationTriggers(highUtilization: false),
+            deliveredDedupKeys: delivered
+        )
+        #expect(disabled.resolvedDedupKeys.isEmpty)
+
+        // Family toggled back ON with the condition still active: because the key
+        // was preserved (still delivered), it is suppressed — no re-fire.
+        let reEnabled = NotificationTriggerSelection.evaluate(
+            accounts: [credit(id: "acct-high-util", current: -4_500, limit: 5_000)],
+            now: fixedNow,
+            config: testConfig,
+            deliveredDedupKeys: delivered
+        )
+        #expect(reEnabled.decisions.contains { $0.dedupKey == utilKey } == false)
+    }
+
     private var testConfig: NotificationTriggers {
         NotificationTriggers(
             largeTransactionThreshold: 500,
@@ -343,12 +421,12 @@ struct NotificationTriggerEvaluationTests {
         )
     }
 
-    private func transaction(id: String, amount: Double) -> TransactionDTO {
+    private func transaction(id: String, amount: Double, date: String = "2026-06-12") -> TransactionDTO {
         TransactionDTO(
             id: id,
             accountId: "acct-\(id)",
             amount: amount,
-            date: "2026-06-12",
+            date: date,
             name: "Synthetic Transaction"
         )
     }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -640,8 +640,10 @@ struct PlaidBarTests {
             from: accounts,
             threshold: threshold
         )
-        #expect(highUtil.count == 1)
-        #expect(highUtil[0].id == "2")
+        // Inclusive boundary: the 90% account ("2") and the exactly-at-threshold
+        // 30% account ("3", -300/1000) both fire, matching the in-app surfaces.
+        #expect(highUtil.count == 2)
+        #expect(highUtil.map(\.id) == ["2", "3"])
     }
 
     // MARK: - Estimated Monthly Recurring Total


### PR DESCRIPTION
Bug-hunt round 3 (core business logic, 6 finders → refute-by-default verify): **4 confirmed, 0 rejected.** All fixed here with regression tests. Strict build clean, **2082 tests**.

### P2 — Budget "Over budget" / "Left" computed against the wrong spend basis
`BudgetsStatusSummary.remaining = totalLimit − totalSpent`, but `totalLimit` is **budgeted-leaves only** while `totalSpent` summed **all** leaves (incl. unbudgeted) — so unbudgeted spend was subtracted from the budgeted limit, flipping the hero tile to a **false "Over budget"** and inflating the usage bar, while the flat table footer (correctly budgeted-only) showed the opposite on the same data. **Fix:** added `budgetedSpent` (budgeted leaves only) and rebased `remaining`/`isAggregateOver`/`fractionUsed` on it (matching `CategoryDashboardTableModel.totals`); kept `totalSpent` for the "Spent" tile. + a `summarize()` regression test (food $50/$200 + shopping $300 unbudgeted → remaining $150, on-track, not over).

### P2 — Large-transaction notifications flooded the ~90-day back-catalog on first link
`largeTransactions(...)` had no recency window, and the dedup set is empty on a fresh install, so the first sync fired an OS notification for **every** large transaction in the 90-day import. **Fix:** added an optional `now`/`windowDays` to `largeTransactions` (windowless callers like AttentionQueue unchanged) and threaded a 7-day window (`largeTransactionNotificationWindowDays`) through `evaluate()` — mirroring AttentionQueue. + tests.

### P3 — Toggling a notification family off→on re-fired still-active alerts
`clearableDeliveredKeys` marked a disabled family's delivered keys "resolved" (its evaluation was skipped, not cleared), so re-enabling re-fired a still-active alert. **Fix:** gate on `isEnabled(kind, in: config)`.

### P3 — Credit-utilization exactly at threshold warned in-app but never notified (`>` vs `>=`)
**Fix:** inclusive `>=`, matching every in-app surface.

@codex please review — esp. the budgeted-vs-all-leaves spend basis and the notification window threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)