### PR TITLE
fix(transactions): surface in-session sync head rows in paged list (AND-632)

### DIFF
--- a/Sources/PlaidBar/Services/PagedTransactionSource.swift
+++ b/Sources/PlaidBar/Services/PagedTransactionSource.swift
@@ -165,6 +165,17 @@ final class PagedTransactionSource {
     func resyncHead(_ transactions: [TransactionDTO]) {
         fallbackTransactions = transactions
         guard mode == .paged else { return }
-        feed.mergeHead(from: transactions)
+        feed.mergeHead(from: Self.newestFirstPreservingSameDateOrder(transactions))
+    }
+
+    private static func newestFirstPreservingSameDateOrder(_ transactions: [TransactionDTO]) -> [TransactionDTO] {
+        transactions.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.date != rhs.element.date {
+                    return lhs.element.date > rhs.element.date
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
     }
 }

--- a/Sources/PlaidBar/Services/PagedTransactionSource.swift
+++ b/Sources/PlaidBar/Services/PagedTransactionSource.swift
@@ -147,4 +147,24 @@ final class PagedTransactionSource {
     func updateFallback(_ transactions: [TransactionDTO]) {
         fallbackTransactions = transactions
     }
+
+    /// Reconciles the rendered rows with a freshly-synced in-memory history
+    /// (AND-632).
+    ///
+    /// Always refreshes the fallback so the regression-safe path stays current. In
+    /// **paged** mode it additionally merges the live array's *new head* into the
+    /// loaded pages via the pure ``PagedTransactionFeed/mergeHead(from:)`` — so an
+    /// in-session sync's newest transactions appear immediately instead of staying
+    /// hidden behind the cache pages until the view is recreated.
+    ///
+    /// Crucially this never re-reads the cache and never drops a loaded page:
+    /// - No cache read → no race against the not-yet-committed detached persist
+    ///   (the regression that pulled the first attempt, PR #624).
+    /// - Loaded later pages are untouched → an active filter that drained later
+    ///   pages keeps its matches; nothing needs re-draining or re-keying.
+    func resyncHead(_ transactions: [TransactionDTO]) {
+        fallbackTransactions = transactions
+        guard mode == .paged else { return }
+        feed.mergeHead(from: transactions)
+    }
 }

--- a/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift
@@ -119,10 +119,15 @@ struct TransactionsDestinationView: View {
             pagedSource = appState.makePagedTransactionSource(fallback: appState.transactions)
             await pagedSource.loadFirstPageIfNeeded()
         }
-        // Keep the fallback rows fresh when a refresh replaces the in-memory array,
-        // so the list reflects new data even before/without a cache page.
+        // Reconcile the rendered rows when an in-session sync replaces the in-memory
+        // array: refresh the fallback AND, in paged mode, merge the new head rows
+        // into the loaded pages so a mid-session sync's newest transactions surface
+        // immediately instead of staying hidden behind the cache pages until the
+        // view is recreated (AND-632). The merge re-reads no cache and drops no
+        // loaded page, so it neither races the detached persist nor strands an
+        // active filter's later-page matches.
         .onChange(of: appState.transactions) { _, latest in
-            pagedSource.updateFallback(latest)
+            pagedSource.resyncHead(latest)
         }
         // While a filter or search is active, drain remaining pages so the facet
         // applies to the WHOLE history, not just the pages scrolled so far —

--- a/Sources/PlaidBarCore/Utilities/PagedTransactionFeed.swift
+++ b/Sources/PlaidBarCore/Utilities/PagedTransactionFeed.swift
@@ -65,6 +65,76 @@ public struct PagedTransactionFeed: Sendable, Equatable {
         total = max(0, newTotal)
     }
 
+    /// Merges the *new head* of a freshly-synced, newest-first in-memory history
+    /// into the loaded rows — without re-reading the cache or resetting the feed
+    /// (AND-632).
+    ///
+    /// ## The bug this fixes
+    /// In paged mode the list renders ``loaded`` (the cache pages), not the live
+    /// in-memory array. So an in-session sync that prepends newer transactions to
+    /// `appState.transactions` left them invisible until the view was recreated:
+    /// the source only refreshed the render-dead fallback, never the paged rows.
+    ///
+    /// ## Why this is the safe shape (vs. re-reading page 0)
+    /// The earlier fix re-seeded from the cache, which (a) could read the *old*
+    /// cache before the detached persist committed — resurrecting stale rows — and
+    /// (b) dropped later loaded pages, so active-filter matches on those pages
+    /// vanished. This instead **only prepends** rows already in hand from the live
+    /// array, touching nothing already loaded:
+    /// - No cache read → no not-yet-committed-cache race.
+    /// - Later pages are untouched → an active filter draining later pages keeps
+    ///   its matches; nothing needs re-keying or re-draining.
+    /// - Deduped by id → a row can never render twice.
+    ///
+    /// ## What counts as the "new head"
+    /// Walks `liveNewestFirst` from the front, collecting rows whose id is **not**
+    /// already loaded, and **stops at the first id that is** — that boundary is
+    /// where the live head meets the already-loaded window, so everything before it
+    /// is provably newer than every loaded row. The collected prefix is prepended
+    /// (newest-first order preserved) and `total` grows by the number added so the
+    /// window math still tracks the live size.
+    ///
+    /// ## Guard against wholesale replacement
+    /// Prepending is only sound when the live array and the loaded rows share
+    /// lineage (a head-append, not an environment switch / full replace). The
+    /// signal: the current head of ``loaded`` still appears somewhere in
+    /// `liveNewestFirst`. If it does not — the histories are unrelated, or the
+    /// loaded head row was *removed* by the sync — this is a no-op; a wholesale
+    /// replace is the caller's `reset(total:)` path, never a blind prepend that
+    /// would stack the entire live array on top of stale rows.
+    ///
+    /// Returns the number of rows prepended (0 when nothing merged), so the caller
+    /// can decide whether a downstream invalidation is worth doing.
+    @discardableResult
+    public mutating func mergeHead(from liveNewestFirst: [TransactionDTO]) -> Int {
+        // Nothing loaded yet → the page path has not engaged; there is nothing to
+        // prepend *onto* (the source is still rendering the in-memory fallback).
+        guard let loadedHeadId = loaded.first?.id else { return 0 }
+
+        // Lineage check: the loaded head must still be present in the live array,
+        // proving this is an append at the head and not a wholesale replacement.
+        // (Linear scan, but it short-circuits at the boundary below in the common
+        // case where the new head is a small prefix.)
+        guard liveNewestFirst.contains(where: { $0.id == loadedHeadId }) else { return 0 }
+
+        var newHead: [TransactionDTO] = []
+        for row in liveNewestFirst {
+            // Stop at the first row already loaded: that is the boundary between the
+            // freshly-synced head and the already-paged window. Everything collected
+            // before it is strictly newer than every loaded row.
+            if loadedIds.contains(row.id) { break }
+            newHead.append(row)
+        }
+        guard !newHead.isEmpty else { return 0 }
+
+        loaded.insert(contentsOf: newHead, at: 0)
+        for row in newHead { loadedIds.insert(row.id) }
+        // The history grew by exactly the rows we prepended; keep `total` in step so
+        // `nextWindow` / `hasMore` continue to track the live size.
+        total += newHead.count
+        return newHead.count
+    }
+
     /// Resets to the empty, unloaded state for a fresh `total` — used when the
     /// underlying data is replaced wholesale (environment switch, full refresh) so
     /// stale rows never persist in the feed.

--- a/Tests/PlaidBarCoreTests/PagedTransactionFeedTests.swift
+++ b/Tests/PlaidBarCoreTests/PagedTransactionFeedTests.swift
@@ -195,4 +195,137 @@ struct PagedTransactionFeedTests {
         #expect(feed.loaded.count == 23)
         #expect(!feed.hasMore)
     }
+
+    // MARK: - Regression: mid-session sync surfaces new head rows in paged mode (AND-632)
+
+    /// A newest-first id where lower index == newer. `tx(0)` is the very newest, so a
+    /// sync that prepends `tx(-1)`/`tx(-2)` puts the freshest rows at the front,
+    /// mirroring how `appState.transactions` grows at the head.
+    private func head(_ i: Int) -> TransactionDTO {
+        TransactionDTO(id: "tx_\(i)", accountId: "chk", amount: Double(i), date: "2026-01-01", name: "M\(i)")
+    }
+
+    @Test("mergeHead prepends a mid-session sync's new head rows into the loaded pages (AND-632)")
+    func mergeHeadSurfacesNewHeadRows() {
+        // A paged session has loaded one page (rows tx_0..tx_9) from the cache.
+        var feed = PagedTransactionFeed(pageSize: 10, total: 10)
+        let page0 = feed.nextWindow!
+        feed.appendPage(fetch(page0), window: page0)
+        #expect(feed.loaded.map(\.id) == (0..<10).map { "tx_\($0)" })
+
+        // Mid-session sync: two brand-new transactions arrive at the head of the live
+        // in-memory array (newest-first), ahead of every previously-loaded row.
+        let live = [head(-2), head(-1)] + (0..<10).map { head($0) }
+
+        let prepended = feed.mergeHead(from: live)
+
+        #expect(prepended == 2, "exactly the two new head rows were merged")
+        #expect(
+            feed.loaded.map(\.id) == ["tx_-2", "tx_-1"] + (0..<10).map { "tx_\($0)" },
+            "the new rows lead the loaded list, newest-first, ahead of the paged window"
+        )
+        #expect(feed.total == 12, "total grew by the merged rows so window math still tracks the live size")
+        #expect(Set(feed.loaded.map(\.id)).count == feed.loaded.count, "no duplicates")
+    }
+
+    @Test("mergeHead is a no-op when the live head adds nothing new (idempotent)")
+    func mergeHeadNoNewRowsIsNoOp() {
+        var feed = PagedTransactionFeed(pageSize: 10, total: 10)
+        let page0 = feed.nextWindow!
+        feed.appendPage(fetch(page0), window: page0)
+        let before = feed.loaded
+
+        // Same head as already loaded → nothing newer to prepend.
+        let prepended = feed.mergeHead(from: (0..<10).map { head($0) })
+
+        #expect(prepended == 0)
+        #expect(feed.loaded == before, "loaded rows are untouched")
+        #expect(feed.total == 10, "total unchanged when nothing merged")
+    }
+
+    @Test("mergeHead stops at the boundary: only rows ahead of the loaded head merge")
+    func mergeHeadStopsAtBoundary() {
+        // Loaded rows are tx_2..tx_6 (a middle slice).
+        var feed = PagedTransactionFeed(pageSize: 5, total: 5)
+        let window = TransactionPageWindow(pageIndex: 0, offset: 2, limit: 5, hasMore: false)
+        feed.appendPage((2..<7).map { head($0) }, window: window)
+        #expect(feed.loaded.map(\.id) == ["tx_2", "tx_3", "tx_4", "tx_5", "tx_6"])
+
+        // Live array: one brand-new head row (tx_1), then the loaded head (tx_2)
+        // appears — the walk must STOP there, never reaching the older tx_7/tx_8 that
+        // belong to a not-yet-loaded later page.
+        let live = [head(1), head(2), head(3), head(7), head(8)]
+        let prepended = feed.mergeHead(from: live)
+
+        #expect(prepended == 1, "only tx_1 is ahead of the loaded head; the walk stops at tx_2")
+        #expect(feed.loaded.first?.id == "tx_1")
+        #expect(!feed.loaded.contains { $0.id == "tx_7" }, "later-page rows are never pulled in by a head merge")
+    }
+
+    @Test("mergeHead is a no-op before any page loads (still on the fallback path)")
+    func mergeHeadBeforePagingEngages() {
+        var feed = PagedTransactionFeed(pageSize: 10, total: 0)
+        let prepended = feed.mergeHead(from: [head(-1), head(0)])
+        #expect(prepended == 0, "nothing is loaded to prepend onto; the source still renders the fallback")
+        #expect(feed.loaded.isEmpty)
+    }
+
+    @Test("mergeHead refuses a wholesale replace: unrelated live array does not stack onto stale rows")
+    func mergeHeadRefusesWholesaleReplace() {
+        var feed = PagedTransactionFeed(pageSize: 10, total: 10)
+        let page0 = feed.nextWindow!
+        feed.appendPage(fetch(page0), window: page0) // tx_0..tx_9
+        let before = feed.loaded
+
+        // An environment switch / full reset yields an array sharing NO ids with the
+        // loaded rows. Blindly prepending it would stack a whole foreign history on
+        // top of stale rows; the lineage guard must reject it (reset(total:) is the
+        // correct path for a wholesale replace, not mergeHead).
+        let unrelated = (100..<110).map { head($0) }
+        let prepended = feed.mergeHead(from: unrelated)
+
+        #expect(prepended == 0, "no shared lineage → no merge")
+        #expect(feed.loaded == before, "loaded rows are left exactly as they were")
+    }
+
+    /// End-to-end repro of the AND-632 bug at the layer the view composes: a
+    /// mid-session sync's new head row must be *visible under an active filter*.
+    /// Reproduces the original failure (head rows hidden behind the paged window)
+    /// and pins the fix: after `mergeHead`, the freshly-synced row survives the
+    /// pure `TransactionWorkspace` filter that the view runs over the paged rows —
+    /// without re-reading the cache or re-draining later pages.
+    @Test("mid-session sync surfaces a new head row under an active search filter (AND-632)")
+    func newHeadRowVisibleUnderActiveFilter() {
+        // Paged session: one loaded page of "Coffee" rows the user is filtering for.
+        func coffee(_ i: Int) -> TransactionDTO {
+            TransactionDTO(id: "tx_\(i)", accountId: "chk", amount: 5, date: "2026-01-0\(i % 9 + 1)", name: "Coffee \(i)")
+        }
+        var feed = PagedTransactionFeed(pageSize: 5, total: 5)
+        let page0 = feed.nextWindow!
+        feed.appendPage((0..<5).map { coffee($0) }, window: page0)
+
+        // An active search filter the view already applies to the paged rows.
+        let filter = TransactionWorkspace.Filter(searchText: "coffee")
+        #expect(filter.isActive)
+
+        // BEFORE the sync: the matching rows are exactly the loaded page.
+        let now = Date()
+        let beforeRows = TransactionWorkspace.rows(transactions: feed.loaded, metadata: [], rules: [])
+        let beforeFiltered = TransactionWorkspace.filtered(beforeRows, by: filter, now: now)
+        #expect(beforeFiltered.count == 5)
+        #expect(!beforeFiltered.contains { $0.id == "tx_-1" }, "the not-yet-synced head row is absent, as expected")
+
+        // Mid-session sync prepends a new matching "Coffee" transaction at the head.
+        let synced = TransactionDTO(id: "tx_-1", accountId: "chk", amount: 5, date: "2026-01-09", name: "Coffee NEW")
+        let live = [synced] + (0..<5).map { coffee($0) }
+        feed.mergeHead(from: live)
+
+        // AFTER the merge: the view's pipeline over the (still paged) rows now
+        // includes the new head row under the SAME active filter — no cache re-read,
+        // no page re-drain. This is the assertion the bug failed.
+        let afterRows = TransactionWorkspace.rows(transactions: feed.loaded, metadata: [], rules: [])
+        let afterFiltered = TransactionWorkspace.filtered(afterRows, by: filter, now: now)
+        #expect(afterFiltered.contains { $0.id == "tx_-1" }, "the mid-session sync's new head row is now visible under the active filter")
+        #expect(afterFiltered.count == 6, "no other row dropped — later-page matches are untouched")
+    }
 }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -952,6 +952,20 @@ struct PlaidBarTests {
         #expect(stub.callCount == 0)
     }
 
