### PR TITLE
fix(cache): treat incompatible store as disposable miss + non-blocking open (AND-656)

### DIFF
--- a/Sources/PlaidBar/App/AppState+ReadModelCache.swift
+++ b/Sources/PlaidBar/App/AppState+ReadModelCache.swift
@@ -66,10 +66,17 @@ extension AppState {
 
     /// Lazily opens (or re-opens) the on-disk disposable store for the active
     /// data directory. Returns `nil` — and stays disabled for this call — when
-    /// the cache is feature-disabled, when in demo mode (demo data is never
-    /// cached), or when the file-backed store fails to open. Reopens when the
-    /// active storage directory changes (e.g. sandbox↔production switch) so the
-    /// store always matches the environment whose key it is asked about.
+    /// the cache is feature-disabled or when in demo mode (demo data is never
+    /// cached). Reopens when the active storage directory changes (e.g.
+    /// sandbox↔production switch) so the store always matches the environment whose
+    /// key it is asked about.
+    ///
+    /// Opening does **no** disk I/O and cannot fail: the backing file is read and
+    /// decoded lazily on the store actor's executor, so this never blocks the
+    /// MainActor with a full decode (AND-656 finding 3). An incompatible/corrupt
+    /// file (e.g. a pre-JSON SwiftData `.store`) is self-healed into a disposable
+    /// miss on that first off-main read rather than disabling the cache (AND-656
+    /// finding 2).
     func readModelCacheStoreIfAvailable() -> ReadModelCacheStore? {
         guard readModelCacheEnabled, !isDemoMode else { return nil }
 
@@ -81,21 +88,10 @@ extension AppState {
             return existing
         }
 
-        do {
-            let store = try ReadModelCacheStore(onDiskIn: directory)
-            readModelCacheStore = store
-            readModelCacheStoreDirectoryPath = directoryPath
-            return store
-        } catch {
-            // Cache unavailable / store unopenable: behave exactly as before
-            // the cache existed. Logged without any financial material.
-            AppState.readModelCacheLogger.error(
-                "Read-model cache unavailable: \(String(describing: error), privacy: .public)"
-            )
-            readModelCacheStore = nil
-            readModelCacheStoreDirectoryPath = nil
-            return nil
-        }
+        let store = ReadModelCacheStore(onDiskIn: directory)
+        readModelCacheStore = store
+        readModelCacheStoreDirectoryPath = directoryPath
+        return store
     }
 
     /// The environment+directory-scoped key for the active context, or `nil`
@@ -168,8 +164,11 @@ extension AppState {
         }
     }
 
-    /// Wipes the disposable cache alongside the JSON/SQLite caches on local reset
-    /// and on the empty-accounts path (last institution removed).
+    /// Wipes **only the read-model store** alongside the JSON/SQLite caches on local
+    /// reset and on the empty-accounts path (last institution removed). The
+    /// per-transaction store is wiped separately by ``clearTransactionCache()``
+    /// (AND-657) — both route through the same ``ReadModelCacheClearGate`` epoch so
+    /// they clear in the same program order.
     ///
     /// Bumps the clear epoch synchronously *first* so any persist already
     /// scheduled in program order observes the clear and drops its write — the

