### PR TITLE
chore(oss): scrub machine-specific paths + harden .gitignore

### DIFF
--- a/.codex/skills/vaultpeek-production-loop/SKILL.md
+++ b/.codex/skills/vaultpeek-production-loop/SKILL.md
@@ -57,7 +57,7 @@ menu-bar instrument over new feature breadth.
 When no focus is supplied, implement the RepoBar-style finance dashboard:
 
 - study `https://repobar.app`, `https://github.com/steipete/RepoBar`, and the
-  local reference clone at `/Users/otto/.openclaw/workspace/repos/RepoBar` when
+  local reference clone at `<your-local-RepoBar-clone>` when
   available,
 - lead the popover with a GitHub-style daily spend/cashflow heatmap,
 - add All/Cash/Credit/Savings/Debt/Status filters,

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,28 @@ build/
 
 # Environment
 .env
-.env.local
+.env.*
+!.env.example
+
+# Signing & credentials — never commit (bring-your-own signing material stays
+# outside the repo; see docs/distribution.md "Bring Your Own Signing")
+*.p8
+*.p12
+*.cer
+*.certSigningRequest
+*.mobileprovision
+*.provisionprofile
+*.entitlements
+*.pem
+*.key
+
+# Local runtime artifacts (the auth token, server config, and SQLite store the
+# docs tell contributors to create/copy locally — never commit real Plaid creds)
+auth-token
+server.conf
+*.sqlite
+*.sqlite3
+*.db
 
 # Local agent coordination state
 .agent-state/

--- a/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
+++ b/Tests/PlaidBarCoreTests/PerformanceTraceTests.swift
@@ -53,7 +53,7 @@ struct PerformanceTraceTests {
         #expect(!encoded.contains("balance"))
         #expect(!encoded.contains("access_token"))
         #expect(!encoded.contains("public_token"))
-        #expect(!encoded.contains("/Users/otto/private/server.conf"))
+        #expect(!encoded.contains("/Users/example/private/server.conf"))
     }
 
     @Test("builds synthetic smoke snapshot")

--- a/commands/goal.md
+++ b/commands/goal.md
@@ -56,7 +56,7 @@ Study RepoBar before changing VaultPeek's primary UI:
 
 - `https://repobar.app`
 - `https://github.com/steipete/RepoBar`
-- local reference clone, when present: `/Users/otto/.openclaw/workspace/repos/RepoBar`
+- local reference clone, when present (path is environment-specific): `<your-local-RepoBar-clone>`
 - attached screenshot target: translucent macOS popover, GitHub contribution
   heatmap header, segmented filters, dense selected rows, and right-arrow drill-in.
 

--- a/commands/vaultpeek-prod-loop.md
+++ b/commands/vaultpeek-prod-loop.md
@@ -38,14 +38,14 @@ The default goal is:
 For Codex CLI non-interactive runs, use a VaultPeek-named checkout or worktree:
 
 ```bash
-codex exec --cd /Users/otto/workspace/VaultPeek \
+codex exec --cd /path/to/VaultPeek \
   "$(cat commands/vaultpeek-prod-loop.md)"
 ```
 
 For a focused autonomous iteration:
 
 ```bash
-codex exec --cd /Users/otto/workspace/VaultPeek \
+codex exec --cd /path/to/VaultPeek \
   "Read commands/vaultpeek-prod-loop.md and complete the next unfinished task from docs/autonomous-loop-backlog.md for: <focus>"
 ```
 

--- a/docs/agent-collaboration.md
+++ b/docs/agent-collaboration.md
@@ -41,7 +41,7 @@ as the only source of truth for a branch.
 ## Worktree Ownership
 
 - Hermes should work from its own builder-owned checkout or temporary worktree,
-  such as `/Users/otto/workspace/VaultPeek` when launched via the Codex CLI
+  such as `/tmp/VaultPeek-build` when launched via the Codex CLI
   examples in `commands/vaultpeek-prod-loop.md`. Legacy local checkouts may
   still keep the `PlaidBar` directory name, but new automation examples should
   use VaultPeek-named paths.

