### PR TITLE
refactor(window): per-window state on NavigationModel, retire single-surface flags (AND-600)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -57,7 +57,6 @@ final class AppState {
         static let firstRunSnapshotDismissedContextPrefix = "firstRunSnapshot.dismissed.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
         static let categoryBudgetCache = "cache.categoryBudgets"
-        static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
     }
 
     // MARK: - State
@@ -115,7 +114,6 @@ final class AppState {
             self.error = sanitized
         }
     }
-    var isPopoverPresented = false
 
     /// Per-window navigation model (AND-594). Owns the destination plus
     /// the dashboard filter / account selection / heatmap metric that previously
@@ -127,7 +125,10 @@ final class AppState {
     /// `appState.dashboardFilter` / `dashboardSelectedAccountID` /
     /// `dashboardHeatmapMode`, which delegate here and persist to the original
     /// UserDefaults keys — so popover behavior and on-disk persistence are
-    /// unchanged.
+    /// unchanged. As of AND-600 it also owns the menu-bar popover's presentation
+    /// flag (`isPopoverPresented`) and the detached-dashboard intent
+    /// (`isDashboardDetached`), retired from `AppState` so each window holds
+    /// independent presentation and detach state.
     let navigationModel: NavigationModel
 
     /// Pending deep-link route awaiting the primary window (AND-597).
@@ -163,19 +164,14 @@ final class AppState {
         set { navigationModel.heatmapMode = newValue }
     }
 
-    /// When true, the dashboard lives in a floating desktop window instead of
-    /// the menu-bar popover (AND-384). Persisted so the window reopens on the
-    /// next launch. While detached, a click on the menu-bar item raises the
-    /// floating window rather than opening the popover; re-docking flips this
-    /// back to false and the popover resumes. Mirrors the `dashboard.detached`
-    /// `@AppStorage` key the Settings toggle writes, so the toggle and the
-    /// in-dashboard pin/re-dock controls stay in sync.
-    var isDashboardDetached = false {
-        didSet {
-            guard isDashboardDetached != oldValue else { return }
-            UserDefaults.standard.set(isDashboardDetached, forKey: Keys.dashboardDetached)
-        }
-    }
+    // AND-600: the menu-bar popover's presentation flag (`isPopoverPresented`) and
+    // the detached-dashboard intent (`isDashboardDetached`) no longer live on
+    // `AppState` as single-surface app-global storage. They moved onto the
+    // per-window ``NavigationModel`` (`appState.navigationModel.isPopoverPresented`
+    // / `.isDashboardDetached`), so a second window holds independent presentation
+    // and detach state. The legacy popover/escape-hatch path drives the menu bar's
+    // single model exactly as before; persistence of the detached intent is
+    // unchanged (still the `dashboard.detached` key, now owned by the model).
 
     /// Persisted across launches so configured installs boot straight into
     /// the dashboard instead of flashing first-run onboarding until the
@@ -674,9 +670,18 @@ final class AppState {
         self.notificationService = notificationService ?? NotificationService.shared
         self.readModelCacheEnabled = readModelCacheEnabled
         // The popover-window navigation model. Hydrates the last
-        // filter/selection/heatmap from the original UserDefaults keys, so
-        // persistence is preserved across the migration (façade).
-        self.navigationModel = navigationModel ?? NavigationModel()
+        // filter/selection/heatmap — and the detached-dashboard intent (AND-600) —
+        // from the original UserDefaults keys, so persistence is preserved across
+        // the migration (façade). Both headless renderers must hydrate the detached
+        // intent deterministically: a stale `dashboard.detached = true` would spawn
+        // the floating window and intercept either harness, so the snapshot flag is
+        // resolved here and threaded into the model's hydration (the resolution that
+        // previously lived in `loadSettings`). The snapshot harness builds its own
+        // off-screen popover; the window-first harness builds its own windows.
+        self.navigationModel = navigationModel ?? NavigationModel(
+            isRenderingSnapshot: CommandLineOptions.isRenderingSnapshot()
+                || CommandLineOptions.isRenderingWindowFirst()
+        )
         loadSettings()
         // Record whether Apple Foundation Models is available so the tier resolver
         // can prefer it (AND-563) and, when available, the insight service routes
@@ -799,24 +804,10 @@ final class AppState {
         loadPersistedWeeklyReviewState()
         // Launch at login
         launchAtLogin = LaunchService.isEnabled
-        // Detached-dashboard intent (AND-384). A headless snapshot render
-        // ignores the persisted intent so the popover-capture path stays
-        // deterministic regardless of host/CI defaults — otherwise a stale
-        // `dashboard.detached = true` would spawn the floating window and
-        // intercept the renderer's popover open. The stored value is left
-        // untouched (no write-back) so the real user preference survives.
-        let storedDetached = defaults.object(forKey: Keys.dashboardDetached) != nil
-            ? defaults.bool(forKey: Keys.dashboardDetached)
-            : nil
-        isDashboardDetached = DetachedDashboardPreferences.resolvedDetachedIntent(
-            storedValue: storedDetached,
-            // Both headless renderers must run deterministically: a stale
-            // `dashboard.detached = true` would spawn the floating window and
-            // intercept either harness. The window-first harness builds its own
-            // off-screen windows, so it likewise wants no detached popover.
-            isRenderingSnapshot: CommandLineOptions.isRenderingSnapshot()
-                || CommandLineOptions.isRenderingWindowFirst()
-        )
+        // Detached-dashboard intent (AND-384) is hydrated by `NavigationModel`
+        // (AND-600), which owns the `dashboard.detached` key and applies the same
+        // snapshot-render override (`DetachedDashboardPreferences.resolvedDetachedIntent`)
+        // the `AppState` init threads into the model. Nothing to resolve here.
     }
 
     private func loadAppLockPreferences(defaults: UserDefaults) {

--- a/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardCoordinator.swift
@@ -2,7 +2,8 @@ import AppKit
 import PlaidBarCore
 import SwiftUI
 
-/// Bridges the declarative `AppState.isDashboardDetached` flag and the menu-bar
+/// Bridges the per-window `NavigationModel.isDashboardDetached` intent (AND-600,
+/// migrated off the retired `AppState.isDashboardDetached` flag) and the menu-bar
 /// popover to the imperative `DetachedDashboardWindowController` (AND-384).
 ///
 /// Owned by the app scene as `@State` so it lives for the process lifetime and
@@ -31,8 +32,9 @@ final class DetachedDashboardCoordinator {
     /// dismiss the menu-bar popover so only one surface is up.
     func detach(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
         nonPersistedLaunchOverrideActive = false
-        appState.isDashboardDetached = true
-        appState.isPopoverPresented = false
+        // `detachDashboard()` sets the intent AND dismisses the popover in one
+        // pure transition (one surface up at a time), persisting the intent.
+        appState.navigationModel.detachDashboard()
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
     }
 
@@ -41,15 +43,15 @@ final class DetachedDashboardCoordinator {
     /// from the menu-bar item on the next click.
     func redock(appState: AppState, reduceMotion: Bool) {
         nonPersistedLaunchOverrideActive = false
-        appState.isDashboardDetached = false
+        appState.navigationModel.redockDashboard()
         controller?.hide(reduceMotion: reduceMotion)
     }
 
     /// Reconciles the window with the persisted/observed `isDashboardDetached`
-    /// flag. Call from `.onChange(of: appState.isDashboardDetached)` and once at
-    /// launch to restore a window that was open when the app last quit.
+    /// intent. Call from `.onChange(of: appState.navigationModel.isDashboardDetached)`
+    /// and once at launch to restore a window that was open when the app last quit.
     func sync(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
-        if appState.isDashboardDetached {
+        if appState.navigationModel.isDashboardDetached {
             present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
         } else {
             // Docking (e.g. the user turning off "Keep dashboard in a floating
@@ -67,7 +69,7 @@ final class DetachedDashboardCoordinator {
     /// raising the window; the caller then keeps `isPopoverPresented` false.
     @discardableResult
     func handleMenuBarActivation(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) -> Bool {
-        guard appState.isDashboardDetached || nonPersistedLaunchOverrideActive else { return false }
+        guard appState.navigationModel.isDashboardDetached || nonPersistedLaunchOverrideActive else { return false }
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
         controller?.raise()
         return true
@@ -78,7 +80,7 @@ final class DetachedDashboardCoordinator {
     /// `dashboard.detached` preference behind (parity with `--show-popover`).
     func presentForLaunchOverride(appState: AppState, forcedColorScheme: ColorScheme?, reduceMotion: Bool) {
         nonPersistedLaunchOverrideActive = true
-        appState.isPopoverPresented = false
+        appState.navigationModel.isPopoverPresented = false
         present(appState: appState, forcedColorScheme: forcedColorScheme, reduceMotion: reduceMotion)
     }
 

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -18,7 +18,8 @@ import SwiftUI
 ///
 /// Frame (origin + size) is persisted by AppKit via `frameAutosaveName`, so the
 /// window reopens where the user left it. Open/closed intent is persisted
-/// separately by `AppState.isDashboardDetached`. Window appearance is left to
+/// separately by the per-window `NavigationModel.isDashboardDetached` (AND-600).
+/// Window appearance is left to
 /// inherit the single `NSApp.appearance` owner (pinned only for the `--appearance`
 /// QA override) so flipping Light/Dark updates the window live.
 ///

--- a/Sources/PlaidBar/App/NavigationModel.swift
+++ b/Sources/PlaidBar/App/NavigationModel.swift
@@ -39,6 +39,13 @@ final class NavigationModel {
         /// The Transaction Workspace sort order's raw value (AND-582). Absent ⇒
         /// the default newest-first sort.
         static let transactionSort = "navigation.transactionSort"
+        /// The detached-dashboard intent (AND-600), migrated off the retired
+        /// `AppState.isDashboardDetached` flag. Kept identical to the key the
+        /// Settings toggle and the `DetachedDashboardWindowController`
+        /// `frameAutosaveName` neighborhood used — `DetachedDashboardPreferences`
+        /// owns it — so an upgrading user's persisted "floating window" preference
+        /// decodes exactly as before.
+        static let dashboardDetached = DetachedDashboardPreferences.detachedStorageKey
     }
 
     /// The pure state. Mutations route through the typed accessors below (which
@@ -49,6 +56,13 @@ final class NavigationModel {
     /// While hydrating from UserDefaults, suppress write-back so loading a value
     /// does not immediately persist it again.
     private var isHydrating = false
+    /// When true, the persisted detached-dashboard intent is ignored at hydration
+    /// (resolved to `false`). A headless snapshot render must never spawn the
+    /// floating window — it would intercept the renderer's popover open — so this
+    /// carries the deterministic override that previously lived in
+    /// `AppState.loadSettings` via `DetachedDashboardPreferences.resolvedDetachedIntent`
+    /// (AND-600).
+    private let isRenderingSnapshot: Bool
 
     /// Creates a window's navigation model.
     ///
@@ -57,11 +71,20 @@ final class NavigationModel {
     ///     two models can prove independent selection without sharing global
     ///     defaults; production uses `.standard`.
     ///   - persistRestore: when `true` (default), the last filter / selection /
-    ///     heatmap metric are restored from `defaults`. A fresh second window can
-    ///     opt out to start from defaults.
-    init(defaults: UserDefaults = .standard, persistRestore: Bool = true) {
+    ///     heatmap metric (and the detached-dashboard intent) are restored from
+    ///     `defaults`. A fresh second window can opt out to start from defaults.
+    ///   - isRenderingSnapshot: when `true`, the persisted detached intent is
+    ///     ignored (resolved to `false`) so a headless snapshot render never spawns
+    ///     the floating window. Defaults to `false`; production resolves it from
+    ///     `CommandLineOptions` at the `AppState` construction site.
+    init(
+        defaults: UserDefaults = .standard,
+        persistRestore: Bool = true,
+        isRenderingSnapshot: Bool = false
+    ) {
         self.defaults = defaults
         self.state = NavigationState()
+        self.isRenderingSnapshot = isRenderingSnapshot
         if persistRestore {
             hydrate()
         }
@@ -96,6 +119,51 @@ final class NavigationModel {
             state.heatmapMode = newValue
             persistHeatmapMode()
         }
+    }
+
+    // MARK: - Surface presentation façade (AND-600)
+
+    /// Whether this window's menu-bar popover is presented. Migrated off the
+    /// retired single `AppState.isPopoverPresented` flag; ephemeral per-window
+    /// session state, **not** persisted (a relaunch never auto-opens the popover).
+    /// Bound by `menuBarExtraAccess(isPresented:)` so it stays the popover's
+    /// presentation source of truth, now scoped to the window's model.
+    var isPopoverPresented: Bool {
+        get { state.isPopoverPresented }
+        set { state.setPopoverPresented(newValue) }
+    }
+
+    /// Whether this window's dashboard lives in the detached floating window
+    /// (AND-384/600). Migrated off the retired single `AppState.isDashboardDetached`
+    /// flag. This is the durable intent — set/cleared it persists to
+    /// `DetachedDashboardPreferences.detachedStorageKey`, so the floating window
+    /// reopens on the next launch exactly as before. The
+    /// `DetachedDashboardCoordinator` reads/writes it to bridge to the AppKit panel.
+    var isDashboardDetached: Bool {
+        get { state.isDashboardDetached }
+        set {
+            guard state.isDashboardDetached != newValue else { return }
+            state.isDashboardDetached = newValue
+            persistDashboardDetached()
+        }
+    }
+
+    /// Detach the dashboard into the floating window: set the intent AND dismiss
+    /// the popover in one transition (only one surface up at a time), persisting
+    /// the intent. The pure `NavigationState.detachDashboard()` owns the rule; this
+    /// mirrors the detach to disk so the floating window reopens next launch.
+    func detachDashboard() {
+        let wasDetached = state.isDashboardDetached
+        state.detachDashboard()
+        if state.isDashboardDetached != wasDetached { persistDashboardDetached() }
+    }
+
+    /// Re-dock the dashboard back into the menu-bar popover, persisting the cleared
+    /// intent so a relaunch lands in the popover.
+    func redockDashboard() {
+        let wasDetached = state.isDashboardDetached
+        state.redockDashboard()
+        if state.isDashboardDetached != wasDetached { persistDashboardDetached() }
     }
 
     // MARK: - Transaction Workspace façade (AND-582)
@@ -295,6 +363,21 @@ final class NavigationModel {
            let sort = TransactionWorkspace.Sort(rawValue: rawSort) {
             restored.transactionSort = sort
         }
+        // Detached-dashboard intent (AND-384/600). A headless snapshot render
+        // ignores the persisted intent so the popover-capture path stays
+        // deterministic regardless of host/CI defaults — otherwise a stale
+        // `dashboard.detached = true` would spawn the floating window and intercept
+        // the renderer's popover open. The stored value is left untouched (no
+        // write-back during hydration) so the real user preference survives.
+        let storedDetached = defaults.object(forKey: Keys.dashboardDetached) != nil
+            ? defaults.bool(forKey: Keys.dashboardDetached)
+            : nil
+        restored.isDashboardDetached = DetachedDashboardPreferences.resolvedDetachedIntent(
+            storedValue: storedDetached,
+            isRenderingSnapshot: isRenderingSnapshot
+        )
+        // `isPopoverPresented` is deliberately not hydrated: a relaunch never
+        // auto-opens the popover. It stays at its `NavigationState()` default.
         state = restored
     }
 
@@ -328,5 +411,10 @@ final class NavigationModel {
     private func persistTransactionSort() {
         guard !isHydrating else { return }
         defaults.set(state.transactionSort.rawValue, forKey: Keys.transactionSort)
+    }
+
+    private func persistDashboardDetached() {
+        guard !isHydrating else { return }
+        defaults.set(state.isDashboardDetached, forKey: Keys.dashboardDetached)
     }
 }

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -85,7 +85,7 @@ struct PlaidBarApp: App {
         if CommandLine.arguments.contains("--show-popover") {
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(700))
-                state.isPopoverPresented = true
+                state.navigationModel.isPopoverPresented = true
 
                 // Debug aid: when the status item is hidden in menu bar
                 // overflow, macOS anchors the popover window beyond every
@@ -204,9 +204,9 @@ struct PlaidBarApp: App {
                 // popover, a Settings-only toggle would not take effect until
                 // then, and — critically — a status-item click while detached
                 // (before the popover ever mounted) would set
-                // `isPopoverPresented = true` with no observer installed yet, so
-                // SwiftUI would open the popover instead of raising the floating
-                // window (AND-384).
+                // `navigationModel.isPopoverPresented = true` with no observer
+                // installed yet, so SwiftUI would open the popover instead of
+                // raising the floating window (AND-384).
                 .task {
                     // Legacy detached-dashboard sync (window-first OFF only). On
                     // the default window-first path `detachedDashboard` is nil and
@@ -259,21 +259,22 @@ struct PlaidBarApp: App {
                 // A `--detach` launch override also has a visible detached window
                 // but intentionally leaves the persisted detached preference off,
                 // so include window visibility in the intercept.
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                .onChange(of: appState.navigationModel.isPopoverPresented) { _, isPresented in
                     // Legacy detached-window intercept (window-first OFF only).
                     // With window-first ON `detachedDashboard` is nil, so the
                     // guard short-circuits and the menu bar mounts the glance.
                     guard let detachedDashboard,
                           isPresented,
-                          appState.isDashboardDetached || detachedDashboard.isWindowVisible else { return }
-                    appState.isPopoverPresented = false
+                          appState.navigationModel.isDashboardDetached
+                              || detachedDashboard.isWindowVisible else { return }
+                    appState.navigationModel.isPopoverPresented = false
                     detachedDashboard.handleMenuBarActivation(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
                         reduceMotion: reduceMotion
                     )
                 }
-                .onChange(of: appState.isDashboardDetached) { _, _ in
+                .onChange(of: appState.navigationModel.isDashboardDetached) { _, _ in
                     detachedDashboard?.sync(
                         appState: appState,
                         forcedColorScheme: Self.forcedColorScheme,
@@ -335,12 +336,12 @@ struct PlaidBarApp: App {
                 // Opening the popover while locked prompts for authentication to
                 // reveal balances; `unlockApp()` is a no-op when App Lock is off
                 // or already unlocked.
-                .onChange(of: appState.isPopoverPresented) { _, isPresented in
+                .onChange(of: appState.navigationModel.isPopoverPresented) { _, isPresented in
                     guard isPresented, appState.isAppLocked else { return }
                     Task { await appState.unlockApp() }
                 }
         }
-        .menuBarExtraAccess(isPresented: $appState.isPopoverPresented) { statusItem in
+        .menuBarExtraAccess(isPresented: popoverPresentedBinding) { statusItem in
             // Attach the unreviewed-count badge to the live status item, then
             // paint the current count immediately so it is correct on first
             // appearance (not only after the next count/mask change). The button
@@ -370,7 +371,7 @@ struct PlaidBarApp: App {
                         ) == true {
                             return
                         }
-                        appState.isPopoverPresented = true
+                        appState.navigationModel.isPopoverPresented = true
                     },
                     openInWindow: {
                         // Window-first (default): "Open in window" routes into the
@@ -404,7 +405,7 @@ struct PlaidBarApp: App {
                         NSApplication.shared.activate(ignoringOtherApps: true)
                     },
                     dismissPopover: {
-                        appState.isPopoverPresented = false
+                        appState.navigationModel.isPopoverPresented = false
                     },
                     togglePrivacyMask: {
                         appState.togglePrivacyMask()
@@ -556,6 +557,20 @@ struct PlaidBarApp: App {
         .defaultSize(width: 1080, height: 720)
     }
 
+    /// Two-way binding to the menu-bar popover's presentation flag, which now
+    /// lives on the per-window `NavigationModel` (AND-600). Built explicitly rather
+    /// than via `$appState.navigationModel.isPopoverPresented` because
+    /// `navigationModel` is a `let` on `AppState`, so the `@State` projection can't
+    /// form a writable key-path through it; reading/writing the settable property on
+    /// the `@Observable` model directly is equivalent and keeps `menuBarExtraAccess`
+    /// the single presentation source of truth.
+    private var popoverPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { appState.navigationModel.isPopoverPresented },
+            set: { appState.navigationModel.isPopoverPresented = $0 }
+        )
+    }
+
     // MARK: - Window-first command map (AND-596)
 
     /// Destinations that own a `⌘N` shortcut (Dashboard…Accounts), in shortcut
@@ -676,7 +691,7 @@ struct PlaidBarApp: App {
         ) == true {
             return
         }
-        appState.isPopoverPresented = true
+        appState.navigationModel.isPopoverPresented = true
     }
 
     /// Brings VaultPeek to the front and shows the dashboard. Window-first
@@ -698,7 +713,7 @@ struct PlaidBarApp: App {
             return
         }
         NSApplication.shared.activate(ignoringOtherApps: true)
-        appState.isPopoverPresented = true
+        appState.navigationModel.isPopoverPresented = true
     }
 
     /// QA aid: "--appearance light|dark" pins the whole app to one appearance

--- a/Sources/PlaidBar/App/SnapshotRenderer.swift
+++ b/Sources/PlaidBar/App/SnapshotRenderer.swift
@@ -48,7 +48,7 @@ enum SnapshotRenderer {
 
         // Dashboard with no selection.
         UserDefaults.standard.set("", forKey: "dashboard.selectedAccountId")
-        appState.isPopoverPresented = true
+        appState.navigationModel.isPopoverPresented = true
         _ = await waitForPopoverWindow(appState: appState)
         try? await Task.sleep(for: .milliseconds(2200))
         if !capturePopoverWindow(to: directoryURL.appendingPathComponent("render-dashboard.png")) {
@@ -81,9 +81,9 @@ enum SnapshotRenderer {
         for attempt in 0..<attempts {
             if popoverWindow() != nil { return true }
             if attempt % 4 == 3 {
-                appState.isPopoverPresented = false
+                appState.navigationModel.isPopoverPresented = false
                 try? await Task.sleep(for: .milliseconds(150))
-                appState.isPopoverPresented = true
+                appState.navigationModel.isPopoverPresented = true
             }
             try? await Task.sleep(for: .milliseconds(500))
         }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -486,6 +486,11 @@ struct GeneralSettingsView: View {
 
     var body: some View {
         @Bindable var state = appState
+        // The detached-dashboard intent moved onto the per-window navigation model
+        // (AND-600); bind directly off it since `appState.navigationModel` is a
+        // `let` (a `$state.navigationModel.…` chain can't form a writable binding
+        // through a `let`).
+        @Bindable var nav = appState.navigationModel
 
         Form {
             Section {
@@ -576,11 +581,11 @@ struct GeneralSettingsView: View {
 
                 // AND-384: pop the dashboard out of the menu bar into a
                 // floating desktop window the user can drag anywhere and that
-                // survives app-switches. Bound to AppState (single source of
-                // truth, persisted to the dashboard.detached key), so toggling
+                // survives app-switches. Bound to the per-window navigation model
+                // (AND-600; persisted to the dashboard.detached key), so toggling
                 // here opens/closes the floating window and stays in sync with
                 // the in-dashboard pin/dock control.
-                Toggle("Keep dashboard in a floating window", isOn: $state.isDashboardDetached)
+                Toggle("Keep dashboard in a floating window", isOn: $nav.isDashboardDetached)
                 Text("Detaches the dashboard from the menu bar into a movable desktop window that stays open when you switch apps. Click the menu bar item to bring it back to the front; dock it again from the window or this toggle.")
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
@@ -590,7 +595,7 @@ struct GeneralSettingsView: View {
                 // original "monitor at a glance while you work" behavior — as an
                 // explicit opt-in rather than the default.
                 Toggle("Keep the floating window on top", isOn: $keepDashboardOnTop)
-                    .disabled(!state.isDashboardDetached)
+                    .disabled(!state.navigationModel.isDashboardDetached)
                 Text("Floats the window above other windows on every Space without taking focus from the app you're working in. Off (default): it behaves like a normal window — one Space, normal order, and visible in Mission Control and the Dock.")
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
+++ b/Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift
@@ -12,7 +12,8 @@ import CoreGraphics
 public enum DetachedDashboardPreferences {
     /// `@AppStorage` key for the user preference that the dashboard should live
     /// in a floating desktop window instead of the menu-bar popover. This is the
-    /// durable intent; `AppState.isDashboardDetached` mirrors it at runtime.
+    /// durable intent; the per-window `NavigationModel.isDashboardDetached`
+    /// (AND-600) mirrors it at runtime.
     public static let detachedStorageKey = "dashboard.detached"
 
     /// `@AppStorage` key for "keep the floating dashboard window on top". When

--- a/Sources/PlaidBarCore/Models/NavigationState.swift
+++ b/Sources/PlaidBarCore/Models/NavigationState.swift
@@ -94,6 +94,23 @@ public struct NavigationState: Sendable, Equatable, Codable {
     /// (`Route.from(weeklyReview:)`) still lands triage.
     public var reviewWorkspaceMode: ReviewWorkspaceMode
 
+    // MARK: Surface presentation state (AND-600 — retired single-surface AppState flags)
+
+    /// Whether this window's menu-bar popover surface is presented. Previously the
+    /// single `AppState.isPopoverPresented` flag — a global property of the whole
+    /// app, so it could only describe one surface. Held per-window here so each
+    /// window's presentation is independent. Ephemeral session state, **not**
+    /// persisted (a relaunch never auto-opens the popover).
+    public var isPopoverPresented: Bool
+
+    /// Whether this window's dashboard lives in the detached floating desktop
+    /// window instead of the menu-bar popover (AND-384). Previously the single
+    /// `AppState.isDashboardDetached` flag. Held per-window here so two windows
+    /// hold independent detach intent. This is the durable intent; the
+    /// `NavigationModel` wrapper persists it to `DetachedDashboardPreferences`'
+    /// key so the floating window reopens on the next launch, exactly as before.
+    public var isDashboardDetached: Bool
+
     public init(
         destination: RouteDestination = .dashboard,
         dashboardFilter: DashboardAccountFilterKind = .all,
@@ -106,7 +123,9 @@ public struct NavigationState: Sendable, Equatable, Codable {
         budgetCategorySelection: SpendingCategory? = nil,
         alertSelection: String = "",
         acknowledgedAlertIDs: Set<String> = [],
-        reviewWorkspaceMode: ReviewWorkspaceMode = .triage
+        reviewWorkspaceMode: ReviewWorkspaceMode = .triage,
+        isPopoverPresented: Bool = false,
+        isDashboardDetached: Bool = false
     ) {
         self.destination = destination
         self.dashboardFilter = dashboardFilter
@@ -120,6 +139,8 @@ public struct NavigationState: Sendable, Equatable, Codable {
         self.alertSelection = alertSelection
         self.acknowledgedAlertIDs = acknowledgedAlertIDs
         self.reviewWorkspaceMode = reviewWorkspaceMode
+        self.isPopoverPresented = isPopoverPresented
+        self.isDashboardDetached = isDashboardDetached
     }
 
     // MARK: - Pure transitions
@@ -326,5 +347,26 @@ public struct NavigationState: Sendable, Equatable, Codable {
     /// "Open review table" affordance to land the table before navigating to Review.
     public mutating func setReviewWorkspaceMode(_ mode: ReviewWorkspaceMode) {
         reviewWorkspaceMode = mode
+    }
+
+    // MARK: - Surface presentation transitions (AND-600)
+
+    /// Present or dismiss this window's menu-bar popover surface.
+    public mutating func setPopoverPresented(_ isPresented: Bool) {
+        isPopoverPresented = isPresented
+    }
+
+    /// Mark the dashboard detached into the floating window. Dismisses the popover —
+    /// only one surface is up at a time (the rule the
+    /// `DetachedDashboardCoordinator.detach` path enforced when these flags lived on
+    /// `AppState`).
+    public mutating func detachDashboard() {
+        isDashboardDetached = true
+        isPopoverPresented = false
+    }
+
+    /// Re-dock the dashboard back into the menu-bar popover.
+    public mutating func redockDashboard() {
+        isDashboardDetached = false
     }
 }

--- a/Tests/PlaidBarCoreTests/NavigationSurfaceStateTests.swift
+++ b/Tests/PlaidBarCoreTests/NavigationSurfaceStateTests.swift
@@ -1,0 +1,126 @@
+import Testing
+@testable import PlaidBarCore
+
+/// Tests for the surface-presentation state migrated off the retired
+/// single-surface `AppState` flags onto the per-window ``NavigationState``
+/// (AND-600): `isPopoverPresented` (the menu-bar popover's presentation) and
+/// `isDashboardDetached` (the floating-window intent). The whole point of the
+/// migration is that two windows hold *independent* presentation/detach state,
+/// so the per-window-independence cases below pin that contract at the pure
+/// value-type layer (where the `NavigationModel` wrapper derives its behavior).
+@Suite("AND-600 per-window surface presentation state")
+struct NavigationSurfaceStateTests {
+
+    // MARK: - Defaults
+
+    @Test("Popover and detached default to false on a fresh window")
+    func defaults() {
+        let state = NavigationState()
+        #expect(!state.isPopoverPresented)
+        #expect(!state.isDashboardDetached)
+    }
+
+    // MARK: - Popover presentation
+
+    @Test("setPopoverPresented toggles the popover presentation flag")
+    func setPopoverPresented() {
+        var state = NavigationState()
+        state.setPopoverPresented(true)
+        #expect(state.isPopoverPresented)
+        state.setPopoverPresented(false)
+        #expect(!state.isPopoverPresented)
+    }
+
+    // MARK: - Detach / re-dock
+
+    @Test("detachDashboard sets the intent AND dismisses the popover (one surface up)")
+    func detachDismissesPopover() {
+        // The popover is open; detaching must close it so only one surface is up —
+        // the rule the AppState `detach` path enforced before AND-600.
+        var state = NavigationState(isPopoverPresented: true)
+        state.detachDashboard()
+        #expect(state.isDashboardDetached)
+        #expect(!state.isPopoverPresented)
+    }
+
+    @Test("redockDashboard clears the detached intent")
+    func redockClearsDetached() {
+        var state = NavigationState(isDashboardDetached: true)
+        state.redockDashboard()
+        #expect(!state.isDashboardDetached)
+    }
+
+    @Test("Detach then re-dock round-trips back to the popover")
+    func detachRedockRoundTrip() {
+        var state = NavigationState()
+        state.detachDashboard()
+        #expect(state.isDashboardDetached)
+        state.redockDashboard()
+        #expect(!state.isDashboardDetached)
+    }
+
+    // MARK: - Per-window independence (R-10 — the migration's reason for existing)
+
+    @Test("Two windows hold independent popover presentation (AND-600)")
+    func independentPopoverPresentation() {
+        var windowA = NavigationState()
+        var windowB = NavigationState()
+
+        windowA.setPopoverPresented(true)
+
+        // B is entirely unaffected — the single-surface flag could never express this.
+        #expect(windowA.isPopoverPresented)
+        #expect(!windowB.isPopoverPresented)
+
+        // And B can hold its own, opposite presentation simultaneously.
+        windowB.setPopoverPresented(true)
+        windowA.setPopoverPresented(false)
+        #expect(!windowA.isPopoverPresented)
+        #expect(windowB.isPopoverPresented)
+    }
+
+    @Test("Two windows hold independent detach intent (AND-600)")
+    func independentDetachIntent() {
+        var windowA = NavigationState()
+        var windowB = NavigationState()
+
+        windowA.detachDashboard()
+
+        // Detaching A's dashboard leaves B docked.
+        #expect(windowA.isDashboardDetached)
+        #expect(!windowB.isDashboardDetached)
+
+        // B re-docks/detaches on its own without disturbing A.
+        windowB.detachDashboard()
+        windowA.redockDashboard()
+        #expect(!windowA.isDashboardDetached)
+        #expect(windowB.isDashboardDetached)
+    }
+
+    @Test("Detaching one window's dashboard does not dismiss another window's popover")
+    func detachDoesNotCrossDismissPopover() {
+        // Window B has its popover open; window A detaching must not reach across
+        // and close B's popover — the cross-surface bug the global flag invited.
+        var windowA = NavigationState()
+        var windowB = NavigationState(isPopoverPresented: true)
+
+        windowA.detachDashboard()
+
+        #expect(windowA.isDashboardDetached)
+        #expect(!windowA.isPopoverPresented)
+        #expect(windowB.isPopoverPresented)
+        #expect(!windowB.isDashboardDetached)
+    }
+
+    // MARK: - Codable (persisted alongside the rest of the navigation state)
+
+    @Test("Surface presentation state round-trips through Codable")
+    func codable() throws {
+        let state = NavigationState(isPopoverPresented: true, isDashboardDetached: true)
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(NavigationState.self, from: data)
+        #expect(decoded.isPopoverPresented)
+        #expect(decoded.isDashboardDetached)
+        #expect(decoded == state)
+    }
+}

--- a/Tests/PlaidBarCoreTests/NavigationSurfaceStateTests.swift
+++ b/Tests/PlaidBarCoreTests/NavigationSurfaceStateTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import PlaidBarCore
 
@@ -102,7 +103,7 @@ struct NavigationSurfaceStateTests {
         // Window B has its popover open; window A detaching must not reach across
         // and close B's popover — the cross-surface bug the global flag invited.
         var windowA = NavigationState()
-        var windowB = NavigationState(isPopoverPresented: true)
+        let windowB = NavigationState(isPopoverPresented: true)
 
         windowA.detachDashboard()
 


### PR DESCRIPTION
## What & why

The menu-bar popover's presentation flag (`isPopoverPresented`) and the detached-dashboard intent (`isDashboardDetached`) lived on the app-global `AppState`. Both are **single-surface by construction** — a global property of the whole app can only ever describe one surface, which is the exact blocker to multiple independent windows.

This migrates both off `AppState` onto the **per-window `NavigationModel`** (the value-type `NavigationState` underneath), so two simultaneous windows hold independent presentation and detach state. The menu bar still owns exactly one `NavigationModel`, so the legacy popover / `--window-first off` escape-hatch path behaves byte-identically.

Stage-2 cleanup, **SAFE non-deleting part only** (AND-600). Out of scope and untouched (gated on on-hardware parity QA, AND-615): `PopoverWindowAnchor`, `AppActivationPolicyCoordinator`, the legacy `NSWindowController`s, and the `--window-first` escape hatch (AND-598/599).

## Change (files)

- `Sources/PlaidBarCore/Models/NavigationState.swift` — add `isPopoverPresented` (ephemeral) + `isDashboardDetached` (durable intent) with pure transitions (`setPopoverPresented`, `detachDashboard` — sets intent **and** dismisses popover so only one surface is up, `redockDashboard`). Codable round-trip preserved.
- `Sources/PlaidBar/App/NavigationModel.swift` — façade for both; persists the detached intent to the **unchanged** `dashboard.detached` key and applies the snapshot-render override (`DetachedDashboardPreferences.resolvedDetachedIntent`) at hydration. `isPopoverPresented` is deliberately not hydrated (a relaunch never auto-opens the popover).
- `Sources/PlaidBar/App/AppState.swift` — remove the two stored properties + the `dashboard.detached` key + the `loadSettings` detached block; thread the snapshot flag into the model at construction.
- `Sources/PlaidBar/App/PlaidBarApp.swift` — all reads/writes go through `appState.navigationModel.*`; the `menuBarExtraAccess(isPresented:)` binding is built explicitly off the `@Observable` model (a `let` `navigationModel` can't carry a writable key-path through the `@State` projection).
- `Sources/PlaidBar/App/DetachedDashboardCoordinator.swift` — `detach`/`redock`/`sync`/`handleMenuBarActivation`/`presentForLaunchOverride` drive the per-window model (via `detachDashboard()` / `redockDashboard()`).
- `Sources/PlaidBar/App/SnapshotRenderer.swift`, `Sources/PlaidBar/Settings/SettingsView.swift` — updated call sites; Settings binds via `@Bindable var nav = appState.navigationModel`.
- `Sources/PlaidBar/App/DetachedDashboardWindowController.swift`, `Sources/PlaidBarCore/Models/DetachedDashboardPreferences.swift` — doc-comment accuracy only.
- `Tests/PlaidBarCoreTests/NavigationSurfaceStateTests.swift` — **new suite** (9 tests).

No references to the single-surface flags remain on `AppState` (only doc-comments referencing the migration). Persistence footprint is unchanged: same `dashboard.detached` key, same raw value.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # exit 0
swift test --filter NavigationSurfaceStateTests                                  # 9 passed
swift test                                                                       # 2192 passed, 0 failures
git diff --check                                                                 # clean
```

The new suite pins the migration's reason for existing — per-window independence: detaching/presenting one window's surface never touches another's, and `detachDashboard()` dismisses only its own popover. Existing `RouteNavigationTests` / `NavigationStateIndependenceTests` / `DetachedDashboardPreferencesTests` (50 tests) still pass.

> Gate note: the legacy popover / escape-hatch (`--window-first off`) build still compiles and works — the menu bar owns one `NavigationModel`, so detach/redock, the status-item click intercept, and on-disk persistence are byte-identical.

## Links

Closes AND-600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
