### PR TITLE
feat(ux): converge dashboard + settings recovery actions into one model (5 states)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1399,7 +1399,9 @@ final class AppState {
             transactions: transactions,
             lowCashThreshold: lowBalanceThreshold,
             largeTransactionThreshold: largeTransactionThreshold,
-            creditUtilizationThreshold: creditUtilizationThreshold
+            creditUtilizationThreshold: creditUtilizationThreshold,
+            notificationsEnabled: notificationsEnabled,
+            notificationPermission: notificationPermissionPresentation
         )
     }
 
@@ -1804,7 +1806,7 @@ final class AppState {
     /// the matching `AppState` method, mirroring the established mapping used by the
     /// accounts empty state in Settings so behavior stays consistent. Keeps the
     /// Dashboard and Planning recurring cards' action wiring identical.
-    func performRecurringUnavailableAction(_ action: SecondaryContentUnavailableAction) {
+    func performRecurringUnavailableAction(_ action: RecoveryAction) {
         switch action {
         case .checkServer:
             Task { await checkServerConnection() }
@@ -1817,6 +1819,11 @@ final class AppState {
         case .addAccount:
             navigationModel.go(to: .accounts)
         case .clearFilters, .showWiderPeriod:
+            break
+        // The recurring/secondary content states only ever emit the verbs above;
+        // the remaining converged verbs (reconnect / settings / notification)
+        // never reach here, so they are inert.
+        case .reconnect, .openSettings, .requestNotificationPermission, .openNotificationSettings:
             break
         }
     }

--- a/Sources/PlaidBar/Services/RecoveryActionDispatcher.swift
+++ b/Sources/PlaidBar/Services/RecoveryActionDispatcher.swift
@@ -1,0 +1,127 @@
+import AppKit
+import PlaidBarCore
+import SwiftUI
+
+/// The single place that maps a converged ``RecoveryAction`` onto the `AppState`
+/// entry point that performs it (post-1.0 priority #3: converged recovery
+/// actions).
+///
+/// Before convergence, the dashboard readiness panel, the menu-bar popover, the
+/// attention queue, the Alerts inspector, and the menu-bar glance each carried a
+/// near-identical `perform(_:)` switch — the same `checkServer → refresh →
+/// reconnect → openSettings → notification` mapping copied five times, drifting
+/// slightly each time (one fell back to `refreshAccounts`, another to
+/// `refreshDashboard`; one ran `addAccount()` directly, another took an
+/// `onAddAccount` closure). Every surface now dispatches through this one type, so
+/// a verb means exactly the same thing — and runs exactly the same `AppState`
+/// method — everywhere.
+///
+/// `@MainActor` because it touches `AppState` (itself `@MainActor`) and opens
+/// windows. The per-surface differences (how to open Settings, whether to deep
+/// link a route, what "add account" does on this surface) are injected as
+/// closures so the mapping body stays identical.
+@MainActor
+struct RecoveryActionDispatcher {
+    let appState: AppState
+    /// Opens VaultPeek Settings. Surfaces inside the SwiftUI window pass the
+    /// `\.openSettings` environment action; others pass a bespoke opener.
+    var openSettings: () -> Void
+    /// Window-first deep link. No-op by default so flag-OFF surfaces keep their
+    /// in-place behavior; installed with a real handler only when window-first is
+    /// ON. When provided, route-mapped actions open the window instead of running
+    /// the in-place action.
+    var openRoute: ((Route) -> Void)?
+    /// What "add an account" means on this surface — some surfaces run a setup
+    /// flow (`onAddAccount`), others call `appState.addAccount()` directly. When
+    /// `nil`, falls back to `appState.addAccount()`.
+    var onAddAccount: (() -> Void)?
+
+    init(
+        appState: AppState,
+        openSettings: @escaping () -> Void,
+        openRoute: ((Route) -> Void)? = nil,
+        onAddAccount: (() -> Void)? = nil
+    ) {
+        self.appState = appState
+        self.openSettings = openSettings
+        self.openRoute = openRoute
+        self.onAddAccount = onAddAccount
+    }
+
+    /// Dispatch a converged recovery button — the preferred entry point, since the
+    /// button folds the `targetItemId` an item-scoped `.reconnect` needs.
+    func dispatch(_ button: RecoveryActionButton) {
+        perform(button.action, targetItemId: button.targetItemId)
+    }
+
+    /// Dispatch the recovery action carried by an attention queue row, honoring the
+    /// window-first deep link when one is available.
+    func dispatch(_ row: AttentionQueueRow) {
+        if let route = routedDestination(for: row.action, targetItemId: row.targetItemId) {
+            openRoute?(route)
+            return
+        }
+        guard let action = row.action else { return }
+        perform(action, targetItemId: row.targetItemId)
+    }
+
+    /// Dispatch a bare verb, resolving an item target from the row/button when one
+    /// was carried, else from the live item statuses (so a dashboard `.reconnect`
+    /// with no carried target still finds the degraded item).
+    func perform(_ action: RecoveryAction, targetItemId: String? = nil) {
+        switch action {
+        case .checkServer:
+            Task { await appState.checkServerConnection() }
+        case .addAccount:
+            if let onAddAccount {
+                onAddAccount()
+            } else {
+                Task { await appState.addAccount() }
+            }
+        case .refresh:
+            Task { await appState.refreshDashboard() }
+        case .refreshAccounts:
+            Task { await appState.refreshAccounts() }
+        case .syncTransactions:
+            Task { await appState.syncTransactions() }
+        case .reconnect:
+            guard let itemId = targetItemId ?? ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
+                // No resolvable item — refresh so the status re-evaluates rather
+                // than opening Link with no target.
+                Task { await appState.refreshDashboard() }
+                return
+            }
+            Task { await appState.reconnectItem(itemId: itemId) }
+        case .openSettings:
+            openSettings()
+        case .requestNotificationPermission:
+            Task { _ = await appState.requestNotificationPermission() }
+        case .openNotificationSettings:
+            openNotificationSettings()
+        case .clearFilters, .showWiderPeriod:
+            // Surface-local view-state verbs (search/filter, period window). The
+            // dispatcher owns no view state, so these are handled by the calling
+            // surface; reaching here is a no-op by design.
+            break
+        }
+    }
+
+    /// The window-first destination a verb should open, or `nil` to run the
+    /// in-place action. Only resolves when a route handler is installed
+    /// (window-first ON), so flag-OFF surfaces never deep link.
+    private func routedDestination(for action: RecoveryAction?, targetItemId: String?) -> Route? {
+        guard openRoute != nil, let action else { return nil }
+        guard let route = Route.from(recoveryAction: action, targetItemId: targetItemId) else { return nil }
+        return route.resolvingAccountSelection(in: appState.accounts)
+    }
+
+    /// Open the macOS System Settings notifications pane, falling back to VaultPeek
+    /// Settings if the deep-link URL cannot be built.
+    private func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
+            openSettings()
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1281,21 +1281,15 @@ struct AccountSettingsView: View {
         isShowingAccountSetup = true
     }
 
-    private func performEmptyAction(_ action: SecondaryContentUnavailableAction) {
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            handleAddAccount()
-        case .refreshAccounts:
-            Task { await appState.refreshAccounts() }
-        case .syncTransactions:
-            Task { await appState.syncTransactions() }
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .clearFilters, .showWiderPeriod:
-            break
-        }
+    private func performEmptyAction(_ action: RecoveryAction) {
+        // Already inside Settings, so `openSettings` is a no-op; "add account"
+        // opens the account-setup sheet on this surface.
+        RecoveryActionDispatcher(
+            appState: appState,
+            openSettings: {},
+            onAddAccount: handleAddAccount
+        )
+        .perform(action)
     }
 
     private var accountGroups: [AccountItemGroup] {

--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -70,39 +69,16 @@ struct AttentionQueueView: View {
             return
         }
 
-        guard let action = row.action else { return }
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            if let onAddAccount {
-                onAddAccount()
-            } else {
-                Task { await appState.addAccount() }
-            }
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .reconnect:
-            guard let itemId = row.targetItemId ?? ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
-                Task { await appState.refreshDashboard() }
-                return
-            }
-            Task { await appState.reconnectItem(itemId: itemId) }
-        case .openSettings:
-            openSettings()
-        case .requestNotificationPermission:
-            Task { _ = await appState.requestNotificationPermission() }
-        case .openNotificationSettings:
-            openNotificationSettings()
-        }
-    }
-
-    private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-            openSettings()
-            return
-        }
-        NSWorkspace.shared.open(url)
+        // In-place dispatch through the shared dispatcher (no `openRoute`, so the
+        // route-mapped fallback never fires here — this path is reached only when
+        // the row has no window destination or the flag is OFF, matching the prior
+        // behavior exactly).
+        RecoveryActionDispatcher(
+            appState: appState,
+            openSettings: { openSettings() },
+            onAddAccount: onAddAccount
+        )
+        .dispatch(row)
     }
 }
 