--- a/docs/agent-coordination-state.example.json
+++ b/docs/agent-coordination-state.example.json
@@ -1,5 +1,5 @@
 {
-  "repo": "ftchvs/PlaidBar",
+  "repo": "ftchvs/VaultPeek",
   "updatedAt": "2026-06-08T00:00:00Z",
   "agents": [
     {
@@ -8,7 +8,7 @@
       "status": "editing",
       "branch": "feature/example-slice",
       "headSha": "0000000000000000000000000000000000000000",
-      "worktree": "/Users/otto/.openclaw/workspace/repos/PlaidBar",
+      "worktree": "/tmp/VaultPeek-build-hermes",
       "pr": null,
       "safeToPush": false,
       "note": "Builder owns edits on this branch until the PR is opened."

--- a/docs/strategy/pricing-and-launch.md
+++ b/docs/strategy/pricing-and-launch.md
@@ -53,7 +53,7 @@ Amended public promise (draft, see launch copy §7; wording pending D1 and must 
 
 ## 3. What exists in code today (grounding)
 
-Read from `/Users/ftchvs/Developer/pb-worktrees/consumer-docs/Sources` on 2026-06-12:
+Grounded in the `Sources/` tree as of 2026-06-12:
 
 - **Demo mode already ships.** `swift run PlaidBar --demo` runs on local fixtures with zero Plaid calls (`Sources/PlaidBar/App/PlaidBarApp.swift`, `AppState.swift`). The Free Demo tier is therefore **already built** — it costs nothing to offer and nothing per user.
 - **No entitlement or institution-cap enforcement exists anywhere.** `LinkRoutes` will mint a link token for any authenticated local request; `TokenStore` has no item cap. Tier caps (3/8 institutions) are net-new work on both server and broker sides.


### PR DESCRIPTION
## OSS-readiness hygiene (paths + .gitignore)

Output of a 5-dimension OSS-readiness audit of `main` (secrets / team-signing residue / PII-paths / real-financial-data / repo-hygiene, each finding adversarially verified).

**🟢 Audit headline: 0 blockers.** No real Plaid credentials, secrets, tokens, or keys are committed; all fixtures/tests/screenshots use synthetic demo data; no entitlements/signing residue after #628. This PR clears the non-blocker **hygiene** items.

### Machine-specific path leaks → neutral placeholders
Tracked files contained absolute home paths that are non-portable and leak account/dir layout:
- `docs/strategy/pricing-and-launch.md` — owner path `/Users/ftchvs/Developer/pb-worktrees/...` → repo-relative wording.
- `commands/vaultpeek-prod-loop.md`, `commands/goal.md`, `.codex/skills/vaultpeek-production-loop/SKILL.md`, `docs/agent-collaboration.md`, `docs/agent-coordination-state.example.json` — `/Users/otto/...` automation-account paths → neutral placeholders (`/path/to/VaultPeek`, `/tmp/VaultPeek-build`, `<your-local-RepoBar-clone>`, etc.).
- `Tests/PlaidBarCoreTests/PerformanceTraceTests.swift` — a redaction-test negative assertion literal (`!encoded.contains(...)`) genericized `/Users/otto/...` → `/Users/example/...` (assertion still holds; the trace only carries operation names + counts).
- Fixed the stale pre-rename slug `ftchvs/PlaidBar` → `ftchvs/VaultPeek` in the example coordination state.

### `.gitignore` hardening (guardrail, no existing leak)
The BYO-signing docs invite contributors to add Apple signing material and copy local runtime artifacts, but `.gitignore` ignored none of those types. Added:
- Signing/credentials: `*.p8 *.p12 *.cer *.certSigningRequest *.mobileprovision *.provisionprofile *.entitlements *.pem *.key`
- Broadened `.env` → `.env.*` (keeps `!.env.example`)
- Local runtime: `auth-token`, `server.conf`, `*.sqlite`, `*.sqlite3`, `*.db`

So an accidental commit of a real Developer ID cert, provisioning profile, or a copied `server.conf`/`auth-token` holding real Plaid creds is blocked by default.

### Not in this PR (your call)
Internal business/strategy docs (README-linked `docs/mvp-launch-decision-log.md`, the `docs/strategy/` pricing/COGS set, agent-coordination plumbing) carry private Linear URLs + unannounced monetization. The repo is currently private + proprietary so nothing is live-leaked; disposition (leave / scrub / relocate, plus a git-history scrub) is best decided as one deliberate step at the actual public flip.

### Verify
- Strict-concurrency build: ✅ `Build complete! (58.43s)`
- `swift test`: ✅ 2091 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
