### PR TITLE
docs: nightly documentation sync (2026-06-24)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,31 +182,34 @@ MenuBarExtra
 
 A `Task` runs every 15 minutes to refresh account balances (free cached endpoint) and every 30 minutes for transaction sync (cursor-based incremental). `EnergyAwareRefreshPolicy` (AND-568) modulates this resident cadence: under Low Power Mode or thermal pressure the automatic Plaid fetch is deferred (back-off clamped to a finite ceiling), while user-initiated manual refresh is always honored.
 
-### PlaidBarCache (App-only SwiftData cache, AND-566)
+### PlaidBarCache (App-only file-backed cache, AND-566)
 
 An app-bound library that backs instant cold render and offline reads with a
-disposable SwiftData store (`@Model` + `@ModelActor`). It depends on
-`PlaidBarCore` for the pure read-model and mapper but is kept out of the server,
-CLI, and widget targets so the SwiftData dependency never reaches them.
+disposable file-backed store: actor-isolated `ReadModelCacheStore` /
+`TransactionCacheStore` types that persist a `Codable` JSON snapshot to disk. It
+depends on `PlaidBarCore` for the pure read-model and mapper but is kept out of
+the server, CLI, and widget targets so private financial cache reads stay
+confined to the app (and so the broad strict-concurrency gate stays clean).
 
 The cache is **disposable**: rebuildable from the authoritative in-memory/JSON
 data, never a source of truth, and scoped per Plaid environment. It is written
 only into the private data dir (`~/.vaultpeek/dashboard-read-model-cache-v1.store`
 plus the per-transaction `transaction-cache-v1.store` — the latter mirrors the
 full transaction history, including transaction IDs, account IDs, merchant names,
-and amounts, so it is the more sensitive of the two; both files `0o600`) with
-`cloudKitDatabase: .none`, so neither syncs to iCloud and neither reaches the
-App Group container. If SwiftData is unavailable or the store fails to open, the
-app falls back to its existing JSON/UserDefaults cold path.
+and amounts, so it is the more sensitive of the two; the directory is `0o700` and
+both files are tightened to `0o600`). Both files are plain local JSON snapshots,
+so neither syncs to iCloud and neither reaches the App Group container. Every
+read/write `throws` and callers wrap in `try?`, so if a store file cannot be
+opened/read/written the app falls back to its existing JSON/UserDefaults cold
+path.
 
-`clearReadModelCache()` deletes both SwiftData stores on local reset and when the
+`clearReadModelCache()` deletes both stores on local reset and when the
 last institution is removed — but **only when a usable `ReadModelCacheStore` can
-be opened**. When SwiftData is unavailable or the store cannot be opened it bumps
-the clear epoch and returns without deleting, so `dashboard-read-model-cache-v1.store`,
-its `-wal`/`-shm` sidecars, and the transaction cache can survive a reset on disk.
-`LocalDataStore.resetLocalData` independently removes the JSON/scoped caches,
-Plaid SQLite files (and sidecars), pending-link state, saved goals, and the logo
-cache. See `SECURITY.md`.
+be opened**. When the store cannot be opened it bumps the clear epoch and returns
+without deleting, so `dashboard-read-model-cache-v1.store` and the transaction
+cache can survive a reset on disk. `LocalDataStore.resetLocalData` independently
+removes the JSON/scoped caches, Plaid SQLite files (and sidecars), pending-link
+state, saved goals, and the logo cache. See `SECURITY.md`.
 
 ## Data Flow
 
@@ -308,7 +311,7 @@ Unit tests span 4 suites, all using Swift Testing framework:
 | PlaidBarCoreTests | DTOs, formatters, constants, Codable roundtrips, routing/navigation, goals |
 | PlaidBarServerTests | Plaid response decoding, config, type conversion |
 | PlaidBarTests | Business logic: net balance, spending aggregation, filtering |
-| PlaidBarCacheTests | SwiftData read-model + transaction cache store behavior |
+| PlaidBarCacheTests | File-backed read-model + transaction cache store behavior |
 
 Server tests cover config, status contracts, Plaid decoding, auth behavior, and
 route-adjacent reducers. Full end-to-end Plaid sandbox coverage remains a manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,13 @@ swiftlint
 
 ## Architecture: two processes, one shared library
 
