### PR TITLE
feat(ux): native Liquid Glass as the unconditional macOS 26 chrome baseline (no material fallback)

### DIFF
--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -878,11 +878,24 @@ struct WindowChromeBackgroundModifier: ViewModifier {
     func body(content: Content) -> some View {
         switch WindowChromeGlass.chromeBackground(reduceTransparency: reduceTransparency) {
         case .glass:
-            content.containerBackground(.ultraThinMaterial, for: .window)
+            // Native macOS 26 Liquid Glass chrome: a clear rectangle carrying
+            // `.glassEffect(.regular)` is the window container background. This is
+            // the same native-glass primitive the popover chrome uses
+            // (`PopoverMaterialBackground`), not the legacy hand-rolled
+            // `.ultraThinMaterial` fill — the system material samples the desktop
+            // behind the window and is the unconditional baseline on macOS 26.
+            content.containerBackground(for: .window) {
+                Rectangle()
+                    .fill(.clear)
+                    .glassEffect(.regular, in: .rect)
+                    .ignoresSafeArea()
+            }
         case .solid:
-            // Solid fallback: the opaque window background color reads correctly
-            // in both light and dark and carries no translucency for the chrome
-            // to sample (AND-588).
+            // NOT a version fallback: this is the Reduce-Transparency accessibility
+            // degradation (the system setting always wins, or the user's reduced
+            // decorative-effects preference). The opaque window background color
+            // reads correctly in both light and dark and carries no translucency
+            // for the chrome to sample (AND-588 / ACCESSIBILITY.md).
             content.containerBackground(Color(nsColor: .windowBackgroundColor), for: .window)
         }
     }

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -100,7 +100,8 @@ struct AccountDetailFlyout: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 // Group the inspector's coexisting glass surfaces (inset/
                 // emphasized action chips) into one GlassEffectContainer sampling
-                // region on macOS 26; passthrough on macOS 15 (AND-381).
+                // region. Native Liquid Glass is the unconditional macOS-26
+                // baseline (AND-511), so there is no version passthrough.
                 // Merge radius = SurfaceTokens.glassMergeRadius.
                 .glassGroup()
             }

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -24,10 +24,11 @@ import SwiftUI
 /// (default OFF), so with the flag off this view is never instantiated and there
 /// is zero behavior change.
 ///
-/// Liquid Glass on chrome is applied at the scene level via
-/// `.containerBackground(.ultraThinMaterial, for: .window)` in `PlaidBarApp`
-/// (with an explicit solid Reduce Transparency fallback), not here —
-/// glass goes on chrome only, never on data.
+/// Liquid Glass on chrome is applied at the scene level via the native
+/// `.glassEffect(.regular)` window container background in `PlaidBarApp`
+/// (`WindowChromeBackgroundModifier`), with an explicit solid Reduce
+/// Transparency degradation — not here. Glass goes on chrome only, never on
+/// data, and native glass is the unconditional macOS-26 baseline (AND-511).
 ///
 /// **App Lock parity (Epic 10 / AND-588):** when content is LOCKED (not
 /// merely masked), this shell paints the shared `AppLockedGateView` over the

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -625,8 +625,9 @@ struct MainPopover: View {
                     .padding(.bottom, Layout.contentBottomPadding)
                     // The dashboard's coexisting glass surfaces (heatmap, status
                     // readiness panel, insights card + chips, overview cards)
-                    // share one GlassEffectContainer sampling region on macOS 26;
-                    // passthrough on macOS 15 (AND-381). Merge radius =
+                    // share one GlassEffectContainer sampling region. Native
+                    // Liquid Glass is the unconditional macOS-26 baseline
+                    // (AND-511) — no version passthrough. Merge radius =
                     // SurfaceTokens.glassMergeRadius (small), so only adjacent
                     // glass fuses — distant cards in this tall column stay distinct.
                     .glassGroup()

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -156,64 +156,95 @@ private extension View {
     }
 }
 
-// MARK: - Native Panel Surface
+// MARK: - Native Panel Surface (chrome = glass, data = solid)
+//
+// The chrome-vs-data split is expressed by the surface *type*, not a boolean:
+// chrome-rank panels (`NativePanelGlassSurface`) unconditionally carry native
+// Liquid Glass; data surfaces (`SolidDataSurface`) are always solid. There is no
+// material fallback path — glass is the macOS-26 baseline (AND-511), and the
+// chrome-vs-data eligibility rule itself is the pure `WindowChromeGlass.allowsGlass`.
 