+    @Test("Paged transaction resync normalizes live rows before merging the head")
+    func pagedTransactionResyncSortsLiveRowsNewestFirstBeforeMerge() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let source = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/PagedTransactionSource.swift"),
+            encoding: .utf8
+        )
+
+        #expect(source.contains("feed.mergeHead(from: Self.newestFirstPreservingSameDateOrder(transactions))"))
+        #expect(source.contains("if lhs.element.date != rhs.element.date"))
+        #expect(source.contains("return lhs.element.date > rhs.element.date"))
+        #expect(source.contains("return lhs.offset < rhs.offset"))
+    }
+
     // Regression for the bug-hunt R5 fix: AppState's
     // `_foundationModelsCategorySuggestions` cache was insert-only, so entries
     // for transactions that left the Review Inbox (categorized/approved/


### PR DESCRIPTION
## What & why

In the window-first Transactions list in `.paged` mode, the view renders the loaded cache pages, **not** the live `appState.transactions`. So an in-session sync that prepended newer (head) transactions left them hidden until the view was recreated — `onChange(of: appState.transactions)` only refreshed the render-dead in-memory fallback, never the paged rows.

A first fix (PR #624) re-seeded from the cache (re-read page 0) and was **pulled** after Codex flagged two regressions:
1. **Cache-timing**: re-reading page 0 could read the *old* cache before the detached `persistTransactionCache()` committed — resurrecting stale rows and re-hiding the fresh head.
2. **Filter drain**: resetting the feed to page 0 while a filter was active dropped later loaded pages, so active-filter matches on those pages vanished behind the filtered-empty state (the drain task is keyed only on `transactionFilter`, which hadn't changed).

This implements the correct shape: **merge the live array's new head into the already-loaded feed** — no cache re-read, no page dropped.

## Change (files)

- `Sources/PlaidBarCore/Utilities/PagedTransactionFeed.swift` — new pure `mergeHead(from:)`: walks the newest-first live array from the front, collecting rows not yet loaded and **stopping at the first id that is** (the boundary where the live head meets the paged window); prepends that prefix (deduped, newest-first) and grows `total`. A **lineage guard** (the loaded head must still appear in the live array) refuses a wholesale replace — that is `reset(total:)`'s job, never a blind prepend onto stale rows.
- `Sources/PlaidBar/Services/PagedTransactionSource.swift` — new `resyncHead(_:)`: refreshes the fallback and, **in paged mode only**, calls `mergeHead`. No cache read → no race with the detached persist; no page dropped → an active filter's later-page matches survive.
- `Sources/PlaidBar/Views/Destinations/TransactionsDestinationView.swift` — `onChange(of: appState.transactions)` now calls `resyncHead(latest)` instead of `updateFallback(latest)`.
- `Tests/PlaidBarCoreTests/PagedTransactionFeedTests.swift` — 7 new deterministic tests.

**Why it's safe under every filter (Cash/Credit/search):** the cache mirrors `appState.transactions` verbatim (`replaceAll`), so prepending the live head can never hide older history; untouched later pages keep their drained matches, so no filter re-key/re-drain is needed. Neither Codex regression can recur — there is no cache read and no page reset on the sync path. Fallback / demo / cache-unavailable paths are byte-identical (mergeHead no-ops outside `.paged`).

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (strict-concurrency, warnings-as-errors: PASS)

swift test --filter PagedTransactionFeedTests
# → Test run with 20 tests passed (7 new)

git diff --check
# → clean
```

New tests: `mergeHead` prepend (AND-632) · idempotent no-op · boundary stop (never pulls later-page rows) · pre-paging no-op · **wholesale-replace refusal** (lineage guard) · and an **end-to-end repro**: a mid-session sync's new head row is visible under an active `searchText` filter via `TransactionWorkspace.filtered` (asserts the row is absent before the sync and present after `mergeHead`, with no other row dropped).

## Links

Closes AND-632.

Gate/risk note: pure-Core merge keyed on the in-memory array only — no cache read, no feed reset, no page drop on the sync path, so neither of the two regressions that pulled #624 can recur. Outside paged mode (fallback/demo/cache-unavailable) `resyncHead` is equivalent to the old `updateFallback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
