### PR TITLE
fix: 5 bugs from bug-hunt round 4 (rule re-categorization, outage status, goals, planning)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1252,6 +1252,13 @@ final class AppState {
         itemStatuses.filter { $0.status == .error }.count
     }
 
+    /// Linked items in a transient, non-actionable provider outage. Degraded but
+    /// self-healing — surfaced as a warning so the status cluster shows, never as
+    /// a blocking reconnect prompt.
+    var providerOutageItemCount: Int {
+        itemStatuses.filter { $0.status.isProviderOutage }.count
+    }
+
     /// Per-number completeness badge (AND-489): nil when data is complete and
     /// fresh, otherwise a `.stale` or `.partial` verdict mounted under derived
     /// numbers (net worth, utilization, cashflow, safe-to-spend).
@@ -1345,6 +1352,7 @@ final class AppState {
             syncedItemCount: serverSyncedItemCount ?? 0,
             needsLoginItemCount: needsLoginItemCount,
             erroredItemCount: erroredItemCount,
+            providerOutageItemCount: providerOutageItemCount,
             isSyncStale: isSyncStale,
             lastSyncRelative: lastSyncRelative,
             errorMessage: error,
@@ -4275,6 +4283,14 @@ final class AppState {
         guard !matcher.isEmpty else { return }
         let resolvedTransfer = markTransfer ?? (item.reasonCodes.contains(.possibleTransfer) ? true : item.isTransfer)
         pushReviewUndoState()
+        // Re-categorization replaces, not stacks: drop any existing rule that
+        // matches the SAME merchant so the user's newer choice wins. Without this
+        // the resolver would keep applying an older same-merchant rule (it resolves
+        // by most-recent `createdAt`, but a stale duplicate is still wasted state
+        // and surfaces as a phantom second rule).
+        transactionRules.removeAll {
+            $0.matchMerchantContains?.compare(matcher, options: .caseInsensitive) == .orderedSame
+        }
         transactionRules.append(TransactionRule(
             matchMerchantContains: matcher,
             matchOriginalNameContains: nil,

--- a/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
@@ -135,7 +135,9 @@ struct GoalsDestinationView: View {
     }
 
     private func remainingDetail(_ summary: GoalsSummary) -> String {
-        let remaining = max(summary.totalTarget - summary.totalSaved, 0)
+        // Per-goal-clamped remaining — an over-funded goal can't mask another
+        // goal's shortfall (matches each row's `Goal.remainingAmount`).
+        let remaining = summary.totalRemaining
         return "\(currency(remaining)) remaining"
     }
 

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -74,6 +74,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         syncedItemCount: Int,
         needsLoginItemCount: Int,
         erroredItemCount: Int,
+        providerOutageItemCount: Int = 0,
         isSyncStale: Bool,
         lastSyncRelative: String?,
         errorMessage: String?,
@@ -166,6 +167,24 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 ),
                 detail: "One or more institutions need Plaid Link update mode for login, consent, or account selection.",
                 primaryAction: .reconnect
+            )
+        }
+
+        // A provider outage is degraded but non-actionable: the connection
+        // recovers on its own once Plaid/the institution is back. It must surface
+        // as a warning (so the status cluster shows) rather than silently reading
+        // as healthy, but it never blocks or asks the user to reconnect.
+        if providerOutageItemCount > 0 {
+            return DashboardStatusReadiness(
+                level: .warning,
+                title: itemRecoveryTitle(
+                    count: providerOutageItemCount,
+                    singularAction: "temporarily unavailable",
+                    pluralAction: "temporarily unavailable"
+                ),
+                detail: "Your bank or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed.",
+                primaryAction: .refresh,
+                primaryActionTitle: "Refresh Now"
             )
         }
 

--- a/Sources/PlaidBarCore/Models/GoalEditorInput.swift
+++ b/Sources/PlaidBarCore/Models/GoalEditorInput.swift
@@ -112,9 +112,14 @@ public enum GoalEditorInput {
         )
     }
 
