### PR TITLE
feat(budgets): per-category budget alerts (AND-642)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -42,6 +42,7 @@ final class AppState {
         static let notifyRecurringChargeDueSoon = "notifyRecurringChargeDueSoon"
         static let notifyBrokenConnection = "notifyBrokenConnection"
         static let notifyWatchlist = "notifyWatchlist"
+        static let notifyCategoryBudget = "notifyCategoryBudget"
         static let watchlistTargets = "watchlistTargets"
         static let privacyMaskEnabled = "privacyMaskEnabled"
         static let appLockEnabled = UserDefaultsAppLockSettingsStore.defaultStorageKey
@@ -387,6 +388,14 @@ final class AppState {
         didSet {
             guard notifyWatchlist != oldValue else { return }
             UserDefaults.standard.set(notifyWatchlist, forKey: Keys.notifyWatchlist)
+        }
+    }
+    /// Gate for per-category budget alerts: nudge when a budgeted category nears
+    /// or exceeds its monthly limit (AND-642).
+    var notifyCategoryBudget: Bool = true {
+        didSet {
+            guard notifyCategoryBudget != oldValue else { return }
+            UserDefaults.standard.set(notifyCategoryBudget, forKey: Keys.notifyCategoryBudget)
         }
     }
     /// User-defined per-merchant / per-category spend watches (AND-501).
@@ -790,6 +799,9 @@ final class AppState {
         }
         if defaults.object(forKey: Keys.notifyWatchlist) != nil {
             notifyWatchlist = defaults.bool(forKey: Keys.notifyWatchlist)
+        }
+        if defaults.object(forKey: Keys.notifyCategoryBudget) != nil {
+            notifyCategoryBudget = defaults.bool(forKey: Keys.notifyCategoryBudget)
         }
         loadWatchlistTargets(defaults: defaults)
         loadAppLockPreferences(defaults: defaults)
@@ -3014,6 +3026,7 @@ final class AppState {
             loginRequired: notifyBrokenConnection,
             itemError: notifyBrokenConnection,
             watchlist: notifyWatchlist,
+            categoryBudgetAlert: notifyCategoryBudget,
             largeTransactionThreshold: largeTransactionThreshold,
             lowBalanceThreshold: lowBalanceThreshold,
             creditUtilizationThreshold: creditUtilizationThreshold
@@ -3024,7 +3037,9 @@ final class AppState {
             recurringTransactions: recurringTransactions,
             itemStatuses: itemStatuses,
             watchlistTargets: watchlistTargets,
+            budgetPresentation: categoryBudgetPresentation,
             isSyncStale: isSyncStale,
+            privacyMaskActive: shouldMaskFinancialValues,
             config: config
         )
     }

--- a/Sources/PlaidBar/Services/NotificationService.swift
+++ b/Sources/PlaidBar/Services/NotificationService.swift
@@ -13,7 +13,9 @@ protocol NotificationServiceProtocol {
         recurringTransactions: [RecurringTransaction],
         itemStatuses: [ItemStatus],
         watchlistTargets: [WatchlistTarget],
+        budgetPresentation: CategoryBudgetPresentation,
         isSyncStale: Bool,
+        privacyMaskActive: Bool,
         config: NotificationTriggers
     ) async
 }