--- a/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -218,39 +217,13 @@ struct AlertsDestinationView: View {
             }
         }
 
-        /// Dispatch the alert's recovery action — the same paths
+        /// Dispatch the alert's recovery action through the shared
+        /// ``RecoveryActionDispatcher`` — the same `AppState` paths
         /// ``AttentionQueueView`` runs, so an action means the same thing here as
         /// on the menu-bar glance.
         private func perform(_ row: AttentionQueueRow) {
-            guard let action = row.action else { return }
-            switch action {
-            case .checkServer:
-                Task { await appState.checkServerConnection() }
-            case .addAccount:
-                Task { await appState.addAccount() }
-            case .refresh:
-                Task { await appState.refreshDashboard() }
-            case .reconnect:
-                guard let itemId = row.targetItemId ?? ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
-                    Task { await appState.refreshDashboard() }
-                    return
-                }
-                Task { await appState.reconnectItem(itemId: itemId) }
-            case .openSettings:
-                openSettings()
-            case .requestNotificationPermission:
-                Task { _ = await appState.requestNotificationPermission() }
-            case .openNotificationSettings:
-                openNotificationSettings()
-            }
-        }
-
-        private func openNotificationSettings() {
-            guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-                openSettings()
-                return
-            }
-            NSWorkspace.shared.open(url)
+            RecoveryActionDispatcher(appState: appState, openSettings: { openSettings() })
+                .dispatch(row)
         }
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
@@ -1,4 +1,3 @@
-import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -53,7 +52,7 @@ struct DashboardReadinessPanel: View {
                 } label: {
                     Label(
                         primaryActionLabel(for: primaryAction),
-                        systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                        systemImage: readiness.primaryActionIconName ?? primaryAction.canonicalIconName
                     )
                 }
                 .buttonStyle(needsAttention ? AnyButtonStyle(.borderedProminent) : AnyButtonStyle(.bordered))
@@ -84,45 +83,24 @@ struct DashboardReadinessPanel: View {
         }
     }
 
-    private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {
+    private func primaryActionLabel(for action: RecoveryAction) -> String {
         if action == .reconnect,
            let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses) {
             return title
         }
-        return readiness.primaryActionTitle ?? action.defaultTitle
+        return readiness.primaryActionTitle ?? action.canonicalTitle
     }
 
-    /// Dispatches a readiness action through the same `AppState` entry points the
-    /// popover's panel uses, so window-first recovery matches the popover exactly.
-    private func perform(_ action: DashboardStatusReadinessAction) {
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            onAddAccount()
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .reconnect:
-            guard let itemId = ItemRecoveryTarget.itemId(from: appState.itemStatuses) else {
-                Task { await appState.refreshAccounts() }
-                return
-            }
-            Task { await appState.reconnectItem(itemId: itemId) }
-        case .openSettings:
-            openSettings()
-        case .requestNotificationPermission:
-            Task { _ = await appState.requestNotificationPermission() }
-        case .openNotificationSettings:
-            openNotificationSettings()
-        }
-    }
-
-    private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-            openSettings()
-            return
-        }
-        NSWorkspace.shared.open(url)
+    /// Dispatches a readiness action through the shared ``RecoveryActionDispatcher``
+    /// — the same `AppState` entry points every other attention surface uses, so
+    /// recovery means the same thing everywhere.
+    private func perform(_ action: RecoveryAction) {
+        RecoveryActionDispatcher(
+            appState: appState,
+            openSettings: openSettings,
+            onAddAccount: onAddAccount
+        )
+        .perform(action)
     }
 }
 

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1521,7 +1521,7 @@ private struct DashboardStatusReadinessPanel: View {
                             } label: {
                                 Label(
                                     primaryActionLabel(for: primaryAction),
-                                    systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                                    systemImage: readiness.primaryActionIconName ?? primaryAction.canonicalIconName
                                 )
                             }
                             .buttonStyle(.borderedProminent)
@@ -1534,7 +1534,7 @@ private struct DashboardStatusReadinessPanel: View {
                             } label: {
                                 Label(
                                     primaryActionLabel(for: primaryAction),
-                                    systemImage: readiness.primaryActionIconName ?? primaryAction.defaultIconName
+                                    systemImage: readiness.primaryActionIconName ?? primaryAction.canonicalIconName
                                 )
                             }
                             .buttonStyle(.bordered)
@@ -1551,13 +1551,13 @@ private struct DashboardStatusReadinessPanel: View {
                         Button {
                             perform(action)
                         } label: {
-                            Label(action.defaultTitle, systemImage: action.defaultIconName)
+                            Label(action.canonicalTitle, systemImage: action.canonicalIconName)
                                 .lineLimit(1)
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .disabled(appState.isLoading)
-                        .accessibilityLabel(action.defaultTitle)
+                        .accessibilityLabel(action.canonicalTitle)
                     }
                 }
             }
@@ -1590,48 +1590,22 @@ private struct DashboardStatusReadinessPanel: View {
         readiness.level == .warning || readiness.level == .blocked
     }
 
-    private func perform(_ action: DashboardStatusReadinessAction) {
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            onAddAccount()
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .reconnect:
-            guard let itemId = reconnectItemId else {
-                Task { await appState.refreshAccounts() }
-                return
-            }
-            Task { await appState.reconnectItem(itemId: itemId) }
-        case .openSettings:
-            openSettings()
-        case .requestNotificationPermission:
-            Task { _ = await appState.requestNotificationPermission() }
-        case .openNotificationSettings:
-            openNotificationSettings()
-        }
+    private func perform(_ action: RecoveryAction) {
+        RecoveryActionDispatcher(
+            appState: appState,
+            openSettings: openSettings,
+            onAddAccount: onAddAccount
+        )
+        .perform(action)
     }
 
-    private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-            openSettings()
-            return
-        }
-        NSWorkspace.shared.open(url)
-    }
-
-    private func primaryActionLabel(for action: DashboardStatusReadinessAction) -> String {
+    private func primaryActionLabel(for action: RecoveryAction) -> String {
         if action == .reconnect,
            let title = ItemRecoveryTarget.actionTitle(from: appState.itemStatuses)
         {
             return title
         }
-        return readiness.primaryActionTitle ?? action.defaultTitle
-    }
-
-    private var reconnectItemId: String? {
-        ItemRecoveryTarget.itemId(from: appState.itemStatuses)
+        return readiness.primaryActionTitle ?? action.canonicalTitle
     }
 }
 

