### PR TITLE
feat(settings): theme + accent color customization (AND-647)

### DIFF
--- a/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/CategoryDashboardWindowController.swift
@@ -181,6 +181,8 @@ final class CategoryDashboardWindowController: NSObject, NSWindowDelegate {
                 // Category Dashboard scales with the same control as the popover
                 // (AND-570). Reads @AppStorage, so it tracks live changes.
                 .appliesAppTextSize()
+                // Tint with the same accent preference as every other surface (AND-647).
+                .appliesAppAccent()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
     }

--- a/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
+++ b/Sources/PlaidBar/App/DetachedDashboardWindowController.swift
@@ -420,6 +420,9 @@ final class DetachedDashboardWindowController: NSObject, NSWindowDelegate {
                 // Apply the in-app text-size preference so the floating desktop
                 // dashboard scales with the same control as the popover (AND-570).
                 .appliesAppTextSize()
+                // Tint the floating desktop dashboard with the same accent
+                // preference as every other surface (AND-647).
+                .appliesAppAccent()
                 // The panel owns its own width via resize; let the dashboard fill
                 // it rather than imposing the popover's screen-anchored width math.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -137,6 +137,7 @@ struct PlaidBarApp: App {
                 .forcedAppColorScheme(Self.forcedColorScheme)
                 .appliesAppAppearance()
                 .appliesAppTextSize()
+                .appliesAppAccent()
         } else {
             MainPopover()
                 .environment(appState)
@@ -176,6 +177,7 @@ struct PlaidBarApp: App {
                 // so this control is the only way users can enlarge VaultPeek's
                 // text (AND-570).
                 .appliesAppTextSize()
+                .appliesAppAccent()
         }
     }
 
@@ -497,6 +499,9 @@ struct PlaidBarApp: App {
                 // Scale the Settings window too, so the user sees the text-size
                 // change reflected in the very control they are adjusting (AND-570).
                 .appliesAppTextSize()
+                // Tint Settings too, so the accent picker's effect is visible in
+                // the very window the user is adjusting (AND-647).
+                .appliesAppAccent()
         }
 
         // Window-first primary workspace (Epic 1 / AND-591). The scene is
@@ -527,6 +532,7 @@ struct PlaidBarApp: App {
                 // competing setter to flash a wrong first-paint theme.
                 .appliesAppAppearance()
                 .appliesAppTextSize()
+                .appliesAppAccent()
                 // Elevate `.accessory → .regular` while this window is on screen and
                 // drop back when the last managed window closes, via the shared
                 // refcounted coordinator (AND-620). SwiftUI gives a
@@ -747,6 +753,14 @@ struct PlaidBarApp: App {
         }
     }
 
+    /// The accent color forced by the `--accent` CLI flag (QA/screenshot aid:
+    /// `--accent system|blue|purple|…`), or `nil` to follow the stored preference.
+    /// Mirrors `forcedColorScheme`/`forcedTextSizePreference`; lets a QA pass cover
+    /// a specific brand accent without leaving a durable preference behind (AND-647).
+    static var forcedAccentColor: AppAccentColor? {
+        CommandLineOptions.value(for: "--accent").flatMap(AppAccentColor.init(rawValue:))
+    }
+
     /// The in-app text-size preference forced by the `--text-size` CLI flag
     /// (QA/screenshot aid: `--text-size default|large|xLarge|accessibility`), or
     /// `nil` to follow the stored preference. Mirrors `forcedColorScheme`; lets a
