### PR TITLE
feat(budgeting): per-month budgets + rollover envelope carry (AND-548)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/MonthlyBudgetEditor.swift
+++ b/Sources/PlaidBarCore/Utilities/MonthlyBudgetEditor.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Pure, deterministic per-month budget editing for budgeting v2 (AND-548).
+///
+/// The carry math lives in ``RolloverBudgetPlanner``; this is the small companion
+/// that *mutates the stored set* of ``MonthlyBudgetV2`` rows while enforcing the
+/// AC's immutability rule: **historical months are frozen, the current and future
+/// months are editable**. Every entry point returns a new ``BudgetingV2Schema``
+/// (value semantics) and leaves the input untouched, so it stays `Sendable` and
+/// trivially testable — no hidden `Date()`; "now" is the explicit `asOf` month key.
+///
+/// Editing a frozen historical month is rejected by returning the schema unchanged
+/// (a no-op), so a stale UI action can never rewrite history. Whether a month is
+/// editable is decided by ``RolloverBudgetPlanner/isMonthEditable(_:asOf:)`` — the
+/// single source of truth shared with the editor's enable/disable state.
+public enum MonthlyBudgetEditor {
+
+    /// The outcome of an edit attempt: the (possibly unchanged) schema plus whether
+    /// the edit was applied. `applied == false` means the target month was frozen
+    /// history and the schema is byte-identical to the input.
+    public struct EditResult: Sendable, Hashable {
+        public let schema: BudgetingV2Schema
+        public let applied: Bool
+
+        public init(schema: BudgetingV2Schema, applied: Bool) {
+            self.schema = schema
+            self.applied = applied
+        }
+    }
+
+    /// Upsert a per-month limit (and rollover flag) for one category, but only when
+    /// `month` is editable as of `asOf` (current or future). A frozen historical
+    /// month is a no-op.
+    ///
+    /// - Parameters:
+    ///   - schema: the current v2 snapshot.
+    ///   - categoryId: the ``BudgetCategoryV2/id`` to budget. Must exist in the
+    ///     schema's category table; an unknown id is rejected (no-op) so a budget can
+    ///     never reference a missing category.
+    ///   - month: the `YYYY-MM` month to set.
+    ///   - monthlyLimit: the new limit. A non-finite or negative value is rejected
+    ///     (no-op) — a budget limit is `>= 0`.
+    ///   - rollover: whether this month's remainder carries into the next month.
+    ///   - asOf: the current `YYYY-MM` (injected "now").
+    /// - Returns: the updated schema and whether the edit applied.
+    public static func setBudget(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        month: String,
+        monthlyLimit: Double,
+        rollover: Bool,
+        asOf: String
+    ) -> EditResult {
+        guard
+            RolloverBudgetPlanner.isMonthEditable(month, asOf: asOf),
+            monthlyLimit.isFinite,
+            monthlyLimit >= 0,
+            schema.category(id: categoryId) != nil
+        else {
+            return EditResult(schema: schema, applied: false)
+        }
+
+        let updatedRow = MonthlyBudgetV2(
+            month: month,
+            categoryId: categoryId,
+            monthlyLimit: monthlyLimit,
+            rollover: rollover
+        )
+
+        var budgets = schema.budgets.filter {
+            !($0.month == month && $0.categoryId == categoryId)
+        }
+        budgets.append(updatedRow)
+        budgets.sort { lhs, rhs in
+            lhs.month != rhs.month ? lhs.month < rhs.month : lhs.categoryId < rhs.categoryId
+        }
+
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+
+    /// Remove a category's budget for `month`, but only when `month` is editable as
+    /// of `asOf`. A frozen historical month is a no-op. Removing a row that doesn't
+    /// exist still reports `applied == true` (the post-state is "no budget for that
+    /// month", which is what was asked) but leaves the schema otherwise equal.
+    public static func removeBudget(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        month: String,
+        asOf: String
+    ) -> EditResult {
+        guard RolloverBudgetPlanner.isMonthEditable(month, asOf: asOf) else {
+            return EditResult(schema: schema, applied: false)
+        }
+        let budgets = schema.budgets.filter {
+            !($0.month == month && $0.categoryId == categoryId)
+        }
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+
+    /// Seed the next month's budget rows from the current month's: every category
+    /// budgeted in `fromMonth` gets the same limit and rollover flag in
+    /// `nextMonthKey(fromMonth)`, unless that next month already has a row for the
+    /// category (existing rows win — never clobber a user's forward edit). Only
+    /// applies when the destination month is editable as of `asOf`.
+    ///
+    /// This is the "carry the budget template forward" convenience the per-month
+    /// editor uses so a user doesn't re-enter every limit each month; the envelope
+    /// *value* carry is separate (``RolloverBudgetPlanner``).
+    public static func rolloverTemplateToNextMonth(
+        in schema: BudgetingV2Schema,
+        fromMonth: String,
+        asOf: String
+    ) -> EditResult {
+        guard
+            let nextMonth = RolloverBudgetPlanner.nextMonthKey(fromMonth),
+            RolloverBudgetPlanner.isMonthEditable(nextMonth, asOf: asOf)
+        else {
+            return EditResult(schema: schema, applied: false)
+        }
+
+        let existingNextKeys = Set(
+            schema.budgets
+                .filter { $0.month == nextMonth }
+                .map(\.categoryId)
+        )
+        let template = schema.budgets.filter { $0.month == fromMonth }
+        guard !template.isEmpty else { return EditResult(schema: schema, applied: false) }
+
+        var budgets = schema.budgets
+        var addedAny = false
+        for row in template where !existingNextKeys.contains(row.categoryId) {
+            budgets.append(
+                MonthlyBudgetV2(
+                    month: nextMonth,
+                    categoryId: row.categoryId,
+                    monthlyLimit: row.monthlyLimit,
+                    rollover: row.rollover
+                )
+            )
+            addedAny = true
+        }
+        guard addedAny else { return EditResult(schema: schema, applied: false) }
+
+        budgets.sort { lhs, rhs in
+            lhs.month != rhs.month ? lhs.month < rhs.month : lhs.categoryId < rhs.categoryId
+        }
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/RolloverBudgetPlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/RolloverBudgetPlanner.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// Pure, deterministic per-month budget + rollover ("envelope carry") planning
+/// for budgeting v2 (AND-548 — deferred epic AND-524).
+///
+/// ## What this adds on top of AND-546
+///
+/// The merged v2 schema (AND-546) already persists ``MonthlyBudgetV2`` rows keyed
+/// by `(month, category)` with a per-row `rollover` flag. The *foundation only
+/// stores* those fields. This planner is the **math**: given a category's
+/// chronological budget rows and that category's per-month spend, it computes the
+/// envelope carry — the unspent (or overspent) remainder of each month rolled into
+/// the next month's available amount when rollover is enabled for that month.
+///
+/// ## Carry-forward rule
+///
+/// For one category, walking its months in chronological order, with `carryIn`
+/// seeded to `0` for the first month:
+///
+/// ```text
+/// available = monthlyLimit + carryIn
+/// spent     = override-aware net spend for the month  (signed; refunds net in)
+/// remaining = available - spent
+/// carryOut  = (this month's row.rollover) ? remaining : 0
+/// ```
+///
+/// `carryOut` feeds the next chronological month's `carryIn`. The carry is a true
+/// **envelope**: a positive `remaining` (under budget) *adds* to next month, and a
+/// negative `remaining` (over budget) *subtracts* from it — overspend carries too,
+/// matching the issue's "unspent **or** overspend" rule. A gap month with no
+/// budget row breaks the chain (there is no envelope to carry through), so a later
+/// month starts fresh from its own limit.
+///
+/// ## Per-category opt-out
+///
+/// Rollover is opt-in per `(month, category)` via the row's `rollover` flag, so a
+/// category opts out simply by having `rollover == false` on its rows — that month
+/// keeps `carryOut == 0` and the next month starts from its bare limit. A whole
+/// category can be opted out in one call with ``optedOutCategoryIds``, which forces
+/// `carryOut == 0` for every one of its months regardless of the row flag (the
+/// UI's per-category toggle); the stored rows are never mutated.
+///
+/// ## Historical immutability
+///
+/// The planner is read-only — it never edits a row. Whether a month is *editable*
+/// is a policy the UI enforces; ``isMonthEditable(_:asOf:calendar:)`` encodes it
+/// (only the current month and the future are editable; past months are frozen
+/// history). The carry math itself reads every month, past and present, so a frozen
+/// historical month still contributes its remainder to the carry.
+///
+/// ## Determinism
+///
+/// Like ``CategoryBudgetPlanner`` and ``SafeToSpendCalculator``, every entry point
+/// takes an explicit `Calendar` (and, where "now" matters, an explicit `asOf`
+/// month key) — there is no hidden `Date()`. Results are fully reproducible in
+/// `PlaidBarCore` unit tests.
+public enum RolloverBudgetPlanner {
+
+    // MARK: - Per-month result
+
+    /// The resolved budget for a single `(category, month)` after applying the
+    /// envelope carry. Pure value type; `Sendable`.
+    public struct MonthResult: Sendable, Hashable {
+        /// The budgeted month, `YYYY-MM`.
+        public let month: String
+        /// The v2 category id (``BudgetCategoryV2/id``).
+        public let categoryId: String
+        /// The month's own stored limit (``MonthlyBudgetV2/monthlyLimit``).
+        public let baseLimit: Double
+        /// Remainder carried *into* this month from the prior month's envelope.
+        /// `0` for the first month in the chain, for a month whose predecessor had
+        /// rollover off, or after a gap. Can be negative (carried overspend).
+        public let carriedIn: Double
+        /// Effective spending power this month: `baseLimit + carriedIn`.
+        public let available: Double
+        /// Override-aware net spend booked against this category this month.
+        public let spent: Double
+        /// What's left after spend: `available - spent`. Negative when overspent.
+        public let remaining: Double
+        /// Remainder carried *out* of this month into the next: `remaining` when
+        /// rollover is active for this month, else `0`.
+        public let carriedOut: Double
+        /// Whether rollover was active for this month (row flag on, category not
+        /// globally opted out). Surfaced so the UI can label the carry without
+        /// re-deriving it (never communicate the on/off state by color alone).
+        public let rolloverActive: Bool
+
+        public init(
+            month: String,
+            categoryId: String,
+            baseLimit: Double,
+            carriedIn: Double,
+            spent: Double,
+            rolloverActive: Bool
+        ) {
+            self.month = month
+            self.categoryId = categoryId
+            self.baseLimit = baseLimit
+            self.carriedIn = carriedIn
+            self.available = baseLimit + carriedIn
+            self.spent = spent
+            self.remaining = (baseLimit + carriedIn) - spent
+            self.carriedOut = rolloverActive ? ((baseLimit + carriedIn) - spent) : 0
+            self.rolloverActive = rolloverActive
+        }
+
+        /// Stable identity — one result per `(month, category)`, matching
+        /// ``MonthlyBudgetV2/id``.
+        public var id: String { "\(month)|\(categoryId)" }
+    }
+
+    // MARK: - Carry-forward over one category's months
+
+    /// Resolve the envelope carry across `budgets` for **one** category, in
+    /// chronological month order.
+    ///
+    /// - Parameters:
+    ///   - budgets: this category's ``MonthlyBudgetV2`` rows (any order; the planner
+    ///     sorts by month). Rows for other categories are ignored. Duplicate months
+    ///     for the category collapse to the last one seen after sort (a malformed
+    ///     input degrades, never crashes).
+    ///   - spendByMonth: override-aware net spend per `YYYY-MM` for this category
+    ///     (typically derived from ``CategoryBudgetPlanner/overrideAwareSpend(transactions:month:metadata:rules:calendar:)``).
+    ///     A missing month is treated as `0` spend.
+    ///   - categoryId: the category these budgets belong to (used to filter
+    ///     `budgets` and to ignore the global opt-out check). Pass the
+    ///     ``BudgetCategoryV2/id``.
+    ///   - optedOut: when `true`, this category is globally opted out of rollover —
+    ///     every month's `carryOut` is forced to `0` regardless of its row flag.
+    /// - Returns: one ``MonthResult`` per budgeted month, in chronological order.
+    public static func resolveCarry(
+        budgets: [MonthlyBudgetV2],
+        spendByMonth: [String: Double],
+        categoryId: String,
+        optedOut: Bool = false
+    ) -> [MonthResult] {
+        // Only this category's rows; collapse dup months (last wins) and sort
+        // chronologically — `YYYY-MM` sorts lexicographically in date order.
+        var rowByMonth: [String: MonthlyBudgetV2] = [:]
+        for budget in budgets where budget.categoryId == categoryId {
+            rowByMonth[budget.month] = budget
+        }
+        let months = rowByMonth.keys.sorted()
+        guard !months.isEmpty else { return [] }
+
+        var results: [MonthResult] = []
+        results.reserveCapacity(months.count)
+
+        var carryIn = 0.0
+        var previousMonth: String?
+
+        for month in months {
+            // A non-contiguous gap breaks the envelope: there's no budget row in the
+            // intervening month(s) to carry through, so the chain restarts here.
+            if let previousMonth, !Self.isImmediateSuccessor(previousMonth, of: month) {
+                carryIn = 0
+            }
+
+            guard let row = rowByMonth[month] else { continue }
+            let spent = spendByMonth[month] ?? 0
+            // Rollover is active only when the row opts in AND the category isn't
+            // globally opted out by the caller's per-category toggle.
+            let rolloverActive = row.rollover && !optedOut
+
+            let result = MonthResult(
+                month: month,
+                categoryId: categoryId,
+                baseLimit: row.monthlyLimit,
+                carriedIn: carryIn,
+                spent: spent,
+                rolloverActive: rolloverActive
+            )
+            results.append(result)
+
+            carryIn = result.carriedOut
+            previousMonth = month
+        }
+        return results
+    }
+
+    /// Resolve the envelope carry for **every** category present in `budgets`,
+    /// returning each category's chronological ``MonthResult`` chain keyed by
+    /// category id. A convenience fan-out over ``resolveCarry(budgets:spendByMonth:categoryId:optedOut:)``.
+    ///
+    /// - Parameters:
+    ///   - budgets: all ``MonthlyBudgetV2`` rows (mixed categories/months).
+    ///   - spendByMonthByCategory: override-aware net spend keyed
+    ///     `categoryId → (YYYY-MM → spend)`.
+    ///   - optedOutCategoryIds: category ids globally opted out of rollover (the
+    ///     per-category toggle); their `carryOut` is forced to `0` every month.
+    public static func resolveCarryByCategory(
+        budgets: [MonthlyBudgetV2],
+        spendByMonthByCategory: [String: [String: Double]],
+        optedOutCategoryIds: Set<String> = []
+    ) -> [String: [MonthResult]] {
+        let categoryIds = Set(budgets.map(\.categoryId))
+        var out: [String: [MonthResult]] = [:]
+        out.reserveCapacity(categoryIds.count)
+        for categoryId in categoryIds {
+            out[categoryId] = resolveCarry(
+                budgets: budgets,
+                spendByMonth: spendByMonthByCategory[categoryId] ?? [:],
+                categoryId: categoryId,
+                optedOut: optedOutCategoryIds.contains(categoryId)
+            )
+        }
+        return out
+    }
+
+    // MARK: - Historical immutability policy
+
+    /// Whether `month` (`YYYY-MM`) is editable as of `asOf` (`YYYY-MM`). The current
+    /// month and any future month are editable; a past month is frozen history.
+    ///
+    /// This is the policy behind the AC "historical months immutable, current
+    /// editable" — the planner exposes it so a single source of truth gates the
+    /// editor UI. The carry math itself still reads frozen months (their stored
+    /// remainder rolls forward); only *editing* a frozen month is disallowed.
+    ///
+    /// A malformed `month` or `asOf` key returns `false` (fail closed — never let a
+    /// bad key make a historical month look editable).
+    public static func isMonthEditable(_ month: String, asOf: String) -> Bool {
+        guard Self.isCanonicalMonthKey(month), Self.isCanonicalMonthKey(asOf) else {
+            return false
+        }
+        return month >= asOf
+    }
+
+    // MARK: - Month-key arithmetic
+
+    /// The `YYYY-MM` month key for the month after `month`, or `nil` for a malformed
+    /// key. Deterministic — pure string arithmetic on the canonical key, so it needs
+    /// no `Calendar` and matches the lexicographic ordering the rest of the app sorts
+    /// months by.
+    public static func nextMonthKey(_ month: String) -> String? {
+        guard let (year, monthValue) = parseMonthKey(month) else { return nil }
+        let next = monthValue == 12 ? (year + 1, 1) : (year, monthValue + 1)
+        return formatMonthKey(year: next.0, month: next.1)
+    }
+
+    /// The `YYYY-MM` month key for the month before `month`, or `nil` for a
+    /// malformed key.
+    public static func previousMonthKey(_ month: String) -> String? {
+        guard let (year, monthValue) = parseMonthKey(month) else { return nil }
+        let prev = monthValue == 1 ? (year - 1, 12) : (year, monthValue - 1)
+        return formatMonthKey(year: prev.0, month: prev.1)
+    }
+
+    /// The `YYYY-MM` month key for the month containing `date` in `calendar`. The one
+    /// entry point that consults a date — and only via an explicit injected
+    /// `Calendar`, so "now" stays testable.
+    public static func monthKey(for date: Date, calendar: Calendar) -> String? {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        guard let year = components.year, let month = components.month else { return nil }
+        return formatMonthKey(year: year, month: month)
+    }
+
+    // MARK: - Internals
+
+    /// Whether `candidate` is exactly the month after `month` (`YYYY-MM`). Used to
+    /// detect a contiguous chain vs. a gap that resets the carry.
+    static func isImmediateSuccessor(_ month: String, of candidate: String) -> Bool {
+        nextMonthKey(month) == candidate
+    }
+
+    /// Fast structural check that `value` is a canonical `YYYY-MM` month key with an
+    /// in-range month (`01`…`12`). Mirrors `Formatters.isCanonicalTransactionDateKey`
+    /// for the month bucket.
+    static func isCanonicalMonthKey(_ value: String) -> Bool {
+        parseMonthKey(value) != nil
+    }
+
+    /// Parse a canonical `YYYY-MM` key into `(year, month)`, or `nil` when malformed
+    /// (wrong length/shape, non-numeric, month out of `1...12`).
+    static func parseMonthKey(_ value: String) -> (year: Int, month: Int)? {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              parts[0].count == 4,
+              parts[1].count == 2,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              (1...12).contains(month)
+        else { return nil }
+        return (year, month)
+    }
+
+    /// Format `(year, month)` back into a zero-padded canonical `YYYY-MM` key.
+    static func formatMonthKey(year: Int, month: Int) -> String {
+        let yearPart = String(format: "%04d", year)
+        let monthPart = String(format: "%02d", month)
+        return "\(yearPart)-\(monthPart)"
+    }
+}

--- a/Tests/PlaidBarCoreTests/MonthlyBudgetEditorTests.swift
+++ b/Tests/PlaidBarCoreTests/MonthlyBudgetEditorTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Per-month budget editing under the historical-immutability rule (AND-548).
+///
+/// "Now" is always an explicit `asOf` month key — no wall-clock `Date()`. Verifies
+/// the editor upserts/removes only on the current/future months, rejects edits to
+/// frozen historical months (no-op), validates inputs, and forward-seeds the budget
+/// template without clobbering existing forward edits.
+@Suite("Monthly budget editor — immutable history (AND-548)")
+struct MonthlyBudgetEditorTests {
+
+    private let food = SpendingCategory.foodAndDrink.rawValue
+    private let shopping = SpendingCategory.shopping.rawValue
+
+    /// A seeded (taxonomy-complete) schema with no budgets — the realistic starting
+    /// point after opt-in.
+    private func emptySchema() -> BudgetingV2Schema {
+        BudgetingV2Migration.seed()
+    }
+
+    // MARK: - Set on an editable month
+
+    @Test("Setting a budget on the current month applies and stores the row")
+    func setOnCurrentMonthApplies() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(),
+            categoryId: food,
+            month: "2026-06",
+            monthlyLimit: 500,
+            rollover: true,
+            asOf: "2026-06"
+        )
+        #expect(result.applied)
+        let row = result.schema.budgets.first { $0.month == "2026-06" && $0.categoryId == food }
+        #expect(row?.monthlyLimit == 500)
+        #expect(row?.rollover == true)
+    }
+
+    @Test("Setting a budget on a future month applies")
+    func setOnFutureMonthApplies() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(),
+            categoryId: food,
+            month: "2026-08",
+            monthlyLimit: 250,
+            rollover: false,
+            asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(result.schema.budgets.contains { $0.month == "2026-08" })
+    }
+
+    @Test("Re-setting the same month/category upserts (no duplicate row)")
+    func resetUpsertsInPlace() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 600, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let matching = schema.budgets.filter { $0.month == "2026-06" && $0.categoryId == food }
+        #expect(matching.count == 1)
+        #expect(matching.first?.monthlyLimit == 600)
+        #expect(matching.first?.rollover == false)
+    }
+
+    // MARK: - Historical immutability
+
+    @Test("Setting a budget on a past month is a no-op — history is frozen")
+    func setOnPastMonthIsNoOp() {
+        let before = emptySchema()
+        let result = MonthlyBudgetEditor.setBudget(
+            in: before,
+            categoryId: food,
+            month: "2026-05", // past relative to asOf
+            monthlyLimit: 500,
+            rollover: true,
+            asOf: "2026-06"
+        )
+        #expect(!result.applied)
+        #expect(result.schema == before) // byte-identical, nothing rewritten
+    }
+
+    @Test("Removing a budget from a past month is a no-op")
+    func removeFromPastMonthIsNoOp() {
+        // Build a schema that already holds a (frozen) historical budget.
+        let seeded = BudgetingV2Migration.seed(
+            carryingForward: [CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500)],
+            month: "2026-05"
+        )
+        let result = MonthlyBudgetEditor.removeBudget(
+            in: seeded, categoryId: food, month: "2026-05", asOf: "2026-06"
+        )
+        #expect(!result.applied)
+        #expect(result.schema == seeded) // the historical row survives
+    }
+
+    @Test("Removing a budget from the current month applies")
+    func removeFromCurrentMonthApplies() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        let result = MonthlyBudgetEditor.removeBudget(
+            in: schema, categoryId: food, month: "2026-06", asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(!result.schema.budgets.contains { $0.month == "2026-06" && $0.categoryId == food })
+    }
+
+    // MARK: - Input validation
+
+    @Test("A negative or non-finite limit is rejected (no-op)")
+    func invalidLimitRejected() {
+        let before = emptySchema()
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: -10, rollover: false, asOf: "2026-06"
+        ).applied)
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: .nan, rollover: false, asOf: "2026-06"
+        ).applied)
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: .infinity, rollover: false, asOf: "2026-06"
+        ).applied)
+    }
+
+    @Test("A zero limit is allowed (a deliberately zeroed envelope)")
+    func zeroLimitAllowed() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: food, month: "2026-06",
+            monthlyLimit: 0, rollover: false, asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(result.schema.budgets.first { $0.month == "2026-06" }?.monthlyLimit == 0)
+    }
+
+    @Test("An unknown category id is rejected — a budget can't reference a missing category")
+    func unknownCategoryRejected() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: "NOT_A_REAL_CATEGORY", month: "2026-06",
+            monthlyLimit: 100, rollover: false, asOf: "2026-06"
+        )
+        #expect(!result.applied)
+    }
+
+    @Test("A malformed asOf freezes everything (fail closed)")
+    func malformedAsOfFreezes() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: food, month: "2026-06",
+            monthlyLimit: 100, rollover: false, asOf: "bad"
+        )
+        #expect(!result.applied)
+    }
+
+    // MARK: - Forward template seeding
+
+    @Test("Forward-seeding copies the current month's budgets into the next month")
+    func forwardSeedCopiesTemplate() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: shopping, month: "2026-06",
+            monthlyLimit: 300, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: schema, fromMonth: "2026-06", asOf: "2026-06"
+        )
+        #expect(result.applied)
+        let july = result.schema.budgets.filter { $0.month == "2026-07" }
+        #expect(july.count == 2)
+        #expect(july.first { $0.categoryId == food }?.monthlyLimit == 500)
+        #expect(july.first { $0.categoryId == food }?.rollover == true)
+        #expect(july.first { $0.categoryId == shopping }?.monthlyLimit == 300)
+    }
+
+    @Test("Forward-seeding never clobbers an existing forward edit")
+    func forwardSeedPreservesExistingNextMonth() {
+        var schema = emptySchema()
+        // Current month template.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        // A deliberate, different July edit already exists.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-07",
+            monthlyLimit: 999, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: schema, fromMonth: "2026-06", asOf: "2026-06"
+        )
+        // Nothing to add — July's food row already exists and must win.
+        #expect(!result.applied)
+        #expect(result.schema.budgets.first { $0.month == "2026-07" && $0.categoryId == food }?
+            .monthlyLimit == 999)
+    }
+
+    @Test("Forward-seeding is a no-op when the template month has no budgets")
+    func forwardSeedEmptyTemplateIsNoOp() {
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: emptySchema(), fromMonth: "2026-06", asOf: "2026-06"
+        )
+        #expect(!result.applied)
+    }
+
+    // MARK: - End-to-end: edit then resolve carry
+
+    @Test("Editing per-month budgets then resolving carry produces the expected envelope")
+    func editThenResolveCarry() {
+        var schema = emptySchema()
+        // June: $500 limit, rollover on.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        // July: $500 limit, rollover on (future month, editable).
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-07",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: schema.budgets,
+            spendByMonth: ["2026-06": 200], // $300 unspent rolls to July
+            categoryId: food
+        )
+        #expect(results.map(\.month) == ["2026-06", "2026-07"])
+        #expect(results[1].carriedIn == 300)
+        #expect(results[1].available == 800)
+    }
+}