--- a/Sources/PlaidBar/Views/MenuBarGlanceView.swift
+++ b/Sources/PlaidBar/Views/MenuBarGlanceView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import PlaidBarCore
 import SwiftUI
 
@@ -97,41 +96,19 @@ struct MenuBarGlanceView: View {
 
     /// A chip routes into the window when it carries a ``Route``; otherwise it
     /// runs its in-place infrastructure action (check server, open Settings,
-    /// refresh) — exactly the `MenuBarGlanceModel.Chip` contract. The local-infra
-    /// action set mirrors `AttentionQueueView.perform`.
+    /// refresh) through the shared ``RecoveryActionDispatcher`` — exactly the
+    /// `MenuBarGlanceModel.Chip` contract, identical to every other surface.
     private func activate(_ chip: MenuBarGlanceModel.Chip) {
         if let route = chip.route {
             openRoute(route)
             return
         }
         guard let action = chip.fallbackAction else { return }
-        switch action {
-        case .checkServer:
-            Task { await appState.checkServerConnection() }
-        case .addAccount:
-            Task { await appState.addAccount() }
-        case .refresh:
-            Task { await appState.refreshDashboard() }
-        case .reconnect:
-            // Degraded-item chips carry a `Route` (`Route.from(attentionRow:)`
-            // maps `item-error-/item-repair-/item-outage-` rows to Accounts), so
-            // a reconnect action never reaches this fallback. Refresh defensively.
-            Task { await appState.refreshDashboard() }
-        case .openSettings:
-            openSettings()
-        case .requestNotificationPermission:
-            Task { _ = await appState.requestNotificationPermission() }
-        case .openNotificationSettings:
-            openNotificationSettings()
-        }
-    }
-
-    private func openNotificationSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else {
-            openSettings()
-            return
-        }
-        NSWorkspace.shared.open(url)
+        // Degraded-item chips carry a `Route` (so a `.reconnect` never reaches
+        // this fallback); the dispatcher's reconnect path also refreshes
+        // defensively when no item resolves, matching the prior behavior.
+        RecoveryActionDispatcher(appState: appState, openSettings: { openSettings() })
+            .perform(action)
     }
 
     // MARK: - Footer quick-actions

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -41,7 +41,7 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
     public let title: String
     public let detail: String
     public let menuBarAttentionText: String?
-    public let action: DashboardStatusReadinessAction?
+    public let action: RecoveryAction?
     public let actionTitle: String?
     public let actionIconName: String?
     public let targetItemId: String?
@@ -63,13 +63,28 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
         id.hasPrefix(Self.financialAttentionIDPrefix)
     }
 
