### PR TITLE
fix(ai): strip quote/delimiters from merchant FM prompt (injection symmetry with #639)

### DIFF
--- a/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
@@ -78,7 +78,13 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
     /// read as an instruction. The constrained-enum output further guarantees a
     /// valid category regardless of any injection attempt.
     static func sanitizedMerchant(_ raw: String, maxLength: Int = 64) -> String {
-        let separators = CharacterSet.whitespacesAndNewlines.union(.controlCharacters)
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(.controlCharacters)
+            // Strip the structural prompt delimiters too — the merchant is embedded
+            // inside a quoted value (`"Categorize this merchant: \"…\""`), so a name
+            // containing a quote/`;`/`:` could otherwise close the quote and inject
+            // same-line instructions. Mirrors `CategorySuggestionContext.sanitizedLine`.
+            .union(CharacterSet(charactersIn: "\";:"))
         let collapsed = raw
             .components(separatedBy: separators)
             .filter { !$0.isEmpty }


### PR DESCRIPTION
Follow-up flagged during #639 review. The bare-merchant FM categorizer embedded the merchant in a quoted prompt (`"Categorize this merchant: \"…\""`) but only collapsed whitespace/control chars — a merchant containing `"`/`;`/`:` could break out and inject same-line instructions (milder than the #639 case since output is enum-constrained). Now strips those delimiters, mirroring `CategorySuggestionContext.sanitizedLine`. App-target seam (not unit-testable); strict build + full suite green.