### PR TITLE
feat(export): local CSV/JSON export for transactions, accounts, budgets (AND-645)

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -731,7 +731,7 @@ struct GeneralSettingsView: View {
 
             Section("Export & Backup") {
                 VStack(alignment: .leading, spacing: Spacing.sm) {
-                    Text("Export a portable copy of your accounts, transactions, and balance history. VaultPeek never uploads these files — they are written only to the folder you choose. Pick a local folder to keep them on this Mac; a synced location (iCloud Drive, Dropbox, a network share) will copy them off-device.")
+                    Text("Export a portable copy of your accounts, transactions, budgets, and balance history. VaultPeek never uploads these files — they are written only to the folder you choose. Pick a local folder to keep them on this Mac; a synced location (iCloud Drive, Dropbox, a network share) will copy them off-device.")
                         .detailText()
                         .fixedSize(horizontal: false, vertical: true)
 
@@ -750,7 +750,7 @@ struct GeneralSettingsView: View {
                     if appState.shouldMaskFinancialValues {
                         Label(
                             appState.isContentLocked
-                                ? "Export is disabled while App Lock is locked, so real balances, accounts, and transactions are never written to disk. Unlock VaultPeek to export."
+                                ? "Export is disabled while App Lock is locked, so real balances, accounts, transactions, and budgets are never written to disk. Unlock VaultPeek to export."
                                 : "Export is disabled while Privacy Mask is on, so real balances are never written to disk. Turn off Privacy Mask to export.",
                             systemImage: appState.isContentLocked ? "lock" : "eye.slash"
                         )
@@ -815,7 +815,7 @@ struct GeneralSettingsView: View {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    // MARK: - Export & Backup (AND-492)
+    // MARK: - Export & Backup (AND-492, budgets added AND-645)
 
     private var isExportDisabled: Bool {
         // Gate on the effective mask state, not just the manual Privacy Mask
@@ -823,8 +823,11 @@ struct GeneralSettingsView: View {
         // active. Settings is a separate scene reachable from the status-item
         // menu while the dashboard is locked, so without this a locked session
         // (Privacy Mask off) could still write the full accounts/transactions/
-        // balances export to disk, bypassing App Lock (Codex P1).
-        appState.shouldMaskFinancialValues
+        // balances/budgets export to disk, bypassing App Lock (Codex P1). The
+        // rule itself lives in `DataExportBuilder` so it is unit-testable.
+        !DataExportBuilder.isExportAllowed(
+            shouldMaskFinancialValues: appState.shouldMaskFinancialValues
+        )
     }
 
     /// Documented backup file path, e.g. `~/.vaultpeek/plaidbar-sandbox.sqlite`.
@@ -855,6 +858,7 @@ struct GeneralSettingsView: View {
         let documents: [(name: String, contents: String)] = [
             ("accounts.csv", DataExportBuilder.accountsCSV(appState.accounts)),
             ("transactions.csv", DataExportBuilder.transactionsCSV(appState.transactions)),
+            ("budgets.csv", DataExportBuilder.budgetsCSV(appState.categoryBudgets)),
             ("balance-history.csv", DataExportBuilder.balanceHistoryCSV(appState.balanceHistory)),
         ]
         // Surface write failures (unwritable/unavailable folder, full disk)
@@ -885,6 +889,7 @@ struct GeneralSettingsView: View {
                 accounts: appState.accounts,
                 transactions: appState.transactions,
                 balanceHistory: appState.balanceHistory,
+                budgets: DataExportBuilder.budgetDTOs(from: appState.categoryBudgets),
                 exportedAt: Date(),
                 environment: appState.serverEnvironment?.rawValue
             )

--- a/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
@@ -5,7 +5,28 @@ import Foundation
 /// AppKit, no I/O — string/Data math over Sendable DTOs, fully unit-testable.
 public enum DataExportBuilder {
     /// Bumped whenever the JSON envelope shape changes so importers can branch.
-    public static let schemaVersion = 1
+    /// v2 adds the optional `budgets` array + `counts.budgets` (AND-645); the
+    /// new fields decode as empty/zero from a v1 file, so importers stay
+    /// backward-compatible.
+    public static let schemaVersion = 2
+
+    // MARK: - Masked-state gating (AND-645)
+
+    /// Pure, testable decision for whether a local export may run, given the
+    /// effective Privacy-Mask state. Keeping this out of the SwiftUI view lets
+    /// the gating rule be unit-tested: the export writes *real* balances,
+    /// accounts, transactions, and budgets to disk, so it must never run while
+    /// the UI is masked (Privacy Mask on) or locked (App Lock) — otherwise a
+    /// quick over-the-shoulder mask or a locked session could be bypassed by
+    /// silently writing the unmasked data to a file.
+    ///
+    /// `shouldMaskFinancialValues` is the app's single source of truth and is
+    /// `true` for *both* the manual Privacy Mask toggle and an active App Lock,
+    /// so a single input covers both cases. Export is allowed only when nothing
+    /// is masked.
+    public static func isExportAllowed(shouldMaskFinancialValues: Bool) -> Bool {
+        !shouldMaskFinancialValues
+    }
 
     // MARK: - CSV
 
@@ -145,21 +166,73 @@ public enum DataExportBuilder {
         return ([header] + rows).joined(separator: "\n") + "\n"
     }
 
+    /// CSV of the user's saved monthly category budgets (AND-645). Rows are
+    /// sorted by the Plaid category raw value so the output is deterministic
+    /// regardless of the `[SpendingCategory: Double]` dictionary iteration order
+    /// the app holds them in — stable column order is required for diff-able,
+    /// re-importable backups. `category` is the machine raw value (e.g.
+    /// `FOOD_AND_DRINK`), `category_name` the human label, both run through the
+    /// same field escaping/neutralization as every other column.
+    public static func budgetsCSV(_ budgets: [CategoryBudgetDTO]) -> String {
+        let header = row(["category", "category_name", "monthly_limit"])
+        let rows = budgets
+            .sorted { $0.category.rawValue < $1.category.rawValue }
+            .map { budget in
+                row([
+                    budget.category.rawValue,
+                    budget.category.displayName,
+                    decimalString(budget.monthlyLimit),
+                ])
+            }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
+    /// Convenience overload that accepts the app's in-memory
+    /// `[SpendingCategory: Double]` budget map and normalizes it into stably
+    /// ordered `CategoryBudgetDTO`s before serializing.
+    public static func budgetsCSV(_ budgets: [SpendingCategory: Double]) -> String {
+        budgetsCSV(budgetDTOs(from: budgets))
+    }
+
+    /// Normalizes the app's budget dictionary into a stably ordered DTO array
+    /// (sorted by category raw value) so both the CSV and the JSON envelope emit
+    /// budgets in the same deterministic order.
+    public static func budgetDTOs(from budgets: [SpendingCategory: Double]) -> [CategoryBudgetDTO] {
+        budgets
+            .map { CategoryBudgetDTO(category: $0.key, monthlyLimit: $0.value) }
+            .sorted { $0.category.rawValue < $1.category.rawValue }
+    }
+
     // MARK: - JSON
 
     /// Versioned, stable backup envelope: schemaVersion, exportedAt, environment,
-    /// per-array counts, then the three DTO arrays (reusing their Codable
+    /// per-array counts, then the DTO arrays (reusing their Codable
     /// conformances). Round-trips back into the original DTO arrays.
+    ///
+    /// `budgets` (and `counts.budgets`) were added in schemaVersion 2 (AND-645).
+    /// They decode as empty/zero when reading a v1 file that lacks them, so
+    /// older backups stay importable.
     public struct Envelope: Codable, Sendable, Equatable {
         public struct Counts: Codable, Sendable, Equatable {
             public let accounts: Int
             public let transactions: Int
             public let balanceHistory: Int
+            public let budgets: Int
 
-            public init(accounts: Int, transactions: Int, balanceHistory: Int) {
+            public init(accounts: Int, transactions: Int, balanceHistory: Int, budgets: Int) {
                 self.accounts = accounts
                 self.transactions = transactions
                 self.balanceHistory = balanceHistory
+                self.budgets = budgets
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                accounts = try container.decode(Int.self, forKey: .accounts)
+                transactions = try container.decode(Int.self, forKey: .transactions)
+                balanceHistory = try container.decode(Int.self, forKey: .balanceHistory)
+                // Absent in v1 envelopes → treat as zero.
+                budgets = try container.decodeIfPresent(Int.self, forKey: .budgets) ?? 0
             }
         }
 
@@ -170,6 +243,7 @@ public enum DataExportBuilder {
         public let accounts: [AccountDTO]
         public let transactions: [TransactionDTO]
         public let balanceHistory: [BalanceSnapshot]
+        public let budgets: [CategoryBudgetDTO]
 
         public init(
             schemaVersion: Int,
@@ -178,7 +252,8 @@ public enum DataExportBuilder {
             counts: Counts,
             accounts: [AccountDTO],
             transactions: [TransactionDTO],
-            balanceHistory: [BalanceSnapshot]
+            balanceHistory: [BalanceSnapshot],
+            budgets: [CategoryBudgetDTO]
         ) {
             self.schemaVersion = schemaVersion
             self.exportedAt = exportedAt
@@ -187,6 +262,20 @@ public enum DataExportBuilder {
             self.accounts = accounts
             self.transactions = transactions
             self.balanceHistory = balanceHistory
+            self.budgets = budgets
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+            exportedAt = try container.decode(Date.self, forKey: .exportedAt)
+            environment = try container.decodeIfPresent(String.self, forKey: .environment)
+            counts = try container.decode(Counts.self, forKey: .counts)
+            accounts = try container.decode([AccountDTO].self, forKey: .accounts)
+            transactions = try container.decode([TransactionDTO].self, forKey: .transactions)
+            balanceHistory = try container.decode([BalanceSnapshot].self, forKey: .balanceHistory)
+            // Absent in v1 envelopes → decode as no budgets.
+            budgets = try container.decodeIfPresent([CategoryBudgetDTO].self, forKey: .budgets) ?? []
         }
     }
 
@@ -194,21 +283,27 @@ public enum DataExportBuilder {
         accounts: [AccountDTO],
         transactions: [TransactionDTO],
         balanceHistory: [BalanceSnapshot],
+        budgets: [CategoryBudgetDTO] = [],
         exportedAt: Date,
         environment: String? = nil
     ) -> Envelope {
-        Envelope(
+        // Stable order: budgets are sorted by category raw value so the JSON
+        // backup matches the CSV order and produces diff-able files.
+        let orderedBudgets = budgets.sorted { $0.category.rawValue < $1.category.rawValue }
+        return Envelope(
             schemaVersion: schemaVersion,
             exportedAt: exportedAt,
             environment: environment,
             counts: Envelope.Counts(
                 accounts: accounts.count,
                 transactions: transactions.count,
-                balanceHistory: balanceHistory.count
+                balanceHistory: balanceHistory.count,
+                budgets: orderedBudgets.count
             ),
             accounts: accounts,
             transactions: transactions,
-            balanceHistory: balanceHistory
+            balanceHistory: balanceHistory,
+            budgets: orderedBudgets
         )
     }
 
@@ -216,6 +311,7 @@ public enum DataExportBuilder {
         accounts: [AccountDTO],
         transactions: [TransactionDTO],
         balanceHistory: [BalanceSnapshot],
+        budgets: [CategoryBudgetDTO] = [],
         exportedAt: Date,
         environment: String? = nil
     ) throws -> Data {
@@ -223,6 +319,7 @@ public enum DataExportBuilder {
             accounts: accounts,
             transactions: transactions,
             balanceHistory: balanceHistory,
+            budgets: budgets,
             exportedAt: exportedAt,
             environment: environment
         )

--- a/Tests/PlaidBarCoreTests/DataExportBuilderBudgetsTests.swift
+++ b/Tests/PlaidBarCoreTests/DataExportBuilderBudgetsTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+/// AND-645: budgets in the CSV/JSON export, plus the pure masked-state gating
+/// rule that protects Privacy Mask / App Lock from being bypassed by writing
+/// real values to disk.
+@Suite("Data Export Builder — Budgets & Masking (AND-645)")
+struct DataExportBuilderBudgetsTests {
+    // MARK: - Masked-state gating
+
+    @Test("Export is blocked whenever financial values are masked (Privacy Mask or App Lock)")
+    func exportGatedOnMask() {
+        #expect(DataExportBuilder.isExportAllowed(shouldMaskFinancialValues: false))
+        // Masked (Privacy Mask on) or locked (App Lock) both surface through
+        // shouldMaskFinancialValues, so a single true input blocks the export.
+        #expect(!DataExportBuilder.isExportAllowed(shouldMaskFinancialValues: true))
+    }
+
+    // MARK: - Budgets CSV
+
+    @Test("budgetsCSV emits a stable header and a row per budget sorted by category raw value")
+    func budgetsCSVHeaderAndStableOrder() {
+        // Intentionally unsorted input order — output must be deterministic.
+        let csv = DataExportBuilder.budgetsCSV([
+            CategoryBudgetDTO(category: .transportation, monthlyLimit: 200),
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 450.5),
+            CategoryBudgetDTO(category: .billsAndUtilities, monthlyLimit: 1000),
+        ])
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        #expect(lines.count == 4) // header + 3 rows
+        #expect(lines[0] == "category,category_name,monthly_limit")
+        // Sorted by rawValue: FOOD_AND_DRINK < RENT_AND_UTILITIES < TRANSPORTATION
+        #expect(lines[1] == "FOOD_AND_DRINK,Food & Drink,450.50")
+        #expect(lines[2] == "RENT_AND_UTILITIES,Bills & Utilities,1000.00")
+        #expect(lines[3] == "TRANSPORTATION,Transportation,200.00")
+    }
+
+    @Test("budgetsCSV dictionary overload sorts deterministically regardless of dictionary order")
+    func budgetsCSVDictionaryOverloadIsStable() {
+        let dictionary: [SpendingCategory: Double] = [
+            .travel: 300,
+            .education: 75,
+            .entertainment: 60,
+        ]
+        // Run twice; dictionary iteration order is non-deterministic but the CSV
+        // must be byte-identical every time.
+        let first = DataExportBuilder.budgetsCSV(dictionary)
+        let second = DataExportBuilder.budgetsCSV(dictionary)
+        #expect(first == second)
+        let lines = first.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        // EDUCATION < ENTERTAINMENT < TRAVEL by raw value.
+        #expect(lines[1].hasPrefix("EDUCATION,"))
+        #expect(lines[2].hasPrefix("ENTERTAINMENT,"))
+        #expect(lines[3].hasPrefix("TRAVEL,"))
+    }
+
+    @Test("budgetsCSV escapes a category display name and neutralizes formula-leading text safely")
+    func budgetsCSVEscapingAndNeutralization() {
+        // The category raw value and a numeric limit are machine values, but
+        // verify the row goes through the shared escaping path: a value that
+        // would need quoting (comma) or formula neutralization is handled. We
+        // can exercise this via csvField directly to prove the row builder uses
+        // it; the displayName values are constants, so no real budget name can
+        // inject — this guards the shared codepath stays wired in.
+        #expect(DataExportBuilder.csvField("Food & Drink") == "Food & Drink")
+        #expect(DataExportBuilder.csvField("Bills, Utilities") == "\"Bills, Utilities\"")
+        #expect(DataExportBuilder.csvField("=cmd") == "'=cmd")
+    }
+
+    @Test("budgetsCSV with no budgets yields a header-only document")
+    func budgetsCSVEmpty() {
+        let csv = DataExportBuilder.budgetsCSV([CategoryBudgetDTO]())
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        #expect(lines.count == 1)
+        #expect(lines[0] == "category,category_name,monthly_limit")
+    }
+
+    @Test("budgetDTOs normalizes the app dictionary into a stably ordered DTO array")
+    func budgetDTOsStableOrder() {
+        let dtos = DataExportBuilder.budgetDTOs(from: [
+            .shopping: 500,
+            .foodAndDrink: 400,
+        ])
+        // FOOD_AND_DRINK < GENERAL_MERCHANDISE by raw value.
+        #expect(dtos.map(\.category) == [.foodAndDrink, .shopping])
+        #expect(dtos.map(\.monthlyLimit) == [400, 500])
+    }
+
+    // MARK: - JSON envelope with budgets
+
+    @Test("combinedJSON carries budgets, a stable budget order, and a budgets count")
+    func combinedJSONIncludesBudgets() throws {
+        let budgets = [
+            CategoryBudgetDTO(category: .transportation, monthlyLimit: 200),
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 450),
+        ]
+        let data = try DataExportBuilder.combinedJSON(
+            accounts: [],
+            transactions: [],
+            balanceHistory: [],
+            budgets: budgets,
+            exportedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            environment: "sandbox"
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
+        #expect(envelope.schemaVersion == 2)
+        #expect(envelope.counts.budgets == 2)
+        // Stable order: sorted by category raw value (FOOD_AND_DRINK first).
+        #expect(envelope.budgets.map(\.category) == [.foodAndDrink, .transportation])
+        #expect(envelope.budgets == [
+            CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 450),
+            CategoryBudgetDTO(category: .transportation, monthlyLimit: 200),
+        ])
+    }
+
+    @Test("combinedJSON omitting budgets yields an empty budgets array and zero count")
+    func combinedJSONDefaultsBudgetsEmpty() throws {
+        let data = try DataExportBuilder.combinedJSON(
+            accounts: [],
+            transactions: [],
+            balanceHistory: [],
+            exportedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
+        #expect(envelope.budgets.isEmpty)
+        #expect(envelope.counts.budgets == 0)
+    }
+
+    @Test("A v1 envelope without budgets/counts.budgets decodes as empty/zero (backward compatible)")
+    func decodesLegacyV1EnvelopeWithoutBudgets() throws {
+        // A schemaVersion-1 backup written before AND-645 has no `budgets` key and
+        // no `counts.budgets`. It must still decode cleanly with empty budgets.
+        let legacyJSON = """
+        {
+          "schemaVersion": 1,
+          "exportedAt": "2026-06-24T00:00:00Z",
+          "environment": "sandbox",
+          "counts": { "accounts": 0, "transactions": 0, "balanceHistory": 0 },
+          "accounts": [],
+          "transactions": [],
+          "balanceHistory": []
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(
+            DataExportBuilder.Envelope.self,
+            from: Data(legacyJSON.utf8)
+        )
+        #expect(envelope.schemaVersion == 1)
+        #expect(envelope.budgets.isEmpty)
+        #expect(envelope.counts.budgets == 0)
+        #expect(envelope.counts.accounts == 0)
+    }
+}


### PR DESCRIPTION
**DEFERRED feature (re-opens scope cut from v1).**

## What & why

Settings → Local data already has an **Export & Backup** section (AND-492) that writes accounts, transactions, and balance history to local CSV/JSON via an NSSavePanel/NSOpenPanel — no upload, fits the local-first model. AND-645 completes that scope cut by adding the user's **saved category budgets** to the same export, so a portable backup matches what the user actually sees in-app (Budgets).

## Change

- **`PlaidBarCore/DataExportBuilder` (pure, Sendable):**
  - `budgetsCSV(_:)` — emits `category,category_name,monthly_limit` with rows **sorted by Plaid category raw value**, so output is deterministic regardless of the app's `[SpendingCategory: Double]` dictionary order. Reuses the existing RFC-4180 escaping + spreadsheet-formula-injection neutralization (`csvField`). A `[SpendingCategory: Double]` overload + `budgetDTOs(from:)` normalize the app's in-memory map.
  - JSON `Envelope` gains an optional `budgets: [CategoryBudgetDTO]` + `counts.budgets`; `schemaVersion` bumped **1 → 2**. Custom `init(from:)` decoders make both new fields decode as **empty/zero from a v1 file**, so older backups stay importable.
  - `isExportAllowed(shouldMaskFinancialValues:)` — the masked-state gating rule, lifted out of the SwiftUI view so it is **unit-testable**. Export writes real values to disk, so it must stay blocked while the UI is masked (Privacy Mask) or locked (App Lock); both surface through `shouldMaskFinancialValues`.
- **App (`Settings/SettingsView.swift`):** CSV export now also writes `budgets.csv`; JSON export includes budgets; `isExportDisabled` delegates to the Core decision; section + masked-state copy updated to mention budgets. The app target still only touches local DTOs it already holds — no new server/credential/token access.

## Testing

Ran with `dangerouslyDisableSandbox` (SwiftPM needs it locally).

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (clean, no warnings-as-errors).
- `swift test --filter DataExportBuilderBudgetsTests` → **9 tests passed** (stable budget CSV order, escaping/neutralization, empty input, JSON envelope with/without budgets, v1 backward-compat decode, masked-gating decision).
- `swift test --filter DataExportBuilderTests --filter DataExportBuilderOverrideTests` → **15 tests passed** (existing export suites — envelope round-trip stays green after the schema bump).
- `git diff --check` → clean.

## Links

Closes AND-645

## Open questions / risks

- CSV uses the documented `category` raw value + `category_name`; the `monthly_limit` column has no currency column because budgets are always the account's local currency in this app — flag if a currency column is wanted.
- Privacy Mask currently **disables** export entirely (the existing AND-492 hard-gate) rather than offering an "export real values anyway" confirmation; this is the stricter, safer interpretation of the requirement and matches the existing behavior. Can switch to a confirmation dialog if preferred.
- No import path yet — this is export-only, as scoped. The JSON envelope is intentionally round-trippable for a future importer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
