### PR TITLE
feat(trust): number-provenance popovers for derived finance figures (AND-641)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -117,7 +117,8 @@ struct DashboardDestinationView: View {
                     systemImage: metric.systemImage,
                     detail: metric.detail,
                     accent: metric.accent,
-                    reduceMotion: reduceMotion
+                    reduceMotion: reduceMotion,
+                    provenance: metric.provenance
                 )
             }
         }
@@ -249,6 +250,9 @@ struct DashboardDestinationView: View {
         let systemImage: String
         let detail: String?
         let accent: Color
+        /// Optional number-provenance for the figure (AND-641). Built masked when
+        /// Privacy Mask is active, so the popover never leaks real values.
+        var provenance: FigureProvenance?
     }
 
     /// The wealth summary the rail also computes — the single source for net worth,
@@ -284,6 +288,7 @@ struct DashboardDestinationView: View {
             cashflow: summary.cashflow,
             asOf: Date()
         )
+        let freshness = appState.lastSyncDate
 
         let netWorth = HeroMetric(
             id: "netWorth",
@@ -291,7 +296,12 @@ struct DashboardDestinationView: View {
             value: PrivacyMaskPresentation.currency(summary.netWorth, format: .compact, isEnabled: masked),
             systemImage: "chart.line.uptrend.xyaxis",
             detail: accountCountDetail(summary.accountCount),
-            accent: SemanticColors.brand
+            accent: SemanticColors.brand,
+            provenance: FigureProvenance.netWorth(
+                accounts: appState.accounts,
+                freshness: freshness,
+                privacyMaskEnabled: masked
+            )
         )
 
         let safe = HeroMetric(
@@ -300,7 +310,12 @@ struct DashboardDestinationView: View {
             value: PrivacyMaskPresentation.currency(safeToSpend.amount, format: .compact, isEnabled: masked),
             systemImage: safeToSpend.confidence.iconName,
             detail: "Through end of month · \(safeToSpend.confidence.label) confidence",
-            accent: safeToSpend.amount >= 0 ? SemanticColors.positive : SemanticColors.warning
+            accent: safeToSpend.amount >= 0 ? SemanticColors.positive : SemanticColors.warning,
+            provenance: FigureProvenance.safeToSpend(
+                result: safeToSpend,
+                freshness: freshness,
+                privacyMaskEnabled: masked
+            )
         )
 
         let spend = HeroMetric(

--- a/Sources/PlaidBar/Views/Destinations/WindowSection.swift
+++ b/Sources/PlaidBar/Views/Destinations/WindowSection.swift
@@ -97,8 +97,35 @@ struct WindowHeroMetricTile: View {
     /// Rolls the figure on change (disabled under Reduce Motion). Pass the live
     /// `reduceMotion` environment value.
     var reduceMotion: Bool
+    /// Optional "where from / how fresh / what excluded" provenance for the figure
+    /// (AND-641). When set, an info affordance is shown beside the label; tapping it
+    /// explains the number's sources, freshness, and exclusions. Already
+    /// privacy-mask-aware (built masked when values are hidden).
+    var provenance: FigureProvenance?
 
     var body: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.xs) {
+                // The figure (label + value + detail) reads as one VoiceOver
+                // element; the provenance affordance, when present, stays a
+                // separately-focusable control beside it (AND-641).
+                figure
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(accessibilityLabel)
+
+                if let provenance {
+                    Spacer(minLength: WindowMetrics.xs)
+                    ProvenancePopoverButton(provenance: provenance)
+                }
+            }
+        }
+        .padding(WindowMetrics.md)
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+        .windowCardSurface()
+        .accessibilityElement(children: .contain)
+    }
+
+    private var figure: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             Label {
                 Text(label)
@@ -127,11 +154,7 @@ struct WindowHeroMetricTile: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(WindowMetrics.md)
-        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
-        .windowCardSurface()
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var accessibilityLabel: String {

--- a/Sources/PlaidBar/Views/ProvenancePopoverButton.swift
+++ b/Sources/PlaidBar/Views/ProvenancePopoverButton.swift
@@ -1,0 +1,157 @@
+import PlaidBarCore
+import SwiftUI
+
+/// A small, reusable "where did this number come from?" affordance (AND-641).
+///
+/// Renders an info glyph next to a high-trust derived figure; tapping it opens a
+/// `.popover` that explains the figure's **sources** (which accounts), **freshness**
+/// (how recently the data synced), and **exclusions** (what was deliberately left
+/// out). All content comes from a pure ``FigureProvenance`` built in `PlaidBarCore`
+/// — this view is presentation only.
+///
+/// Accessibility: the button is keyboard-focusable (a plain `Button`), carries a
+/// descriptive VoiceOver label, and its meaning rides on the glyph SHAPE +
+/// text, never color (ACCESSIBILITY.md). The popover body honors Privacy Mask —
+/// the caller passes an already-masked ``FigureProvenance`` so no real values are
+/// rendered while masked.
+struct ProvenancePopoverButton: View {
+    let provenance: FigureProvenance
+
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+        }
+        .buttonStyle(.plain)
+        .help("Where this number comes from")
+        .accessibilityLabel("\(provenance.figureTitle): where this number comes from")
+        .accessibilityHint("Shows sources, freshness, and what's excluded.")
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            ProvenancePopoverContent(provenance: provenance)
+        }
+    }
+}
+
+/// The popover body for ``ProvenancePopoverButton``. Pure presentation over a
+/// ``FigureProvenance``.
+private struct ProvenancePopoverContent: View {
+    let provenance: FigureProvenance
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            header
+
+            Text(provenance.derivation)
+                .microText()
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            freshnessRow
+
+            if !provenance.sources.isEmpty {
+                section(title: "Sources", systemImage: "tray.full") {
+                    ForEach(provenance.sources) { source in
+                        sourceRow(source)
+                    }
+                }
+            }
+
+            if !provenance.exclusions.isEmpty {
+                section(title: "Not included", systemImage: "minus.circle") {
+                    ForEach(Array(provenance.exclusions.enumerated()), id: \.offset) { _, line in
+                        Label {
+                            Text(line)
+                                .microText()
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } icon: {
+                            Image(systemName: "circle.fill")
+                                .font(.system(size: 4))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+            }
+        }
+        .padding(Spacing.md)
+        .frame(width: 280, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(provenance.accessibilitySummary)
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.xs) {
+            Text(provenance.figureTitle)
+                .font(.subheadline.weight(.semibold))
+
+            Spacer(minLength: Spacing.sm)
+
+            // Local-only reassurance — paired glyph + text, never color alone.
+            Label(provenance.localOnlyBadge, systemImage: "lock.laptopcomputer")
+                .microText()
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("\(provenance.localOnlyBadge), computed on this device.")
+        }
+    }
+
+    private var freshnessRow: some View {
+        Label {
+            Text(provenance.freshnessText)
+                .microText()
+                .foregroundStyle(.secondary)
+        } icon: {
+            Image(systemName: "clock")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func section(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Label(title, systemImage: systemImage)
+                .sectionTitle()
+                .foregroundStyle(.secondary)
+                .accessibilityAddTraits(.isHeader)
+
+            content()
+        }
+    }
+
+    private func sourceRow(_ source: FigureProvenance.Source) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Label {
+                Text(source.label)
+                    .microText()
+                    .lineLimit(1)
+            } icon: {
+                Image(systemName: source.systemImage)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            if let value = source.value {
+                Text(value)
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(source.accessibilityLabel)
+    }
+}

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -102,6 +102,8 @@ struct WealthSummaryFlyout: View {
 
                     WealthCreditSection(
                         summary: presentation.creditUtilization,
+                        creditAccounts: appState.accounts.filter { $0.type == .credit },
+                        freshness: appState.lastSyncDate,
                         threshold: appState.creditUtilizationThreshold,
                         privacyMaskEnabled: privacyMaskEnabled
                     )
@@ -607,12 +609,30 @@ private struct ProjectedBalanceSection: View {
 
 private struct WealthCreditSection: View {
     let summary: WealthSummaryPresentation.CreditUtilizationSummary?
+    /// Credit accounts that fed the utilization figure, for the provenance popover
+    /// (AND-641). Display-safe; only names/balances are surfaced, never raw IDs.
+    var creditAccounts: [AccountDTO] = []
+    /// When the credit balances were last synced; drives the provenance freshness.
+    var freshness: Date?
     let threshold: Double
     let privacyMaskEnabled: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            WealthFlyoutSectionLabel("Credit")
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+                WealthFlyoutSectionLabel("Credit")
+
+                if let summary {
+                    ProvenancePopoverButton(
+                        provenance: FigureProvenance.creditUtilization(
+                            summary: summary,
+                            creditAccounts: creditAccounts,
+                            freshness: freshness,
+                            privacyMaskEnabled: privacyMaskEnabled
+                        )
+                    )
+                }
+            }
 
             if let summary {
                 HStack(alignment: .top, spacing: Spacing.sm) {

--- a/Sources/PlaidBarCore/Models/FigureProvenance.swift
+++ b/Sources/PlaidBarCore/Models/FigureProvenance.swift
@@ -1,0 +1,344 @@
+import Foundation
+
+/// Display-safe "where from / how fresh / what excluded" provenance for a single
+/// high-trust derived finance figure (AND-641).
+///
+/// This generalizes the receipt pattern already used by ``LocalAIInsightReceipt``
+/// and ``DashboardChangeReceipt``: a pure, `Sendable`, deterministic value built
+/// by a `static` factory from data the figure was *already* derived from. It
+/// answers the three questions a number-provenance affordance must answer:
+///
+/// - **Sources** — which accounts (by display name + type) fed the figure, as
+///   user-facing rows. Never raw `account_id`/`item_id` values.
+/// - **Freshness** — when the underlying data was last produced (`generatedAt`),
+///   rendered relative ("2 min ago") so the user knows how stale the figure is.
+/// - **Exclusions** — what was deliberately left out (hidden categories, pending
+///   holds, a date range, account types that don't count as spendable cash, etc.),
+///   so the number is honest about its boundaries.
+///
+/// Privacy: like every value surface, provenance honors Privacy Mask / App Lock.
+/// When `privacyMaskEnabled` is passed to a factory the source rows carry the
+/// dotted placeholder instead of real balances, and exclusion copy never bakes in
+/// a real amount. The model itself carries no identifiers, tokens, or Plaid
+/// payloads — only display-safe names, counts, and pre-formatted strings.
+public struct FigureProvenance: Equatable, Sendable {
+    /// One contributing source row — a single account (or an aggregate "row") that
+    /// fed the figure, reduced to a display-safe label, an optional value string
+    /// (already privacy-mask-aware), and an SF Symbol that pairs with the text so
+    /// the row never relies on color alone (ACCESSIBILITY.md).
+    public struct Source: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let label: String
+        /// Pre-formatted, privacy-mask-aware value (e.g. a balance or "••••"). Nil
+        /// when the row contributes no displayable amount.
+        public let value: String?
+        public let systemImage: String
+        /// Spoken description — never an abbreviation, so VoiceOver reads the row
+        /// in full and meaning is never carried by glyph alone.
+        public let accessibilityLabel: String
+
+        public init(
+            id: String,
+            label: String,
+            value: String?,
+            systemImage: String,
+            accessibilityLabel: String
+        ) {
+            self.id = id
+            self.label = label
+            self.value = value
+            self.systemImage = systemImage
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    /// The figure this provenance describes (e.g. "Net worth"). Used as the popover
+    /// title.
+    public let figureTitle: String
+    /// One-line explanation of how the figure is derived, in plain language.
+    public let derivation: String
+    /// Contributing source rows (accounts), display-safe.
+    public let sources: [Source]
+    /// When the underlying data was produced. The UI renders this relative.
+    public let freshness: Date?
+    /// Pre-rendered relative freshness string (e.g. "Updated 2 min ago"). Falls
+    /// back to a "not yet synced" phrasing when `freshness` is nil.
+    public let freshnessText: String
+    /// What was deliberately excluded from the figure (date range, hidden
+    /// categories, pending holds, non-cash account types …). Display-safe copy.
+    public let exclusions: [String]
+    /// Local-only reassurance badge copy, mirroring the receipt pattern.
+    public let localOnlyBadge: String
+    /// Flattened VoiceOver summary of the whole popover.
+    public let accessibilitySummary: String
+
+    public init(
+        figureTitle: String,
+        derivation: String,
+        sources: [Source],
+        freshness: Date?,
+        freshnessText: String,
+        exclusions: [String],
+        localOnlyBadge: String = "Local-only",
+        accessibilitySummary: String
+    ) {
+        self.figureTitle = figureTitle
+        self.derivation = derivation
+        self.sources = sources
+        self.freshness = freshness
+        self.freshnessText = freshnessText
+        self.exclusions = exclusions
+        self.localOnlyBadge = localOnlyBadge
+        self.accessibilitySummary = accessibilitySummary
+    }
+
+    // MARK: - Net worth
+
+    /// Provenance for the net-worth headline (`WealthSummaryPresentation.netWorth`).
+    ///
+    /// Net worth is the sum of asset-account effective balances minus debt-account
+    /// balances. Every non-zero account is listed as a source row; debt accounts
+    /// are noted as subtractions. Investment accounts are excluded (the headline
+    /// reflects cash + debt only) and are listed as an explicit exclusion when any
+    /// are linked, so the number's boundary is visible rather than silent.
+    public static func netWorth(
+        accounts: [AccountDTO],
+        freshness: Date?,
+        privacyMaskEnabled: Bool = false,
+        now: Date = Date()
+    ) -> FigureProvenance {
+        let contributing = accounts.filter { $0.type != .investment }
+        let sources = contributing
+            .sorted { abs($0.balances.effectiveBalance) > abs($1.balances.effectiveBalance) }
+            .prefix(maxSourceRows)
+            .map { account -> Source in
+                sourceRow(
+                    for: account,
+                    amount: account.balances.effectiveBalance,
+                    privacyMaskEnabled: privacyMaskEnabled
+                )
+            }
+
+        var exclusions: [String] = []
+        let investmentCount = accounts.count { $0.type == .investment }
+        if investmentCount > 0 {
+            exclusions.append("Investment accounts (\(investmentCount)) are not counted in this cash-and-debt net worth.")
+        }
+        if contributing.count > maxSourceRows {
+            exclusions.append("Showing the \(maxSourceRows) largest of \(contributing.count) contributing accounts.")
+        }
+        exclusions.append("Reflects the latest balance each bank reported, not pending authorizations.")
+
+        return make(
+            figureTitle: "Net worth",
+            derivation: "Assets minus debts across your linked cash and credit accounts.",
+            sources: Array(sources),
+            freshness: freshness,
+            exclusions: exclusions,
+            now: now
+        )
+    }
+
+    // MARK: - Safe to spend
+
+    /// Provenance for the safe-to-spend headline (`SafeToSpendResult.amount`).
+    ///
+    /// The component breakdown already lives in ``SafeToSpendResult``; this surfaces
+    /// the *boundary* of the number: which signed components fed it (as source
+    /// rows), the confidence caveat, and what it deliberately leaves out (estimated
+    /// income, the horizon date range, the safety buffer).
+    public static func safeToSpend(
+        result: SafeToSpendResult,
+        freshness: Date?,
+        privacyMaskEnabled: Bool = false,
+        now: Date = Date()
+    ) -> FigureProvenance {
+        let sources = result.visibleComponents.map { component -> Source in
+            let value = privacyMaskEnabled
+                ? PrivacyMaskPresentation.compactValue
+                : signedCurrency(component.amount)
+            let spoken = privacyMaskEnabled
+                ? "hidden while Privacy Mask is on"
+                : signedSpokenCurrency(component.amount)
+            return Source(
+                id: component.kind.rawValue,
+                label: component.label,
+                value: value,
+                systemImage: component.kind.iconName,
+                accessibilityLabel: "\(component.label), \(spoken)."
+            )
+        }
+
+        var exclusions: [String] = [
+            "Looks ahead through \(Formatters.displayDate(result.horizonEnd)) only.",
+        ]
+        switch result.confidence {
+        case .insufficientData:
+            exclusions.append("Income and obligations are too thin to stand behind — treat this as indicative only.")
+        case .lowConfidence:
+            exclusions.append("Expected income is estimated, not a confirmed pay schedule, so the upside is softer.")
+        case .ok:
+            break
+        }
+        exclusions.append("Excludes anything past the horizon and any buffer you've set aside.")
+
+        return make(
+            figureTitle: "Safe to spend",
+            derivation: "Spendable cash and expected income, minus upcoming bills, holds, and reserves.",
+            sources: sources,
+            freshness: freshness,
+            exclusions: exclusions,
+            now: now
+        )
+    }
+
+    // MARK: - Credit utilization
+
+    /// Provenance for the credit-utilization figure
+    /// (`WealthSummaryPresentation.CreditUtilizationSummary`).
+    ///
+    /// Utilization is used credit over total limit across credit-card accounts.
+    /// This lists the credit accounts as sources and notes that accounts without a
+    /// known limit are excluded from the ratio (they can't contribute a denominator).
+    public static func creditUtilization(
+        summary: WealthSummaryPresentation.CreditUtilizationSummary,
+        creditAccounts: [AccountDTO],
+        freshness: Date?,
+        privacyMaskEnabled: Bool = false,
+        now: Date = Date()
+    ) -> FigureProvenance {
+        let withLimit = creditAccounts.filter { ($0.balances.limit ?? 0) > 0 }
+        let withoutLimit = creditAccounts.count - withLimit.count
+
+        let sources = withLimit
+            .sorted { abs($0.balances.current ?? 0) > abs($1.balances.current ?? 0) }
+            .prefix(maxSourceRows)
+            .map { account -> Source in
+                sourceRow(
+                    for: account,
+                    amount: abs(account.balances.current ?? 0),
+                    privacyMaskEnabled: privacyMaskEnabled,
+                    forceCreditGlyph: true
+                )
+            }
+
+        var exclusions: [String] = []
+        if withoutLimit > 0 {
+            exclusions.append("\(withoutLimit) card\(withoutLimit == 1 ? "" : "s") without a reported limit are excluded from the ratio.")
+        }
+        if withLimit.count > maxSourceRows {
+            exclusions.append("Showing the \(maxSourceRows) largest of \(withLimit.count) cards with a limit.")
+        }
+        exclusions.append("Based on the balance and limit each bank last reported.")
+
+        let derivation = privacyMaskEnabled
+            ? "Balance used divided by total limit across your credit cards."
+            : "Balance used divided by total limit across your credit cards (\(summary.statusLabel))."
+
+        return make(
+            figureTitle: "Credit utilization",
+            derivation: derivation,
+            sources: Array(sources),
+            freshness: freshness,
+            exclusions: exclusions,
+            now: now
+        )
+    }
+
+    // MARK: - Shared builders
+
+    /// Cap on rendered source rows so the popover stays a glance, not a ledger.
+    private static let maxSourceRows = 6
+
+    private static func make(
+        figureTitle: String,
+        derivation: String,
+        sources: [Source],
+        freshness: Date?,
+        exclusions: [String],
+        now: Date
+    ) -> FigureProvenance {
+        let freshnessText = freshnessText(for: freshness, now: now)
+        let sourceSummary = sources.isEmpty
+            ? "No contributing accounts."
+            : sources.map(\.accessibilityLabel).joined(separator: " ")
+        let accessibility = [
+            "\(figureTitle) provenance.",
+            derivation,
+            freshnessText + ".",
+            "Sources: " + sourceSummary,
+            "Excluded: " + exclusions.joined(separator: " "),
+            "Computed on this device.",
+        ].joined(separator: " ")
+
+        return FigureProvenance(
+            figureTitle: figureTitle,
+            derivation: derivation,
+            sources: sources,
+            freshness: freshness,
+            freshnessText: freshnessText,
+            exclusions: exclusions,
+            accessibilitySummary: accessibility
+        )
+    }
+
+    /// Builds one account source row. The label is the display name plus the masked
+    /// last-4 when present; the value is the privacy-mask-aware balance. No raw
+    /// account/item IDs ever appear.
+    private static func sourceRow(
+        for account: AccountDTO,
+        amount: Double,
+        privacyMaskEnabled: Bool,
+        forceCreditGlyph: Bool = false
+    ) -> Source {
+        let suffix = account.mask.map { " ••\($0)" } ?? ""
+        let label = account.name + suffix
+        let value = privacyMaskEnabled
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(amount, format: .compact)
+        let spokenValue = privacyMaskEnabled
+            ? "balance hidden while Privacy Mask is on"
+            : "balance \(Formatters.currency(amount, format: .full))"
+        let glyph = forceCreditGlyph ? "creditcard" : account.type.provenanceGlyph
+        return Source(
+            id: account.id,
+            label: label,
+            value: value,
+            systemImage: glyph,
+            accessibilityLabel: "\(account.name), \(spokenValue)."
+        )
+    }
+
+    private static func freshnessText(for freshness: Date?, now: Date) -> String {
+        guard let freshness else { return "Not yet synced" }
+        return "Updated \(Formatters.relativeDate(freshness))"
+    }
+
+    private static func signedCurrency(_ amount: Double) -> String {
+        let magnitude = Formatters.currency(abs(amount), format: .compact)
+        if amount > 0 { return "+\(magnitude)" }
+        if amount < 0 { return "-\(magnitude)" }
+        return magnitude
+    }
+
+    private static func signedSpokenCurrency(_ amount: Double) -> String {
+        let magnitude = Formatters.currency(abs(amount), format: .full)
+        if amount > 0 { return "plus \(magnitude)" }
+        if amount < 0 { return "minus \(magnitude)" }
+        return magnitude
+    }
+}
+
+private extension AccountType {
+    /// SF Symbol that pairs a shape with the source-row text so the account kind is
+    /// distinguishable without relying on color (ACCESSIBILITY.md).
+    var provenanceGlyph: String {
+        switch self {
+        case .depository: "banknote"
+        case .credit: "creditcard"
+        case .loan: "building.columns"
+        case .investment: "chart.line.uptrend.xyaxis"
+        case .other: "square.stack.3d.up"
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Models/FigureProvenance.swift
+++ b/Sources/PlaidBarCore/Models/FigureProvenance.swift
@@ -96,34 +96,34 @@ public struct FigureProvenance: Equatable, Sendable {
 
     /// Provenance for the net-worth headline (`WealthSummaryPresentation.netWorth`).
     ///
-    /// Net worth is the sum of asset-account effective balances minus debt-account
-    /// balances. Every non-zero account is listed as a source row; debt accounts
-    /// are noted as subtractions. Investment accounts are excluded (the headline
-    /// reflects cash + debt only) and are listed as an explicit exclusion when any
-    /// are linked, so the number's boundary is visible rather than silent.
+    /// Net worth mirrors ``MenuBarSummary.netCash(from:)``: depository,
+    /// investment, and other accounts contribute their effective balances, while
+    /// credit and loan accounts subtract their latest current balance. Every
+    /// non-zero account is listed as a source row; debt accounts are shown as
+    /// negative contributions.
     public static func netWorth(
         accounts: [AccountDTO],
         freshness: Date?,
         privacyMaskEnabled: Bool = false,
         now: Date = Date()
     ) -> FigureProvenance {
-        let contributing = accounts.filter { $0.type != .investment }
+        let contributing = accounts
+            .map { account in (account, netWorthContribution(for: account)) }
+            .filter { $0.1 != 0 }
         let sources = contributing
-            .sorted { abs($0.balances.effectiveBalance) > abs($1.balances.effectiveBalance) }
+            .sorted { abs($0.1) > abs($1.1) }
             .prefix(maxSourceRows)
-            .map { account -> Source in
+            .enumerated()
+            .map { index, row -> Source in
                 sourceRow(
-                    for: account,
-                    amount: account.balances.effectiveBalance,
+                    id: "net-worth-source-\(index)",
+                    for: row.0,
+                    amount: row.1,
                     privacyMaskEnabled: privacyMaskEnabled
                 )
             }
 
         var exclusions: [String] = []
-        let investmentCount = accounts.count { $0.type == .investment }
-        if investmentCount > 0 {
-            exclusions.append("Investment accounts (\(investmentCount)) are not counted in this cash-and-debt net worth.")
-        }
         if contributing.count > maxSourceRows {
             exclusions.append("Showing the \(maxSourceRows) largest of \(contributing.count) contributing accounts.")
         }
@@ -131,7 +131,7 @@ public struct FigureProvenance: Equatable, Sendable {
 
         return make(
             figureTitle: "Net worth",
-            derivation: "Assets minus debts across your linked cash and credit accounts.",
+            derivation: "Assets minus debts across your linked accounts.",
             sources: Array(sources),
             freshness: freshness,
             exclusions: exclusions,
@@ -199,7 +199,7 @@ public struct FigureProvenance: Equatable, Sendable {
     ///
     /// Utilization is used credit over total limit across credit-card accounts.
     /// This lists the credit accounts as sources and notes that accounts without a
-    /// known limit are excluded from the ratio (they can't contribute a denominator).
+    /// known limit contribute used balance but cannot contribute a denominator.
     public static func creditUtilization(
         summary: WealthSummaryPresentation.CreditUtilizationSummary,
         creditAccounts: [AccountDTO],
@@ -207,14 +207,15 @@ public struct FigureProvenance: Equatable, Sendable {
         privacyMaskEnabled: Bool = false,
         now: Date = Date()
     ) -> FigureProvenance {
-        let withLimit = creditAccounts.filter { ($0.balances.limit ?? 0) > 0 }
-        let withoutLimit = creditAccounts.count - withLimit.count
+        let withoutLimit = creditAccounts.count { ($0.balances.limit ?? 0) <= 0 }
 
-        let sources = withLimit
+        let sources = creditAccounts
             .sorted { abs($0.balances.current ?? 0) > abs($1.balances.current ?? 0) }
             .prefix(maxSourceRows)
-            .map { account -> Source in
+            .enumerated()
+            .map { index, account -> Source in
                 sourceRow(
+                    id: "credit-utilization-source-\(index)",
                     for: account,
                     amount: abs(account.balances.current ?? 0),
                     privacyMaskEnabled: privacyMaskEnabled,
@@ -224,10 +225,10 @@ public struct FigureProvenance: Equatable, Sendable {
 
         var exclusions: [String] = []
         if withoutLimit > 0 {
-            exclusions.append("\(withoutLimit) card\(withoutLimit == 1 ? "" : "s") without a reported limit are excluded from the ratio.")
+            exclusions.append("\(withoutLimit) card\(withoutLimit == 1 ? "" : "s") without a reported limit contribute used balance but not total limit.")
         }
-        if withLimit.count > maxSourceRows {
-            exclusions.append("Showing the \(maxSourceRows) largest of \(withLimit.count) cards with a limit.")
+        if creditAccounts.count > maxSourceRows {
+            exclusions.append("Showing the \(maxSourceRows) largest of \(creditAccounts.count) credit cards.")
         }
         exclusions.append("Based on the balance and limit each bank last reported.")
 
@@ -249,6 +250,17 @@ public struct FigureProvenance: Equatable, Sendable {
 
     /// Cap on rendered source rows so the popover stays a glance, not a ledger.
     private static let maxSourceRows = 6
+
+    private static func netWorthContribution(for account: AccountDTO) -> Double {
+        switch account.type {
+        case .depository, .investment:
+            return account.balances.effectiveBalance
+        case .credit, .loan:
+            return -abs(account.balances.current ?? 0)
+        case .other:
+            return account.balances.effectiveBalance
+        }
+    }
 
     private static func make(
         figureTitle: String,
@@ -286,12 +298,13 @@ public struct FigureProvenance: Equatable, Sendable {
     /// last-4 when present; the value is the privacy-mask-aware balance. No raw
     /// account/item IDs ever appear.
     private static func sourceRow(
+        id: String,
         for account: AccountDTO,
         amount: Double,
         privacyMaskEnabled: Bool,
         forceCreditGlyph: Bool = false
     ) -> Source {
-        let suffix = account.mask.map { " ••\($0)" } ?? ""
+        let suffix = account.mask.map { privacyMaskEnabled ? " ••••" : " ••\($0)" } ?? ""
         let label = account.name + suffix
         let value = privacyMaskEnabled
             ? PrivacyMaskPresentation.compactValue
@@ -301,7 +314,7 @@ public struct FigureProvenance: Equatable, Sendable {
             : "balance \(Formatters.currency(amount, format: .full))"
         let glyph = forceCreditGlyph ? "creditcard" : account.type.provenanceGlyph
         return Source(
-            id: account.id,
+            id: id,
             label: label,
             value: value,
             systemImage: glyph,

--- a/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
+++ b/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct FigureProvenanceTests {
     // MARK: - Net worth
 
-    @Test("Net worth provenance lists contributing accounts and excludes investments")
+    @Test("Net worth provenance lists contributing accounts including investments")
     func netWorthProvenance() {
         let accounts = [
             AccountDTO(id: "acct_checking", itemId: "item_1", name: "Everyday Checking", type: .depository, mask: "4321", balances: BalanceDTO(available: 4_200, current: 4_250)),
@@ -18,11 +18,11 @@ struct FigureProvenanceTests {
         let provenance = FigureProvenance.netWorth(accounts: accounts, freshness: freshness)
 
         #expect(provenance.figureTitle == "Net worth")
-        // Investments are excluded; only the two cash/debt accounts contribute.
-        #expect(provenance.sources.count == 2)
+        // Mirrors MenuBarSummary.netCash: investments contribute, debts subtract.
+        #expect(provenance.sources.count == 3)
         #expect(provenance.sources.contains { $0.label.contains("Everyday Checking") })
-        // The investment exclusion is surfaced explicitly.
-        #expect(provenance.exclusions.contains { $0.contains("Investment accounts (1)") })
+        #expect(provenance.sources.contains { $0.label.contains("Brokerage") })
+        #expect(!provenance.exclusions.contains { $0.contains("Investment accounts") })
         #expect(provenance.localOnlyBadge == "Local-only")
     }
 
@@ -37,8 +37,10 @@ struct FigureProvenanceTests {
         let blob = provenance.accessibilitySummary
             + provenance.sources.map { "\($0.id)\($0.label)\($0.accessibilityLabel)\($0.value ?? "")" }.joined()
         #expect(blob.contains("••9911"))
-        // The source `id` carries the account id for SwiftUI identity, but no
-        // user-visible label or accessibility string leaks the raw account/item id.
+        // Source IDs are synthetic for SwiftUI identity, and no user-visible label
+        // or accessibility string leaks the raw account/item id.
+        #expect(provenance.sources.allSatisfy { !$0.id.contains("acct_secret_id") })
+        #expect(provenance.sources.allSatisfy { !$0.id.contains("item_secret_id") })
         #expect(!provenance.accessibilitySummary.contains("acct_secret_id"))
         #expect(!provenance.accessibilitySummary.contains("item_secret_id"))
         #expect(provenance.sources.allSatisfy { !$0.label.contains("acct_secret_id") })
@@ -72,6 +74,24 @@ struct FigureProvenanceTests {
             + provenance.accessibilitySummary
         #expect(!blob.contains("12,345"))
         #expect(!blob.contains("12345"))
+    }
+
+    @Test("Masked account source labels hide last-4 digits")
+    func maskedAccountSourceLabelsHideLast4() {
+        let accounts = [
+            AccountDTO(id: "acct", itemId: "item", name: "Checking", type: .depository, mask: "9911", balances: BalanceDTO(current: 12_345.67)),
+        ]
+
+        let provenance = FigureProvenance.netWorth(
+            accounts: accounts,
+            freshness: nil,
+            privacyMaskEnabled: true
+        )
+
+        #expect(provenance.sources.first?.label == "Checking ••••")
+        let blob = provenance.sources.map { "\($0.id)\($0.label)\($0.accessibilityLabel)\($0.value ?? "")" }.joined()
+            + provenance.accessibilitySummary
+        #expect(!blob.contains("9911"))
     }
 
     // MARK: - Safe to spend
@@ -124,7 +144,7 @@ struct FigureProvenanceTests {
 
     // MARK: - Credit utilization
 
-    @Test("Credit-utilization provenance lists cards and excludes limit-less cards")
+    @Test("Credit-utilization provenance lists all cards and explains limit-less cards")
     func creditUtilizationProvenance() {
         let summary = WealthSummaryPresentation.CreditUtilizationSummary(
             percent: 24,
@@ -145,11 +165,12 @@ struct FigureProvenanceTests {
         )
 
         #expect(provenance.figureTitle == "Credit utilization")
-        // Only the card with a limit contributes a source row.
-        #expect(provenance.sources.count == 1)
+        // Mirrors WealthSummaryPresentation: no-limit cards still contribute used
+        // credit to the numerator, even though they cannot add to total limit.
+        #expect(provenance.sources.count == 2)
         #expect(provenance.sources.contains { $0.label.contains("Cashback Card") })
-        // The limit-less card is surfaced as an exclusion.
-        #expect(provenance.exclusions.contains { $0.contains("without a reported limit") })
+        #expect(provenance.sources.contains { $0.label.contains("Store Card") })
+        #expect(provenance.exclusions.contains { $0.contains("contribute used balance but not total limit") })
         // Unmasked derivation includes the status label.
         #expect(provenance.derivation.contains("Healthy"))
     }

--- a/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
+++ b/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Figure Provenance Tests")
+struct FigureProvenanceTests {
+    // MARK: - Net worth
+
+    @Test("Net worth provenance lists contributing accounts and excludes investments")
+    func netWorthProvenance() {
+        let accounts = [
+            AccountDTO(id: "acct_checking", itemId: "item_1", name: "Everyday Checking", type: .depository, mask: "4321", balances: BalanceDTO(available: 4_200, current: 4_250)),
+            AccountDTO(id: "acct_card", itemId: "item_1", name: "Travel Card", type: .credit, balances: BalanceDTO(current: -800, limit: 5_000)),
+            AccountDTO(id: "acct_brokerage", itemId: "item_2", name: "Brokerage", type: .investment, balances: BalanceDTO(current: 30_000)),
+        ]
+        let freshness = Formatters.parseTransactionDate("2026-06-20")
+
+        let provenance = FigureProvenance.netWorth(accounts: accounts, freshness: freshness)
+
+        #expect(provenance.figureTitle == "Net worth")
+        // Investments are excluded; only the two cash/debt accounts contribute.
+        #expect(provenance.sources.count == 2)
+        #expect(provenance.sources.contains { $0.label.contains("Everyday Checking") })
+        // The investment exclusion is surfaced explicitly.
+        #expect(provenance.exclusions.contains { $0.contains("Investment accounts (1)") })
+        #expect(provenance.localOnlyBadge == "Local-only")
+    }
+
+    @Test("Net worth source labels carry the masked last-4 but never raw IDs")
+    func netWorthNoRawIdentifiers() {
+        let accounts = [
+            AccountDTO(id: "acct_secret_id", itemId: "item_secret_id", name: "Checking", type: .depository, mask: "9911", balances: BalanceDTO(current: 1_000)),
+        ]
+
+        let provenance = FigureProvenance.netWorth(accounts: accounts, freshness: nil)
+
+        let blob = provenance.accessibilitySummary
+            + provenance.sources.map { "\($0.id)\($0.label)\($0.accessibilityLabel)\($0.value ?? "")" }.joined()
+        #expect(blob.contains("••9911"))
+        // The source `id` carries the account id for SwiftUI identity, but no
+        // user-visible label or accessibility string leaks the raw account/item id.
+        #expect(!provenance.accessibilitySummary.contains("acct_secret_id"))
+        #expect(!provenance.accessibilitySummary.contains("item_secret_id"))
+        #expect(provenance.sources.allSatisfy { !$0.label.contains("acct_secret_id") })
+        #expect(provenance.sources.allSatisfy { !$0.accessibilityLabel.contains("item_secret_id") })
+    }
+
+    @Test("Net worth without a sync reports a not-yet-synced freshness")
+    func netWorthFreshnessFallback() {
+        let provenance = FigureProvenance.netWorth(accounts: [], freshness: nil)
+        #expect(provenance.freshnessText == "Not yet synced")
+        #expect(provenance.freshness == nil)
+    }
+
+    // MARK: - Privacy mask
+
+    @Test("Masked net worth provenance never renders a real balance")
+    func maskedNetWorthHidesValues() {
+        let accounts = [
+            AccountDTO(id: "acct", itemId: "item", name: "Checking", type: .depository, balances: BalanceDTO(current: 12_345.67)),
+        ]
+
+        let provenance = FigureProvenance.netWorth(
+            accounts: accounts,
+            freshness: nil,
+            privacyMaskEnabled: true
+        )
+
+        // Every source value is the dotted placeholder, never the real amount.
+        #expect(provenance.sources.allSatisfy { $0.value == PrivacyMaskPresentation.compactValue })
+        let blob = provenance.sources.map { "\($0.value ?? "")\($0.accessibilityLabel)" }.joined()
+            + provenance.accessibilitySummary
+        #expect(!blob.contains("12,345"))
+        #expect(!blob.contains("12345"))
+    }
+
+    // MARK: - Safe to spend
+
+    @Test("Safe-to-spend provenance maps visible components to source rows")
+    func safeToSpendProvenance() {
+        let result = SafeToSpendResult(
+            amount: 420,
+            components: [
+                SafeToSpendComponent(kind: .startingCash, label: "Starting cash", amount: 1_000),
+                SafeToSpendComponent(kind: .expectedIncome, label: "Expected income", amount: 0),
+                SafeToSpendComponent(kind: .upcomingObligations, label: "Upcoming bills", amount: -580),
+            ],
+            confidence: .lowConfidence,
+            horizonEnd: Formatters.parseTransactionDate("2026-06-30") ?? Date()
+        )
+
+        let provenance = FigureProvenance.safeToSpend(result: result, freshness: nil)
+
+        #expect(provenance.figureTitle == "Safe to spend")
+        // startingCash + expectedIncome are always visible; upcomingObligations is non-zero.
+        #expect(provenance.sources.count == 3)
+        #expect(provenance.sources.contains { $0.label == "Upcoming bills" })
+        // The low-confidence caveat is surfaced as an exclusion.
+        #expect(provenance.exclusions.contains { $0.contains("estimated") })
+        // The horizon date range is surfaced.
+        #expect(provenance.exclusions.contains { $0.contains("Looks ahead through") })
+    }
+
+    @Test("Masked safe-to-spend provenance hides component amounts")
+    func maskedSafeToSpendHidesValues() {
+        let result = SafeToSpendResult(
+            amount: 999,
+            components: [
+                SafeToSpendComponent(kind: .startingCash, label: "Starting cash", amount: 5_555),
+            ],
+            confidence: .ok,
+            horizonEnd: Date()
+        )
+
+        let provenance = FigureProvenance.safeToSpend(
+            result: result,
+            freshness: nil,
+            privacyMaskEnabled: true
+        )
+
+        #expect(provenance.sources.allSatisfy { $0.value == PrivacyMaskPresentation.compactValue })
+        #expect(!provenance.accessibilitySummary.contains("5,555"))
+    }
+
+    // MARK: - Credit utilization
+
+    @Test("Credit-utilization provenance lists cards and excludes limit-less cards")
+    func creditUtilizationProvenance() {
+        let summary = WealthSummaryPresentation.CreditUtilizationSummary(
+            percent: 24,
+            usedCredit: 1_200,
+            totalLimit: 5_000,
+            statusLabel: "Healthy",
+            exceedsThreshold: false
+        )
+        let creditAccounts = [
+            AccountDTO(id: "card_a", itemId: "item", name: "Cashback Card", type: .credit, balances: BalanceDTO(current: -1_200, limit: 5_000)),
+            AccountDTO(id: "card_b", itemId: "item", name: "Store Card", type: .credit, balances: BalanceDTO(current: -50)), // no limit
+        ]
+
+        let provenance = FigureProvenance.creditUtilization(
+            summary: summary,
+            creditAccounts: creditAccounts,
+            freshness: nil
+        )
+
+        #expect(provenance.figureTitle == "Credit utilization")
+        // Only the card with a limit contributes a source row.
+        #expect(provenance.sources.count == 1)
+        #expect(provenance.sources.contains { $0.label.contains("Cashback Card") })
+        // The limit-less card is surfaced as an exclusion.
+        #expect(provenance.exclusions.contains { $0.contains("without a reported limit") })
+        // Unmasked derivation includes the status label.
+        #expect(provenance.derivation.contains("Healthy"))
+    }
+
+    @Test("Masked credit-utilization derivation drops the status label and amounts")
+    func maskedCreditUtilizationHidesValues() {
+        let summary = WealthSummaryPresentation.CreditUtilizationSummary(
+            percent: 88,
+            usedCredit: 4_400,
+            totalLimit: 5_000,
+            statusLabel: "High",
+            exceedsThreshold: true
+        )
+        let creditAccounts = [
+            AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -4_400, limit: 5_000)),
+        ]
+
+        let provenance = FigureProvenance.creditUtilization(
+            summary: summary,
+            creditAccounts: creditAccounts,
+            freshness: nil,
+            privacyMaskEnabled: true
+        )
+
+        // The status label ("High") is a value-ish judgement; mask drops it.
+        #expect(!provenance.derivation.contains("High"))
+        #expect(provenance.sources.allSatisfy { $0.value == PrivacyMaskPresentation.compactValue })
+        #expect(!provenance.accessibilitySummary.contains("4,400"))
+    }
+}


### PR DESCRIPTION
## What & why

VaultPeek surfaces many derived finance numbers (net worth, safe-to-spend, credit utilization, category/budget totals, recurring estimates). Local-first **trust** is the product, so users should be able to answer at a glance: *where did this number come from, how fresh is it, and what's excluded?* Today only AI summaries carry a "receipt"; ordinary figures have no consistent provenance interaction.

This generalizes the existing receipt pattern (`LocalAIInsightReceipt`, `DashboardChangeReceipt`) into a reusable **number-provenance** affordance and wires it into three representative high-trust figures.

## Change (files)

**New — PlaidBarCore (pure, `Sendable`, unit-tested):**
- `Sources/PlaidBarCore/Models/FigureProvenance.swift` — a small `FigureProvenance` value plus pure per-figure factory functions:
  - `netWorth(accounts:freshness:privacyMaskEnabled:)` — contributing cash/debt accounts as sources; excludes investments (surfaced explicitly).
  - `safeToSpend(result:freshness:privacyMaskEnabled:)` — the visible `SafeToSpendResult` components as signed source rows; exclusions cover the horizon date range, low-confidence/estimated income, and the buffer.
  - `creditUtilization(summary:creditAccounts:freshness:privacyMaskEnabled:)` — credit cards with a known limit as sources; excludes limit-less cards.
  - Each derivation produces `{ sources (display-safe account names + masked last-4, never raw Plaid IDs), freshness timestamp, exclusions, accessibilitySummary }`. **Privacy-mask aware**: masked provenance renders `••••` placeholders and drops value-ish copy (e.g. the utilization status label).

**New — app:**
- `Sources/PlaidBar/Views/ProvenancePopoverButton.swift` — one reusable, keyboard-focusable `info.circle` button with a VoiceOver label/hint that opens a `.popover` rendering a `FigureProvenance` (sources / freshness / "Not included" / local-only badge). Meaning rides on glyph shape + text, never color.

**Wired (2–3 representative figures, to keep the PR reviewable):**
- `Sources/PlaidBar/Views/Destinations/WindowSection.swift` — `WindowHeroMetricTile` gains an optional `provenance:`; the affordance sits beside the figure as a separately-focusable control (figure stays one a11y element).
- `Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift` — net-worth and safe-to-spend hero tiles pass provenance built from the same Core engines they already use.
- `Sources/PlaidBar/Views/WealthSummaryFlyout.swift` — credit-utilization section header gains the provenance button.

## Testing

```
swift test --filter FigureProvenanceTests
# ✔ 8 tests passed (sources/exclusions, no-raw-ID redaction, freshness fallback,
#   and masked-state hides values for all three factories)

swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# Build complete! (strict-concurrency CI gate — clean)

git diff --check
# clean
```

UI screenshots can be regenerated via `./Scripts/screenshots.sh` (demo data).

## Follow-up (remaining high-trust figures from AND-641)

Out of scope here to stay reviewable — the model/component already supports them:
- Menu-bar value snapshot
- Category totals / budget progress
- Recurring estimate
- Demo fixture with a stale/offline sync state so the freshness caveat is visible in QA/screenshots

## Links

Closes AND-641
