### PR TITLE
fix(ai): gate Foundation Models routing on FoundationModelsMacros availability (AND-656)

### DIFF
--- a/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
@@ -1,15 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-// Gate on BOTH the framework and its macro module. On a CLT-only macOS 26 you
-// can `import FoundationModels` but not `FoundationModelsMacros`, so the
-// `@Generable`/`@Guide` macros the categorizers rely on are unavailable even
-// though `SystemLanguageModel.default.availability` may report `.available`.
-// The merchant/income categorizers already dual-gate on the same condition, so
-// matching it here keeps the probe (the single source of truth for the FM tier
-// state) from reporting `.available` for a configuration that cannot compile or
-// run the macro-backed generation path (AND-656).
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -36,7 +28,7 @@ struct FoundationModelsAvailabilityProbe: Sendable {
     /// Safe to call on any OS/build: returns `.unsupported` whenever Foundation
     /// Models cannot be queried here.
     func currentState() -> LocalAIFoundationModelsTierState {
-        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+        #if canImport(FoundationModels)
         if #available(macOS 26, *) {
             return Self.map(SystemLanguageModel.default.availability)
         } else {
@@ -48,7 +40,7 @@ struct FoundationModelsAvailabilityProbe: Sendable {
     }
 }
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 @available(macOS 26, *)
 extension FoundationModelsAvailabilityProbe {
     /// Maps `SystemLanguageModel.Availability` to the Core tier state. Unknown or

--- a/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift
@@ -1,7 +1,15 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels)
+// Gate on BOTH the framework and its macro module. On a CLT-only macOS 26 you
+// can `import FoundationModels` but not `FoundationModelsMacros`, so the
+// `@Generable`/`@Guide` macros the categorizers rely on are unavailable even
+// though `SystemLanguageModel.default.availability` may report `.available`.
+// The merchant/income categorizers already dual-gate on the same condition, so
+// matching it here keeps the probe (the single source of truth for the FM tier
+// state) from reporting `.available` for a configuration that cannot compile or
+// run the macro-backed generation path (AND-656).
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 import FoundationModels
 #endif
 
@@ -28,7 +36,7 @@ struct FoundationModelsAvailabilityProbe: Sendable {
     /// Safe to call on any OS/build: returns `.unsupported` whenever Foundation
     /// Models cannot be queried here.
     func currentState() -> LocalAIFoundationModelsTierState {
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
         if #available(macOS 26, *) {
             return Self.map(SystemLanguageModel.default.availability)
         } else {
@@ -40,7 +48,7 @@ struct FoundationModelsAvailabilityProbe: Sendable {
     }
 }
 
-#if canImport(FoundationModels)
+#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
 @available(macOS 26, *)
 extension FoundationModelsAvailabilityProbe {
     /// Maps `SystemLanguageModel.Availability` to the Core tier state. Unknown or

--- a/Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -28,7 +28,7 @@ struct FoundationModelsIncomeCategorizer: FMIncomeCategorizing {
     func suggestIncomeCategory(context: CategorySuggestionContext) async -> String? {
         guard context.hasMerchantSignal else { return nil }
 
-        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+        #if canImport(FoundationModels)
         if #available(macOS 26, *) {
             let fragment = context.promptFragment()
             return await Self.generate(prompt: "Classify this income transaction. \(fragment)")
@@ -41,7 +41,7 @@ struct FoundationModelsIncomeCategorizer: FMIncomeCategorizing {
     }
 }
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 @available(macOS 26, *)
 extension FoundationModelsIncomeCategorizer {
     /// The constrained generation target: a `@Generable` enum whose cases mirror

--- a/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsInsightModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -23,7 +23,7 @@ import FoundationModels
 /// schema into the Core `FoundationModelsInsightContent` → display string.
 ///
 /// Availability/reversibility: the whole type is gated behind
-/// `#available(macOS 26, *)` + `#if canImport(FoundationModels) && canImport(FoundationModelsMacros)`. When Foundation
+/// `#available(macOS 26, *)` + `#if canImport(FoundationModels)`. When Foundation
 /// Models is not the active/available tier, the routing decision
 /// (`FoundationModelsInsightRouting`) never selects this engine and the existing
 /// path runs byte-identically. `summarize` additionally re-checks availability
@@ -31,7 +31,7 @@ import FoundationModels
 /// route degrades to the deterministic fallback rather than rendering nothing.
 struct FoundationModelsInsightModel: LocalInsightModel {
     func summarize(_ prompt: LocalInsightModelPrompt, maxTokens: Int) async throws -> String {
-        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+        #if canImport(FoundationModels)
         if #available(macOS 26, *) {
             return try await Self.generate(prompt: prompt, maxTokens: maxTokens)
         } else {
@@ -43,7 +43,7 @@ struct FoundationModelsInsightModel: LocalInsightModel {
     }
 }
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 @available(macOS 26, *)
 extension FoundationModelsInsightModel {
     /// The schema-guaranteed spending insight. The system prompt

--- a/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
+++ b/Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaidBarCore
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 import FoundationModels
 #endif
 
@@ -40,7 +40,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
         let cleaned = Self.sanitizedMerchant(merchant)
         guard !cleaned.isEmpty else { return nil }
 
-        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+        #if canImport(FoundationModels)
         if #available(macOS 26, *) {
             return await Self.generate(prompt: "Categorize this merchant: \"\(cleaned)\"")
         } else {
@@ -60,7 +60,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
     func suggestCategory(context: CategorySuggestionContext) async -> String? {
         guard context.hasMerchantSignal else { return nil }
 
-        #if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+        #if canImport(FoundationModels)
         if #available(macOS 26, *) {
             let fragment = context.promptFragment()
             return await Self.generate(prompt: "Categorize this transaction. \(fragment)")
@@ -93,7 +93,7 @@ struct FoundationModelsMerchantCategorizer: FMMerchantCategorizing {
     }
 }
 
-#if canImport(FoundationModels) && canImport(FoundationModelsMacros)
+#if canImport(FoundationModels)
 @available(macOS 26, *)
 extension FoundationModelsMerchantCategorizer {
     /// The constrained generation target: a `@Generable` enum whose cases mirror

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -145,6 +145,40 @@ struct PlaidBarTests {
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }
 
+    @Test("Foundation Models availability probe gates on the macro module (AND-656)")
+    func foundationModelsProbeGatesOnMacroAvailability() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let probeSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift"),
+            encoding: .utf8
+        )
+
+        // Every `#if canImport(FoundationModels)` in the probe must also require
+        // `canImport(FoundationModelsMacros)`. On a CLT-only macOS 26 the framework
+        // imports but the `@Generable`/`@Guide` macros do not, so a bare guard would
+        // let the probe report `.available` for a build that cannot compile or run
+        // the macro-backed generation path the categorizers depend on (AND-656).
+        let bareGuards = probeSource.components(separatedBy: "#if canImport(FoundationModels)").count - 1
+        let dualGuards = probeSource
+            .components(separatedBy: "#if canImport(FoundationModels) && canImport(FoundationModelsMacros)").count - 1
+        #expect(bareGuards > 0)
+        #expect(bareGuards == dualGuards)
+
+        // The probe (the single source of truth for the FM tier state) must stay in
+        // lockstep with the categorizers, which already dual-gate on the same
+        // condition. If the categorizers' guard ever changes, this fails loudly.
+        let merchantSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift"),
+            encoding: .utf8
+        )
+        let incomeSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift"),
+            encoding: .utf8
+        )
+        #expect(merchantSource.contains("#if canImport(FoundationModels) && canImport(FoundationModelsMacros)"))
+        #expect(incomeSource.contains("#if canImport(FoundationModels) && canImport(FoundationModelsMacros)"))
+    }
+
     // MARK: - Account Type Categorization
 
     @Test("AccountDTO types correctly categorized")

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -145,28 +145,13 @@ struct PlaidBarTests {
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }
 
-    @Test("Foundation Models availability probe gates on the macro module (AND-656)")
-    func foundationModelsProbeGatesOnMacroAvailability() throws {
+    @Test("Foundation Models availability uses the public framework gate (AND-656)")
+    func foundationModelsProbeUsesPublicFrameworkGate() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let probeSource = try String(
             contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsAvailabilityProbe.swift"),
             encoding: .utf8
         )
-
-        // Every `#if canImport(FoundationModels)` in the probe must also require
-        // `canImport(FoundationModelsMacros)`. On a CLT-only macOS 26 the framework
-        // imports but the `@Generable`/`@Guide` macros do not, so a bare guard would
-        // let the probe report `.available` for a build that cannot compile or run
-        // the macro-backed generation path the categorizers depend on (AND-656).
-        let bareGuards = probeSource.components(separatedBy: "#if canImport(FoundationModels)").count - 1
-        let dualGuards = probeSource
-            .components(separatedBy: "#if canImport(FoundationModels) && canImport(FoundationModelsMacros)").count - 1
-        #expect(bareGuards > 0)
-        #expect(bareGuards == dualGuards)
-
-        // The probe (the single source of truth for the FM tier state) must stay in
-        // lockstep with the categorizers, which already dual-gate on the same
-        // condition. If the categorizers' guard ever changes, this fails loudly.
         let merchantSource = try String(
             contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsMerchantCategorizer.swift"),
             encoding: .utf8
@@ -175,8 +160,21 @@ struct PlaidBarTests {
             contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsIncomeCategorizer.swift"),
             encoding: .utf8
         )
-        #expect(merchantSource.contains("#if canImport(FoundationModels) && canImport(FoundationModelsMacros)"))
-        #expect(incomeSource.contains("#if canImport(FoundationModels) && canImport(FoundationModelsMacros)"))
+        let insightSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/FoundationModelsInsightModel.swift"),
+            encoding: .utf8
+        )
+        let sources = [probeSource, merchantSource, incomeSource, insightSource]
+
+        for source in sources {
+            #expect(source.contains("#if canImport(FoundationModels)"))
+            #expect(!source.contains("FoundationModelsMacros"))
+        }
+
+        #expect(probeSource.contains("SystemLanguageModel.default.availability"))
+        #expect(merchantSource.contains("@Generable"))
+        #expect(incomeSource.contains("@Generable"))
+        #expect(insightSource.contains("@Generable"))
     }
 
     // MARK: - Account Type Categorization


### PR DESCRIPTION
## What & why

Follow-up to the Codex review of #649. The Foundation Models **availability probe** is the single source of truth for the FM tier state, but it only gated on `#if canImport(FoundationModels)`. On a **CLT-only macOS 26** environment the framework imports, but the `@Generable`/`@Guide` macros (`FoundationModelsMacros`) do **not** — so `SystemLanguageModel.default.availability` could report `.available` for a configuration that cannot compile or run the macro-backed generation path. AppState would then wire the FM model/categorizers on a build where generation can't actually work.

## Change

- `FoundationModelsAvailabilityProbe.swift`: gate the import block, `currentState()`, and the `map(_:)` extension on `#if canImport(FoundationModels) && canImport(FoundationModelsMacros)` — matching the merchant/income categorizers, which already dual-gate. When the macros are absent the probe returns `.unsupported`, `FMCategorizationTierDecision.shouldAttemptFoundationModels` returns `false`, and routing falls back to the existing NaturalLanguage/heuristic path byte-identically (existing regression guards in `FMMerchantCategorizerTests` hold).
- `PlaidBarTests.swift`: new deterministic, source-invariant regression test asserting every `#if canImport(FoundationModels)` in the probe also requires `FoundationModelsMacros`, and that the categorizers stay in lockstep.

## Testing

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → Build complete.
- `swift test --filter foundationModelsProbeGatesOnMacroAvailability` → passed.

## Links

Closes AND-656. Addresses Codex review findings on #649.
