### PR TITLE
refactor: extract review-reason glyph + explanation copy → PlaidBarCore

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift
@@ -287,7 +287,7 @@ struct ReviewDestinationView: View {
         private func reasonRow(_ reason: TransactionReviewReason) -> some View {
             let tint: Color = reason.isHighPriority ? SemanticColors.warning : .secondary
             return HStack(alignment: .top, spacing: WindowMetrics.sm) {
-                Image(systemName: ReviewReasonGuide.systemImage(for: reason))
+                Image(systemName: reason.glyphName)
                     .font(.body)
                     .foregroundStyle(tint)
                     .frame(width: 24, alignment: .center)
@@ -307,7 +307,7 @@ struct ReviewDestinationView: View {
                                 .background(SemanticColors.warning.opacity(0.12), in: Capsule())
                         }
                     }
-                    Text(ReviewReasonGuide.explanation(for: reason))
+                    Text(reason.explanation)
                         .windowSupportingText()
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -315,7 +315,7 @@ struct ReviewDestinationView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(
-                "\(reason.displayName)\(reason.isHighPriority ? ", high priority" : ""). \(ReviewReasonGuide.explanation(for: reason))"
+                "\(reason.displayName)\(reason.isHighPriority ? ", high priority" : ""). \(reason.explanation)"
             )
         }
 
@@ -362,42 +362,6 @@ private enum ReviewShortcutGuide {
         Shortcut(key: "I", action: "Ignore", systemImage: "eye.slash"),
         Shortcut(key: "⌘Z", action: "Undo last action", systemImage: "arrow.uturn.backward"),
     ]
-}
-
-/// Plain-language explanations + glyphs for each review reason code, for the
-/// inspector legend. The glyphs mirror the inbox row's leading glyph so the two
-/// surfaces read consistently; the copy explains *why* a transaction surfaced.
-private enum ReviewReasonGuide {
-    static func systemImage(for reason: TransactionReviewReason) -> String {
-        switch reason {
-        case .uncategorized: "tag"
-        case .newMerchant: "person.crop.circle.badge.questionmark"
-        case .unusualAmount: "chart.line.uptrend.xyaxis"
-        case .possibleTransfer: "arrow.left.arrow.right"
-        case .recurringChanged: "calendar.badge.exclamationmark"
-        case .pendingChanged: "clock.badge.exclamationmark"
-        case .changedSinceReview: "arrow.triangle.2.circlepath"
-        }
-    }
-
-    static func explanation(for reason: TransactionReviewReason) -> String {
-        switch reason {
-        case .uncategorized:
-            "No category yet. Recategorize so it counts toward the right budget."
-        case .newMerchant:
-            "First time you've seen this merchant. Confirm it's expected."
-        case .unusualAmount:
-            "Larger or more unusual than this merchant's usual charges."
-        case .possibleTransfer:
-            "Looks like a transfer or card payment. Mark transfer to exclude it from budgets."
-        case .recurringChanged:
-            "A recurring charge changed amount or timing."
-        case .pendingChanged:
-            "This pending charge changed before it posted."
-        case .changedSinceReview:
-            "Changed since you last reviewed it, so it reopened."
-        }
-    }
 }
 
 #if canImport(PreviewsMacros)

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -885,7 +885,7 @@ private struct ReviewInboxRow: View {
     private var reasonChips: some View {
         HStack(spacing: Spacing.xxs) {
             ForEach(item.reasonCodes, id: \.self) { reason in
-                Label(reason.displayName, systemImage: symbolName(for: reason))
+                Label(reason.displayName, systemImage: reason.glyphName)
                     .font(.caption2.weight(.semibold))
                     .labelStyle(.titleAndIcon)
                     .foregroundStyle(tint(for: reason))
@@ -1040,7 +1040,7 @@ private struct ReviewInboxRow: View {
     }
 
     private var leadingSymbolName: String {
-        item.reasonCodes.first.map(symbolName(for:)) ?? "tray"
+        item.reasonCodes.first.map(\.glyphName) ?? "tray"
     }
 
     private var leadingTint: Color {
@@ -1075,18 +1075,6 @@ private struct ReviewInboxRow: View {
         let category = isShowingSuggestion ? "\(baseCategory) (suggested on device)" : baseCategory
         let amount = Formatters.currency(item.transaction.displayAmount, format: .full)
         return "\(item.effectiveMerchantName), \(amount), \(category), reasons: \(reasons)"
-    }
-
-    private func symbolName(for reason: TransactionReviewReason) -> String {
-        switch reason {
-        case .uncategorized: "tag"
-        case .newMerchant: "person.crop.circle.badge.questionmark"
-        case .unusualAmount: "chart.line.uptrend.xyaxis"
-        case .possibleTransfer: "arrow.left.arrow.right"
-        case .recurringChanged: "calendar.badge.exclamationmark"
-        case .pendingChanged: "clock.badge.exclamationmark"
-        case .changedSinceReview: "arrow.triangle.2.circlepath"
-        }
     }
 
     private func tint(for reason: TransactionReviewReason) -> Color {

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -38,6 +38,43 @@ public enum TransactionReviewReason: String, Codable, Sendable, CaseIterable, Eq
     public var isHighPriority: Bool {
         priority == 0 || self == .unusualAmount
     }
+
+    /// SF Symbol name for this reason's leading glyph. Shared by the inbox row
+    /// and the inspector legend so the two surfaces read consistently; the glyph
+    /// is always a redundant layer alongside the `displayName` text, never the
+    /// sole carrier of meaning (ACCESSIBILITY.md).
+    public var glyphName: String {
+        switch self {
+        case .uncategorized: "tag"
+        case .newMerchant: "person.crop.circle.badge.questionmark"
+        case .unusualAmount: "chart.line.uptrend.xyaxis"
+        case .possibleTransfer: "arrow.left.arrow.right"
+        case .recurringChanged: "calendar.badge.exclamationmark"
+        case .pendingChanged: "clock.badge.exclamationmark"
+        case .changedSinceReview: "arrow.triangle.2.circlepath"
+        }
+    }
+
+    /// Plain-language explanation of *why* a transaction surfaced for this
+    /// reason, shown in the inspector legend.
+    public var explanation: String {
+        switch self {
+        case .uncategorized:
+            "No category yet. Recategorize so it counts toward the right budget."
+        case .newMerchant:
+            "First time you've seen this merchant. Confirm it's expected."
+        case .unusualAmount:
+            "Larger or more unusual than this merchant's usual charges."
+        case .possibleTransfer:
+            "Looks like a transfer or card payment. Mark transfer to exclude it from budgets."
+        case .recurringChanged:
+            "A recurring charge changed amount or timing."
+        case .pendingChanged:
+            "This pending charge changed before it posted."
+        case .changedSinceReview:
+            "Changed since you last reviewed it, so it reopened."
+        }
+    }
 }
 
 public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equatable {

--- a/Tests/PlaidBarCoreTests/TransactionReviewReasonPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewReasonPresentationTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import PlaidBarCore
+
+/// Pins the per-reason presentation copy (`glyphName`, `explanation`) extracted
+/// from the inbox row + inspector legend views into `TransactionReviewReason`.
+/// These strings drive what the user sees, so the golden values are asserted
+/// verbatim — any change is intentional and must update the test.
+@Suite struct TransactionReviewReasonPresentationTests {
+    @Test func glyphNamePinsEveryCase() {
+        #expect(TransactionReviewReason.uncategorized.glyphName == "tag")
+        #expect(TransactionReviewReason.newMerchant.glyphName == "person.crop.circle.badge.questionmark")
+        #expect(TransactionReviewReason.unusualAmount.glyphName == "chart.line.uptrend.xyaxis")
+        #expect(TransactionReviewReason.possibleTransfer.glyphName == "arrow.left.arrow.right")
+        #expect(TransactionReviewReason.recurringChanged.glyphName == "calendar.badge.exclamationmark")
+        #expect(TransactionReviewReason.pendingChanged.glyphName == "clock.badge.exclamationmark")
+        #expect(TransactionReviewReason.changedSinceReview.glyphName == "arrow.triangle.2.circlepath")
+    }
+
+    @Test func explanationPinsEveryCase() {
+        #expect(TransactionReviewReason.uncategorized.explanation
+            == "No category yet. Recategorize so it counts toward the right budget.")
+        #expect(TransactionReviewReason.newMerchant.explanation
+            == "First time you've seen this merchant. Confirm it's expected.")
+        #expect(TransactionReviewReason.unusualAmount.explanation
+            == "Larger or more unusual than this merchant's usual charges.")
+        #expect(TransactionReviewReason.possibleTransfer.explanation
+            == "Looks like a transfer or card payment. Mark transfer to exclude it from budgets.")
+        #expect(TransactionReviewReason.recurringChanged.explanation
+            == "A recurring charge changed amount or timing.")
+        #expect(TransactionReviewReason.pendingChanged.explanation
+            == "This pending charge changed before it posted.")
+        #expect(TransactionReviewReason.changedSinceReview.explanation
+            == "Changed since you last reviewed it, so it reopened.")
+    }
+
+    /// Every case must yield a non-empty glyph + explanation — guards against a
+    /// future case being added to the enum without presentation copy.
+    @Test func everyReasonHasNonEmptyPresentation() {
+        for reason in TransactionReviewReason.allCases {
+            #expect(!reason.glyphName.isEmpty)
+            #expect(!reason.explanation.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Hoists the per-reason SF Symbol glyph and the inspector-legend explanation copy for `TransactionReviewReason` out of two view files into pure, `Sendable`, unit-tested computed properties (`glyphName`, `explanation`) on the enum in **PlaidBarCore**, alongside the existing `displayName`/`priority`/`isHighPriority`.
- The glyph switch was **duplicated byte-for-byte** across `ReviewReasonGuide.systemImage(for:)` (ReviewDestinationView) and `symbolName(for:)` (ReviewInboxView); the explanation copy was untested. Both inline copies are deleted and all call sites rerouted.
- Behavior-preserving: all 7×2 strings are byte-identical to the deleted helpers (adversarially verified) and the `?? "tray"` fallback is unchanged.

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` (Step 10)
- Backlog slice: AppState/god-object decomposition — pure presentation logic → Core
- Scope note: one focused, behavior-preserving extraction

## Agent coordination

- Builder agent: Claude (Opus 4.8), autonomous scheduled run
- Builder branch/worktree: `refactor/auto-2026-06-24` (throwaway worktree off `origin/main`)
- Reviewer/merge steward: Otto / Felipe
- Coordination note: review-only; no other agent should push to this branch

## Changed files

- `Sources/PlaidBarCore/Models/TransactionReview.swift` — add `glyphName` + `explanation` to `TransactionReviewReason`
- `Sources/PlaidBar/Views/Destinations/ReviewDestinationView.swift` — route to Core props, delete `ReviewReasonGuide` enum
- `Sources/PlaidBar/Views/ReviewInboxView.swift` — route to Core props, delete `symbolName(for:)`
- `Tests/PlaidBarCoreTests/TransactionReviewReasonPresentationTests.swift` — new; pins all 7 cases of both props

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean (CI gate)
- [x] `swift build --target PlaidBarServer` — covered by the strict full-package build above (no server code changed)
- [x] `swift test` — full suite **2183 green** (incl. the sometimes-flaky LocalInsightModelRuntime test); demo app boot-smoke OK (9s, no crash)
- [x] Secret scan completed — no credentials/tokens/balances in the diff

## GitHub checks

- [ ] Required GitHub checks green before merge.

## Privacy and safety impact

None. Pure UI-copy/glyph mapping; no Plaid calls, no credentials, no data-flow change. Synthetic/no data in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)