### PR TITLE
fix: 2 reachable bugs from bug-hunt round 5 (transactions search perf, FM cache eviction)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1927,6 +1927,14 @@ final class AppState {
     func refreshFoundationModelsCategorySuggestions() async {
         guard foundationModelsTierState.isAvailable else { return }
         let categorizer = merchantCategorizer
+        // Evict cache entries whose transactions have left the Review Inbox
+        // (categorized/approved/ignored/dropped). The cache is otherwise
+        // insert-only, so without this prune it grows with session-cumulative
+        // throughput rather than live inbox size (unbounded memory creep).
+        // `foundationModelsCategorySuggestion(for:)` only reads ids currently
+        // in the inbox, so dropping absent ids removes nothing on display.
+        let liveIDs = Set(transactionReviewInboxSnapshot.items.map(\.id))
+        _foundationModelsCategorySuggestions = _foundationModelsCategorySuggestions.filter { liveIDs.contains($0.key) }
         // Only items still flagged as needing a category benefit from a
         // suggestion; a row the user already categorized must not be second-
         // guessed. Skip ones already suggested this session to avoid redundant

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -47,6 +47,14 @@ struct TransactionsDestinationView: View {
     /// rather than all at once.
     @State private var pagedSource: PagedTransactionSource
 
+    /// Memoizes the *search-independent* build phase (page → override-aware rows),
+    /// mirroring `AppState._cachedCategoryDashboardPresentation`. Held as `@State`
+    /// so it survives body re-evaluations; it rebuilds only when the build inputs
+    /// (transactions / review metadata / rules) change — **not** when `searchText`
+    /// (or any other filter/sort facet) changes. So a search keystroke runs only the
+    /// cheap `filtered` scan + final `sort`, never the O(n) build + dictionary again.
+    @State private var rowBuildCache = BuiltRowCache()
+
     @MainActor
     init() {
         // A placeholder source until `.task` rebuilds it against the live AppState
@@ -63,24 +71,38 @@ struct TransactionsDestinationView: View {
     private var sourceTransactions: [TransactionDTO] { pagedSource.rows }
 
     /// The fully composed rows: page → build → filter → search → sort (pure Core).
+    ///
+    /// The build phase (`TransactionWorkspace.rows`) is search-independent and is
+    /// served from `rowBuildCache`, so a search keystroke only re-runs the cheap
+    /// `filtered` + `sort`. Read **once** per body pass (bound to a `let` in `body`)
+    /// rather than recomputed for every reader (count, `.onChange`, content,
+    /// table) — collapsing the old 3–4 pipeline runs per invalidation into 1.
     private var rows: [TransactionWorkspace.Row] {
-        TransactionWorkspace.resolve(
+        let built = rowBuildCache.rows(
             transactions: sourceTransactions,
             metadata: appState.transactionReviewMetadata,
-            rules: appState.transactionRules,
-            filter: navigationModel.transactionFilter,
-            sort: navigationModel.transactionSort,
+            rules: appState.transactionRules
+        )
+        let narrowed = TransactionWorkspace.filtered(
+            built,
+            by: navigationModel.transactionFilter,
             now: Date()
         )
+        return navigationModel.transactionSort.sorted(narrowed)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+        // Compute the composed rows ONCE per body pass and thread the result to
+        // every reader. Previously `rows` was an uncached computed property read 3–4×
+        // per pass (result count, selection reconcile, content `isEmpty`, table),
+        // so each search keystroke ran the whole pipeline 3–4× on the MainActor.
+        let resolved = rows
+        return VStack(alignment: .leading, spacing: WindowMetrics.sm) {
             TransactionsFilterBar(
                 filter: filterBinding,
                 sort: sortBinding,
                 accounts: appState.accounts,
-                resultCount: rows.count,
+                resultCount: resolved.count,
                 isSearchFocused: $isSearchFocused
             )
             .padding(.horizontal, WindowMetrics.canvasMargin)
@@ -88,7 +110,7 @@ struct TransactionsDestinationView: View {
 
             Divider().opacity(0.4)
 
-            content
+            content(rows: resolved)
         }
         .navigationTitle(RouteDestination.transactions.title)
         // Build the paged source against the live AppState cache once, then load the
@@ -115,7 +137,8 @@ struct TransactionsDestinationView: View {
         }
         // Self-heal: if the selected row falls out of the filtered set, clear it so
         // the inspector returns to its prompt instead of pointing at a hidden row.
-        .onChange(of: rows.map(\.id)) { _, ids in
+        // Observes the already-computed `resolved` ids (no extra pipeline run).
+        .onChange(of: resolved.map(\.id)) { _, ids in
             navigationModel.reconcileTransactionSelection(visibleTransactionIDs: ids)
         }
     }
@@ -123,7 +146,7 @@ struct TransactionsDestinationView: View {
     // MARK: - Content states
 
     @ViewBuilder
-    private var content: some View {
+    private func content(rows: [TransactionWorkspace.Row]) -> some View {
         if appState.isBootLoadInFlight {
             TransactionsLoadingSkeleton()
         } else if let error = appState.error, appState.transactions.isEmpty {
@@ -135,11 +158,11 @@ struct TransactionsDestinationView: View {
         } else if rows.isEmpty {
             filteredEmptyState
         } else {
-            table
+            table(rows: rows)
         }
     }
 
-    private var table: some View {
+    private func table(rows: [TransactionWorkspace.Row]) -> some View {
         TransactionsTable(
             rows: rows,
             selection: selectionBinding,
@@ -256,6 +279,63 @@ struct TransactionsDestinationView: View {
             TransactionInspectorView()
                 .environment(appState)
         }
+    }
+}
+
+/// Memoizes the **search-independent** build phase of the Transaction Workspace
+/// pipeline (`TransactionWorkspace.rows` — page → override-aware row view-models),
+/// mirroring `AppState._cachedCategoryDashboardPresentation`.
+///
+/// `TransactionsDestinationView.body` re-evaluates on every search keystroke
+/// (`searchText` writes the navigation model's filter). The build phase is the
+/// expensive part — O(transactions) `EffectiveCategoryResolver` calls plus a
+/// metadata dictionary build — and it depends only on `(transactions, metadata,
+/// rules)`, never on the filter/search/sort. Caching it here keys the rebuild to
+/// those three inputs only, so a keystroke runs just the cheap `filtered` scan and
+/// final `sort` over the cached rows instead of rebuilding from scratch.
+///
+/// `@Observable` + held in `@State`: a class so the cache survives body
+/// re-evaluations, and so `rows(transactions:metadata:rules:)` may populate it
+/// when called from `body` (mutating a reference type, not `@State` struct storage).
+/// Not registering observation tracking here is intentional — invalidation is keyed
+/// on the inputs, which the view already observes via `AppState`.
+@MainActor
+@Observable
+final class BuiltRowCache {
+    /// The inputs that produced `cachedRows`. Compared by value: an array of
+    /// `Equatable` elements is `Equatable`, and `==` short-circuits on a count
+    /// mismatch / first differing element. Walking the inputs once per body pass is
+    /// far cheaper than the build it guards, and it never produces a stale result
+    /// (any edit — recategorize, rename, transfer, page append — changes one of the
+    /// three inputs and forces a rebuild).
+    @ObservationIgnored private var keyTransactions: [TransactionDTO] = []
+    @ObservationIgnored private var keyMetadata: [TransactionReviewMetadata] = []
+    @ObservationIgnored private var keyRules: [TransactionRule] = []
+    @ObservationIgnored private var cachedRows: [TransactionWorkspace.Row]?
+
+    /// The cached build, rebuilt only when `(transactions, metadata, rules)` differ
+    /// from the inputs that produced the current cache.
+    func rows(
+        transactions: [TransactionDTO],
+        metadata: [TransactionReviewMetadata],
+        rules: [TransactionRule]
+    ) -> [TransactionWorkspace.Row] {
+        if let cachedRows,
+           transactions == keyTransactions,
+           metadata == keyMetadata,
+           rules == keyRules {
+            return cachedRows
+        }
+        let built = TransactionWorkspace.rows(
+            transactions: transactions,
+            metadata: metadata,
+            rules: rules
+        )
+        keyTransactions = transactions
+        keyMetadata = metadata
+        keyRules = rules
+        cachedRows = built
+        return built
     }
 }
 

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -940,6 +940,48 @@ struct PlaidBarTests {
         #expect(suggestion?.tier != .foundationModels)
         #expect(stub.callCount == 0)
     }
+
+    // Regression for the bug-hunt R5 fix: AppState's
+    // `_foundationModelsCategorySuggestions` cache was insert-only, so entries
+    // for transactions that left the Review Inbox (categorized/approved/
+    // ignored/dropped) were never evicted and memory grew with session-
+    // cumulative throughput instead of live inbox size. AppState is an
+    // executable @main target (not @testable-importable), so this pins the
+    // exact prune expression the fix runs at the top of
+    // `refreshFoundationModelsCategorySuggestions()`:
+    //   cache = cache.filter { liveIDs.contains($0.key) }
+    @Test("FM suggestion cache evicts entries whose transactions left the inbox")
+    func fmSuggestionCacheEvictsDepartedInboxItems() {
+        // Two items previously cached this session.
+        var cache: [String: MerchantCategorySuggestion] = [
+            "txn-still-here": MerchantCategorySuggestion(category: .foodAndDrink, tier: .foundationModels, isTrusted: true),
+            "txn-left-inbox": MerchantCategorySuggestion(category: .travel, tier: .foundationModels, isTrusted: true),
+        ]
+
+        // The live inbox now contains only the first item; the second was
+        // categorized/approved/dropped and no longer appears.
+        let liveIDs = Set(["txn-still-here"])
+
+        // The prune AppState performs after the availability guard.
+        cache = cache.filter { liveIDs.contains($0.key) }
+
+        #expect(cache["txn-still-here"] != nil, "live inbox item's suggestion must be retained")
+        #expect(cache["txn-left-inbox"] == nil, "departed item's suggestion must be evicted")
+        #expect(cache.count == 1, "cache must track live inbox size, not cumulative throughput")
+    }
+
+    @Test("FM suggestion cache prune is a no-op when every cached item is still live")
+    func fmSuggestionCachePruneNoOpWhenAllLive() {
+        var cache: [String: MerchantCategorySuggestion] = [
+            "a": MerchantCategorySuggestion(category: .foodAndDrink, tier: .foundationModels, isTrusted: true),
+            "b": MerchantCategorySuggestion(category: .travel, tier: .foundationModels, isTrusted: true),
+        ]
+        let liveIDs = Set(["a", "b"])
+
+        cache = cache.filter { liveIDs.contains($0.key) }
+
+        #expect(cache.count == 2, "no eviction when every cached id is still in the inbox")
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.


### PR DESCRIPTION
## Bug-hunt round 5 — 2 reachable fixes

The cross-cutting (round 5) adversarial bug-hunt confirmed 3 real defects; the 2 **reachable** ones are fixed here. The 3rd (a webhook concurrent-delivery race) is on a currently-dormant code path and is tracked in AND-634 alongside the other webhook ordering defects, to be fixed when a real Plaid webhook signature verifier is wired.

### 1. Transactions search input-lag (P2) — `TransactionsDestinationView.swift`
Per keystroke, the uncached `rows` computed property ran the full **build → filter → sort** pipeline 3–4× per body pass (it was read by the filter bar's result count, the selection-reconcile `onChange`, `content`, and `table`), and the O(n) override-aware build (`EffectiveCategoryResolver` + metadata dictionary) re-ran on every character even though search doesn't change it.
- **Part 1:** `body` binds `let resolved = rows` once and threads it to every reader (`content`/`table` converted to functions taking the rows). Eliminates the 3–4× redundant pipeline runs.
- **Part 2:** a small `@MainActor @Observable BuiltRowCache` (in `@State`, mirroring `AppState._cachedCategoryDashboardPresentation`) memoizes `TransactionWorkspace.rows(transactions:metadata:rules:)` keyed by value-equality on `(transactions, reviewMetadata, rules)` — rebuilds only when those change, **not** on `searchText`. Per keystroke now runs only the cheap `filtered(...)` scan + `sort.sorted(...)`.

Behavior-identical (same final rows). `TransactionWorkspace` was already split into `rows`/`filtered`/`Sort.sorted`, so no Core change was needed.

### 2. Foundation Models suggestion cache grows unbounded (P3) — `AppState.swift`
`_foundationModelsCategorySuggestions` was insert-only, so it tracked session-cumulative review throughput instead of live inbox size — slow memory creep over a long session. `refreshFoundationModelsCategorySuggestions()` now prunes to the live Review Inbox before computing pending:
```swift
let liveIDs = Set(transactionReviewInboxSnapshot.items.map(\.id))
_foundationModelsCategorySuggestions = _foundationModelsCategorySuggestions.filter { liveIDs.contains($0.key) }
```
Display-behavior-preserving (suggestions are only consulted for items currently in the inbox). +2 regression tests pinning the eviction expression.

### Verify (combined merge of both fixes)
- Strict-concurrency build: ✅ `Build complete! (71.63s)`
- `swift test`: ✅ **2091 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
