### PR TITLE
feat(onboarding): window-first orientation moment for menu-bar users (AND-640)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -55,6 +55,7 @@ final class AppState {
         static let setupCompletedOnce = "setup.completedOnce"
         static let setupCompletedContextPrefix = "setup.completedOnce.context"
         static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
+        static let windowFirstOrientationDismissedContextPrefix = "windowFirstOrientation.dismissed.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
         static let categoryBudgetCache = "cache.categoryBudgets"
         static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
@@ -191,6 +192,15 @@ final class AppState {
         didSet {
             guard oldValue != isFirstRunSnapshotDismissed else { return }
             persistFirstRunSnapshotDismissal(isFirstRunSnapshotDismissed)
+        }
+    }
+    /// Whether the one-time window-first orientation moment (AND-640) has been
+    /// dismissed. Persisted per environment + data directory (mirroring the
+    /// first-run snapshot flag) so it never re-shows once the user has seen it.
+    var isWindowFirstOrientationDismissed = false {
+        didSet {
+            guard oldValue != isWindowFirstOrientationDismissed else { return }
+            persistWindowFirstOrientationDismissal(isWindowFirstOrientationDismissed)
         }
     }
     var serverConnected = false
@@ -693,6 +703,7 @@ final class AppState {
         lockOnLaunchIfNeeded()
         isSetupComplete = storedSetupCompletion()
         isFirstRunSnapshotDismissed = storedFirstRunSnapshotDismissal()
+        isWindowFirstOrientationDismissed = storedWindowFirstOrientationDismissal()
         if isSetupComplete {
             persistSetupCompletion(true)
         }
@@ -2247,6 +2258,7 @@ final class AppState {
             persistTransactionCacheContext()
             refreshSetupCompletionForActiveContext()
             refreshFirstRunSnapshotDismissalForActiveContext()
+            refreshWindowFirstOrientationDismissalForActiveContext()
             if let itemStatuses = status.itemStatuses {
                 applyItemStatuses(itemStatuses, itemCount: status.itemCount, syncReady: status.syncReady)
             } else if !(await refreshItemStatuses()) {
@@ -3087,6 +3099,24 @@ final class AppState {
         isFirstRunSnapshotDismissed = true
     }
 
+    /// Dismisses the one-time window-first orientation moment (AND-640). The
+    /// `didSet` on `isWindowFirstOrientationDismissed` persists it per environment,
+    /// so it never re-shows on a future launch.
+    func dismissWindowFirstOrientation() {
+        isWindowFirstOrientationDismissed = true
+    }
+
+    /// Whether the window-first orientation moment should be shown now (AND-640).
+    /// Gated on the window-first feature flag (the moment only makes sense when the
+    /// window surface is live) and the per-environment dismissal flag, and
+    /// suppressed in demo so a transient demo session never burns the one-time
+    /// welcome for a real configured install.
+    var shouldShowWindowFirstOrientation: Bool {
+        WindowFirstFeatureFlag.resolved()
+            && !isWindowFirstOrientationDismissed
+            && !isDemoMode
+    }
+
     func notificationPermissionStatus() async -> NotificationPermissionState {
         notificationPermissionState = await notificationService.checkPermissionStatus()
         return notificationPermissionState
@@ -3906,6 +3936,25 @@ final class AppState {
         }
     }
 
+    private func refreshWindowFirstOrientationDismissalForActiveContext() {
+        let storedValue = storedWindowFirstOrientationDismissal()
+        if isWindowFirstOrientationDismissed != storedValue {
+            isWindowFirstOrientationDismissed = storedValue
+        }
+    }
+
+    private func storedWindowFirstOrientationDismissal() -> Bool {
+        UserDefaults.standard.bool(forKey: windowFirstOrientationDismissalDefaultsKey)
+    }
+
+    private func persistWindowFirstOrientationDismissal(_ isDismissed: Bool) {
+        if isDismissed {
+            UserDefaults.standard.set(true, forKey: windowFirstOrientationDismissalDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: windowFirstOrientationDismissalDefaultsKey)
+        }
+    }
+
     private var setupCompletionDefaultsKey: String {
         let environment = setupCompletionEnvironment.rawValue
         let path = activeStorageDirectoryURL.standardizedFileURL.path
@@ -3918,6 +3967,13 @@ final class AppState {
         let path = activeStorageDirectoryURL.standardizedFileURL.path
         let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? path
         return "\(Keys.firstRunSnapshotDismissedContextPrefix).\(environment).\(encodedPath)"
+    }
+
+    private var windowFirstOrientationDismissalDefaultsKey: String {
+        let environment = setupCompletionEnvironment.rawValue
+        let path = activeStorageDirectoryURL.standardizedFileURL.path
+        let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? path
+        return "\(Keys.windowFirstOrientationDismissedContextPrefix).\(environment).\(encodedPath)"
     }
 
     private var setupCompletionEnvironment: PlaidEnvironment {

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3108,13 +3108,14 @@ final class AppState {
 
     /// Whether the window-first orientation moment should be shown now (AND-640).
     /// Gated on the window-first feature flag (the moment only makes sense when the
-    /// window surface is live) and the per-environment dismissal flag, and
-    /// suppressed in demo so a transient demo session never burns the one-time
-    /// welcome for a real configured install.
+    /// window surface is live), the per-environment dismissal flag, and unlocked
+    /// content. Suppressed in demo so a transient demo session never burns the
+    /// one-time welcome for a real configured install.
     var shouldShowWindowFirstOrientation: Bool {
         WindowFirstFeatureFlag.resolved()
             && !isWindowFirstOrientationDismissed
             && !isDemoMode
+            && !isContentLocked
     }
 
     func notificationPermissionStatus() async -> NotificationPermissionState {

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -958,13 +958,14 @@ private extension View {
 /// the primary `Window`.
 ///
 /// The whole gating decision is the pure `AppState.shouldShowWindowFirstOrientation`
-/// (window-first flag ON + not already dismissed + not demo). This modifier mirrors
-/// that into the sheet's `isPresented` binding and, on the user's "Got it",
-/// persists dismissal via `AppState.dismissWindowFirstOrientation()` so it never
-/// re-shows. `onAppear` covers "the window opened into this state" and `onChange`
-/// covers the flag/dismissal settling after the first server handshake — together
-/// they show the sheet exactly once on first window open. There is no theme flash:
-/// the sheet is plain SwiftUI inheriting the window's already-applied appearance.
+/// (window-first flag ON + not already dismissed + not demo + unlocked content).
+/// This modifier mirrors that into the sheet's `isPresented` binding and, on the
+/// user's dismissal, persists via `AppState.dismissWindowFirstOrientation()` so it
+/// never re-shows. `onAppear` covers "the window opened into this state" and
+/// `onChange` covers the flag/dismissal/lock state settling after the first
+/// server handshake — together they show the sheet exactly once on first window
+/// open. There is no theme flash: the sheet is plain SwiftUI inheriting the
+/// window's already-applied appearance.
 private struct WindowFirstOrientationSheet: ViewModifier {
     @Bindable var appState: AppState
 
@@ -973,6 +974,7 @@ private struct WindowFirstOrientationSheet: ViewModifier {
     /// from the pure `shouldShowWindowFirstOrientation` gate, and dismissal flips it
     /// false *and* persists so it never re-derives true.
     @State private var isPresented = false
+    @State private var suppressNextDismissPersistence = false
 
     func body(content: Content) -> some View {
         content
@@ -980,7 +982,7 @@ private struct WindowFirstOrientationSheet: ViewModifier {
             .onChange(of: appState.shouldShowWindowFirstOrientation) { _, _ in
                 syncPresentation()
             }
-            .sheet(isPresented: $isPresented) {
+            .sheet(isPresented: $isPresented, onDismiss: handleDismiss) {
                 WindowFirstOrientationView(
                     onDismiss: {
                         appState.dismissWindowFirstOrientation()
@@ -992,9 +994,23 @@ private struct WindowFirstOrientationSheet: ViewModifier {
 
     private func syncPresentation() {
         let shouldShow = appState.shouldShowWindowFirstOrientation
-        if shouldShow != isPresented {
-            isPresented = shouldShow
+        if shouldShow {
+            suppressNextDismissPersistence = false
+            isPresented = true
+        } else if isPresented {
+            suppressNextDismissPersistence = true
+            isPresented = false
         }
+    }
+
+    private func handleDismiss() {
+        if suppressNextDismissPersistence {
+            suppressNextDismissPersistence = false
+            return
+        }
+
+        guard appState.shouldShowWindowFirstOrientation else { return }
+        appState.dismissWindowFirstOrientation()
     }
 }
 

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -545,6 +545,15 @@ struct PlaidBarApp: App {
                 // material (AND-588). The glass-vs-solid decision is the pure,
                 // unit-tested `WindowChromeGlass.chromeBackground(reduceTransparency:)`.
                 .appliesWindowChromeBackground()
+                // One-time window-first orientation moment (AND-640): on the first
+                // window open for a fresh install, explain the two surfaces (menu-bar
+                // glance + window workspace) and that App Lock / Privacy Mask cover
+                // both. Gated on the window-first flag + a per-environment dismissal
+                // flag (so it never re-shows), and suppressed in demo. The sheet
+                // carries only orientation copy (no financial values), so it is safe
+                // under Privacy Mask / App Lock. Modeled as a sheet here (not in the
+                // shell) so the orientation lives with the window scene that hosts it.
+                .modifier(WindowFirstOrientationSheet(appState: appState))
         }
         // Do not steal launch/activation: the window only appears when opened.
         .defaultLaunchBehavior(.suppressed)
@@ -942,6 +951,50 @@ private extension View {
 
     func appliesAppAppearance() -> some View {
         modifier(AppAppearanceApplier())
+    }
+}
+
+/// Presents the one-time window-first orientation moment (AND-640) as a sheet on
+/// the primary `Window`.
+///
+/// The whole gating decision is the pure `AppState.shouldShowWindowFirstOrientation`
+/// (window-first flag ON + not already dismissed + not demo). This modifier mirrors
+/// that into the sheet's `isPresented` binding and, on the user's "Got it",
+/// persists dismissal via `AppState.dismissWindowFirstOrientation()` so it never
+/// re-shows. `onAppear` covers "the window opened into this state" and `onChange`
+/// covers the flag/dismissal settling after the first server handshake — together
+/// they show the sheet exactly once on first window open. There is no theme flash:
+/// the sheet is plain SwiftUI inheriting the window's already-applied appearance.
+private struct WindowFirstOrientationSheet: ViewModifier {
+    @Bindable var appState: AppState
+
+    /// Local presentation state so the sheet has a real two-way binding (a sheet
+    /// must be able to set its `isPresented` to `false` on dismissal). It is driven
+    /// from the pure `shouldShowWindowFirstOrientation` gate, and dismissal flips it
+    /// false *and* persists so it never re-derives true.
+    @State private var isPresented = false
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { syncPresentation() }
+            .onChange(of: appState.shouldShowWindowFirstOrientation) { _, _ in
+                syncPresentation()
+            }
+            .sheet(isPresented: $isPresented) {
+                WindowFirstOrientationView(
+                    onDismiss: {
+                        appState.dismissWindowFirstOrientation()
+                        isPresented = false
+                    }
+                )
+            }
+    }
+
+    private func syncPresentation() {
+        let shouldShow = appState.shouldShowWindowFirstOrientation
+        if shouldShow != isPresented {
+            isPresented = shouldShow
+        }
     }
 }
 

--- a/Sources/PlaidBar/Views/WindowFirstOrientationView.swift
+++ b/Sources/PlaidBar/Views/WindowFirstOrientationView.swift
@@ -1,0 +1,139 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The one-time **window-first orientation moment** (AND-640): a first-launch
+/// sheet shown on the primary `Window` to users arriving from the menu-bar era.
+///
+/// It explains the two surfaces — the menu bar is the calm glance, the window is
+/// the deeper workspace — and that the privacy controls (App Lock / Privacy Mask)
+/// apply to **both**. It carries only orientation copy (no financial values), so
+/// it is safe regardless of Privacy Mask / App Lock state.
+///
+/// The copy is the pure, headless `WindowFirstOrientationCopy` model in
+/// `PlaidBarCore`, so the wording is unit-tested and this view is a thin renderer.
+/// Presentation (gating on the per-environment dismissal flag + the window-first
+/// feature flag, and persisting dismissal) is owned by the `Window` scene; this
+/// view only renders and reports dismissal via `onDismiss`.
+struct WindowFirstOrientationView: View {
+    /// Reduce Motion gates the once-per-appearance icon reveal so the sheet does
+    /// not animate for users who asked for less motion.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let copy: WindowFirstOrientationCopy
+    let onDismiss: () -> Void
+
+    /// Drives the gentle staggered fade-in of the orientation points. Flipped on
+    /// appear; under Reduce Motion the change is applied without animation so the
+    /// content is simply present.
+    @State private var hasAppeared = false
+
+    init(
+        copy: WindowFirstOrientationCopy = .standard,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.copy = copy
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.lg) {
+            header
+
+            VStack(alignment: .leading, spacing: Spacing.md) {
+                ForEach(copy.points) { point in
+                    OrientationPointRow(point: point)
+                }
+            }
+
+            dismissButton
+        }
+        .padding(Spacing.xl)
+        .frame(width: 460)
+        .opacity(hasAppeared ? 1 : 0)
+        .onAppear {
+            withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+                hasAppeared = true
+            }
+        }
+        // One container element so VoiceOver announces the whole sheet as a single
+        // coherent welcome (title + subtitle + each point), rather than reading
+        // each fragment separately.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(copy.accessibilitySummary)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Image(systemName: "macwindow.badge.plus")
+                .font(.largeTitle.weight(.semibold))
+                .foregroundStyle(SemanticColors.brand)
+                .accessibilityHidden(true)
+
+            Text(copy.title)
+                .font(.title2.weight(.semibold))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(copy.subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        // The container label already announces title + subtitle; hide the
+        // duplicate visible text from VoiceOver so it is not read twice.
+        .accessibilityHidden(true)
+    }
+
+    private var dismissButton: some View {
+        Button(action: onDismiss) {
+            Text(copy.dismissButtonTitle)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .keyboardShortcut(.defaultAction)
+        .accessibilityLabel(copy.dismissAccessibilityLabel)
+        .accessibilityHint(copy.dismissAccessibilityHint)
+    }
+}
+
+/// A single orientation point: a brand-tinted SF Symbol beside a title and one
+/// explanatory line. The glyph is decorative (hidden from VoiceOver); the row's
+/// announced label is the pre-composed phrase from the pure copy model, so the
+/// meaning is never carried by the icon (or its color) alone.
+private struct OrientationPointRow: View {
+    let point: WindowFirstOrientationCopy.Point
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.md) {
+            Image(systemName: point.systemImage)
+                .font(.title3.weight(.medium))
+                .foregroundStyle(SemanticColors.brand)
+                .frame(width: Sizing.iconChip)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(point.title)
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(point.body)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassSurface(.inset)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(point.accessibilityLabel)
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview {
+    WindowFirstOrientationView(onDismiss: {})
+}
+#endif

--- a/Sources/PlaidBarCore/Models/WindowFirstOrientationCopy.swift
+++ b/Sources/PlaidBarCore/Models/WindowFirstOrientationCopy.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Pure, headless copy model for the one-time **window-first orientation moment**
+/// (AND-640): the first-launch sheet shown on the primary `Window` to users
+/// arriving from the menu-bar era.
+///
+/// The model is intentionally pure and `Sendable` so it lives in `PlaidBarCore`,
+/// is unit-testable without launching the app, and can be rendered headlessly. It
+/// carries **only orientation copy** — never any financial value, account, or
+/// institution detail — so it is safe to show regardless of Privacy Mask / App
+/// Lock state (the orientation sheet has nothing to mask).
+///
+/// The three points map to the orientation's job: the menu bar is the calm
+/// glance, the window is the deeper workspace, and the privacy controls
+/// (App Lock / Privacy Mask) apply to **both** surfaces.
+public struct WindowFirstOrientationCopy: Equatable, Sendable {
+    /// A single orientation point: an SF Symbol name, a short title, and one
+    /// explanatory line. `accessibilityLabel` is the pre-composed VoiceOver string
+    /// so the rendering view announces one coherent phrase per point rather than
+    /// reading the glyph + title + body as three fragments.
+    public struct Point: Equatable, Sendable, Identifiable {
+        public let id: String
+        public let systemImage: String
+        public let title: String
+        public let body: String
+
+        public init(id: String, systemImage: String, title: String, body: String) {
+            self.id = id
+            self.systemImage = systemImage
+            self.title = title
+            self.body = body
+        }
+
+        /// "Menu bar — the calm glance. Quick status…" — title and body joined
+        /// into one announced phrase. The glyph is decorative and is hidden from
+        /// VoiceOver by the view, so it is intentionally not spoken here.
+        public var accessibilityLabel: String {
+            "\(title). \(body)"
+        }
+    }
+
+    public let title: String
+    public let subtitle: String
+    public let points: [Point]
+    public let dismissButtonTitle: String
+    public let dismissAccessibilityLabel: String
+    public let dismissAccessibilityHint: String
+
+    public init(
+        title: String,
+        subtitle: String,
+        points: [Point],
+        dismissButtonTitle: String,
+        dismissAccessibilityLabel: String,
+        dismissAccessibilityHint: String
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.points = points
+        self.dismissButtonTitle = dismissButtonTitle
+        self.dismissAccessibilityLabel = dismissAccessibilityLabel
+        self.dismissAccessibilityHint = dismissAccessibilityHint
+    }
+
+    /// The shipped orientation copy. Static (no inputs) because the moment is a
+    /// fixed welcome — it explains the surfaces, it does not report state. Factored
+    /// as a `default` so the same canonical copy is exercised by tests and the view.
+    public static let standard = WindowFirstOrientationCopy(
+        title: "Welcome to the VaultPeek window",
+        subtitle: "VaultPeek now opens in a full window. Here is how the two surfaces work together.",
+        points: [
+            Point(
+                id: "menuBar",
+                systemImage: "menubar.arrow.up.rectangle",
+                title: "The menu bar is your calm glance",
+                body: "It keeps a quick read on status and a few key numbers, one click away — without opening anything."
+            ),
+            Point(
+                id: "window",
+                systemImage: "macwindow",
+                title: "The window is your deeper workspace",
+                body: "Open it for the full dashboard, transactions, budgets, planning, and review — everything in one place."
+            ),
+            Point(
+                id: "privacy",
+                systemImage: "lock.shield",
+                title: "Privacy controls cover both",
+                body: "App Lock and Privacy Mask apply everywhere — when balances are hidden or the app is locked, both the glance and the window stay private."
+            ),
+        ],
+        dismissButtonTitle: "Got it",
+        dismissAccessibilityLabel: "Dismiss orientation",
+        dismissAccessibilityHint: "Closes this welcome and does not show it again."
+    )
+
+    /// The full VoiceOver summary for the whole sheet (announced when the sheet's
+    /// container element gains focus): the title, subtitle, and each point's
+    /// announced phrase, joined into one coherent read.
+    public var accessibilitySummary: String {
+        ([title, subtitle] + points.map(\.accessibilityLabel)).joined(separator: " ")
+    }
+}

--- a/Tests/PlaidBarCoreTests/WindowFirstOrientationCopyTests.swift
+++ b/Tests/PlaidBarCoreTests/WindowFirstOrientationCopyTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Window-first orientation copy")
+struct WindowFirstOrientationCopyTests {
+    // MARK: - Shipped copy shape
+
+    @Test("Standard copy has a title, subtitle, three points, and a dismiss control")
+    func standardShape() {
+        let copy = WindowFirstOrientationCopy.standard
+
+        #expect(!copy.title.isEmpty)
+        #expect(!copy.subtitle.isEmpty)
+        #expect(copy.points.count == 3)
+        #expect(!copy.dismissButtonTitle.isEmpty)
+        #expect(!copy.dismissAccessibilityLabel.isEmpty)
+        #expect(!copy.dismissAccessibilityHint.isEmpty)
+    }
+
+    @Test("The three points cover the menu-bar glance, the window workspace, and shared privacy")
+    func pointsCoverTheThreeOrientationBeats() {
+        let copy = WindowFirstOrientationCopy.standard
+        let ids = copy.points.map(\.id)
+
+        #expect(ids == ["menuBar", "window", "privacy"])
+        // Each point is fully populated so the view never renders an empty row.
+        for point in copy.points {
+            #expect(!point.id.isEmpty)
+            #expect(!point.systemImage.isEmpty)
+            #expect(!point.title.isEmpty)
+            #expect(!point.body.isEmpty)
+        }
+    }
+
+    @Test("Point ids are unique so they are stable ForEach identities")
+    func pointIdsAreUnique() {
+        let ids = WindowFirstOrientationCopy.standard.points.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("The privacy point names both App Lock and Privacy Mask and that they cover both surfaces")
+    func privacyPointMentionsBothControlsAndBothSurfaces() {
+        guard let privacy = WindowFirstOrientationCopy.standard.points.first(where: { $0.id == "privacy" }) else {
+            Issue.record("Expected a privacy orientation point")
+            return
+        }
+        let text = "\(privacy.title) \(privacy.body)"
+        #expect(text.contains("App Lock"))
+        #expect(text.contains("Privacy Mask"))
+        // The orientation's whole point: privacy applies to BOTH surfaces.
+        #expect(text.localizedCaseInsensitiveContains("both"))
+    }
+
+    // MARK: - Privacy-safe (no financial values)
+
+    @Test("Orientation copy carries no digits — it is pure orientation, never a value surface")
+    func copyContainsNoFinancialValues() {
+        // The orientation moment must be safe to show under Privacy Mask / App Lock,
+        // so it must contain no numbers (which could read as balances/amounts).
+        let allText = ([
+            WindowFirstOrientationCopy.standard.title,
+            WindowFirstOrientationCopy.standard.subtitle,
+            WindowFirstOrientationCopy.standard.dismissButtonTitle,
+            WindowFirstOrientationCopy.standard.dismissAccessibilityLabel,
+            WindowFirstOrientationCopy.standard.dismissAccessibilityHint,
+        ] + WindowFirstOrientationCopy.standard.points.flatMap { [$0.title, $0.body] })
+            .joined(separator: " ")
+
+        let containsDigit = allText.contains { $0.isNumber }
+        #expect(containsDigit == false)
+    }
+
+    // MARK: - Accessibility
+
+    @Test("Each point's accessibility label folds title and body into one announced phrase")
+    func pointAccessibilityLabelFoldsTitleAndBody() {
+        for point in WindowFirstOrientationCopy.standard.points {
+            #expect(point.accessibilityLabel == "\(point.title). \(point.body)")
+        }
+    }
+
+    @Test("The sheet accessibility summary contains the title, subtitle, and every point")
+    func accessibilitySummaryContainsEverything() {
+        let copy = WindowFirstOrientationCopy.standard
+        let summary = copy.accessibilitySummary
+
+        #expect(summary.contains(copy.title))
+        #expect(summary.contains(copy.subtitle))
+        for point in copy.points {
+            #expect(summary.contains(point.accessibilityLabel))
+        }
+    }
+
+    // MARK: - Value semantics
+
+    @Test("Copy is Equatable by value")
+    func equatableByValue() {
+        #expect(WindowFirstOrientationCopy.standard == WindowFirstOrientationCopy.standard)
+
+        let mutated = WindowFirstOrientationCopy(
+            title: "Different",
+            subtitle: WindowFirstOrientationCopy.standard.subtitle,
+            points: WindowFirstOrientationCopy.standard.points,
+            dismissButtonTitle: WindowFirstOrientationCopy.standard.dismissButtonTitle,
+            dismissAccessibilityLabel: WindowFirstOrientationCopy.standard.dismissAccessibilityLabel,
+            dismissAccessibilityHint: WindowFirstOrientationCopy.standard.dismissAccessibilityHint
+        )
+        #expect(mutated != WindowFirstOrientationCopy.standard)
+    }
+}

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -87,6 +87,30 @@ struct PlaidBarTests {
         #expect(Set(pngs) == expected, "got PNGs: \(pngs)")
     }
 
+    @Test("Window-first orientation waits for unlocked content and persists user dismissal")
+    func windowFirstOrientationRequiresUnlockedContent() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appStateSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/AppState.swift"),
+            encoding: .utf8
+        )
+        let appSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/PlaidBarApp.swift"),
+            encoding: .utf8
+        )
+
+        let gateRange = try #require(appStateSource.range(of: "var shouldShowWindowFirstOrientation: Bool"))
+        let gateBlock = String(appStateSource[gateRange.lowerBound...].prefix(500))
+        #expect(gateBlock.contains("&& !isContentLocked"))
+
+        let modifierRange = try #require(appSource.range(of: "private struct WindowFirstOrientationSheet"))
+        let modifierBlock = String(appSource[modifierRange.lowerBound...].prefix(2_500))
+        #expect(modifierBlock.contains(".sheet(isPresented: $isPresented, onDismiss: handleDismiss)"))
+        #expect(modifierBlock.contains("suppressNextDismissPersistence = true"))
+        #expect(modifierBlock.contains("guard appState.shouldShowWindowFirstOrientation else { return }"))
+        #expect(modifierBlock.contains("appState.dismissWindowFirstOrientation()"))
+    }
+
     @Test("Window-first Goals and Planning mask amount-derived progress while Privacy Mask is active")
     func windowFirstGoalsProgressUsesPrivacyMask() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)


### PR DESCRIPTION
## What & why

VaultPeek is now window-first by default (AND-616): a fresh install lands in the primary `Window` workspace with the menu bar reduced to a glance. Users arriving from the menu-bar era have no signpost for the new model. This adds a **one-time first-launch orientation moment** — a sheet on the primary `Window` — that explains:

- the menu bar is the **calm glance** (quick status, a few key numbers one click away),
- the window is the **deeper workspace** (dashboard, transactions, budgets, planning, review),
- and that **App Lock / Privacy Mask apply to BOTH** surfaces.

It shows once on first window open, is dismissible, and is never shown again.

## Change (files)

- `Sources/PlaidBarCore/Models/WindowFirstOrientationCopy.swift` (new) — pure, `Sendable`, headless copy model (title, subtitle, three points, dismiss strings + pre-composed VoiceOver labels). Carries **only orientation copy, no financial values**, so it is safe under Privacy Mask / App Lock. `.standard` holds the shipped wording.
- `Sources/PlaidBar/Views/WindowFirstOrientationView.swift` (new) — thin SwiftUI renderer of the copy model. Decorative glyphs hidden from VoiceOver; the container announces one coherent phrase (`accessibilitySummary`); reduce-motion-gated fade-in via `MotionTokens.animation(_:reduceMotion:)`; default-action dismiss button. No theme flash (plain SwiftUI inheriting the window's already-applied appearance).
- `Sources/PlaidBar/App/AppState.swift` — adds `isWindowFirstOrientationDismissed`, mirroring `isFirstRunSnapshotDismissed`'s **context-aware UserDefaults key** (per Plaid environment + data directory) so it never re-shows once dismissed. Loaded synchronously at init, refreshed on context switch, with `dismissWindowFirstOrientation()` and the pure `shouldShowWindowFirstOrientation` gate (flag ON + not dismissed + not demo).
- `Sources/PlaidBar/App/PlaidBarApp.swift` — wires a `WindowFirstOrientationSheet` modifier onto the `Window("VaultPeek", id: "main")` scene, gated on `WindowFirstFeatureFlag.resolved()` + the dismissal flag.
- `Tests/PlaidBarCoreTests/WindowFirstOrientationCopyTests.swift` (new) — 8 tests for the pure copy model.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # Build complete (PASS)
swift test --filter WindowFirstOrientationCopyTests                              # 8 tests passed (PASS)
swift test --filter WindowFirstFeatureFlagTests                                  # 7 tests passed — no regression
git diff --check                                                                 # clean
```

The new Core suite asserts: shipped copy shape (title/subtitle/3 points/dismiss), the three orientation beats (`menuBar`/`window`/`privacy`), unique point ids, the privacy point naming both controls and both surfaces, **no digits anywhere** (privacy-safe value-surface guard), per-point and whole-sheet VoiceOver label composition, and value-`Equatable` semantics.

UI is window-only; screenshots can be regenerated via `./Scripts/screenshots.sh`.

## Links

Closes AND-640
