### PR TITLE
fix(privacy): clear Spotlight when system controls mask

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4160,11 +4160,14 @@ final class AppState {
             balanceHistory: balanceHistory
         ).cashflow
 
+        let systemSurfaceMaskEnabled = shouldMaskFinancialValues
+            || ((try? PrivacyMaskControlCommandReader.peek()?.maskEnabled) == true)
+
         let snapshot = FinanceSnapshotBuilder.make(
             accounts: accounts,
             recurringTransactions: recurringTransactions,
             cashflow: cashflow,
-            isMasked: shouldMaskFinancialValues,
+            isMasked: systemSurfaceMaskEnabled,
             transactions: transactions,
             reviewMetadata: transactionReviewMetadata,
             transactionRules: transactionRules,
@@ -4185,11 +4188,12 @@ final class AppState {
         // Keep the display-only Spotlight account index in lockstep with the
         // finance snapshot: this is the shared seam for account load/refresh
         // (via `writeGlanceSnapshot`), demo data, and the Privacy Mask / App Lock
-        // transitions (`togglePrivacyMask` / `lockApp`). `refresh` clears the
-        // index when masked, so masking removes account names from system search
-        // immediately; the empty-accounts clear lives in `writeGlanceSnapshot` /
-        // `clearGlanceSnapshot` (AND-513).
-        AccountSpotlightIndexer.refresh(accounts: accounts, isMasked: shouldMaskFinancialValues)
+        // transitions (`togglePrivacyMask` / `lockApp`). Pending background ON
+        // commands are also treated as masked so automatic refreshes cannot
+        // re-publish account names before the next app activation consumes the
+        // command. `refresh` clears the index when masked; the empty-accounts
+        // clear lives in `writeGlanceSnapshot` / `clearGlanceSnapshot` (AND-513).
+        AccountSpotlightIndexer.refresh(accounts: accounts, isMasked: systemSurfaceMaskEnabled)
     }
 
     private func clearGlanceSnapshot() async {

--- a/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
+++ b/Sources/PlaidBar/Controls/PrivacyMaskControlCommandReader.swift
@@ -68,6 +68,21 @@ enum PrivacyMaskControlCommandReader {
         return try decoder.decode(PrivacyMaskControlCommand.self, from: data)
     }
 
+    /// Reads the pending privacy command without consuming it. This is a defensive
+    /// system-surface guard for background refresh paths: when Control Center or a
+    /// Focus filter has requested Privacy Mask while the app is still backgrounded,
+    /// later app-side snapshot/Spotlight writes must treat the pending ON command
+    /// as masked until activation consumes it.
+    static func peek(
+        directory: URL = directory(),
+        fileManager: FileManager = .default
+    ) throws -> PrivacyMaskControlCommand? {
+        let url = commandURL(directory: directory)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(PrivacyMaskControlCommand.self, from: data)
+    }
+
     /// Writes a pending privacy command into the shared container so it is applied
     /// on the next `applyPendingPrivacyMaskControlCommand()` activation — the same
     /// channel the Control Center toggle uses (`WidgetControlCommandStore`), but

--- a/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
+++ b/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
@@ -89,7 +89,9 @@ struct FocusPrivacyFilterIntent: SetFocusFilterIntent {
                 // Spotlight account-name domain here prevents searchable account
                 // names from lingering until the app next foregrounds and applies
                 // the queued command.
-                AccountSpotlightIndexer.clear()
+                await MainActor.run {
+                    AccountSpotlightIndexer.clear()
+                }
             }
             // Reload the Control Center toggle + widgets so the "Privacy Mask"
             // control reflects the new state even before the app applies it.

--- a/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
+++ b/Sources/PlaidBar/Intents/FocusPrivacyFilterIntent.swift
@@ -85,6 +85,11 @@ struct FocusPrivacyFilterIntent: SetFocusFilterIntent {
             // the non-leaking direction, and only the app holds the real numbers.
             if outcome.desiredMaskEnabled {
                 PrivacyMaskControlCommandReader.redactPublishedSnapshots()
+                // Focus filters run while the app may be backgrounded. Clearing the
+                // Spotlight account-name domain here prevents searchable account
+                // names from lingering until the app next foregrounds and applies
+                // the queued command.
+                AccountSpotlightIndexer.clear()
             }
             // Reload the Control Center toggle + widgets so the "Privacy Mask"
             // control reflects the new state even before the app applies it.

--- a/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
+++ b/Sources/PlaidBar/Spotlight/AccountSpotlightIndexer.swift
@@ -72,7 +72,7 @@ enum AccountSpotlightIndexer {
     /// Groups VaultPeek's searchable items so the whole set can be replaced or
     /// cleared atomically. `nonisolated` so the display-safe `AccountSpotlightEntry`
     /// (a plain value type) can salt its identifier with it off the main actor.
-    nonisolated static let domainIdentifier = "com.ftchvs.PlaidBar.accounts"
+    nonisolated static let domainIdentifier = PlaidBarConstants.accountSpotlightDomainIdentifier
 
     /// Deep link selecting a result opens — the shared dashboard URL.
     nonisolated static let deepLinkURL = GlanceSnapshot.deepLinkURL

--- a/Sources/PlaidBarCore/Utilities/Constants.swift
+++ b/Sources/PlaidBarCore/Utilities/Constants.swift
@@ -84,6 +84,12 @@ public enum PlaidBarConstants {
     public static let appVersion: String = "1.0.0"
     public static let appName: String = "VaultPeek"
 
+    // System search
+    /// Core Spotlight domain used for VaultPeek account-name results. Kept in Core
+    /// so the app and WidgetKit/Control Center extension clear the same index when
+    /// Privacy Mask or App Lock engages.
+    public static let accountSpotlightDomainIdentifier = "com.ftchvs.PlaidBar.accounts"
+
     // Repository
     public static let repositoryURL: String = "https://github.com/ftchvs/VaultPeek"
 

--- a/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
+++ b/Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift
@@ -1,4 +1,5 @@
 import AppIntents
+import CoreSpotlight
 import PlaidBarCore
 import SwiftUI
 import WidgetKit
@@ -428,6 +429,9 @@ struct SetPrivacyMaskIntent: SetValueIntent {
                 try? AppGroupSnapshotStore.save(snapshot.masked())
             }
             try? GlanceSnapshotStore.redactIfAvailable()
+            try? await CSSearchableIndex.default().deleteSearchableItems(
+                withDomainIdentifiers: [PlaidBarConstants.accountSpotlightDomainIdentifier]
+            )
         }
         // Reload the widgets + controls so the toggle and every figure reflect the
         // new state even before the app has applied the command and rewritten the

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -112,8 +112,8 @@ struct PlaidBarTests {
         #expect(planningSource.contains("ProgressView(value: summary.overallFraction)"))
     }
 
-    @Test("Control and Focus privacy mask paths redact both App Group snapshots")
-    func privacyMaskControlPathsRedactEveryPublishedSnapshot() throws {
+    @Test("Control and Focus privacy mask paths redact snapshots and clear Spotlight")
+    func privacyMaskControlPathsRedactEveryPublishedSystemSurface() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let widgetSource = try String(
             contentsOf: root.appending(path: "Sources/PlaidBarWidgetExtension/PlaidBarWidgetBundle.swift"),
@@ -129,7 +129,9 @@ struct PlaidBarTests {
         )
 
         #expect(widgetSource.contains("GlanceSnapshotStore.redactIfAvailable()"))
+        #expect(widgetSource.contains("deleteSearchableItems(withDomainIdentifiers: [PlaidBarConstants.accountSpotlightDomainIdentifier])"))
         #expect(focusSource.contains("PrivacyMaskControlCommandReader.redactPublishedSnapshots()"))
+        #expect(focusSource.contains("AccountSpotlightIndexer.clear()"))
         #expect(appStateSource.contains("queued OFF command must restore the"))
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -129,9 +129,12 @@ struct PlaidBarTests {
         )
 
         #expect(widgetSource.contains("GlanceSnapshotStore.redactIfAvailable()"))
-        #expect(widgetSource.contains("deleteSearchableItems(withDomainIdentifiers: [PlaidBarConstants.accountSpotlightDomainIdentifier])"))
+        #expect(widgetSource.contains("deleteSearchableItems("))
+        #expect(widgetSource.contains("withDomainIdentifiers: [PlaidBarConstants.accountSpotlightDomainIdentifier]"))
         #expect(focusSource.contains("PrivacyMaskControlCommandReader.redactPublishedSnapshots()"))
+        #expect(focusSource.contains("MainActor.run"))
         #expect(focusSource.contains("AccountSpotlightIndexer.clear()"))
+        #expect(appStateSource.contains("PrivacyMaskControlCommandReader.peek()?.maskEnabled"))
         #expect(appStateSource.contains("queued OFF command must restore the"))
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }


### PR DESCRIPTION
## Summary

- Fixes #643 by clearing VaultPeek's Core Spotlight account-name domain when Privacy Mask is enabled from Control Center or Focus before the main app foregrounds.
- Adds a shared `PlaidBarConstants.accountSpotlightDomainIdentifier` so app and widget extension clear the same domain.
- Extends the existing source-invariant privacy test to require both snapshot redaction and Spotlight clearing.

## Verification

- `git diff --check`
- `swift build --target PlaidBarWidgetExtension -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`

## Blocked broader gate

- `swift test --filter privacyMaskControlPathsRedactEveryPublishedSystemSurface` and `swift build --target PlaidBar -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` are blocked before this app/test slice executes by the existing SwiftData macro toolchain issue in `Sources/PlaidBarCache/*`: `external macro implementation type 'SwiftDataMacros.PersistentModelMacro' could not be found` / `SwiftDataMacros.PersistentModelActorMacro`.

## Privacy/security

- No Plaid credentials, provider tokens, account IDs, transaction IDs, balances, prompts, or raw payloads are introduced or logged.
- OFF/reveal still defers to the app state path; the widget/control path only removes indexed account-name search results and redacts already-published snapshots.

Linear: AND-648