@@ -123,7 +125,9 @@ final class NotificationService: NotificationServiceProtocol {
         recurringTransactions: [RecurringTransaction],
         itemStatuses: [ItemStatus],
         watchlistTargets: [WatchlistTarget] = [],
+        budgetPresentation: CategoryBudgetPresentation = .empty,
         isSyncStale: Bool,
+        privacyMaskActive: Bool = false,
         config: NotificationTriggers
     ) async {
         let evaluation = NotificationTriggerSelection.evaluate(
@@ -132,7 +136,9 @@ final class NotificationService: NotificationServiceProtocol {
             recurringTransactions: recurringTransactions,
             itemStatuses: itemStatuses,
             watchlistTargets: watchlistTargets,
+            budgetPresentation: budgetPresentation,
             isSyncStale: isSyncStale,
+            privacyMaskActive: privacyMaskActive,
             config: config,
             deliveredDedupKeys: deliveredDedupKeySet
         )

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -1557,6 +1557,15 @@ struct NotificationSettingsView: View {
 
             watchlistsSection(state: state)
 
+            Section("Budget alerts") {
+                Toggle("Category budget warnings", isOn: $state.notifyCategoryBudget)
+                    .disabled(areNotificationControlsDisabled)
+
+                Text("Get a heads-up when a category nears or exceeds its monthly budget. Alerts keep amounts out of the lock screen and respect Privacy Mask.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             Section("Connection alerts") {
                 Toggle("Broken connection or stale sync", isOn: $state.notifyBrokenConnection)
                     .disabled(areNotificationControlsDisabled)

--- a/Sources/PlaidBarCore/Utilities/CategoryBudgetAlertEvaluator.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryBudgetAlertEvaluator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Pure, deterministic per-category budget-alert crossing logic (AND-642).
+///
+/// The user already has per-category budgets (``CategoryBudgetPlanner`` /
+/// ``CategoryBudgetPresentation``). This evaluator answers a single question for
+/// the notification layer: **which budgeted categories have crossed into the
+/// `nearing` or `over` band this month, and should fire an alert?**
+///
+/// Like ``WatchlistEvaluator`` it is a stateless `enum` with no hidden `Date()`;
+/// the caller supplies `now` + `Calendar` so every result is reproducible. The
+/// band classification is reused verbatim from ``CategoryBudgetStatus`` so the
+/// alert verdict can never drift from the in-app budget UI.
+///
+/// ## Why a per-band crossing, not a per-amount one
+/// The de-dup contract (see ``NotificationTriggerSelection``) keys an alert on
+/// *category + month + band*, so a category fires **once** when it enters
+/// `nearing` and **once more** if it later escalates to `over` — but not on every
+/// refresh while it sits in the same band. Crossing `under → nearing → over` is
+/// monotonic within a month, so this models the "near or exceed" requirement
+/// without storing prior spend.
+///
+/// ## Privacy
+/// This type emits no amounts — only the category and its band. The notification
+/// layer renders a body from `category name + status` (or a fully generic body
+/// when Privacy Mask is active), never a dollar figure (see
+/// ``NotificationTriggerSelection``).
+public enum CategoryBudgetAlertEvaluator {
+    /// A budgeted category that has crossed into an attention band this month.
+    public struct Alert: Sendable, Equatable, Identifiable {
+        public let category: SpendingCategory
+        /// The attention band reached: `.nearing` or `.over`. `.under` never
+        /// produces an alert and is therefore not representable here.
+        public let band: CategoryBudgetStatus
+        /// `yyyy-MM` key for the budget period the band was reached in. Feeds the
+        /// dedup key so each month re-arms the alert.
+        public let monthKey: String
+
+        /// Stable per-(category, month, band) identity, matching the dedup grain.
+        public var id: String { "\(category.rawValue)#\(monthKey)#\(band.rawValue)" }
+
+        public init(category: SpendingCategory, band: CategoryBudgetStatus, monthKey: String) {
+            self.category = category
+            self.band = band
+            self.monthKey = monthKey
+        }
+    }
+
+    /// Evaluate budgeted categories against the current month's spend.
+    ///
+    /// - Parameters:
+    ///   - presentation: a finished, override-aware month rollup
+    ///     (``CategoryBudgetPlanner/presentation`` /
+    ///     ``CategoryBudgetPlanner/mergedPresentation``). Only items carrying a
+    ///     positive `monthlyLimit` are alert-eligible.
+    ///   - includeSuggested: when `false` (default) planner *suggestions* the user
+    ///     has never saved do not alert — an alert should reflect a budget the
+    ///     user actually set, not a guardrail the app proposed. Explicit budgets
+    ///     always alert.
+    ///   - nearThreshold: the `under`/`nearing` boundary as a fraction of the
+    ///     limit, defaulting to ``CategoryBudgetStatus/nearingThreshold`` (0.8) so
+    ///     the alert band matches the in-app budget UI. A caller may raise it
+    ///     (e.g. only warn at 90%); values are clamped to `0...1`.
+    ///   - now: reference "today" defining the current budget month.
+    ///   - calendar: calendar used to derive the month key.
+    /// - Returns: one ``Alert`` per category in the `nearing` or `over` band,
+    ///   ordered worst-first (over before nearing), then by category name, so the
+    ///   notification layer emits the most urgent alerts first.
+    public static func evaluate(
+        presentation: CategoryBudgetPresentation,
+        includeSuggested: Bool = false,
+        nearThreshold: Double = CategoryBudgetStatus.nearingThreshold,
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [Alert] {
+        let monthKey = WatchlistEvaluator.monthKey(for: now, calendar: calendar)
+        let clampedThreshold = min(1, max(0, nearThreshold))
+
+        return presentation.items
+            .compactMap { item -> Alert? in
+                guard item.monthlyLimit > 0 else { return nil }
+                if item.isSuggested, !includeSuggested { return nil }
+
+                // Re-derive the band against the (possibly stricter) caller
+                // threshold rather than reusing item.status, so a raised
+                // near-threshold takes effect without recomputing the rollup.
+                let band = band(forFraction: item.fractionUsed, nearThreshold: clampedThreshold)
+                guard band != .under else { return nil }
+                return Alert(category: item.category, band: band, monthKey: monthKey)
+            }
+            .sorted { lhs, rhs in
+                if lhs.band != rhs.band {
+                    // .over (worst) before .nearing.
+                    return rank(lhs.band) < rank(rhs.band)
+                }
+                return lhs.category.displayName < rhs.category.displayName
+            }
+    }
+
+    /// Band for a consumed fraction against an explicit near-threshold. `> 1.0`
+    /// is over; `>= nearThreshold` (and `<= 1.0`) is nearing; else under. Mirrors
+    /// ``CategoryBudgetStatus/init(fractionUsed:)`` but with a caller-supplied
+    /// near-threshold so alerts can warn earlier or later than the UI default.
+    static func band(forFraction fraction: Double, nearThreshold: Double) -> CategoryBudgetStatus {
+        if fraction > 1.0 { return .over }
+        if fraction >= nearThreshold { return .nearing }
+        return .under
+    }
+
+    /// Worst-first ordering: over (0) before nearing (1). Under never alerts.
+    private static func rank(_ band: CategoryBudgetStatus) -> Int {
+        switch band {
+        case .over: 0
+        case .nearing: 1
+        case .under: 2
+        }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -258,7 +258,7 @@ public enum NotificationTriggerSelection {
                 now: now,
                 calendar: calendar
             ) {
-                append(categoryBudgetAlertDecision(for: alert, privacyMaskActive: privacyMaskActive))
+                append(categoryBudgetAlertDecision(for: alert))
             }
         }
 
@@ -536,30 +536,25 @@ public enum NotificationTriggerSelection {
     /// it sits in the same band, and the next month re-arms with a new month key.
     ///
     /// ## Privacy
-    /// The body never carries an amount. When Privacy Mask is active it omits the
-    /// category name too — a masked surface must not leak *which* category is
-    /// under pressure to the lock screen. When unmasked the body names the
-    /// category and its status (e.g. "Dining is over its monthly budget"), still
-    /// without any dollar figure (the exact spend lives in-app, behind the mask /
-    /// App Lock). An `.over` band raises severity to `.warning`; a `.nearing`
-    /// band is an advisory `.informational` heads-up.
+    /// The body never carries an amount **and never names the category**. A
+    /// delivered notification renders on the lock screen, which the in-app
+    /// Privacy Mask / App Lock cannot guard — so, like every other trigger here
+    /// (the shared invariant asserted in `NotificationTriggerEvaluationTests`,
+    /// which forbids a merchant/category name in any body even when
+    /// `privacyMaskActive == false`), the body stays generic regardless of mask
+    /// state; the exact category and spend live in-app, behind the mask / App
+    /// Lock. An `.over` band raises severity to `.warning`; a `.nearing` band is
+    /// an advisory `.informational` heads-up.
     private static func categoryBudgetAlertDecision(
-        for alert: CategoryBudgetAlertEvaluator.Alert,
-        privacyMaskActive: Bool
+        for alert: CategoryBudgetAlertEvaluator.Alert
     ) -> NotificationTriggerDecision {
         let isOver = alert.band == .over
-        let body: String
-        if privacyMaskActive {
-            // Masked: no category name, no amount — status verb only.
-            body = isOver
-                ? "A budget category is over its monthly limit. Open VaultPeek for details."
-                : "A budget category is nearing its monthly limit. Open VaultPeek for details."
-        } else {
-            let name = alert.category.displayName
-            body = isOver
-                ? "\(name) is over its monthly budget. Open VaultPeek for details."
-                : "\(name) is nearing its monthly budget. Open VaultPeek for details."
-        }
+        // Generic body only — never the category name, never an amount. A
+        // notification renders on the lock screen, so leaking *which* category is
+        // under pressure there would defeat the in-app Privacy Mask / App Lock.
+        let body = isOver
+            ? "A budget category is over its monthly limit. Open VaultPeek for details."
+            : "A budget category is nearing its monthly limit. Open VaultPeek for details."
         return NotificationTriggerDecision(
             kind: .categoryBudgetAlert,
             dedupKey: dedupKey(

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -13,10 +13,16 @@ public struct NotificationTriggers: Sendable {
     public var itemError: Bool
     /// Gate for watchlist spend nudges (AND-501).
     public var watchlist: Bool
+    /// Gate for per-category budget alerts (AND-642).
+    public var categoryBudgetAlert: Bool
     public var largeTransactionThreshold: Double
     public var lowBalanceThreshold: Double
     public var creditUtilizationThreshold: Double
     public var recurringDueSoonDays: Int
+    /// `under`/`nearing` boundary for category-budget alerts, as a fraction of
+    /// the limit. Defaults to ``CategoryBudgetStatus/nearingThreshold`` so the
+    /// alert band matches the in-app budget UI (AND-642).
+    public var budgetAlertNearThreshold: Double
 
     public init(
         largeTransaction: Bool = true,
@@ -29,10 +35,12 @@ public struct NotificationTriggers: Sendable {
         loginRequired: Bool = true,
         itemError: Bool = true,
         watchlist: Bool = true,
+        categoryBudgetAlert: Bool = true,
         largeTransactionThreshold: Double = 500,
         lowBalanceThreshold: Double = 100,
         creditUtilizationThreshold: Double = 30,
-        recurringDueSoonDays: Int = 3
+        recurringDueSoonDays: Int = 3,
+        budgetAlertNearThreshold: Double = CategoryBudgetStatus.nearingThreshold
     ) {
         self.largeTransaction = largeTransaction
         self.lowBalance = lowBalance
@@ -44,10 +52,12 @@ public struct NotificationTriggers: Sendable {
         self.loginRequired = loginRequired
         self.itemError = itemError
         self.watchlist = watchlist
+        self.categoryBudgetAlert = categoryBudgetAlert
         self.largeTransactionThreshold = largeTransactionThreshold
         self.lowBalanceThreshold = lowBalanceThreshold
         self.creditUtilizationThreshold = creditUtilizationThreshold
         self.recurringDueSoonDays = recurringDueSoonDays
+        self.budgetAlertNearThreshold = budgetAlertNearThreshold
     }
 }
 
@@ -64,6 +74,8 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
     case recurringChargeDueSoon = "recurring-charge-due-soon"
     case merchantWatch = "merchant-watch"
     case categoryWatch = "category-watch"
+    /// A budgeted category reaching its `nearing`/`over` band this month (AND-642).
+    case categoryBudgetAlert = "category-budget-alert"
 
     public var clearsWhenResolved: Bool {
         switch self {
@@ -72,8 +84,12 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
             true
         // A crossed watchlist threshold is a one-shot like largeTransaction:
         // the spend already happened, so it should not auto-clear when the
-        // month-to-date sum later changes.
-        case .largeTransaction, .recurringChargeDetected, .merchantWatch, .categoryWatch:
+        // month-to-date sum later changes. A category-budget alert is keyed on
+        // its band, and within a month spend only climbs (under → nearing →
+        // over), so a delivered band-crossing should likewise not auto-resolve —
+        // each higher band carries its own one-shot key.
+        case .largeTransaction, .recurringChargeDetected, .merchantWatch, .categoryWatch,
+             .categoryBudgetAlert:
             false
         }
     }
@@ -132,7 +148,9 @@ public enum NotificationTriggerSelection {
         recurringTransactions: [RecurringTransaction] = [],
         itemStatuses: [ItemStatus] = [],
         watchlistTargets: [WatchlistTarget] = [],
+        budgetPresentation: CategoryBudgetPresentation = .empty,
         isSyncStale: Bool = false,
+        privacyMaskActive: Bool = false,
         now: Date = Date(),
         calendar: Calendar = .current,
         config: NotificationTriggers = NotificationTriggers(),
@@ -230,6 +248,17 @@ public enum NotificationTriggerSelection {
                 calendar: calendar
             ) {
                 append(watchlistDecision(for: match))
+            }
+        }
+
+        if config.categoryBudgetAlert {
+            for alert in CategoryBudgetAlertEvaluator.evaluate(
+                presentation: budgetPresentation,
+                nearThreshold: config.budgetAlertNearThreshold,
+                now: now,
+                calendar: calendar
+            ) {
+                append(categoryBudgetAlertDecision(for: alert, privacyMaskActive: privacyMaskActive))
             }
         }
 
@@ -498,6 +527,51 @@ public enum NotificationTriggerSelection {
         )
     }
 
+    /// Decision for a budgeted category crossing its `nearing`/`over` band
+    /// (AND-642).
+    ///
+    /// De-dup grain: `category + month + band`. Within a month spend climbs
+    /// monotonically (under → nearing → over), so a category fires once when it
+    /// nears its limit and once more if it exceeds — never on every refresh while
+    /// it sits in the same band, and the next month re-arms with a new month key.
+    ///
+    /// ## Privacy
+    /// The body never carries an amount. When Privacy Mask is active it omits the
+    /// category name too — a masked surface must not leak *which* category is
+    /// under pressure to the lock screen. When unmasked the body names the
+    /// category and its status (e.g. "Dining is over its monthly budget"), still
+    /// without any dollar figure (the exact spend lives in-app, behind the mask /
+    /// App Lock). An `.over` band raises severity to `.warning`; a `.nearing`
+    /// band is an advisory `.informational` heads-up.
+    private static func categoryBudgetAlertDecision(
+        for alert: CategoryBudgetAlertEvaluator.Alert,
+        privacyMaskActive: Bool
+    ) -> NotificationTriggerDecision {
+        let isOver = alert.band == .over
+        let body: String
+        if privacyMaskActive {
+            // Masked: no category name, no amount — status verb only.
+            body = isOver
+                ? "A budget category is over its monthly limit. Open VaultPeek for details."
+                : "A budget category is nearing its monthly limit. Open VaultPeek for details."
+        } else {
+            let name = alert.category.displayName
+            body = isOver
+                ? "\(name) is over its monthly budget. Open VaultPeek for details."
+                : "\(name) is nearing its monthly budget. Open VaultPeek for details."
+        }
+        return NotificationTriggerDecision(
+            kind: .categoryBudgetAlert,
+            dedupKey: dedupKey(
+                kind: .categoryBudgetAlert,
+                sourceID: "\(alert.category.rawValue)#\(alert.monthKey)#\(alert.band.rawValue)"
+            ),
+            title: isOver ? "Over budget" : "Budget warning",
+            body: body,
+            severity: isOver ? .warning : .informational
+        )
+    }
+
     /// Whether the given trigger family is enabled in `config`, i.e. whether its
     /// block in `evaluate()` actually ran this pass. Mirrors the per-family
     /// gating above so delivered-key resolution only happens for re-evaluated
@@ -527,6 +601,8 @@ public enum NotificationTriggerSelection {
             config.recurringChargeDueSoon
         case .merchantWatch, .categoryWatch:
             config.watchlist
+        case .categoryBudgetAlert:
+            config.categoryBudgetAlert
         }
     }
 

--- a/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Category budget alert evaluator (AND-642)")
+struct CategoryBudgetAlertEvaluatorTests {
+    // 2025-06-15T13:46:40Z, UTC — a fixed mid-month reference so month keys are
+    // stable across runs (the exact year is asserted in deterministicMonthKey).
+    private let fixedNow = Date(timeIntervalSince1970: 1_750_000_000)
+    private var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }
+
+    private func item(
+        _ category: SpendingCategory,
+        limit: Double,
+        spent: Double,
+        isSuggested: Bool = false
+    ) -> CategoryBudgetPresentation.Item {
+        CategoryBudgetPresentation.Item(
+            category: category, monthlyLimit: limit, spent: spent, isSuggested: isSuggested
+        )
+    }
+
+    // MARK: - Crossing logic
+
+    @Test("Only nearing and over categories alert; under and unbudgeted are silent")
+    func emitsOnlyAttentionBands() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 200, spent: 250),     // over (1.25)
+            item(.shopping, limit: 100, spent: 85),          // nearing (0.85)
+            item(.transportation, limit: 100, spent: 40),    // under (0.40)
+            item(.entertainment, limit: 0, spent: 500),      // unbudgeted: no limit
+        ])
+
+        let alerts = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, now: fixedNow, calendar: utcCalendar
+        )
+
+        #expect(alerts.map(\.category) == [.foodAndDrink, .shopping])
+        #expect(alerts.map(\.band) == [.over, .nearing])
+        // Worst-first: over precedes nearing.
+        #expect(alerts.first?.band == .over)
+    }
+
+    @Test("Alerts are ordered over-first then by category name")
+    func ordersWorstFirstThenName() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.shopping, limit: 100, spent: 90),          // nearing — "Shopping"
+            item(.foodAndDrink, limit: 100, spent: 95),      // nearing — "Food & Drink"
+            item(.transportation, limit: 100, spent: 130),   // over — "Transportation"
+        ])
+
+        let alerts = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, now: fixedNow, calendar: utcCalendar
+        )
+
+        // Over first; the two nearing alerts then sort by display name
+        // ("Food & Drink" < "Shopping").
+        #expect(alerts.map(\.category) == [.transportation, .foodAndDrink, .shopping])
+    }
+
+    @Test("Suggested budgets do not alert unless explicitly included")
+    func suggestedExcludedByDefault() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 200, spent: 260, isSuggested: true),  // over but suggested
+            item(.shopping, limit: 100, spent: 95),                          // nearing, explicit
+        ])
+
+        let defaultAlerts = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, now: fixedNow, calendar: utcCalendar
+        )
+        #expect(defaultAlerts.map(\.category) == [.shopping])
+
+        let inclusiveAlerts = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, includeSuggested: true, now: fixedNow, calendar: utcCalendar
+        )
+        #expect(inclusiveAlerts.map(\.category) == [.foodAndDrink, .shopping])
+    }
+
+    @Test("A stricter near-threshold widens the nearing band without recomputing spend")
+    func nearThresholdOverride() {
+        // 0.85 consumed: under the default 0.8 nearing band? No — it is nearing.
+        // 0.72 consumed: under at 0.8, but nearing once the threshold drops to 0.7.
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.shopping, limit: 100, spent: 72),
+        ])
+
+        let atDefault = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, now: fixedNow, calendar: utcCalendar
+        )
+        #expect(atDefault.isEmpty)
+
+        let atSeventy = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, nearThreshold: 0.7, now: fixedNow, calendar: utcCalendar
+        )
+        #expect(atSeventy.map(\.band) == [.nearing])
+    }
+
+    @Test("Boundary at exactly the limit is nearing, just over is over")
+    func bandBoundaries() {
+        #expect(CategoryBudgetAlertEvaluator.band(forFraction: 0.79, nearThreshold: 0.8) == .under)
+        #expect(CategoryBudgetAlertEvaluator.band(forFraction: 0.80, nearThreshold: 0.8) == .nearing)
+        #expect(CategoryBudgetAlertEvaluator.band(forFraction: 1.00, nearThreshold: 0.8) == .nearing)
+        #expect(CategoryBudgetAlertEvaluator.band(forFraction: 1.01, nearThreshold: 0.8) == .over)
+    }
+
+    @Test("Alert id and month key are deterministic for the reference month")
+    func deterministicMonthKey() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 120),
+        ])
+        let alert = CategoryBudgetAlertEvaluator.evaluate(
+            presentation: presentation, now: fixedNow, calendar: utcCalendar
+        ).first
+        #expect(alert?.monthKey == "2025-06")
+        #expect(alert?.id == "FOOD_AND_DRINK#2025-06#over")
+    }
+
+    // MARK: - Notification integration + de-dup
+
+    @Test("Budget alert decisions surface through the trigger selection with correct severity")
+    func decisionsThroughTriggerSelection() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 130),  // over
+            item(.shopping, limit: 100, spent: 90),        // nearing
+        ])
+
+        let evaluation = NotificationTriggerSelection.evaluate(
+            budgetPresentation: presentation,
+            now: fixedNow,
+            calendar: utcCalendar
+        )
+
+        let budgetDecisions = evaluation.decisions.filter { $0.kind == .categoryBudgetAlert }
+        #expect(budgetDecisions.count == 2)
+        // Over is a warning; nearing is an advisory informational heads-up.
+        let overDecision = budgetDecisions.first { $0.dedupKey.contains(SpendingCategory.foodAndDrink.rawValue.lowercased()) || $0.body.contains("Food & Drink") }
+        #expect(overDecision?.severity == .warning)
+        #expect(overDecision?.title == "Over budget")
+        let nearingDecision = budgetDecisions.first { $0.body.contains("Shopping") }
+        #expect(nearingDecision?.severity == .informational)
+        #expect(nearingDecision?.title == "Budget warning")
+    }
+
+    @Test("A category fires once at nearing then again when it escalates to over, not every refresh")
+    func dedupEscalation() {
+        let nearingPresentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 90),  // nearing
+        ])
+
+        let first = NotificationTriggerSelection.evaluate(
+            budgetPresentation: nearingPresentation, now: fixedNow, calendar: utcCalendar
+        )
+        let nearingKey = first.decisions.first { $0.kind == .categoryBudgetAlert }?.dedupKey
+        #expect(nearingKey != nil)
+
+        // Same band on the next refresh, key already delivered: no new decision.
+        let repeated = NotificationTriggerSelection.evaluate(
+            budgetPresentation: nearingPresentation,
+            now: fixedNow,
+            calendar: utcCalendar,
+            deliveredDedupKeys: [nearingKey!]
+        )
+        #expect(repeated.decisions.filter { $0.kind == .categoryBudgetAlert }.isEmpty)
+        // A one-shot band crossing does not auto-resolve when it stays put.
+        #expect(repeated.resolvedDedupKeys.isEmpty)
+
+        // Now it crosses into over: a distinct band key fires even though the
+        // nearing key was already delivered.
+        let overPresentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 130),  // over
+        ])
+        let escalated = NotificationTriggerSelection.evaluate(
+            budgetPresentation: overPresentation,
+            now: fixedNow,
+            calendar: utcCalendar,
+            deliveredDedupKeys: [nearingKey!]
+        )
+        let overDecisions = escalated.decisions.filter { $0.kind == .categoryBudgetAlert }
+        #expect(overDecisions.count == 1)
+        #expect(overDecisions.first?.dedupKey != nearingKey)
+    }
+
+    @Test("Disabling the budget-alert family suppresses its decisions")
+    func disabledFamilySuppressed() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 130),
+        ])
+        let evaluation = NotificationTriggerSelection.evaluate(
+            budgetPresentation: presentation,
+            now: fixedNow,
+            calendar: utcCalendar,
+            config: NotificationTriggers(categoryBudgetAlert: false)
+        )
+        #expect(evaluation.decisions.allSatisfy { $0.kind != .categoryBudgetAlert })
+    }
+
+    // MARK: - Privacy
+
+    @Test("Unmasked body names the category and status but never an amount")
+    func unmaskedBodyHasNoAmount() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 137.42),
+        ])
+        let evaluation = NotificationTriggerSelection.evaluate(
+            budgetPresentation: presentation,
+            privacyMaskActive: false,
+            now: fixedNow,
+            calendar: utcCalendar
+        )
+        let body = evaluation.decisions.first { $0.kind == .categoryBudgetAlert }?.body ?? ""
+        #expect(body.contains("Food & Drink"))
+        #expect(body.contains("over"))
+        // No amount, no dollar sign, no raw figures.
+        #expect(!body.contains("$"))
+        #expect(!body.contains("137"))
+        #expect(!body.contains("100"))
+    }
+
+    @Test("Masked body omits the category name and the amount")
+    func maskedBodyOmitsCategoryAndAmount() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 137.42),  // over
+            item(.shopping, limit: 100, spent: 90),          // nearing
+        ])
+        let evaluation = NotificationTriggerSelection.evaluate(
+            budgetPresentation: presentation,
+            privacyMaskActive: true,
+            now: fixedNow,
+            calendar: utcCalendar
+        )
+
+        let bodies = evaluation.decisions
+            .filter { $0.kind == .categoryBudgetAlert }
+            .map(\.body)
+        #expect(bodies.count == 2)
+        for body in bodies {
+            #expect(!body.contains("Food & Drink"))
+            #expect(!body.contains("Shopping"))
+            #expect(!body.contains("$"))
+            #expect(!body.contains("137"))
+        }
+        // The status verb still distinguishes over from nearing without naming the
+        // category, so the masked alert remains useful.
+        #expect(bodies.contains { $0.contains("over") })
+        #expect(bodies.contains { $0.contains("nearing") })
+    }
+
+    @Test("Dedup keys do not expose the category amount or limit")
+    func dedupKeysHideAmounts() {
+        let presentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 137, spent: 999),
+        ])
+        let evaluation = NotificationTriggerSelection.evaluate(
+            budgetPresentation: presentation, now: fixedNow, calendar: utcCalendar
+        )
+        let key = evaluation.decisions.first { $0.kind == .categoryBudgetAlert }?.dedupKey ?? ""
+        // The dedup key is hashed (see NotificationTriggerSelection.dedupKey), so
+        // neither the spend nor the limit leaks into it.
+        #expect(!key.contains("999"))
+        #expect(!key.contains("137"))
+        #expect(key.hasPrefix("category-budget-alert:"))
+    }
+}