-Three core SPM targets in `Package.swift` define the security split (the package also builds a widget extension, a CLI, and an app-only SwiftData cache — see below). The split is a hard security boundary, not just organization:
+Three core SPM targets in `Package.swift` define the security split (the package also builds a widget extension, a CLI, and an app-only file-backed read-model cache — see below). The split is a hard security boundary, not just organization:
 
 - **`PlaidBar`** (`Sources/PlaidBar/`) — SwiftUI `MenuBarExtra` app. The UI layer. It **only** talks to the local server over HTTP; it never sees Plaid `client_secret` or `access_token`.
 - **`PlaidBarServer`** (`Sources/PlaidBarServer/`) — Hummingbird 2 companion server. Proxies all Plaid API calls, owns credentials and token storage. Binds to `127.0.0.1` only.
 - **`PlaidBarCore`** (`Sources/PlaidBarCore/`) — shared library. DTOs (`Models/`) and pure utilities (`Utilities/`) used by both. **Most testable business logic lives here** — summaries, formatters, recurring detection, sync reduction, presentation/state mapping, typed routing/navigation state, goals. Prefer adding logic here over embedding it in views or routes.
 
-Additional targets: **`PlaidBarCache`** (`Sources/PlaidBarCache/`) — app-only library holding the disposable SwiftData read-model cache (`@Model` + `@ModelActor` store, AND-566). It is kept out of the lean server/CLI/widget targets so the SwiftData dependency never reaches them; the pure read-model and mapper stay in `PlaidBarCore`. The cache is disposable, rebuildable, scoped per Plaid environment, and written only to the private data dir (see `SECURITY.md`). **`PlaidBarWidgetExtension`** and **`PlaidBarCLI`** (`plaidbar-cli`) round out the source targets.
+Additional targets: **`PlaidBarCache`** (`Sources/PlaidBarCache/`) — app-only library holding the disposable file-backed read-model cache (actor-isolated stores persisting a `Codable` JSON snapshot to the private data dir, AND-566). It is kept out of the lean server/CLI/widget targets so private financial cache reads stay confined to the app; the pure read-model and mapper stay in `PlaidBarCore`. The cache is disposable, rebuildable, scoped per Plaid environment, and written only to the private data dir (see `SECURITY.md`). **`PlaidBarWidgetExtension`** and **`PlaidBarCLI`** (`plaidbar-cli`) round out the source targets.
 
 Data flow: `PlaidBar.app` → HTTP `localhost:8484` → `PlaidBarServer` → HTTPS → Plaid API.
 

--- a/README.md
+++ b/README.md
@@ -444,14 +444,14 @@ PlaidBar/                            # repo checkout (repo rename pending)
 │   ├── PlaidBarCore/                # Shared library
 │   │   ├── Models/                  # DTOs, dashboard presenters, local AI receipts, routes, goals
 │   │   └── Utilities/               # Currency formatters, constants, reducers
-│   └── PlaidBarCache/               # App-only disposable SwiftData read-model cache
+│   └── PlaidBarCache/               # App-only disposable file-backed read-model cache
 ├── Tests/                           # Swift Testing suites for the app, server, core, and cache libraries
 ├── Scripts/                         # build.sh, run.sh, screenshots.sh
 ├── Assets/                          # README screenshots
 ├── DESIGN.md                        # Design system spec
 ├── PRD.md                           # Product requirements
 ├── .github/workflows/ci.yml        # GitHub Actions CI
-├── Package.swift                    # SPM with 6 source targets (app, widget extension, server, CLI, core, app-only SwiftData cache)
+├── Package.swift                    # SPM with 6 source targets (app, widget extension, server, CLI, core, app-only file-backed cache)
 └── LICENSE                          # Proprietary
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,30 +68,30 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
 - Existing legacy `plaidbar.sqlite` data, SQLite sidecar files, and matching transaction cache are copied into a scoped database only when the legacy environment is explicit (`PLAIDBAR_MIGRATE_LEGACY_DATABASE=sandbox|production`) or can be inferred from the existing transaction-cache context. Ambiguous legacy databases are left untouched to avoid sandbox/production token crossover. Explicit migration can replace an existing scoped store, backs up the previous scoped SQLite store and transaction cache before copying legacy data, and writes a migration marker so restarts do not reapply stale legacy data.
 - The app/server auth token is generated locally under `~/.vaultpeek/auth-token`
   (or `$PLAIDBAR_DATA_DIR/auth-token`).
-- The disposable SwiftData read-model cache (AND-566) accelerates cold render and
+- The disposable file-backed read-model cache (AND-566) accelerates cold render and
   offline reads. It holds financial values and Plaid identifiers, so — like the
   existing `accounts.json` / `transactions.json` caches — it is written **only**
   into the local private data dir (`~/.vaultpeek/dashboard-read-model-cache-v1.store`
   plus the per-transaction `transaction-cache-v1.store`, or `$PLAIDBAR_DATA_DIR`),
