### PR TITLE
feat(insights): selectable 7-day / 30-day / year-over-year local AI summaries

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -51,6 +51,7 @@ final class AppState {
         static let appLockLockWhenBackgrounded = "appLock.lockWhenBackgrounded"
         static let localAIEnabled = "localAIEnabled"
         static let localAIModelName = "localAIModelName"
+        static let selectedInsightWindow = "localAI.selectedInsightWindow"
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
@@ -542,6 +543,19 @@ final class AppState {
             invalidateLocalAIActivitySummaries()
         }
     }
+    /// The insight time-window the user last chose in the Insights surface
+    /// (AND-585 follow-up). All three windows — 7-day, 30-day, year-over-year — are
+    /// already computed on-device every refresh; this only selects which one the
+    /// surfaces read. Persisted like the other local-AI preferences; defaults to
+    /// `.lastMonth` (the historical hardcoded window) so behavior is unchanged for
+    /// anyone who never touches the selector. UI-only — no model run is triggered.
+    var selectedInsightWindow: LocalAIInsightWindow = .lastMonth {
+        didSet {
+            guard selectedInsightWindow != oldValue, !isLoadingLocalAISettings else { return }
+            UserDefaults.standard.set(selectedInsightWindow.rawValue, forKey: Keys.selectedInsightWindow)
+        }
+    }
+
     var isCheckingLocalAIAvailability = false
 
     var launchAtLogin: Bool = false {
@@ -961,6 +975,14 @@ final class AppState {
         } else {
             localAIModelNamePreference = nil
             localAIModelName = Self.normalizedLocalAIModelName(environment["PLAIDBAR_LOCAL_AI_MODEL"]) ?? "llama3.2"
+        }
+
+        if let storedWindow = defaults.string(forKey: Keys.selectedInsightWindow),
+           let window = LocalAIInsightWindow(rawValue: storedWindow)
+        {
+            selectedInsightWindow = window
+        } else {
+            selectedInsightWindow = .lastMonth
         }
     }
 
@@ -1978,6 +2000,33 @@ final class AppState {
             transactionCount: transactions.count
         )
         return result
+    }
+
+    /// The on-device summary for a specific window, or the closest available
+    /// fallback (the requested window, then `.lastMonth`, then the first summary).
+    /// All three windows are computed every refresh, so selecting one never starts
+    /// a new model run.
+    func summary(for window: LocalAIInsightWindow) -> LocalAIActivitySummary? {
+        let summaries = localAIActivitySummaries
+        return summaries.first { $0.window == window }
+            ?? summaries.first { $0.window == .lastMonth }
+            ?? summaries.first
+    }
+
+    /// The summary for the window the user currently has selected in the Insights
+    /// surface. Convenience over `summary(for: selectedInsightWindow)`.
+    var selectedInsightSummary: LocalAIActivitySummary? {
+        summary(for: selectedInsightWindow)
+    }
+
+    /// The selector presentation (ordered options + which are usable + the resolved
+    /// selection) for the chosen window. Pure logic lives in Core; this binds it to
+    /// the live summaries and persisted selection.
+    var localAIWindowSelection: LocalAIInsightWindowSelection {
+        LocalAIInsightWindowSelection.make(
+            summaries: localAIActivitySummaries,
+            requestedSelection: selectedInsightWindow
+        )
     }
 
     private func invalidateLocalAIActivitySummaries() {

--- a/Sources/PlaidBar/Services/LocalAIInsightsService.swift
+++ b/Sources/PlaidBar/Services/LocalAIInsightsService.swift
@@ -172,8 +172,8 @@ struct LocalAIInsightsService: Sendable {
                 window: input.window,
                 availability: availability,
                 input: input,
-                generatedSummary: Self.summaryText(for: input),
-                generatedBullets: Self.bullets(for: input),
+                generatedSummary: LocalAIDeterministicSummary.summaryText(for: input),
+                generatedBullets: LocalAIDeterministicSummary.bullets(for: input),
                 evidence: input.evidence
             )
         }