--- a/Tests/PlaidBarCoreTests/RolloverBudgetPlannerTests.swift
+++ b/Tests/PlaidBarCoreTests/RolloverBudgetPlannerTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Per-month budgets + rollover ("envelope carry") math (AND-548 — deferred epic
+/// AND-524).
+///
+/// Every test is deterministic: budget rows and per-month spend are supplied
+/// directly, and "now" is an explicit `YYYY-MM` key or an injected UTC `Calendar`
+/// — never wall-clock `Date()`. Covers carry-forward of unspent and overspend,
+/// per-category opt-out (row flag + global toggle), gap/boundary resets, the
+/// historical-immutability policy, month-key arithmetic, and the additive guarantee
+/// that an empty/unbudgeted input yields no carry.
+@Suite("Rollover budget planner — per-month carry-forward (AND-548)")
+struct RolloverBudgetPlannerTests {
+
+    private let food = SpendingCategory.foodAndDrink.rawValue
+
+    private func budget(
+        _ month: String,
+        _ limit: Double,
+        rollover: Bool,
+        category: String? = nil
+    ) -> MonthlyBudgetV2 {
+        MonthlyBudgetV2(
+            month: month,
+            categoryId: category ?? food,
+            monthlyLimit: limit,
+            rollover: rollover
+        )
+    }
+
+    // MARK: - Carry of unspent (positive remainder)
+
+    @Test("Unspent remainder of a rollover month adds to the next month's available")
+    func unspentCarriesForward() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        // Spent $300 in Jan → $200 unspent carries into Feb.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 300, "2026-02": 0],
+            categoryId: food
+        )
+
+        #expect(results.count == 2)
+        let jan = results[0]
+        #expect(jan.carriedIn == 0)
+        #expect(jan.available == 500)
+        #expect(jan.remaining == 200)
+        #expect(jan.carriedOut == 200)
+
+        let feb = results[1]
+        #expect(feb.carriedIn == 200)
+        #expect(feb.available == 700) // 500 limit + 200 carried
+        #expect(feb.remaining == 700)
+        #expect(feb.carriedOut == 700)
+    }
+
+    @Test("Carry compounds across three contiguous rollover months")
+    func carryCompoundsAcrossMonths() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true),
+            budget("2026-02", 100, rollover: true),
+            budget("2026-03", 100, rollover: true),
+        ]
+        // Spend nothing — each month's full limit should pile up.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.map(\.available) == [100, 200, 300])
+        #expect(results.map(\.carriedOut) == [100, 200, 300])
+    }
+
+    // MARK: - Carry of overspend (negative remainder)
+
+    @Test("Overspend carries as a negative remainder, reducing next month's available")
+    func overspendCarriesForward() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        // Spent $650 in Jan → -$150 overspend carries into Feb.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 650],
+            categoryId: food
+        )
+        let jan = results[0]
+        #expect(jan.remaining == -150)
+        #expect(jan.carriedOut == -150)
+
+        let feb = results[1]
+        #expect(feb.carriedIn == -150)
+        #expect(feb.available == 350) // 500 - 150 overspend
+    }
+
+    // MARK: - Per-category opt-out (row flag)
+
+    @Test("A month with rollover off carries nothing; the next month starts from its bare limit")
+    func rolloverOffBreaksCarry() {
+        let budgets = [
+            budget("2026-01", 500, rollover: false), // opted out this month
+            budget("2026-02", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 100], // $400 unspent — but not carried
+            categoryId: food
+        )
+        #expect(results[0].rolloverActive == false)
+        #expect(results[0].carriedOut == 0)
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500) // bare limit, no carry
+    }
+
+    // MARK: - Per-category opt-out (global toggle)
+
+    @Test("Global per-category opt-out forces every month's carry to zero, even with row flag on")
+    func globalOptOutForcesZeroCarry() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 100],
+            categoryId: food,
+            optedOut: true
+        )
+        #expect(results.allSatisfy { !$0.rolloverActive })
+        #expect(results.allSatisfy { $0.carriedOut == 0 })
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500)
+    }
+
+    @Test("resolveCarryByCategory honors the opted-out category set independently per category")
+    func optOutSetIsPerCategory() {
+        let dining = SpendingCategory.foodAndDrink.rawValue
+        let shopping = SpendingCategory.shopping.rawValue
+        let budgets = [
+            budget("2026-01", 200, rollover: true, category: dining),
+            budget("2026-02", 200, rollover: true, category: dining),
+            budget("2026-01", 300, rollover: true, category: shopping),
+            budget("2026-02", 300, rollover: true, category: shopping),
+        ]
+        let byCategory = RolloverBudgetPlanner.resolveCarryByCategory(
+            budgets: budgets,
+            spendByMonthByCategory: [
+                dining: ["2026-01": 50],   // $150 unspent
+                shopping: ["2026-01": 50], // $250 unspent
+            ],
+            optedOutCategoryIds: [shopping] // only shopping opted out
+        )
+        // Dining carries: Feb available = 200 + 150 = 350.
+        #expect(byCategory[dining]?[1].available == 350)
+        // Shopping opted out: Feb available stays the bare 300.
+        #expect(byCategory[shopping]?[1].available == 300)
+        #expect(byCategory[shopping]?.allSatisfy { !$0.rolloverActive } == true)
+    }
+
+    // MARK: - Month boundaries
+
+    @Test("Carry crosses a year boundary (Dec → Jan)")
+    func carryCrossesYearBoundary() {
+        let budgets = [
+            budget("2025-12", 400, rollover: true),
+            budget("2026-01", 400, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2025-12": 100], // $300 unspent
+            categoryId: food
+        )
+        #expect(results[1].month == "2026-01")
+        #expect(results[1].carriedIn == 300)
+        #expect(results[1].available == 700)
+    }
+
+    @Test("A gap month (no budget row) resets the carry — a later month starts fresh")
+    func gapResetsCarry() {
+        // Jan and March budgeted; Feb has no row → the envelope can't carry through.
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-03", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 0], // $500 unspent in Jan
+            categoryId: food
+        )
+        #expect(results.count == 2)
+        #expect(results[0].month == "2026-01")
+        #expect(results[1].month == "2026-03")
+        // March does NOT inherit January's $500 across the missing February.
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500)
+    }
+
+    @Test("Unsorted input is resolved in chronological order")
+    func inputIsSortedChronologically() {
+        let budgets = [
+            budget("2026-03", 100, rollover: true),
+            budget("2026-01", 100, rollover: true),
+            budget("2026-02", 100, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.map(\.month) == ["2026-01", "2026-02", "2026-03"])
+        #expect(results.map(\.available) == [100, 200, 300])
+    }
+
+    @Test("Rows for other categories are ignored")
+    func otherCategoryRowsIgnored() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true, category: food),
+            budget("2026-01", 999, rollover: true, category: SpendingCategory.shopping.rawValue),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.count == 1)
+        #expect(results[0].baseLimit == 100)
+    }
+
+    @Test("Empty budgets yield no results — an unbudgeted category has no carry (additive)")
+    func emptyBudgetsYieldNoCarry() {
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: [],
+            spendByMonth: ["2026-01": 100],
+            categoryId: food
+        )
+        #expect(results.isEmpty)
+    }
+
+    @Test("Missing spend for a month is treated as zero")
+    func missingSpendIsZero() {
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: [budget("2026-01", 250, rollover: true)],
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results[0].spent == 0)
+        #expect(results[0].remaining == 250)
+        #expect(results[0].carriedOut == 250)
+    }
+
+    @Test("Duplicate month rows collapse to the last one (degrades, never crashes)")
+    func duplicateMonthCollapses() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true),
+            budget("2026-01", 200, rollover: true), // dup month, last wins
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.count == 1)
+        #expect(results[0].baseLimit == 200)
+    }
+
+    // MARK: - Historical immutability policy
+
+    @Test("Current and future months are editable; past months are frozen")
+    func editabilityPolicy() {
+        #expect(RolloverBudgetPlanner.isMonthEditable("2026-06", asOf: "2026-06")) // current
+        #expect(RolloverBudgetPlanner.isMonthEditable("2026-07", asOf: "2026-06")) // future
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-05", asOf: "2026-06")) // past
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2025-12", asOf: "2026-01")) // past, prior year
+    }
+
+    @Test("A malformed month key is never editable (fail closed)")
+    func malformedMonthNotEditable() {
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-13", asOf: "2026-06"))
+        #expect(!RolloverBudgetPlanner.isMonthEditable("nope", asOf: "2026-06"))
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-06", asOf: "garbage"))
+    }
+
+    // MARK: - Month-key arithmetic
+
+    @Test("nextMonthKey / previousMonthKey roll across month and year boundaries")
+    func monthKeyArithmetic() {
+        #expect(RolloverBudgetPlanner.nextMonthKey("2026-01") == "2026-02")
+        #expect(RolloverBudgetPlanner.nextMonthKey("2026-12") == "2027-01")
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-01") == "2025-12")
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-03") == "2026-02")
+        #expect(RolloverBudgetPlanner.nextMonthKey("bad") == nil)
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-00") == nil)
+    }
+
+    @Test("monthKey(for:calendar:) derives the bucket from an injected calendar (no wall clock)")
+    func monthKeyFromInjectedCalendar() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        // 2026-06-13T12:00:00Z
+        let date = Date(timeIntervalSince1970: 1_781_352_000)
+        #expect(RolloverBudgetPlanner.monthKey(for: date, calendar: calendar) == "2026-06")
+    }
+}


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.**