@@ -844,6 +858,35 @@ struct AppTextSizeApplier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.dynamicTypeSize(resolvedSize)
+    }
+}
+
+/// Applies the stored accent-color preference as the SwiftUI `.tint` at the scene
+/// root, so every surface that reads `Color.accentColor`/`SemanticColors.brand`
+/// (hero glyphs, active controls, selection washes) re-tints live when the user
+/// picks a different accent (AND-647). The accent is **decorative/brand only** —
+/// it is never used to convey over/under budget, gain/loss, currency, or status,
+/// which keep their own semantic colors plus non-color cues. "System" applies no
+/// tint so the macOS accent is inherited. The `--accent` CLI override (QA aid)
+/// wins over the stored preference, mirroring `AppTextSizeApplier`. Reading
+/// `@AppStorage` here re-tints the whole subtree the instant the Settings picker
+/// changes the value.
+struct AppAccentApplier: ViewModifier {
+    @AppStorage(AppAccentColor.storageKey) private var accentRaw = AppAccentColor.defaultValue.rawValue
+
+    private var resolvedTint: Color? {
+        let stored = AppAccentColor(rawValue: accentRaw) ?? .system
+        guard let swatch = AppAccentColor.resolvedSwatch(
+            cliOverride: PlaidBarApp.forcedAccentColor,
+            storedAccent: stored
+        ) else { return nil }
+        return Color(accentSwatch: swatch)
+    }
+
+    func body(content: Content) -> some View {
+        // `.tint(nil)` is a no-op that follows the system accent, so "System"
+        // never overrides the user's macOS-wide choice.
+        content.tint(resolvedTint)
     }
 }
 
