### PR TITLE
fix(webhooks): dormant ordering/state defects + gated real signature verifier (AND-634, AND-646)

### DIFF
--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import CryptoKit
 import FluentSQLiteDriver
 import Foundation
 import Hummingbird
@@ -138,7 +139,7 @@ struct PlaidBarServer: AsyncParsableCommand {
         )
         .register(with: router)
         WebhookRoutes(
-            verifier: StrictPlaidWebhookVerifier(),
+            verifier: Self.webhookVerifier(config: serverConfig, logger: logger),
             tokenStore: tokenStore,
             eventStore: webhookEventStore
         )
@@ -185,6 +186,57 @@ struct PlaidBarServer: AsyncParsableCommand {
                     break
                 }
             }
+        }
+    }
+
+    /// Selects the webhook JWT verifier (AND-646). GATED: by default
+    /// (`webhookVerification.enabled == false`) this returns the exact same
+    /// `StrictPlaidWebhookVerifier()` the server has always wired — its default
+    /// `UnconfiguredPlaidWebhookSignatureValidator` always throws, so the
+    /// receiver stays dormant and shipped behavior is byte-for-byte unchanged.
+    /// The real ES256 validator is only constructed when the operator explicitly
+    /// opts in; if the opt-in is present but supplies no parseable signing key,
+    /// the validator is still wired but trusts no key (it rejects every
+    /// delivery), so processing remains inert from the user's perspective.
+    static func webhookVerifier(
+        config: ServerConfig,
+        logger: Logger
+    ) -> any PlaidWebhookVerifier {
+        guard config.webhookVerification.enabled else {
+            return StrictPlaidWebhookVerifier()
+        }
+        let keySource = StaticPlaidWebhookKeySource(
+            keysByID: pinnedWebhookKeys(config: config, logger: logger)
+        )
+        logger.info("Plaid webhook signature verification ENABLED (opt-in).")
+        return StrictPlaidWebhookVerifier(
+            signatureValidator: ES256PlaidWebhookSignatureValidator(keySource: keySource)
+        )
+    }
+
+    /// Parses the optional operator-pinned signing key (JWK JSON) into a
+    /// `kid`-indexed key set. Returns an empty set (verifier rejects everything)
+    /// if absent or unparseable, never crashing the server boot.
+    private static func pinnedWebhookKeys(
+        config: ServerConfig,
+        logger: Logger
+    ) -> [String: P256.Signing.PublicKey] {
+        guard let json = config.webhookVerification.signingKeyJWKJSON,
+              let data = json.data(using: .utf8)
+        else {
+            logger.warning("Webhook verification enabled but no signing key configured; all deliveries will be rejected.")
+            return [:]
+        }
+        do {
+            let jwk = try JSONDecoder().decode(PlaidWebhookJWK.self, from: data)
+            guard let kid = jwk.kid, !kid.isEmpty else {
+                logger.warning("Configured webhook signing JWK has no `kid`; all deliveries will be rejected.")
+                return [:]
+            }
+            return [kid: try jwk.publicKey()]
+        } catch {
+            logger.warning("Failed to parse configured webhook signing JWK: \(String(describing: error)); all deliveries will be rejected.")
+            return [:]
         }
     }
 }

--- a/Sources/PlaidBarServer/Config/DeploymentMode.swift
+++ b/Sources/PlaidBarServer/Config/DeploymentMode.swift
@@ -104,3 +104,55 @@ struct RemoteBridgeConfig: Sendable, Equatable {
         )
     }
 }
