### PR TITLE
fix(ux): window-scale shared sub-components + unified toolbar search (AND-625)

### DIFF
--- a/Sources/PlaidBar/Theme/WindowMetrics.swift
+++ b/Sources/PlaidBar/Theme/WindowMetrics.swift
@@ -187,6 +187,31 @@ struct WindowFigureCaption: ViewModifier {
     }
 }
 
+// MARK: - Component scale (popover vs window)
+
+/// The surface a *shared* sub-component is rendering on, so one view can pick the
+/// right type ramp for its host (AND-625).
+///
+/// A handful of presentational sub-components (e.g. ``RecurringObligationsSection``,
+/// ``BalanceTimeMachineView``) are re-hosted verbatim in both the compact menu-bar
+/// popover and the desk-distance window workspace. Without this hint they read at
+/// popover caption-scale (`.caption2`/`.microText`) everywhere, so inside a window
+/// card their figures look shrunken next to the window's own `.body`-scale rows.
+///
+/// `.popover` is the default so every existing popover/glance call site stays
+/// byte-for-byte unchanged (flag-OFF parity); window call sites pass `.window`,
+/// which swaps the figure/caption roles to their window counterparts
+/// (``WindowDataText`` / ``WindowFigureCaption``). It carries no color and no
+/// financial meaning — only which type ramp to read at — so it is safe to thread
+/// through `Sendable` views.
+enum ComponentScale: Sendable {
+    /// Compact, arm's-length menu-bar popover (the default). Caption-scale figures.
+    case popover
+    /// Desk-distance window workspace. `.body`-scale tabular figures and `.caption2`
+    /// sub-labels, matching the window's own rows.
+    case window
+}
+
 extension View {
     /// Window page identity (`largeTitle`, bold).
     func windowLargeTitle() -> some View { modifier(WindowLargeTitle()) }

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -104,6 +104,7 @@ struct AppShellView: View {
         )
 
         let destination = appState.navigationModel.destination
+        let isSearchEnabled = destinationSupportsSearch(destination) && !appState.isContentLocked
 
         // Column policy per destination (driven by the pure
         // `RouteDestination.prefersThreeColumnLayout` in PlaidBarCore). 3-column
@@ -137,7 +138,7 @@ struct AppShellView: View {
                 // propagation pass migrates those to the shell field one at a time.
                 .modifier(
                     ShellSearchable(
-                        isEnabled: destinationSupportsSearch(destination),
+                        isEnabled: isSearchEnabled,
                         text: $searchText,
                         prompt: searchPrompt(for: destination)
                     )
@@ -155,7 +156,7 @@ struct AppShellView: View {
         // filter their own rows (the shell owns the field, each canvas owns the
         // filtering). Cleared for non-adopting destinations so a stale query never
         // leaks in.
-        .environment(\.shellSearchQuery, destinationSupportsSearch(destination) ? searchText : "")
+        .environment(\.shellSearchQuery, isSearchEnabled ? searchText : "")
         // Reroute the legacy "open detached window" affordances into in-window
         // navigation (AND-616). The Dashboard canvas embeds
         // `CategoryDashboardCard` (its "Open dashboard" button) and the Review
@@ -239,8 +240,13 @@ struct AppShellView: View {
         )
         .onChange(of: appState.isContentLocked) { _, isLocked in
             // A locked window must not keep the ⌘K palette mounted underneath the
-            // gate; dismiss it so unlocking returns to the bare workspace.
-            if isLocked { paletteModel.dismiss() }
+            // gate; dismiss it so unlocking returns to the bare workspace. The
+            // toolbar search field lives in chrome outside the lock overlay, so
+            // clear it too instead of preserving account names under the gate.
+            if isLocked {
+                paletteModel.dismiss()
+                searchText = ""
+            }
         }
     }
 

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -54,9 +54,9 @@ struct AppShellView: View {
     /// injected from the scene. No-op until per-destination search lands.
     private let focusSearch: () -> Void
 
-    /// The window's unified `.searchable` query (AND-624). The shell owns one
-    /// search field in the toolbar; it is threaded into the destination that
-    /// supports search (currently the Dashboard, via `\.dashboardSearchQuery`).
+    /// The window's unified `.searchable` query (AND-624 / AND-625). The shell owns
+    /// one search field in the toolbar; it is threaded into the destinations that
+    /// adopt search (Dashboard and Accounts, via `\.shellSearchQuery`).
     /// Window-scoped `@State` so each window searches independently, and reset on
     /// a destination switch so a stale query never leaks across surfaces.
     @State private var searchText = ""
@@ -151,9 +151,11 @@ struct AppShellView: View {
             searchText = ""
             isInspectorPresented = true
         }
-        // The Dashboard reads the live query from the environment to filter its
-        // account rows (the shell owns the field, the canvas owns the filtering).
-        .environment(\.dashboardSearchQuery, destinationSupportsSearch(destination) ? searchText : "")
+        // Search-adopting destinations read the live query from the environment to
+        // filter their own rows (the shell owns the field, each canvas owns the
+        // filtering). Cleared for non-adopting destinations so a stale query never
+        // leaks in.
+        .environment(\.shellSearchQuery, destinationSupportsSearch(destination) ? searchText : "")
         // Reroute the legacy "open detached window" affordances into in-window
         // navigation (AND-616). The Dashboard canvas embeds
         // `CategoryDashboardCard` (its "Open dashboard" button) and the Review
@@ -318,18 +320,22 @@ struct AppShellView: View {
         return Binding(get: { isInspectorPresented }, set: { isInspectorPresented = $0 })
     }
 
-    /// Whether a destination adopts the shell's unified `.searchable` field. Only
-    /// the Dashboard does today (it filters its account rows via
-    /// `\.dashboardSearchQuery`); destinations with their own inline search keep it
-    /// until the propagation pass migrates them, so there is never a second field.
+    /// Whether a destination adopts the shell's unified `.searchable` field. The
+    /// Dashboard and Accounts do (both filter their account list by display name via
+    /// `\.shellSearchQuery`); destinations with their own inline search (e.g.
+    /// Transactions' filter bar) keep it until the propagation pass migrates them, so
+    /// there is never a competing second field.
     private func destinationSupportsSearch(_ destination: RouteDestination) -> Bool {
-        destination == .dashboard
+        switch destination {
+        case .dashboard, .accounts: true
+        default: false
+        }
     }
 
     /// The search-field prompt for a search-adopting destination.
     private func searchPrompt(for destination: RouteDestination) -> String {
         switch destination {
-        case .dashboard: "Search accounts"
+        case .dashboard, .accounts: "Search accounts"
         default: "Search"
         }
     }

--- a/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
+++ b/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
@@ -9,6 +9,13 @@ import SwiftUI
 struct BalanceTimeMachineView: View {
     @Environment(AppState.self) private var appState
 
+    /// Which surface is hosting this strip. `.popover` (the default) keeps the
+    /// compact glance caption-scale; the window dashboard passes `.window` so the
+    /// account names, balances, and dates read at desk-distance type
+    /// (``WindowBodyText`` / ``WindowDataText`` / ``WindowFigureCaption``) instead
+    /// of shrunken popover caption-scale (AND-625).
+    var scale: ComponentScale = .popover
+
     /// Latest per-account ledger rows, intersected with currently-linked
     /// accounts. After an institution is disconnected, `removeAccount` prunes the
     /// account but not the ledger, so an un-filtered list would keep showing the
@@ -49,6 +56,53 @@ struct BalanceTimeMachineView: View {
         SyncHistoryDiff.maskCurrencyTokens(in: text, isEnabled: privacyMaskEnabled)
     }
 
+    /// "What the bank said" head — popover `sectionTitle` (caption, uppercase),
+    /// window `windowCardTitle` (`title3`) so it matches the dashboard's heads.
+    @ViewBuilder
+    private var titleLabel: some View {
+        switch scale {
+        case .popover:
+            Text("What the bank said").sectionTitle()
+        case .window:
+            Text("What the bank said").windowCardTitle()
+        }
+    }
+
+    /// Account display name — popover caption-scale `microText`, window `.body`.
+    @ViewBuilder
+    private func nameLabel(_ text: String) -> some View {
+        switch scale {
+        case .popover:
+            Text(text).microText()
+        case .window:
+            Text(text).windowBodyText()
+        }
+    }
+
+    /// Bank-reported balance figure — popover caption-scale tabular, window tabular
+    /// (``WindowDataText``) so the amount column aligns at desk distance.
+    @ViewBuilder
+    private func balanceLabel(_ text: String) -> some View {
+        switch scale {
+        case .popover:
+            Text(text).microText().monospacedDigit()
+        case .window:
+            Text(text).windowDataText()
+        }
+    }
+
+    /// Date / restatement sub-label — popover `microText`, window
+    /// `windowFigureCaption` (`caption2`) so the small label reads at window scale.
+    @ViewBuilder
+    private func dateLabel(_ text: String) -> some View {
+        switch scale {
+        case .popover:
+            Text(text).microText()
+        case .window:
+            Text(text).windowFigureCaption()
+        }
+    }
+
     var body: some View {
         let entries = latestEntries
         if !entries.isEmpty {
@@ -57,23 +111,18 @@ struct BalanceTimeMachineView: View {
                     Image(systemName: "clock.arrow.circlepath")
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
-                    Text("What the bank said")
-                        .sectionTitle()
+                    titleLabel
                         .foregroundStyle(.secondary)
                 }
 
                 ForEach(entries) { entry in
                     HStack(spacing: 6) {
-                        Text(displayName(for: entry.accountId))
-                            .microText()
+                        nameLabel(displayName(for: entry.accountId))
                             .lineLimit(1)
                         Spacer(minLength: 4)
-                        Text(balanceText(for: entry))
-                            .microText()
-                            .monospacedDigit()
+                        balanceLabel(balanceText(for: entry))
                             .foregroundStyle(.secondary)
-                        Text(Formatters.displayDate(entry.date))
-                            .microText()
+                        dateLabel(Formatters.displayDate(entry.date))
                             .foregroundStyle(.secondary)
                     }
                     .accessibilityElement(children: .combine)
@@ -87,8 +136,7 @@ struct BalanceTimeMachineView: View {
                         Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(.secondary)
-                        Text(maskedDelta(row.summary))
-                            .microText()
+                        dateLabel(maskedDelta(row.summary))
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }

--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -127,7 +127,7 @@ struct AccountsDestinationView: View {
             // Self-heal: if the selected account falls out of the list (removed /
             // disconnected), clear it so the inspector returns to its prompt instead
             // of pointing at a vanished account. Mirrors the popover's reconcile.
-            .onChange(of: accounts.map(\.id)) { _, ids in
+            .onChange(of: filteredAccounts.map(\.id)) { _, ids in
                 navigationModel.reconcileSelection(visibleAccountIDs: ids)
             }
     }
@@ -332,17 +332,30 @@ struct AccountsDestinationView: View {
     /// from `AppState.navigationModel`.
     struct Inspector: View {
         @Environment(AppState.self) private var appState
+        @Environment(\.shellSearchQuery) private var searchQuery
 
         private var navigationModel: NavigationModel { appState.navigationModel }
+
+        private var trimmedQuery: String {
+            searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        private var visibleAccounts: [AccountDTO] {
+            let query = trimmedQuery
+            guard !query.isEmpty else { return appState.accounts }
+            return appState.accounts.filter {
+                AccountPresentation.displayName(for: $0).localizedCaseInsensitiveContains(query)
+            }
+        }
 
         /// The selected account resolved against the live (visible) accounts — `nil`
         /// when nothing is selected or the selection is no longer present, which
         /// content-gates the inspector to its prompt.
         private var selectedAccount: AccountDTO? {
             guard let id = navigationModel.resolvedSelectedID(
-                visibleAccountIDs: appState.accounts.map(\.id)
+                visibleAccountIDs: visibleAccounts.map(\.id)
             ) else { return nil }
-            return appState.accounts.first { $0.id == id }
+            return visibleAccounts.first { $0.id == id }
         }
 
         var body: some View {

--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -56,11 +56,32 @@ import SwiftUI
 struct AccountsDestinationView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The shell's unified `.searchable` query (AND-625). Empty ⇒ no filter, so the
+    /// flag-OFF popover (which never injects it) is unchanged. The shell owns the
+    /// field; this canvas owns the filtering, mirroring the Dashboard.
+    @Environment(\.shellSearchQuery) private var searchQuery
 
     private var navigationModel: NavigationModel { appState.navigationModel }
     private var accounts: [AccountDTO] { appState.accounts }
+
+    private var trimmedQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Accounts narrowed by the shell search query. Case-insensitive substring match
+    /// on the displayed account *name* — the one field the user reads in the row, and
+    /// never a masked value (it matches names, not amounts), so search stays safe
+    /// under Privacy Mask. Empty query ⇒ all accounts (the default).
+    private var filteredAccounts: [AccountDTO] {
+        let query = trimmedQuery
+        guard !query.isEmpty else { return accounts }
+        return accounts.filter {
+            AccountPresentation.displayName(for: $0).localizedCaseInsensitiveContains(query)
+        }
+    }
+
     private var sections: [AccountListGrouping.Section] {
-        AccountListGrouping.sections(for: accounts)
+        AccountListGrouping.sections(for: filteredAccounts)
     }
 
     var body: some View {
@@ -132,14 +153,23 @@ struct AccountsDestinationView: View {
             VStack(alignment: .leading, spacing: WindowMetrics.xl) {
                 heroMetricsRow
 
-                VStack(alignment: .leading, spacing: WindowMetrics.lg) {
-                    ForEach(sections) { section in
-                        AccountsGroupSection(
-                            section: section,
-                            selectedID: selectedID,
-                            onSelect: toggleSelection
-                        )
-                        .environment(appState)
+                if sections.isEmpty {
+                    // A search query that matches no account name. Keep the hero row
+                    // (it summarizes the whole ledger) and show a contextual "no
+                    // results" state below it rather than a blank canvas. Names the
+                    // query in text, no color cue.
+                    ContentUnavailableView.search(text: trimmedQuery)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else {
+                    VStack(alignment: .leading, spacing: WindowMetrics.lg) {
+                        ForEach(sections) { section in
+                            AccountsGroupSection(
+                                section: section,
+                                selectedID: selectedID,
+                                onSelect: toggleSelection
+                            )
+                            .environment(appState)
+                        }
                     }
                 }
             }

--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -98,7 +98,7 @@ struct DashboardOverviewColumn: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     /// The shell's unified `.searchable` query (AND-624). Empty ⇒ no filter, so the
     /// flag-OFF popover (which never injects it) is unchanged.
-    @Environment(\.dashboardSearchQuery) private var searchQuery
+    @Environment(\.shellSearchQuery) private var searchQuery
 
     /// Routed by the destination to the Accounts destination (no local inspector
     /// on a 2-column canvas).
@@ -199,7 +199,7 @@ struct DashboardOverviewColumn: View {
             appState.accounts.contains { $0.id == entry.accountId }
         }) {
             Divider().opacity(0.4)
-            BalanceTimeMachineView()
+            BalanceTimeMachineView(scale: .window)
         }
     }
 

--- a/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift
@@ -45,7 +45,8 @@ struct DashboardRecurringCard: View {
             RecurringObligationsSection(
                 presentation: presentation,
                 onOpenSubscriptions: onOpen,
-                privacyMaskEnabled: appState.shouldMaskFinancialValues
+                privacyMaskEnabled: appState.shouldMaskFinancialValues,
+                scale: .window
             )
         }
     }

--- a/Sources/PlaidBar/Views/Destinations/DashboardSearchQuery.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardSearchQuery.swift
@@ -1,26 +1,28 @@
 import SwiftUI
 
-/// The window's Dashboard search query, threaded from the shell's `.searchable`
-/// toolbar field into the Dashboard canvas (AND-624).
+/// The window shell's unified search query, threaded from the shell's `.searchable`
+/// toolbar field into whichever destination canvas adopts it (AND-624 / AND-625).
 ///
-/// The window-first shell owns the unified `.searchable` toolbar (so search lives
-/// in the window chrome, not inside the canvas), and the Dashboard reads the live
-/// query from the environment to filter its account rows. Routing it through the
-/// environment (rather than a threaded binding) keeps the content-column router
-/// (`DestinationContentView`) signature untouched, so the propagation pass can
-/// adopt the same pattern per destination without a shared plumbing change.
+/// The window-first shell owns ONE unified `.searchable` toolbar (so search lives
+/// in the window chrome, not inside each canvas), and the search-adopting
+/// destinations read the live query from the environment to filter their own rows
+/// — the Dashboard and Accounts filter their account list by display name. Routing
+/// it through the environment (rather than a threaded binding) keeps the
+/// content-column router (`DestinationContentView`) signature untouched, so the
+/// propagation pass adopts the same pattern per destination without a shared
+/// plumbing change.
 ///
 /// Empty string ⇒ no filter (the default), so the popover build — which never
 /// mounts the shell — is unaffected.
-private struct DashboardSearchQueryKey: EnvironmentKey {
+private struct ShellSearchQueryKey: EnvironmentKey {
     static let defaultValue: String = ""
 }
 
 extension EnvironmentValues {
-    /// The live Dashboard search query from the shell's `.searchable` field.
-    /// Trimmed/empty means "no filter".
-    var dashboardSearchQuery: String {
-        get { self[DashboardSearchQueryKey.self] }
-        set { self[DashboardSearchQueryKey.self] = newValue }
+    /// The live unified search query from the shell's `.searchable` field, scoped to
+    /// the destination that adopts it. Trimmed/empty means "no filter".
+    var shellSearchQuery: String {
+        get { self[ShellSearchQueryKey.self] }
+        set { self[ShellSearchQueryKey.self] = newValue }
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift
@@ -280,7 +280,8 @@ struct PlanningDestinationView: View {
             RecurringObligationsSection(
                 presentation: presentation,
                 onOpenSubscriptions: nil,
-                privacyMaskEnabled: isMasked
+                privacyMaskEnabled: isMasked,
+                scale: .window
             )
             .loadingRedaction(appState.loadState(for: .recurring))
         }

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -18,6 +18,11 @@ struct RecurringObligationsSection: View {
     /// When true, recurring amounts and the monthly total are masked while
     /// Privacy Mask or App Lock is active.
     var privacyMaskEnabled: Bool = false
+    /// Which surface is hosting these rows. `.popover` (the default) keeps the
+    /// compact glance scale; window canvases pass `.window` so the rows read at
+    /// desk-distance type (``WindowDataText`` / ``WindowFigureCaption``) instead of
+    /// shrunken popover caption-scale (AND-625).
+    var scale: ComponentScale = .popover
 
     /// Keep the narrow column dense: show the most relevant few, summarize the
     /// rest. Attention-first ordering means flagged items are never hidden
@@ -31,7 +36,7 @@ struct RecurringObligationsSection: View {
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     ForEach(Array(presentation.items.prefix(visibleLimit))) { item in
-                        RecurringObligationRow(item: item, privacyMaskEnabled: privacyMaskEnabled)
+                        RecurringObligationRow(item: item, privacyMaskEnabled: privacyMaskEnabled, scale: scale)
                     }
                 }
 
@@ -50,15 +55,12 @@ struct RecurringObligationsSection: View {
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
-            Text("Recurring")
-                .sectionTitle()
+            titleLabel
                 .foregroundStyle(.secondary)
 
             Spacer(minLength: Spacing.sm)
 
-            Text("~\(PrivacyMaskPresentation.currency(presentation.estimatedMonthlyTotal, format: .compact, isEnabled: privacyMaskEnabled))/mo")
-                .microText()
-                .monospacedDigit()
+            monthlyTotalLabel
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .accessibilityHidden(true)
@@ -74,6 +76,32 @@ struct RecurringObligationsSection: View {
                 .help("Open recurring payments")
                 .accessibilityLabel("Open recurring payments")
             }
+        }
+    }
+
+    /// "Recurring" card head — `sectionTitle` (caption, uppercase) in the popover,
+    /// `windowCardTitle` (`title3`) on a window canvas so the head matches the
+    /// window's other section heads (AND-625).
+    @ViewBuilder
+    private var titleLabel: some View {
+        switch scale {
+        case .popover:
+            Text("Recurring").sectionTitle()
+        case .window:
+            Text("Recurring").windowCardTitle()
+        }
+    }
+
+    /// Estimated monthly total — caption-scale in the popover, window tabular
+    /// (``WindowDataText``) on a window canvas so it aligns with the rows' figures.
+    @ViewBuilder
+    private var monthlyTotalLabel: some View {
+        let text = "~\(PrivacyMaskPresentation.currency(presentation.estimatedMonthlyTotal, format: .compact, isEnabled: privacyMaskEnabled))/mo"
+        switch scale {
+        case .popover:
+            Text(text).microText().monospacedDigit()
+        case .window:
+            Text(text).windowDataText()
         }
     }
 
@@ -94,13 +122,13 @@ struct RecurringObligationsSection: View {
 private struct RecurringObligationRow: View {
     let item: RecurringObligationsPresentation.Item
     var privacyMaskEnabled: Bool = false
+    var scale: ComponentScale = .popover
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.xxs) {
             HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
                 Label {
-                    Text(item.merchantName)
-                        .font(.subheadline)
+                    merchantNameLabel
                         .lineLimit(1)
                 } icon: {
                     Image(systemName: item.frequency.iconName)
@@ -110,16 +138,13 @@ private struct RecurringObligationRow: View {
 
                 Spacer(minLength: Spacing.sm)
 
-                Text(PrivacyMaskPresentation.currency(item.expectedAmount, format: .compact, isEnabled: privacyMaskEnabled))
-                    .font(.subheadline.weight(.semibold))
-                    .monospacedDigit()
+                amountLabel
                     .foregroundStyle(AppearanceTextColors.primary)
                     .lineLimit(1)
             }
 
             HStack(spacing: Spacing.xs) {
-                Text("\(item.frequency.displayName) · next \(Formatters.displayTransactionDate(item.nextExpectedDate))")
-                    .microText()
+                detailLabel
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
@@ -136,6 +161,43 @@ private struct RecurringObligationRow: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// Merchant name — popover `.subheadline`, window `.body` (``WindowBodyText``).
+    @ViewBuilder
+    private var merchantNameLabel: some View {
+        switch scale {
+        case .popover:
+            Text(item.merchantName).font(.subheadline)
+        case .window:
+            Text(item.merchantName).windowBodyText()
+        }
+    }
+
+    /// Expected amount — popover `.subheadline` semibold, window tabular
+    /// (``WindowDataText``) so the figure aligns with the window's other rows.
+    @ViewBuilder
+    private var amountLabel: some View {
+        let text = PrivacyMaskPresentation.currency(item.expectedAmount, format: .compact, isEnabled: privacyMaskEnabled)
+        switch scale {
+        case .popover:
+            Text(text).font(.subheadline.weight(.semibold)).monospacedDigit()
+        case .window:
+            Text(text).windowDataText()
+        }
+    }
+
+    /// Cadence + next-date detail line — popover `microText`, window
+    /// `windowFigureCaption` so the sub-label reads at the window's caption scale.
+    @ViewBuilder
+    private var detailLabel: some View {
+        let text = "\(item.frequency.displayName) · next \(Formatters.displayTransactionDate(item.nextExpectedDate))"
+        switch scale {
+        case .popover:
+            Text(text).microText()
+        case .window:
+            Text(text).windowFigureCaption()
+        }
     }
 
     /// Deterministic flag order so badges don't reshuffle between renders.

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1075,7 +1075,9 @@ struct PlaidBarTests {
         // The shell routes its single field to both Dashboard and Accounts and
         // injects the neutral, unified env key (not the old Dashboard-specific one).
         #expect(shell.contains("case .dashboard, .accounts: true"))
+        #expect(shell.contains("let isSearchEnabled = destinationSupportsSearch(destination) && !appState.isContentLocked"))
         #expect(shell.contains(".environment(\\.shellSearchQuery,"))
+        #expect(shell.contains("searchText = \"\""))
         #expect(!shell.contains("dashboardSearchQuery"))
 
         // Accounts reads the shared query and filters by display name (never a masked
@@ -1083,6 +1085,8 @@ struct PlaidBarTests {
         #expect(accounts.contains("@Environment(\\.shellSearchQuery)"))
         #expect(accounts.contains("localizedCaseInsensitiveContains(query)"))
         #expect(accounts.contains("ContentUnavailableView.search(text:"))
+        #expect(accounts.contains(".onChange(of: filteredAccounts.map(\\.id))"))
+        #expect(accounts.contains("visibleAccounts.map(\\.id)"))
     }
 }
 

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -993,6 +993,97 @@ struct PlaidBarTests {
 
         #expect(cache.count == 2, "no eviction when every cached id is still in the inbox")
     }
+
+    // MARK: - Window-scale shared sub-components + unified search (AND-625)
+
+    /// Source-invariant guard for AND-625 part (1): the shared sub-components that
+    /// are re-hosted in both the popover and the window must carry a
+    /// `ComponentScale` hint and reference the window type roles
+    /// (`windowDataText` / `windowFigureCaption` / `windowBodyText` /
+    /// `windowCardTitle`), so window canvases render them at desk-distance scale
+    /// rather than shrunken popover caption-scale. Default `.popover` keeps the
+    /// glance byte-for-byte. Asserts the call sites, not pixels — the app target is
+    /// an `@main` executable that can't be `@testable import`ed.
+    @Test("Shared sub-components adopt the window type roles when hosted in a window (AND-625)")
+    func sharedSubComponentsScaleToWindowRoles() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let recurringSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/RecurringObligationsSection.swift"),
+            encoding: .utf8
+        )
+        let balanceSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/BalanceTimeMachineView.swift"),
+            encoding: .utf8
+        )
+
+        // Both components must take a ComponentScale that defaults to .popover so
+        // the glance is unaffected and only window callers opt into window scale.
+        for source in [recurringSource, balanceSource] {
+            #expect(source.contains("var scale: ComponentScale = .popover"))
+            // The window branch must reach for the window roles, not the popover's
+            // caption-scale microText/sectionTitle.
+            #expect(source.contains("windowDataText()"))
+            #expect(source.contains("windowFigureCaption()"))
+            #expect(source.contains("windowBodyText()"))
+            #expect(source.contains("windowCardTitle()"))
+        }
+
+        // The window call sites must pass `.window`; the popover call site keeps the
+        // default. (Window: DashboardRecurringCard, PlanningDestinationView,
+        // DashboardOverviewColumn. Popover: WealthSummaryFlyout, MainPopover.)
+        let dashboardRecurring = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift"),
+            encoding: .utf8
+        )
+        let planning = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/PlanningDestinationView.swift"),
+            encoding: .utf8
+        )
+        let overviewColumn = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift"),
+            encoding: .utf8
+        )
+        let wealthFlyout = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/WealthSummaryFlyout.swift"),
+            encoding: .utf8
+        )
+
+        #expect(dashboardRecurring.contains("scale: .window"))
+        #expect(planning.contains("scale: .window"))
+        #expect(overviewColumn.contains("BalanceTimeMachineView(scale: .window)"))
+        // The popover host must NOT opt into window scale (would inflate the glance).
+        #expect(!wealthFlyout.contains("scale: .window"))
+    }
+
+    /// Source-invariant guard for AND-625 part (2): the window shell's unified
+    /// `.searchable` field now propagates to a second destination (Accounts), which
+    /// filters its account list by the shared `\.shellSearchQuery` environment value
+    /// exactly like the Dashboard — one consistent toolbar field, no competing
+    /// inline search, no leak across destinations.
+    @Test("Accounts adopts the shell's unified search field via \\.shellSearchQuery (AND-625)")
+    func accountsAdoptsUnifiedShellSearch() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let shell = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/AppShellView.swift"),
+            encoding: .utf8
+        )
+        let accounts = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift"),
+            encoding: .utf8
+        )
+
+        // The shell routes its single field to both Dashboard and Accounts and
+        // injects the neutral, unified env key (not the old Dashboard-specific one).
+        #expect(shell.contains("case .dashboard, .accounts: true"))
+        #expect(shell.contains(".environment(\\.shellSearchQuery,"))
+        #expect(!shell.contains("dashboardSearchQuery"))
+
+        // Accounts reads the shared query and filters by display name (never a masked
+        // amount), with a contextual no-results state.
+        #expect(accounts.contains("@Environment(\\.shellSearchQuery)"))
+        #expect(accounts.contains("localizedCaseInsensitiveContains(query)"))
+        #expect(accounts.contains("ContentUnavailableView.search(text:"))
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.


### PR DESCRIPTION
## What & why

Shared presentational sub-components that are re-hosted **verbatim** in both the compact menu-bar popover and the desk-distance window workspace were rendering at popover caption-scale everywhere. Inside a window card their figures looked shrunken next to the window's own `.body`-scale rows. This workstream (W9 / AND-625) fixes the type-role mismatch and extends the window's unified toolbar search to a second destination.

Two parts; the type-role fix (part 1) is the higher-value / lower-risk half and is the core of this PR.

### Part 1 — window-scale shared sub-components
- New `ComponentScale` (`.popover` / `.window`) hint in `WindowMetrics.swift`, defaulting to `.popover` so every existing glance/popover call site stays **byte-for-byte** (flag-OFF parity). It carries no color and no financial meaning — only which type ramp to read at — so it is safe to thread through `Sendable` views.
- `RecurringObligationsSection` rows and `BalanceTimeMachineView` ("what the bank said" balance rows + restatement line) now switch, in their `.window` branch, to the window type ramp introduced in AND-628 — `WindowDataText` / `WindowFigureCaption` / `WindowBodyText` / `WindowCardTitle` — with tabular figures, matching how `DashboardDestinationView` / `AccountsDestinationView` read at desk distance.
- Window callers pass `scale: .window` (`DashboardRecurringCard`, `PlanningDestinationView`, the `DashboardOverviewColumn` "bank said" footer); popover hosts (`WealthSummaryFlyout`, `MainPopover`) keep the default, so the glance is unchanged.
- Privacy Mask / App Lock behavior is untouched — amounts still route through `PrivacyMaskPresentation`; only the font role changes.

### Part 2 — unified toolbar search propagation
- The window shell already owns ONE unified `.searchable` toolbar field (AND-624); its per-destination adoption explicitly anticipated a "propagation pass." This extends that pass to **Accounts**, which filters its account list by the shared query exactly like the Dashboard: case-insensitive display-name match (never a masked amount, so search stays safe under Privacy Mask), with a contextual `ContentUnavailableView.search` no-results state.
- Renamed the now-misnamed env key `dashboardSearchQuery` → `shellSearchQuery` (the field is shell-owned and shared by two destinations).
- **Follow-up:** `TransactionsDestinationView` keeps its own inline filter bar (`TransactionsFilterBar`) — migrating that to the shell field is a larger, more opinionated change (it carries date/category/amount facets, not just a name match) and is intentionally left out of this PR to keep the diff reviewable. Tracked as the next step of the same propagation pass.

## Change (files)
- `Sources/PlaidBar/Theme/WindowMetrics.swift` — add `ComponentScale` enum.
- `Sources/PlaidBar/Views/RecurringObligationsSection.swift` — `scale` param; scale-aware title/total/merchant/amount/detail roles.
- `Sources/PlaidBar/Views/BalanceTimeMachineView.swift` — `scale` param; scale-aware title/name/balance/date roles.
- `Sources/PlaidBar/Views/Destinations/DashboardRecurringCard.swift`, `.../PlanningDestinationView.swift`, `.../DashboardOverviewColumn.swift` — pass `scale: .window`.
- `Sources/PlaidBar/Views/Destinations/DashboardSearchQuery.swift` — env key `dashboardSearchQuery` → `shellSearchQuery` + docs.
- `Sources/PlaidBar/Views/AppShellView.swift` — Accounts adopts the unified field; prompt + injection updated.
- `Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift` — read `\.shellSearchQuery`, filter by display name, no-results state.
- `Tests/PlaidBarTests/PlaidBarTests.swift` — two source-invariant tests.

## Testing
Run with the SwiftPM sandbox disabled (SwiftPM spawns its own sandbox).

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (strict-concurrency gate, the CI gate, passes).
- `swift test --filter sharedSubComponentsScaleToWindowRoles` → **1 test passed**.
- `swift test --filter accountsAdoptsUnifiedShellSearch` → **1 test passed**.
- `swift test --filter PlaidBarTests` → **53 tests passed** (no regression in the app suite).
- `git diff --check` → clean.

The two new tests are source-invariant (the app is an `@main` executable that can't be `@testable import`ed): they assert the shared sub-components carry a `ComponentScale` defaulting to `.popover` and reference the window type roles, that window call sites pass `.window` while the popover host does not, and that Accounts wires the unified `\.shellSearchQuery`.

UI changes are type-scale + a toolbar search field; screenshots can be regenerated via `./Scripts/screenshots.sh` (not run here — no fixture/data change).

## Links
Closes AND-625