-    /// Parse a currency-ish string ("1,250.50", "$1250", "1250") into a `Double`,
-    /// or `nil` when it has no parseable numeric content. Tolerant of grouping
-    /// separators, a leading currency symbol, and surrounding whitespace.
+    /// Parse a currency-ish string ("1,250.50", "$1250", "1250", "1.250,50") into a
+    /// `Double`, or `nil` when it has no parseable numeric content. Tolerant of
+    /// grouping separators, a leading currency symbol, and surrounding whitespace.
+    ///
+    /// Handles both the US ("1,250.50") and European ("1.250,50") conventions: when
+    /// both `.` and `,` are present, the *last-occurring* one is treated as the
+    /// decimal separator and the other as grouping. The comma-only case keeps US
+    /// grouping semantics ("5,000" ⇒ 5000) to preserve existing behavior.
     public static func parseAmount(_ text: String) -> Double? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -123,8 +128,21 @@ public enum GoalEditorInput {
         let stripped = String(trimmed.filter { allowed.contains($0) })
         guard !stripped.isEmpty else { return nil }
 
-        // Remove thousands separators, keep the decimal point.
-        let normalized = stripped.replacingOccurrences(of: ",", with: "")
+        // Decide the decimal separator: the last-occurring of '.'/',' when both are
+        // present (the other is grouping); comma-only stays US grouping.
+        let lastDot = stripped.lastIndex(of: ".")
+        let lastComma = stripped.lastIndex(of: ",")
+        let normalized: String
+        switch (lastDot, lastComma) {
+        case let (d?, c?):
+            normalized = d > c
+                ? stripped.replacingOccurrences(of: ",", with: "")
+                : stripped.replacingOccurrences(of: ".", with: "").replacingOccurrences(of: ",", with: ".")
+        case (nil, _?):
+            normalized = stripped.replacingOccurrences(of: ",", with: "")
+        default:
+            normalized = stripped
+        }
         return Double(normalized)
     }
 }