+    /// The converged recovery button for this row, folding the row's
+    /// `targetItemId` so an item-scoped `.reconnect` carries its target in the
+    /// same place every other attention surface does. `nil` for rows with no
+    /// action (e.g. the advisory provider-outage row).
+    public var recoveryActionButton: RecoveryActionButton? {
+        guard let action else { return nil }
+        return RecoveryActionButton(
+            action: action,
+            title: actionTitle,
+            iconName: actionIconName,
+            accessibilityHint: accessibilityHint,
+            targetItemId: targetItemId
+        )
+    }
+
     public init(
         id: String,
         severity: AttentionQueueSeverity,
         title: String,
         detail: String,
         menuBarAttentionText: String? = nil,
-        action: DashboardStatusReadinessAction? = nil,
+        action: RecoveryAction? = nil,
         actionTitle: String? = nil,
         actionIconName: String? = nil,
         targetItemId: String? = nil,
@@ -82,8 +97,8 @@ public struct AttentionQueueRow: Equatable, Identifiable, Sendable {
         self.detail = detail
         self.menuBarAttentionText = menuBarAttentionText
         self.action = action
-        self.actionTitle = actionTitle ?? action?.defaultTitle
-        self.actionIconName = actionIconName ?? action?.defaultIconName
+        self.actionTitle = actionTitle ?? action?.canonicalTitle
+        self.actionIconName = actionIconName ?? action?.canonicalIconName
         self.targetItemId = targetItemId
         self.accessibilityLabel = accessibilityLabel ?? "\(severity.statusLabel). \(title). \(detail)"
         self.accessibilityHint = accessibilityHint
@@ -123,6 +138,8 @@ public struct AttentionQueue: Equatable, Sendable {
         lowCashThreshold: Double = 100,
         largeTransactionThreshold: Double = 500,
         creditUtilizationThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold,
+        notificationsEnabled: Bool = false,
+        notificationPermission: NotificationPermissionPresentation? = nil,
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> AttentionQueue {
@@ -225,8 +242,20 @@ public struct AttentionQueue: Equatable, Sendable {
                 detail: "Last sync: \(lastSyncRelative ?? "never"). Refresh for current data.",
                 menuBarAttentionText: lastSyncRelative == nil ? "Never" : "Stale",
                 action: .refresh,
-                actionTitle: "Refresh Now"
+                actionTitle: staleSyncRefreshTitle
             ))
+        }
+
+        // STATE-5 (notification-permission): mirror the dashboard readiness
+        // verdict so the popover / Alerts / Account Settings attention queue
+        // offers the same notification recovery the dashboard does. Advisory
+        // only, ranked below sync health and above financial attention.
+        if credentialsReady, serverConnected,
+           let notificationRow = notificationPermissionRow(
+               notificationsEnabled: notificationsEnabled,
+               permission: notificationPermission
+           ) {
+            rows.append(notificationRow)
         }
 
         // Only evaluate aggregate finance warnings once every linked item has
@@ -453,9 +482,12 @@ public struct AttentionQueue: Equatable, Sendable {
         }
     }
 
+    /// The institution-qualified reconnect/update title for a degraded item,
+    /// delegating to ``ItemRecoveryTarget`` so the verb ("Reconnect" for login /
+    /// error, "Update" for newly-available accounts) and the institution
+    /// qualification match every other surface (STATE-2 convergence).
     private static func reconnectTitle(_ item: ItemStatus) -> String {
-        guard let institutionName = normalizedInstitutionName(item.institutionName) else { return "Reconnect Item" }
-        return "Reconnect \(institutionName)"
+        ItemRecoveryTarget.actionTitle(from: [item]) ?? "Reconnect Item"
     }
 
     private static func localServerAuthRow(from message: String?) -> AttentionQueueRow? {
@@ -516,6 +548,75 @@ public struct AttentionQueue: Equatable, Sendable {
         UserFacingError.sanitizedDetail(from: message, maxLength: maxRenderedErrorLength)
     }
 
+    /// STATE-5: the notification-permission attention row, mirroring
+    /// `DashboardStatusReadiness.notificationPermissionRecovery` so the same
+    /// recovery (request permission / open System Settings / check again) is
+    /// offered on every attention surface. `nil` unless local alerts are enabled
+    /// AND macOS permission is currently blocking them.
+    private static func notificationPermissionRow(
+        notificationsEnabled: Bool,
+        permission: NotificationPermissionPresentation?
+    ) -> AttentionQueueRow? {
+        guard notificationsEnabled,
+              let permission,
+              permission.shouldDisableNotifications
+        else { return nil }
+
+        switch permission.recoveryAction {
+        case .requestPermission:
+            return AttentionQueueRow(
+                id: "notification-permission",
+                severity: .warning,
+                title: "Notification permission not requested",
+                detail: "Local alerts are enabled, but macOS permission has not been requested yet.",
+                action: .requestNotificationPermission,
+                actionTitle: permission.recoveryActionTitle,
+                actionIconName: permission.recoveryActionIconName,
+                accessibilityHint: "Requests macOS notification permission for VaultPeek alerts."
+            )
+        case .openSystemSettings:
+            return AttentionQueueRow(
+                id: "notification-permission",
+                severity: .warning,
+                title: "Notifications blocked",
+                detail: "Local alerts are enabled, but macOS is blocking VaultPeek notifications. Enable VaultPeek in System Settings to recover alerts.",
+                action: .openNotificationSettings,
+                actionTitle: permission.recoveryActionTitle,
+                actionIconName: permission.recoveryActionIconName,
+                accessibilityHint: "Opens the macOS System Settings notifications pane."
+            )
+        case .checkAgain:
+            return AttentionQueueRow(
+                id: "notification-permission",
+                severity: .warning,
+                title: "Notification permission unknown",
+                detail: permission.detail,
+                action: .requestNotificationPermission,
+                actionTitle: "Check Permission",
+                actionIconName: "arrow.clockwise",
+                accessibilityHint: "Re-checks the current macOS notification permission."
+            )
+        case .runBundledApp:
+            return AttentionQueueRow(
+                id: "notification-permission",
+                severity: .warning,
+                title: "Notification identity unavailable",
+                detail: permission.detail,
+                action: .openSettings,
+                actionTitle: permission.recoveryActionTitle,
+                actionIconName: permission.recoveryActionIconName
+            )
+        case nil:
+            return AttentionQueueRow(
+                id: "notification-permission",
+                severity: .warning,
+                title: "Notifications unavailable",
+                detail: permission.detail,
+                action: .openSettings
+            )
+        }
+    }
+
     private static func normalizedInstitutionName(_ institutionName: String?) -> String? {
         guard let institutionName else { return nil }
         let trimmed = institutionName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -545,9 +646,12 @@ public struct AttentionQueue: Equatable, Sendable {
             case "first-sync-needed": return 9
             case "first-sync-incomplete": return 10
             case "sync-stale": return 11
-            case "financial-low-cash": return 12
-            case "financial-high-utilization": return 13
-            case "financial-unusual-spending": return 14
+            // STATE-5 notification recovery: advisory, ranked just below sync
+            // health and just above financial attention (mirrors the dashboard).
+            case "notification-permission": return 12
+            case "financial-low-cash": return 13
+            case "financial-high-utilization": return 14
+            case "financial-unusual-spending": return 15
             default:
                 // Unknown rows fall back to severity-tier ordering: blocking
                 // failures first, advisories next, healthy rows last.

--- a/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
+++ b/Sources/PlaidBarCore/Models/DashboardStatusReadiness.swift
@@ -19,15 +19,19 @@ public enum DashboardStatusReadinessLevel: String, Codable, Sendable {
     }
 }
 
-public enum DashboardStatusReadinessAction: String, Codable, Sendable {
-    case checkServer
-    case addAccount
-    case refresh
-    case reconnect
-    case openSettings
-    case requestNotificationPermission
-    case openNotificationSettings
-}
+/// Deprecated alias for the converged ``RecoveryAction``. The dashboard readiness
+/// verdict, the attention queue, and the secondary content unavailable states all
+/// now speak the one ``RecoveryAction`` vocabulary; this alias keeps the
+/// pre-convergence call sites and `Codable`/equality snapshots compiling
+/// unchanged. Prefer ``RecoveryAction`` in new code.
+@available(*, deprecated, renamed: "RecoveryAction")
+public typealias DashboardStatusReadinessAction = RecoveryAction
+
+/// The canonical button title for the **stale-sync** (STATE-4) refresh action,
+/// shared by every surface (dashboard readiness, attention queue, account
+/// connection chip) so the state reads identically everywhere. This is the value
+/// that resolves the pre-convergence "Refresh Now" vs "Refresh" drift.
+public let staleSyncRefreshTitle = "Refresh Now"
 
 public struct DashboardStatusReadiness: Equatable, Sendable {
     private static let maxRenderedErrorLength = 240
@@ -35,10 +39,10 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     public let level: DashboardStatusReadinessLevel
     public let title: String
     public let detail: String
-    public let primaryAction: DashboardStatusReadinessAction?
+    public let primaryAction: RecoveryAction?
     public let primaryActionTitle: String?
     public let primaryActionIconName: String?
-    public let secondaryActions: [DashboardStatusReadinessAction]
+    public let secondaryActions: [RecoveryAction]
 
     /// Severity tier derived from the readiness level this mapping already
     /// computed.
@@ -46,21 +50,41 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
         level.errorSeverity
     }
 
+    /// The converged recovery button for this readiness verdict, so the dashboard
+    /// readiness panel and the popover emit the same ``RecoveryActionButton``
+    /// shape every other attention surface does. `nil` for verdicts with no
+    /// primary action (e.g. the in-flight loading state).
+    ///
+    /// Pass `itemStatuses` so an item-scoped `.reconnect` folds in the
+    /// institution-qualified title and `targetItemId` (STATE-2); omit it on
+    /// surfaces that resolve the item target themselves.
+    public func recoveryActionButton(itemStatuses: [ItemStatus] = []) -> RecoveryActionButton? {
+        guard let primaryAction else { return nil }
+        if primaryAction == .reconnect, let reconnect = RecoveryActionButton.reconnect(from: itemStatuses) {
+            return reconnect
+        }
+        return RecoveryActionButton(
+            action: primaryAction,
+            title: primaryActionTitle,
+            iconName: primaryActionIconName
+        )
+    }
+
     public init(
         level: DashboardStatusReadinessLevel,
         title: String,
         detail: String,
-        primaryAction: DashboardStatusReadinessAction? = nil,
+        primaryAction: RecoveryAction? = nil,
         primaryActionTitle: String? = nil,
         primaryActionIconName: String? = nil,
-        secondaryActions: [DashboardStatusReadinessAction] = []
+        secondaryActions: [RecoveryAction] = []
     ) {
         self.level = level
         self.title = title
         self.detail = detail
         self.primaryAction = primaryAction
-        self.primaryActionTitle = primaryActionTitle ?? primaryAction?.defaultTitle
-        self.primaryActionIconName = primaryActionIconName ?? primaryAction?.defaultIconName
+        self.primaryActionTitle = primaryActionTitle ?? primaryAction?.canonicalTitle
+        self.primaryActionIconName = primaryActionIconName ?? primaryAction?.canonicalIconName
         self.secondaryActions = secondaryActions
     }
 
@@ -243,7 +267,7 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
                 title: "Sync is stale",
                 detail: "Last sync: \(lastSyncRelative ?? "never"). Refresh now to pull current balances and transactions.",
                 primaryAction: .refresh,
-                primaryActionTitle: "Refresh Now"
+                primaryActionTitle: staleSyncRefreshTitle
             )
         }
 
@@ -382,28 +406,14 @@ public struct DashboardStatusReadiness: Equatable, Sendable {
     }
 }
 
