### PR TITLE
feat(intents): interactive finance snippets + App Intents tests (AND-637, AND-638)

### DIFF
--- a/Sources/PlaidBar/Intents/FinanceAppIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceAppIntents.swift
@@ -86,5 +86,32 @@ struct PlaidBarShortcutsProvider: AppShortcutsProvider {
             shortTitle: "Credit Utilization",
             systemImageName: "creditcard"
         )
+        // Focused rich snippets (AND-637). The package's minimum deployment is
+        // macOS 26, so these `@available(macOS 26.0, *)` SnippetIntents are always
+        // available here — no #available gate is needed at this call site.
+        AppShortcut(
+            intent: SafeToSpendSnippetIntent(),
+            phrases: [
+                "Show my safe to spend snippet in \(.applicationName)",
+            ],
+            shortTitle: "Safe to Spend Snippet",
+            systemImageName: "wallet.pass"
+        )
+        AppShortcut(
+            intent: NextBillsSnippetIntent(),
+            phrases: [
+                "Show my next bills snippet in \(.applicationName)",
+            ],
+            shortTitle: "Next Bills Snippet",
+            systemImageName: "calendar.badge.clock"
+        )
+        AppShortcut(
+            intent: CreditUtilizationSnippetIntent(),
+            phrases: [
+                "Show my credit utilization snippet in \(.applicationName)",
+            ],
+            shortTitle: "Credit Utilization Snippet",
+            systemImageName: "creditcard"
+        )
     }
 }