+
+/// Opt-in configuration for real Plaid webhook signature verification (AND-646).
+///
+/// GATED / NON-ACTIVATING BY DEFAULT. The shipped server keeps the dormant
+/// webhook receiver: it wires `UnconfiguredPlaidWebhookSignatureValidator`,
+/// which always throws, so no inbound webhook is ever accepted unless the
+/// operator explicitly opts in. This config records *whether* the real ES256
+/// validator should be wired and, optionally, a statically pinned EC public key
+/// (JWK JSON) to verify against. Until `enabled` is `true`, nothing constructs
+/// the real validator and the receiver stays off exactly as before.
+///
+/// `enabled` is parsed from `PLAIDBAR_WEBHOOK_VERIFICATION` (`on`/`true`/`1`);
+/// any other value (including absent) resolves to disabled — a malformed config
+/// can never silently activate webhook processing. The optional pinned key is
+/// read from `PLAIDBAR_WEBHOOK_SIGNING_JWK` (the JWK JSON Plaid returns from
+/// `/webhook_verification_key/get`), letting an operator verify against a known
+/// key without any live key fetch. Any hosted relay stores nothing — this is a
+/// local verification posture only.
+struct PlaidWebhookVerificationConfig: Sendable, Equatable {
+    /// When `false` (the default), the real signature validator is never wired
+    /// and the webhook receiver stays dormant.
+    let enabled: Bool
+
+    /// Optional statically pinned signing key, as the JWK JSON Plaid serves. When
+    /// present and `enabled`, the real validator verifies against this key by its
+    /// `kid`. `nil` keeps the validator wired but with no trusted key (it will
+    /// reject every delivery), which is still inert from the user's perspective.
+    let signingKeyJWKJSON: String?
+
+    /// Disabled, no pinned key — today's behavior. The default everywhere.
+    static let disabled = PlaidWebhookVerificationConfig(enabled: false, signingKeyJWKJSON: nil)
+
+    static let enabledEnvironmentVariable = "PLAIDBAR_WEBHOOK_VERIFICATION"
+    static let signingKeyEnvironmentVariable = "PLAIDBAR_WEBHOOK_SIGNING_JWK"
+
+    /// Resolve from a config/env dictionary. Defaults to `.disabled`; only the
+    /// explicit affirmative tokens enable it, so the dormant receiver can never
+    /// be activated by a typo or a blank value.
+    static func resolved(from environment: [String: String]) -> PlaidWebhookVerificationConfig {
+        let rawEnabled = environment[enabledEnvironmentVariable]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let enabled = ["on", "true", "1", "yes"].contains(rawEnabled ?? "")
+        guard enabled else { return .disabled }
+        let key = environment[signingKeyEnvironmentVariable]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return PlaidWebhookVerificationConfig(
+            enabled: true,
+            signingKeyJWKJSON: (key?.isEmpty == false) ? key : nil
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Config/ServerConfig.swift
+++ b/Sources/PlaidBarServer/Config/ServerConfig.swift
@@ -38,6 +38,11 @@ struct ServerConfig: Sendable {
     /// until the bridge is provisioned. Nothing dials these endpoints yet.
     let remoteBridge: RemoteBridgeConfig
 
+    /// Opt-in real-webhook-signature-verification posture (AND-646). Defaults to
+    /// `.disabled` so the webhook receiver stays dormant exactly as today; the
+    /// real ES256 validator is only wired when the operator opts in.
+    var webhookVerification: PlaidWebhookVerificationConfig = .disabled
+
     var dataDirectoryPath: String {
         URL(fileURLWithPath: databasePath)
             .deletingLastPathComponent()
@@ -130,6 +135,9 @@ struct ServerConfig: Sendable {
         // until the owner provisions them (see consumer-production-checklist.md).
         let deployment = DeploymentMode.resolved(from: environmentValues)
         let remoteBridge = RemoteBridgeConfig.resolved(from: environmentValues)
+        // Opt-in webhook signature verification. Defaults to `.disabled`; the
+        // dormant receiver only activates when the operator explicitly opts in.
+        let webhookVerification = PlaidWebhookVerificationConfig.resolved(from: environmentValues)
         if deployment == .hostedBridge, link.webhookURL == nil {
             throw ServerConfigError.missingManagedLinkWebhookURL
         }
@@ -159,7 +167,8 @@ struct ServerConfig: Sendable {
             linkClientUserId: linkClientUserId,
             link: link,
             deployment: deployment,
-            remoteBridge: remoteBridge
+            remoteBridge: remoteBridge,
+            webhookVerification: webhookVerification
         )
     }
 

--- a/Sources/PlaidBarServer/Routes/PlaidWebhookSignatureVerifier.swift
+++ b/Sources/PlaidBarServer/Routes/PlaidWebhookSignatureVerifier.swift
@@ -1,0 +1,161 @@
+import CryptoKit
+import Foundation
+
+/// Real ES256 (ECDSA P-256 / SHA-256) signature validator for Plaid webhook
+/// JWTs (AND-646).
+///
+/// GATED / NON-ACTIVATING BY DEFAULT. The shipped server still wires
+/// `UnconfiguredPlaidWebhookSignatureValidator` (which always throws
+/// `.signatureVerificationUnavailable`), so the webhook receiver stays dormant
+/// exactly as before. This type only participates when the operator explicitly
+/// opts in via `PlaidWebhookVerificationConfig` (see `ServerConfig`); absent
+/// that opt-in nothing constructs it and webhook processing remains off.
+///
+/// Plaid signs each webhook with an ES256 JWT in the `Plaid-Verification`
+/// header. Verification has two halves, split here so each is independently
+/// testable:
+///   1. **Structural / claims / body-hash** checks — already done by
+///      `StrictPlaidWebhookVerifier` (alg, iat skew, request-body SHA-256).
+///   2. **Cryptographic signature** — this type. It resolves the EC public key
+///      for the JWT's `kid` from a `PlaidWebhookKeySource`, reconstructs the
+///      JWS signing input (`header.payload`), and verifies the P-256 signature.
+///
+/// The cryptographic core (`verifySignature`) takes a `P256.Signing.PublicKey`
+/// and is fully unit-testable with a synthetic keypair — no Plaid call, no
+/// credentials. Production key resolution (fetch-by-`kid` from Plaid's
+/// `/webhook_verification_key/get`) lives behind `PlaidWebhookKeySource` and is
+/// only constructed when the operator provisions it.
+struct ES256PlaidWebhookSignatureValidator: PlaidWebhookSignatureValidator {
+    let keySource: any PlaidWebhookKeySource
+
+    func validate(jwt: String, header: PlaidWebhookJWTHeader, claims: PlaidWebhookJWTClaims) async throws {
+        guard let kid = header.kid, !kid.isEmpty else {
+            throw PlaidWebhookSignatureError.missingKeyID
+        }
+        let key = try await keySource.publicKey(forKeyID: kid)
+        try Self.verifySignature(jwt: jwt, publicKey: key)
+    }
+
+    /// Verifies the ES256 signature of a compact JWS string against a P-256
+    /// public key. Pure and synchronous: reconstructs the signing input
+    /// (`base64url(header) "." base64url(payload)`), decodes the third segment
+    /// as the raw 64-byte `r||s` signature, and checks it with SHA-256/P-256.
+    /// Throws on any structural or cryptographic failure (never returns `false`).
+    static func verifySignature(jwt: String, publicKey: P256.Signing.PublicKey) throws {
+        let components = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 3 else {
+            throw PlaidWebhookSignatureError.malformedJWT
+        }
+        let signingInput = "\(components[0]).\(components[1])"
+        guard let signingData = signingInput.data(using: .utf8) else {
+            throw PlaidWebhookSignatureError.malformedJWT
+        }
+        let signatureBytes = try base64URLDecode(String(components[2]))
+        // JWS ES256 signatures are the raw fixed-width concatenation r||s
+        // (32 + 32 bytes), not DER. CryptoKit's `rawRepresentation` initializer
+        // expects exactly that layout.
+        guard signatureBytes.count == 64 else {
+            throw PlaidWebhookSignatureError.malformedSignature
+        }
+        let signature: P256.Signing.ECDSASignature
+        do {
+            signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureBytes)
+        } catch {
+            throw PlaidWebhookSignatureError.malformedSignature
+        }
+        guard publicKey.isValidSignature(signature, for: SHA256.hash(data: signingData)) else {
+            throw PlaidWebhookSignatureError.signatureMismatch
+        }
+    }
+
+    private static func base64URLDecode(_ value: String) throws -> Data {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = (4 - base64.count % 4) % 4
+        base64.append(String(repeating: "=", count: padding))
+        guard let data = Data(base64Encoded: base64) else {
+            throw PlaidWebhookSignatureError.malformedSignature
+        }
+        return data
+    }
+}
+
+/// Resolves the EC public key Plaid signed a webhook with, keyed by the JWT
+/// `kid`. Abstracted so the cryptographic validator stays testable with a
+/// synthetic key and the production fetch (Plaid `/webhook_verification_key/get`,
+/// which needs the server's Plaid credentials) is injected, cached, and
+/// owner-gated.
+protocol PlaidWebhookKeySource: Sendable {
+    func publicKey(forKeyID kid: String) async throws -> P256.Signing.PublicKey
+}
+
+/// A `kid`-indexed, in-memory set of trusted P-256 keys. Used by tests (with a
+/// synthetic keypair) and as the storage shape a real Plaid-backed resolver
+/// would populate. Pure and `Sendable`; never reaches out to the network.
+struct StaticPlaidWebhookKeySource: PlaidWebhookKeySource {
+    let keysByID: [String: P256.Signing.PublicKey]
+
+    func publicKey(forKeyID kid: String) async throws -> P256.Signing.PublicKey {
+        guard let key = keysByID[kid] else {
+            throw PlaidWebhookSignatureError.unknownKeyID
+        }
+        return key
+    }
+}
+
+/// Parses a Plaid `JWK` (`{"kty":"EC","crv":"P-256","x":..,"y":..}`) into a
+/// `P256.Signing.PublicKey`. Plaid's `/webhook_verification_key/get` returns the
+/// signing key in exactly this JWK shape, so a real key source can decode the
+/// response into this DTO and build the key with no extra crypto plumbing.
+struct PlaidWebhookJWK: Decodable, Sendable, Equatable {
+    let kty: String
+    let crv: String
+    let x: String
+    let y: String
+    let kid: String?
+
+    /// Builds the P-256 public key from the JWK's affine coordinates. The X9.63
+    /// uncompressed-point encoding CryptoKit expects is `0x04 || x || y`, each
+    /// coordinate a fixed 32-byte big-endian integer (base64url in the JWK).
+    func publicKey() throws -> P256.Signing.PublicKey {
+        guard kty == "EC", crv == "P-256" else {
+            throw PlaidWebhookSignatureError.unsupportedKeyType
+        }
+        let xBytes = try Self.base64URLDecode(x)
+        let yBytes = try Self.base64URLDecode(y)
+        guard xBytes.count == 32, yBytes.count == 32 else {
+            throw PlaidWebhookSignatureError.malformedKey
+        }
+        var x963 = Data([0x04])
+        x963.append(xBytes)
+        x963.append(yBytes)
+        do {
+            return try P256.Signing.PublicKey(x963Representation: x963)
+        } catch {
+            throw PlaidWebhookSignatureError.malformedKey
+        }
+    }
+
+    private static func base64URLDecode(_ value: String) throws -> Data {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = (4 - base64.count % 4) % 4
+        base64.append(String(repeating: "=", count: padding))
+        guard let data = Data(base64Encoded: base64) else {
+            throw PlaidWebhookSignatureError.malformedKey
+        }
+        return data
+    }
+}
+
+enum PlaidWebhookSignatureError: Error, Equatable {
+    case missingKeyID
+    case unknownKeyID
+    case malformedJWT
+    case malformedSignature
+    case malformedKey
+    case unsupportedKeyType
+    case signatureMismatch
+}

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -72,10 +72,25 @@ struct StatusRoutes: Sendable {
     private func safeItemStatuses() async throws -> [ItemStatus] {
         let items = try await tokenStore.getAllItems()
         let webhookEvents = try await webhookEventStore?.latestEventsByItem() ?? [:]
-        return items.map { Self.safeItemStatus(from: $0, webhookEvent: webhookEvents[$0.id ?? ""]) }
+        // The sync signal is read from a *separate*, sync-only projection so a
+        // later non-sync webhook (e.g. PENDING_EXPIRATION) cannot mask an earlier
+        // still-pending SYNC_UPDATES_AVAILABLE. The latest-overall event still
+        // drives the display fields (`lastWebhookAt`, `lastWebhookEvent`).
+        let syncEvents = try await webhookEventStore?.latestSyncEventsByItem() ?? [:]
+        return items.map {
+            Self.safeItemStatus(
+                from: $0,
+                webhookEvent: webhookEvents[$0.id ?? ""],
+                syncEvent: syncEvents[$0.id ?? ""]
+            )
+        }
     }
 
-    private static func safeItemStatus(from item: ItemModel, webhookEvent: WebhookItemSignal? = nil) -> ItemStatus {
+    private static func safeItemStatus(
+        from item: ItemModel,
+        webhookEvent: WebhookItemSignal? = nil,
+        syncEvent: WebhookItemSignal? = nil
+    ) -> ItemStatus {
         ItemStatus(
             id: item.id ?? "",
             institutionName: item.institutionName,
@@ -83,14 +98,18 @@ struct StatusRoutes: Sendable {
             lastSync: item.updatedAt,
             lastWebhookAt: webhookEvent?.effectiveDate,
             lastWebhookEvent: webhookEvent.map { "\($0.webhookType).\($0.webhookCode)" },
-            needsSync: Self.needsPollingSync(item: item, webhookEvent: webhookEvent)
+            needsSync: Self.needsPollingSync(item: item, syncEvent: syncEvent)
         )
     }
 
-    private static func needsPollingSync(item: ItemModel, webhookEvent: WebhookItemSignal?) -> Bool {
-        guard let webhookEvent, webhookEvent.needsSync else { return false }
+    /// Whether the item still has unconsumed sync work pending. Driven by the
+    /// item's latest *sync-relevant* webhook (sticky — see
+    /// `WebhookEventStore.latestSyncEventsByItem`), cleared once the item's
+    /// `updatedAt` (its last refresh) advances past the sync event.
+    private static func needsPollingSync(item: ItemModel, syncEvent: WebhookItemSignal?) -> Bool {
+        guard let syncEvent else { return false }
         guard let lastSync = item.updatedAt else { return true }
-        return lastSync < webhookEvent.effectiveDate
+        return lastSync < syncEvent.effectiveDate
     }
 
     static func includesItems(_ request: Request) -> Bool {

--- a/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
@@ -47,7 +47,7 @@ struct StrictPlaidWebhookVerifier: PlaidWebhookVerifier {
         }
 
         guard let bodyHash = claims.requestBodySHA256 ?? claims.bodySHA256,
-              bodyHash == Self.sha256Hex(body)
+              Self.constantTimeEquals(bodyHash, Self.sha256Hex(body))
         else {
             throw PlaidWebhookVerificationError.bodyHashMismatch
         }
@@ -69,6 +69,19 @@ struct StrictPlaidWebhookVerifier: PlaidWebhookVerifier {
 
     static func sha256Hex(_ data: Data) -> String {
         SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Length-checked constant-time comparison for webhook body hashes.
+    static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        guard lhsBytes.count == rhsBytes.count else { return false }
+
+        var difference: UInt8 = 0
+        for index in lhsBytes.indices {
+            difference |= lhsBytes[index] ^ rhsBytes[index]
+        }
+        return difference == 0
     }
 }
 

--- a/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/WebhookRoutes.swift
@@ -238,9 +238,19 @@ struct WebhookRoutes: Sendable {
             receivedAt: now(),
             bodyHash: StrictPlaidWebhookVerifier.sha256Hex(body)
         )
-        let result = try await eventStore.record(signal)
-        if result.disposition == .stored {
-            try await apply(signal)
+        // Serialize record-and-apply per item id. `record`'s find-then-save and
+        // `apply`'s status read-modify-write each straddle suspending Fluent
+        // calls, so without a per-item gate two concurrent distinct-hash
+        // deliveries for the same item could both resolve `.stored` and apply
+        // interleaved status mutations (last-writer-wins). Holding the lock
+        // across both makes the out-of-order check, the save, and the status RMW
+        // atomic for one item; distinct items stay concurrent.
+        let result = try await eventStore.withItemLock(itemId: signal.itemId) {
+            let result = try await eventStore.record(signal)
+            if result.disposition == .stored {
+                try await apply(signal)
+            }
+            return result
         }
 
         return try Self.jsonResponse(WebhookReceiveResponse(disposition: result.disposition.rawValue))

--- a/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
+++ b/Sources/PlaidBarServer/Storage/WebhookEventStore.swift
@@ -99,8 +99,33 @@ struct WebhookStoreResult: Sendable, Equatable {
 actor WebhookEventStore {
     private let fluent: Fluent
 
+    // Serializes `record` (existence check -> out-of-order check -> save -> the
+    // caller's status RMW) per item id. The find-then-save and the downstream
+    // `apply` straddle several suspending Fluent calls, so an actor method alone
+    // is not atomic across them: two concurrent distinct-hash deliveries for the
+    // same item could both resolve `.stored` and both apply a status mutation in
+    // an interleaved, last-writer-wins fashion. A per-item in-process FIFO gate
+    // (mirroring `TokenStore`'s lock idiom) fully orders deliveries for one item
+    // while leaving distinct items concurrent. The companion server is a single
+    // local process, so an in-process gate is sufficient.
+    private var lockedItemIds: Set<String> = []
+    private var itemWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
     init(fluent: Fluent) {
         self.fluent = fluent
+    }
+
+    /// Runs `body` while holding the per-item serialization lock, so the
+    /// out-of-order decision, the save, and any status mutation the caller
+    /// performs on `body`'s result are atomic for a single item. Distinct items
+    /// never contend.
+    func withItemLock<T: Sendable>(
+        itemId: String,
+        _ body: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        await acquireItemLock(itemId: itemId)
+        defer { releaseItemLock(itemId: itemId) }
+        return try await body()
     }
 
     func record(_ signal: WebhookItemSignal) async throws -> WebhookStoreResult {
@@ -109,7 +134,19 @@ actor WebhookEventStore {
         }
 
         let latest = try await latestEvent(itemId: signal.itemId)
-        let isOutOfOrder = latest.map { $0.effectiveDate > signal.effectiveDate } ?? false
+        // Out-of-order is a statement about *event* ordering. Comparing a stored
+        // `receivedAt` against a new `eventAt` (or vice versa) mixes two
+        // unrelated clocks — the delivery clock and Plaid's event clock — and can
+        // spuriously flag (or miss) reordering. Only decide ordering when BOTH
+        // the stored latest event and the incoming signal carry an `eventAt`;
+        // absent that, treat the delivery as in-order (`.stored`) and rely on the
+        // status mapper to avoid regressions.
+        let isOutOfOrder: Bool
+        if let latestEventAt = latest?.eventAt, let signalEventAt = signal.eventAt {
+            isOutOfOrder = latestEventAt > signalEventAt
+        } else {
+            isOutOfOrder = false
+        }
         let model = WebhookEventModel(
             itemId: signal.itemId,
             webhookType: signal.webhookType,
@@ -155,6 +192,65 @@ actor WebhookEventStore {
                 result[signal.itemId] = signal
             }
         }
+    }
+
+    /// The latest *sync-relevant* webhook per item, independent of any later
+    /// non-sync delivery. `latestEventsByItem` collapses each item to its single
+    /// max-`effectiveDate` event, so a later non-sync code (e.g.
+    /// `PENDING_EXPIRATION`) hides an earlier still-pending
+    /// `SYNC_UPDATES_AVAILABLE`, silently dropping the sync signal. Filtering to
+    /// `needsSync` events *before* the max reduce keeps the sync signal sticky
+    /// until the owning item's refresh advances past it (see
+    /// `StatusRoutes.needsPollingSync`).
+    func latestSyncEventsByItem() async throws -> [String: WebhookItemSignal] {
+        let events = try await WebhookEventModel.query(on: fluent.db()).all()
+        return events
+            .compactMap(Self.signal(from:))
+            .filter(\.needsSync)
+            .reduce(into: [:]) { result, signal in
+                guard let existing = result[signal.itemId] else {
+                    result[signal.itemId] = signal
+                    return
+                }
+                if existing.effectiveDate < signal.effectiveDate {
+                    result[signal.itemId] = signal
+                }
+            }
+    }
+
+    // MARK: - Per-item serialization lock
+
+    private func acquireItemLock(itemId: String) async {
+        if !lockedItemIds.contains(itemId) {
+            lockedItemIds.insert(itemId)
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            itemWaiters[itemId, default: []].append(continuation)
+        }
+        // Resumed: the lock was handed off to us; the id stays in `lockedItemIds`.
+    }
+
+    private func releaseItemLock(itemId: String) {
+        if var waiters = itemWaiters[itemId], !waiters.isEmpty {
+            let next = waiters.removeFirst()
+            if waiters.isEmpty {
+                itemWaiters[itemId] = nil
+            } else {
+                itemWaiters[itemId] = waiters
+            }
+            next.resume()
+        } else {
+            lockedItemIds.remove(itemId)
+        }
+    }
+
+    /// Test seam: the number of persisted event rows for an item. Used to assert
+    /// no write is lost when concurrent distinct-hash deliveries are serialized.
+    func allEventCountForTest(itemId: String) async throws -> Int {
+        try await WebhookEventModel.query(on: fluent.db())
+            .filter(\.$itemId == itemId)
+            .count()
     }
 
     private static func signal(from model: WebhookEventModel) -> WebhookItemSignal? {

--- a/Tests/PlaidBarServerTests/WebhookDefectAndVerifierTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookDefectAndVerifierTests.swift
@@ -1,0 +1,478 @@
+import CryptoKit
+import FluentKit
+import FluentSQLiteDriver
+import Foundation
+import Hummingbird
+import HummingbirdFluent
+import HTTPTypes
+import Logging
+import NIOCore
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+/// AND-634 (dormant ordering/state defect fixes) + AND-646 (gated real ES256
+/// signature verifier). The three AND-634 cases are regressions: each fails on
+/// the pre-fix code and passes after.
+@Suite("Webhook ordering/state defects and gated verifier")
+struct WebhookDefectAndVerifierTests {
+    // MARK: - AND-634 #1: clock-mixing out-of-order key
+
+    @Test("Out-of-order is decided only when both events carry an eventAt")
+    func outOfOrderOnlyWhenBothHaveEventAt() async throws {
+        try await Self.withStore { eventStore in
+            // First delivery: NO eventAt, only receivedAt (far in the future).
+            let first = Self.signal(
+                hash: "h1",
+                eventAt: nil,
+                receivedAt: Date(timeIntervalSince1970: 2_000_000_000),
+                code: "DEFAULT_UPDATE"
+            )
+            let firstResult = try await eventStore.record(first)
+            #expect(firstResult.disposition == .stored)
+
+            // Second delivery: HAS an eventAt that is *earlier* than the stored
+            // receivedAt. The pre-fix code compared stored receivedAt
+            // (2_000_000_000) against the new eventAt and spuriously flagged
+            // out-of-order. With the fix, ordering is undecidable (the stored
+            // event has no eventAt) so it is treated as in-order (.stored).
+            let second = Self.signal(
+                hash: "h2",
+                eventAt: Date(timeIntervalSince1970: 1_000_000_000),
+                receivedAt: Date(timeIntervalSince1970: 2_000_000_001),
+                code: "DEFAULT_UPDATE"
+            )
+            let secondResult = try await eventStore.record(second)
+            #expect(secondResult.disposition == .stored)
+        }
+    }
+
+    @Test("Out-of-order still fires when both events carry an eventAt")
+    func outOfOrderFiresWhenBothHaveEventAt() async throws {
+        try await Self.withStore { eventStore in
+            let newer = Self.signal(
+                hash: "n1",
+                eventAt: Date(timeIntervalSince1970: 1_000_000_200),
+                receivedAt: Date(timeIntervalSince1970: 1_000_000_200),
+                code: "DEFAULT_UPDATE"
+            )
+            _ = try await eventStore.record(newer)
+
+            let older = Self.signal(
+                hash: "n2",
+                eventAt: Date(timeIntervalSince1970: 1_000_000_100),
+                receivedAt: Date(timeIntervalSince1970: 1_000_000_300),
+                code: "DEFAULT_UPDATE"
+            )
+            let result = try await eventStore.record(older)
+            #expect(result.disposition == .outOfOrder)
+        }
+    }
+
+    // MARK: - AND-634 #2: needsPollingSync masked by a later non-sync webhook
+
+    @Test("A later non-sync webhook does not mask an earlier pending sync signal")
+    func laterNonSyncDoesNotMaskPendingSync() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            // Both events are dated *after* the item's creation `updatedAt` so the
+            // sync is genuinely pending (the item has not refreshed past it).
+            let base = Date().addingTimeInterval(60)
+            // Earlier: SYNC_UPDATES_AVAILABLE (needsSync) at T0.
+            _ = try await eventStore.record(Self.signal(
+                hash: "sync-1",
+                eventAt: base,
+                receivedAt: base,
+                code: "SYNC_UPDATES_AVAILABLE"
+            ))
+            // Later: PENDING_EXPIRATION (NOT needsSync) at T1 > T0. Pre-fix this
+            // collapsed the per-item state to the max-effectiveDate event and
+            // hid the still-pending sync signal.
+            _ = try await eventStore.record(Self.signal(
+                hash: "pending-1",
+                eventAt: base.addingTimeInterval(60),
+                receivedAt: base.addingTimeInterval(60),
+                code: "PENDING_EXPIRATION"
+            ))
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+            let status = try await statusRoutes.statusSnapshot(includeItems: true)
+            let item = try #require(status.itemStatuses?.first)
+            // Sync remains needed despite the later non-sync delivery.
+            #expect(item.needsSync)
+            // Display still reflects the latest-overall event.
+            #expect(item.lastWebhookEvent == "ITEM.PENDING_EXPIRATION")
+        }
+    }
+
+    @Test("Sticky sync signal clears once the item refresh advances past it")
+    func stickySyncClearsAfterRefresh() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            // Events dated "now" sit after the item's creation `updatedAt`, so the
+            // sync is pending; a later refresh bumps `updatedAt` past them.
+            let syncAt = Date()
+            _ = try await eventStore.record(Self.signal(
+                hash: "sync-2",
+                eventAt: syncAt,
+                receivedAt: syncAt,
+                code: "SYNC_UPDATES_AVAILABLE"
+            ))
+            // A later non-sync delivery must not clear the still-pending sync.
+            _ = try await eventStore.record(Self.signal(
+                hash: "pending-2",
+                eventAt: syncAt.addingTimeInterval(1),
+                receivedAt: syncAt.addingTimeInterval(1),
+                code: "PENDING_EXPIRATION"
+            ))
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+            #expect(try #require(try await statusRoutes.statusSnapshot(includeItems: true).itemStatuses?.first).needsSync)
+
+            // Item refresh advances updatedAt to a fresh now, past the sync event.
+            try await Task.sleep(for: .milliseconds(20))
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            let refreshed = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(!(try #require(refreshed.itemStatuses?.first).needsSync))
+        }
+    }
+
+    // MARK: - AND-634 #3: concurrent-delivery race serialized per item
+
+    @Test("Concurrent distinct-hash deliveries for one item are serialized and both apply in order")
+    func concurrentDistinctDeliveriesAreSerialized() async throws {
+        try await Self.withStores { tokenStore, eventStore in
+            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            let route = WebhookRoutes(
+                verifier: Self.acceptingVerifier,
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            )
+            // Two distinct webhooks (different codes -> different hashes) for the
+            // SAME item, delivered concurrently. Pre-fix, both could resolve
+            // .stored and interleave their status read-modify-writes. The
+            // per-item lock serializes record+apply, so both are stored and the
+            // store ends with exactly two rows for the item.
+            let loginRequired = Self.payload(code: "ITEM_LOGIN_REQUIRED", timestamp: "2026-06-14T12:00:00Z")
+            let pendingExpiration = Self.payload(code: "PENDING_EXPIRATION", timestamp: "2026-06-14T12:05:00Z")
+
+            @Sendable func deliver(_ body: String) async throws {
+                _ = try await route.receive(
+                    request: Self.request(body: body, jwt: "header.payload.sig"),
+                    context: WebhookDefectTestContext(source: WebhookDefectTestContextSource())
+                )
+            }
+
+            async let a: Void = deliver(loginRequired)
+            async let b: Void = deliver(pendingExpiration)
+            _ = try await (a, b)
+
+            // Both rows persisted (no lost write under the lock).
+            let rows = try await eventStore.allEventCountForTest(itemId: "item-webhook")
+            #expect(rows == 2)
+            // Final status is a valid one of the two applied codes — never a
+            // torn/interleaved value. (Both map deterministically off .connected.)
+            let status = try await tokenStore.getItem(id: "item-webhook")?.status
+            #expect(
+                status == ItemConnectionStatus.loginRequired.rawValue
+                    || status == ItemConnectionStatus.pendingExpiration.rawValue
+            )
+        }
+    }
+
+    @Test("Distinct items are not blocked by each other's lock")
+    func distinctItemsDoNotBlock() async throws {
+        try await Self.withStore { eventStore in
+            // Two locks on different ids can be held concurrently without
+            // deadlock; both bodies run and return.
+            async let a = eventStore.withItemLock(itemId: "item-a") { "a" }
+            async let b = eventStore.withItemLock(itemId: "item-b") { "b" }
+            let results = await Set([a, b])
+            #expect(results == ["a", "b"])
+        }
+    }
+
+    // MARK: - AND-646: real ES256 signature verifier (synthetic keypair)
+
+    @Test("ES256 validator accepts a correctly signed JWT and rejects tampering")
+    func es256ValidatorAcceptsAndRejects() async throws {
+        let privateKey = P256.Signing.PrivateKey()
+        let kid = "test-kid"
+        let keySource = StaticPlaidWebhookKeySource(keysByID: [kid: privateKey.publicKey])
+        let validator = ES256PlaidWebhookSignatureValidator(keySource: keySource)
+
+        let headerJSON = #"{"alg":"ES256","kid":"\#(kid)"}"#
+        let claimsJSON = #"{"iat":1800000000,"request_body_sha256":"abc"}"#
+        let signingInput = "\(Self.base64URL(Data(headerJSON.utf8))).\(Self.base64URL(Data(claimsJSON.utf8)))"
+        let signature = try privateKey.signature(for: SHA256.hash(data: Data(signingInput.utf8)))
+        let validJWT = "\(signingInput).\(Self.base64URL(signature.rawRepresentation))"
+
+        let header = PlaidWebhookJWTHeader(alg: "ES256", kid: kid)
+        let claims = PlaidWebhookJWTClaims(iat: 1_800_000_000, requestBodySHA256: "abc", bodySHA256: nil)
+
+        // Correct signature passes.
+        try await validator.validate(jwt: validJWT, header: header, claims: claims)
+
+        // Tampered payload -> signature mismatch.
+        let tamperedJWT = "\(Self.base64URL(Data(headerJSON.utf8))).\(Self.base64URL(Data(#"{"iat":1}"#.utf8))).\(Self.base64URL(signature.rawRepresentation))"
+        await #expect(throws: PlaidWebhookSignatureError.signatureMismatch) {
+            try await validator.validate(jwt: tamperedJWT, header: header, claims: claims)
+        }
+
+        // Unknown kid -> rejected before any crypto.
+        let unknownHeader = PlaidWebhookJWTHeader(alg: "ES256", kid: "other-kid")
+        await #expect(throws: PlaidWebhookSignatureError.unknownKeyID) {
+            try await validator.validate(jwt: validJWT, header: unknownHeader, claims: claims)
+        }
+
+        // Missing kid -> rejected.
+        let noKidHeader = PlaidWebhookJWTHeader(alg: "ES256", kid: nil)
+        await #expect(throws: PlaidWebhookSignatureError.missingKeyID) {
+            try await validator.validate(jwt: validJWT, header: noKidHeader, claims: claims)
+        }
+    }
+
+    @Test("JWK round-trips to a usable P-256 public key")
+    func jwkParsesToPublicKey() throws {
+        let privateKey = P256.Signing.PrivateKey()
+        let x963 = privateKey.publicKey.x963Representation
+        // x963 layout: 0x04 || x(32) || y(32).
+        let x = x963.subdata(in: 1..<33)
+        let y = x963.subdata(in: 33..<65)
+        let jwkJSON = """
+        {"kty":"EC","crv":"P-256","x":"\(Self.base64URL(x))","y":"\(Self.base64URL(y))","kid":"k1"}
+        """
+        let jwk = try JSONDecoder().decode(PlaidWebhookJWK.self, from: Data(jwkJSON.utf8))
+        let rebuilt = try jwk.publicKey()
+        #expect(rebuilt.x963Representation == privateKey.publicKey.x963Representation)
+
+        // Non-EC key type is rejected.
+        let rsaJWK = PlaidWebhookJWK(kty: "RSA", crv: "P-256", x: "AA", y: "AA", kid: "k2")
+        #expect(throws: PlaidWebhookSignatureError.unsupportedKeyType) {
+            try rsaJWK.publicKey()
+        }
+    }
+
+    @Test("StrictPlaidWebhookVerifier end-to-end with the real ES256 validator")
+    func strictVerifierEndToEndWithES256() async throws {
+        let privateKey = P256.Signing.PrivateKey()
+        let kid = "e2e-kid"
+        let keySource = StaticPlaidWebhookKeySource(keysByID: [kid: privateKey.publicKey])
+        let verifier = StrictPlaidWebhookVerifier(
+            signatureValidator: ES256PlaidWebhookSignatureValidator(keySource: keySource)
+        )
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data(#"{"webhook_type":"ITEM","webhook_code":"LOGIN_REPAIRED","item_id":"x"}"#.utf8)
+        let headerJSON = #"{"alg":"ES256","kid":"\#(kid)"}"#
+        let claimsJSON = #"{"iat":1800000000,"request_body_sha256":"\#(StrictPlaidWebhookVerifier.sha256Hex(body))"}"#
+        let signingInput = "\(Self.base64URL(Data(headerJSON.utf8))).\(Self.base64URL(Data(claimsJSON.utf8)))"
+        let signature = try privateKey.signature(for: SHA256.hash(data: Data(signingInput.utf8)))
+        let jwt = "\(signingInput).\(Self.base64URL(signature.rawRepresentation))"
+
+        // Full structural + claims + body-hash + signature path passes.
+        try await verifier.verify(jwt: jwt, body: body, now: now)
+
+        // A signature made over a *different* body fails the body-hash gate
+        // before crypto even runs.
+        await #expect(throws: PlaidWebhookVerificationError.bodyHashMismatch) {
+            try await verifier.verify(jwt: jwt, body: Data("{}".utf8), now: now)
+        }
+    }
+
+    // MARK: - AND-646 gating: default config ships dormant
+
+    @Test("Webhook verification config defaults to disabled and only opts in explicitly")
+    func webhookVerificationConfigGating() throws {
+        #expect(PlaidWebhookVerificationConfig.resolved(from: [:]) == .disabled)
+        #expect(PlaidWebhookVerificationConfig.resolved(from: ["PLAIDBAR_WEBHOOK_VERIFICATION": ""]) == .disabled)
+        #expect(PlaidWebhookVerificationConfig.resolved(from: ["PLAIDBAR_WEBHOOK_VERIFICATION": "nonsense"]) == .disabled)
+
+        let enabled = PlaidWebhookVerificationConfig.resolved(from: ["PLAIDBAR_WEBHOOK_VERIFICATION": "on"])
+        #expect(enabled.enabled)
+        #expect(enabled.signingKeyJWKJSON == nil)
+
+        let withKey = PlaidWebhookVerificationConfig.resolved(from: [
+            "PLAIDBAR_WEBHOOK_VERIFICATION": "true",
+            "PLAIDBAR_WEBHOOK_SIGNING_JWK": #"{"kty":"EC"}"#,
+        ])
+        #expect(withKey.enabled)
+        #expect(withKey.signingKeyJWKJSON == #"{"kty":"EC"}"#)
+    }
+
+    @Test("Default-config verifier keeps the dormant unconfigured signature validator")
+    func defaultVerifierStaysDormant() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-webhook-cfg-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=
+        PLAID_SECRET=
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(directory.appendingPathComponent("data").path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        let config = try ServerConfig.load(from: configURL.path)
+        #expect(config.webhookVerification == .disabled)
+
+        let logger = Logger(label: "test.webhook.gating")
+        let verifier = PlaidBarServer.webhookVerifier(config: config, logger: logger)
+        // The default-config verifier rejects with the unavailable signal,
+        // proving the dormant `UnconfiguredPlaidWebhookSignatureValidator` is
+        // still wired (receiver never activates).
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data(#"{"webhook_type":"ITEM","webhook_code":"LOGIN_REPAIRED","item_id":"x"}"#.utf8)
+        let headerJSON = #"{"alg":"ES256","kid":"k"}"#
+        let claimsJSON = #"{"iat":1800000000,"request_body_sha256":"\#(StrictPlaidWebhookVerifier.sha256Hex(body))"}"#
+        let jwt = "\(Self.base64URL(Data(headerJSON.utf8))).\(Self.base64URL(Data(claimsJSON.utf8))).sig"
+        await #expect(throws: PlaidWebhookVerificationError.signatureVerificationUnavailable) {
+            try await verifier.verify(jwt: jwt, body: body, now: now)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let acceptingVerifier = NoopDefectVerifier()
+
+    private static func signal(
+        hash: String,
+        eventAt: Date?,
+        receivedAt: Date,
+        code: String,
+        itemId: String = "item-webhook"
+    ) -> WebhookItemSignal {
+        WebhookItemSignal(
+            itemId: itemId,
+            webhookType: "ITEM",
+            webhookCode: code,
+            requestId: "req-\(hash)",
+            idempotencyHash: hash,
+            eventAt: eventAt,
+            receivedAt: receivedAt,
+            needsSync: PlaidWebhookEvent.needsSync(webhookCode: code)
+        )
+    }
+
+    private static func payload(code: String, timestamp: String) -> String {
+        """
+        {"webhook_type":"ITEM","webhook_code":"\(code)","item_id":"item-webhook","request_id":"request-safe","timestamp":"\(timestamp)"}
+        """
+    }
+
+    private static func request(body: String, jwt: String) -> Request {
+        var headers = HTTPFields()
+        headers[HTTPField.Name("Plaid-Verification")!] = jwt
+        headers[.contentType] = "application/json"
+        return Request(
+            head: HTTPRequest(method: .post, scheme: nil, authority: nil, path: "/webhooks/plaid", headerFields: headers),
+            body: RequestBody(buffer: ByteBuffer(data: Data(body.utf8)))
+        )
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func withStore(
+        _ body: (WebhookEventStore) async throws -> Void
+    ) async throws {
+        try await withStores { _, eventStore in
+            try await body(eventStore)
+        }
+    }
+
+    private static func withStores(
+        _ body: (TokenStore, WebhookEventStore) async throws -> Void
+    ) async throws {
+        try await withStatusStores { tokenStore, _, eventStore, _ in
+            try await body(tokenStore, eventStore)
+        }
+    }
+
+    private static func withStatusStores(
+        _ body: (TokenStore, BillingSubscriptionStore, WebhookEventStore, ServerConfig) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-webhook-defect-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.webhook-defects")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
+        await fluent.migrations.add(CreateSyncCursors())
+        await fluent.migrations.add(CreateBillingSubscriptions())
+        await fluent.migrations.add(CreateWebhookEvents())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await ItemModel(
+                id: "item-webhook",
+                accessToken: "token-webhook",
+                institutionId: "ins-webhook",
+                institutionName: "Webhook Bank"
+            ).save(on: fluent.db())
+            try await body(
+                TokenStore(fluent: fluent, logger: logger),
+                BillingSubscriptionStore(fluent: fluent),
+                WebhookEventStore(fluent: fluent),
+                try setupStateConfig(in: directory)
+            )
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError {
+            throw bodyError
+        }
+    }
+
+    private static func setupStateConfig(in directory: URL) throws -> ServerConfig {
+        let dataDirectory = directory.appendingPathComponent("data", isDirectory: true)
+        let configURL = directory.appendingPathComponent("plaidbar.conf")
+        try """
+        PLAID_CLIENT_ID=
+        PLAID_SECRET=
+        PLAID_ENV=sandbox
+        PLAIDBAR_DATA_DIR=\(dataDirectory.path)
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+        return try ServerConfig.load(from: configURL.path)
+    }
+}
+
+/// Bypasses all JWT verification so the concurrency test exercises only the
+/// record-and-apply path under the per-item lock.
+private struct NoopDefectVerifier: PlaidWebhookVerifier {
+    func verify(jwt: String, body: Data, now: Date) async throws {}
+}
+
+private struct WebhookDefectTestContextSource: RequestContextSource {
+    let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.webhook-defects")
+}
+
+private struct WebhookDefectTestContext: RequestContext {
+    typealias Source = WebhookDefectTestContextSource
+
+    var coreContext: CoreRequestContextStorage
+
+    init(source: WebhookDefectTestContextSource) {
+        coreContext = CoreRequestContextStorage(source: source)
+    }
+}

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -58,6 +58,18 @@ struct WebhookReceiverTests {
         }
     }
 
+    @Test("Verifier body-hash comparison is length-checked and constant-time")
+    func verifierBodyHashComparison() {
+        let body = Data(Self.payload(webhookCode: "SYNC_UPDATES_AVAILABLE").utf8)
+        let hash = StrictPlaidWebhookVerifier.sha256Hex(body)
+        let changedLast = hash.last == "0" ? "1" : "0"
+        let sameLengthMismatch = String(hash.dropLast()) + changedLast
+
+        #expect(StrictPlaidWebhookVerifier.constantTimeEquals(hash, hash))
+        #expect(!StrictPlaidWebhookVerifier.constantTimeEquals(hash, sameLengthMismatch))
+        #expect(!StrictPlaidWebhookVerifier.constantTimeEquals(hash, hash + "0"))
+    }
+
     @Test("Duplicate delivery is idempotent and stores metadata only")
     func duplicateDeliveryIsIdempotent() async throws {
         try await Self.withStores { tokenStore, eventStore in


### PR DESCRIPTION
**DEFERRED feature (re-opens scope cut from v1).**

## What & why

Two coupled, deferred webhook-path items in the `PlaidBarServer` target.

**AND-634 (primary, fully tested)** fixes three real but currently-dormant defects in the server webhook path. They are latent because inbound webhook processing ships disabled (the receiver's signature validator always throws). Each fix lands with a regression test that fails on the pre-fix code:

1. **Clock-mixing out-of-order key.** `WebhookEventStore.record` computed ordering by comparing a stored event's `receivedAt` (delivery clock) against a new signal's `eventAt` (Plaid's event clock) — two unrelated clocks — and could spuriously flag (or miss) reordering.
2. **`needsPollingSync` masked by a later non-sync webhook.** The status path collapsed each item to its single max-`effectiveDate` event, so a later `PENDING_EXPIRATION` hid an earlier still-pending `SYNC_UPDATES_AVAILABLE`, silently dropping the sync signal.
3. **Concurrent-delivery race.** `record` suspends between the existence check and the save, and `apply` does an unlocked status read-modify-write, so two concurrent distinct-hash deliveries for the same item could both resolve `.stored` and interleave their status mutations (last-writer-wins).

**AND-646 (secondary, gated / non-activating)** wires a real ES256 webhook signature verifier to replace `UnconfiguredPlaidWebhookSignatureValidator` — but only when the operator explicitly opts in. The shipped default is byte-for-byte unchanged: the receiver stays dormant.

## Change

- **Fix 1** — `WebhookEventStore.record`: out-of-order is decided only when BOTH the stored latest event and the incoming signal carry an `eventAt`; otherwise the delivery is treated as in-order.
- **Fix 2** — new `WebhookEventStore.latestSyncEventsByItem()` filters to `needsSync` events *before* the max reduce, keeping the sync signal sticky. `StatusRoutes.needsPollingSync` reads from this sync-only projection; the latest-overall event still drives the display fields (`lastWebhookAt`, `lastWebhookEvent`). The sticky signal clears once the item's `updatedAt` advances past it.
- **Fix 3** — per-item async FIFO lock in `WebhookEventStore` (`withItemLock`, mirroring `TokenStore`'s lock idiom). `WebhookRoutes.receive` holds it across `record` + `apply`, making the out-of-order check, save, and status RMW atomic per item; distinct items stay concurrent.
- **AND-646** — new `PlaidWebhookSignatureVerifier.swift`: `ES256PlaidWebhookSignatureValidator` (pure, testable P-256/SHA-256 signature check over the JWS signing input), `PlaidWebhookKeySource` abstraction + `StaticPlaidWebhookKeySource`, and `PlaidWebhookJWK` (JWK → `P256.Signing.PublicKey`). Gated behind new `PlaidWebhookVerificationConfig` (`PLAIDBAR_WEBHOOK_VERIFICATION` opt-in; optional pinned key via `PLAIDBAR_WEBHOOK_SIGNING_JWK`), resolved in `ServerConfig.load`. `App.webhookVerifier(config:logger:)` returns the existing `StrictPlaidWebhookVerifier()` (dormant) unless explicitly enabled.

Scope is confined to the SERVER target. No app/`PlaidBarCore` changes, no secrets, no new persisted state. Any future hosted relay stores nothing — this is a local verification posture only.

## Testing

All run with the SwiftPM sandbox disabled (the repo's known requirement).

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (clean, no warnings).
- `swift test --filter "WebhookDefectAndVerifierTests"` → **11 tests passed** (new suite: the three AND-634 regressions incl. concurrent serialization, plus AND-646 ES256 accept/reject, JWK round-trip, strict-verifier end-to-end, and the gating/dormant-default assertions).
- `swift test --filter "WebhookReceiverTests"` → **9 tests passed** (existing suite, no regression).
- `git diff --check` → clean.
- `./Scripts/smoke-sandbox.sh` → could not run the full preflight here: it exits early requesting `PLAID_CLIENT_ID`/`PLAID_SECRET`, which are unavailable in this environment. The changes do not touch `/health` or `/api/status`; they are confined to the (dormant-by-default) `/webhooks/plaid` receiver and the `needsSync` computation in the status snapshot.

## Links

Closes AND-634
Closes AND-646

## Open questions / risks

- The real ES256 validator's cryptographic core is fully covered with a synthetic keypair, but the *production* key source — fetching Plaid's signing key by `kid` from `/webhook_verification_key/get` (which needs the server's Plaid credentials) — is intentionally left as the `PlaidWebhookKeySource` seam plus an operator-pinned-JWK path, not a live fetcher. Enabling end-to-end production verification still requires provisioning a key (or implementing a Plaid-backed key source) and flipping the opt-in; until then the receiver stays dormant.
- AND-634 fixes are inert in shipped behavior today (the receiver is disabled), so they cannot regress current users; they harden the path for whenever AND-646 is activated.