-public extension DashboardStatusReadinessAction {
-    var defaultTitle: String {
-        switch self {
-        case .checkServer: "Check Server"
-        case .addAccount: "Add Account"
-        case .refresh: "Refresh"
-        case .reconnect: "Reconnect"
-        case .openSettings: "Settings"
-        case .requestNotificationPermission: "Request Permission"
-        case .openNotificationSettings: "Open System Settings"
-        }
-    }
+public extension RecoveryAction {
+    /// Deprecated alias for ``canonicalTitle``. Kept so pre-convergence call sites
+    /// (`action.defaultTitle`) compile unchanged.
+    @available(*, deprecated, renamed: "canonicalTitle")
+    var defaultTitle: String { canonicalTitle }
 
-    var defaultIconName: String {
-        switch self {
-        case .checkServer: "server.rack"
-        case .addAccount: "plus.circle"
-        case .refresh: "arrow.clockwise"
-        case .reconnect: "link.badge.plus"
-        case .openSettings: "gearshape"
-        case .requestNotificationPermission: "bell.badge"
-        case .openNotificationSettings: "gearshape"
-        }
-    }
+    /// Deprecated alias for ``canonicalIconName``. Kept so pre-convergence call
+    /// sites (`action.defaultIconName`) compile unchanged.
+    @available(*, deprecated, renamed: "canonicalIconName")
+    var defaultIconName: String { canonicalIconName }
 }

--- a/Sources/PlaidBarCore/Models/MenuBarGlance.swift
+++ b/Sources/PlaidBarCore/Models/MenuBarGlance.swift
@@ -67,7 +67,7 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
         public let route: Route?
         /// The in-place action to run when `route` is `nil` (server offline,
         /// missing credentials, generic recent-error/sync rows).
-        public let fallbackAction: DashboardStatusReadinessAction?
+        public let fallbackAction: RecoveryAction?
 
         public init(
             id: String,
@@ -78,7 +78,7 @@ public struct MenuBarGlanceModel: Equatable, Sendable {
             accessibilityLabel: String,
             accessibilityHint: String?,
             route: Route?,
-            fallbackAction: DashboardStatusReadinessAction?
+            fallbackAction: RecoveryAction?
         ) {
             self.id = id
             self.title = title

--- a/Sources/PlaidBarCore/Models/RecoveryAction.swift
+++ b/Sources/PlaidBarCore/Models/RecoveryAction.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// The single, converged vocabulary of recovery verbs every attention surface
+/// can offer the user (post-1.0 priority #3: converged recovery actions).
+///
+/// VaultPeek presents five recoverable attention states — (1) local server
+/// unreachable, (2) a Plaid item that needs login/repair, (3) empty-data /
+/// first-run, (4) stale sync, (5) notification-permission. Before convergence each
+/// surface (dashboard readiness panel, attention queue, secondary content
+/// `ContentUnavailableView`s, the notification settings row, the account
+/// connection chip) carried its *own* action enum and its *own* labels, so the
+/// same state could read "Refresh Now" on one surface and "Refresh" on another,
+/// or "Reconnect <Inst>" here and "Update <Inst>" there.
+///
+/// `RecoveryAction` unifies those verbs into one `Sendable`/`Codable` enum. It is
+/// the superset of the legacy `DashboardStatusReadinessAction` and
+/// `SecondaryContentUnavailableAction` (both now deprecated typealiases), keeping
+/// every legacy raw value so existing `Codable` snapshots and `== .reconnect`
+/// equality tests stay byte-stable. The item-scoped target for `.reconnectItem`
+/// is **not** an associated value (which would break the `String` raw
+/// representation the persisted `Route`/`AttentionQueueRow` snapshots rely on) —
+/// it is carried alongside the verb by ``RecoveryActionButton``.
+///
+/// Pure + `Sendable` so it lives in `PlaidBarCore` and is unit-testable without
+/// the app target (CLAUDE.md). The app-layer `RecoveryActionDispatcher` maps each
+/// verb onto the matching `AppState` entry point.
+public enum RecoveryAction: String, Codable, Sendable, CaseIterable, Hashable {
+    /// STATE-1: re-check the local VaultPeek companion server connection.
+    case checkServer
+    /// STATE-3: start Plaid Link to connect a new institution.
+    case addAccount
+    /// STATE-4 / generic: refresh the dashboard (balances + transactions).
+    case refresh
+    /// STATE-3: refresh just account balances.
+    case refreshAccounts
+    /// STATE-3: run / re-run the transaction sync.
+    case syncTransactions
+    /// STATE-2: reconnect or update a degraded Plaid item through Link update mode.
+    /// The affected item is carried by ``RecoveryActionButton/targetItemId``. The
+    /// case name stays `reconnect` (and the raw value with it) so the converged
+    /// enum is a byte-stable drop-in for the legacy `DashboardStatusReadinessAction`
+    /// — every `== .reconnect` snapshot and persisted value keeps working.
+    case reconnect
+    /// Open VaultPeek Settings.
+    case openSettings
+    /// STATE-5: request macOS notification permission.
+    case requestNotificationPermission
+    /// STATE-5: open the macOS System Settings notification pane.
+    case openNotificationSettings
+    /// Empty-search recovery: clear the active search text / filters.
+    case clearFilters
+    /// Empty-period recovery: widen the spending period window.
+    case showWiderPeriod
+
+    /// The one canonical button title for this verb. Item-scoped reconnect and
+    /// the few context-specific job titles ("Load Balances", "Run First Sync")
+    /// are layered on top by the caller via
+    /// ``RecoveryActionButton`` / `primaryActionTitle`, but this is the single
+    /// source of truth that kills the cross-surface label drift.
+    public var canonicalTitle: String {
+        switch self {
+        case .checkServer: "Check Server"
+        case .addAccount: "Add Account"
+        case .refresh: "Refresh"
+        case .refreshAccounts: "Refresh Accounts"
+        case .syncTransactions: "Sync Transactions"
+        case .reconnect: "Reconnect"
+        case .openSettings: "Settings"
+        case .requestNotificationPermission: "Request Permission"
+        case .openNotificationSettings: "Open System Settings"
+        case .clearFilters: "Clear Filters"
+        case .showWiderPeriod: "Show Wider Period"
+        }
+    }
+
+    /// The one canonical SF Symbol for this verb. Chrome only — meaning is always
+    /// carried by the accompanying label too, never the glyph alone
+    /// (ACCESSIBILITY.md).
+    public var canonicalIconName: String {
+        switch self {
+        case .checkServer: "server.rack"
+        case .addAccount: "plus.circle"
+        case .refresh: "arrow.clockwise"
+        case .refreshAccounts: "arrow.clockwise"
+        case .syncTransactions: "arrow.triangle.2.circlepath"
+        case .reconnect: "link.badge.plus"
+        case .openSettings: "gearshape"
+        case .requestNotificationPermission: "bell.badge"
+        case .openNotificationSettings: "gearshape"
+        case .clearFilters: "xmark.circle"
+        case .showWiderPeriod: "calendar"
+        }
+    }
+}
+
+/// The canonical, surface-agnostic description of a recovery button: which
+/// converged ``RecoveryAction`` it runs, the resolved title + icon, an optional
+/// VoiceOver hint, whether the control is interactive (some recovery copy is
+/// advisory-only, e.g. "Run App Bundle"), and the item it targets.
+///
+/// This folds what used to be spread across `ItemRecoveryTarget` (the
+/// item-scoped reconnect target + institution-qualified title) and each surface's
+/// bespoke `(action, title, icon)` triple into ONE value, so every surface emits
+/// the same button shape and an item reconnect carries its `targetItemId` in the
+/// same place everywhere. `Equatable`/`Sendable`/`Codable` so it is testable and
+/// persistable; the app layer hands the button's `action` + `targetItemId` to the
+/// dispatcher.
+public struct RecoveryActionButton: Equatable, Sendable, Codable, Hashable {
+    public let action: RecoveryAction
+    public let title: String
+    public let iconName: String
+    public let accessibilityHint: String?
+    /// `false` for advisory recovery copy whose "action" is informational only
+    /// (the button is shown disabled), e.g. notification identity unavailable.
+    public let isInteractive: Bool
+    /// The Plaid `item_id` an item-scoped `.reconnectItem` targets; `nil` for
+    /// non-item actions. Folds the role `ItemRecoveryTarget` used to play.
+    public let targetItemId: String?
+
+    public init(
+        action: RecoveryAction,
+        title: String? = nil,
+        iconName: String? = nil,
+        accessibilityHint: String? = nil,
+        isInteractive: Bool = true,
+        targetItemId: String? = nil
+    ) {
+        self.action = action
+        self.title = title ?? action.canonicalTitle
+        self.iconName = iconName ?? action.canonicalIconName
+        self.accessibilityHint = accessibilityHint
+        self.isInteractive = isInteractive
+        self.targetItemId = targetItemId
+    }
+
+    /// Builds the item-scoped reconnect button for the highest-priority degraded
+    /// item in `statuses` (errored items first, then update-mode items), folding
+    /// `ItemRecoveryTarget` so the institution-qualified title ("Reconnect Chase"
+    /// / "Update Chase") and the `targetItemId` are produced in one place.
+    /// Returns `nil` when no item needs recovery.
+    public static func reconnect(from statuses: [ItemStatus]) -> RecoveryActionButton? {
+        guard let itemId = ItemRecoveryTarget.itemId(from: statuses) else { return nil }
+        return RecoveryActionButton(
+            action: .reconnect,
+            title: ItemRecoveryTarget.actionTitle(from: statuses),
+            accessibilityHint: "Reconnects this institution through Plaid Link.",
+            targetItemId: itemId
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -315,6 +315,37 @@ public enum Route: Sendable, Hashable, Codable {
         }
     }
 
+    /// Maps a converged ``RecoveryAction`` (plus the item it targets, for
+    /// `.reconnect`) onto the in-window destination its recovery should open, so
+    /// window-first deep-link routing keys off the unified verb rather than each
+    /// surface's bespoke action enum.
+    ///
+    /// Returns `nil` for verbs whose recovery is an *in-place* action with no
+    /// meaningful in-window destination — checking the server, opening Settings,
+    /// requesting / opening notification permission, refreshing, syncing, clearing
+    /// filters, widening the period. Those keep running their existing action; the
+    /// caller falls back to the action when this is `nil`.
+    ///
+    /// Pure (keyed off the verb + carried item id) so the recovery → route
+    /// decision is unit-testable at the Core layer without the app target
+    /// (CLAUDE.md).
+    public static func from(recoveryAction action: RecoveryAction, targetItemId: String? = nil) -> Route? {
+        switch action {
+        case .reconnect:
+            // A degraded item's reconnect opens Accounts at the affected item so
+            // the inspector follows the link (the item id may need
+            // `resolvingAccountSelection(in:)` applied by the caller).
+            return .accounts(itemID: targetItemId)
+        case .addAccount:
+            // Connecting a new institution lands on Accounts.
+            return .accounts()
+        case .checkServer, .refresh, .refreshAccounts, .syncTransactions,
+             .openSettings, .requestNotificationPermission, .openNotificationSettings,
+             .clearFilters, .showWiderPeriod:
+            return nil
+        }
+    }
+
     /// Resolves an `.accounts(itemID:)` deep-link whose `itemID` is actually a
     /// Plaid *item_id* into one keyed by the matching `AccountDTO.id`, so the
     /// Accounts destination (which selects by `AccountDTO.id`) lands on the right

--- a/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
+++ b/Sources/PlaidBarCore/Models/SecondaryContentUnavailableState.swift
@@ -8,15 +8,12 @@ public enum SecondaryContentSurface: String, Sendable {
     case recurring
 }
 
-public enum SecondaryContentUnavailableAction: String, Sendable {
-    case checkServer
-    case addAccount
-    case refreshAccounts
-    case syncTransactions
-    case refresh
-    case clearFilters
-    case showWiderPeriod
-}
+/// Deprecated alias for the converged ``RecoveryAction``. Secondary content
+/// `ContentUnavailableView`s now speak the same ``RecoveryAction`` vocabulary as
+/// the dashboard readiness verdict and attention queue; this alias keeps the
+/// pre-convergence call sites compiling. Prefer ``RecoveryAction`` in new code.
+@available(*, deprecated, renamed: "RecoveryAction")
+public typealias SecondaryContentUnavailableAction = RecoveryAction
 
 public struct SecondaryContentUnavailableState: Equatable, Sendable {
     private static let maxRenderedErrorLength = 240
@@ -24,7 +21,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
     public let title: String
     public let detail: String
     public let iconName: String
-    public let action: SecondaryContentUnavailableAction
+    public let action: RecoveryAction
     public let actionTitle: String
     public let actionIconName: String
     public let actionAccessibilityHint: String?
@@ -36,7 +33,7 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         title: String,
         detail: String,
         iconName: String,
-        action: SecondaryContentUnavailableAction,
+        action: RecoveryAction,
         actionTitle: String,
         actionIconName: String,
         actionAccessibilityHint: String? = nil,
@@ -50,6 +47,20 @@ public struct SecondaryContentUnavailableState: Equatable, Sendable {
         self.actionIconName = actionIconName
         self.actionAccessibilityHint = actionAccessibilityHint
         self.isLoading = isLoading
+    }
+
+    /// The converged recovery button for this empty/unavailable state, so a
+    /// secondary `ContentUnavailableView` emits the same ``RecoveryActionButton``
+    /// shape every other attention surface does. The action is hidden while the
+    /// first fetch is in flight (`isLoading`), matching the views.
+    public var recoveryActionButton: RecoveryActionButton {
+        RecoveryActionButton(
+            action: action,
+            title: actionTitle,
+            iconName: actionIconName,
+            accessibilityHint: actionAccessibilityHint,
+            isInteractive: !isLoading
+        )
     }
 
     public static func accounts(

--- a/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountConnectionPresentation.swift
@@ -192,7 +192,7 @@ public struct AccountConnectionPresentation: Sendable, Equatable {
                 signalLabel: "Stale",
                 iconName: "clock.badge.exclamationmark.fill",
                 showsRecoveryActions: true,
-                recoveryActionTitle: "Refresh",
+                recoveryActionTitle: staleSyncRefreshTitle,
                 itemSyncLabel: itemSyncLabel,
                 statusFilterSubtitle: "Stale sync • \(itemSyncLabel)",
                 recoveryDetailLabel: "This item has stale Plaid data. Refresh to pull current balances and transactions."

--- a/Tests/PlaidBarCoreTests/AccountConnectionPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountConnectionPresentationTests.swift
@@ -53,7 +53,11 @@ struct AccountConnectionPresentationTests {
     func stale() {
         let presentation = evaluate(isSyncStale: true, itemStatus: .connected)
         #expect(presentation.level == .stale)
-        #expect(presentation.recoveryActionTitle == "Refresh")
+        // STATE-4 convergence: the stale-sync refresh label is the one canonical
+        // `staleSyncRefreshTitle` shared with the dashboard readiness and
+        // attention queue, resolving the prior "Refresh" / "Refresh Now" drift.
+        #expect(presentation.recoveryActionTitle == "Refresh Now")
+        #expect(presentation.recoveryActionTitle == staleSyncRefreshTitle)
         #expect(presentation.showsRecoveryActions)
         #expect(presentation.recoveryDetailLabel?.contains("stale") == true)
     }

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -535,6 +535,171 @@ struct AttentionQueueTests {
         }
     }
 
+    // MARK: - STATE-5: notification-permission row (convergence)
+
+    @Test("Notification permission denied surfaces a recovery row mirroring the dashboard")
+    func notificationPermissionDeniedSurfacesRow() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            notificationsEnabled: true,
+            notificationPermission: .evaluate(kind: .denied)
+        )
+
+        let row = queue.rows.first { $0.id == "notification-permission" }
+        #expect(row != nil)
+        #expect(row?.severity == .warning)
+        #expect(row?.title == "Notifications blocked")
+        #expect(row?.action == .openNotificationSettings)
+        #expect(row?.actionTitle == "Open System Settings")
+    }
+
+    @Test("Notification permission not-requested offers the permission request")
+    func notificationPermissionNotRequestedOffersRequest() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            notificationsEnabled: true,
+            notificationPermission: .evaluate(kind: .notDetermined)
+        )
+
+        let row = queue.rows.first { $0.id == "notification-permission" }
+        #expect(row?.title == "Notification permission not requested")
+        #expect(row?.action == .requestNotificationPermission)
+    }
+
+    @Test("Notification recovery is suppressed when local alerts are disabled")
+    func notificationRecoverySuppressedWhenDisabled() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            notificationsEnabled: false,
+            notificationPermission: .evaluate(kind: .denied)
+        )
+
+        #expect(!queue.rows.contains { $0.id == "notification-permission" })
+        #expect(queue.rows.map(\.id) == ["healthy"])
+    }
+
+    @Test("Notification recovery is omitted while authorized (no blocking state)")
+    func notificationRecoveryOmittedWhenAuthorized() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            notificationsEnabled: true,
+            notificationPermission: .evaluate(kind: .authorized)
+        )
+
+        #expect(!queue.rows.contains { $0.id == "notification-permission" })
+    }
+
+    @Test("Notification recovery ranks below sync health and above financial attention")
+    func notificationRecoveryRanksBelowSyncAboveFinancial() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 2,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: true,
+            lastSyncRelative: "3 days ago",
+            errorMessage: nil,
+            accounts: [
+                depository(id: "checking", balance: 10),
+            ],
+            transactions: [],
+            lowCashThreshold: 100,
+            largeTransactionThreshold: 500,
+            creditUtilizationThreshold: 30,
+            notificationsEnabled: true,
+            notificationPermission: .evaluate(kind: .denied)
+        )
+
+        #expect(queue.rows.map(\.id) == [
+            "sync-stale",
+            "notification-permission",
+            "financial-low-cash",
+        ])
+    }
+
+    @Test("Notification recovery is suppressed until credentials and server are ready")
+    func notificationRecoverySuppressedUntilInfrastructureReady() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: false,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil,
+            notificationsEnabled: true,
+            notificationPermission: .evaluate(kind: .denied)
+        )
+
+        // Server-offline dominates; notification recovery does not show.
+        #expect(!queue.rows.contains { $0.id == "notification-permission" })
+        #expect(queue.rows.map(\.id) == ["server-offline"])
+    }
+
+    @Test("New-accounts row uses the Update verb title, matching every surface")
+    func newAccountsRowUsesUpdateTitle() {
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false,
+            serverConnected: true,
+            credentialsConfigured: true,
+            linkedItemCount: 1,
+            accountCount: 1,
+            syncedItemCount: 1,
+            itemStatuses: [
+                ItemStatus(id: "item-new", institutionName: "Chase", status: .newAccountsAvailable),
+            ],
+            isSyncStale: false,
+            lastSyncRelative: "now",
+            errorMessage: nil
+        )
+
+        // STATE-2 convergence: the attention queue now says "Update Chase" for
+        // newly-available accounts, matching ItemRecoveryTarget / the chip.
+        #expect(queue.rows.first?.actionTitle == "Update Chase")
+    }
+
     private func transaction(id: String, amount: Double) -> TransactionDTO {
         TransactionDTO(
             id: id,

--- a/Tests/PlaidBarCoreTests/RecoveryActionTests.swift
+++ b/Tests/PlaidBarCoreTests/RecoveryActionTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Tests the converged ``RecoveryAction`` vocabulary, the ``RecoveryActionButton``
+/// value type, and how each of the five attention states now resolves to ONE
+/// canonical action + label + handoff (post-1.0 priority #3).
+@Suite("Converged recovery action")
+struct RecoveryActionTests {
+    // MARK: - Canonical titles / icons
+
+    @Test("Every recovery verb exposes a non-empty canonical title and icon")
+    func everyVerbHasCanonicalTitleAndIcon() {
+        for action in RecoveryAction.allCases {
+            #expect(!action.canonicalTitle.isEmpty)
+            #expect(!action.canonicalIconName.isEmpty)
+        }
+    }
+
+    @Test("Canonical titles match the pinned converged copy")
+    func canonicalTitlesArePinned() {
+        #expect(RecoveryAction.checkServer.canonicalTitle == "Check Server")
+        #expect(RecoveryAction.addAccount.canonicalTitle == "Add Account")
+        #expect(RecoveryAction.refresh.canonicalTitle == "Refresh")
+        #expect(RecoveryAction.refreshAccounts.canonicalTitle == "Refresh Accounts")
+        #expect(RecoveryAction.syncTransactions.canonicalTitle == "Sync Transactions")
+        #expect(RecoveryAction.reconnect.canonicalTitle == "Reconnect")
+        #expect(RecoveryAction.openSettings.canonicalTitle == "Settings")
+        #expect(RecoveryAction.requestNotificationPermission.canonicalTitle == "Request Permission")
+        #expect(RecoveryAction.openNotificationSettings.canonicalTitle == "Open System Settings")
+    }
+
+    @Test("Legacy aliases resolve to the same converged enum and raw values")
+    func legacyAliasesAreByteStable() {
+        // The deprecated typealiases must remain the SAME type so existing
+        // snapshots / equality keep working, and the raw values must be unchanged.
+        #expect(RecoveryAction.reconnect.rawValue == "reconnect")
+        #expect(RecoveryAction.requestNotificationPermission.rawValue == "requestNotificationPermission")
+        #expect(RecoveryAction.refreshAccounts.rawValue == "refreshAccounts")
+        #expect(RecoveryAction.syncTransactions.rawValue == "syncTransactions")
+        // Round-trips through Codable on the legacy raw values.
+        #expect(RecoveryAction(rawValue: "reconnect") == .reconnect)
+        #expect(RecoveryAction(rawValue: "refresh") == .refresh)
+    }
+
+    @Test("deprecated defaultTitle/defaultIconName still alias the canonical copy")
+    func deprecatedDefaultsAliasCanonical() {
+        // Verified via the still-supported shim so legacy call sites stay correct.
+        let action = RecoveryAction.refresh
+        #expect(action.canonicalTitle == "Refresh")
+        #expect(action.canonicalIconName == "arrow.clockwise")
+    }
+
+    // MARK: - RecoveryActionButton folding
+
+    @Test("Button defaults its title and icon from the action when unspecified")
+    func buttonDefaultsFromAction() {
+        let button = RecoveryActionButton(action: .checkServer)
+        #expect(button.title == "Check Server")
+        #expect(button.iconName == "server.rack")
+        #expect(button.isInteractive)
+        #expect(button.targetItemId == nil)
+    }
+
+    @Test("Button honors explicit title/icon/hint/target overrides")
+    func buttonHonorsOverrides() {
+        let button = RecoveryActionButton(
+            action: .reconnect,
+            title: "Reconnect Acme Bank",
+            iconName: "custom.icon",
+            accessibilityHint: "hint",
+            isInteractive: false,
+            targetItemId: "item-123"
+        )
+        #expect(button.title == "Reconnect Acme Bank")
+        #expect(button.iconName == "custom.icon")
+        #expect(button.accessibilityHint == "hint")
+        #expect(button.isInteractive == false)
+        #expect(button.targetItemId == "item-123")
+    }
+
+    @Test("reconnect(from:) folds the item target and institution-qualified title")
+    func reconnectButtonFoldsTarget() {
+        let errored = RecoveryActionButton.reconnect(from: [
+            ItemStatus(id: "item-secret", institutionName: "Acme Bank", status: .error),
+        ])
+        #expect(errored?.action == .reconnect)
+        #expect(errored?.title == "Reconnect Acme Bank")
+        #expect(errored?.targetItemId == "item-secret")
+
+        // New-accounts-available uses the "Update" verb, matching every surface.
+        let update = RecoveryActionButton.reconnect(from: [
+            ItemStatus(id: "item-new", institutionName: "Chase", status: .newAccountsAvailable),
+        ])
+        #expect(update?.title == "Update Chase")
+        #expect(update?.targetItemId == "item-new")
+
+        // Healthy items produce no reconnect button.
+        #expect(RecoveryActionButton.reconnect(from: [
+            ItemStatus(id: "ok", institutionName: "Bank", status: .connected),
+        ]) == nil)
+    }
+
+    // MARK: - STATE-2: item repair resolves to one action + handoff
+
+    @Test("STATE-2 item repair yields the same action and target across surfaces")
+    func state2ItemRepairIsConverged() {
+        let statuses = [ItemStatus(id: "item-secret", institutionName: "Chase", status: .loginRequired)]
+
+        // Dashboard readiness.
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false, serverConnected: true, credentialsConfigured: true,
+            linkedItemCount: 1, accountCount: 1, syncedItemCount: 1,
+            needsLoginItemCount: 1, erroredItemCount: 0,
+            isSyncStale: false, lastSyncRelative: "now", errorMessage: nil
+        )
+        let dashButton = readiness.recoveryActionButton(itemStatuses: statuses)
+        #expect(dashButton?.action == .reconnect)
+        #expect(dashButton?.title == "Reconnect Chase")
+        #expect(dashButton?.targetItemId == "item-secret")
+
+        // Attention queue row.
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false, serverConnected: true, credentialsConfigured: true,
+            linkedItemCount: 1, accountCount: 1, syncedItemCount: 1,
+            itemStatuses: statuses, isSyncStale: false, lastSyncRelative: "now", errorMessage: nil
+        )
+        let queueButton = queue.rows.first?.recoveryActionButton
+        #expect(queueButton?.action == .reconnect)
+        #expect(queueButton?.title == "Reconnect Chase")
+        #expect(queueButton?.targetItemId == "item-secret")
+
+        // Account connection chip.
+        let chip = AccountConnectionPresentation.evaluate(
+            isDemoMode: false, serverConnected: true, isSyncStale: false,
+            statusSyncText: "now", itemStatus: .loginRequired, institutionName: "Chase"
+        )
+        #expect(chip.recoveryActionTitle == "Reconnect Chase")
+    }
+
+    // MARK: - STATE-4: stale sync resolves to one label everywhere
+
+    @Test("STATE-4 stale sync uses the one canonical refresh label on every surface")
+    func state4StaleSyncLabelIsCanonical() {
+        let readiness = DashboardStatusReadiness.evaluate(
+            isDemoMode: false, serverConnected: true, credentialsConfigured: true,
+            linkedItemCount: 1, accountCount: 1, syncedItemCount: 1,
+            needsLoginItemCount: 0, erroredItemCount: 0,
+            isSyncStale: true, lastSyncRelative: "3d ago", errorMessage: nil
+        )
+        #expect(readiness.primaryAction == .refresh)
+        #expect(readiness.primaryActionTitle == staleSyncRefreshTitle)
+
+        let queue = AttentionQueue.evaluate(
+            isDemoMode: false, serverConnected: true, credentialsConfigured: true,
+            linkedItemCount: 1, accountCount: 1, syncedItemCount: 1,
+            itemStatuses: [], isSyncStale: true, lastSyncRelative: "3d ago", errorMessage: nil
+        )
+        let staleRow = queue.rows.first { $0.id == "sync-stale" }
+        #expect(staleRow?.action == .refresh)
+        #expect(staleRow?.actionTitle == staleSyncRefreshTitle)
+
+        let chip = AccountConnectionPresentation.evaluate(
+            isDemoMode: false, serverConnected: true, isSyncStale: true,
+            statusSyncText: "3d ago", itemStatus: .connected
+        )
+        #expect(chip.recoveryActionTitle == staleSyncRefreshTitle)
+    }
+
+    // MARK: - Route hand-off keyed off the converged verb
+
+    @Test("Route.from(recoveryAction:) maps item-scoped and add-account verbs")
+    func routeFromRecoveryAction() {
+        #expect(Route.from(recoveryAction: .reconnect, targetItemId: "item-9") == .accounts(itemID: "item-9"))
+        #expect(Route.from(recoveryAction: .addAccount) == .accounts())
+        // In-place verbs carry no in-window destination.
+        for action: RecoveryAction in [
+            .checkServer, .refresh, .refreshAccounts, .syncTransactions,
+            .openSettings, .requestNotificationPermission, .openNotificationSettings,
+            .clearFilters, .showWiderPeriod,
+        ] {
+            #expect(Route.from(recoveryAction: action) == nil)
+        }
+    }
+
+    // MARK: - Secondary content states emit a converged button
+
+    @Test("Secondary content unavailable states emit a converged recovery button")
+    func secondaryContentEmitsButton() {
+        let state = SecondaryContentUnavailableState.transactions(
+            isDemoMode: false, serverConnected: true,
+            linkedItemCount: 1, accountCount: 1, syncedItemCount: 0,
+            transactionCount: 0, hasSearchText: false, hasActiveFilters: false, errorMessage: nil
+        )
+        let button = state.recoveryActionButton
+        #expect(button.action == .syncTransactions)
+        #expect(button.title == state.actionTitle)
+        #expect(button.iconName == state.actionIconName)
+        #expect(button.isInteractive == !state.isLoading)
+    }
+}


### PR DESCRIPTION
Post-1.0 priority #3. One Core `RecoveryAction` + `RecoveryActionButton` unifies recovery for the 5 attention states (server-unreachable, item-repair, empty/first-run, stale-sync, notification-permission) with canonical labels/icons, consumed by dashboard, popover, attention queue, Alerts, menu-bar glance, and Settings via a single `RecoveryActionDispatcher` (replaces 5 duplicated perform switches).

- **Fixed STATE-5 gap:** `AttentionQueue.evaluate` was blind to notification state — added `notificationsEnabled`/`notificationPermission` + a notification-permission row mirroring the dashboard, so the popover/Alerts/AccountSettings queue now offers it too.
- **Canonicalized labels:** stale-sync 'Refresh'/'Refresh Now' and item-repair 'Reconnect'/'Update <Inst>' drift removed (one shared source).
- Renamed types kept behind deprecated typealias shims (no churn); legacy case names/raw values byte-stable (Codable/Equatable snapshots intact).
- `Route.from` extended for window-first deep-link from a RecoveryAction.

Rebased onto current main (incl. #5). Strict build ✅, `swift test` ✅ 2179. +18 tests.