### PR TITLE
fix: make broad strict Swift gates pass

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,10 +114,10 @@ let package = Package(
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
 
-        // MARK: - PlaidBarCache (Disposable SwiftData read-model cache, AND-566)
-        // App-only library so the SwiftData dependency never reaches the lean
-        // server / CLI / widget targets. Holds the @Model + @ModelActor store;
-        // the pure read-model + mapper live in PlaidBarCore.
+        // MARK: - PlaidBarCache (Disposable file-backed read-model cache, AND-566)
+        // App-only library so private financial cache reads stay out of the lean
+        // server / CLI / widget targets. The pure read-model + mapper live in
+        // PlaidBarCore; this target only persists disposable local snapshots.
         .target(
             name: "PlaidBarCache",
             dependencies: ["PlaidBarCore"],

--- a/Sources/PlaidBar/App/AppState+ReadModelCache.swift
+++ b/Sources/PlaidBar/App/AppState+ReadModelCache.swift
@@ -3,7 +3,7 @@ import OSLog
 import PlaidBarCache
 import PlaidBarCore
 
-/// AppState wiring for the disposable SwiftData read-model cache (AND-566).
+/// AppState wiring for the disposable read-model cache (AND-566).
 ///
 /// Two seams only:
 ///   1. **Cold-start hydrate** — `hydrateFromReadModelCache()` runs inside

--- a/Sources/PlaidBar/App/AppState+TransactionCache.swift
+++ b/Sources/PlaidBar/App/AppState+TransactionCache.swift
@@ -3,7 +3,7 @@ import OSLog
 import PlaidBarCache
 import PlaidBarCore
 
-/// AppState wiring for the disposable per-transaction SwiftData cache that backs
+/// AppState wiring for the disposable per-transaction cache that backs
 /// the virtualized large-history list (AND-567).
 ///
 /// Built on the AND-566 seams: it reuses ``readModelCacheKey()`` for environment

--- a/Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 import FoundationModels
 #endif
 
@@ -28,7 +28,7 @@ struct FoundationModelsIncomeCategorizer: FMIncomeCategorizing {
     func suggestIncomeCategory(context: CategorySuggestionContext) async -> String? {
         guard context.hasMerchantSignal else { return nil }
 
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
         if #available(macOS 26, *) {
             let fragment = context.promptFragment()
             return await Self.generate(prompt: "Classify this income transaction. \(fragment)")
@@ -41,7 +41,7 @@ struct FoundationModelsIncomeCategorizer: FMIncomeCategorizing {
     }
 }
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 @available(macOS 26, *)
 extension FoundationModelsIncomeCategorizer {
     /// The constrained generation target: a `@Generable` enum whose cases mirror

--- a/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 import FoundationModels
 #endif
 
@@ -23,7 +23,7 @@ import FoundationModels
 /// schema into the Core `FoundationModelsInsightContent` → display string.
 ///
 /// Availability/reversibility: the whole type is gated behind
-/// `#available(macOS 26, *)` + `#if canImport(FoundationModels)`. When Foundation
+/// `#available(macOS 26, *)` + `#if canImport(FoundationModels) && canImport(FoundationModelsMacros)`. When Foundation
 /// Models is not the active/available tier, the routing decision
 /// (`FoundationModelsInsightRouting`) never selects this engine and the existing
 /// path runs byte-identically. `summarize` additionally re-checks availability
@@ -31,7 +31,7 @@ import FoundationModels
 /// route degrades to the deterministic fallback rather than rendering nothing.
 struct FoundationModelsInsightModel: LocalInsightModel {
     func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
         if #available(macOS 26, *) {
             return try await Self.generate(prompt: prompt, maxTokens: maxTokens)
         } else {
@@ -43,7 +43,7 @@ struct FoundationModelsInsightModel: LocalInsightModel {
     }
 }
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 @available(macOS 26, *)
 extension FoundationModelsInsightModel {
     /// The schema-guaranteed spending insight. The system prompt

--- a/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 import FoundationModels
 #endif
 
@@ -40,7 +40,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
         let cleaned = Self.sanitizedMerchant(merchant)
         guard !cleaned.isEmpty else { return nil }
 
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
         if #available(macOS 26, *) {
             return await Self.generate(prompt: "Categorize this merchant: \"\(cleaned)\"")
         } else {
@@ -60,7 +60,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
     func suggestCategory(context: CategorySuggestionContext) async -> String? {
         guard context.hasMerchantSignal else { return nil }
 
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
         if #available(macOS 26, *) {
             let fragment = context.promptFragment()
             return await Self.generate(prompt: "Categorize this transaction. \(fragment)")
@@ -93,7 +93,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
     }
 }
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 @available(macOS 26, *)
 extension FoundationModelsMerchantCategorizer {
     /// The constrained generation target: a `@Generable` enum whose cases mirror

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -530,7 +530,9 @@ private struct DataModeChip: View {
 // placeholder it showed inline before (`DestinationPlaceholder`), preserving
 // current behavior; the 2-col vs 3-col policy is applied in `body` above.
 
+#if canImport(PreviewsMacros)
 #Preview {
     AppShellView()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -220,6 +220,7 @@ private struct SeverityStatusBadge: View {
 // `swift test`). Without this guard the whole package fails to compile, taking
 // the test suite down with it (#314).
 #if !SWIFT_PACKAGE
+#if canImport(PreviewsMacros)
 #Preview("Attention rows") {
     VStack(spacing: Spacing.xs) {
         AttentionQueueRowView(
@@ -249,4 +250,5 @@ private struct SeverityStatusBadge: View {
     .padding()
     .frame(width: 360)
 }
+#endif
 #endif

--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -513,14 +513,18 @@ private struct AccountListRow: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     AccountsDestinationView()
         .environment(AppState())
         .frame(width: 640, height: 480)
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     AccountsDestinationView.Inspector()
         .environment(AppState())
         .frame(width: 320, height: 480)
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AlertsDestinationView.swift
@@ -523,12 +523,16 @@ private struct AlertSeverityBadge: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     AlertsDestinationView()
         .environment(AppState())
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     AlertsDestinationView.Inspector()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -603,12 +603,16 @@ struct BudgetsDestinationView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     BudgetsDestinationView()
         .environment(AppState())
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     BudgetsDestinationView.Inspector()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -320,7 +320,9 @@ struct DashboardDestinationView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     DashboardDestinationView()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
@@ -51,9 +51,11 @@ struct DashboardRecurringCard: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     DashboardRecurringCard(onOpen: {})
         .environment(AppState())
         .padding()
         .frame(width: 360)
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/DestinationPlaceholder.swift
+++ b/Sources/PlaidBar/Views/Destinations/DestinationPlaceholder.swift
@@ -52,10 +52,14 @@ struct DestinationInspectorPlaceholder: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content placeholder") {
     DestinationPlaceholder(destination: .dashboard)
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector placeholder") {
     DestinationInspectorPlaceholder(destination: .review)
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/GoalEditorSheet.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalEditorSheet.swift
@@ -203,7 +203,9 @@ struct GoalEditorSheet: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("New") {
     GoalEditorSheet(state: .creating)
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/GoalsDestinationView.swift
@@ -560,14 +560,18 @@ private struct GoalDetailPane: View {
     }()
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     GoalsDestinationView()
         .environment(AppState())
         .frame(width: 720, height: 600)
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     GoalsDestinationView.Inspector()
         .environment(AppState())
         .frame(width: 360, height: 600)
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
@@ -117,7 +117,9 @@ struct InsightsDestinationView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     InsightsDestinationView()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -456,7 +456,9 @@ struct PlanningDestinationView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     PlanningDestinationView()
         .environment(AppState())
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
@@ -400,10 +400,14 @@ private enum ReviewReasonGuide {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     ReviewDestinationView()
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     ReviewDestinationView.Inspector()
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -339,14 +339,18 @@ final class BuiltRowCache {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Content") {
     TransactionsDestinationView()
         .environment(AppState())
         .frame(width: 640, height: 480)
 }
+#endif
 
+#if canImport(PreviewsMacros)
 #Preview("Inspector") {
     TransactionsDestinationView.Inspector()
         .environment(AppState())
         .frame(width: 320, height: 480)
 }
+#endif

--- a/Sources/PlaidBar/Views/Destinations/WindowSection.swift
+++ b/Sources/PlaidBar/Views/Destinations/WindowSection.swift
@@ -170,6 +170,7 @@ extension View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Window section") {
     VStack(spacing: WindowMetrics.lg) {
         HStack(spacing: WindowMetrics.lg) {
@@ -201,3 +202,4 @@ extension View {
     .padding(WindowMetrics.canvasMargin)
     .frame(width: 720)
 }
+#endif

--- a/Sources/PlaidBarCache/CachedDashboardReadModel.swift
+++ b/Sources/PlaidBarCache/CachedDashboardReadModel.swift
@@ -1,31 +1,16 @@
 import Foundation
-import SwiftData
 
-/// SwiftData row backing the disposable dashboard read-model cache (AND-566).
+/// Row backing the disposable dashboard read-model cache (AND-566).
 ///
-/// The structured, authoritative payload is the pure ``DashboardReadModel``
-/// value type in `PlaidBarCore`; this `@Model` stores that value as a single
-/// JSON `payload` blob alongside two queryable scalar columns (`cacheKey`,
-/// `schemaVersion`). Keeping the SwiftData schema to three flat, primitive
-/// properties is deliberate:
-///
-/// - The store is **disposable**: with no relationships and no per-field schema
-///   to migrate, a shape change is handled by bumping
-///   ``DashboardReadModel/currentSchemaVersion`` and treating mismatched rows as
-///   a cache miss — the file can always be deleted and rebuilt from the
-///   authoritative refresh.
-/// - The Codable round-trip is already proven by `DashboardReadModelMapper`
-///   tests, so the on-disk format inherits that guarantee instead of forking a
-///   second SwiftData-specific mapping.
-///
-/// `@Model` classes are reference types and are **not** `Sendable`; instances of
-/// this type never leave ``ReadModelCacheStore``'s actor isolation. Only the
-/// `Sendable` ``DashboardReadModel`` value crosses the boundary.
-@Model
-final class CachedDashboardReadModel {
+/// The authoritative payload is the pure ``DashboardReadModel`` value type in
+/// `PlaidBarCore`; this row stores that value as a JSON `payload` blob alongside
+/// two queryable scalar columns (`cacheKey`, `schemaVersion`). The store is
+/// deliberately disposable: a schema mismatch is a cache miss and the file can be
+/// deleted and rebuilt from the authoritative refresh at any time.
+struct CachedDashboardReadModel: Codable, Equatable, Sendable {
     /// Environment + data-dir scoped key. Unique so the cache holds exactly one
     /// row per environment (the last-known dashboard).
-    @Attribute(.unique) var cacheKey: String
+    var cacheKey: String
     /// The schema version the payload was written with, mirrored out of the blob
     /// so a version sweep can run without decoding every row.
     var schemaVersion: Int

--- a/Sources/PlaidBarCache/CachedTransaction.swift
+++ b/Sources/PlaidBarCache/CachedTransaction.swift
@@ -1,38 +1,16 @@
 import Foundation
-import SwiftData
 
-/// SwiftData row backing the disposable **per-transaction** cache used for
-/// large-history paging (AND-567).
+/// Row backing the disposable **per-transaction** cache used for large-history
+/// paging (AND-567).
 ///
 /// Like ``CachedDashboardReadModel``, this is a disposable read-model row, never a
 /// source of truth: it is written *after* a successful decode from the
 /// authoritative DTOs and read back in pages to feed a virtualized list. The file
 /// can be deleted at any time and rebuilt from the next refresh.
-///
-/// ## Shape
-/// The authoritative ``TransactionDTO`` is stored as a single JSON `payload` blob
-/// alongside flat, queryable scalar columns:
-/// - `uniqueKey` — `@Attribute(.unique)`, `"<cacheKey>|<transactionId>"`. Making
-///   the key composite means a re-sync of the same transaction **upserts** (the
-///   unique constraint replaces the row) while two Plaid environments sharing one
-///   store file can never collide on a bare transaction id.
-/// - `cacheKey` — environment + data-dir scope, so a page read filters to the
-///   active environment.
-/// - `sortDate` — the `YYYY-MM-DD` string (lexicographically sortable), used as the
-///   primary newest-first sort key; `transactionId` breaks ties for a stable order.
-///
-/// Keeping the schema to flat primitives + one blob mirrors the AND-566 cache: a
-/// shape change is handled by bumping the disposable store filename and deleting
-/// the old file, not by a SwiftData migration.
-///
-/// `@Model` classes are reference types and are **not** `Sendable`; instances of
-/// this type never leave ``TransactionCacheStore``'s actor isolation. Only the
-/// `Sendable` ``TransactionDTO`` value crosses the boundary.
-@Model
-final class CachedTransaction {
+struct CachedTransaction: Codable, Equatable, Sendable {
     /// `"<cacheKey>|<transactionId>"`. Unique so a re-synced transaction replaces
     /// its row in place (upsert) instead of duplicating.
-    @Attribute(.unique) var uniqueKey: String
+    var uniqueKey: String
     /// Environment + data-dir scope key (matches the dashboard cache's key space).
     var cacheKey: String
     /// Plaid `transaction_id`, mirrored out of the blob for tie-breaking the sort.

--- a/Sources/PlaidBarCache/ReadModelCacheStore+Factory.swift
+++ b/Sources/PlaidBarCache/ReadModelCacheStore+Factory.swift
@@ -1,19 +1,17 @@
 import Foundation
-import SwiftData
 
 public extension ReadModelCacheStore {
     /// Opens the disposable on-disk cache store under `directory` (the local
     /// private data dir). Throwing initializer: AppState wraps construction in
-    /// `try?` so a SwiftData failure leaves the app on its existing cold path.
+    /// `try?` so a store failure leaves the app on its existing cold path.
     init(onDiskIn directory: URL, fileManager: FileManager = .default) throws {
-        let container = try ReadModelCacheStore.makeOnDiskContainer(in: directory, fileManager: fileManager)
-        self.init(modelContainer: container)
+        let storeURL = directory.appendingPathComponent(Self.storeFilename)
+        try self.init(storeURL: storeURL, fileManager: fileManager)
     }
 
     /// Opens an in-memory store (tests and non-persisting fallback).
     init(inMemory: Bool) throws {
         precondition(inMemory, "Use init(onDiskIn:) for the persistent store")
-        let container = try ReadModelCacheStore.makeInMemoryContainer()
-        self.init(modelContainer: container)
+        try self.init(storeURL: nil)
     }
 }

--- a/Sources/PlaidBarCache/ReadModelCacheStore.swift
+++ b/Sources/PlaidBarCache/ReadModelCacheStore.swift
@@ -1,37 +1,34 @@
 import Foundation
 import PlaidBarCore
-import SwiftData
 
-/// Actor-isolated SwiftData store for the **disposable** dashboard read-model
-/// cache (AND-566).
+/// Actor-isolated store for the **disposable** dashboard read-model cache
+/// (AND-566).
 ///
 /// ## Contract
 /// - **Disposable cache, never authoritative.** It is written *after* a
-///   successful refresh/decode from the authoritative in-memory data, and read
-///   on cold start to paint frame 1 before the HTTP refresh returns. The live
-///   refresh then overwrites it. Deleting the store file at any time is safe:
-///   it rebuilds on the next refresh.
-/// - **Fallback-safe.** Every operation is `throws`; callers wrap reads/writes
-///   in `try?` so any SwiftData init/read/write failure (or an unavailable
-///   store) degrades to exactly today's behavior — the empty/loading cold path
-///   driven by the existing JSON/UserDefaults caches.
-///
-/// ## Isolation
-/// `@ModelActor` makes this a `Sendable` actor that owns its non-`Sendable`
-/// `ModelContext`. The `@Model` rows never escape the actor; only the `Sendable`
-/// ``DashboardReadModel`` value is passed in and out, which keeps the
-/// strict-concurrency build clean.
+///   successful refresh/decode from the authoritative in-memory data, and read on
+///   cold start to paint frame 1 before the HTTP refresh returns. Deleting the
+///   store file at any time is safe: it rebuilds on the next refresh.
+/// - **Fallback-safe.** Every operation is `throws`; callers wrap reads/writes in
+///   `try?` so any init/read/write failure degrades to exactly today's behavior —
+///   the empty/loading cold path driven by the existing JSON/UserDefaults caches.
 ///
 /// ## Privacy
 /// The on-disk store lives only in the local private data dir (`~/.vaultpeek/`),
 /// created with `0o700`/`0o600` like the existing SQLite/JSON caches — never the
-/// App Group container or iCloud. See ``makeOnDiskContainer(in:)``.
-@ModelActor
+/// App Group container or iCloud.
 public actor ReadModelCacheStore {
-    /// Filename of the disposable SwiftData store inside the local data dir.
-    /// `v1` is namespaced so a future incompatible store can ship beside it and
-    /// the old file can simply be deleted.
+    /// Filename of the disposable store inside the local data dir. The `.store`
+    /// suffix is preserved for compatibility with existing reset/privacy docs.
     public static let storeFilename = "dashboard-read-model-cache-v1.store"
+
+    private struct Snapshot: Codable, Sendable {
+        var rows: [String: CachedDashboardReadModel]
+    }
+
+    private let storeURL: URL?
+    private let fileManager: FileManager
+    private var rowsByKey: [String: CachedDashboardReadModel]
 
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -46,84 +43,41 @@ public actor ReadModelCacheStore {
         return decoder
     }
 
-    // MARK: - Container factories
-
-    /// Builds the schema for the disposable cache. Single `@Model`, no
-    /// relationships — intentionally trivial so the store stays rebuildable.
-    public static func schema() -> Schema {
-        Schema([CachedDashboardReadModel.self])
-    }
-
-    /// Builds an on-disk container for the disposable store under `directory`
-    /// (the local private data dir). Creates the directory with owner-only
-    /// permissions when missing, then tightens the store file to `0o600` after
-    /// SwiftData materializes it — matching the existing JSON/SQLite caches so
-    /// the financial payload never widens the on-disk privacy boundary.
-    public static func makeOnDiskContainer(
-        in directory: URL,
-        fileManager: FileManager = .default
-    ) throws -> ModelContainer {
-        try fileManager.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
-        let storeURL = directory.appendingPathComponent(storeFilename)
-        let configuration = ModelConfiguration(
-            "DashboardReadModelCache",
-            schema: schema(),
-            url: storeURL,
-            allowsSave: true,
-            cloudKitDatabase: .none
-        )
-        let container = try ModelContainer(for: schema(), configurations: configuration)
-        #if os(macOS)
-        // SwiftData may create sidecar files (-wal/-shm); tighten whatever exists.
-        for suffix in ["", "-wal", "-shm"] {
-            let path = storeURL.path + suffix
-            if fileManager.fileExists(atPath: path) {
-                try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
-            }
+    init(storeURL: URL?, fileManager: FileManager = .default) throws {
+        self.storeURL = storeURL
+        self.fileManager = fileManager
+        if let storeURL, fileManager.fileExists(atPath: storeURL.path) {
+            let data = try Data(contentsOf: storeURL)
+            self.rowsByKey = try Self.decoder.decode(Snapshot.self, from: data).rows
+        } else {
+            self.rowsByKey = [:]
         }
-        #endif
-        return container
-    }
-
-    /// Builds an in-memory container for tests (and as a non-persisting fallback).
-    /// Nothing touches disk.
-    public static func makeInMemoryContainer() throws -> ModelContainer {
-        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        return try ModelContainer(for: schema(), configurations: configuration)
     }
 
     // MARK: - Operations
 
     /// Persists the read-model, replacing any existing row for the same
     /// `cacheKey`. The cache holds a single row per environment, so a save is an
-    /// upsert: the prior row is deleted before the new one is inserted.
+    /// upsert.
     public func save(_ model: DashboardReadModel) throws {
-        let key = model.cacheKey
-        try deleteRow(cacheKey: key)
         let payload = try Self.encoder.encode(model)
-        let row = CachedDashboardReadModel(
-            cacheKey: key,
+        rowsByKey[model.cacheKey] = CachedDashboardReadModel(
+            cacheKey: model.cacheKey,
             schemaVersion: model.schemaVersion,
             payload: payload
         )
-        modelContext.insert(row)
-        try modelContext.save()
+        try persist()
     }
 
     /// Reads the cached read-model for `cacheKey`. Returns `nil` on a miss or
     /// when the stored row is from an older schema (which is also purged so the
-    /// store self-heals). A decode failure throws so the caller's `try?` can
-    /// drop back to today's cold path.
+    /// store self-heals). A decode failure throws so the caller's `try?` can drop
+    /// back to today's cold path.
     public func load(cacheKey: String) throws -> DashboardReadModel? {
-        guard let row = try fetchRow(cacheKey: cacheKey) else { return nil }
+        guard let row = rowsByKey[cacheKey] else { return nil }
         guard row.schemaVersion == DashboardReadModel.currentSchemaVersion else {
-            // Stale schema: discard so the next save writes a clean current row.
-            modelContext.delete(row)
-            try? modelContext.save()
+            rowsByKey.removeValue(forKey: cacheKey)
+            try? persist()
             return nil
         }
         let model = try Self.decoder.decode(DashboardReadModel.self, from: row.payload)
@@ -134,31 +88,28 @@ public actor ReadModelCacheStore {
     /// Removes the row for `cacheKey` (e.g. after a local-data reset). Safe to
     /// call when no row exists.
     public func clear(cacheKey: String) throws {
-        try deleteRow(cacheKey: cacheKey)
-        try modelContext.save()
+        rowsByKey.removeValue(forKey: cacheKey)
+        try persist()
     }
 
     /// Removes every cached row. Used by the local-data reset path so the
     /// disposable cache is wiped alongside the JSON/SQLite caches.
     public func clearAll() throws {
-        try modelContext.delete(model: CachedDashboardReadModel.self)
-        try modelContext.save()
+        rowsByKey.removeAll()
+        try persist()
     }
 
     // MARK: - Private
 
-    private func fetchRow(cacheKey: String) throws -> CachedDashboardReadModel? {
-        // The cache holds at most one row per environment (a handful total), so
-        // fetching all and matching in Swift is cheap. It also sidesteps the
-        // `#Predicate` macro capturing a non-`Sendable` `KeyPath`, which is an
-        // error under the project's Swift 6 strict-concurrency gate.
-        let rows = try modelContext.fetch(FetchDescriptor<CachedDashboardReadModel>())
-        return rows.first { $0.cacheKey == cacheKey }
-    }
-
-    private func deleteRow(cacheKey: String) throws {
-        if let existing = try fetchRow(cacheKey: cacheKey) {
-            modelContext.delete(existing)
-        }
+    private func persist() throws {
+        guard let storeURL else { return }
+        let data = try Self.encoder.encode(Snapshot(rows: rowsByKey))
+        try fileManager.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try data.write(to: storeURL, options: [.atomic])
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storeURL.path)
     }
 }

--- a/Sources/PlaidBarCache/TransactionCacheStore+Factory.swift
+++ b/Sources/PlaidBarCache/TransactionCacheStore+Factory.swift
@@ -1,20 +1,18 @@
 import Foundation
-import SwiftData
 
 public extension TransactionCacheStore {
     /// Opens the disposable on-disk per-transaction cache under `directory` (the
     /// local private data dir). Throwing initializer: AppState wraps construction
-    /// in `try?` so a SwiftData failure leaves the app on its existing in-memory
+    /// in `try?` so a store failure leaves the app on its existing in-memory
     /// rendering path.
     init(onDiskIn directory: URL, fileManager: FileManager = .default) throws {
-        let container = try TransactionCacheStore.makeOnDiskContainer(in: directory, fileManager: fileManager)
-        self.init(modelContainer: container)
+        let storeURL = directory.appendingPathComponent(Self.storeFilename)
+        try self.init(storeURL: storeURL, fileManager: fileManager)
     }
 
     /// Opens an in-memory store (tests and non-persisting fallback).
     init(inMemory: Bool) throws {
         precondition(inMemory, "Use init(onDiskIn:) for the persistent store")
-        let container = try TransactionCacheStore.makeInMemoryContainer()
-        self.init(modelContainer: container)
+        try self.init(storeURL: nil)
     }
 }

--- a/Sources/PlaidBarCache/TransactionCacheStore.swift
+++ b/Sources/PlaidBarCache/TransactionCacheStore.swift
@@ -1,9 +1,8 @@
 import Foundation
 import PlaidBarCore
-import SwiftData
 
-/// Actor-isolated SwiftData store for the **disposable per-transaction** cache
-/// that feeds the virtualized large-history list (AND-567).
+/// Actor-isolated store for the **disposable per-transaction** cache that feeds
+/// the virtualized large-history list (AND-567).
 ///
 /// ## Contract
 /// - **Disposable cache, never authoritative.** Written after a successful
@@ -11,56 +10,20 @@ import SwiftData
 ///   pages to paint a virtualized list. Deleting the store file is always safe:
 ///   it rebuilds on the next refresh.
 /// - **Fallback-safe.** Every operation `throws`; callers wrap in `try?` so any
-///   SwiftData init/read/write failure (or an unavailable store) degrades to
-///   exactly today's in-memory rendering — no regression.
-///
-/// ## Why a second store
-/// The dashboard read-model cache (``ReadModelCacheStore``) holds one bounded
-/// row (the cold-start snapshot). This store holds the *full* transaction history
-/// for on-demand paging, so it gets its own schema and file. Both are disposable
-/// and live only in the local private data dir.
-///
-/// ## Paging
-/// A page is the `TransactionPageWindow` slice (`offset`/`limit` from the pure
-/// page-window math) of the newest-first ordering.
-///
-/// `FetchDescriptor(sortBy:)` and `#Predicate` are **not** usable here: both
-/// capture a non-`Sendable` `KeyPath`, which is an error under the project's
-/// Swift 6 strict-concurrency gate (the same constraint ``ReadModelCacheStore``
-/// documents). So the cacheKey scoping and the newest-first ordering (`sortDate`
-/// then `transactionId`, both descending) are done in Swift. To keep that from
-/// re-loading every payload blob and re-sorting on every page request, two
-/// bounds apply:
-///
-/// 1. **Scalar-only ordering fetch.** The fetch that builds the order sets
-///    `propertiesToFetch` to the lightweight scalar columns (`cacheKey`,
-///    `sortDate`, `transactionId`) and *excludes* the heavy `payload` blob.
-///    `propertiesToFetch` takes `PartialKeyPath`s, which — unlike `sortBy:` /
-///    `#Predicate` — do compile under strict concurrency, so the JSON blobs stay
-///    faulted out of memory while the order is computed.
-/// 2. **Cached ordering per data generation.** The sorted row references are
-///    memoized against a monotonically increasing generation counter that every
-///    write bumps. Consecutive `page()`/`count()` calls within one paging
-///    session reuse the sort instead of redoing `O(N log N)` each time; the
-///    first write invalidates it.
-///
-/// Only the requested page's `payload` blobs are then faulted in and decoded —
-/// so a multi-thousand-row history decodes just one page of `TransactionDTO`s at
-/// a time regardless of history size.
-///
-/// The store file is opened per data directory and the active environment is the
-/// only one seeded into it (an environment switch calls
-/// ``replaceAll(cacheKey:transactions:)`` which wipes first).
+///   init/read/write failure degrades to exactly today's in-memory rendering.
 ///
 /// ## Isolation / Privacy
-/// `@ModelActor` owns the non-`Sendable` `ModelContext`; only `Sendable`
-/// ``TransactionDTO`` values cross the boundary. The on-disk file lives only in
-/// `~/.vaultpeek/` (`0o700`/`0o600`), never the App Group container or iCloud.
-@ModelActor
+/// Only `Sendable` ``TransactionDTO`` values cross the actor boundary. The
+/// on-disk file lives only in `~/.vaultpeek/` (`0o700`/`0o600`), never the App
+/// Group container or iCloud.
 public actor TransactionCacheStore {
-    /// Filename of the disposable per-transaction store. `v1` is namespaced so a
-    /// future incompatible store can ship beside it and the old file be deleted.
+    /// Filename of the disposable per-transaction store. The `.store` suffix is
+    /// preserved for compatibility with existing reset/privacy docs.
     public static let storeFilename = "transaction-cache-v1.store"
+
+    private struct Snapshot: Codable, Sendable {
+        var rowsByUniqueKey: [String: CachedTransaction]
+    }
 
     /// Monotonic data generation, bumped by every write (`upsert`/`replaceAll`/
     /// `clearAll`). The cached ordering (``orderCache``) is keyed off this so a
@@ -70,10 +33,12 @@ public actor TransactionCacheStore {
     /// Memoized newest-first row ordering for one `cacheKey`, plus the generation
     /// it was built for. Reused across consecutive reads of the same key within one
     /// paging session so the `O(N log N)` filter+sort runs once per data
-    /// generation, not per page. Keyed by `cacheKey` as well as generation because
-    /// a single store file can briefly hold more than one environment (e.g. before
-    /// an environment switch wipes via `replaceAll`).
+    /// generation, not per page.
     private var orderCache: (generation: UInt64, cacheKey: String, rows: [CachedTransaction])?
+
+    private let storeURL: URL?
+    private let fileManager: FileManager
+    private var rowsByUniqueKey: [String: CachedTransaction]
 
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -88,99 +53,42 @@ public actor TransactionCacheStore {
         return decoder
     }
 
-    // MARK: - Container factories
-
-    public static func schema() -> Schema {
-        Schema([CachedTransaction.self])
-    }
-
-    /// On-disk container under `directory` (the local private data dir), created
-    /// with owner-only permissions and tightened to `0o600` after SwiftData
-    /// materializes the file — matching the existing caches.
-    public static func makeOnDiskContainer(
-        in directory: URL,
-        fileManager: FileManager = .default
-    ) throws -> ModelContainer {
-        try fileManager.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
-        let storeURL = directory.appendingPathComponent(storeFilename)
-        let configuration = ModelConfiguration(
-            "TransactionCache",
-            schema: schema(),
-            url: storeURL,
-            allowsSave: true,
-            cloudKitDatabase: .none
-        )
-        let container = try ModelContainer(for: schema(), configurations: configuration)
-        #if os(macOS)
-        for suffix in ["", "-wal", "-shm"] {
-            let path = storeURL.path + suffix
-            if fileManager.fileExists(atPath: path) {
-                try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
-            }
+    init(storeURL: URL?, fileManager: FileManager = .default) throws {
+        self.storeURL = storeURL
+        self.fileManager = fileManager
+        if let storeURL, fileManager.fileExists(atPath: storeURL.path) {
+            let data = try Data(contentsOf: storeURL)
+            self.rowsByUniqueKey = try Self.decoder.decode(Snapshot.self, from: data).rowsByUniqueKey
+        } else {
+            self.rowsByUniqueKey = [:]
         }
-        #endif
-        return container
-    }
-
-    /// In-memory container for tests and a non-persisting fallback.
-    public static func makeInMemoryContainer() throws -> ModelContainer {
-        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        return try ModelContainer(for: schema(), configurations: configuration)
     }
 
     // MARK: - Writes
 
     /// Upserts a batch of transactions for `cacheKey`. Re-syncing a transaction
-    /// (same id) replaces its row in place via the `@Attribute(.unique)` key — no
-    /// duplicates. The dedup/insert-vs-update decision is the pure
-    /// ``CachedTransactionUpsert`` (last-write-wins within the batch). Returns the
-    /// plan so callers/tests can assert the blast radius. One `save()` at the end.
+    /// (same id) replaces its row in place — no duplicates. The dedup/insert-vs-
+    /// update decision is the pure ``CachedTransactionUpsert`` (last-write-wins
+    /// within the batch). Returns the plan so callers/tests can assert the blast
+    /// radius. One persistence write at the end.
     @discardableResult
     public func upsert(cacheKey: String, transactions: [TransactionDTO]) throws -> CachedTransactionUpsert.Plan {
-        let existingIds = try existingTransactionIds(cacheKey: cacheKey)
+        let existingIds = existingTransactionIds(cacheKey: cacheKey)
         let plan = CachedTransactionUpsert.plan(incoming: transactions, existingIds: existingIds)
         guard !plan.rows.isEmpty else { return plan }
-
-        // Index the existing rows we may need to overwrite so an update mutates the
-        // stored row in place rather than inserting a duplicate (belt-and-braces on
-        // top of the unique constraint, and avoids relying on insert-replaces-by-id
-        // semantics for the payload columns).
-        let updatedKeys = Set(plan.updatedIds.map {
-            CachedTransaction.makeUniqueKey(cacheKey: cacheKey, transactionId: $0)
-        })
-        var rowsByKey: [String: CachedTransaction] = [:]
-        if !updatedKeys.isEmpty {
-            for row in try modelContext.fetch(FetchDescriptor<CachedTransaction>())
-            where updatedKeys.contains(row.uniqueKey) {
-                rowsByKey[row.uniqueKey] = row
-            }
-        }
 
         for dto in plan.rows {
             let key = CachedTransaction.makeUniqueKey(cacheKey: cacheKey, transactionId: dto.id)
             let payload = try Self.encoder.encode(dto)
-            if let existing = rowsByKey[key] {
-                existing.cacheKey = cacheKey
-                existing.transactionId = dto.id
-                existing.sortDate = dto.date
-                existing.payload = payload
-            } else {
-                modelContext.insert(
-                    CachedTransaction(
-                        uniqueKey: key,
-                        cacheKey: cacheKey,
-                        transactionId: dto.id,
-                        sortDate: dto.date,
-                        payload: payload
-                    )
-                )
-            }
+            rowsByUniqueKey[key] = CachedTransaction(
+                uniqueKey: key,
+                cacheKey: cacheKey,
+                transactionId: dto.id,
+                sortDate: dto.date,
+                payload: payload
+            )
         }
-        try modelContext.save()
+        try persist()
         invalidateOrderCache()
         return plan
     }
@@ -191,15 +99,17 @@ public actor TransactionCacheStore {
     /// do not linger in the cache.
     @discardableResult
     public func replaceAll(cacheKey: String, transactions: [TransactionDTO]) throws -> CachedTransactionUpsert.Plan {
-        try clearAll()
+        rowsByUniqueKey.removeAll()
+        try persist()
+        invalidateOrderCache()
         return try upsert(cacheKey: cacheKey, transactions: transactions)
     }
 
     /// Removes every cached transaction (any environment). Used on local-data reset
     /// and before reseeding a different environment.
     public func clearAll() throws {
-        try modelContext.delete(model: CachedTransaction.self)
-        try modelContext.save()
+        rowsByUniqueKey.removeAll()
+        try persist()
         invalidateOrderCache()
     }
 
@@ -209,42 +119,22 @@ public actor TransactionCacheStore {
     ///
     /// Reuses the memoized newest-first ordering (rebuilt only when a write bumped
     /// the data generation), so a `count()` adjacent to `page()` calls in the same
-    /// paging session shares one scalar-only fetch+sort rather than redoing it.
+    /// paging session shares one filter+sort rather than redoing it.
     public func count(cacheKey: String) throws -> Int {
         try orderedRows(cacheKey: cacheKey).count
     }
 
     /// Reads one newest-first page of transactions for `cacheKey`.
-    ///
-    /// `FetchDescriptor(sortBy:)` + `fetchOffset/fetchLimit` is unavailable: the
-    /// `SortDescriptor(\.keyPath)` captures the model's `KeyPath`, which is
-    /// non-`Sendable` and an error under the project's Swift 6 strict-concurrency
-    /// gate — the same class of constraint AND-566 hit with `#Predicate`. So the
-    /// scope filter and newest-first ordering run in Swift instead, but bounded:
-    ///
-    /// - The ordering fetch sets `propertiesToFetch` to the scalar columns only,
-    ///   so the JSON `payload` blobs stay faulted out while the order is built.
-    /// - That ordering is memoized per data generation (``orderedRows``), so a
-    ///   multi-page scroll sorts once, not once per page.
-    /// - Only the requested page's rows have their `payload` faulted in and
-    ///   decoded — so a multi-thousand-row history still decodes just one page of
-    ///   `TransactionDTO`s.
-    ///
-    /// A zero-limit window short-circuits to an empty page without touching the
-    /// store.
     public func page(cacheKey: String, window: TransactionPageWindow) throws -> [TransactionDTO] {
         guard window.limit > 0 else { return [] }
         let ordered = try orderedRows(cacheKey: cacheKey)
         let pageSlice = ordered.dropFirst(window.offset).prefix(window.limit)
-        // `payload` was excluded from the ordering fetch; accessing it here faults
-        // in only this page's blobs — bounded to `window.limit` rows.
         return try pageSlice.map { try Self.decoder.decode(TransactionDTO.self, from: $0.payload) }
     }
 
     /// Newest-first ordering over the stored scalar columns: `sortDate` descending
     /// (lexicographic order of `YYYY-MM-DD` equals chronological), `transactionId`
-    /// descending as a stable tiebreak within a day. Pure string comparison — no
-    /// `KeyPath`, so it is strict-concurrency clean.
+    /// descending as a stable tiebreak within a day.
     nonisolated private static func isNewerFirst(_ lhs: CachedTransaction, _ rhs: CachedTransaction) -> Bool {
         if lhs.sortDate != rhs.sortDate {
             return lhs.sortDate > rhs.sortDate
@@ -254,31 +144,12 @@ public actor TransactionCacheStore {
 
     // MARK: - Private
 
-    /// A `FetchDescriptor` that materializes only the lightweight scalar columns
-    /// used for scoping/ordering and leaves the heavy `payload` blob faulted.
-    ///
-    /// `propertiesToFetch` takes `PartialKeyPath`s; unlike `sortBy:` / `#Predicate`
-    /// it compiles cleanly under the project's strict-concurrency gate, so this is
-    /// the one SwiftData lever available to keep the JSON blobs out of memory while
-    /// the order is computed.
-    private static func scalarOnlyDescriptor() -> FetchDescriptor<CachedTransaction> {
-        var descriptor = FetchDescriptor<CachedTransaction>()
-        descriptor.propertiesToFetch = [\.cacheKey, \.sortDate, \.transactionId]
-        return descriptor
-    }
-
     /// The newest-first ordered rows for `cacheKey`, memoized per data generation.
-    ///
-    /// Built from a scalar-only fetch (no `payload`), filtered to `cacheKey`, and
-    /// sorted by ``isNewerFirst``. The result is cached against `(dataGeneration,
-    /// cacheKey)` so repeated reads of the same key in a paging session reuse it; a
-    /// read for a different key (or after a write) rebuilds.
     private func orderedRows(cacheKey: String) throws -> [CachedTransaction] {
         if let cached = orderCache, cached.generation == dataGeneration, cached.cacheKey == cacheKey {
             return cached.rows
         }
-        let rows = try modelContext.fetch(Self.scalarOnlyDescriptor())
-        let ordered = rows
+        let ordered = rowsByUniqueKey.values
             .filter { $0.cacheKey == cacheKey }
             .sorted(by: Self.isNewerFirst)
         orderCache = (dataGeneration, cacheKey, ordered)
@@ -293,10 +164,20 @@ public actor TransactionCacheStore {
     }
 
     /// The transaction ids currently stored for `cacheKey`. Used inside `upsert`
-    /// to decide insert-vs-update, so it always reads live (scalar-only) rather
-    /// than the memoized ordering, which a half-applied write may not reflect.
-    private func existingTransactionIds(cacheKey: String) throws -> Set<String> {
-        let rows = try modelContext.fetch(Self.scalarOnlyDescriptor())
-        return Set(rows.filter { $0.cacheKey == cacheKey }.map(\.transactionId))
+    /// to decide insert-vs-update.
+    private func existingTransactionIds(cacheKey: String) -> Set<String> {
+        Set(rowsByUniqueKey.values.filter { $0.cacheKey == cacheKey }.map(\.transactionId))
+    }
+
+    private func persist() throws {
+        guard let storeURL else { return }
+        let data = try Self.encoder.encode(Snapshot(rowsByUniqueKey: rowsByUniqueKey))
+        try fileManager.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try data.write(to: storeURL, options: [.atomic])
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storeURL.path)
     }
 }

--- a/Tests/PlaidBarCacheTests/ReadModelCacheStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/ReadModelCacheStoreTests.swift
@@ -3,11 +3,10 @@ import Testing
 @testable import PlaidBarCache
 @testable import PlaidBarCore
 
-// Serialized: each test spins up its own in-memory `ModelContainer`, and
-// initializing several SwiftData containers for the same schema concurrently
-// (the default parallel test run) crashes the SwiftData runtime. The suite is
-// tiny and fast, so serial execution costs nothing.
-@Suite("Disposable SwiftData read-model cache store (AND-566)", .serialized)
+// Serialized: each test exercises its own in-memory or temporary on-disk store.
+// The suite is tiny and fast, so serial execution keeps file-backed cache tests
+// deterministic without affecting broader runtime.
+@Suite("Disposable read-model cache store (AND-566)", .serialized)
 struct ReadModelCacheStoreTests {
 
     private func accounts() -> [AccountDTO] {

--- a/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
@@ -3,10 +3,8 @@ import Testing
 @testable import PlaidBarCache
 @testable import PlaidBarCore
 
-// Serialized: each test spins up its own in-memory `ModelContainer`, and
-// initializing several SwiftData containers for the same schema concurrently
-// (the default parallel test run) crashes the SwiftData runtime — the same
-// constraint `ReadModelCacheStoreTests` documents.
+// Serialized: each test exercises its own in-memory or temporary on-disk store;
+// serial execution keeps cache-generation assertions deterministic.
 @Suite("Disposable per-transaction cache store (AND-567)", .serialized)
 struct TransactionCacheStoreTests {
 

--- a/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardStatusReadinessTests.swift
@@ -193,15 +193,15 @@ struct DashboardStatusReadinessTests {
         #expect(evaluate(notificationsEnabled: false, notificationPermission: .evaluate(kind: .denied)).level == .healthy)
     }
 
-    @Test("Every action exposes a default title and icon")
+    @Test("Every action exposes a canonical title and icon")
     func actionDefaults() {
-        let actions: [DashboardStatusReadinessAction] = [
+        let actions: [RecoveryAction] = [
             .checkServer, .addAccount, .refresh, .reconnect, .openSettings,
             .requestNotificationPermission, .openNotificationSettings,
         ]
         for action in actions {
-            #expect(!action.defaultTitle.isEmpty)
-            #expect(!action.defaultIconName.isEmpty)
+            #expect(!action.canonicalTitle.isEmpty)
+            #expect(!action.canonicalIconName.isEmpty)
         }
     }
 

--- a/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
+++ b/Tests/PlaidBarCoreTests/MenuBarGlanceModelTests.swift
@@ -24,7 +24,7 @@ struct MenuBarGlanceModelTests {
 
     /// A local-infrastructure row (server / credentials) that keeps its in-place
     /// action and carries no route.
-    private func infraRow(id: String, action: DashboardStatusReadinessAction) -> AttentionQueueRow {
+    private func infraRow(id: String, action: RecoveryAction) -> AttentionQueueRow {
         AttentionQueueRow(
             id: id,
             severity: .blocked,

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import Testing
 @testable import PlaidBarCore
 
@@ -994,11 +995,9 @@ struct PlaidBarTests {
 /// (which an executable target cannot expose to tests).
 private final class StubFMCategorizer: FMMerchantCategorizing, @unchecked Sendable {
     private let result: SpendingCategory?
-    private let lock = NSLock()
-    private var _callCount = 0
+    private let callCountStorage = Mutex(0)
     var callCount: Int {
-        lock.lock(); defer { lock.unlock() }
-        return _callCount
+        callCountStorage.withLock { $0 }
     }
 
     init(result: SpendingCategory?) {
@@ -1006,7 +1005,7 @@ private final class StubFMCategorizer: FMMerchantCategorizing, @unchecked Sendab
     }
 
     func suggestCategory(merchant: String) async -> String? {
-        lock.lock(); _callCount += 1; lock.unlock()
+        callCountStorage.withLock { $0 += 1 }
         return result?.rawValue
     }
 }


### PR DESCRIPTION
## Summary

Fixes the broad local strict Swift gates that were blocked after the privacy PR merges.

- Replaces the app-only `PlaidBarCache` SwiftData macro stores with actor-isolated Codable file-backed stores that preserve the existing public cache API, disposable local-only behavior, 0o600 on-disk file, in-memory tests, upsert semantics, paging, and clear-wins behavior.
- Gates FoundationModels guided-generation code on both `FoundationModels` and `FoundationModelsMacros` so CLT-only macOS 26 environments compile and safely fall back when the macro plugin is unavailable.
- Gates SwiftUI `#Preview` blocks on `PreviewsMacros` availability so command-line builds do not require the Xcode-only preview macro plugin.
- Updates strict-concurrency test helpers away from deprecated recovery aliases and async `NSLock` usage.

## Verification

- `git diff --check`
- `swift build --target PlaidBarCache -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift build --target PlaidBar -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift test --filter PlaidBarCacheTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 28 tests passed
- `swift test --filter RecurringObligationsPresentationTests/privacyMaskedCountCopyWithholdsExactCounts -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 1 test passed
- `swift test --filter privacyMaskControlPathsRedactEveryPublishedSystemSurface -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 1 test passed
- `swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 2180 tests passed

## Notes

No Plaid credentials, provider tokens, raw payloads, account IDs, transaction IDs, balances, local SQLite data, prompts, or response bodies are introduced or logged.