@@ -953,6 +996,16 @@ extension View {
     /// in `App/` can share the one definition.
     func appliesAppTextSize() -> some View {
         modifier(AppTextSizeApplier())
+    }
+
+    /// Applies the stored accent-color preference as the SwiftUI `.tint` at this
+    /// point in the tree (AND-647). Used at every scene/window root — the popover,
+    /// menu-bar label, Settings, and the three detached AppKit-hosted windows — so
+    /// the chosen brand accent tints every surface uniformly. Internal (not
+    /// file-private) so the window controllers in `App/` can share the one
+    /// definition, exactly like `appliesAppTextSize()`.
+    func appliesAppAccent() -> some View {
+        modifier(AppAccentApplier())
     }
 
     /// Applies the window-first shell's chrome background (Liquid Glass on chrome

--- a/Sources/PlaidBar/App/ReviewTableWindowController.swift
+++ b/Sources/PlaidBar/App/ReviewTableWindowController.swift
@@ -178,6 +178,8 @@ final class ReviewTableWindowController: NSObject, NSWindowDelegate {
                 // Scale the detached review Table with the same in-app text-size
                 // preference as every other surface (AND-570).
                 .appliesAppTextSize()
+                // Tint with the same accent preference as every other surface (AND-647).
+                .appliesAppAccent()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         )
     }

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -76,6 +76,7 @@ struct AppearanceSettingsView: View {
     @AppStorage(AppContrastPreference.storageKey) private var contrastRaw = AppContrastPreference.defaultValue.rawValue
     @AppStorage(DecorativeEffectsPreference.storageKey) private var decorativeRaw = DecorativeEffectsPreference.defaultValue.rawValue
     @AppStorage(AppDensityPreference.storageKey) private var densityRaw = AppDensityPreference.defaultValue.rawValue
+    @AppStorage(AppAccentColor.storageKey) private var accentRaw = AppAccentColor.defaultValue.rawValue
     @AppStorage(TextSizePreference.storageKey) private var textSizeRaw = TextSizePreference.defaultValue.rawValue
     @AppStorage(HapticFeedbackPreference.storageKey) private var hapticRaw = HapticFeedbackPreference.defaultValue.rawValue
     @Environment(\.colorSchemeContrast) private var systemContrast
@@ -88,6 +89,7 @@ struct AppearanceSettingsView: View {
     private var contrastPreference: AppContrastPreference { AppContrastPreference(rawValue: contrastRaw) ?? .followSystem }
     private var decorativePreference: DecorativeEffectsPreference { DecorativeEffectsPreference(rawValue: decorativeRaw) ?? .followSystem }
     private var density: AppDensityPreference { AppDensityPreference(rawValue: densityRaw) ?? .comfortable }
+    private var accent: AppAccentColor { AppAccentColor(rawValue: accentRaw) ?? .system }
     private var textSize: TextSizePreference { TextSizePreference(rawValue: textSizeRaw) ?? .default }
     private var hapticPreference: HapticFeedbackPreference { HapticFeedbackPreference(rawValue: hapticRaw) ?? .on }
 
@@ -208,7 +210,31 @@ struct AppearanceSettingsView: View {
                 }
                 .accessibilityValue(density.title)
 
-                Text("Light or Dark force VaultPeek regardless of the system setting. macOS Reduce Motion, Reduce Transparency, and Increase Contrast always take priority, and the --appearance launch flag overrides Appearance here. Density currently adjusts the preview and Appearance chrome; broader per-surface spacing is rolling out separately.")
+                // Accent color (AND-647): a decorative/brand tint only. The picker
+                // labels every option by name (not color alone), and the row also
+                // shows the resolved swatch with a name caption so the choice is
+                // legible to color-blind users and VoiceOver. "System" follows the
+                // macOS accent and applies no override.
+                Picker("Accent Color", selection: Binding(
+                    get: { accent },
+                    set: { accentRaw = $0.rawValue }
+                )) {
+                    ForEach(AppAccentColor.allCases) { option in
+                        Label {
+                            Text(option.title)
+                        } icon: {
+                            AccentSwatchDot(accent: option)
+                        }
+                        .tag(option)
+                    }
+                }
+                .accessibilityValue(accent.title)
+                .accessibilityHint("Sets the decorative accent tint for VaultPeek. Does not change any financial or status colors.")
+
+                AccentSwatchPreviewRow(accent: accent)
+                    .padding(.vertical, Spacing.xxs)
+
+                Text("Light or Dark force VaultPeek regardless of the system setting. macOS Reduce Motion, Reduce Transparency, and Increase Contrast always take priority, and the --appearance launch flag overrides Appearance here. Density currently adjusts the preview and Appearance chrome; broader per-surface spacing is rolling out separately. Accent is a decorative brand tint only — it never changes the colors that show over/under budget, gains and losses, or sync status.")
                     .detailText()
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -366,6 +392,81 @@ private struct AppearancePreviewCard: View {
         .accessibilityLabel(
             "Live preview of the popover at \(setting.displayPercent) percent transparency, with sample data only."
         )
+    }
+}
+
+/// A small color swatch for an accent option, used as the leading icon in the
+/// accent `Picker` rows (AND-647). "System" shows a hatched/neutral dot so it
+/// reads distinctly from the colored options even in grayscale. The swatch is
+/// purely decorative — the picker row always carries the accent's name too, so
+/// meaning never depends on the color (ACCESSIBILITY.md).
+private struct AccentSwatchDot: View {
+    let accent: AppAccentColor
+
+    var body: some View {
+        Group {
+            if let color = SemanticColors.resolvedAccent(for: accent) {
+                Circle().fill(color)
+            } else {
+                // "System": a neutral ring (no fill) so it never masquerades as a
+                // concrete colored accent and stays distinguishable in grayscale.
+                Circle()
+                    .strokeBorder(Color.secondary, lineWidth: 1.5)
+                    .background(Circle().fill(Color.secondary.opacity(0.12)))
+            }
+        }
+        .frame(width: 12, height: 12)
+        .accessibilityHidden(true)
+    }
+}
+
+/// Privacy-safe live preview of the chosen accent (AND-647). Shows the resolved
+/// swatch with its name, plus a sample "active control" chip and selection wash so
+/// the user sees how the decorative tint reads — with synthetic labels only, never
+/// real account data. The accent is brand decoration: this preview deliberately
+/// shows no finance value colored by it.
+private struct AccentSwatchPreviewRow: View {
+    let accent: AppAccentColor
+
+    private var resolvedColor: Color {
+        // Fall back to the live system accent when "System" is selected, so the
+        // preview reflects what the user will actually see.
+        SemanticColors.resolvedAccent(for: accent) ?? Color.accentColor
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.sm) {
+            RoundedRectangle(cornerRadius: Radius.control)
+                .fill(resolvedColor)
+                .frame(width: 28, height: 20)
+                .overlay {
+                    RoundedRectangle(cornerRadius: Radius.control)
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+                }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(accent.title)
+                    .font(.callout.weight(.medium))
+                Text(accent == .system ? "Follows the macOS accent" : "Decorative tint only")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            // A sample "active" control to show the tint in context. Uses a
+            // checkmark glyph so the accented state reads without relying on the
+            // color alone.
+            Label("Active", systemImage: "checkmark.circle.fill")
+                .font(.caption.weight(.medium))
+                .labelStyle(.titleAndIcon)
+                .foregroundStyle(resolvedColor)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.chipVertical)
+                .background(resolvedColor.opacity(0.14), in: Capsule())
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Accent preview: \(accent.title). Decorative tint only; does not change any financial or status colors.")
     }
 }
 