-  with the directory at `0o700` and the store files (and their `-wal`/`-shm`
-  sidecars) tightened to `0o600`. `transaction-cache-v1.store` mirrors the full
-  transaction history (transaction IDs, account IDs, merchant names, amounts), so
-  it is the more sensitive of the two and must not be overlooked in a local-data
-  audit. Both use `ModelConfiguration(..., cloudKitDatabase: .none)`, so neither
-  is **ever** synced to iCloud, and neither is **ever** written to the
-  world-readable App Group container — that boundary remains exclusive to the
-  redacted glance / `FinanceSnapshot` payloads. The cache is a **disposable**
-  read-model: rebuildable from the authoritative in-memory/JSON data, never a
-  source of truth, scoped per Plaid environment, and safe to delete at any time.
+  with the directory at `0o700` and the store files tightened to `0o600`. Each
+  store is a single plain JSON snapshot written by an actor-isolated store type —
+  there are no SQLite `-wal`/`-shm` sidecars. `transaction-cache-v1.store` mirrors
+  the full transaction history (transaction IDs, account IDs, merchant names,
+  amounts), so it is the more sensitive of the two and must not be overlooked in a
+  local-data audit. Being local-only JSON files, neither is **ever** synced to
+  iCloud, and neither is **ever** written to the world-readable App Group
+  container — that boundary remains exclusive to the redacted glance /
+  `FinanceSnapshot` payloads. The cache is a **disposable** read-model:
+  rebuildable from the authoritative in-memory/JSON data, never a source of truth,
+  scoped per Plaid environment, and safe to delete at any time.
   `clearReadModelCache()` deletes both stores on local reset and when the last
   institution is removed, but **only when a usable `ReadModelCacheStore` can be
-  opened**; if SwiftData is unavailable or the store cannot be opened it returns
-  without deleting, so both `.store` files (and their sidecars) can survive a
-  reset on disk. `LocalDataStore.resetLocalData` separately removes the
-  JSON/scoped caches, Plaid SQLite files, pending-link state, goals, and logo
-  cache. If SwiftData is unavailable or the store fails to open/read/write, the
-  app falls back to its existing JSON/UserDefaults cold path with no behavior
-  change.
+  opened**; if the store cannot be opened it returns without deleting, so both
+  `.store` files can survive a reset on disk. `LocalDataStore.resetLocalData`
+  separately removes the JSON/scoped caches, Plaid SQLite files, pending-link
+  state, goals, and logo cache. Every cache read/write `throws` and callers wrap
+  in `try?`, so if a store file fails to open/read/write, the app falls back to
+  its existing JSON/UserDefaults cold path with no behavior change.
 - `/api/status` is authenticated and exposes readiness metadata: version,
   environment, credential availability, storage path, linked item count,
   synced item count, sync readiness, and last sync time. With the opt-in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ executable names below intentionally keep the PlaidBar name; see
 | `PlaidBar` | SwiftUI menu bar app, popover, setup flow, settings, local client calls, notification UX | Store Plaid secrets, call Plaid directly, contain server persistence logic |
 | `PlaidBarCore` | Shared DTOs, formatting, sync reducers, recurring detection, dashboard presenters, attention queue models, local insight receipt models, local data path helpers | Depend on SwiftUI, Hummingbird, Plaid network clients, or cloud AI SDKs |
 | `PlaidBarServer` | Hummingbird localhost API, Plaid API client, SQLite storage, link flow, token vault, auth middleware | Render UI, depend on app state, expose secrets in status responses |
-| `PlaidBarCache` | App-only disposable SwiftData read-model cache (`@Model` + `@ModelActor`) for instant cold render and offline reads, scoped per Plaid environment | Become a source of truth, reach the server/CLI/widget targets, write to the App Group container, or sync to iCloud |
+| `PlaidBarCache` | App-only disposable file-backed read-model cache (actor-isolated stores persisting a `Codable` JSON snapshot) for instant cold render and offline reads, scoped per Plaid environment | Become a source of truth, reach the server/CLI/widget targets, write to the App Group container, or sync to iCloud |
 
 ## Runtime Topology
 