--- a/Sources/PlaidBar/Intents/FinanceDashboardSnippetIntent.swift
+++ b/Sources/PlaidBar/Intents/FinanceDashboardSnippetIntent.swift
@@ -22,6 +22,7 @@ struct FinanceDashboardSnippetIntent: SnippetIntent {
     static let description = IntentDescription(
         "A glance at your balance, safe-to-spend, and spending — inline in Spotlight."
     )
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ShowsSnippetView {

--- a/Sources/PlaidBar/Intents/FinanceSnippetIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceSnippetIntents.swift
@@ -31,6 +31,7 @@ struct SafeToSpendSnippetIntent: SnippetIntent {
     static let description = IntentDescription(
         "A glance at your safe-to-spend amount, confidence, and horizon — inline in Spotlight."
     )
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ShowsSnippetView {
@@ -90,6 +91,7 @@ struct NextBillsSnippetIntent: SnippetIntent {
     static let description = IntentDescription(
         "Your next few recurring bills with dates and amounts — inline in Spotlight."
     )
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ShowsSnippetView {
@@ -153,6 +155,7 @@ struct CreditUtilizationSnippetIntent: SnippetIntent {
     static let description = IntentDescription(
         "Your aggregate credit utilization as a gauge — inline in Spotlight."
     )
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ShowsSnippetView {

--- a/Sources/PlaidBar/Intents/FinanceSnippetIntents.swift
+++ b/Sources/PlaidBar/Intents/FinanceSnippetIntents.swift
@@ -1,0 +1,256 @@
+import AppIntents
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Focused finance SnippetIntents (AND-637)
+//
+// `SnippetIntent` (macOS 26+) renders a small SwiftUI view inline in Spotlight /
+// Siri / Shortcuts results. `FinanceDashboardSnippetIntent` already renders the
+// *combined* mini-dashboard; these give each headline metric — safe-to-spend,
+// next bills, credit utilization — its own richer, single-purpose snippet.
+//
+// Each follows the same contract as the dashboard snippet:
+//   • The system may call `perform()` MULTIPLE times, so every intent RE-LOADS the
+//     shared `FinanceSnapshot` inside `perform()` and rebuilds its model — it never
+//     caches a value-bearing model across invocations.
+//   • All row selection / formatting / masking lives in the pure
+//     `FinanceSnippetPresentation` (PlaidBarCore); these views are thin renderers.
+//   • A masked / missing / empty snapshot yields the withheld affordance — no real
+//     figure is ever drawn past App Lock / Privacy Mask.
+//
+// They live in the app target (not Core / the widget extension) because the views
+// are SwiftUI and are extracted against the app, exactly like the dashboard
+// snippet. `PlaidBarShortcutsProvider` lists them so Shortcuts/Spotlight discover
+// them alongside the value-returning intents.
+
+// MARK: - Safe to spend
+
+@available(macOS 26.0, *)
+struct SafeToSpendSnippetIntent: SnippetIntent {
+    static let title: LocalizedStringResource = "Safe to Spend Snippet"
+    static let description = IntentDescription(
+        "A glance at your safe-to-spend amount, confidence, and horizon — inline in Spotlight."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ShowsSnippetView {
+        let model = FinanceSnippetPresentation.safeToSpend(from: AppGroupSnapshotStore.loadIfAvailable())
+        return .result(view: SafeToSpendSnippetView(model: model))
+    }
+}
+
+@available(macOS 26.0, *)
+private struct SafeToSpendSnippetView: View {
+    let model: FinanceSnippetPresentation.SafeToSpendModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SnippetHeader(title: "Safe to Spend", systemImage: "wallet.pass")
+
+            if let reason = model.withholdReason {
+                WithheldRow(reason: reason)
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    if model.isOverBudget {
+                        Image(systemName: "exclamationmark.triangle")
+                            .imageScale(.small)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(model.amount)
+                        .font(.title2.weight(.semibold))
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                if let confidence = model.confidenceLabel {
+                    Label(confidence, systemImage: model.confidenceSystemImage ?? "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let horizon = model.horizonLabel {
+                    Text(horizon)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            SnippetFooter(updatedAt: model.updatedAt)
+        }
+        .padding(14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(model.accessibilityLabel)
+    }
+}
+
+// MARK: - Next recurring bills
+
+@available(macOS 26.0, *)
+struct NextBillsSnippetIntent: SnippetIntent {
+    static let title: LocalizedStringResource = "Next Bills Snippet"
+    static let description = IntentDescription(
+        "Your next few recurring bills with dates and amounts — inline in Spotlight."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ShowsSnippetView {
+        let model = FinanceSnippetPresentation.nextBills(from: AppGroupSnapshotStore.loadIfAvailable())
+        return .result(view: NextBillsSnippetView(model: model))
+    }
+}
+
+@available(macOS 26.0, *)
+private struct NextBillsSnippetView: View {
+    let model: FinanceSnippetPresentation.NextBillsModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SnippetHeader(title: model.headline, systemImage: "calendar.badge.clock")
+
+            if let reason = model.withholdReason {
+                WithheldRow(reason: reason)
+            } else if model.rows.isEmpty {
+                Text("Nothing due in your tracked window.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(model.rows) { row in
+                    HStack(spacing: 8) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(row.merchantName)
+                                .font(.callout.weight(.medium))
+                                .lineLimit(1)
+                            Text(row.dueLabel)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 8)
+                        Text(row.amount)
+                            .font(.callout)
+                            .monospacedDigit()
+                            .lineLimit(1)
+                    }
+                }
+                if model.remainderCount > 0 {
+                    Text("+\(model.remainderCount) more")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            SnippetFooter(updatedAt: model.updatedAt)
+        }
+        .padding(14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(model.accessibilityLabel)
+    }
+}
+
+// MARK: - Credit utilization gauge
+
+@available(macOS 26.0, *)
+struct CreditUtilizationSnippetIntent: SnippetIntent {
+    static let title: LocalizedStringResource = "Credit Utilization Snippet"
+    static let description = IntentDescription(
+        "Your aggregate credit utilization as a gauge — inline in Spotlight."
+    )
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ShowsSnippetView {
+        let model = FinanceSnippetPresentation.creditUtilization(from: AppGroupSnapshotStore.loadIfAvailable())
+        return .result(view: CreditUtilizationSnippetView(model: model))
+    }
+}
+
+@available(macOS 26.0, *)
+private struct CreditUtilizationSnippetView: View {
+    let model: FinanceSnippetPresentation.CreditUtilizationModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SnippetHeader(title: "Credit Utilization", systemImage: "creditcard")
+
+            if let reason = model.withholdReason {
+                WithheldRow(reason: reason)
+            } else if let message = model.noLimitMessage {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                HStack(spacing: 6) {
+                    if model.isHigh {
+                        Image(systemName: "exclamationmark.triangle")
+                            .imageScale(.small)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(model.percentText)
+                        .font(.title2.weight(.semibold))
+                        .monospacedDigit()
+                    if model.isHigh {
+                        Text("High")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if let fraction = model.fraction {
+                    // Gauge fill encodes the same percent; the numeric label above
+                    // carries the meaning so the bar is never the only signal.
+                    Gauge(value: fraction) { EmptyView() }
+                        .gaugeStyle(.accessoryLinearCapacity)
+                        .tint(model.isHigh ? .secondary : .primary)
+                }
+            }
+
+            SnippetFooter(updatedAt: model.updatedAt)
+        }
+        .padding(14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(model.accessibilityLabel)
+    }
+}
+
+// MARK: - Shared snippet chrome
+
+@available(macOS 26.0, *)
+private struct SnippetHeader: View {
+    let title: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: systemImage)
+                .imageScale(.small)
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+@available(macOS 26.0, *)
+private struct SnippetFooter: View {
+    let updatedAt: Date
+
+    var body: some View {
+        Text("Updated \(updatedAt, style: .time)")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+}
+
+@available(macOS 26.0, *)
+private struct WithheldRow: View {
+    let reason: FinanceSnippetPresentation.WithholdReason
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: reason.systemImage)
+                .imageScale(.small)
+            Text(reason.headline)
+                .font(.callout.weight(.medium))
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift
+++ b/Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift
@@ -102,6 +102,7 @@ public struct GetSafeToSpendIntent: AppIntent {
     public static let description = IntentDescription(
         "How much you can safely spend through the current window, from local VaultPeek data."
     )
+    public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     public init() {}
 
@@ -116,6 +117,7 @@ public struct GetTotalBalanceIntent: AppIntent {
     public static let description = IntentDescription(
         "Your total spendable balance across linked accounts, from local VaultPeek data."
     )
+    public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     public init() {}
 
@@ -130,6 +132,7 @@ public struct NextRecurringBillsIntent: AppIntent {
     public static let description = IntentDescription(
         "Your upcoming recurring bills, from local VaultPeek data."
     )
+    public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     public init() {}
 
@@ -144,6 +147,7 @@ public struct GetCreditUtilizationIntent: AppIntent {
     public static let description = IntentDescription(
         "Your aggregate credit-card utilization percentage, from local VaultPeek data."
     )
+    public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     public init() {}
 
@@ -162,6 +166,7 @@ public struct ShowSpendingIntent: AppIntent {
     public static let description = IntentDescription(
         "Show how much you've spent this period and open VaultPeek to your budgets."
     )
+    public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     public init() {}
 

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -107,6 +107,16 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
     /// Top spending categories this period, largest first, already truncated to a
     /// small count (the writer keeps only the leaders). Empty when unknown.
     public let topSpendingCategories: [CategorySpend]
+    /// How much trust to place in `safeToSpend`, mirroring
+    /// ``SafeToSpendResult/confidence`` so the safe-to-spend snippet can show the
+    /// same "Estimate only / Lower confidence / On track" cue the in-app view does.
+    /// `nil` for a pre-AND-637 snapshot (decoded defensively) — the snippet then
+    /// simply omits the cue.
+    public let safeToSpendConfidence: SafeToSpendConfidence?
+    /// Inclusive end of the look-ahead window `safeToSpend` covers, mirroring
+    /// ``SafeToSpendResult/horizonEnd`` so the snippet can say "through <date>"
+    /// without re-deriving the horizon. `nil` for a pre-AND-637 snapshot.
+    public let safeToSpendHorizonEnd: Date?
 
     public init(
         safeToSpend: Double,
@@ -118,7 +128,9 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         generatedAt: Date,
         isMasked: Bool,
         periodSpending: Double = 0,
-        topSpendingCategories: [CategorySpend] = []
+        topSpendingCategories: [CategorySpend] = [],
+        safeToSpendConfidence: SafeToSpendConfidence? = nil,
+        safeToSpendHorizonEnd: Date? = nil
     ) {
         self.safeToSpend = safeToSpend
         self.totalBalance = totalBalance
@@ -130,6 +142,8 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         self.isMasked = isMasked
         self.periodSpending = periodSpending
         self.topSpendingCategories = topSpendingCategories
+        self.safeToSpendConfidence = safeToSpendConfidence
+        self.safeToSpendHorizonEnd = safeToSpendHorizonEnd
     }
 
     // Decode the spending fields defensively: a snapshot written by an older build
@@ -139,6 +153,7 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         case safeToSpend, totalBalance, accountBalances, nextRecurringBills
         case creditUtilization, isoCurrencyCode, generatedAt, isMasked
         case periodSpending, topSpendingCategories
+        case safeToSpendConfidence, safeToSpendHorizonEnd
     }
 
     public init(from decoder: Decoder) throws {
@@ -153,6 +168,11 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         isMasked = try container.decode(Bool.self, forKey: .isMasked)
         periodSpending = try container.decodeIfPresent(Double.self, forKey: .periodSpending) ?? 0
         topSpendingCategories = try container.decodeIfPresent([CategorySpend].self, forKey: .topSpendingCategories) ?? []
+        // Defensive: a pre-AND-637 snapshot has neither key — decode them as nil so
+        // the upgrade still reads the older payload, and an unknown confidence raw
+        // value degrades to nil rather than throwing the whole read.
+        safeToSpendConfidence = try container.decodeIfPresent(SafeToSpendConfidence.self, forKey: .safeToSpendConfidence)
+        safeToSpendHorizonEnd = try container.decodeIfPresent(Date.self, forKey: .safeToSpendHorizonEnd)
     }
 
     /// Empty placeholder used before the first real snapshot exists. Treated as

--- a/Sources/PlaidBarCore/Models/SafeToSpend.swift
+++ b/Sources/PlaidBarCore/Models/SafeToSpend.swift
@@ -110,7 +110,7 @@ public enum SafeToSpendComponentKind: String, Sendable, CaseIterable, Hashable {
 
 /// Confidence in the headline number. Ordered from least to most trustworthy so
 /// callers can compare and the UI can pick a matching cue.
-public enum SafeToSpendConfidence: String, Sendable, CaseIterable, Comparable {
+public enum SafeToSpendConfidence: String, Sendable, CaseIterable, Comparable, Codable {
     /// Inputs too thin to stand behind a number (no obligation history AND no
     /// income signal). The UI should treat `amount` as indicative only.
     case insufficientData

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -115,7 +115,12 @@ public enum FinanceSnapshotBuilder {
             generatedAt: generatedAt,
             isMasked: isMasked,
             periodSpending: spending.total,
-            topSpendingCategories: spending.categories
+            topSpendingCategories: spending.categories,
+            // Carry the confidence + horizon the calculator already produced so the
+            // safe-to-spend snippet shows the same cue + "through <date>" the in-app
+            // view does (AND-637) without re-deriving them on the read side.
+            safeToSpendConfidence: safeToSpend.confidence,
+            safeToSpendHorizonEnd: safeToSpend.horizonEnd
         )
     }
 

--- a/Sources/PlaidBarCore/Utilities/FinanceSnippetPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnippetPresentation.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+/// Pure presentation models for the *focused* finance `SnippetIntent` views
+/// (AND-637): safe-to-spend, next recurring bills, and credit utilization. Each
+/// is a small, rich snippet the system can render inline in Spotlight / Siri /
+/// Shortcuts results without launching the app.
+///
+/// These complement ``SnippetDashboardPresentation`` (the combined mini-dashboard)
+/// by giving each headline metric its own interactive snippet. As with that type,
+/// every row-selection / formatting / masking decision lives here in
+/// ``PlaidBarCore`` so it is `Sendable` and unit-tested without the SwiftUI view —
+/// the app-target snippet views are thin renderers over these models.
+///
+/// Privacy mirrors ``FinanceIntentQueries`` and ``SnippetDashboardPresentation``:
+/// when the snapshot is masked, missing, or empty every figure is withheld
+/// (replaced with the shared dot placeholder) and the view shows a locked / setup
+/// affordance — a real value is never leaked past App Lock / Privacy Mask.
+///
+/// `SnippetIntent.perform()` may be invoked multiple times by the system, so the
+/// intent must re-load the snapshot on each call and rebuild the model through one
+/// of these `model(from:)` entry points — never cache a value-bearing model.
+public enum FinanceSnippetPresentation {
+    // MARK: - Shared state
+
+    /// Why a snippet is showing the withheld affordance instead of figures.
+    public enum WithholdReason: Sendable, Equatable {
+        /// App Lock / Privacy Mask is active — figures exist but must stay hidden.
+        case masked
+        /// No usable snapshot yet (first run / post-reset) — prompt setup.
+        case unavailable
+
+        /// Headline shown in the withheld affordance.
+        public var headline: String {
+            switch self {
+            case .masked: "Figures hidden"
+            case .unavailable: "Open VaultPeek"
+            }
+        }
+
+        /// SF Symbol whose SHAPE carries the state (never colour alone).
+        public var systemImage: String {
+            switch self {
+            case .masked: "eye.slash"
+            case .unavailable: "arrow.down.circle"
+            }
+        }
+    }
+
+    // MARK: - Safe to spend
+
+    /// A rendered safe-to-spend snippet: the headline amount plus the confidence
+    /// cue and the look-ahead horizon line.
+    public struct SafeToSpendModel: Sendable, Equatable {
+        /// Formatted amount, or the dot placeholder when withheld.
+        public let amount: String
+        /// True when the underlying amount is negative (over budget). Drives an
+        /// icon/text cue — never colour alone. Always `false` while withheld.
+        public let isOverBudget: Bool
+        /// Short confidence cue ("Estimate only" / "Lower confidence" / "On
+        /// track"), or `nil` when unknown / withheld.
+        public let confidenceLabel: String?
+        /// SF Symbol paired with `confidenceLabel`, or `nil` when there is no cue.
+        public let confidenceSystemImage: String?
+        /// "through <date>" horizon line, or `nil` when unknown / withheld.
+        public let horizonLabel: String?
+        /// Withheld reason, or `nil` when real figures are shown.
+        public let withholdReason: WithholdReason?
+        /// When the snapshot was produced (chrome, never sensitive).
+        public let updatedAt: Date
+        /// Self-contained VoiceOver sentence for the whole snippet.
+        public let accessibilityLabel: String
+
+        public var isWithheld: Bool { withholdReason != nil }
+
+        public init(
+            amount: String,
+            isOverBudget: Bool,
+            confidenceLabel: String?,
+            confidenceSystemImage: String?,
+            horizonLabel: String?,
+            withholdReason: WithholdReason?,
+            updatedAt: Date,
+            accessibilityLabel: String
+        ) {
+            self.amount = amount
+            self.isOverBudget = isOverBudget
+            self.confidenceLabel = confidenceLabel
+            self.confidenceSystemImage = confidenceSystemImage
+            self.horizonLabel = horizonLabel
+            self.withholdReason = withholdReason
+            self.updatedAt = updatedAt
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    public static func safeToSpend(from snapshot: FinanceSnapshot?) -> SafeToSpendModel {
+        guard let reason = withholdReason(for: snapshot) else {
+            // Safe: gate() guarantees a non-nil, non-masked, non-empty snapshot.
+            let snapshot = snapshot!
+            let amount = snapshot.safeToSpend
+            let formatted = Formatters.currency(amount, format: .full, currencyCode: snapshot.isoCurrencyCode)
+            let confidenceLabel = snapshot.safeToSpendConfidence?.label
+            let confidenceImage = snapshot.safeToSpendConfidence?.iconName
+            let horizon = snapshot.safeToSpendHorizonEnd.map { "through \(Formatters.displayDate($0))" }
+
+            var a11y = amount < 0
+                ? "Over budget by \(Formatters.currency(abs(amount), format: .full, currencyCode: snapshot.isoCurrencyCode))."
+                : "\(formatted) safe to spend."
+            if let confidenceLabel { a11y += " \(confidenceLabel)." }
+            if let horizon { a11y += " \(horizon.capitalizedFirst)." }
+
+            return SafeToSpendModel(
+                amount: formatted,
+                isOverBudget: amount < 0,
+                confidenceLabel: confidenceLabel,
+                confidenceSystemImage: confidenceImage,
+                horizonLabel: horizon,
+                withholdReason: nil,
+                updatedAt: snapshot.generatedAt,
+                accessibilityLabel: a11y
+            )
+        }
+
+        return SafeToSpendModel(
+            amount: PrivacyMaskPresentation.compactValue,
+            isOverBudget: false,
+            confidenceLabel: nil,
+            confidenceSystemImage: nil,
+            horizonLabel: nil,
+            withholdReason: reason,
+            updatedAt: snapshot?.generatedAt ?? Date(),
+            accessibilityLabel: withheldAccessibility(reason, metric: "Safe to spend")
+        )
+    }
+
+    // MARK: - Next recurring bills
+
+    /// One bill row in the next-bills snippet.
+    public struct BillRow: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let merchantName: String
+        /// Formatted amount.
+        public let amount: String
+        /// Short due-date label (e.g. "Jul 2").
+        public let dueLabel: String
+
+        public init(id: String, merchantName: String, amount: String, dueLabel: String) {
+            self.id = id
+            self.merchantName = merchantName
+            self.amount = amount
+            self.dueLabel = dueLabel
+        }
+    }
+
+    /// A rendered next-bills snippet: up to ``maxBills`` rows plus an optional
+    /// "+N more" remainder, or a withheld / empty affordance.
+    public struct NextBillsModel: Sendable, Equatable {
+        public let headline: String
+        public let rows: [BillRow]
+        /// Count of bills beyond the displayed rows, or 0.
+        public let remainderCount: Int
+        public let withholdReason: WithholdReason?
+        public let updatedAt: Date
+        public let accessibilityLabel: String
+
+        public var isWithheld: Bool { withholdReason != nil }
+
+        public init(
+            headline: String,
+            rows: [BillRow],
+            remainderCount: Int,
+            withholdReason: WithholdReason?,
+            updatedAt: Date,
+            accessibilityLabel: String
+        ) {
+            self.headline = headline
+            self.rows = rows
+            self.remainderCount = remainderCount
+            self.withholdReason = withholdReason
+            self.updatedAt = updatedAt
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    /// How many bills the snippet lists before summarizing the remainder.
+    public static let maxBills = 3
+
+    public static func nextBills(from snapshot: FinanceSnapshot?) -> NextBillsModel {
+        if let reason = withholdReason(for: snapshot) {
+            return NextBillsModel(
+                headline: reason.headline,
+                rows: [],
+                remainderCount: 0,
+                withholdReason: reason,
+                updatedAt: snapshot?.generatedAt ?? Date(),
+                accessibilityLabel: withheldAccessibility(reason, metric: "Upcoming bills")
+            )
+        }
+
+        let snapshot = snapshot!
+        let bills = snapshot.nextRecurringBills
+        guard !bills.isEmpty else {
+            return NextBillsModel(
+                headline: "No upcoming bills",
+                rows: [],
+                remainderCount: 0,
+                withholdReason: nil,
+                updatedAt: snapshot.generatedAt,
+                accessibilityLabel: "No upcoming bills in your tracked window."
+            )
+        }
+
+        let rows = bills.prefix(maxBills).map { bill in
+            BillRow(
+                id: bill.id,
+                merchantName: bill.merchantName,
+                amount: Formatters.currency(bill.amount, format: .full, currencyCode: snapshot.isoCurrencyCode),
+                dueLabel: Formatters.displayTransactionDate(bill.nextExpectedDate)
+            )
+        }
+        let remainder = bills.count - rows.count
+
+        let spoken = rows.map { "\($0.merchantName) \($0.amount) on \($0.dueLabel)" }
+            .joined(separator: ", ")
+        var a11y = "Upcoming bills: \(spoken)."
+        if remainder > 0 { a11y += " Plus \(remainder) more." }
+
+        return NextBillsModel(
+            headline: "Next bills",
+            rows: Array(rows),
+            remainderCount: remainder,
+            withholdReason: nil,
+            updatedAt: snapshot.generatedAt,
+            accessibilityLabel: a11y
+        )
+    }
+
+    // MARK: - Credit utilization gauge
+
+    /// A rendered credit-utilization snippet driving a gauge.
+    public struct CreditUtilizationModel: Sendable, Equatable {
+        /// Formatted percent (e.g. "42.0%"), or the dot placeholder when withheld.
+        public let percentText: String
+        /// Gauge fill fraction in `0...1`, or `nil` when withheld / unknown so the
+        /// view can show an empty/indeterminate gauge.
+        public let fraction: Double?
+        /// True when utilization is at or above the warning threshold. Paired with
+        /// an icon + text so the warning is never colour-only. `false` while
+        /// withheld.
+        public let isHigh: Bool
+        /// Set when no credit card with a known limit is linked (a real "no data"
+        /// answer, distinct from masked/setup).
+        public let noLimitMessage: String?
+        public let withholdReason: WithholdReason?
+        public let updatedAt: Date
+        public let accessibilityLabel: String
+
+        public var isWithheld: Bool { withholdReason != nil }
+
+        public init(
+            percentText: String,
+            fraction: Double?,
+            isHigh: Bool,
+            noLimitMessage: String?,
+            withholdReason: WithholdReason?,
+            updatedAt: Date,
+            accessibilityLabel: String
+        ) {
+            self.percentText = percentText
+            self.fraction = fraction
+            self.isHigh = isHigh
+            self.noLimitMessage = noLimitMessage
+            self.withholdReason = withholdReason
+            self.updatedAt = updatedAt
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    public static func creditUtilization(
+        from snapshot: FinanceSnapshot?,
+        warningThreshold: Double = PlaidBarConstants.creditUtilizationWarningThreshold
+    ) -> CreditUtilizationModel {
+        if let reason = withholdReason(for: snapshot) {
+            return CreditUtilizationModel(
+                percentText: PrivacyMaskPresentation.compactValue,
+                fraction: nil,
+                isHigh: false,
+                noLimitMessage: nil,
+                withholdReason: reason,
+                updatedAt: snapshot?.generatedAt ?? Date(),
+                accessibilityLabel: withheldAccessibility(reason, metric: "Credit utilization")
+            )
+        }
+
+        let snapshot = snapshot!
+        guard let percent = snapshot.creditUtilization else {
+            let message = "No credit cards with a known limit are linked."
+            return CreditUtilizationModel(
+                percentText: "—",
+                fraction: nil,
+                isHigh: false,
+                noLimitMessage: message,
+                withholdReason: nil,
+                updatedAt: snapshot.generatedAt,
+                accessibilityLabel: message
+            )
+        }
+
+        let clamped = min(max(percent, 0), 100)
+        let isHigh = percent >= warningThreshold
+        let formatted = Formatters.percent(percent)
+        let a11y = isHigh
+            ? "Credit utilization \(formatted). High — above your \(Formatters.percent(warningThreshold)) warning level."
+            : "Credit utilization \(formatted)."
+
+        return CreditUtilizationModel(
+            percentText: formatted,
+            fraction: clamped / 100,
+            isHigh: isHigh,
+            noLimitMessage: nil,
+            withholdReason: nil,
+            updatedAt: snapshot.generatedAt,
+            accessibilityLabel: a11y
+        )
+    }
+
+    // MARK: - Shared gating
+
+    /// Returns the withhold reason for a snapshot, or `nil` to proceed with real
+    /// figures. Mirrors ``FinanceIntentQueries`` and ``SnippetDashboardPresentation``
+    /// so every snippet surface withholds identically.
+    private static func withholdReason(for snapshot: FinanceSnapshot?) -> WithholdReason? {
+        guard let snapshot else { return .unavailable }
+        if snapshot.isMasked { return .masked }
+        if snapshot.isEmpty { return .unavailable }
+        return nil
+    }
+
+    private static func withheldAccessibility(_ reason: WithholdReason, metric: String) -> String {
+        switch reason {
+        case .masked:
+            return "\(metric) is hidden while Privacy Mask is on."
+        case .unavailable:
+            return "VaultPeek hasn't synced yet. Open VaultPeek to connect an account."
+        }
+    }
+}
+
+private extension String {
+    /// Capitalizes only the first character, leaving the rest unchanged (so
+    /// "through Jul 2" reads as a sentence start without lower-casing "Jul").
+    var capitalizedFirst: String {
+        guard let first else { return self }
+        return first.uppercased() + dropFirst()
+    }
+}

--- a/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
@@ -105,6 +105,24 @@ struct FinanceAppIntentsPackageTests {
         }
     }
 
+    @Test("Snapshot-reading finance intents require local device authentication")
+    func snapshotReadingFinanceIntentsRequireLocalDeviceAuthentication() throws {
+        let source = try financeAppIntentsPackageSource()
+        for intentName in [
+            "GetSafeToSpendIntent",
+            "GetTotalBalanceIntent",
+            "NextRecurringBillsIntent",
+            "GetCreditUtilizationIntent",
+            "ShowSpendingIntent",
+        ] {
+            let block = try #require(intentBlock(named: intentName, in: source))
+            #expect(
+                block.contains("public static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication"),
+                "\(intentName) reads the shared finance snapshot and must not run while the local device is locked"
+            )
+        }
+    }
+
     // MARK: - Deep-link URL building (openRouteIntent)
     //
     // The navigation intents open the window via `openRouteIntent(_:)`, which wraps
@@ -297,5 +315,22 @@ struct FinanceAppIntentsPackageTests {
             safeToSpendConfidence: confidence,
             safeToSpendHorizonEnd: horizonEnd
         )
+    }
+
+    private func financeAppIntentsPackageSource() throws -> String {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        return try String(
+            contentsOf: root.appending(path: "Sources/PlaidBarCore/AppIntents/FinanceAppIntentsPackage.swift"),
+            encoding: .utf8
+        )
+    }
+
+    private func intentBlock(named intentName: String, in source: String) -> String? {
+        guard let start = source.range(of: "public struct \(intentName): AppIntent")?.lowerBound else {
+            return nil
+        }
+        let rest = source[start...]
+        let end = rest.dropFirst().range(of: "\npublic struct ")?.lowerBound ?? source.endIndex
+        return String(source[start..<end])
     }
 }

--- a/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
@@ -1,0 +1,301 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Intent-layer tests for the finance App Intents package (AND-638): the
+/// value/dialog mapping the intents surface, the value-free error contract for the
+/// locked / unavailable states, the deep-link URLs the navigation intents open, and
+/// the pure ``FinanceSnippetPresentation`` models the AND-637 SnippetIntents render.
+///
+/// The intents themselves (`GetSafeToSpendIntent` …) are thin shells that load the
+/// shared snapshot and map a ``FinanceIntentResolution`` into an AppIntents result;
+/// driving their `perform()` would read the process-global App Group store (real
+/// `~/.vaultpeek/` on a dev machine), so these pin the deterministic, injectable
+/// logic those shells delegate to instead.
+@Suite("Finance App Intents package (AND-637 / AND-638)")
+struct FinanceAppIntentsPackageTests {
+    private let asOf = Date(timeIntervalSince1970: 1_780_000_000)
+
+    // MARK: - Value / dialog mapping (what the value intents return)
+
+    @Test("Safe-to-spend value intent surfaces the value and a spoken dialog")
+    func safeToSpendValueAndDialog() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.safeToSpend(from: snapshot(safeToSpend: 1_500)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 1_500)
+        #expect(dialog.contains("safe to spend"))
+    }
+
+    @Test("Total-balance value intent surfaces the value")
+    func totalBalanceValue() {
+        guard case let .value(value, _) = FinanceIntentQueries.totalBalance(from: snapshot(totalBalance: 8_400)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 8_400)
+    }
+
+    @Test("Credit-utilization value intent surfaces the percent")
+    func creditUtilizationValue() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.creditUtilization(from: snapshot(creditUtilization: 42)) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 42)
+        #expect(dialog.contains("utilization"))
+    }
+
+    @Test("Bills message intent reads a dialog-only list")
+    func billsMessage() {
+        let bills = [FinanceSnapshot.UpcomingBill(merchantName: "Rent", amount: 1_800, nextExpectedDate: "2026-07-01")]
+        guard case let .message(text) = FinanceIntentQueries.nextRecurringBills(from: snapshot(bills: bills)) else {
+            Issue.record("Expected .message")
+            return
+        }
+        #expect(text.contains("Rent"))
+    }
+
+    // MARK: - Error throwing (.locked / .unavailable)
+    //
+    // `FinanceAppIntentsPackage.valueResult`/`messageResult` map a withheld
+    // resolution to `FinanceAppIntentError.locked` and an unavailable one to
+    // `.unavailable`, throwing rather than returning a fabricated value. These pin
+    // the error contract those throws rely on: the spoken resource is the safe,
+    // value-free sentence.
+
+    @Test("locked error carries the resolution's value-free dialog")
+    func lockedErrorIsValueFree() {
+        guard case let .withheld(dialog) = FinanceIntentQueries.safeToSpend(from: snapshot(safeToSpend: 4_321, isMasked: true)) else {
+            Issue.record("Expected .withheld for a masked snapshot")
+            return
+        }
+        let error = FinanceAppIntentError.locked(dialog)
+        let spoken = String(localized: error.localizedStringResource)
+        #expect(spoken == dialog)
+        #expect(!spoken.contains("4,321"))
+        #expect(!spoken.contains("4321"))
+    }
+
+    @Test("unavailable error carries the resolution's setup dialog")
+    func unavailableErrorCarriesSetupDialog() {
+        guard case let .unavailable(dialog) = FinanceIntentQueries.totalBalance(from: nil) else {
+            Issue.record("Expected .unavailable for a nil snapshot")
+            return
+        }
+        let error = FinanceAppIntentError.unavailable(dialog)
+        let spoken = String(localized: error.localizedStringResource)
+        #expect(spoken == dialog)
+        #expect(spoken.lowercased().contains("vaultpeek"))
+    }
+
+    @Test("A masked snapshot withholds every value query the intents map")
+    func maskedWithholdsEveryValueQuery() {
+        let masked = snapshot(isMasked: true)
+        for resolution in [
+            FinanceIntentQueries.safeToSpend(from: masked),
+            FinanceIntentQueries.totalBalance(from: masked),
+            FinanceIntentQueries.creditUtilization(from: masked),
+        ] {
+            guard case .withheld = resolution else {
+                Issue.record("Expected .withheld, got \(resolution)")
+                continue
+            }
+        }
+    }
+
+    // MARK: - Deep-link URL building (openRouteIntent)
+    //
+    // The navigation intents open the window via `openRouteIntent(_:)`, which wraps
+    // `RouteDeepLink.url(for:)`. These pin that every destination the intents open
+    // forms the expected, non-nil `vaultpeek://route/<dest>` URL.
+
+    @Test("Every navigation destination the intents open builds a non-nil deep link")
+    func navigationDestinationsBuildDeepLinks() throws {
+        for destination in [RouteDestination.budgets, .review, .dashboard] {
+            let url = try #require(RouteDeepLink.url(for: destination))
+            #expect(url.scheme == RouteDeepLink.scheme)
+            #expect(url.absoluteString == "vaultpeek://route/\(destination.rawValue)")
+            // Round-trips back to the destination's canonical route.
+            #expect(RouteDeepLink.route(from: url) == Route.canonical(for: destination))
+        }
+    }
+
+    @Test("Show-spending opens the budgets destination and returns the period total")
+    func showSpendingOpensBudgetsWithTotal() throws {
+        let categories = [FinanceSnapshot.CategorySpend(category: .foodAndDrink, amount: 320)]
+        guard case let .value(value, _) = FinanceIntentQueries.showSpending(
+            from: snapshot(periodSpending: 500, categories: categories)
+        ) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 500)
+        // The intent maps this value to opening `.budgets`.
+        let url = try #require(RouteDeepLink.url(for: .budgets))
+        #expect(RouteDeepLink.route(from: url) == .budgets())
+    }
+
+    // MARK: - Snippet presentation: safe to spend (AND-637)
+
+    @Test("Safe-to-spend snippet shows amount, confidence cue, and horizon")
+    func safeToSpendSnippetPopulated() {
+        let model = FinanceSnippetPresentation.safeToSpend(from: snapshot(
+            safeToSpend: 1_200,
+            confidence: .ok,
+            horizonEnd: asOf
+        ))
+        #expect(!model.isWithheld)
+        #expect(!model.isOverBudget)
+        #expect(model.confidenceLabel == SafeToSpendConfidence.ok.label)
+        #expect(model.confidenceSystemImage == SafeToSpendConfidence.ok.iconName)
+        #expect(model.horizonLabel?.hasPrefix("through ") == true)
+        #expect(!model.amount.isEmpty)
+    }
+
+    @Test("Negative safe-to-spend flags over budget without leaking via the placeholder")
+    func safeToSpendSnippetOverBudget() {
+        let model = FinanceSnippetPresentation.safeToSpend(from: snapshot(safeToSpend: -250))
+        #expect(model.isOverBudget)
+        #expect(model.amount != PrivacyMaskPresentation.compactValue)
+        #expect(model.accessibilityLabel.lowercased().contains("over budget"))
+    }
+
+    @Test("Masked safe-to-spend snippet withholds the figure with the dot placeholder")
+    func safeToSpendSnippetMasked() {
+        let model = FinanceSnippetPresentation.safeToSpend(from: snapshot(safeToSpend: 9_999, isMasked: true))
+        #expect(model.isWithheld)
+        #expect(model.withholdReason == .masked)
+        #expect(model.amount == PrivacyMaskPresentation.compactValue)
+        #expect(model.confidenceLabel == nil)
+        #expect(model.horizonLabel == nil)
+        #expect(!model.accessibilityLabel.contains("9,999"))
+        #expect(!model.accessibilityLabel.contains("9999"))
+    }
+
+    @Test("Nil snapshot drives the safe-to-spend setup affordance")
+    func safeToSpendSnippetUnavailable() {
+        let model = FinanceSnippetPresentation.safeToSpend(from: nil)
+        #expect(model.isWithheld)
+        #expect(model.withholdReason == .unavailable)
+    }
+
+    @Test("A pre-AND-637 snapshot (no confidence/horizon) simply omits the cue")
+    func safeToSpendSnippetWithoutConfidence() {
+        let model = FinanceSnippetPresentation.safeToSpend(from: snapshot(safeToSpend: 800))
+        #expect(!model.isWithheld)
+        #expect(model.confidenceLabel == nil)
+        #expect(model.horizonLabel == nil)
+    }
+
+    // MARK: - Snippet presentation: next bills (AND-637)
+
+    @Test("Next-bills snippet lists up to the cap and summarizes the remainder")
+    func nextBillsSnippetCapAndRemainder() {
+        let bills = (0..<5).map { index in
+            FinanceSnapshot.UpcomingBill(
+                merchantName: "Bill\(index)",
+                amount: Double(index + 1),
+                nextExpectedDate: "2026-07-0\(index + 1)"
+            )
+        }
+        let model = FinanceSnippetPresentation.nextBills(from: snapshot(bills: bills))
+        #expect(!model.isWithheld)
+        #expect(model.rows.count == FinanceSnippetPresentation.maxBills)
+        #expect(model.remainderCount == 5 - FinanceSnippetPresentation.maxBills)
+        #expect(model.accessibilityLabel.contains("2 more"))
+    }
+
+    @Test("Next-bills snippet with no bills shows the no-bills state, not setup")
+    func nextBillsSnippetEmpty() {
+        let model = FinanceSnippetPresentation.nextBills(from: snapshot(bills: []))
+        #expect(!model.isWithheld)
+        #expect(model.rows.isEmpty)
+        #expect(model.remainderCount == 0)
+        #expect(model.headline.lowercased().contains("no upcoming bills"))
+    }
+
+    @Test("Masked next-bills snippet withholds every row")
+    func nextBillsSnippetMasked() {
+        let bills = [FinanceSnapshot.UpcomingBill(merchantName: "Rent", amount: 1_800, nextExpectedDate: "2026-07-01")]
+        let model = FinanceSnippetPresentation.nextBills(from: snapshot(bills: bills, isMasked: true))
+        #expect(model.isWithheld)
+        #expect(model.rows.isEmpty)
+        #expect(!model.accessibilityLabel.contains("Rent"))
+        #expect(!model.accessibilityLabel.contains("1,800"))
+    }
+
+    // MARK: - Snippet presentation: credit utilization gauge (AND-637)
+
+    @Test("Credit-utilization snippet drives a clamped gauge fraction")
+    func creditUtilizationSnippetGauge() {
+        let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: 42))
+        #expect(!model.isWithheld)
+        #expect(model.fraction == 0.42)
+        #expect(model.percentText.contains("42"))
+        #expect(model.noLimitMessage == nil)
+    }
+
+    @Test("Utilization at or above the warning threshold flags high with a non-colour cue")
+    func creditUtilizationSnippetHigh() {
+        let threshold = PlaidBarConstants.creditUtilizationWarningThreshold
+        let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: threshold + 5))
+        #expect(model.isHigh)
+        #expect(model.accessibilityLabel.lowercased().contains("high"))
+    }
+
+    @Test("Utilization over 100% clamps the gauge fraction to 1")
+    func creditUtilizationSnippetClampsAbove100() {
+        let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: 130))
+        #expect(model.fraction == 1.0)
+    }
+
+    @Test("No credit limit shows a real no-data message, distinct from masked/setup")
+    func creditUtilizationSnippetNoLimit() {
+        let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: nil))
+        #expect(!model.isWithheld)
+        #expect(model.fraction == nil)
+        #expect(model.noLimitMessage != nil)
+    }
+
+    @Test("Masked credit-utilization snippet withholds the percent with the dot placeholder")
+    func creditUtilizationSnippetMasked() {
+        let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: 88, isMasked: true))
+        #expect(model.isWithheld)
+        #expect(model.withholdReason == .masked)
+        #expect(model.percentText == PrivacyMaskPresentation.compactValue)
+        #expect(model.fraction == nil)
+        #expect(!model.accessibilityLabel.contains("88"))
+    }
+
+    // MARK: - Helpers
+
+    private func snapshot(
+        safeToSpend: Double = 1_000,
+        totalBalance: Double = 5_000,
+        bills: [FinanceSnapshot.UpcomingBill] = [],
+        creditUtilization: Double? = 20,
+        isMasked: Bool = false,
+        periodSpending: Double = 0,
+        categories: [FinanceSnapshot.CategorySpend] = [],
+        confidence: SafeToSpendConfidence? = nil,
+        horizonEnd: Date? = nil
+    ) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: safeToSpend,
+            totalBalance: totalBalance,
+            accountBalances: [
+                FinanceSnapshot.AccountBalance(displayName: "Checking", balance: totalBalance),
+            ],
+            nextRecurringBills: bills,
+            creditUtilization: creditUtilization,
+            generatedAt: asOf,
+            isMasked: isMasked,
+            periodSpending: periodSpending,
+            topSpendingCategories: categories,
+            safeToSpendConfidence: confidence,
+            safeToSpendHorizonEnd: horizonEnd
+        )
+    }
+}

--- a/Tests/PlaidBarTests/FinanceDashboardSnippetIntentTests.swift
+++ b/Tests/PlaidBarTests/FinanceDashboardSnippetIntentTests.swift
@@ -132,6 +132,10 @@ struct FinanceDashboardSnippetIntentTests {
         #expect(source.contains("struct SafeToSpendSnippetIntent: SnippetIntent"))
         #expect(source.contains("struct NextBillsSnippetIntent: SnippetIntent"))
         #expect(source.contains("struct CreditUtilizationSnippetIntent: SnippetIntent"))
+        let localAuthPolicies = source
+            .components(separatedBy: "static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication")
+            .count - 1
+        #expect(localAuthPolicies == 3, "each focused finance snippet must require local device authentication")
 
         // Each renders through the pure presentation, never inline figure math.
         #expect(source.contains("FinanceSnippetPresentation.safeToSpend(from:"))
@@ -148,6 +152,7 @@ struct FinanceDashboardSnippetIntentTests {
         let source = try dashboardSnippetIntentSource()
         #expect(source.contains("@available(macOS 26.0, *)"))
         #expect(source.contains("struct FinanceDashboardSnippetIntent: SnippetIntent"))
+        #expect(source.contains("static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication"))
         // Re-loads inside perform() (multiple-invocation contract) and renders the
         // pure SnippetDashboardPresentation model.
         #expect(source.contains("func perform() async throws"))

--- a/Tests/PlaidBarTests/FinanceDashboardSnippetIntentTests.swift
+++ b/Tests/PlaidBarTests/FinanceDashboardSnippetIntentTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Tests for the app-target finance SnippetIntents (AND-637 / AND-638):
+/// `FinanceDashboardSnippetIntent` and the focused AND-637 snippets
+/// (`SafeToSpendSnippetIntent`, `NextBillsSnippetIntent`,
+/// `CreditUtilizationSnippetIntent`).
+///
+/// PlaidBar is a `@main` executable target, so it can't be `@testable import`ed
+/// (mirroring the note in `PlaidBarTests`). This suite therefore exercises the
+/// SnippetIntents two ways:
+///   1. **Model → view contract** through the pure `PlaidBarCore` presentation
+///      models the views render 1:1 — the masked / nil / populated snapshot cases
+///      and the timestamp the snippet footer formats.
+///   2. **Source-level invariants** on the intent files: each `perform()` RE-LOADS
+///      the snapshot (the SnippetIntent multiple-invocation contract), is gated to
+///      macOS 26+, renders through `FinanceSnippetPresentation` /
+///      `SnippetDashboardPresentation`, and handles the withheld state — none of
+///      which CI can assert by running the GUI executable.
+@Suite("Finance SnippetIntents (AND-637 / AND-638)")
+struct FinanceDashboardSnippetIntentTests {
+    private let asOf = Date(timeIntervalSince1970: 1_780_000_000)
+
+    // MARK: - perform() model: dashboard snippet (the model FinanceDashboardSnippetIntent renders)
+
+    @Test("Populated snapshot renders the dashboard snippet model the intent shows")
+    func dashboardSnippetPopulated() {
+        let model = SnippetDashboardPresentation.model(from: populatedSnapshot())
+        #expect(!model.isWithheld)
+        #expect(model.rows.count == 3)
+        // The footer renders `updatedAt`; it must carry the snapshot timestamp.
+        #expect(model.updatedAt == asOf)
+    }
+
+    @Test("Masked snapshot renders the withheld dashboard snippet — no leaked figure")
+    func dashboardSnippetMasked() {
+        let model = SnippetDashboardPresentation.model(from: populatedSnapshot(isMasked: true))
+        #expect(model.isWithheld)
+        for row in model.rows {
+            #expect(row.value == PrivacyMaskPresentation.compactValue)
+        }
+        #expect(!model.accessibilityLabel.contains("8,000"))
+    }
+
+    @Test("Nil snapshot renders the dashboard snippet setup state")
+    func dashboardSnippetNil() {
+        let model = SnippetDashboardPresentation.model(from: nil)
+        #expect(model.isWithheld)
+        #expect(model.rows.isEmpty)
+    }
+
+    // MARK: - perform() model: focused snippets
+
+    @Test("Safe-to-spend snippet model: populated vs masked vs nil")
+    func safeToSpendSnippetStates() {
+        let populated = FinanceSnippetPresentation.safeToSpend(from: populatedSnapshot(confidence: .ok, horizonEnd: asOf))
+        #expect(!populated.isWithheld)
+        #expect(populated.confidenceLabel == SafeToSpendConfidence.ok.label)
+        #expect(populated.updatedAt == asOf)
+
+        let masked = FinanceSnippetPresentation.safeToSpend(from: populatedSnapshot(isMasked: true))
+        #expect(masked.isWithheld)
+        #expect(masked.amount == PrivacyMaskPresentation.compactValue)
+
+        let unavailable = FinanceSnippetPresentation.safeToSpend(from: nil)
+        #expect(unavailable.withholdReason == .unavailable)
+    }
+
+    @Test("Next-bills snippet model: populated vs masked vs nil")
+    func nextBillsSnippetStates() {
+        let bills = [
+            FinanceSnapshot.UpcomingBill(merchantName: "Rent", amount: 1_800, nextExpectedDate: "2026-07-01"),
+            FinanceSnapshot.UpcomingBill(merchantName: "Gym", amount: 40, nextExpectedDate: "2026-07-05"),
+        ]
+        let populated = FinanceSnippetPresentation.nextBills(from: populatedSnapshot(bills: bills))
+        #expect(!populated.isWithheld)
+        #expect(populated.rows.count == 2)
+        #expect(populated.rows.first?.merchantName == "Rent")
+
+        let masked = FinanceSnippetPresentation.nextBills(from: populatedSnapshot(bills: bills, isMasked: true))
+        #expect(masked.isWithheld)
+        #expect(masked.rows.isEmpty)
+
+        let unavailable = FinanceSnippetPresentation.nextBills(from: nil)
+        #expect(unavailable.withholdReason == .unavailable)
+    }
+
+    @Test("Credit-utilization snippet model: populated vs masked vs nil")
+    func creditUtilizationSnippetStates() {
+        let populated = FinanceSnippetPresentation.creditUtilization(from: populatedSnapshot(creditUtilization: 30))
+        #expect(!populated.isWithheld)
+        #expect(populated.fraction == 0.30)
+
+        let masked = FinanceSnippetPresentation.creditUtilization(from: populatedSnapshot(creditUtilization: 30, isMasked: true))
+        #expect(masked.isWithheld)
+        #expect(masked.percentText == PrivacyMaskPresentation.compactValue)
+
+        let unavailable = FinanceSnippetPresentation.creditUtilization(from: nil)
+        #expect(unavailable.withholdReason == .unavailable)
+    }
+
+    // MARK: - Timestamp formatting (the snippet footers render `updatedAt`)
+
+    @Test("Every snippet model surfaces the snapshot timestamp for its footer")
+    func snippetModelsCarryTimestamp() {
+        let snapshot = populatedSnapshot()
+        #expect(FinanceSnippetPresentation.safeToSpend(from: snapshot).updatedAt == asOf)
+        #expect(FinanceSnippetPresentation.nextBills(from: snapshot).updatedAt == asOf)
+        #expect(FinanceSnippetPresentation.creditUtilization(from: snapshot).updatedAt == asOf)
+        #expect(SnippetDashboardPresentation.model(from: snapshot).updatedAt == asOf)
+    }
+
+    // MARK: - Source-level invariants on the intent files
+    //
+    // The app target can't be @testable-imported and CI can't run the SnippetIntent
+    // pipeline, so these pin the SnippetIntent contract as source invariants —
+    // exactly the pattern PlaidBarTests uses for AccountSpotlightIndexer etc.
+
+    @Test("Each focused SnippetIntent re-loads the snapshot inside perform() and is macOS-26 gated")
+    func focusedSnippetIntentsReloadAndGate() throws {
+        let source = try snippetIntentsSource()
+
+        // SnippetIntent.perform() may be called multiple times → re-load per call.
+        // Each of the three focused intents reads the store inside perform().
+        let reloads = source.components(separatedBy: "AppGroupSnapshotStore.loadIfAvailable()").count - 1
+        #expect(reloads == 3, "each focused snippet intent must re-load the snapshot in perform()")
+
+        // All three intents + their views are gated to macOS 26 (SnippetIntent's
+        // minimum). Six declarations: 3 intents + 3 views, plus shared chrome.
+        #expect(source.contains("@available(macOS 26.0, *)"))
+        #expect(source.contains("struct SafeToSpendSnippetIntent: SnippetIntent"))
+        #expect(source.contains("struct NextBillsSnippetIntent: SnippetIntent"))
+        #expect(source.contains("struct CreditUtilizationSnippetIntent: SnippetIntent"))
+
+        // Each renders through the pure presentation, never inline figure math.
+        #expect(source.contains("FinanceSnippetPresentation.safeToSpend(from:"))
+        #expect(source.contains("FinanceSnippetPresentation.nextBills(from:"))
+        #expect(source.contains("FinanceSnippetPresentation.creditUtilization(from:"))
+
+        // Each view handles the withheld affordance.
+        let withheldHandling = source.components(separatedBy: "if let reason = model.withholdReason").count - 1
+        #expect(withheldHandling == 3, "each snippet view must render the withheld state")
+    }
+
+    @Test("Dashboard SnippetIntent re-loads the snapshot inside perform() and is macOS-26 gated")
+    func dashboardSnippetIntentReloadsAndGates() throws {
+        let source = try dashboardSnippetIntentSource()
+        #expect(source.contains("@available(macOS 26.0, *)"))
+        #expect(source.contains("struct FinanceDashboardSnippetIntent: SnippetIntent"))
+        // Re-loads inside perform() (multiple-invocation contract) and renders the
+        // pure SnippetDashboardPresentation model.
+        #expect(source.contains("func perform() async throws"))
+        #expect(source.contains("SnippetDashboardPresentation.model(from: AppGroupSnapshotStore.loadIfAvailable())"))
+    }
+
+    @Test("The focused snippets are registered with the AppShortcutsProvider")
+    func focusedSnippetsAreRegistered() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let source = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Intents/FinanceAppIntents.swift"),
+            encoding: .utf8
+        )
+        #expect(source.contains("intent: SafeToSpendSnippetIntent()"))
+        #expect(source.contains("intent: NextBillsSnippetIntent()"))
+        #expect(source.contains("intent: CreditUtilizationSnippetIntent()"))
+    }
+
+    // MARK: - Helpers
+
+    private func snippetIntentsSource() throws -> String {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        return try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Intents/FinanceSnippetIntents.swift"),
+            encoding: .utf8
+        )
+    }
+
+    private func dashboardSnippetIntentSource() throws -> String {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        return try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Intents/FinanceDashboardSnippetIntent.swift"),
+            encoding: .utf8
+        )
+    }
+
+    private func populatedSnapshot(
+        bills: [FinanceSnapshot.UpcomingBill] = [],
+        creditUtilization: Double? = 22,
+        isMasked: Bool = false,
+        confidence: SafeToSpendConfidence? = nil,
+        horizonEnd: Date? = nil
+    ) -> FinanceSnapshot {
+        FinanceSnapshot(
+            safeToSpend: 1_200,
+            totalBalance: 8_000,
+            accountBalances: [FinanceSnapshot.AccountBalance(displayName: "Checking", balance: 8_000)],
+            nextRecurringBills: bills,
+            creditUtilization: creditUtilization,
+            generatedAt: asOf,
+            isMasked: isMasked,
+            periodSpending: 540,
+            topSpendingCategories: [
+                FinanceSnapshot.CategorySpend(category: .foodAndDrink, amount: 320),
+                FinanceSnapshot.CategorySpend(category: .shopping, amount: 180),
+            ],
+            safeToSpendConfidence: confidence,
+            safeToSpendHorizonEnd: horizonEnd
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Adds the AND-637 interactive App Intents snippets and the AND-638 intent-layer
tests in one PR.

The combined Spotlight mini-dashboard snippet (`FinanceDashboardSnippetIntent`)
already existed. This adds three **focused, rich** `SnippetIntent`s (macOS 26+) so
each headline metric gets its own glance surface inline in Spotlight / Siri /
Shortcuts:

- **Safe to spend** — amount + confidence cue (Estimate only / Lower confidence /
  On track) + look-ahead horizon ("through &lt;date&gt;").
- **Next recurring bills** — top 3 with dates and amounts, plus a "+N more"
  remainder.
- **Credit utilization** — a gauge driven by the clamped percent, with a
  shape+text high-usage cue (never colour alone).

All row selection, formatting, and the masked/unavailable decision live in a new
**pure `PlaidBarCore` model** (`FinanceSnippetPresentation`); the app-target views
are thin renderers. Per Apple's `SnippetIntent` guidance, the system may call
`perform()` multiple times, so every intent **re-loads the snapshot inside
`perform()`**. Masked / missing / empty snapshots withhold every figure with the
shared dot placeholder — no real value is drawn past App Lock / Privacy Mask. The
intents are gated `@available(macOS 26.0, *)` and registered with
`PlaidBarShortcutsProvider`.

To feed the safe-to-spend snippet, `FinanceSnapshot` gains two **optional,
defensively-decoded** fields (`safeToSpendConfidence`, `safeToSpendHorizonEnd`)
populated from the `SafeToSpendResult` the builder already computes. A pre-AND-637
snapshot decodes them as `nil` and the snippet omits the cue; `masked()` /
`placeholder()` leave them `nil` so a masked snapshot withholds them too.

The architecture boundary is unchanged — the app talks only to localhost, the
server/Plaid client/Keychain are untouched, and all new logic is `Sendable` Core.

## Change (files)

- `Sources/PlaidBarCore/Models/SafeToSpend.swift` — `SafeToSpendConfidence: Codable`.
- `Sources/PlaidBarCore/Models/FinanceSnapshot.swift` — two optional fields +
  defensive decode (back-compatible with pre-AND-637 snapshots).
- `Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift` — populate the
  confidence + horizon from the computed `SafeToSpendResult`.
- `Sources/PlaidBarCore/Utilities/FinanceSnippetPresentation.swift` — **new** pure
  presentation models (safe-to-spend / next bills / credit-utilization gauge) with
  shared withheld gating.
- `Sources/PlaidBar/Intents/FinanceSnippetIntents.swift` — **new** three
  `SnippetIntent`s + SwiftUI views (re-load in `perform()`, macOS-26 gated).
- `Sources/PlaidBar/Intents/FinanceAppIntents.swift` — register the three snippets
  with the `AppShortcutsProvider`.
- `Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift` — **new** (AND-638).
- `Tests/PlaidBarTests/FinanceDashboardSnippetIntentTests.swift` — **new** (AND-638).

For UI changes, README screenshots can be regenerated via `./Scripts/screenshots.sh`.

## Testing

All commands run with the SwiftPM sandbox disabled (manifest compile otherwise
fails under the command sandbox).

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (all targets, incl. PlaidBar app + server)

swift test --filter FinanceAppIntentsPackageTests --filter FinanceDashboardSnippetIntentTests
# → Test run with 32 tests passed

swift test
# → Test run with 2215 tests passed   (no regression from the new snapshot fields)

git diff --check
# → clean
```

## Links

Closes AND-637
Closes AND-638