--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -1,3 +1,4 @@
+import PlaidBarCore
 import SwiftUI
 
 // MARK: - Semantic Colors
@@ -43,11 +44,28 @@ enum SemanticColors {
 
     // MARK: - Brand Identity
 
-    /// Primary app accent — hero icons, step dots, active controls.
-    static let brand = Color(nsColor: .systemBlue)
+    /// Primary app accent — hero icons, step dots, active controls. This is the
+    /// **decorative** brand tint and is deliberately `Color.accentColor`, which
+    /// follows the resolved app accent preference (AND-647): the scene roots set
+    /// `.tint(...)` from `AppAccentColor`, so every surface using `brand` re-tints
+    /// when the user picks a different accent, and "System" inherits the macOS
+    /// accent. It carries no financial/status meaning — those keep their own
+    /// semantic colors plus non-color cues (ACCESSIBILITY.md).
+    static let brand = Color.accentColor
 
-    /// Secondary accent — sandbox mode icon, complementary highlights.
+    /// Secondary accent — sandbox mode icon, complementary highlights. Stays a
+    /// fixed warm hue (independent of the chosen accent) so the sandbox-mode
+    /// indicator does not collide with a warm primary accent.
     static let brandSecondary = Color(nsColor: .systemOrange)
+
+    /// Bridges the SwiftUI-free Core accent choice to a concrete `Color`, or `nil`
+    /// to follow the system accent (no app-level tint override). This 1:1 mapping
+    /// is the only place the Core `AppAccentColor`/`AppAccentSwatch` meets SwiftUI —
+    /// parity with the `ForcedColorScheme → ColorScheme` bridge — so the choice →
+    /// swatch decision stays pure and unit-tested in Core.
+    static func resolvedAccent(for accent: AppAccentColor) -> Color? {
+        accent.swatch.map(Color.init(accentSwatch:))
+    }
 
     // MARK: - Recurring
 
@@ -78,6 +96,15 @@ enum SemanticColors {
 enum AppearanceTextColors {
     static let primary = Color(nsColor: .labelColor)
     static let secondary = Color(nsColor: .secondaryLabelColor)
+}
+
+extension Color {
+    /// Builds a `Color` from a SwiftUI-free Core `AppAccentSwatch` (sRGB). Used by
+    /// `SemanticColors.resolvedAccent(for:)` to bridge the Core accent choice into
+    /// SwiftUI; the swatch components are unit-tested in Core (AND-647).
+    init(accentSwatch swatch: AppAccentSwatch) {
+        self.init(.sRGB, red: swatch.red, green: swatch.green, blue: swatch.blue)
+    }
 }
 
 // MARK: - Spacing (8pt grid)

--- a/Sources/PlaidBarCore/Models/AppearancePreferences.swift
+++ b/Sources/PlaidBarCore/Models/AppearancePreferences.swift
@@ -53,6 +53,97 @@ public enum ForcedColorScheme: String, Sendable, Equatable {
     case dark
 }
 
+// MARK: - Accent color
+
+/// User-chosen brand/accent color (AND-647). This is **decorative/brand only** —
+/// it tints hero glyphs, active controls, selection washes, and the app-wide
+/// `.tint`. It MUST NEVER carry financial or status *meaning*: over/under budget,
+/// gain/loss, currency, and sync status keep their own semantic colors plus the
+/// non-color cues (icons, signs, labels) they already use, so changing the accent
+/// can never flip the read of a value (ACCESSIBILITY.md). Mirrors the SwiftUI-free
+/// Core pattern of `AppAppearanceMode`/`ForcedColorScheme`: the enum and its
+/// resolution live here (pure, `Sendable`, unit-tested); the single SwiftUI
+/// `Color` bridge lives in the app layer, alongside the `ForcedColorScheme →
+/// ColorScheme` bridge.
+public enum AppAccentColor: String, CaseIterable, Sendable, Identifiable {
+    /// Follow the macOS system accent color (the default — VaultPeek does not
+    /// override the user's system-wide choice unless they opt in here).
+    case system
+    case blue
+    case purple
+    case pink
+    case red
+    case orange
+    case green
+    case teal
+    case graphite
+
+    public static let storageKey = "appearance.accentColor"
+    public static let defaultValue: AppAccentColor = .system
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .system: "System"
+        case .blue: "Blue"
+        case .purple: "Purple"
+        case .pink: "Pink"
+        case .red: "Red"
+        case .orange: "Orange"
+        case .green: "Green"
+        case .teal: "Teal"
+        case .graphite: "Graphite"
+        }
+    }
+
+    /// The resolved accent for this choice: `nil` swatch means "follow the system
+    /// accent" (no app override). A concrete `AppAccentSwatch` is an sRGB triple
+    /// the SwiftUI bridge turns into a `Color`. Kept pure so the choice → swatch
+    /// mapping is unit-testable without SwiftUI/AppKit.
+    public var swatch: AppAccentSwatch? {
+        switch self {
+        case .system: nil
+        // sRGB components chosen to track Apple's system palette closely while
+        // staying legible as a tint in both light and dark. These are brand
+        // decoration only — never a semantic finance/status color.
+        case .blue: AppAccentSwatch(red: 0.0, green: 0.478, blue: 1.0)
+        case .purple: AppAccentSwatch(red: 0.686, green: 0.322, blue: 0.871)
+        case .pink: AppAccentSwatch(red: 1.0, green: 0.176, blue: 0.333)
+        case .red: AppAccentSwatch(red: 1.0, green: 0.231, blue: 0.188)
+        case .orange: AppAccentSwatch(red: 1.0, green: 0.584, blue: 0.0)
+        case .green: AppAccentSwatch(red: 0.196, green: 0.804, blue: 0.196)
+        case .teal: AppAccentSwatch(red: 0.188, green: 0.69, blue: 0.78)
+        case .graphite: AppAccentSwatch(red: 0.557, green: 0.557, blue: 0.576)
+        }
+    }
+
+    /// Resolve the effective accent given an optional CLI override (a QA aid that
+    /// mirrors `--appearance`) and the stored choice. The override wins, exactly
+    /// like `AppAppearanceMode.resolvedScheme`. A `nil` result means "follow the
+    /// system accent" (no app-level tint override).
+    public static func resolvedSwatch(
+        cliOverride: AppAccentColor?,
+        storedAccent: AppAccentColor
+    ) -> AppAccentSwatch? {
+        (cliOverride ?? storedAccent).swatch
+    }
+}
+
+/// An sRGB color triple for an accent, kept SwiftUI-free so it lives in Core.
+/// The app layer bridges this to a single SwiftUI `Color`; Core stays testable.
+public struct AppAccentSwatch: Sendable, Equatable {
+    public let red: Double
+    public let green: Double
+    public let blue: Double
+
+    public init(red: Double, green: Double, blue: Double) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+}
+
 // MARK: - Contrast
 
 public enum AppContrastPreference: String, CaseIterable, Sendable, Identifiable {

--- a/Tests/PlaidBarCoreTests/AppAccentColorTests.swift
+++ b/Tests/PlaidBarCoreTests/AppAccentColorTests.swift
@@ -1,0 +1,118 @@
+import PlaidBarCore
+import Testing
+
+/// Pure preference → accent-swatch mapping for the theme/accent customization
+/// feature (AND-647). The accent is decorative/brand only; these tests pin the
+/// resolution (including CLI-override precedence and the system-follows default)
+/// without touching SwiftUI/AppKit.
+@Suite("App accent color resolution")
+struct AppAccentColorTests {
+    // MARK: Defaults
+
+    @Test("Default accent follows the system accent (no app override)")
+    func defaultFollowsSystem() {
+        #expect(AppAccentColor.defaultValue == .system)
+        #expect(AppAccentColor.system.swatch == nil)
+    }
+
+    // MARK: Swatch mapping
+
+    @Test("Every non-system case maps to a concrete sRGB swatch; system maps to nil")
+    func swatchPresence() {
+        for accent in AppAccentColor.allCases {
+            if accent == .system {
+                #expect(accent.swatch == nil)
+            } else {
+                #expect(accent.swatch != nil)
+            }
+        }
+    }
+
+    @Test("Concrete swatches are in-gamut sRGB (0...1 per channel)")
+    func swatchComponentsInRange() {
+        for accent in AppAccentColor.allCases {
+            guard let swatch = accent.swatch else { continue }
+            #expect((0.0...1.0).contains(swatch.red))
+            #expect((0.0...1.0).contains(swatch.green))
+            #expect((0.0...1.0).contains(swatch.blue))
+        }
+    }
+
+    @Test("Distinct accents produce distinct swatches (no accidental duplicates)")
+    func swatchesAreDistinct() {
+        let swatches = AppAccentColor.allCases.compactMap(\.swatch)
+        // Eight concrete (non-system) accents, all different.
+        #expect(swatches.count == AppAccentColor.allCases.count - 1)
+        #expect(Set(swatches.map { "\($0.red)-\($0.green)-\($0.blue)" }).count == swatches.count)
+    }
+
+    @Test("A representative swatch round-trips its exact components")
+    func swatchComponentsExact() {
+        #expect(AppAccentColor.blue.swatch == AppAccentSwatch(red: 0.0, green: 0.478, blue: 1.0))
+    }
+
+    // MARK: CLI override precedence
+
+    @Test("The accent CLI override wins over the stored choice (mirrors --appearance)")
+    func cliOverrideWins() {
+        // Override says graphite, stored says blue -> override wins.
+        #expect(
+            AppAccentColor.resolvedSwatch(cliOverride: .graphite, storedAccent: .blue)
+                == AppAccentColor.graphite.swatch
+        )
+        // No override -> stored choice decides.
+        #expect(
+            AppAccentColor.resolvedSwatch(cliOverride: nil, storedAccent: .purple)
+                == AppAccentColor.purple.swatch
+        )
+        // Stored "system" with no override -> follow the system accent (nil).
+        #expect(AppAccentColor.resolvedSwatch(cliOverride: nil, storedAccent: .system) == nil)
+        // Override of "system" also means follow the system accent.
+        #expect(AppAccentColor.resolvedSwatch(cliOverride: .system, storedAccent: .red) == nil)
+    }
+
+    // MARK: Titles / identifiers / storage
+
+    @Test("Each accent exposes a stable human-readable title")
+    func titles() {
+        #expect(AppAccentColor.system.title == "System")
+        #expect(AppAccentColor.blue.title == "Blue")
+        #expect(AppAccentColor.purple.title == "Purple")
+        #expect(AppAccentColor.pink.title == "Pink")
+        #expect(AppAccentColor.red.title == "Red")
+        #expect(AppAccentColor.orange.title == "Orange")
+        #expect(AppAccentColor.green.title == "Green")
+        #expect(AppAccentColor.teal.title == "Teal")
+        #expect(AppAccentColor.graphite.title == "Graphite")
+    }
+
+    @Test("Identifiable id mirrors the persisted raw value for every case")
+    func identifiersMatchRawValues() {
+        for accent in AppAccentColor.allCases { #expect(accent.id == accent.rawValue) }
+    }
+
+    @Test("Storage key is namespaced under appearance.* and distinct from siblings")
+    func storageKey() {
+        #expect(AppAccentColor.storageKey == "appearance.accentColor")
+        let keys = Set([
+            AppAppearanceMode.storageKey,
+            AppContrastPreference.storageKey,
+            DecorativeEffectsPreference.storageKey,
+            AppDensityPreference.storageKey,
+            AppAccentColor.storageKey,
+        ])
+        #expect(keys.count == 5)
+    }
+
+    @Test("Raw values round-trip through the persisted string representation")
+    func rawValueRoundTrip() {
+        #expect(AppAccentColor(rawValue: "graphite") == .graphite)
+        #expect(AppAccentColor(rawValue: "system") == .system)
+        #expect(AppAccentColor(rawValue: "nope") == nil)
+    }
+
+    @Test("CaseIterable exposes system plus eight concrete accents")
+    func caseCount() {
+        #expect(AppAccentColor.allCases.count == 9)
+    }
+}