-struct NativePanelSurface: ViewModifier {
+/// Chrome-rank panel surface: a fill + hairline stroke under native Liquid Glass.
+/// For navigation/chrome surfaces only — never dense data, which must stay solid
+/// (see `SolidDataSurface`).
+struct NativePanelGlassSurface: ViewModifier {
     let cornerRadius: CGFloat
     let fill: AnyShapeStyle
     let stroke: Color
-    let useLiquidGlass: Bool
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        content
+            .background(fill, in: shape)
+            .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+            .overlay {
+                shape.stroke(stroke, lineWidth: 1)
+            }
+    }
+}
 
-        if useLiquidGlass {
-            content
-                .background(fill, in: shape)
-                .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
-                .overlay {
-                    shape.stroke(stroke, lineWidth: 1)
-                }
-        } else {
-            content
-                .background(fill, in: shape)
-                .overlay {
-                    shape.stroke(stroke, lineWidth: 1)
-                }
-        }
+/// Solid data surface: a fill + hairline stroke with **no** glass. Used for data
+/// (lists, rows, dense cards, insight bodies) so values never sample a
+/// translucent backdrop — the "Liquid Glass on chrome, not data" doctrine (R-08).
+struct SolidDataSurface: ViewModifier {
+    let cornerRadius: CGFloat
+    let fill: AnyShapeStyle
+    let stroke: Color
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        content
+            .background(fill, in: shape)
+            .overlay {
+                shape.stroke(stroke, lineWidth: 1)
+            }
     }
 }
 
 extension View {
-    /// Legacy fill+stroke surface treatment. New surfaces should use the
-    /// rank-based `glassSurface(_:cornerRadius:)` vibrancy system above;
-    /// this remains for setup/attention surfaces not yet migrated.
+    /// Chrome-rank fill+stroke surface under native Liquid Glass. New surfaces
+    /// should prefer the rank-based `glassSurface(_:cornerRadius:)` vibrancy
+    /// system above; this remains for setup/attention chrome not yet migrated.
+    /// Chrome only — route data surfaces through ``solidDataSurface`` /
+    /// ``nativeInsetSurface``.
     func nativePanelSurface(
         cornerRadius: CGFloat = SurfaceTokens.panelCornerRadius,
         fill: AnyShapeStyle = AnyShapeStyle(SurfaceTokens.panelFill()),
-        stroke: Color = SurfaceTokens.panelStroke(),
-        useLiquidGlass: Bool = true
+        stroke: Color = SurfaceTokens.panelStroke()
     ) -> some View {
         modifier(
-            NativePanelSurface(
+            NativePanelGlassSurface(
                 cornerRadius: cornerRadius,
                 fill: fill,
-                stroke: stroke,
-                useLiquidGlass: useLiquidGlass
+                stroke: stroke
             )
         )
     }
 
+    /// Solid (non-glass) data surface: fill + hairline stroke. The explicit
+    /// data-surface treatment — values stay legible over an opaque backdrop and
+    /// never sample translucency (R-08).
+    func solidDataSurface(
+        cornerRadius: CGFloat = SurfaceTokens.compactCornerRadius,
+        fill: AnyShapeStyle = AnyShapeStyle(Color.primary.opacity(SurfaceTokens.insetFillOpacity)),
+        stroke: Color = Color.primary.opacity(0.055)
+    ) -> some View {
+        modifier(
+            SolidDataSurface(
+                cornerRadius: cornerRadius,
+                fill: fill,
+                stroke: stroke
+            )
+        )
+    }
+
+    /// Quiet inset data surface. A thin convenience over ``solidDataSurface`` for
+    /// the common inset-card case (secondary rows, metric strips); always solid.
     func nativeInsetSurface(
         cornerRadius: CGFloat = SurfaceTokens.compactCornerRadius,
         stroke: Color = Color.primary.opacity(0.055)
     ) -> some View {
-        nativePanelSurface(
-            cornerRadius: cornerRadius,
-            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.insetFillOpacity)),
-            stroke: stroke,
-            useLiquidGlass: false
-        )
+        solidDataSurface(cornerRadius: cornerRadius, stroke: stroke)
     }
 }
 

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -123,8 +123,9 @@ struct WealthSummaryFlyout: View {
                 .padding(Spacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 // Group the flyout's coexisting glass panels (metric tiles) into
-                // one GlassEffectContainer sampling region on macOS 26; passthrough
-                // on macOS 15 (AND-381). Merge radius = SurfaceTokens.glassMergeRadius.
+                // one GlassEffectContainer sampling region. Native Liquid Glass is
+                // the unconditional macOS-26 baseline (AND-511), so there is no
+                // version passthrough. Merge radius = SurfaceTokens.glassMergeRadius.
                 .glassGroup()
             }
             .scrollContentBackground(.hidden)

--- a/Sources/PlaidBarCore/Utilities/WindowChromeGlass.swift
+++ b/Sources/PlaidBarCore/Utilities/WindowChromeGlass.swift
@@ -59,7 +59,9 @@ public enum WindowChromeGlass {
 }
 
 /// Classifies a window-first surface for the glass-on-chrome-only policy.
-public enum WindowSurfaceKind: Sendable, Equatable {
+/// `CaseIterable` so the chrome-vs-data policy can be asserted exhaustively in
+/// tests — every surface kind has an explicit glass eligibility.
+public enum WindowSurfaceKind: Sendable, Equatable, CaseIterable {
     /// Navigation chrome — sidebar, toolbar, nav bars, window container. May use
     /// Liquid Glass.
     case chrome

--- a/Tests/PlaidBarCoreTests/WindowChromeGlassTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowChromeGlassTests.swift
@@ -27,6 +27,35 @@ struct WindowChromeGlassTests {
         #expect(WindowChromeGlass.allowsGlass(on: .data) == false)
     }
 
+    @Test("The chrome-vs-data glass policy is exhaustive: every surface kind maps to chrome⇒glass / data⇒solid")
+    func policyExhaustiveOverAllSurfaceKinds() {
+        // Iterate ALL cases so adding a new `WindowSurfaceKind` without an
+        // explicit glass decision fails this test (the switch in `allowsGlass`
+        // is non-exhaustive at compile time, this guards the runtime contract).
+        for surface in WindowSurfaceKind.allCases {
+            let allowsGlass = WindowChromeGlass.allowsGlass(on: surface)
+            switch surface {
+            case .chrome:
+                #expect(allowsGlass == true, "Chrome surfaces must be glass-eligible")
+            case .data:
+                #expect(allowsGlass == false, "Data surfaces must never carry glass (R-08)")
+            }
+        }
+        // Exactly one kind is glass-eligible (chrome), and at least one is not
+        // (data) — there is no fallback path that silently solidifies chrome.
+        let glassEligible = WindowSurfaceKind.allCases.filter(WindowChromeGlass.allowsGlass(on:))
+        #expect(glassEligible == [.chrome])
+    }
+
+    @Test("Glass is the unconditional default when transparency is not reduced (no material fallback)")
+    func glassIsTheDefault() {
+        // With Reduce Transparency off, the chrome is ALWAYS glass — there is no
+        // version-gated material fallback (AND-511). Solid is reachable only via
+        // the accessibility degradation path.
+        #expect(WindowChromeGlass.chromeBackground(reduceTransparency: false) == .glass)
+        #expect(WindowChromeGlass.chromeBackground(reduceTransparency: false) != .solid)
+    }
+
     // MARK: - Cross-check against the decorative-effects resolution
 
     @Test("Reduced decorative-effects preference forces the solid fallback even when the system setting is off")


### PR DESCRIPTION
Post-1.0 priority #2. Makes native macOS 26 Liquid Glass the unconditional chrome baseline; removes the `useLiquidGlass: Bool` material fallback.

- Window chrome: `.containerBackground(for: .window){ Rectangle().fill(.clear).glassEffect(.regular, in: .rect) }` replaces `.ultraThinMaterial`.
- `NativePanelSurface` split into `NativePanelGlassSurface` (chrome, always `.glassEffect`) + `SolidDataSurface` (data, always solid); `nativeInsetSurface`→solid. 6 data callers stay solid (now explicit).
- **Preserved (not fallbacks):** Reduce-Transparency→solid accessibility degradation; the popover transparency slider.
- Stale macOS-15 material-fallback comments removed.
- `WindowSurfaceKind` now CaseIterable; +exhaustive chrome⇒glass / data⇒solid policy test + glass-is-default test.

Rebased onto current main (includes #4). Strict build ✅, `swift test` ✅ 2107.