@@ -314,7 +314,7 @@ struct LocalAIInsightsService: Sendable {
             if Task.isCancelled { break }
 
             let fallbackSummary: @Sendable (LocalAIActivitySummaryInput) -> String = { input in
-                Self.summaryText(for: input)
+                LocalAIDeterministicSummary.summaryText(for: input)
             }
             let generated = await LocalInsightModelRuntime.generateSummary(
                 input: input,
@@ -334,7 +334,7 @@ struct LocalAIInsightsService: Sendable {
                     availability: summaryAvailability,
                     input: input,
                     generatedSummary: generated.summary,
-                    generatedBullets: Self.bullets(for: input),
+                    generatedBullets: LocalAIDeterministicSummary.bullets(for: input),
                     evidence: input.evidence
                 )
             )
@@ -411,61 +411,6 @@ struct LocalAIInsightsService: Sendable {
         return OllamaLocalInsightModel.isLocalhost(baseURL)
     }
 
-    private static func summaryText(for input: LocalAIActivitySummaryInput) -> String {
-        let expenseText = Formatters.currency(input.current.expenseTotal, format: .compact)
-        let incomeText = Formatters.currency(input.current.incomeTotal, format: .compact)
-        let netText = signedCurrency(input.current.netCashflow)
-        return "\(input.window.displayName): \(expenseText) expenses, \(incomeText) income, \(netText) net cashflow."
-    }
-
-    private static func bullets(for input: LocalAIActivitySummaryInput) -> [String] {
-        var bullets: [String] = []
-
-        if let topCategory = input.current.categoryTotals.first {
-            bullets
-                .append(
-                    "\(topCategory.category.displayName) led expenses at \(Formatters.currency(topCategory.totalAmount, format: .compact)) from \(topCategory.transactionCount) transaction\(topCategory.transactionCount == 1 ? "" : "s")."
-                )
-        }
-
-        if let topExpense = input.current.topExpenses.first {
-            bullets
-                .append(
-                    "Largest outflow was \(topExpense.displayName) at \(Formatters.currency(topExpense.amount, format: .compact))."
-                )
-        }
-
-        if let prior = input.prior, prior.expenseTotal > 0 {
-            let delta = input.current.expenseTotal - prior.expenseTotal
-            let direction = delta >= 0 ? "up" : "down"
-            bullets
-                .append(
-                    "Expenses are \(direction) \(Formatters.currency(abs(delta), format: .compact)) versus the comparison window."
-                )
-        }
-
-        if input.current.netCashflow != 0 {
-            bullets.append("Net cashflow is \(signedCurrency(input.current.netCashflow)) after income and expenses.")
-        }
-
-        if input.recurringSnapshot.estimatedMonthlyTotal > 0 {
-            bullets
-                .append(
-                    "Recurring charges estimate \(Formatters.currency(input.recurringSnapshot.estimatedMonthlyTotal, format: .compact)) per month."
-                )
-        }
-
-        if bullets.isEmpty {
-            bullets.append("No transaction activity is available for this local summary window.")
-        }
-
-        return Array(bullets.prefix(4))
-    }
-
-    private static func signedCurrency(_ amount: Double) -> String {
-        let prefix = amount > 0 ? "+" : amount < 0 ? "-" : ""
-        return "\(prefix)\(Formatters.currency(abs(amount), format: .compact))"
-    }
 }
 
 private extension String {

--- a/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
@@ -23,12 +23,10 @@ import SwiftUI
 struct DashboardLocalInsightCard: View {
     @Environment(AppState.self) private var appState
 
-    private var summaries: [LocalAIActivitySummary] {
-        appState.localAIActivitySummaries
-    }
-
     private var primarySummary: LocalAIActivitySummary? {
-        summaries.first { $0.window == .lastMonth } ?? summaries.first
+        // Follow the shared insight-window selection so the Dashboard card and the
+        // Insights hero agree on which window they're summarizing.
+        appState.selectedInsightSummary
     }
 
     private var availability: LocalAIAvailability {

--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -35,7 +35,20 @@ struct InsightsAIInsightView: View {
     }
 
     private var primarySummary: LocalAIActivitySummary? {
-        summaries.first { $0.window == .lastMonth } ?? summaries.first
+        appState.selectedInsightSummary
+    }
+
+    /// Ordered window options + which are usable + the resolved selection, computed
+    /// in Core from the already-on-device summaries (no new model run).
+    private var windowSelection: LocalAIInsightWindowSelection {
+        appState.localAIWindowSelection
+    }
+
+    private var selectedWindowBinding: Binding<LocalAIInsightWindow> {
+        Binding(
+            get: { appState.selectedInsightWindow },
+            set: { appState.selectedInsightWindow = $0 }
+        )
     }
 
     private var availability: LocalAIAvailability {
@@ -78,6 +91,7 @@ struct InsightsAIInsightView: View {
             if phase == .off {
                 offState
             } else {
+                windowSelector
                 insightBody
             }
         }
@@ -182,6 +196,75 @@ struct InsightsAIInsightView: View {
             text += " (\(probe))"
         }
         return text
+    }
+
+    // MARK: - Window selector
+
+    /// Three-window switcher (7-day / 30-day / year-over-year). A chip row rather
+    /// than a plain segmented `Picker` so an unusable window (e.g. year-over-year
+    /// before a year of history) can be disabled in place with an explanation,
+    /// keeping the menu shape stable. Each chip carries an SF Symbol + text label so
+    /// the selected/disabled state never rides on color alone (ACCESSIBILITY.md).
+    private var windowSelector: some View {
+        let selection = windowSelection
+        return HStack(spacing: WindowMetrics.xs) {
+            ForEach(selection.options) { option in
+                windowChip(for: option)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Insight time window")
+    }
+
+    @ViewBuilder
+    private func windowChip(for option: LocalAIInsightWindowSelection.Option) -> some View {
+        let window = option.window
+        let isSelected = appState.selectedInsightWindow == window
+        Button {
+            selectedWindowBinding.wrappedValue = window
+        } label: {
+            Label {
+                Text(window.longDisplayName)
+            } icon: {
+                Image(systemName: window.systemImage)
+            }
+            .labelStyle(.titleAndIcon)
+            .font(.subheadline.weight(isSelected ? .semibold : .regular))
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .frame(maxWidth: .infinity)
+            .background(
+                isSelected ? AnyShapeStyle(SemanticColors.brand.opacity(0.16)) : AnyShapeStyle(Color.primary.opacity(0.05)),
+                in: Capsule()
+            )
+            .overlay {
+                Capsule().stroke(
+                    isSelected ? SemanticColors.brand.opacity(0.45) : Color.primary.opacity(0.08),
+                    lineWidth: isSelected ? 1.5 : 1
+                )
+            }
+            // The selected chip also carries a checkmark so selection reads without
+            // relying on the tint/weight difference alone.
+            .overlay(alignment: .topTrailing) {
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(SemanticColors.brand)
+                        .padding(2)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!option.isUsable)
+        .opacity(option.isUsable ? 1 : 0.5)
+        .help(option.isUsable ? window.accessibilityName : (option.unavailableReason ?? "Not available yet."))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(window.accessibilityName)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityHint(option.isUsable
+            ? "Shows the \(window.accessibilityName.lowercased()) spending summary."
+            : (option.unavailableReason ?? "Not available yet."))
     }
 
     // MARK: - Off state (consent)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1245,16 +1245,15 @@ private struct LocalInsightsCard: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openSettings) private var openSettings
 
-    private var summaries: [LocalAIActivitySummary] {
-        appState.localAIActivitySummaries
-    }
-
     private var availability: LocalAIAvailability {
         primarySummary?.availability ?? appState.localAIAvailability
     }
 
     private var primarySummary: LocalAIActivitySummary? {
-        summaries.first { $0.window == .lastMonth } ?? summaries.first
+        // The menu-bar glance stays on the 30-day window by design, but reads
+        // through the shared accessor so it can never diverge from how the window
+        // surfaces resolve a summary (fallbacks included).
+        appState.summary(for: .lastMonth)
     }
 
     private var bullets: [String] {

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -9,12 +9,148 @@ public enum LocalAIInsightWindow: String, Codable, Sendable, CaseIterable, Hasha
         rawValue
     }
 
+    /// Compact label for tight chrome (pills, evidence chips, prompt period line).
     public var displayName: String {
         switch self {
         case .last7days: "Last 7D"
         case .lastMonth: "Last Month"
         case .yearOverYear: "YoY"
         }
+    }
+
+    /// Fuller label for the segmented window selector, where there is room to be
+    /// unambiguous about the comparison span.
+    public var longDisplayName: String {
+        switch self {
+        case .last7days: "Last 7 days"
+        case .lastMonth: "Last 30 days"
+        case .yearOverYear: "Year over year"
+        }
+    }
+
+    /// Spoken/accessibility label — never an abbreviation, so VoiceOver reads the
+    /// span in full and the selector never communicates meaning by glyph alone.
+    public var accessibilityName: String {
+        switch self {
+        case .last7days: "Last 7 days"
+        case .lastMonth: "Last 30 days"
+        case .yearOverYear: "Year over year"
+        }
+    }
+
+    /// SF Symbol that pairs text with a shape so the segment is distinguishable
+    /// without relying on color (ACCESSIBILITY.md).
+    public var systemImage: String {
+        switch self {
+        case .last7days: "calendar.day.timeline.left"
+        case .lastMonth: "calendar"
+        case .yearOverYear: "calendar.badge.clock"
+        }
+    }
+}
+
+/// Presentation helper for the three-window insight selector.
+///
+/// Pure, `Sendable`, and unit-tested: it computes the ordered list of windows the
+/// UI offers and which of them are currently *usable* given the on-device summaries
+/// that already exist. A window is usable when a summary has at least one source
+/// row in its current range; year-over-year additionally requires a comparison
+/// (prior) window with history, since its entire value is the comparison.
+///
+/// The selector never hides an unusable window — it disables it and explains why —
+/// so the menu shape is stable and the user can see what becomes available as more
+/// history syncs.
+public struct LocalAIInsightWindowSelection: Equatable, Sendable {
+    /// A single selectable window plus its current usability and the reason it is
+    /// (or is not) usable.
+    public struct Option: Equatable, Sendable, Identifiable {
+        public let window: LocalAIInsightWindow
+        public let isUsable: Bool
+        /// Short, display-safe explanation of the option's state (e.g. why a
+        /// window is not yet usable). Identifier-free.
+        public let unavailableReason: String?
+
+        public var id: String { window.id }
+
+        public init(window: LocalAIInsightWindow, isUsable: Bool, unavailableReason: String?) {
+            self.window = window
+            self.isUsable = isUsable
+            self.unavailableReason = unavailableReason
+        }
+    }
+
+    public let options: [Option]
+    /// The window the UI should actually present, after resolving the requested
+    /// selection against what is usable. Falls back to the first usable window, or
+    /// — when nothing is usable — to the requested window so the selector still
+    /// shows a stable choice.
+    public let resolvedSelection: LocalAIInsightWindow
+
+    public init(options: [Option], resolvedSelection: LocalAIInsightWindow) {
+        self.options = options
+        self.resolvedSelection = resolvedSelection
+    }
+
+    /// Build the selection presentation from the available summaries.
+    ///
+    /// - Parameters:
+    ///   - summaries: the on-device summaries already computed for each window.
+    ///   - requestedSelection: the window the user last chose (persisted).
+    public static func make(
+        summaries: [LocalAIActivitySummary],
+        requestedSelection: LocalAIInsightWindow
+    ) -> LocalAIInsightWindowSelection {
+        let summariesByWindow = Dictionary(
+            summaries.map { ($0.window, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let options = LocalAIInsightWindow.allCases.map { window -> Option in
+            let summary = summariesByWindow[window]
+            let usable = isUsable(window: window, summary: summary)
+            return Option(
+                window: window,
+                isUsable: usable,
+                unavailableReason: usable ? nil : unavailableReason(window: window, summary: summary)
+            )
+        }
+
+        let usableWindows = options.filter(\.isUsable).map(\.window)
+        let resolved: LocalAIInsightWindow
+        if usableWindows.contains(requestedSelection) {
+            resolved = requestedSelection
+        } else if let firstUsable = usableWindows.first {
+            resolved = firstUsable
+        } else {
+            // Nothing usable yet — keep the requested window so the selector still
+            // renders a stable, explained choice rather than snapping elsewhere.
+            resolved = requestedSelection
+        }
+
+        return LocalAIInsightWindowSelection(options: options, resolvedSelection: resolved)
+    }
+
+    private static func isUsable(window: LocalAIInsightWindow, summary: LocalAIActivitySummary?) -> Bool {
+        guard let summary else { return false }
+        guard summary.input.current.transactionCount > 0 else { return false }
+        // Year-over-year is only meaningful with a prior window that has history.
+        if window == .yearOverYear {
+            guard let prior = summary.input.prior, prior.transactionCount > 0 else { return false }
+        }
+        return true
+    }
+
+    private static func unavailableReason(
+        window: LocalAIInsightWindow,
+        summary: LocalAIActivitySummary?
+    ) -> String {
+        guard let summary, summary.input.current.transactionCount > 0 else {
+            return "No transactions in \(window.accessibilityName.lowercased()) yet."
+        }
+        if window == .yearOverYear {
+            return "Needs at least a year of history to compare."
+        }
+        return "Not enough local history yet."
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalAIInsightBuilder.swift
@@ -1,5 +1,88 @@
 import Foundation
 
+/// The deterministic, no-runtime fallback copy for a local AI activity summary.
+///
+/// This is the always-available baseline phrasing VaultPeek shows when no on-device
+/// model runtime contributed (the consent contract: there is no cloud fallback).
+/// It lives in `PlaidBarCore` so it is pure, `Sendable`, and unit-testable — the
+/// app-side service simply delegates here, so the user-facing copy can never drift
+/// between the deterministic and model-enhanced paths.
+///
+/// Phrasing is window-aware via ``LocalAIInsightWindow/displayName`` and stays
+/// identifier-free: only display-safe aggregates (totals, category/merchant display
+/// names) are rendered, never raw transaction/account IDs.
+public enum LocalAIDeterministicSummary {
+    /// One-to-two sentence headline of the window's cashflow.
+    public static func summaryText(for input: LocalAIActivitySummaryInput) -> String {
+        let expenseText = Formatters.currency(input.current.expenseTotal, format: .compact)
+        let incomeText = Formatters.currency(input.current.incomeTotal, format: .compact)
+        let netText = signedCurrency(input.current.netCashflow)
+        return "\(input.window.displayName): \(expenseText) expenses, \(incomeText) income, \(netText) net cashflow."
+    }
+
+    /// Up to four supporting bullets: top category, largest outflow, a window-aware
+    /// comparison-window delta, net cashflow, and recurring estimate.
+    public static func bullets(for input: LocalAIActivitySummaryInput) -> [String] {
+        var bullets: [String] = []
+
+        if let topCategory = input.current.categoryTotals.first {
+            bullets
+                .append(
+                    "\(topCategory.category.displayName) led expenses at \(Formatters.currency(topCategory.totalAmount, format: .compact)) from \(topCategory.transactionCount) transaction\(topCategory.transactionCount == 1 ? "" : "s")."
+                )
+        }
+
+        if let topExpense = input.current.topExpenses.first {
+            bullets
+                .append(
+                    "Largest outflow was \(topExpense.displayName) at \(Formatters.currency(topExpense.amount, format: .compact))."
+                )
+        }
+
+        if let prior = input.prior, prior.expenseTotal > 0 {
+            let delta = input.current.expenseTotal - prior.expenseTotal
+            let direction = delta >= 0 ? "up" : "down"
+            bullets
+                .append(
+                    "Expenses are \(direction) \(Formatters.currency(abs(delta), format: .compact)) versus \(comparisonWindowPhrase(for: input.window))."
+                )
+        }
+
+        if input.current.netCashflow != 0 {
+            bullets.append("Net cashflow is \(signedCurrency(input.current.netCashflow)) after income and expenses.")
+        }
+
+        if input.recurringSnapshot.estimatedMonthlyTotal > 0 {
+            bullets
+                .append(
+                    "Recurring charges estimate \(Formatters.currency(input.recurringSnapshot.estimatedMonthlyTotal, format: .compact)) per month."
+                )
+        }
+
+        if bullets.isEmpty {
+            bullets.append("No transaction activity is available for this local summary window.")
+        }
+
+        return Array(bullets.prefix(4))
+    }
+
+    /// Window-aware phrasing for the comparison span the delta is measured against.
+    /// Year-over-year compares to the same span a year earlier; the rolling windows
+    /// compare to the immediately preceding span of equal length.
+    public static func comparisonWindowPhrase(for window: LocalAIInsightWindow) -> String {
+        switch window {
+        case .last7days: "the prior 7 days"
+        case .lastMonth: "the prior 30 days"
+        case .yearOverYear: "the same period a year ago"
+        }
+    }
+
+    public static func signedCurrency(_ amount: Double) -> String {
+        let prefix = amount > 0 ? "+" : amount < 0 ? "-" : ""
+        return "\(prefix)\(Formatters.currency(abs(amount), format: .compact))"
+    }
+}
+
 public enum LocalAICategorizationResolver {
     public static let defaultHighConfidenceThreshold = 0.85
 

--- a/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
+++ b/Sources/PlaidBarCore/Utilities/LocalInsightModelPrompt.swift
@@ -90,13 +90,17 @@ public enum LocalInsightPromptBuilder {
         }
 
         if let prior = input.prior, prior.expenseTotal > 0 {
+            // Window-aware comparison wording so a year-over-year prompt reads as a
+            // year-ago comparison, not a generic "prior period" the way the 7-day
+            // and 30-day rolling windows do.
+            let comparisonPhrase = comparisonPhrase(for: input.window)
             let delta = input.current.expenseTotal - prior.expenseTotal
             if delta == 0 {
-                lines.append("Versus the prior period: spending is unchanged (prior expenses \(money(prior.expenseTotal))).")
+                lines.append("Versus \(comparisonPhrase): spending is unchanged (prior expenses \(money(prior.expenseTotal))).")
             } else {
                 let direction = delta > 0 ? "up" : "down"
                 lines.append(
-                    "Versus the prior period: spending is \(direction) "
+                    "Versus \(comparisonPhrase): spending is \(direction) "
                         + "\(money(abs(delta))) (prior expenses \(money(prior.expenseTotal)))."
                 )
             }
@@ -131,6 +135,16 @@ public enum LocalInsightPromptBuilder {
             : collapsed
         let escaped = capped.replacingOccurrences(of: "\"", with: "'")
         return "\"\(escaped)\""
+    }
+
+    /// Window-aware noun phrase for the comparison span used in the "Versus …"
+    /// line. Identifier-free and injection-safe (fixed strings only).
+    private static func comparisonPhrase(for window: LocalAIInsightWindow) -> String {
+        switch window {
+        case .last7days: "the prior 7 days"
+        case .lastMonth: "the prior 30 days"
+        case .yearOverYear: "the same period a year ago"
+        }
     }
 
     private static func money(_ value: Double) -> String {

--- a/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
@@ -39,4 +39,243 @@ struct LocalAIInsightsModelTests {
         )
         #expect(suggestion.id == "t1-GENERAL_MERCHANDISE")
     }
+
+    // MARK: - Window labels
+
+    @Test("Each window has a distinct compact, long, and accessibility label")
+    func windowLabels() {
+        #expect(LocalAIInsightWindow.last7days.displayName == "Last 7D")
+        #expect(LocalAIInsightWindow.lastMonth.displayName == "Last Month")
+        #expect(LocalAIInsightWindow.yearOverYear.displayName == "YoY")
+
+        #expect(LocalAIInsightWindow.last7days.longDisplayName == "Last 7 days")
+        #expect(LocalAIInsightWindow.lastMonth.longDisplayName == "Last 30 days")
+        #expect(LocalAIInsightWindow.yearOverYear.longDisplayName == "Year over year")
+
+        #expect(LocalAIInsightWindow.last7days.accessibilityName == "Last 7 days")
+        #expect(LocalAIInsightWindow.lastMonth.accessibilityName == "Last 30 days")
+        #expect(LocalAIInsightWindow.yearOverYear.accessibilityName == "Year over year")
+
+        // SF Symbols pair text with a shape so the selector never rides on color
+        // alone, and the three symbols are distinct.
+        let symbols = Set(LocalAIInsightWindow.allCases.map(\.systemImage))
+        #expect(symbols.count == LocalAIInsightWindow.allCases.count)
+        for window in LocalAIInsightWindow.allCases {
+            #expect(!window.systemImage.isEmpty)
+        }
+    }
+
+    // MARK: - Date ranges (window-specific spans)
+
+    @Test("7d / 30d / YoY windows produce their own current+prior spans")
+    func windowDateRanges() throws {
+        let anchor = try #require(Formatters.parseTransactionDate("2026-03-15"))
+
+        let last7 = LocalAIInsightInputBuilder.dateRanges(for: .last7days, anchorDate: anchor)
+        #expect(last7.current.startDate == "2026-03-09")
+        #expect(last7.current.endDate == "2026-03-15")
+        #expect(last7.prior?.startDate == "2026-03-02")
+        #expect(last7.prior?.endDate == "2026-03-08")
+
+        let lastMonth = LocalAIInsightInputBuilder.dateRanges(for: .lastMonth, anchorDate: anchor)
+        #expect(lastMonth.current.startDate == "2026-02-14")
+        #expect(lastMonth.current.endDate == "2026-03-15")
+
+        let yoy = LocalAIInsightInputBuilder.dateRanges(for: .yearOverYear, anchorDate: anchor)
+        #expect(yoy.current.startDate == "2025-03-16")
+        #expect(yoy.current.endDate == "2026-03-15")
+        #expect(yoy.prior?.startDate == "2024-03-16")
+        #expect(yoy.prior?.endDate == "2025-03-15")
+
+        // The three windows are distinct spans.
+        #expect(last7.current.startDate != lastMonth.current.startDate)
+        #expect(lastMonth.current.startDate != yoy.current.startDate)
+    }
+
+    // MARK: - Deterministic summary copy
+
+    @Test("Deterministic summary headline is window-labeled with totals")
+    func deterministicSummaryHeadline() {
+        let input = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
+        let text = LocalAIDeterministicSummary.summaryText(for: input)
+        #expect(text.hasPrefix("Last Month:"))
+        #expect(text.contains("expenses"))
+        #expect(text.contains("income"))
+        #expect(text.contains("net cashflow"))
+    }
+
+    @Test("Deterministic bullets phrase the comparison span per window")
+    func deterministicBulletsAreWindowAware() {
+        let prior = Self.makeMetrics(expenseTotal: 800, incomeTotal: 3000)
+
+        let lastMonth = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800, prior: prior)
+        let monthBullets = LocalAIDeterministicSummary.bullets(for: lastMonth).joined(separator: " ")
+        #expect(monthBullets.contains("the prior 30 days"))
+
+        let yoy = Self.makeInput(window: .yearOverYear, expenseTotal: 1200, incomeTotal: 3000, net: 1800, prior: prior)
+        let yoyBullets = LocalAIDeterministicSummary.bullets(for: yoy).joined(separator: " ")
+        #expect(yoyBullets.contains("the same period a year ago"))
+        #expect(!yoyBullets.contains("the prior 30 days"))
+
+        let last7 = Self.makeInput(window: .last7days, expenseTotal: 1200, incomeTotal: 3000, net: 1800, prior: prior)
+        let weekBullets = LocalAIDeterministicSummary.bullets(for: last7).joined(separator: " ")
+        #expect(weekBullets.contains("the prior 7 days"))
+    }
+
+    @Test("Comparison-window phrase differs across all three windows")
+    func comparisonWindowPhrasePerWindow() {
+        let phrases = LocalAIInsightWindow.allCases.map(LocalAIDeterministicSummary.comparisonWindowPhrase)
+        #expect(Set(phrases).count == LocalAIInsightWindow.allCases.count)
+        #expect(LocalAIDeterministicSummary.comparisonWindowPhrase(for: .yearOverYear) == "the same period a year ago")
+    }
+
+    @Test("signedCurrency prefixes positive, negative, and zero correctly")
+    func signedCurrency() {
+        #expect(LocalAIDeterministicSummary.signedCurrency(100).hasPrefix("+"))
+        #expect(LocalAIDeterministicSummary.signedCurrency(-100).hasPrefix("-"))
+        let zero = LocalAIDeterministicSummary.signedCurrency(0)
+        #expect(!zero.hasPrefix("+"))
+        #expect(!zero.hasPrefix("-"))
+    }
+
+    // MARK: - Window selection availability
+
+    @Test("A window with no source rows is unusable and explained")
+    func selectionMarksEmptyWindowsUnusable() {
+        let summaries = [
+            Self.makeSummary(window: .last7days, currentCount: 0),
+            Self.makeSummary(window: .lastMonth, currentCount: 12),
+            Self.makeSummary(window: .yearOverYear, currentCount: 0),
+        ]
+        let selection = LocalAIInsightWindowSelection.make(summaries: summaries, requestedSelection: .last7days)
+
+        let byWindow = Dictionary(uniqueKeysWithValues: selection.options.map { ($0.window, $0) })
+        #expect(byWindow[.last7days]?.isUsable == false)
+        #expect(byWindow[.last7days]?.unavailableReason != nil)
+        #expect(byWindow[.lastMonth]?.isUsable == true)
+        #expect(byWindow[.lastMonth]?.unavailableReason == nil)
+        // Requested 7-day window is unusable → resolves to the first usable one.
+        #expect(selection.resolvedSelection == .lastMonth)
+    }
+
+    @Test("Year-over-year needs a prior window with history to be usable")
+    func selectionYearOverYearNeedsPrior() {
+        // YoY current has rows but no prior history → unusable.
+        let noPrior = LocalAIInsightWindowSelection.make(
+            summaries: [Self.makeSummary(window: .yearOverYear, currentCount: 20, priorCount: 0)],
+            requestedSelection: .yearOverYear
+        )
+        let noPriorYoY = noPrior.options.first { $0.window == .yearOverYear }
+        #expect(noPriorYoY?.isUsable == false)
+        #expect(noPriorYoY?.unavailableReason?.contains("year of history") == true)
+
+        // With prior history → usable and the request is honored.
+        let withPrior = LocalAIInsightWindowSelection.make(
+            summaries: [Self.makeSummary(window: .yearOverYear, currentCount: 20, priorCount: 18)],
+            requestedSelection: .yearOverYear
+        )
+        let withPriorYoY = withPrior.options.first { $0.window == .yearOverYear }
+        #expect(withPriorYoY?.isUsable == true)
+        #expect(withPrior.resolvedSelection == .yearOverYear)
+    }
+
+    @Test("Always offers all three windows in order, even when none are usable")
+    func selectionAlwaysOffersAllWindows() {
+        let selection = LocalAIInsightWindowSelection.make(summaries: [], requestedSelection: .lastMonth)
+        #expect(selection.options.map(\.window) == LocalAIInsightWindow.allCases)
+        #expect(selection.options.allSatisfy { !$0.isUsable })
+        // Nothing usable → keep the requested window so the selector stays stable.
+        #expect(selection.resolvedSelection == .lastMonth)
+    }
+
+    @Test("A usable requested window is honored over the default order")
+    func selectionHonorsUsableRequest() {
+        let summaries = [
+            Self.makeSummary(window: .last7days, currentCount: 5),
+            Self.makeSummary(window: .lastMonth, currentCount: 20),
+            Self.makeSummary(window: .yearOverYear, currentCount: 30, priorCount: 25),
+        ]
+        let selection = LocalAIInsightWindowSelection.make(summaries: summaries, requestedSelection: .yearOverYear)
+        #expect(selection.resolvedSelection == .yearOverYear)
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeMetrics(
+        transactionCount: Int = 5,
+        expenseTotal: Double = 1000,
+        incomeTotal: Double = 0
+    ) -> LocalAIActivityMetrics {
+        LocalAIActivityMetrics(
+            transactionCount: transactionCount,
+            incomeTotal: incomeTotal,
+            expenseTotal: expenseTotal,
+            netCashflow: incomeTotal - expenseTotal,
+            incomeTransactionIds: [],
+            expenseTransactionIds: [],
+            transferTransactionIds: [],
+            categoryTotals: [],
+            topExpenses: [],
+            topIncome: []
+        )
+    }
+
+    private static func makeInput(
+        window: LocalAIInsightWindow,
+        expenseTotal: Double,
+        incomeTotal: Double,
+        net: Double,
+        prior: LocalAIActivityMetrics? = nil
+    ) -> LocalAIActivitySummaryInput {
+        let current = LocalAIActivityMetrics(
+            transactionCount: 10,
+            incomeTotal: incomeTotal,
+            expenseTotal: expenseTotal,
+            netCashflow: net,
+            incomeTransactionIds: [],
+            expenseTransactionIds: [],
+            transferTransactionIds: [],
+            categoryTotals: [],
+            topExpenses: [],
+            topIncome: []
+        )
+        return LocalAIActivitySummaryInput(
+            window: window,
+            currentRange: LocalAIInsightDateRange(startDate: "2026-05-13", endDate: "2026-06-11"),
+            priorRange: prior == nil ? nil : LocalAIInsightDateRange(startDate: "2026-04-13", endDate: "2026-05-12"),
+            categorySuggestions: [],
+            accountSnapshot: LocalAIAccountSnapshot(accountCount: 1, accountIds: [], cashTotal: 0, debtTotal: 0, creditUtilization: nil),
+            current: current,
+            prior: prior,
+            recurringSnapshot: LocalAIRecurringSnapshot(estimatedMonthlyTotal: 0, items: []),
+            evidence: []
+        )
+    }
+
+    private static func makeSummary(
+        window: LocalAIInsightWindow,
+        currentCount: Int,
+        priorCount: Int? = nil
+    ) -> LocalAIActivitySummary {
+        let prior = priorCount.map { makeMetrics(transactionCount: $0) }
+        let input = LocalAIActivitySummaryInput(
+            window: window,
+            currentRange: LocalAIInsightDateRange(startDate: "2026-05-13", endDate: "2026-06-11"),
+            priorRange: prior == nil ? nil : LocalAIInsightDateRange(startDate: "2025-05-13", endDate: "2025-06-11"),
+            categorySuggestions: [],
+            accountSnapshot: LocalAIAccountSnapshot(accountCount: 1, accountIds: [], cashTotal: 0, debtTotal: 0, creditUtilization: nil),
+            current: makeMetrics(transactionCount: currentCount),
+            prior: prior,
+            recurringSnapshot: LocalAIRecurringSnapshot(estimatedMonthlyTotal: 0, items: []),
+            evidence: []
+        )
+        return LocalAIActivitySummary(
+            window: window,
+            availability: LocalAIAvailability(state: .disabled, detail: "test"),
+            input: input,
+            generatedSummary: "",
+            generatedBullets: [],
+            evidence: []
+        )
+    }
 }

--- a/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
@@ -11,7 +11,7 @@ struct LocalInsightModelPromptTests {
     private let rawSourceId = "RAWSOURCEID_SENTINEL_5560"
     private let rawItemId = "RAWITEMID_SENTINEL_9921"
 
-    private func input(prior: Bool = true) -> LocalAIActivitySummaryInput {
+    private func input(prior: Bool = true, window: LocalAIInsightWindow = .lastMonth) -> LocalAIActivitySummaryInput {
         let evidence = [
             LocalAIInsightEvidence(
                 kind: .transaction,
@@ -67,7 +67,7 @@ struct LocalInsightModelPromptTests {
             topIncome: []
         )
         return LocalAIActivitySummaryInput(
-            window: .lastMonth,
+            window: window,
             currentRange: LocalAIInsightDateRange(startDate: "2026-05-13", endDate: "2026-06-11"),
             priorRange: LocalAIInsightDateRange(startDate: "2026-04-13", endDate: "2026-05-12"),
             categorySuggestions: [],
@@ -122,7 +122,22 @@ struct LocalInsightModelPromptTests {
     func omitsPriorWhenAbsent() {
         let prompt = LocalInsightPromptBuilder.make(from: input(prior: false)).user
         #expect(!prompt.contains("prior expenses"))
-        #expect(!prompt.contains("Versus the prior period"))
+        #expect(!prompt.contains("Versus"))
+    }
+
+    @Test("Comparison wording is window-aware (7d / 30d / YoY phrase differently)")
+    func windowAwareComparisonPhrasing() {
+        let last7 = LocalInsightPromptBuilder.make(from: input(window: .last7days)).user
+        #expect(last7.contains("Versus the prior 7 days"))
+        #expect(!last7.contains("a year ago"))
+
+        let lastMonth = LocalInsightPromptBuilder.make(from: input(window: .lastMonth)).user
+        #expect(lastMonth.contains("Versus the prior 30 days"))
+
+        let yoy = LocalInsightPromptBuilder.make(from: input(window: .yearOverYear)).user
+        #expect(yoy.contains("Versus the same period a year ago"))
+        #expect(!yoy.contains("prior 30 days"))
+        #expect(!yoy.contains("prior 7 days"))
     }
 
     @Test("System instruction carries the local-only guardrails")


### PR DESCRIPTION
Post-1.0 priority #4. Surfaces the local on-device AI spending summaries for **last 7 days / last month / year-over-year** in Insights. All three windows were already computed every refresh on-device; surfaces hardcoded `.lastMonth` (7d + YoY were dead-coded). Adding the selector triggers **zero new model runs** and preserves the on-device guarantee + deterministic fallback.

- Core: `LocalAIInsightWindow` gains long/accessibility names + per-window SF Symbol; new `LocalAIInsightWindowSelection` (ordered + usability, YoY needs ≥1yr); deterministic fallback extracted to a pure `LocalAIDeterministicSummary` in Core (window-aware comparison phrasing); window-aware prompt phrasing.
- App: `AppState.selectedInsightWindow` (@Observable, persisted) + `summary(for:)` accessor.
- View: 3-window chip selector (text + SF Symbol + checkmark, never color-only; unusable windows disabled+explained) in Insights; Dashboard card + popover read the shared accessor.
- Tests: +260 lines across 2 Core suites (ranges, per-window copy, YoY phrasing, availability matrix).

Strict-concurrency build ✅, `swift test` ✅ 2105.