### PR DESCRIPTION
**DEFERRED feature (re-opens scope cut from v1).**

## What & why

AND-647 (post-1.0 deferred candidate, "Dark/light theme customization") asked to extend the existing appearance preference (follow-system / light / dark via `AppAppearance`) with user-facing theme customization — at minimum an accent color — surfaced in Settings, while keeping the single authoritative `NSApp.appearance` owner and the accessibility rule that meaning is never conveyed by color alone.

This ships a user-selectable **accent color** (System + 8 named accents). It is decorative/brand only: it tints hero glyphs, active controls, selection washes, and the app-wide `.tint` — it never carries financial or status meaning.

## Change

- **PlaidBarCore (pure, Sendable):** new `AppAccentColor` enum + `AppAccentSwatch` in `Sources/PlaidBarCore/Models/AppearancePreferences.swift`, alongside the existing appearance enums. Provides `storageKey` (`appearance.accentColor`), `defaultValue` (`.system`), `title`, per-case `swatch` (sRGB triple, `nil` for System), and a pure `resolvedSwatch(cliOverride:storedAccent:)` resolver — the override-wins precedence mirrors `AppAppearanceMode.resolvedScheme`.
- **App bridge:** `SemanticColors.resolvedAccent(for:)` + `Color(accentSwatch:)` in `Theme/DesignTokens.swift` are the single place the Core choice meets SwiftUI (parity with the existing `ForcedColorScheme → ColorScheme` bridge). `SemanticColors.brand` now resolves to `Color.accentColor`, so every brand surface re-tints live.
- **Single appearance owner preserved:** the accent is applied as SwiftUI `.tint(...)` only, via a new `appliesAppAccent()` modifier (`AppAccentApplier`) that mirrors `appliesAppTextSize()`, wired at every scene/window root (glance, popover, Settings, primary Window, and the three detached AppKit-hosted windows). No new `NSApp.appearance` writer is introduced — `AppAppearance.applyToNSApp` remains the sole owner. "System" applies no tint override (inherits the macOS accent). A `--accent` CLI flag (QA/screenshot aid) wins over the stored choice, mirroring `--appearance`.
- **Settings UI:** accent `Picker` in the Display section — every row labels the accent by **name** with a swatch icon (never color alone), plus an accessible `AccentSwatchPreviewRow` (swatch + name caption + a sample "Active" control with a checkmark glyph). Explanatory copy states the accent is decorative and never changes over/under-budget, gain/loss, or status colors.

