### PR TITLE
refactor: extract Goals hero detail copy → PlaidBarCore

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
@@ -87,7 +87,7 @@ struct GoalsDestinationView: View {
                     label: "Total saved",
                     value: currency(summary.totalSaved),
                     systemImage: "banknote",
-                    detail: savedDetail(summary),
+                    detail: summary.savedDetail,
                     accent: SemanticColors.brand,
                     reduceMotion: reduceMotion
                 )
@@ -95,7 +95,7 @@ struct GoalsDestinationView: View {
                     label: "Total target",
                     value: currency(summary.totalTarget),
                     systemImage: "target",
-                    detail: targetDetail(summary),
+                    detail: summary.targetDetail,
                     accent: .secondary,
                     reduceMotion: reduceMotion
                 )
@@ -117,21 +117,6 @@ struct GoalsDestinationView: View {
                 isMasked: isMasked
             )
         }
-    }
-
-    private func savedDetail(_ summary: GoalsSummary) -> String {
-        let goals = summary.goalCount == 1 ? "1 goal" : "\(summary.goalCount) goals"
-        if summary.fundedCount > 0 {
-            return "\(goals) · \(summary.fundedCount) funded"
-        }
-        return "Across \(goals)"
-    }
-
-    private func targetDetail(_ summary: GoalsSummary) -> String {
-        if summary.behindCount > 0 {
-            return summary.behindCount == 1 ? "1 goal behind pace" : "\(summary.behindCount) goals behind pace"
-        }
-        return "Everything on pace"
     }
 
     private func remainingDetail(_ summary: GoalsSummary) -> String {

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -339,7 +339,7 @@ struct PlanningDestinationView: View {
             }
 
             HStack(spacing: WindowMetrics.md) {
-                Label("\(summary.goalCount) goal\(summary.goalCount == 1 ? "" : "s")", systemImage: "flag")
+                Label(summary.goalCountLabel, systemImage: "flag")
                     .windowSupportingText()
                 if summary.fundedCount > 0 {
                     Label("\(summary.fundedCount) funded", systemImage: "checkmark.seal")
@@ -355,7 +355,7 @@ struct PlanningDestinationView: View {
 
     private func goalsAccessibilityLabel(_ summary: GoalsSummary) -> String {
         guard !summary.isEmpty else { return "Goals: no goals yet." }
-        var parts = ["Goals: \(goalsPercent(summary.overallPercent)) of total saved across \(summary.goalCount) goal\(summary.goalCount == 1 ? "" : "s")"]
+        var parts = ["Goals: \(goalsPercent(summary.overallPercent)) of total saved across \(summary.goalCountLabel)"]
         if summary.fundedCount > 0 { parts.append("\(summary.fundedCount) funded") }
         if summary.behindCount > 0 { parts.append("\(summary.behindCount) behind") }
         return parts.joined(separator: ". ")

--- a/Sources/PlaidBarCore/Models/GoalsSummary.swift
+++ b/Sources/PlaidBarCore/Models/GoalsSummary.swift
@@ -56,6 +56,33 @@ public struct GoalsSummary: Sendable, Equatable {
         Int((overallFraction * 100).rounded())
     }
 
+    // MARK: - Presentation copy
+
+    /// Grammatically correct goal-count noun phrase ("1 goal" / "N goals"),
+    /// shared by the Goals hero detail and the Planning goals card so the two
+    /// surfaces always pluralize identically.
+    public var goalCountLabel: String {
+        goalCount == 1 ? "1 goal" : "\(goalCount) goals"
+    }
+
+    /// Detail line under the "Total saved" hero tile: how many goals are tracked,
+    /// surfacing the funded count when any goal has reached its target.
+    public var savedDetail: String {
+        if fundedCount > 0 {
+            return "\(goalCountLabel) · \(fundedCount) funded"
+        }
+        return "Across \(goalCountLabel)"
+    }
+
+    /// Detail line under the "Total target" hero tile: surfaces how many goals are
+    /// behind their target-date pace, with singular/plural grammar, or an all-clear.
+    public var targetDetail: String {
+        if behindCount > 0 {
+            return behindCount == 1 ? "1 goal behind pace" : "\(behindCount) goals behind pace"
+        }
+        return "Everything on pace"
+    }
+
     /// Build the summary from a goal list, evaluating pace `asOf` a reference date.
     public static func make(from goals: [Goal], asOf now: Date = Date()) -> GoalsSummary {
         var totalSaved = 0.0

--- a/Tests/PlaidBarCoreTests/GoalsSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/GoalsSummaryTests.swift
@@ -76,4 +76,43 @@ struct GoalsSummaryTests {
         // Overall fraction still clamps to 1 (totalSaved 1500 / totalTarget 2000 = 0.75).
         #expect(summary.overallFraction == 0.75)
     }
+
+    // MARK: - Presentation copy
+
+    private func summary(
+        goalCount: Int = 0,
+        fundedCount: Int = 0,
+        behindCount: Int = 0
+    ) -> GoalsSummary {
+        GoalsSummary(
+            goalCount: goalCount,
+            totalSaved: 0,
+            totalTarget: 0,
+            totalRemaining: 0,
+            fundedCount: fundedCount,
+            behindCount: behindCount
+        )
+    }
+
+    @Test("Goal-count label pluralizes the noun")
+    func goalCountLabel() {
+        #expect(summary(goalCount: 0).goalCountLabel == "0 goals")
+        #expect(summary(goalCount: 1).goalCountLabel == "1 goal")
+        #expect(summary(goalCount: 2).goalCountLabel == "2 goals")
+    }
+
+    @Test("Saved detail surfaces the funded count only when any goal is funded")
+    func savedDetail() {
+        #expect(summary(goalCount: 1, fundedCount: 0).savedDetail == "Across 1 goal")
+        #expect(summary(goalCount: 3, fundedCount: 0).savedDetail == "Across 3 goals")
+        #expect(summary(goalCount: 1, fundedCount: 1).savedDetail == "1 goal · 1 funded")
+        #expect(summary(goalCount: 4, fundedCount: 2).savedDetail == "4 goals · 2 funded")
+    }
+
+    @Test("Target detail surfaces behind-pace count with singular/plural grammar")
+    func targetDetail() {
+        #expect(summary(goalCount: 2, behindCount: 0).targetDetail == "Everything on pace")
+        #expect(summary(goalCount: 2, behindCount: 1).targetDetail == "1 goal behind pace")
+        #expect(summary(goalCount: 3, behindCount: 2).targetDetail == "2 goals behind pace")
+    }
 }


### PR DESCRIPTION
## Summary

- Move the Goals destination's pure count-grammar hero copy onto `GoalsSummary` (Core), mirroring the Step 7 `BudgetsStatusSummary` precedent, and DRY the duplicated goal-count pluralization the Planning goals card carried separately.
- Behavior-preserving extraction; no product behavior changes.

## Autonomous task IDs

- Task ID(s): autonomous architecture-refactor pass (Step 8)
- Backlog slice: shrink `AppState`/view-layer inline logic → pure, tested `PlaidBarCore`
- Scope note: one focused, pure-logic extraction; no behavior change.

## Agent coordination

- Builder agent: Claude (scheduled `vaultpeek-architecture-refactor`)
- Builder branch/worktree: `refactor/auto-2026-06-22` (temp worktree off `origin/main`)
- Reviewer/merge steward: Otto
- Coordination note: review-only; no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Models/GoalsSummary.swift` — add `goalCountLabel`, `savedDetail`, `targetDetail` computed `String` properties.
- `Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift` — route hero tiles to `summary.savedDetail`/`.targetDetail`; delete the two private helpers.
- `Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift` — route two inline goal-count grammar sites to `summary.goalCountLabel`.
- `Tests/PlaidBarCoreTests/GoalsSummaryTests.swift` — 3 golden-string tests pinning every branch.

## Behavior preservation

The moved bodies are character-identical bar the implicit-self rename. Both pluralization forms (`n==1 ? "1 goal" : "\(n) goals"` and `"\(n) goal\(n==1 ? "" : "s")"`) yield identical output for every count, so consolidating onto `goalCountLabel` is byte-equivalent at all four call sites.

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (the CI gate) — clean across all targets.
- [x] `swift build` covers PlaidBar + PlaidBarServer + shared Core (DTO changed).
- [x] `swift test` — full suite 2094 green (incl. the sometimes-flaky `LocalInsightModelRuntime` timeout); `--filter GoalsSummary` 8/8. Demo app boot-smoked 9s, no crash.
- [x] Secret scan completed over the diff.

## Privacy and safety impact

- [x] Used only synthetic data in tests; no real Plaid credentials, tokens, account IDs, or balances.
- [x] Preserves the local-first boundary (pure presentation logic; no backend/telemetry/cloud).
- [x] User-facing copy unchanged (byte-identical output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)