## What & why

Moves budgeting from a single, undated per-category limit (v1) to **per-month budgets with optional rollover ("envelope carry")**, per AND-548. Builds directly on the merged AND-546 schema — `MonthlyBudgetV2(month, categoryId, monthlyLimit, rollover)` already models the per-(month, category) row with a per-row rollover flag; the foundation only *stored* those fields. This PR adds the **math and the per-month editing rules** on top, as pure `Sendable` `PlaidBarCore` logic.

Purely **additive**: no existing file is modified. A user who does not opt into v2 (or has no v2 data) reads/writes none of this and sees byte-identical v1 behavior.

## Change

- **`RolloverBudgetPlanner` (PlaidBarCore, new)** — pure, deterministic envelope carry across a category's chronological `MonthlyBudgetV2` rows:
  - `available = baseLimit + carriedIn`; `remaining = available - spent`; `carriedOut = rolloverActive ? remaining : 0`, fed into the next month's `carriedIn`.
  - **Unspent *and* overspend carry** — the remainder is signed, so over-budget months subtract from the next month (true envelope).
  - **Per-category opt-out**: the row's `rollover` flag (a category opts out by setting it `false` on its rows) *and* a global `optedOutCategoryIds` toggle that forces `carryOut == 0` for a whole category.
  - A **budget-row gap** (a missing intervening month) or a **rollover-off month** resets the chain — a later month starts from its bare limit.
  - **Historical immutability policy** `isMonthEditable(_:asOf:)` (current + future editable, past frozen) and **month-key arithmetic** (`nextMonthKey` / `previousMonthKey` / `monthKey(for:calendar:)`) as the single source of truth.
  - No hidden `Date()` — explicit `Calendar` / `asOf` month key throughout.
