### PR TITLE
fix(privacy): mask recurring count copy

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -439,7 +439,7 @@ struct PlanningDestinationView: View {
                     label: "Committed monthly",
                     value: PrivacyMaskPresentation.currency(recurring.estimatedMonthlyTotal, format: .compact, isEnabled: masked),
                     systemImage: "repeat",
-                    detail: recurringDetail(recurring),
+                    detail: recurringDetail(recurring, privacyMaskEnabled: masked),
                     accent: .secondary
                 )
             )
@@ -448,12 +448,11 @@ struct PlanningDestinationView: View {
         return tiles
     }
 
-    private func recurringDetail(_ recurring: RecurringObligationsPresentation) -> String {
-        let charges = "\(recurring.count) recurring charge\(recurring.count == 1 ? "" : "s")"
-        if recurring.attentionCount > 0 {
-            return "\(charges) · \(recurring.attentionCount) need attention"
-        }
-        return charges
+    private func recurringDetail(
+        _ recurring: RecurringObligationsPresentation,
+        privacyMaskEnabled: Bool
+    ) -> String {
+        recurring.detailLine(privacyMaskEnabled: privacyMaskEnabled)
     }
 }
 

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -36,7 +36,7 @@ struct RecurringObligationsSection: View {
                 }
 
                 if presentation.count > visibleLimit {
-                    Text("+\(presentation.count - visibleLimit) more")
+                    Text(privacyMaskEnabled ? "More recurring charges" : "+\(presentation.count - visibleLimit) more")
                         .microText()
                         .foregroundStyle(.secondary)
                 }
@@ -78,13 +78,13 @@ struct RecurringObligationsSection: View {
     }
 
     private var accessibilitySummary: String {
-        let countText = "\(presentation.count) recurring \(presentation.count == 1 ? "charge" : "charges")"
+        let countText = presentation.countLabel(privacyMaskEnabled: privacyMaskEnabled)
         let total = PrivacyMaskPresentation.currency(
             presentation.estimatedMonthlyTotal,
             format: .full,
             isEnabled: privacyMaskEnabled
         )
-        let attention = presentation.attentionCount > 0
+        let attention = !privacyMaskEnabled && presentation.attentionCount > 0
             ? " \(presentation.attentionCount) need attention."
             : ""
         return "\(countText), about \(total) per month.\(attention)"

--- a/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
+++ b/Sources/PlaidBarCore/Models/RecurringObligationsPresentation.swift
@@ -90,6 +90,21 @@ public struct RecurringObligationsPresentation: Sendable, Hashable {
     public var isEmpty: Bool { items.isEmpty }
     public var count: Int { items.count }
 
+    /// Shared count phrase for recurring surfaces. Privacy Mask/App Lock withholds
+    /// exact counts because they are behavioral finance metadata even when amounts
+    /// are already redacted.
+    public func countLabel(privacyMaskEnabled: Bool = false) -> String {
+        privacyMaskEnabled ? "Recurring charges" : "\(count) recurring charge\(count == 1 ? "" : "s")"
+    }
+
+    /// Shared detail line for compact summary surfaces. In masked mode this avoids
+    /// both the exact recurring count and the exact attention count.
+    public func detailLine(privacyMaskEnabled: Bool = false) -> String {
+        let label = countLabel(privacyMaskEnabled: privacyMaskEnabled)
+        guard !privacyMaskEnabled, attentionCount > 0 else { return label }
+        return "\(label) · \(attentionCount) need attention"
+    }
+
     /// Build the presentation from detected recurring series.
     ///
     /// Ordering: likely-forgotten subscriptions first (so "you may have forgotten

--- a/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/RecurringObligationsPresentationTests.swift
@@ -122,6 +122,25 @@ struct RecurringObligationsPresentationTests {
         #expect(RecurringConfidenceLevel(confidence: 0.59) == .low)
     }
 
+    @Test("Recurring count copy withholds exact counts when Privacy Mask is active")
+    func privacyMaskedCountCopyWithholdsExactCounts() {
+        let presentation = RecurringObligationsPresentation.make(
+            from: [
+                recurring(merchantName: "Gym", latestAmount: 22, trailingAverageAmount: 20, confidence: 0.95),
+                recurring(merchantName: "Dormant", lastDate: "2026-01-01"),
+                recurring(merchantName: "Spotify"),
+            ],
+            asOf: Self.asOf
+        )
+
+        #expect(presentation.count == 3)
+        #expect(presentation.attentionCount == 2)
+        #expect(presentation.countLabel() == "3 recurring charges")
+        #expect(presentation.detailLine() == "3 recurring charges · 2 need attention")
+        #expect(presentation.countLabel(privacyMaskEnabled: true) == "Recurring charges")
+        #expect(presentation.detailLine(privacyMaskEnabled: true) == "Recurring charges")
+    }
+
     @Test("Stream flags expose label + icon so they never read through color alone")
     func flagDisplayMetadata() {
         #expect(RecurringStreamFlag.priceIncrease.label == "Price up")


### PR DESCRIPTION
## Summary

Fixes #647 and AND-649 by treating exact recurring-obligation counts as privacy-sensitive summary metadata under Privacy Mask/App Lock.

- Adds a Core recurring count/detail copy helper that preserves exact normal-mode copy but returns generic `Recurring charges` when masked.
- Uses the masked helper for the Planning "Committed monthly" hero detail.
- Withholds exact recurring overflow counts and attention counts from the recurring section's masked visual/VoiceOver summary.

## Verification

- `git diff --check` ✅
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` ✅
- `swift test --filter RecurringObligationsPresentationTests/privacyMaskedCountCopyWithholdsExactCounts -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` blocked before test execution by existing SwiftData macro/toolchain errors in `Sources/PlaidBarCache/*`.
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` blocked by unrelated deprecated test-helper warnings in `Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift` / `DashboardStatusReadinessTests.swift`.
- `swift build --target PlaidBar` blocked by existing SwiftData macro/plugin errors in `Sources/PlaidBarCache/*`.

## Privacy/security

No Plaid credentials, tokens, raw payloads, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies are moved or logged. This is a local UI/VoiceOver copy fix only.