--- a/Sources/PlaidBar/App/AppState+TransactionCache.swift
+++ b/Sources/PlaidBar/App/AppState+TransactionCache.swift
@@ -46,9 +46,16 @@ extension AppState {
 
     /// Lazily opens (or re-opens) the on-disk per-transaction store for the active
     /// data directory. Returns `nil` — and stays disabled for this call — when the
-    /// cache is feature-disabled, in demo mode, or when the file-backed store fails
-    /// to open. Reopens when the active storage directory changes so the store always
-    /// matches the environment whose key it is asked about.
+    /// cache is feature-disabled or in demo mode. Reopens when the active storage
+    /// directory changes so the store always matches the environment whose key it is
+    /// asked about.
+    ///
+    /// Opening does **no** disk I/O and cannot fail: the (potentially large) backing
+    /// file is read and decoded lazily on the store actor's executor, so this never
+    /// blocks the MainActor with a full-history decode (AND-656 finding 3). An
+    /// incompatible/corrupt file (e.g. a pre-JSON SwiftData `.store`) is self-healed
+    /// into a disposable miss on that first off-main read rather than disabling the
+    /// cache (AND-656 finding 2).
     func transactionCacheStoreIfAvailable() -> TransactionCacheStore? {
         guard readModelCacheEnabled, !isDemoMode else { return nil }
 
@@ -60,19 +67,10 @@ extension AppState {
             return existing
         }
 
-        do {
-            let store = try TransactionCacheStore(onDiskIn: directory)
-            transactionCacheStore = store
-            transactionCacheStoreDirectoryPath = directoryPath
-            return store
-        } catch {
-            AppState.transactionCacheLogger.error(
-                "Transaction cache unavailable: \(String(describing: error), privacy: .public)"
-            )
-            transactionCacheStore = nil
-            transactionCacheStoreDirectoryPath = nil
-            return nil
-        }
+        let store = TransactionCacheStore(onDiskIn: directory)
+        transactionCacheStore = store
+        transactionCacheStoreDirectoryPath = directoryPath
+        return store
     }
 
     /// Best-effort persist of the current authoritative transactions into the

--- a/Sources/PlaidBarCache/ReadModelCacheStore+Factory.swift
+++ b/Sources/PlaidBarCache/ReadModelCacheStore+Factory.swift
@@ -2,16 +2,19 @@ import Foundation
 
 public extension ReadModelCacheStore {
     /// Opens the disposable on-disk cache store under `directory` (the local
-    /// private data dir). Throwing initializer: AppState wraps construction in
-    /// `try?` so a store failure leaves the app on its existing cold path.
-    init(onDiskIn directory: URL, fileManager: FileManager = .default) throws {
+    /// private data dir). Opening performs **no** disk I/O: the backing file is read
+    /// and decoded lazily on first access, so this never blocks the caller with a
+    /// full-history decode (AND-656 finding 3). An incompatible/corrupt file is then
+    /// self-healed into a clean miss on that first read rather than disabling the
+    /// cache.
+    init(onDiskIn directory: URL, fileManager: FileManager = .default) {
         let storeURL = directory.appendingPathComponent(Self.storeFilename)
-        try self.init(storeURL: storeURL, fileManager: fileManager)
+        self.init(storeURL: storeURL, fileManager: fileManager)
     }
 
     /// Opens an in-memory store (tests and non-persisting fallback).
-    init(inMemory: Bool) throws {
+    init(inMemory: Bool) {
         precondition(inMemory, "Use init(onDiskIn:) for the persistent store")
-        try self.init(storeURL: nil)
+        self.init(storeURL: nil)
     }
 }

--- a/Sources/PlaidBarCache/ReadModelCacheStore.swift
+++ b/Sources/PlaidBarCache/ReadModelCacheStore.swift
@@ -28,7 +28,13 @@ public actor ReadModelCacheStore {
 
     private let storeURL: URL?
     private let fileManager: FileManager
-    private var rowsByKey: [String: CachedDashboardReadModel]
+
+    /// In-memory rows, lazily hydrated from disk on first access. `nil` means the
+    /// store has not yet read its backing file — opening the actor performs **no**
+    /// disk I/O (AND-656 finding 3), so construction never blocks the MainActor
+    /// caller with a full-history decode. The read+decode is deferred to
+    /// ``loadedRows()`` on the actor's own executor.
+    private var rowsByKey: [String: CachedDashboardReadModel]?
 
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -43,15 +49,54 @@ public actor ReadModelCacheStore {
         return decoder
     }
 
-    init(storeURL: URL?, fileManager: FileManager = .default) throws {
+    /// Opens the store **without** touching disk. Constructing the actor is now a
+    /// pure, non-throwing handoff of the URL; the backing file is read lazily on the
+    /// actor's executor (see ``loadedRows()``), so a MainActor caller never decodes
+    /// the full history synchronously during open (AND-656 finding 3).
+    init(storeURL: URL?, fileManager: FileManager = .default) {
         self.storeURL = storeURL
         self.fileManager = fileManager
-        if let storeURL, fileManager.fileExists(atPath: storeURL.path) {
-            let data = try Data(contentsOf: storeURL)
-            self.rowsByKey = try Self.decoder.decode(Snapshot.self, from: data).rows
-        } else {
-            self.rowsByKey = [:]
+        self.rowsByKey = nil
+    }
+
+    // MARK: - Lazy load / self-heal
+
+    /// The in-memory rows, hydrating from disk on first access.
+    ///
+    /// An **incompatible or corrupt backing file** (e.g. a pre-JSON SwiftData
+    /// `.store` that cannot decode as our `Snapshot`) is treated as a disposable
+    /// cache *miss*, not a hard failure: the unreadable file is discarded and the
+    /// store starts empty so the next refresh rebuilds it (AND-656 finding 2). This
+    /// is why the disposable cache never permanently disables itself and never loses
+    /// real data — the authoritative source is always the live in-memory data.
+    private func loadedRows() -> [String: CachedDashboardReadModel] {
+        if let rowsByKey { return rowsByKey }
+
+        guard let storeURL, fileManager.fileExists(atPath: storeURL.path) else {
+            rowsByKey = [:]
+            return [:]
         }
+
+        do {
+            let data = try Data(contentsOf: storeURL)
+            let rows = try Self.decoder.decode(Snapshot.self, from: data).rows
+            rowsByKey = rows
+            return rows
+        } catch {
+            // Undecodable file (incompatible/corrupt): discard it so the store
+            // self-heals into a clean miss instead of staying permanently broken.
+            discardIncompatibleStoreFile()
+            rowsByKey = [:]
+            return [:]
+        }
+    }
+
+    /// Removes the unreadable backing file so a subsequent ``persist()`` writes a
+    /// fresh, decodable snapshot. Best-effort: a failure to delete leaves the empty
+    /// in-memory state, and the next atomic write overwrites the file anyway.
+    private func discardIncompatibleStoreFile() {
+        guard let storeURL else { return }
+        try? fileManager.removeItem(at: storeURL)
     }
 
     // MARK: - Operations
@@ -60,12 +105,14 @@ public actor ReadModelCacheStore {
     /// `cacheKey`. The cache holds a single row per environment, so a save is an
     /// upsert.
     public func save(_ model: DashboardReadModel) throws {
+        var rows = loadedRows()
         let payload = try Self.encoder.encode(model)
-        rowsByKey[model.cacheKey] = CachedDashboardReadModel(
+        rows[model.cacheKey] = CachedDashboardReadModel(
             cacheKey: model.cacheKey,
             schemaVersion: model.schemaVersion,
             payload: payload
         )
+        rowsByKey = rows
         try persist()
     }
 
@@ -74,9 +121,11 @@ public actor ReadModelCacheStore {
     /// store self-heals). A decode failure throws so the caller's `try?` can drop
     /// back to today's cold path.
     public func load(cacheKey: String) throws -> DashboardReadModel? {
-        guard let row = rowsByKey[cacheKey] else { return nil }
+        var rows = loadedRows()
+        guard let row = rows[cacheKey] else { return nil }
         guard row.schemaVersion == DashboardReadModel.currentSchemaVersion else {
-            rowsByKey.removeValue(forKey: cacheKey)
+            rows.removeValue(forKey: cacheKey)
+            rowsByKey = rows
             try? persist()
             return nil
         }
@@ -88,14 +137,19 @@ public actor ReadModelCacheStore {
     /// Removes the row for `cacheKey` (e.g. after a local-data reset). Safe to
     /// call when no row exists.
     public func clear(cacheKey: String) throws {
-        rowsByKey.removeValue(forKey: cacheKey)
+        var rows = loadedRows()
+        rows.removeValue(forKey: cacheKey)
+        rowsByKey = rows
         try persist()
     }
 
     /// Removes every cached row. Used by the local-data reset path so the
     /// disposable cache is wiped alongside the JSON/SQLite caches.
     public func clearAll() throws {
-        rowsByKey.removeAll()
+        // The store becomes empty regardless of any on-disk content, so this never
+        // needs to (and never triggers) a decode of an incompatible file: a clear
+        // unconditionally wins and rewrites a fresh empty snapshot.
+        rowsByKey = [:]
         try persist()
     }
 
@@ -103,7 +157,7 @@ public actor ReadModelCacheStore {
 
     private func persist() throws {
         guard let storeURL else { return }
-        let data = try Self.encoder.encode(Snapshot(rows: rowsByKey))
+        let data = try Self.encoder.encode(Snapshot(rows: rowsByKey ?? [:]))
         try fileManager.createDirectory(
             at: storeURL.deletingLastPathComponent(),
             withIntermediateDirectories: true,

--- a/Sources/PlaidBarCache/TransactionCacheStore+Factory.swift
+++ b/Sources/PlaidBarCache/TransactionCacheStore+Factory.swift
@@ -2,17 +2,19 @@ import Foundation
 
 public extension TransactionCacheStore {
     /// Opens the disposable on-disk per-transaction cache under `directory` (the
-    /// local private data dir). Throwing initializer: AppState wraps construction
-    /// in `try?` so a store failure leaves the app on its existing in-memory
-    /// rendering path.
-    init(onDiskIn directory: URL, fileManager: FileManager = .default) throws {
+    /// local private data dir). Opening performs **no** disk I/O: the (potentially
+    /// large) backing file is read and decoded lazily on first access, so this never
+    /// blocks the caller with a full-history decode (AND-656 finding 3). An
+    /// incompatible/corrupt file is self-healed into a clean miss on that first read
+    /// rather than disabling the cache.
+    init(onDiskIn directory: URL, fileManager: FileManager = .default) {
         let storeURL = directory.appendingPathComponent(Self.storeFilename)
-        try self.init(storeURL: storeURL, fileManager: fileManager)
+        self.init(storeURL: storeURL, fileManager: fileManager)
     }
 
     /// Opens an in-memory store (tests and non-persisting fallback).
-    init(inMemory: Bool) throws {
+    init(inMemory: Bool) {
         precondition(inMemory, "Use init(onDiskIn:) for the persistent store")
-        try self.init(storeURL: nil)
+        self.init(storeURL: nil)
     }
 }

--- a/Sources/PlaidBarCache/TransactionCacheStore.swift
+++ b/Sources/PlaidBarCache/TransactionCacheStore.swift
@@ -38,7 +38,13 @@ public actor TransactionCacheStore {
 
     private let storeURL: URL?
     private let fileManager: FileManager
-    private var rowsByUniqueKey: [String: CachedTransaction]
+
+    /// In-memory rows, lazily hydrated from disk on first access. `nil` means the
+    /// store has not yet read its backing file — opening the actor performs **no**
+    /// disk I/O (AND-656 finding 3), so construction never blocks the MainActor
+    /// caller with a full-history JSON decode. The potentially large read+decode is
+    /// deferred to ``loadedRows()`` on the actor's own executor, off any UI path.
+    private var rowsByUniqueKey: [String: CachedTransaction]?
 
     private static var encoder: JSONEncoder {
         let encoder = JSONEncoder()
@@ -53,15 +59,55 @@ public actor TransactionCacheStore {
         return decoder
     }
 
-    init(storeURL: URL?, fileManager: FileManager = .default) throws {
+    /// Opens the store **without** touching disk. Constructing the actor is now a
+    /// pure, non-throwing handoff of the URL; the (potentially large) backing file
+    /// is read lazily on the actor's executor (see ``loadedRows()``), so a MainActor
+    /// caller never decodes the full transaction history synchronously during open
+    /// (AND-656 finding 3) — opening stays cheap and paging stays the bounded path.
+    init(storeURL: URL?, fileManager: FileManager = .default) {
         self.storeURL = storeURL
         self.fileManager = fileManager
-        if let storeURL, fileManager.fileExists(atPath: storeURL.path) {
-            let data = try Data(contentsOf: storeURL)
-            self.rowsByUniqueKey = try Self.decoder.decode(Snapshot.self, from: data).rowsByUniqueKey
-        } else {
-            self.rowsByUniqueKey = [:]
+        self.rowsByUniqueKey = nil
+    }
+
+    // MARK: - Lazy load / self-heal
+
+    /// The in-memory rows, hydrating from disk on first access.
+    ///
+    /// An **incompatible or corrupt backing file** (e.g. a pre-JSON SwiftData
+    /// `.store` that cannot decode as our `Snapshot`) is treated as a disposable
+    /// cache *miss*, not a hard failure: the unreadable file is discarded and the
+    /// store starts empty so the next refresh rebuilds it (AND-656 finding 2). The
+    /// disposable cache therefore never permanently disables itself and never loses
+    /// real data — the authoritative source is always the live in-memory data.
+    private func loadedRows() -> [String: CachedTransaction] {
+        if let rowsByUniqueKey { return rowsByUniqueKey }
+
+        guard let storeURL, fileManager.fileExists(atPath: storeURL.path) else {
+            rowsByUniqueKey = [:]
+            return [:]
         }
+
+        do {
+            let data = try Data(contentsOf: storeURL)
+            let rows = try Self.decoder.decode(Snapshot.self, from: data).rowsByUniqueKey
+            rowsByUniqueKey = rows
+            return rows
+        } catch {
+            // Undecodable file (incompatible/corrupt): discard it so the store
+            // self-heals into a clean miss instead of staying permanently broken.
+            discardIncompatibleStoreFile()
+            rowsByUniqueKey = [:]
+            return [:]
+        }
+    }
+
+    /// Removes the unreadable backing file so a subsequent ``persist()`` writes a
+    /// fresh, decodable snapshot. Best-effort: a failure to delete leaves the empty
+    /// in-memory state, and the next atomic write overwrites the file anyway.
+    private func discardIncompatibleStoreFile() {
+        guard let storeURL else { return }
+        try? fileManager.removeItem(at: storeURL)
     }
 
     // MARK: - Writes
@@ -73,14 +119,15 @@ public actor TransactionCacheStore {
     /// radius. One persistence write at the end.
     @discardableResult
     public func upsert(cacheKey: String, transactions: [TransactionDTO]) throws -> CachedTransactionUpsert.Plan {
-        let existingIds = existingTransactionIds(cacheKey: cacheKey)
+        var rows = loadedRows()
+        let existingIds = existingTransactionIds(in: rows, cacheKey: cacheKey)
         let plan = CachedTransactionUpsert.plan(incoming: transactions, existingIds: existingIds)
         guard !plan.rows.isEmpty else { return plan }
 
         for dto in plan.rows {
             let key = CachedTransaction.makeUniqueKey(cacheKey: cacheKey, transactionId: dto.id)
             let payload = try Self.encoder.encode(dto)
-            rowsByUniqueKey[key] = CachedTransaction(
+            rows[key] = CachedTransaction(
                 uniqueKey: key,
                 cacheKey: cacheKey,
                 transactionId: dto.id,
@@ -88,6 +135,7 @@ public actor TransactionCacheStore {
                 payload: payload
             )
         }
+        rowsByUniqueKey = rows
         try persist()
         invalidateOrderCache()
         return plan
@@ -99,7 +147,10 @@ public actor TransactionCacheStore {
     /// do not linger in the cache.
     @discardableResult
     public func replaceAll(cacheKey: String, transactions: [TransactionDTO]) throws -> CachedTransactionUpsert.Plan {
-        rowsByUniqueKey.removeAll()
+        // Replacing the whole history starts from empty regardless of any on-disk
+        // content, so this never needs to (and never triggers) a decode of an
+        // incompatible file before the subsequent `upsert` rebuilds it.
+        rowsByUniqueKey = [:]
         try persist()
         invalidateOrderCache()
         return try upsert(cacheKey: cacheKey, transactions: transactions)
@@ -108,7 +159,10 @@ public actor TransactionCacheStore {
     /// Removes every cached transaction (any environment). Used on local-data reset
     /// and before reseeding a different environment.
     public func clearAll() throws {
-        rowsByUniqueKey.removeAll()
+        // The store becomes empty regardless of any on-disk content, so a clear
+        // unconditionally wins and rewrites a fresh empty snapshot without first
+        // decoding a (possibly incompatible) file.
+        rowsByUniqueKey = [:]
         try persist()
         invalidateOrderCache()
     }
@@ -149,7 +203,7 @@ public actor TransactionCacheStore {
         if let cached = orderCache, cached.generation == dataGeneration, cached.cacheKey == cacheKey {
             return cached.rows
         }
-        let ordered = rowsByUniqueKey.values
+        let ordered = loadedRows().values
             .filter { $0.cacheKey == cacheKey }
             .sorted(by: Self.isNewerFirst)
         orderCache = (dataGeneration, cacheKey, ordered)
@@ -163,15 +217,18 @@ public actor TransactionCacheStore {
         orderCache = nil
     }
 
-    /// The transaction ids currently stored for `cacheKey`. Used inside `upsert`
-    /// to decide insert-vs-update.
-    private func existingTransactionIds(cacheKey: String) -> Set<String> {
-        Set(rowsByUniqueKey.values.filter { $0.cacheKey == cacheKey }.map(\.transactionId))
+    /// The transaction ids in `rows` for `cacheKey`. Used inside `upsert` to decide
+    /// insert-vs-update over the already-loaded snapshot (avoids re-reading disk).
+    nonisolated private func existingTransactionIds(
+        in rows: [String: CachedTransaction],
+        cacheKey: String
+    ) -> Set<String> {
+        Set(rows.values.filter { $0.cacheKey == cacheKey }.map(\.transactionId))
     }
 
     private func persist() throws {
         guard let storeURL else { return }
-        let data = try Self.encoder.encode(Snapshot(rowsByUniqueKey: rowsByUniqueKey))
+        let data = try Self.encoder.encode(Snapshot(rowsByUniqueKey: rowsByUniqueKey ?? [:]))
         try fileManager.createDirectory(
             at: storeURL.deletingLastPathComponent(),
             withIntermediateDirectories: true,

--- a/Tests/PlaidBarCacheTests/CacheStoreOpenRobustnessTests.swift
+++ b/Tests/PlaidBarCacheTests/CacheStoreOpenRobustnessTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import PlaidBarCache
+@testable import PlaidBarCore
+
+/// Robustness coverage for the disposable cache *open* path (AND-656 findings 2 & 3).
+///
+/// Two invariants are pinned here:
+///   1. **Incompatible/corrupt store = disposable miss.** A backing file that
+///      cannot decode as the current JSON `Snapshot` (e.g. a leftover pre-JSON
+///      SwiftData `.store`) must read as a clean cache miss, be discarded, and let
+///      the next write rebuild it — never permanently disable the cache and never
+///      lose authoritative (live in-memory) data.
+///   2. **Opening does no synchronous full decode.** Constructing the store must
+///      perform zero disk I/O; the read+decode is deferred to the first
+///      actor-isolated operation, so a MainActor caller never blocks on a
+///      full-history decode at open time.
+@Suite("Disposable cache open robustness (AND-656)", .serialized)
+struct CacheStoreOpenRobustnessTests {
+
+    // MARK: - Helpers
+
+    /// A `FileManager` that counts `fileExists(atPath:)` calls so a test can prove
+    /// the store touched disk lazily (zero probes at construction, exactly the
+    /// expected probes once an operation runs).
+    private final class CountingFileManager: FileManager, @unchecked Sendable {
+        private(set) var fileExistsCallCount = 0
+
+        override func fileExists(atPath path: String) -> Bool {
+            fileExistsCallCount += 1
+            return super.fileExists(atPath: path)
+        }
+    }
+
+    private func makeTempDirectory(_ tag: String) -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vaultpeek-open-robustness-\(tag)-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    /// Writes bytes that are NOT a valid `Snapshot` JSON at the store's filename,
+    /// standing in for a leftover incompatible (e.g. SwiftData) `.store` file.
+    private func writeIncompatibleFile(at url: URL) throws {
+        // Arbitrary non-JSON bytes — decoding as our `Snapshot` must fail.
+        let garbage = Data([0x00, 0x01, 0x02, 0xFF, 0xFE, 0x53, 0x51, 0x4C, 0x69, 0x74, 0x65])
+        try garbage.write(to: url)
+    }
+
+    private func sampleReadModel(cacheKey: String) -> DashboardReadModel {
+        DashboardReadModelMapper.makeReadModel(
+            cacheKey: cacheKey,
+            accounts: [
+                AccountDTO(id: "chk", itemId: "i1", name: "Checking", type: .depository, balances: BalanceDTO(available: 4200)),
+            ],
+            transactions: [
+                TransactionDTO(id: "t1", accountId: "chk", amount: 9.99, date: "2026-03-01", name: "Coffee"),
+            ],
+            generatedAt: Date(timeIntervalSince1970: 1_700_000)
+        )
+    }
+
+    private func sampleTransactions(count: Int) -> [TransactionDTO] {
+        (0..<count).map { i in
+            TransactionDTO(
+                id: "tx_\(String(format: "%04d", i))",
+                accountId: "chk",
+                amount: Double(i + 1),
+                date: "2026-03-\(String(format: "%02d", (i % 28) + 1))",
+                name: "Merchant \(i)"
+            )
+        }
+    }
+
+    // MARK: - Finding 2: incompatible store is a disposable miss
+
+    @Test("read-model: an incompatible store file reads as a miss and self-heals on write")
+    func readModelIncompatibleFileIsDisposableMiss() async throws {
+        let directory = makeTempDirectory("rm-incompat")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent(ReadModelCacheStore.storeFilename)
+        try writeIncompatibleFile(at: storeURL)
+
+        let key = "sandbox|/x"
+        let store = ReadModelCacheStore(onDiskIn: directory)
+
+        // The undecodable file is a clean miss, not a hard error: load returns nil
+        // (caller's `try?` would see a value, not a thrown failure).
+        #expect(try await store.load(cacheKey: key) == nil)
+
+        // ...and the incompatible file was discarded so the cache is NOT permanently
+        // disabled. A subsequent write rebuilds a fresh, decodable store.
+        let model = sampleReadModel(cacheKey: key)
+        try await store.save(model)
+        #expect(try await store.load(cacheKey: key) == model)
+
+        // A brand-new store actor over the same directory now reads the rebuilt row,
+        // proving the file on disk is valid JSON again (real-data round-trips, no loss).
+        let reopened = ReadModelCacheStore(onDiskIn: directory)
+        #expect(try await reopened.load(cacheKey: key) == model)
+    }
+
+    @Test("transaction: an incompatible store file reads as a miss and self-heals on write")
+    func transactionIncompatibleFileIsDisposableMiss() async throws {
+        let directory = makeTempDirectory("tx-incompat")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent(TransactionCacheStore.storeFilename)
+        try writeIncompatibleFile(at: storeURL)
+
+        let key = "sandbox|/x"
+        let store = TransactionCacheStore(onDiskIn: directory)
+
+        // Incompatible file → clean miss: count is zero, no thrown failure.
+        #expect(try await store.count(cacheKey: key) == 0)
+
+        // The cache rebuilds from the next refresh rather than staying disabled.
+        let all = sampleTransactions(count: 6)
+        try await store.upsert(cacheKey: key, transactions: all)
+        #expect(try await store.count(cacheKey: key) == 6)
+
+        // Re-opening over the same directory reads the rebuilt rows back.
+        let reopened = TransactionCacheStore(onDiskIn: directory)
+        #expect(try await reopened.count(cacheKey: key) == 6)
+    }
+
+    @Test("read-model: a clearAll on an incompatible file wins without decoding it")
+    func readModelClearAllOverIncompatibleFile() async throws {
+        let directory = makeTempDirectory("rm-clear")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent(ReadModelCacheStore.storeFilename)
+        try writeIncompatibleFile(at: storeURL)
+
+        // A clear/reset path (e.g. last institution removed) over an incompatible
+        // file must still succeed and leave a clean, empty, decodable store.
+        let store = ReadModelCacheStore(onDiskIn: directory)
+        try await store.clearAll()
+
+        let reopened = ReadModelCacheStore(onDiskIn: directory)
+        #expect(try await reopened.load(cacheKey: "sandbox|/x") == nil)
+    }
+
+    // MARK: - Finding 3: opening does no synchronous full decode
+
+    @Test("read-model: constructing the store performs no disk I/O (lazy open)")
+    func readModelOpenIsLazy() async throws {
+        let directory = makeTempDirectory("rm-lazy")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Seed a real, valid, non-trivial store so an *eager* open would have to
+        // decode it. The lazy contract means construction must not read it.
+        let seeded = ReadModelCacheStore(onDiskIn: directory)
+        try await seeded.save(sampleReadModel(cacheKey: "sandbox|/x"))
+
+        let counter = CountingFileManager()
+        let store = ReadModelCacheStore(onDiskIn: directory, fileManager: counter)
+
+        // Opening touched disk zero times — no `fileExists`, no read, no decode.
+        #expect(counter.fileExistsCallCount == 0, "open must not probe or read the backing file")
+
+        // The first operation hydrates lazily (now disk is touched) and still reads
+        // the seeded row correctly.
+        let loaded = try await store.load(cacheKey: "sandbox|/x")
+        #expect(loaded?.cacheKey == "sandbox|/x")
+        #expect(counter.fileExistsCallCount >= 1, "the first operation triggers the deferred load")
+    }
+
+    @Test("transaction: constructing the store performs no disk I/O (lazy open)")
+    func transactionOpenIsLazy() async throws {
+        let directory = makeTempDirectory("tx-lazy")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Seed a large-ish history so an eager open would decode the whole file.
+        let seeded = TransactionCacheStore(onDiskIn: directory)
+        try await seeded.upsert(cacheKey: "sandbox|/x", transactions: sampleTransactions(count: 50))
+
+        let counter = CountingFileManager()
+        let store = TransactionCacheStore(onDiskIn: directory, fileManager: counter)
+
+        // Opening the (potentially large) store decodes nothing and touches no disk.
+        #expect(counter.fileExistsCallCount == 0, "open must not probe or read the full history")
+
+        // The first read faults in the history lazily, off the open path.
+        #expect(try await store.count(cacheKey: "sandbox|/x") == 50)
+        #expect(counter.fileExistsCallCount >= 1, "the first read triggers the deferred load")
+    }
+
+    @Test("transaction: replaceAll never decodes a pre-existing incompatible file")
+    func transactionReplaceAllOverIncompatibleFile() async throws {
+        let directory = makeTempDirectory("tx-replace")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent(TransactionCacheStore.storeFilename)
+        try writeIncompatibleFile(at: storeURL)
+
+        // A full refresh (`replaceAll`) starts from empty, so it must rebuild the
+        // store over the incompatible file without a decode failure surfacing.
+        let store = TransactionCacheStore(onDiskIn: directory)
+        try await store.replaceAll(cacheKey: "sandbox|/x", transactions: sampleTransactions(count: 4))
+        #expect(try await store.count(cacheKey: "sandbox|/x") == 4)
+
+        let reopened = TransactionCacheStore(onDiskIn: directory)
+        #expect(try await reopened.count(cacheKey: "sandbox|/x") == 4)
+    }
+}

--- a/Tests/PlaidBarCacheTests/ReadModelCacheClearRaceTests.swift
+++ b/Tests/PlaidBarCacheTests/ReadModelCacheClearRaceTests.swift
@@ -47,7 +47,7 @@ struct ReadModelCacheClearRaceTests {
     /// This is exactly the ordering the app-side gate prevents.
     @Test("stale write after clear resurrects removed balances (the bug the gate prevents)")
     func staleWriteAfterClearResurrects() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let key = "sandbox|/x"
 
         // Prior non-empty refresh persisted a row.
@@ -66,7 +66,7 @@ struct ReadModelCacheClearRaceTests {
     /// clear request ensures — the cold-start load is a clean miss.
     @Test("clear sequenced after a stale write wins; cold start sees no removed balances")
     func clearAfterStaleWriteWins() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let key = "sandbox|/x"
 
         try await store.save(nonEmptyModel(cacheKey: key))
@@ -84,7 +84,7 @@ struct ReadModelCacheClearRaceTests {
     /// no in-flight write can survive it.
     @Test("terminal clear after concurrent persists always wins")
     func terminalClearWinsOverConcurrentPersists() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let key = "sandbox|/x"
         let model = nonEmptyModel(cacheKey: key)
 

--- a/Tests/PlaidBarCacheTests/ReadModelCacheStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/ReadModelCacheStoreTests.swift
@@ -34,7 +34,7 @@ struct ReadModelCacheStoreTests {
 
     @Test("write then read returns an equal read-model (round-trip)")
     func roundTrip() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let model = sampleModel()
 
         try await store.save(model)
@@ -45,14 +45,14 @@ struct ReadModelCacheStoreTests {
 
     @Test("load returns nil for an unknown key (cold miss)")
     func missReturnsNil() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let loaded = try await store.load(cacheKey: "never|written")
         #expect(loaded == nil)
     }
 
     @Test("save upserts: a second save replaces the row for the same key")
     func upsert() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let key = "sandbox|/x"
 
         try await store.save(sampleModel(cacheKey: key))
@@ -71,7 +71,7 @@ struct ReadModelCacheStoreTests {
 
     @Test("two environments keep independent rows (no cross-environment bleed)")
     func environmentScoping() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let sandbox = sampleModel(cacheKey: "sandbox|/x")
         let production = DashboardReadModelMapper.makeReadModel(
             cacheKey: "production|/x",
@@ -89,7 +89,7 @@ struct ReadModelCacheStoreTests {
 
     @Test("a stale-schema row reads as a miss and is purged (disposable upgrade)")
     func staleSchemaPurged() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let key = "sandbox|/x"
         // Persist a row tagged with an older schema version directly through the
         // store so we exercise the version sweep on load.
@@ -111,7 +111,7 @@ struct ReadModelCacheStoreTests {
 
     @Test("clear removes a key; clearAll empties the store")
     func clearing() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         try await store.save(sampleModel(cacheKey: "a|/x"))
         try await store.save(sampleModel(cacheKey: "b|/x"))
 
@@ -132,7 +132,7 @@ struct ReadModelCacheStoreTests {
     /// hydration.
     @Test("empty/disabled cache produces no hydration (no cold-start regression)")
     func emptyCacheIsANoOp() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
 
         // Empty store: a load is a clean miss.
         let loaded = try await store.load(cacheKey: "sandbox|/x")
@@ -159,7 +159,7 @@ struct ReadModelCacheStoreTests {
 
     @Test("hydrate from a loaded row yields the dashboard DTOs")
     func hydrateFromLoaded() async throws {
-        let store = try ReadModelCacheStore(inMemory: true)
+        let store = ReadModelCacheStore(inMemory: true)
         let model = sampleModel()
         try await store.save(model)
 
@@ -176,7 +176,7 @@ struct ReadModelCacheStoreTests {
             .appendingPathComponent("vaultpeek-readmodel-test-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: directory) }
 
-        let store = try ReadModelCacheStore(onDiskIn: directory)
+        let store = ReadModelCacheStore(onDiskIn: directory)
         let model = sampleModel()
         try await store.save(model)
         #expect(try await store.load(cacheKey: model.cacheKey) == model)
@@ -200,12 +200,12 @@ struct ReadModelCacheStoreTests {
 
         let model = sampleModel()
         do {
-            let store = try ReadModelCacheStore(onDiskIn: directory)
+            let store = ReadModelCacheStore(onDiskIn: directory)
             try await store.save(model)
         }
         // A brand-new store actor over the same on-disk file still reads the row,
         // proving persistence survives an AppState/process restart.
-        let reopened = try ReadModelCacheStore(onDiskIn: directory)
+        let reopened = ReadModelCacheStore(onDiskIn: directory)
         #expect(try await reopened.load(cacheKey: model.cacheKey) == model)
     }
 }

--- a/Tests/PlaidBarCacheTests/TransactionCacheClearRaceTests.swift
+++ b/Tests/PlaidBarCacheTests/TransactionCacheClearRaceTests.swift
@@ -55,7 +55,7 @@ struct TransactionCacheClearRaceTests {
     /// start. This is exactly the ordering the app-side gate prevents.
     @Test("stale persist after clear resurrects removed transactions (the bug the gate prevents)")
     func staleWriteAfterClearResurrects() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let key = Self.key
 
         // Prior non-empty refresh persisted the history.
@@ -74,7 +74,7 @@ struct TransactionCacheClearRaceTests {
     /// `replaceAll` never runs and the cold-start paged read is a clean miss.
     @Test("captured-epoch persist landing after beginClear does NOT commit")
     func capturedEpochPersistAfterClearIsDropped() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let key = Self.key
         let gate = ClearGateStub()
 
@@ -103,7 +103,7 @@ struct TransactionCacheClearRaceTests {
     /// cold-start paged read is a clean miss even if a write slipped the recheck.
     @Test("clear sequenced after a stale persist wins; cold start pages nothing")
     func clearAfterStaleWriteWins() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let key = Self.key
 
         try await store.replaceAll(cacheKey: key, transactions: removedInstitutionTransactions())

--- a/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/TransactionCacheStoreTests.swift
@@ -29,7 +29,7 @@ struct TransactionCacheStoreTests {
 
     @Test("upsert then paged read returns the rows newest-first")
     func upsertThenPage() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let all = transactions(count: 10)
         try await store.upsert(cacheKey: key, transactions: all)
 
@@ -46,7 +46,7 @@ struct TransactionCacheStoreTests {
 
     @Test("#Unique upsert replaces a re-synced transaction instead of duplicating")
     func uniqueUpsertReplaces() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let original = TransactionDTO(id: "t1", accountId: "chk", amount: 10, date: "2026-01-10", name: "Old")
         try await store.upsert(cacheKey: key, transactions: [original])
 
@@ -71,7 +71,7 @@ struct TransactionCacheStoreTests {
 
     @Test("paging walks the whole history with no overlap and no gaps")
     func pagingCoversHistory() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let all = transactions(count: 23)
         try await store.upsert(cacheKey: key, transactions: all)
         let total = try await store.count(cacheKey: key)
@@ -93,7 +93,7 @@ struct TransactionCacheStoreTests {
 
     @Test("an out-of-range page reads empty")
     func outOfRangePage() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: key, transactions: transactions(count: 3))
         let total = try await store.count(cacheKey: key)
         let window = TransactionPageWindow.make(pageIndex: 5, pageSize: 10, total: total)
@@ -103,7 +103,7 @@ struct TransactionCacheStoreTests {
 
     @Test("replaceAll drops removed transactions")
     func replaceAllDropsRemoved() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: key, transactions: transactions(count: 10))
         #expect(try await store.count(cacheKey: key) == 10)
 
@@ -114,7 +114,7 @@ struct TransactionCacheStoreTests {
 
     @Test("rows for a different environment key are not returned for this key")
     func cacheKeyScoping() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: "sandbox|/x", transactions: transactions(count: 4))
         try await store.upsert(cacheKey: "production|/x", transactions: transactions(count: 6))
 
@@ -124,7 +124,7 @@ struct TransactionCacheStoreTests {
 
     @Test("clearAll empties the store")
     func clearAllEmpties() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: key, transactions: transactions(count: 5))
         try await store.clearAll()
         #expect(try await store.count(cacheKey: key) == 0)
@@ -132,7 +132,7 @@ struct TransactionCacheStoreTests {
 
     @Test("empty upsert is a no-op")
     func emptyUpsert() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let plan = try await store.upsert(cacheKey: key, transactions: [])
         #expect(plan.writeCount == 0)
         #expect(try await store.count(cacheKey: key) == 0)
@@ -145,7 +145,7 @@ struct TransactionCacheStoreTests {
     /// stable, correct slices — the cache must not corrupt or stale the ordering.
     @Test("repeated page reads reuse the cached ordering and stay correct")
     func cachedOrderingStableAcrossPages() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let all = transactions(count: 30)
         try await store.upsert(cacheKey: key, transactions: all)
         let total = try await store.count(cacheKey: key)
@@ -171,7 +171,7 @@ struct TransactionCacheStoreTests {
     /// is the cache-correctness guarantee behind the bounded paging path.
     @Test("a write invalidates the cached ordering so later reads see new rows")
     func writeInvalidatesCachedOrdering() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: key, transactions: transactions(count: 5))
 
         // Prime the order cache with a read.
@@ -200,7 +200,7 @@ struct TransactionCacheStoreTests {
     /// key's ordering for the second key.
     @Test("the ordering cache does not bleed across cache keys within one generation")
     func cachedOrderingScopedPerKey() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         try await store.upsert(cacheKey: "sandbox|/x", transactions: transactions(count: 4))
         try await store.upsert(cacheKey: "production|/x", transactions: transactions(count: 6))
 
@@ -223,7 +223,7 @@ struct TransactionCacheStoreTests {
     /// that the page path faults in the fresh blob rather than a stale one.
     @Test("an in-place update is reflected after cache invalidation")
     func updateReflectedAfterInvalidation() async throws {
-        let store = try TransactionCacheStore(inMemory: true)
+        let store = TransactionCacheStore(inMemory: true)
         let original = TransactionDTO(id: "t1", accountId: "chk", amount: 10, date: "2026-01-10", name: "Old")
         try await store.upsert(cacheKey: key, transactions: [original])
         // Prime the cache.


### PR DESCRIPTION
## What & why

Closes the two remaining Codex findings on **AND-656** (PR #649) that PR #655 (FoundationModelsMacros gate) did not cover. Both are about the disposable read-model and per-transaction cache *open/load* path in `PlaidBarCache`.

- **Finding 2 — incompatible store permanently disabled the cache.** After the SwiftData→JSON cache migration, an existing SwiftData `.store` file (or any corrupt file) decode-fails as JSON. The old throwing `init` meant the store could never reopen or replace itself until the user manually deleted the file — the cache stayed dead. It now self-heals: a decode failure on first read is a **disposable cache miss**, the unreadable file is discarded, and the next refresh rebuilds it. No permanent disable, no real-data loss (live in-memory data is always authoritative).
- **Finding 3 — synchronous full-history decode on the MainActor open path.** `transactionCacheStoreIfAvailable()` is `@MainActor`, and an actor's `init` runs in the caller's executor — so the old `init` decoded the entire JSON history synchronously on the UI thread, defeating paging and risking stalls. Opening now does **zero disk I/O**; the read+decode is deferred to the actor's executor on the first operation.

Also fixes the **AND-657 finding #2** doc inaccuracy: `clearReadModelCache()` wipes only the read-model store; the per-transaction wipe is `clearTransactionCache()` — they are no longer conflated in the doc-comment.

Stays in the store open/load lane only — no changes to view paging or the clear-gate (AND-632 / AND-633).

## Change (files)

- `Sources/PlaidBarCache/ReadModelCacheStore.swift` — non-throwing, no-I/O `init`; lazy `loadedRows()` that discards an undecodable file and starts empty; `clearAll` resets to empty without decoding.
- `Sources/PlaidBarCache/TransactionCacheStore.swift` — same lazy/self-heal treatment; `clearAll`/`replaceAll` reset without decoding; `existingTransactionIds(in:cacheKey:)` reads the already-loaded snapshot.
- `Sources/PlaidBarCache/{ReadModelCacheStore,TransactionCacheStore}+Factory.swift` — `onDiskIn:` / `inMemory:` inits are now non-throwing (no eager open).
- `Sources/PlaidBar/App/AppState+TransactionCache.swift`, `Sources/PlaidBar/App/AppState+ReadModelCache.swift` — open helpers drop the now-dead `do/catch`; corrected `clearReadModelCache()` doc-comment (AND-657 #2).
- `Tests/PlaidBarCacheTests/CacheStoreOpenRobustnessTests.swift` — **new suite** (6 tests).
- `Tests/PlaidBarCacheTests/{ReadModelCacheStoreTests,ReadModelCacheClearRaceTests,TransactionCacheStoreTests,TransactionCacheClearRaceTests}.swift` — mechanical `try` removal at the now-non-throwing init call sites only.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # Build complete!
swift test --filter CacheStoreOpenRobustnessTests                                 # 6/6 passed
swift test --filter PlaidBarCacheTests                                            # 34/34 passed (28 pre-existing + 6 new)
git diff --check                                                                  # clean
```

New tests assert: (a) an incompatible/corrupt file reads as a miss and self-heals on the next write for **both** stores, with a reopened store round-tripping the rebuilt rows (no data loss); (b) `clearAll`/`replaceAll` win over an incompatible file without a decode failure; (c) construction performs **no** disk I/O (counted via a `FileManager` spy), with the first operation triggering the deferred load.

## Links

Closes AND-656 (remaining cache-robustness findings 2 & 3); also addresses AND-657 finding #2 doc inaccuracy.

## Gate / risk note

Behavior-preserving for the happy path (valid store round-trips unchanged). The store inits became non-throwing — all call sites (AppState helpers + existing tests) are updated in this PR. Disposable-cache contract is unchanged: any open/read/write failure still degrades to the existing cold path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