@@ -181,6 +181,15 @@ independent gates — the redacted-at-write glance file **and** the read-time
 `FinanceSnapshot.isMasked` check (the widget shows its placeholder/unavailable
 state when masked) — so a reader that ignored `isMasked` would still find no real
 net-worth, today's-change, or sparkline values on disk to leak.
+
+The display-only Core Spotlight account index (`AccountSpotlightIndexer`) is kept
+in lockstep with the same seam: `refresh(accounts:isMasked:)` clears the index
+whenever masked, so account names leave system search immediately on a Privacy
+Mask / App Lock transition. A *pending* background Privacy Mask ON command (set
+via Control Center or a Focus filter while the app is backgrounded) is also
+treated as masked — `PrivacyMaskControlCommandReader.peek()` is consulted on the
+snapshot/Spotlight write path — so an automatic refresh cannot re-publish account
+names before the next activation consumes the command (AND-513, hardened in #644).
 
 If a future change adds any field to `GlanceSnapshot` or `FinanceSnapshot`, it
 must be reviewed against this boundary, `SECURITY.md`, and the status-endpoint


### PR DESCRIPTION
## Summary

Nightly docs sync for the code merged 2026-06-23 → 2026-06-24. The driving change is the **PlaidBarCache** migration off SwiftData onto a file-backed JSON cache; several docs still described it as a `SwiftData` (`@Model` / `@ModelActor`) store. Also documents the Privacy Mask Spotlight-index hardening.

Docs-only — no code changes.

## Code changes reviewed

| PR / commit | Change | Doc impact |
|---|---|---|
| [#649](https://github.com/ftchvs/VaultPeek/pull/649) / `004f612` `fix: make broad strict Swift gates pass` | `PlaidBarCache` dropped the SwiftData/macro dependency; the cache is now actor-isolated stores persisting a `Codable` JSON snapshot. `Package.swift` comment updated to "file-backed read-model cache". | **Yes** — cache described as SwiftData across 5 docs |
| [#644](https://github.com/ftchvs/VaultPeek/pull/644) / `8650ab3` `fix(privacy): clear Spotlight when system controls mask` | Treats a *pending* background Privacy Mask ON command (Control Center / Focus filter) as masked on the snapshot/Spotlight write path, so auto-refresh can't re-publish account names; adds `PlaidBarConstants.accountSpotlightDomainIdentifier`. | **Yes** — Privacy Mask contract didn't mention the Spotlight account index |
| [#648](https://github.com/ftchvs/VaultPeek/pull/648) / `992b49a` `fix(privacy): mask recurring count copy` | UI copy masking fix. | No |

## Files changed

- **CLAUDE.md** — "app-only SwiftData cache" → "app-only file-backed read-model cache"; describe `PlaidBarCache` as actor-isolated stores persisting a `Codable` JSON snapshot; drop the now-inapplicable "SwiftData dependency never reaches them" rationale. _(#649)_
- **README.md** — directory tree entry and `Package.swift` target summary: SwiftData → file-backed. _(#649)_
- **ARCHITECTURE.md** — rewrote the `PlaidBarCache` section (`ReadModelCacheStore` / `TransactionCacheStore` actors, JSON snapshots, `0o700`/`0o600`, `throws`+`try?` fallback, no `-wal`/`-shm` sidecars); updated the `PlaidBarCacheTests` row. _(#649)_
- **SECURITY.md** — corrected the cache bullet: plain local JSON files (no SQLite sidecars, no `ModelConfiguration(cloudKitDatabase: .none)`), still local-only and never iCloud/App Group; clarified the `throws`/`try?` fallback. _(#649)_
- **docs/architecture.md** — target-responsibility table row (SwiftData → file-backed) and a new Privacy Mask note that `AccountSpotlightIndexer` clears the account index on mask, including pending background Control Center / Focus commands. _(#649, #644)_

## Verification

- `grep -rn "SwiftData|@Model|ModelActor"` over `Sources/PlaidBarCache/` and `Package.swift` → no matches (SwiftData fully removed).
- Confirmed file-backed stores: `ReadModelCacheStore` / `TransactionCacheStore` are `actor`s encoding a `Codable` `Snapshot` to `.store` files, dir `0o700` / files `0o600`, all ops `throws`.
- No remaining `SwiftData`/`@Model`/`ModelConfiguration`/`-wal`/`-shm` cache references in docs (the surviving `-wal`/`-shm` mentions refer to the Plaid Fluent/SQLite item store, which is unchanged).
- Naming-compatibility distinctions (PlaidBar SwiftPM targets, executables, `PLAIDBAR_*`, Keychain, legacy `~/.plaidbar/`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)