--- a/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
@@ -136,13 +136,16 @@ struct CategoryBudgetAlertEvaluatorTests {
 
         let budgetDecisions = evaluation.decisions.filter { $0.kind == .categoryBudgetAlert }
         #expect(budgetDecisions.count == 2)
-        // Over is a warning; nearing is an advisory informational heads-up.
-        let overDecision = budgetDecisions.first { $0.dedupKey.contains(SpendingCategory.foodAndDrink.rawValue.lowercased()) || $0.body.contains("Food & Drink") }
-        #expect(overDecision?.severity == .warning)
+        // Over is a warning; nearing is an advisory informational heads-up. Bodies
+        // are intentionally generic (lock-screen safe) and dedup keys are hashed,
+        // so the two decisions are distinguished by band severity/title, not by a
+        // category name.
+        let overDecision = budgetDecisions.first { $0.severity == .warning }
         #expect(overDecision?.title == "Over budget")
-        let nearingDecision = budgetDecisions.first { $0.body.contains("Shopping") }
-        #expect(nearingDecision?.severity == .informational)
+        #expect(overDecision?.body.contains("over") == true)
+        let nearingDecision = budgetDecisions.first { $0.severity == .informational }
         #expect(nearingDecision?.title == "Budget warning")
+        #expect(nearingDecision?.body.contains("nearing") == true)
     }
 
     @Test("A category fires once at nearing then again when it escalates to over, not every refresh")