- **`MonthlyBudgetEditor` (PlaidBarCore, new)** — pure upsert / remove / forward-seed over `BudgetingV2Schema` that **enforces immutability**: an edit to a frozen historical month is a no-op (schema returned byte-identical). Validates the limit (finite, `>= 0`) and that the category exists; `rolloverTemplateToNextMonth` copies the current month's budgets forward without clobbering an existing forward edit.

## Testing

Exact commands and results:

```
$ swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
Build complete! (126.76s)

$ swift test --filter RolloverBudgetPlannerTests --filter MonthlyBudgetEditorTests
Test run with 31 tests passed after 0.006 seconds.

$ git diff --check
(clean)
```

31 new deterministic Core tests: carry of unspent / overspend, compounding across months, Dec→Jan year boundary, gap-resets-carry, row-flag and global opt-out (incl. independent per-category in `resolveCarryByCategory`), unsorted/duplicate input degradation, editability policy + fail-closed on malformed keys, editor immutability + input validation + forward-seed, and an edit-then-resolve end-to-end.

## Links

Closes AND-548

## Follow-ups

- Wire these into the app's per-month Budgets UI and the `BudgetingV2Store` save path (later AND-524 subtree; out of scope here — this PR is the pure Core engine).
- `overrideAwareSpend` (AND-546) is the intended `spendByMonth` source; a thin adapter that fans it out per month/category can live with the UI wiring.
