### PR TITLE
refactor: extract recurring obligations count/detail copy → PlaidBarCore

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -439,21 +439,13 @@ struct PlanningDestinationView: View {
                     label: "Committed monthly",
                     value: PrivacyMaskPresentation.currency(recurring.estimatedMonthlyTotal, format: .compact, isEnabled: masked),
                     systemImage: "repeat",
-                    detail: recurringDetail(recurring),
+                    detail: recurring.detailLine,
                     accent: .secondary
                 )
             )
         }
 
         return tiles
-    }
-
-    private func recurringDetail(_ recurring: RecurringObligationsPresentation) -> String {
-        let charges = "\(recurring.count) recurring charge\(recurring.count == 1 ? "" : "s")"
-        if recurring.attentionCount > 0 {
-            return "\(charges) · \(recurring.attentionCount) need attention"
-        }
-        return charges
     }
 }
 

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -78,7 +78,7 @@ struct RecurringObligationsSection: View {
     }
 
     private var accessibilitySummary: String {
-        let countText = "\(presentation.count) recurring \(presentation.count == 1 ? "charge" : "charges")"
+        let countText = presentation.countLabel
         let total = PrivacyMaskPresentation.currency(
             presentation.estimatedMonthlyTotal,
             format: .full,

--- a/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
@@ -90,6 +90,21 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
     public var isEmpty: Bool { items.isEmpty }
     public var count: Int { items.count }
 
+    /// "N recurring charge(s)" — the count phrase shared across surfaces (the
+    /// Planning hero tile and the recurring section's accessibility summary both
+    /// spelled this inline). Pluralizes only the noun.
+    public var countLabel: String {
+        "\(count) recurring charge\(count == 1 ? "" : "s")"
+    }
+
+    /// Planning hero-tile detail line: the count phrase, plus a mid-dot attention
+    /// clause when any series is flagged. The "N need attention" clause is
+    /// intentionally not pluralized on N (pre-existing copy, preserved verbatim).
+    public var detailLine: String {
+        guard attentionCount > 0 else { return countLabel }
+        return "\(countLabel) · \(attentionCount) need attention"
+    }
+
     /// Build the presentation from detected recurring series.
     ///
     /// Ordering: likely-forgotten subscriptions first (so "you may have forgotten

--- a/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
@@ -122,6 +122,56 @@ struct RecurringObligationsPresentationTests {
         #expect(RecurringConfidenceLevel(confidence: 0.59) == .low)
     }
 
+    @Test("countLabel pluralizes only the noun (0 / 1 / many)")
+    func countLabelGrammar() {
+        let none = RecurringObligationsPresentation.make(from: [], asOf: Self.asOf)
+        #expect(none.countLabel == "0 recurring charges")
+
+        let one = RecurringObligationsPresentation.make(from: [recurring(merchantName: "Spotify")], asOf: Self.asOf)
+        #expect(one.countLabel == "1 recurring charge")
+
+        let many = RecurringObligationsPresentation.make(
+            from: [recurring(merchantName: "Spotify"), recurring(merchantName: "iCloud")],
+            asOf: Self.asOf
+        )
+        #expect(many.countLabel == "2 recurring charges")
+    }
+
+    @Test("detailLine appends the attention clause only when something is flagged")
+    func detailLineAttentionClause() {
+        // No flags → just the count phrase.
+        let clean = RecurringObligationsPresentation.make(
+            from: [recurring(merchantName: "Spotify"), recurring(merchantName: "iCloud")],
+            asOf: Self.asOf
+        )
+        #expect(clean.attentionCount == 0)
+        #expect(clean.detailLine == "2 recurring charges")
+
+        // One flagged (price increase) → mid-dot attention clause.
+        let flagged = RecurringObligationsPresentation.make(
+            from: [
+                recurring(merchantName: "Gym", latestAmount: 22, trailingAverageAmount: 20, confidence: 0.95),
+                recurring(merchantName: "Spotify"),
+            ],
+            asOf: Self.asOf
+        )
+        #expect(flagged.attentionCount == 1)
+        // "N need attention" is intentionally NOT pluralized on N (pre-existing copy).
+        #expect(flagged.detailLine == "2 recurring charges · 1 need attention")
+
+        // Multiple flagged → clause carries the count; still no verb pluralization.
+        let multiFlagged = RecurringObligationsPresentation.make(
+            from: [
+                recurring(merchantName: "Gym", latestAmount: 22, trailingAverageAmount: 20, confidence: 0.95),
+                recurring(merchantName: "Dormant", lastDate: "2026-01-01"),
+                recurring(merchantName: "Spotify"),
+            ],
+            asOf: Self.asOf
+        )
+        #expect(multiFlagged.attentionCount == 2)
+        #expect(multiFlagged.detailLine == "3 recurring charges · 2 need attention")
+    }
+
     @Test("Stream flags expose label + icon so they never read through color alone")
     func flagDisplayMetadata() {
         #expect(RecurringStreamFlag.priceIncrease.label == "Price up")


### PR DESCRIPTION
## Summary

- Extracts the `"N recurring charge(s)"` count phrase + the Planning hero-tile detail line into two pure, `Sendable` computed properties on `RecurringObligationsPresentation` (already in `PlaidBarCore`): `countLabel` and `detailLine`.
- The count phrase was duplicated across two surfaces with different source spelling but byte-identical output: `PlanningDestinationView.recurringDetail` (suffix `charge`+`"s"`) and `RecurringObligationsSection.accessibilitySummary` (noun-swap `charge`/`charges`). Both now delegate to `countLabel`.
- `PlanningDestinationView`'s inline+untested `recurringDetail` helper is deleted; the view uses `recurring.detailLine`.
- Behavior-preserving: the `"N need attention"` clause is intentionally left non-pluralized on N to match the prior copy exactly (pinned in tests).

Continues the architecture thesis — pure presentation logic belongs in `PlaidBarCore`, app/views stay thin (follows prior runs that extracted Budgets/Goals hero detail copy).

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` pass (Step 9)
- Backlog slice: behavior-preserving AppState/view → Core extraction
- Scope note: one focused, pure-logic extraction; no product behavior change

## Agent coordination

- Builder agent: Claude (scheduled autonomous refactor task)
- Builder branch/worktree: `refactor/auto-2026-06-23` (worktree off `origin/main`)
- Reviewer/merge steward: Otto / Felipe
- Coordination note: review only — no other agent should push to this branch

## Changed files

- `Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift` — add `countLabel`, `detailLine`
- `Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift` — delegate to `detailLine`; delete inline helper
- `Sources/PlaidBar/Views/RecurringObligationsSection.swift` — delegate count phrase to `countLabel`
- `Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift` — +2 tests pinning grammar/clause

## Local gates

- [x] `git diff --check` (clean)
- [x] Strict-concurrency build clean: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (the CI gate; all 3 targets)
- [x] `swift test` — full suite **2181 tests green** (incl. the sometimes-flaky LocalInsightModelRuntime test, passed this run); `--filter RecurringObligationsPresentation` 9/9
- [x] Secret scan completed over the diff — none found
- Demo app boot-smoke: `.build/debug/PlaidBar --demo` ran 9s, no crash

## Privacy and safety impact

- [x] Synthetic/demo data only; no real Plaid credentials, tokens, account IDs, or balances
- [x] Local-first boundary unchanged (no backend/telemetry/cloud)
- [x] User-facing copy unchanged (strings byte-identical)

## UI and accessibility checks

- [x] No visual/behavioral UI change — the rendered/announced strings are byte-identical (verified by an adversarial review + golden-string tests). The `accessibilitySummary` text is unchanged.

## Merge safety

- [x] Final diff reviewed for secrets, private data, scope creep — clean (+55/−10, 4 files)
- [ ] PR head SHA rechecked immediately before merge
- [x] No other agent is mutating this branch/worktree