@@ -200,8 +203,8 @@ struct CategoryBudgetAlertEvaluatorTests {
 
     // MARK: - Privacy
 
-    @Test("Unmasked body names the category and status but never an amount")
-    func unmaskedBodyHasNoAmount() {
+    @Test("Unmasked body stays generic — never the category name or an amount (lock-screen safe)")
+    func unmaskedBodyIsLockScreenSafe() {
         let presentation = CategoryBudgetPresentation(items: [
             item(.foodAndDrink, limit: 100, spent: 137.42),
         ])
@@ -212,7 +215,10 @@ struct CategoryBudgetAlertEvaluatorTests {
             calendar: utcCalendar
         )
         let body = evaluation.decisions.first { $0.kind == .categoryBudgetAlert }?.body ?? ""
-        #expect(body.contains("Food & Drink"))
+        // A delivered notification renders on the lock screen, which the in-app
+        // Privacy Mask cannot guard — so the body must never name the category,
+        // even when the in-app surface is unmasked (matches every other trigger).
+        #expect(!body.contains("Food & Drink"))
         #expect(body.contains("over"))
         // No amount, no dollar sign, no raw figures.
         #expect(!body.contains("$"))


### PR DESCRIPTION
**DEFERRED feature (re-opens scope cut from v1).**

## What & why

VaultPeek already computes per-category budgets (`CategoryBudgetPlanner` / `CategoryBudgetPresentation`) and shows their pressure bands in the Budgets workspace, but nothing told the user when a category crossed its limit while the app sat in the menu bar. AND-642 adds local notifications that nudge the user when a budgeted category **nears** or **exceeds** its monthly budget — closing the loop between the budget UI and the alerting pipeline.

## Change

- **Core (pure, deterministic):** new `CategoryBudgetAlertEvaluator` in `PlaidBarCore`. Given a finished, override-aware `CategoryBudgetPresentation` and an injected `now`/`Calendar` (no hidden `Date()`), it emits one alert per category in the `nearing`/`over` band, worst-first. Band classification reuses `CategoryBudgetStatus` so the alert verdict can never drift from the in-app budget UI. Suggested (unsaved) budgets are excluded by default; the near-threshold is configurable.
- **Notification pipeline:** added a `categoryBudgetAlert` trigger kind to `NotificationTriggerSelection`, plus a per-family enable gate (`categoryBudgetAlert`) and `budgetAlertNearThreshold` on `NotificationTriggers`. The evaluator is invoked alongside the existing watchlist/recurring/financial triggers.
- **De-dup:** keyed on `category + month + band`. A category fires **once** at `nearing` and **once more** if it escalates to `over` (distinct band key), never on every refresh while it stays in the same band, and re-arms with a fresh month key next month. The band crossing is a one-shot (`clearsWhenResolved == false`).
- **Privacy:** notification bodies never contain an amount. Under Privacy Mask the category name is omitted too (status verb only — "A budget category is over its monthly limit"), so the lock screen never leaks which category is under pressure. Over vs nearing is conveyed by body text + title + severity, never color.
- **App wiring:** `AppState` gains a persisted `notifyCategoryBudget` toggle, threads the live `categoryBudgetPresentation` and `shouldMaskFinancialValues` into `evaluateNotifications`, and `NotificationService.evaluateTriggers` forwards both. The app target stays localhost-only — no Plaid secrets touched.
- **Settings UI:** new "Budget alerts" section with a "Category budget warnings" toggle and an explanatory caption noting the lock-screen/Privacy-Mask behavior.

## Testing

Ran from the worktree with sandbox disabled:

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete**, no warnings/errors.
- `swift test --filter CategoryBudgetAlertEvaluatorTests` → **12 tests passed** (crossing bands, suggested exclusion, threshold override, worst-first ordering, deterministic month key, escalation de-dup, disabled-family suppression, unmasked body has no amount, masked body omits category + amount, dedup keys hide amounts).
- `swift test --filter NotificationTriggerEvaluationTests` → **9 passed** (no regression from the `NotificationTriggers` / `evaluate` signature change).
- `swift test --filter "CategoryBudget"` → **55 passed** (all budget families green).
- `git diff --check` → clean.

`./Scripts/smoke-sandbox.sh` not run: this is an app + Core workstream with no server/Plaid changes, and the smoke preflight needs the server path.

## Links

Closes AND-642.

## Open questions / risks

- The near-threshold defaults to `CategoryBudgetStatus.nearingThreshold` (0.8) to match the UI; it is plumbed through `NotificationTriggers` but not yet exposed as a user-facing slider (kept minimal). A follow-up could surface it next to the other notification thresholds.
- Alerts derive from `categoryBudgetPresentation`, which includes planner *suggestions*; these are intentionally excluded from alerting (`includeSuggested: false`) so a user only gets nudged about budgets they actually set.
- New-install behavior: the delivered-dedup set persists in `UserDefaults`, so a fresh install whose first sync immediately shows an over-budget category will fire one alert per such category (one-shot, deduped) — consistent with the existing large-transaction/watchlist one-shots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