--- a/Sources/PlaidBarCore/Models/GoalsSummary.swift
+++ b/Sources/PlaidBarCore/Models/GoalsSummary.swift
@@ -14,6 +14,11 @@ public struct GoalsSummary: Sendable, Equatable {
     public let totalSaved: Double
     /// Sum of every goal's target amount.
     public let totalTarget: Double
+    /// Sum of every goal's *per-goal-clamped* remaining amount
+    /// (`Σ max(target − contributed, 0)`). Unlike `totalTarget − totalSaved`,
+    /// an over-funded goal contributes `0` rather than a negative that would
+    /// cancel another goal's genuine shortfall.
+    public let totalRemaining: Double
     /// Goals that have reached their target.
     public let fundedCount: Int
     /// Goals behind their target-date pace (excludes funded and no-deadline goals).
@@ -23,12 +28,14 @@ public struct GoalsSummary: Sendable, Equatable {
         goalCount: Int,
         totalSaved: Double,
         totalTarget: Double,
+        totalRemaining: Double,
         fundedCount: Int,
         behindCount: Int
     ) {
         self.goalCount = goalCount
         self.totalSaved = totalSaved
         self.totalTarget = totalTarget
+        self.totalRemaining = totalRemaining
         self.fundedCount = fundedCount
         self.behindCount = behindCount
     }
@@ -53,12 +60,14 @@ public struct GoalsSummary: Sendable, Equatable {
     public static func make(from goals: [Goal], asOf now: Date = Date()) -> GoalsSummary {
         var totalSaved = 0.0
         var totalTarget = 0.0
+        var totalRemaining = 0.0
         var fundedCount = 0
         var behindCount = 0
 
         for goal in goals {
             totalSaved += goal.contributedAmount
             totalTarget += goal.targetAmount
+            totalRemaining += goal.remainingAmount
             if goal.isComplete {
                 fundedCount += 1
             } else if goal.pace(asOf: now) == .behind {
@@ -70,6 +79,7 @@ public struct GoalsSummary: Sendable, Equatable {
             goalCount: goals.count,
             totalSaved: totalSaved,
             totalTarget: totalTarget,
+            totalRemaining: totalRemaining,
             fundedCount: fundedCount,
             behindCount: behindCount
         )

--- a/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
+++ b/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
@@ -56,7 +56,9 @@ public enum BalanceProjector {
             horizon
         )
 
-        // Per-day net delta across the span, keyed by day index 1...totalDays.
+        // Per-day net delta across the span, keyed by day index 0...totalDays.
+        // Index 0 captures any obligation due exactly on the anchor day; it is
+        // folded into the seed below so the anchor snapshot already reflects it.
         var deltasByDayIndex: [Int: Double] = [:]
         var hasSignal = false
 
@@ -86,7 +88,7 @@ public enum BalanceProjector {
 
             while occurrence <= horizonEnd {
                 if let dayIndex = calendar.dateComponents([.day], from: startDay, to: occurrence).day,
-                   dayIndex >= 1, dayIndex <= totalDays {
+                   dayIndex >= 0, dayIndex <= totalDays {
                     deltasByDayIndex[dayIndex, default: 0] += signed
                 }
                 guard let next = calendar.date(byAdding: .day, value: step, to: occurrence) else { break }
@@ -98,7 +100,11 @@ public enum BalanceProjector {
         // day), 1...totalDays forward through the horizon end.
         var series: [BalanceSnapshot] = []
         series.reserveCapacity(totalDays + 1)
-        var running = anchor.balance
+        // Fold any day-0 obligation (due exactly on the anchor day) into the seed
+        // so the projected line agrees with SafeToSpendCalculator's inclusive
+        // (nextDay >= referenceDay) window. The 1...totalDays loop starts at 1,
+        // so this does not double-count the day-0 delta.
+        var running = anchor.balance + (deltasByDayIndex[0] ?? 0)
         series.append(BalanceSnapshot(date: startDay, balance: running))
         for dayIndex in 1...totalDays {
             running += deltasByDayIndex[dayIndex] ?? 0

--- a/Sources/PlaidBarCore/Utilities/EffectiveCategoryResolver.swift
+++ b/Sources/PlaidBarCore/Utilities/EffectiveCategoryResolver.swift
@@ -136,15 +136,26 @@ public enum EffectiveCategoryResolver {
     ///   `false`, which would otherwise short-circuit and suppress both rule-based
     ///   and transfer-default exclusion.)
     ///
-    /// When several rules match, the earliest in `rules` order with a value for a
-    /// given field wins (callers keep rules in their intended priority order).
+    /// When several rules match, the **most recently created** matching rule (by
+    /// `createdAt`, descending) with a value for a given field wins. A user's newer
+    /// same-merchant rule must take effect over an older one; resolving by array
+    /// index instead silently kept the earliest rule and made re-categorization
+    /// look dead.
     public static func resolve(
         transaction: TransactionDTO,
         metadata: TransactionReviewMetadata? = nil,
         rules: [TransactionRule] = [],
         nlCategorizer: NLMerchantCategorizer = NLMerchantCategorizer()
     ) -> Resolution {
-        let matchedRules = rules.filter { $0.matches(transaction) }
+        // Newest-first so `firstRuleValue` picks the most recently created matching
+        // rule's value for each field. `id` is the deterministic tiebreaker for
+        // equal timestamps (e.g. fixtures with a shared `createdAt`).
+        let matchedRules = rules
+            .filter { $0.matches(transaction) }
+            .sorted {
+                if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+                return $0.id.uuidString > $1.id.uuidString
+            }
 
         // Budget category: user override wins outright; otherwise a matching rule's
         // category is an explicit user intent; otherwise a *confident* Plaid
@@ -220,7 +231,8 @@ public enum EffectiveCategoryResolver {
         category == .transfer || category == .transferOut
     }
 
-    /// The first non-nil value of `keyPath` across the matched rules, in order.
+    /// The first non-nil value of `keyPath` across the matched rules, in the
+    /// order they are passed (callers pre-sort newest-first by `createdAt`).
     private static func firstRuleValue<Value>(
         _ rules: [TransactionRule],
         _ keyPath: KeyPath<TransactionRule, Value?>

--- a/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
@@ -169,6 +169,30 @@ struct BalanceProjectorTests {
         #expect(projection.projectedLow.balance == 800)
     }
 
+    @Test("Obligation due exactly on the anchor day is applied to the seed (bug-hunt R4)")
+    func obligationDueExactlyTodayHitsAnchor() {
+        // An annual obligation due exactly on asOf (day index 0) must be folded
+        // into the anchor seed — not dropped — so the projected line agrees with
+        // SafeToSpendCalculator's inclusive (nextDay >= referenceDay) window.
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let dueToday = Self.recurring(
+            "Today", amount: 200, frequency: .annual, nextExpectedDate: "2026-06-01", category: .billsAndUtilities
+        )
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [dueToday],
+            asOf: Self.asOf, // 2026-06-01
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        // The very first (anchor) point already reflects the day-0 charge.
+        #expect(projection.series.first?.balance == 800)
+        // The annual stream recurs +365 days, past the horizon, so the line is
+        // flat at the post-charge balance — every snapshot is 800.
+        #expect(projection.projectedLow.balance == 800)
+        #expect(projection.series.allSatisfy { $0.balance == 800 })
+    }
+
     @Test("Current anchor keeps the horizon + 1 series length")
     func currentAnchorKeepsLength() {
         let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)

--- a/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
@@ -14,6 +14,7 @@ struct DashboardStatusReadinessTests {
         syncedItemCount: Int = 2,
         needsLoginItemCount: Int = 0,
         erroredItemCount: Int = 0,
+        providerOutageItemCount: Int = 0,
         isSyncStale: Bool = false,
         lastSyncRelative: String? = "2m ago",
         errorMessage: String? = nil,
@@ -30,6 +31,7 @@ struct DashboardStatusReadinessTests {
             syncedItemCount: syncedItemCount,
             needsLoginItemCount: needsLoginItemCount,
             erroredItemCount: erroredItemCount,
+            providerOutageItemCount: providerOutageItemCount,
             isSyncStale: isSyncStale,
             lastSyncRelative: lastSyncRelative,
             errorMessage: errorMessage,
@@ -100,6 +102,16 @@ struct DashboardStatusReadinessTests {
         #expect(readiness.level == .warning)
         #expect(readiness.title == "1 item needs update")
         #expect(readiness.primaryAction == .reconnect)
+    }
+
+    @Test("Provider outage warns (not healthy) with a self-healing retry message")
+    func providerOutage() {
+        let readiness = evaluate(providerOutageItemCount: 1)
+        #expect(readiness.level == .warning)
+        #expect(readiness.title == "1 item temporarily unavailable")
+        #expect(readiness.detail.contains("retry automatically"))
+        #expect(readiness.primaryAction == .refresh)
+        #expect(readiness.primaryActionTitle == "Refresh Now")
     }
 
     @Test("A recent action failure warns with the sanitized detail")

--- a/Tests/PlaidBarCoreTests/EffectiveCategoryResolverTests.swift
+++ b/Tests/PlaidBarCoreTests/EffectiveCategoryResolverTests.swift
@@ -136,6 +136,33 @@ struct EffectiveCategoryResolverTests {
         #expect(resolution.category == .foodAndDrink)
     }
 
+    @Test("The most recently created same-merchant rule wins over an older one")
+    func newestSameMerchantRuleWins() {
+        // Re-categorization: the user first filed Acme → shopping, then later
+        // re-filed Acme → foodAndDrink. The newer rule (by createdAt) must win,
+        // regardless of array order — the bug resolved by array index, so the
+        // stale earliest rule kept applying and the newer choice looked dead.
+        let transaction = tx(id: "recat", category: nil, merchantName: "Acme Corp")
+        let older = TransactionRule(
+            matchMerchantContains: "Acme",
+            category: .shopping,
+            createdAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let newer = TransactionRule(
+            matchMerchantContains: "Acme",
+            category: .foodAndDrink,
+            createdAt: Date(timeIntervalSince1970: 2_000)
+        )
+
+        // Older first in the array (the natural append order) — newer must still win.
+        let resolution = EffectiveCategoryResolver.resolve(
+            transaction: transaction,
+            rules: [older, newer]
+        )
+
+        #expect(resolution.category == .foodAndDrink)
+    }
+
     // MARK: - Override vs rule precedence
 
     @Test("A user category override wins over a matching rule's category")

--- a/Tests/PlaidBarCoreTests/GoalEditorInputTests.swift
+++ b/Tests/PlaidBarCoreTests/GoalEditorInputTests.swift
@@ -18,6 +18,28 @@ struct GoalEditorInputTests {
         #expect(GoalEditorInput.parseAmount("abc") == nil)
     }
 
+    @Test("parseAmount handles European grouping/decimal, US cases unchanged")
+    func parseAmountLocaleAware() {
+        // European: '.' grouping, ',' decimal — last separator wins.
+        #expect(GoalEditorInput.parseAmount("1.250,50") == 1250.50)
+        // Existing US cases must still pass.
+        #expect(GoalEditorInput.parseAmount("1,250.50") == 1250.50)
+        #expect(GoalEditorInput.parseAmount("5,000") == 5000)
+        #expect(GoalEditorInput.parseAmount("1250") == 1250)
+    }
+
+    @Test("validate accepts a European-formatted target amount")
+    func validateEuropeanTarget() {
+        let outcome = GoalEditorInput.validate(
+            nameText: "Fund",
+            targetText: "1.250,50",
+            contributedText: "",
+            targetDate: nil,
+            linkedCategory: nil
+        )
+        #expect(outcome.draft?.targetAmount == 1250.50)
+    }
+
     // MARK: - Name
 
     @Test("A blank name is invalid")

--- a/Tests/PlaidBarCoreTests/GoalsSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/GoalsSummaryTests.swift
@@ -59,4 +59,21 @@ struct GoalsSummaryTests {
         #expect(summary.overallFraction == 1.0)
         #expect(summary.overallPercent == 100)
     }
+
+    @Test("Total remaining is per-goal clamped — an over-funded goal can't mask another's shortfall")
+    func totalRemainingPerGoalClamped() {
+        let goals = [
+            // Over-funded: contributes 0 to remaining (not −500).
+            Goal(name: "Over", targetAmount: 1000, contributedAmount: 1500),
+            // Untouched: a genuine 1000 shortfall.
+            Goal(name: "Behind", targetAmount: 1000, contributedAmount: 0),
+        ]
+        let summary = GoalsSummary.make(from: goals)
+        // Per-goal clamp: max(1000−1500,0) + max(1000−0,0) == 0 + 1000.
+        #expect(summary.totalRemaining == 1000)
+        // The naive flat-totals formula would (wrongly) report 500.
+        #expect(summary.totalTarget - summary.totalSaved == 500)
+        // Overall fraction still clamps to 1 (totalSaved 1500 / totalTarget 2000 = 0.75).
+        #expect(summary.overallFraction == 0.75)
+    }
 }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -369,6 +369,39 @@ struct PlaidBarTests {
         #expect(transactions[0].accountId == "a3")
     }
 
+    // MARK: - Rule Replacement (mirrors AppState.createRule)
+
+    @Test("Creating a rule for an existing merchant replaces it instead of stacking")
+    func createRuleReplacesSameMerchant() {
+        // Mirrors AppState.createRule: before appending the new rule it drops any
+        // existing rule whose `matchMerchantContains` case-insensitively equals the
+        // new matcher, so re-categorizing the same merchant keeps a single rule
+        // (the user's newest choice) rather than leaving a dead earlier rule behind.
+        var transactionRules = [
+            TransactionRule(matchMerchantContains: "Acme", category: .shopping),
+        ]
+
+        let matcher = "acme" // different case — must still match and replace
+        transactionRules.removeAll {
+            $0.matchMerchantContains?.compare(matcher, options: .caseInsensitive) == .orderedSame
+        }
+        transactionRules.append(TransactionRule(matchMerchantContains: matcher, category: .foodAndDrink))
+
+        #expect(transactionRules.count == 1)
+        #expect(transactionRules[0].category == .foodAndDrink)
+
+        // And the resolver attributes spend to the surviving (newest) category.
+        let transaction = TransactionDTO(
+            id: "recat", accountId: "a", amount: 12, date: "2026-06-01",
+            name: "ACME CORP", merchantName: "Acme Corp", category: nil
+        )
+        let resolution = EffectiveCategoryResolver.resolve(
+            transaction: transaction,
+            rules: transactionRules
+        )
+        #expect(resolution.category == .foodAndDrink)
+    }
+
     // MARK: - Currency Format
 
     @Test("Currency format compact has no decimals")


### PR DESCRIPTION
Bug-hunt round 4 (goals/planning/rules/billing/energy/derived, 6 finders → refute-by-default verify): **5 confirmed, 0 rejected.** All fixed here with regression tests. Strict build clean, **2089 tests**.

### P2 — Re-categorizing a merchant was silently dead
`EffectiveCategoryResolver` resolved the **earliest** matching rule (array order), and `createRule` appended without replacing — so a user's newer same-merchant rule never took effect. **Fix:** `createRule` removes any existing same-merchant rule before appending (replace, not stack; ⌘Z preserved); resolver picks the **most recently created** matching rule (createdAt desc, id tiebreak).

### P2 — A provider-outage item was reported as "Plaid sync healthy"
`DashboardStatusReadiness` had no outage branch, so an outage item fell through to the healthy default — suppressing the dashboard status cluster. **Fix:** new `.warning` branch (advisory, self-healing copy, Refresh action) gated on `providerOutageItemCount`, ranked below reconnect-actionable states.

### P3 — Goals overall "remaining" understated when a goal is over-funded
Flat `totalTarget − totalSaved` let an over-funded goal cancel another's shortfall. **Fix:** sum per-goal clamped `remainingAmount` via new `GoalsSummary.totalRemaining`.

### P3 — Goal target amount mis-parsed for European number format
`"1.250,50"` parsed to ~$1.25. **Fix:** locale-aware decimal-vs-grouping detection (last separator is the decimal); US formats unchanged.

### P3 — A recurring obligation due exactly today was dropped from the projection
Day-index-0 occurrence survived the skip but was filtered out and never folded into the seed → overstated projected balance, disagreeing with safe-to-spend. **Fix:** admit day 0 and fold it into the anchor.

@codex please review — esp. the resolver "newest wins" ordering + createRule replace, and the outage readiness ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)