### PR TITLE
docs: scrub stale SwiftData references from cache doc-comments

### DIFF
--- a/Sources/PlaidBar/App/AppState+ReadModelCache.swift
+++ b/Sources/PlaidBar/App/AppState+ReadModelCache.swift
@@ -67,7 +67,7 @@ extension AppState {
     /// Lazily opens (or re-opens) the on-disk disposable store for the active
     /// data directory. Returns `nil` — and stays disabled for this call — when
     /// the cache is feature-disabled, when in demo mode (demo data is never
-    /// cached), or when SwiftData fails to open the store. Reopens when the
+    /// cached), or when the file-backed store fails to open. Reopens when the
     /// active storage directory changes (e.g. sandbox↔production switch) so the
     /// store always matches the environment whose key it is asked about.
     func readModelCacheStoreIfAvailable() -> ReadModelCacheStore? {
@@ -87,7 +87,7 @@ extension AppState {
             readModelCacheStoreDirectoryPath = directoryPath
             return store
         } catch {
-            // SwiftData unavailable / store unopenable: behave exactly as before
+            // Cache unavailable / store unopenable: behave exactly as before
             // the cache existed. Logged without any financial material.
             AppState.readModelCacheLogger.error(
                 "Read-model cache unavailable: \(String(describing: error), privacy: .public)"

--- a/Sources/PlaidBar/App/AppState+TransactionCache.swift
+++ b/Sources/PlaidBar/App/AppState+TransactionCache.swift
@@ -46,8 +46,8 @@ extension AppState {
 
     /// Lazily opens (or re-opens) the on-disk per-transaction store for the active
     /// data directory. Returns `nil` — and stays disabled for this call — when the
-    /// cache is feature-disabled, in demo mode, or when SwiftData fails to open the
-    /// store. Reopens when the active storage directory changes so the store always
+    /// cache is feature-disabled, in demo mode, or when the file-backed store fails
+    /// to open. Reopens when the active storage directory changes so the store always
     /// matches the environment whose key it is asked about.
     func transactionCacheStoreIfAvailable() -> TransactionCacheStore? {
         guard readModelCacheEnabled, !isDemoMode else { return nil }
@@ -110,7 +110,7 @@ extension AppState {
     }
 
     /// Builds a data source for the virtualized transaction list. When the cache is
-    /// available it pages from SwiftData; otherwise (disabled / unavailable / no
+    /// available it pages from the file-backed store; otherwise (disabled / unavailable / no
     /// context yet) the source stays on `fallback` and the list renders exactly the
     /// in-memory rows it does today — no regression.
     func makePagedTransactionSource(fallback: [TransactionDTO]) -> PagedTransactionSource {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -595,8 +595,8 @@ final class AppState {
     /// destination ever reads it, so with `WindowFirstFeatureFlag` OFF nothing
     /// touches goals storage and the popover boot path is byte-identical.
     let goalsStore = GoalsStore()
-    /// Disposable SwiftData read-model cache for instant cold render (AND-566).
-    /// Opened lazily and behind `try?`; `nil` whenever SwiftData is unavailable
+    /// Disposable file-backed read-model cache for instant cold render (AND-566).
+    /// Opened lazily and behind `try?`; `nil` whenever the cache is unavailable
     /// or the store fails to open, in which case the app behaves exactly as it
     /// did before this cache existed (the JSON/UserDefaults cold path). Opened
     /// against the directory it was created for so a server-directory change
@@ -605,7 +605,7 @@ final class AppState {
     /// `AppState+ReadModelCache.swift` can read/mutate it; still module-scoped.
     var readModelCacheStore: ReadModelCacheStore?
     var readModelCacheStoreDirectoryPath: String?
-    /// Disposable per-transaction SwiftData cache for large-history paging
+    /// Disposable per-transaction file-backed cache for large-history paging
     /// (AND-567). Like ``readModelCacheStore`` it is lazily opened, scoped to the
     /// active data directory, never the source of truth, and gated by
     /// ``readModelCacheEnabled``. The AND-567 wiring extension in
@@ -3377,7 +3377,7 @@ final class AppState {
     /// mismatches fall through to the normal post-connect cache path without
     /// surfacing an error during boot.
     private func preloadCachedDataBeforeFirstConnect() async {
-        // Fast path: paint frame 1 from the disposable SwiftData read-model cache
+        // Fast path: paint frame 1 from the disposable file-backed read-model cache
         // before the (slower) JSON warm path and well before the HTTP refresh
         // (AND-566). Best-effort; on any failure or miss it leaves `accounts` /
         // `transactions` empty so the JSON path below runs exactly as before.

--- a/Sources/PlaidBar/Services/PagedTransactionSource.swift
+++ b/Sources/PlaidBar/Services/PagedTransactionSource.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// `@Observable` data source for the virtualized, page-on-demand transaction list
 /// (AND-567).
 ///
-/// It drives the disposable per-transaction SwiftData cache
+/// It drives the disposable per-transaction file-backed cache
 /// (``TransactionCacheStore``) through the pure ``PagedTransactionFeed``
 /// accumulator: page 0 loads on appear, the next page loads when the list scrolls
 /// near the end. Only one page (``PlaidBarConstants/transactionPageSize`` rows) is
@@ -19,7 +19,7 @@ import SwiftUI
 /// available. When the cache is unavailable — `readModelCacheEnabled == false`,
 /// the store fails to open, or no environment context is known yet — the source
 /// stays in ``Mode/fallback`` and ``rows`` is exactly the in-memory array the list
-/// renders today. The SwiftData path is a pure optimization layered on top; if any
+/// renders today. The cache path is a pure optimization layered on top; if any
 /// part of it fails, rendering is byte-for-byte today's behavior.
 @MainActor
 @Observable
@@ -62,7 +62,7 @@ final class PagedTransactionSource {
         self.feed = PagedTransactionFeed(pageSize: pageSize, total: 0)
     }
 
-    /// An in-memory-only source: no SwiftData store, so it stays on the fallback
+    /// An in-memory-only source: no cache store, so it stays on the fallback
     /// path (today's rows) but renders them through the virtualized `LazyVStack`.
     /// Used for per-account surfaces where the global cache's scope does not apply
     /// but the list should still virtualize a large per-account history.

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -39,7 +39,7 @@ struct TransactionsDestinationView: View {
 
     /// Large-history paging engine (AND-567), reused verbatim: page 0 loads on
     /// appear, the next page loads as the table nears the end of the loaded rows.
-    /// When the disposable SwiftData cache is unavailable/disabled the source stays
+    /// When the disposable file-backed cache is unavailable/disabled the source stays
     /// on the in-memory `appState.transactions` fallback, so a small history (or a
     /// cache-less environment) renders exactly today's rows — no regression. The
     /// source's `rows` are the *input* to the pure ``TransactionWorkspace`` pipeline

--- a/Sources/PlaidBarCore/Models/DashboardReadModel.swift
+++ b/Sources/PlaidBarCore/Models/DashboardReadModel.swift
@@ -6,15 +6,15 @@ import Foundation
 ///
 /// This is a **read-model cache**, never a source of truth. The authoritative
 /// data path stays the in-memory DTOs + JSON ledger + UserDefaults caches the
-/// app already keeps. This struct is the serialized shape the SwiftData
-/// disposable store persists after a successful refresh/decode and reads back
+/// app already keeps. This struct is the serialized shape the disposable
+/// file-backed store persists after a successful refresh/decode and reads back
 /// on the next launch. If it is missing, stale, or fails to decode, the app
 /// falls back to exactly its prior behavior (empty/loading → HTTP refresh).
 ///
 /// It carries the same `Sendable` DTOs the dashboard already renders
 /// (``AccountDTO`` / ``TransactionDTO``) plus a small derived summary so the
 /// menu-bar headline can render without recomputation. It is a pure value type
-/// so it can be unit-tested and mapped without touching SwiftData.
+/// so it can be unit-tested and mapped without touching the cache store.
 ///
 /// ## Privacy
 /// This read-model holds financial values and Plaid identifiers (account/item

--- a/Sources/PlaidBarCore/Utilities/CachedTransactionUpsert.swift
+++ b/Sources/PlaidBarCore/Utilities/CachedTransactionUpsert.swift
@@ -3,14 +3,15 @@ import Foundation
 /// Pure, testable upsert/dedup decision for the disposable per-transaction cache
 /// (AND-567).
 ///
-/// The SwiftData `CachedTransaction` row is keyed `@Attribute(.unique)` on the
-/// stable Plaid `transaction_id`, so re-syncing a transaction must *replace* the
-/// existing row rather than duplicate it. This type decides — given the ids
+/// The file-backed ``TransactionCacheStore`` keeps one `CachedTransaction` per
+/// stable Plaid `transaction_id` — its `Codable` snapshot is a dictionary keyed on
+/// a unique key derived from that id — so re-syncing a transaction must *replace*
+/// the existing row rather than duplicate it. This type decides — given the ids
 /// already in the store and the freshly decoded authoritative DTOs — which ids are
 /// inserts and which are updates, and collapses duplicate ids *within* the
 /// incoming batch (a sync page can re-list the same id; the newest occurrence
-/// wins). Keeping the decision out of the `@ModelActor` lets the boundary
-/// conditions be unit-tested without SwiftData.
+/// wins). Keeping the decision out of the storage actor lets the boundary
+/// conditions be unit-tested without standing up the cache store.
 public enum CachedTransactionUpsert {
     /// The classification of an incoming batch against the store's existing ids.
     public struct Plan: Sendable, Equatable {

--- a/Sources/PlaidBarCore/Utilities/DashboardReadModelMapper.swift
+++ b/Sources/PlaidBarCore/Utilities/DashboardReadModelMapper.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Pure, testable mapping between the authoritative in-memory DTOs and the
 /// disposable ``DashboardReadModel`` cache payload (AND-566).
 ///
-/// Kept free of SwiftData and of any I/O so the DTO↔read-model transform can be
-/// unit-tested in isolation. The SwiftData persistence layer (app target) calls
+/// Kept free of the persistence layer and of any I/O so the DTO↔read-model transform can be
+/// unit-tested in isolation. The file-backed cache layer (app target) calls
 /// into this to build the row it stores and to read a hydrated model back; it
 /// never re-derives these numbers itself.
 public enum DashboardReadModelMapper {

--- a/Sources/PlaidBarCore/Utilities/PagedTransactionFeed.swift
+++ b/Sources/PlaidBarCore/Utilities/PagedTransactionFeed.swift
@@ -6,8 +6,8 @@ import Foundation
 /// The virtualized list view owns only rendering; this value type owns the
 /// "what's loaded, what loads next, are we done" state machine so the
 /// append-page / dedup-across-pages / stop-at-end logic is unit-tested rather than
-/// tangled in a SwiftUI `onAppear`. It is deliberately free of SwiftData and
-/// SwiftUI: the view (or an `@Observable` source) feeds it pages read from the
+/// tangled in a SwiftUI `onAppear`. It is deliberately free of the storage layer
+/// and SwiftUI: the view (or an `@Observable` source) feeds it pages read from the
 /// ``TransactionCacheStore`` and asks it for the next ``TransactionPageWindow``.
 ///
 /// Rows are newest-first and de-duplicated by id across pages, so a transaction

--- a/Sources/PlaidBarCore/Utilities/TransactionPageWindow.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionPageWindow.swift
@@ -4,8 +4,8 @@ import Foundation
 /// (AND-567).
 ///
 /// Owns the offset/limit/`hasMore` arithmetic for an infinite-scroll list backed
-/// by a paged store (the SwiftData `CachedTransaction` cache, or any ordered
-/// collection). Keeping this free of SwiftData and SwiftUI means the page-on-demand
+/// by a paged store (the file-backed `CachedTransaction` cache, or any ordered
+/// collection). Keeping this free of the storage layer and SwiftUI means the page-on-demand
 /// boundary conditions — last partial page, empty history, a `total` that shrinks
 /// under the loaded window after a re-sync — are unit-tested in isolation rather
 /// than discovered in a scrolling view.


### PR DESCRIPTION
## Summary

`PlaidBarCache` was migrated **off SwiftData** onto a file-backed JSON cache (actor-isolated `ReadModelCacheStore` / `TransactionCacheStore` persisting a `Codable` snapshot, dir `0o700` / files `0o600`) in [#649](https://github.com/ftchvs/VaultPeek/pull/649) / `004f612`. The 2026-06-24 nightly docs sync ([#652](https://github.com/ftchvs/VaultPeek/pull/652)) corrected the **markdown** docs (CLAUDE.md, README, ARCHITECTURE.md, SECURITY.md, docs/architecture.md) but missed the **source-level doc-comments**, which still described the cache as SwiftData (`@Model` / `@ModelActor` / `@Attribute(.unique)`).

Some of these were not just anachronistic but **factually wrong**, e.g. `DashboardReadModelMapper.swift`: *"The SwiftData persistence layer (app target) calls into this"* — there is no SwiftData persistence layer anymore.

This is a **comment-only** sweep: reword every stale reference to the file-backed-cache vocabulary while preserving each comment's intent. The original follow-up was scoped to `CachedTransactionUpsert.swift`; the repo-wide `grep` gate surfaced the same stale-comment class across 9 more files, so the sweep was broadened to make the grep truly clean (confirmed via `AskUserQuestion`).

## Files changed (10, comment-only)

**PlaidBarCore**
- `Utilities/CachedTransactionUpsert.swift` — the originally-flagged file (`@Attribute(.unique)` / `@ModelActor` / SwiftData → file-backed `TransactionCacheStore`, unique-keyed `Codable` snapshot)
- `Models/DashboardReadModel.swift`
- `Utilities/DashboardReadModelMapper.swift`
- `Utilities/PagedTransactionFeed.swift`
- `Utilities/TransactionPageWindow.swift`

**PlaidBar (app target)**
- `App/AppState.swift`
- `App/AppState+ReadModelCache.swift`
- `App/AppState+TransactionCache.swift`
- `Views/Destinations/TransactionsDestinationView.swift`
- `Services/PagedTransactionSource.swift`

## Verification

- `grep -rnE 'SwiftData|@Model|@Attribute|@ModelActor|ModelConfiguration|ModelContainer|ModelContext' Sources/ Package.swift` → **no matches**
- Diff is **comment-only** — every added/removed line is a `//` or `///` comment (28 ins / 27 del); zero code lines touched
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (the CI gate)

## Privacy and safety impact

None. Doc-comment wording only; no code, no Plaid calls, no credentials, no data-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)