Accessibility / privacy: meaning never depends on the chosen accent — over/under budget, gain/loss, currency, and sync status keep their own semantic colors and non-color cues. The Settings preview uses synthetic labels only (no real financial data), so it is Privacy-Mask / App-Lock safe.

## Testing

Run from the worktree with the sandbox disabled.

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (clean, Swift 6 strict concurrency, warnings-as-errors).
- `swift test --filter AppAccentColorTests` → **11 tests passed** (pure preference → swatch mapping, CLI-override precedence, in-gamut + distinct swatches, defaults, titles, identifiers, storage-key namespacing).
- `swift test --filter AppearancePreferencesTests` → **12 tests passed** (no regression in the sibling appearance enums).
- `git diff --check` → clean (no whitespace errors).

Not run: `./Scripts/smoke-sandbox.sh` (app/Core-only change; no server surface touched).

## Links

Closes AND-647.

## Open questions / risks

- The 8 accent swatches are hand-tuned sRGB triples that track Apple's system palette; they are decorative only, so exact hue is not load-bearing. A future pass could swap to a `Color` asset catalog for automatic light/dark variants if desired.
- The monochrome menu-bar **label** glyph is deliberately left untinted to avoid fighting the menu bar's template-image rendering; the accent tints content surfaces only.
- `SemanticColors.brand` moving from a fixed `.systemBlue` to `Color.accentColor` means the default install now follows the user's macOS accent (previously always blue). This is the intended "System" default and matches platform convention, but is a visible default-appearance change for existing users.
