### PR TITLE
fix(privacy): honor pending mask for glance snapshot

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4076,6 +4076,8 @@ final class AppState {
             }
             return
         }
+        let systemSurfaceMaskEnabled = shouldMaskFinancialValues
+            || ((try? PrivacyMaskControlCommandReader.peek()?.maskEnabled) == true)
         // Keep the App Intents snapshot fresh on the same path that already
         // recomputes summaries for the widget (AND-512).
         writeFinanceSnapshot(updatedAt: updatedAt)
@@ -4100,7 +4102,7 @@ final class AppState {
             balanceHistory: balanceHistory,
             updatedAt: updatedAt,
             isDemo: isDemoMode,
-            isMasked: shouldMaskFinancialValues
+            isMasked: systemSurfaceMaskEnabled
         )
         let debouncer = glanceSnapshotWriteDebouncer
         Task { [snapshot, debouncer, generation] in

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -129,6 +129,9 @@ struct PlaidBarTests {
             encoding: .utf8
         )
 
+        let glanceMakeRange = try #require(appStateSource.range(of: "let snapshot = GlanceSnapshot.make"))
+        let glanceMakeBlock = String(appStateSource[glanceMakeRange.lowerBound...].prefix(500))
+
         #expect(widgetSource.contains("GlanceSnapshotStore.redactIfAvailable()"))
         #expect(widgetSource.contains("deleteSearchableItems("))
         #expect(widgetSource.contains("withDomainIdentifiers: [PlaidBarConstants.accountSpotlightDomainIdentifier]"))
@@ -136,6 +139,8 @@ struct PlaidBarTests {
         #expect(focusSource.contains("MainActor.run"))
         #expect(focusSource.contains("AccountSpotlightIndexer.clear()"))
         #expect(appStateSource.contains("PrivacyMaskControlCommandReader.peek()?.maskEnabled"))
+        #expect(glanceMakeBlock.contains("isMasked: systemSurfaceMaskEnabled"))
+        #expect(!glanceMakeBlock.contains("isMasked: shouldMaskFinancialValues"))
         #expect(appStateSource.contains("queued OFF command must restore the"))
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }


### PR DESCRIPTION
## Summary
- fix the app-side glance snapshot writer to treat a pending background Privacy Mask ON command as masked
- keep `glance-snapshot.json` aligned with the existing finance snapshot / Spotlight effective mask logic
- add a regression source-invariant because the app target is an `@main` executable and cannot be imported directly by tests

Fixes #650
Linear: AND-653
Kanban: t_b35d788a

## Verification
- `swift test --filter privacyMaskControlPathsRedactEveryPublishedSystemSurface -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — 1 test passed
- `git diff --check` — passed
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed
- `swift build --target PlaidBar -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed

## Privacy/security
No credentials, Plaid tokens, account IDs, transaction IDs, balances, raw payloads, prompts, or local SQLite data were added to code/tests/reporting. Impact is local system-surface disclosure prevention for widget/glance snapshot bytes while a background Privacy Mask ON command is pending.