### PR TITLE
fix(currency): honest mixed-currency menu-bar glance (AND-643 follow-up)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1120,6 +1120,31 @@ final class AppState {
         )
     }
 
+    /// Spoken form of the menu-bar value. Matches ``menuBarText`` for every mode
+    /// except mixed-currency balances, where it names the dominant currency's
+    /// subtotal in words (so VoiceOver does not read a bare `"€1,200+"` whose `+`
+    /// and currency are visual-only). Goes through the same app-lock/icon-only
+    /// masking as ``menuBarText`` so a locked or masked state never leaks a figure.
+    var menuBarAccessibleValueText: String {
+        let safeToSpend: Double? = menuBarSummaryMode == .safeToSpend
+            ? currentSafeToSpendAmount()
+            : nil
+        let rawText = MenuBarSummary.accessibleValueText(
+            mode: menuBarSummaryMode,
+            accounts: accounts,
+            transactions: transactions,
+            currencyFormat: balanceFormat,
+            isInitialLoad: isBootLoadInFlight,
+            privacyMaskEnabled: shouldMaskFinancialValues,
+            precomputedSafeToSpend: safeToSpend
+        )
+        return appLockPreferences.menuBarText(
+            currentText: rawText,
+            isAppLocked: isAppLocked,
+            isIconOnly: menuBarSummaryMode == .iconOnly
+        )
+    }
+
     var menuBarStatusPresentation: MenuBarStatusPresentation {
         MenuBarStatusPresentation.evaluate(
             isDemoMode: isDemoMode,
@@ -1187,7 +1212,7 @@ final class AppState {
         // status to keep VoiceOver in sync with the badge sighted users see.
         MenuBarAnnouncement.accessibilityLabel(
             mode: menuBarSummaryMode,
-            valueText: menuBarText,
+            valueText: menuBarAccessibleValueText,
             reviewCount: transactionReviewCount,
             diagnosticsSummary: diagnosticsSummary,
             attentionText: menuBarAttentionText,

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -220,24 +220,24 @@ public enum MenuBarSummary {
         case .netWorth:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
-            return MultiCurrencyBalancePresentation.displayText(
+            return MultiCurrencyBalancePresentation.glance(
                 from: MultiCurrencyBalancePresentation.netWorth(accounts: accounts),
                 format: currencyFormat
-            )
+            ).text
         case .netCash:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
-            return MultiCurrencyBalancePresentation.displayText(
+            return MultiCurrencyBalancePresentation.glance(
                 from: MultiCurrencyBalancePresentation.netWorth(accounts: accounts),
                 format: currencyFormat
-            )
+            ).text
         case .totalCash:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
-            return MultiCurrencyBalancePresentation.displayText(
+            return MultiCurrencyBalancePresentation.glance(
                 from: MultiCurrencyBalancePresentation.totalCash(accounts: accounts),
                 format: currencyFormat
-            )
+            ).text
         case .creditUtilization:
             guard !accounts.isEmpty else { return PlaidBarConstants.appName }
             guard let utilization = creditUtilization(from: accounts) else { return "No credit" }
@@ -276,6 +276,47 @@ public enum MenuBarSummary {
             return Formatters.currency(amount, format: currencyFormat)
         case .iconOnly:
             return ""
+        }
+    }
+
+    /// The spoken value for VoiceOver. Identical to ``text(mode:accounts:...)`` for
+    /// every mode **except** the multi-currency balance modes: there it returns the
+    /// glance's spoken label, which names the dominant currency's subtotal in words
+    /// and notes that other currencies are shown separately — so a VoiceOver user is
+    /// not read a bare `"€1,200+"` whose `+` and currency are visual-only cues.
+    ///
+    /// For single-currency (or fully converted) balances the spoken value equals the
+    /// visible text, so this is a no-op for the common case.
+    public static func accessibleValueText(
+        mode: MenuBarSummaryMode,
+        accounts: [AccountDTO],
+        transactions: [TransactionDTO],
+        currencyFormat: CurrencyFormat,
+        isInitialLoad: Bool = false,
+        privacyMaskEnabled: Bool = false,
+        precomputedSafeToSpend: Double? = nil
+    ) -> String {
+        switch mode {
+        case .netWorth, .netCash, .totalCash:
+            guard !accounts.isEmpty else { return PlaidBarConstants.appName }
+            guard !privacyMaskEnabled else { return PrivacyMaskPresentation.heroValue }
+            let aggregation = mode == .totalCash
+                ? MultiCurrencyBalancePresentation.totalCash(accounts: accounts)
+                : MultiCurrencyBalancePresentation.netWorth(accounts: accounts)
+            return MultiCurrencyBalancePresentation.glance(
+                from: aggregation,
+                format: currencyFormat
+            ).accessibilityLabel
+        default:
+            return text(
+                mode: mode,
+                accounts: accounts,
+                transactions: transactions,
+                currencyFormat: currencyFormat,
+                isInitialLoad: isInitialLoad,
+                privacyMaskEnabled: privacyMaskEnabled,
+                precomputedSafeToSpend: precomputedSafeToSpend
+            )
         }
     }
 }

--- a/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
@@ -183,6 +183,97 @@ public enum MultiCurrencyBalancePresentation {
         }
     }
 
+    /// A single-line menu-bar **glance** figure plus its spoken label, sized for
+    /// the constrained menu-bar surface where the multi-line ``headline``
+    /// disclosure does not fit.
+    ///
+    /// Unlike the dashboard, the glance must show *a number*, not a "By currency"
+    /// prompt. When the figure is exact (one currency) or a real cross-currency
+    /// conversion is available, that single figure is used verbatim — so a
+    /// single-currency user sees byte-identical text to before. When currencies
+    /// are mixed and unpriceable, the glance shows the **dominant** currency's
+    /// subtotal (largest by absolute value) in that currency's own symbol, with a
+    /// trailing ``multiCurrencyMarker`` (a non-color "+" cue) signalling that other
+    /// currencies exist but are not summed into this figure. It never fabricates a
+    /// cross-currency `$` total.
+    public struct Glance: Sendable, Equatable {
+        /// The figure to render in the menu bar, e.g. `"$1,234"`, `"€1.200+"`.
+        public let text: String
+        /// VoiceOver label naming the figure (and, when mixed, the dominant
+        /// currency + that other currencies exist) in words, never by color.
+        public let accessibilityLabel: String
+
+        public init(text: String, accessibilityLabel: String) {
+            self.text = text
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    /// Non-color marker appended to a mixed-currency dominant-subtotal glance to
+    /// signal "other currencies exist, not included in this figure". Kept ASCII so
+    /// it renders in the menu bar across locales and is read by VoiceOver via the
+    /// glance's spoken label rather than this glyph.
+    public static let multiCurrencyMarker = "+"
+
+    public static func glance(
+        from aggregation: CurrencyAggregation,
+        format: CurrencyFormat = .compact,
+        privacyMaskEnabled: Bool = false
+    ) -> Glance {
+        let headline = headline(
+            from: aggregation,
+            format: format,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+
+        // Exact (single currency) or a real cross-currency conversion → use the
+        // single figure verbatim. Single-currency text is byte-identical to the
+        // pre-multi-currency menu bar.
+        if let total = headline.formattedTotal {
+            return Glance(text: total, accessibilityLabel: headline.accessibilityLabel)
+        }
+
+        // Mixed + unpriceable → dominant currency's subtotal + non-color marker.
+        // No conversion is invented; the omitted currencies are named in the
+        // spoken label so VoiceOver users know the figure is one currency only.
+        guard let dominant = dominantSubtotal(in: aggregation) else {
+            // Defensive: no subtotals at all (empty input never reaches here via
+            // aggregate, which yields .exact 0) — keep the prior subtotals prompt.
+            return Glance(
+                text: displayText(from: aggregation, format: format, privacyMaskEnabled: privacyMaskEnabled),
+                accessibilityLabel: headline.accessibilityLabel
+            )
+        }
+
+        let figure = privacyMaskEnabled
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(dominant.amount, in: dominant.currency, format: format)
+        let others = aggregation.subtotals
+            .filter { $0.currency != dominant.currency }
+            .map(\.currency)
+        let othersNote = others.isEmpty
+            ? ""
+            : " Other currencies (\(listCurrencyNames(others))) shown separately, not included."
+
+        return Glance(
+            text: figure + multiCurrencyMarker,
+            accessibilityLabel:
+                "\(figure) \(dominant.currency.accessibleName) subtotal.\(othersNote)"
+        )
+    }
+
+    /// The subtotal that dominates by absolute magnitude. Ties resolve to the
+    /// first in ``CurrencyAggregation``'s deterministic order (resolved-first,
+    /// alphabetical), so the chosen currency is stable across renders.
+    static func dominantSubtotal(
+        in aggregation: CurrencyAggregation
+    ) -> CurrencyAggregation.Subtotal? {
+        aggregation.subtotals.reduce(nil) { current, candidate in
+            guard let current else { return candidate }
+            return abs(candidate.amount) > abs(current.amount) ? candidate : current
+        }
+    }
+
     private static func listCurrencyNames(_ currencies: [CurrencyCode]) -> String {
         let names = currencies.map(\.accessibleName)
         switch names.count {

--- a/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
+++ b/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
@@ -282,8 +282,9 @@ struct MultiCurrencyTests {
         #expect(unavailable.disclosure.lowercased().contains("per currency"))
     }
 
-    @Test("Menu bar balance modes use subtotals-only text for mixed currencies")
-    func menuBarMixedCurrencyAvoidsScalarBalance() {
+    @Test("Menu bar shows the dominant currency's subtotal (no fabricated $ sum) for mixed currencies")
+    func menuBarMixedCurrencyShowsDominantSubtotal() {
+        // USD subtotal 5,000 dominates the EUR 2,000 subtotal by absolute value.
         let accounts = [
             depository(name: "US Checking", current: 5_000, currency: "USD"),
             depository(name: "Euro Savings", current: 2_000, currency: "EUR"),
@@ -296,7 +297,101 @@ struct MultiCurrencyTests {
             currencyFormat: .compact
         )
 
-        #expect(text == "By currency")
+        // Dominant USD subtotal in its own symbol + the non-color "+" marker; the
+        // EUR figure is never blind-summed into the dollar number.
+        #expect(text == "$5,000+")
+        #expect(!text.contains("7,000")) // no fabricated 5000 + 2000 cross-currency sum
+        #expect(!text.contains("€")) // the headline figure is the dollar one, not euro
+    }
+
+    @Test("Mixed-currency glance names the dominant subtotal for VoiceOver and notes the others")
+    func menuBarMixedCurrencyAccessibilityLabel() {
+        let accounts = [
+            depository(name: "US Checking", current: 5_000, currency: "USD"),
+            depository(name: "Euro Savings", current: 2_000, currency: "EUR"),
+        ]
+        let aggregation = MultiCurrencyBalancePresentation.netWorth(accounts: accounts)
+        let glance = MultiCurrencyBalancePresentation.glance(from: aggregation, format: .compact)
+
+        // Visible figure carries the dominant USD subtotal + non-color marker...
+        #expect(glance.text == "$5,000+")
+        // ...and the spoken label names the dominant currency in words (not the "+"
+        // glyph) and discloses that other currencies are shown separately.
+        #expect(!glance.accessibilityLabel.isEmpty)
+        #expect(glance.accessibilityLabel.contains("$5,000"))
+        #expect(glance.accessibilityLabel.lowercased().contains("subtotal"))
+        #expect(glance.accessibilityLabel.lowercased().contains("other currencies"))
+        // The accessible value text path used by the menu bar matches the glance.
+        let spoken = MenuBarSummary.accessibleValueText(
+            mode: .netWorth,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact
+        )
+        #expect(spoken == glance.accessibilityLabel)
+    }
+
+    @Test("Dominant subtotal is picked by absolute magnitude, including negative debt")
+    func menuBarDominantPicksByAbsoluteValue() {
+        // EUR net worth is strongly negative (debt); it dominates the small USD
+        // asset by absolute value, so the glance shows the EUR figure.
+        let accounts = [
+            depository(name: "US Checking", current: 500, currency: "USD"),
+            credit(name: "Euro Card", current: 9_000, limit: 12_000, currency: "EUR"),
+        ]
+        let aggregation = MultiCurrencyBalancePresentation.netWorth(accounts: accounts)
+        let dominant = MultiCurrencyBalancePresentation.dominantSubtotal(in: aggregation)
+        #expect(dominant?.currency == CurrencyCode("EUR"))
+
+        let text = MenuBarSummary.text(
+            mode: .netWorth,
+            accounts: accounts,
+            transactions: [],
+            currencyFormat: .compact
+        )
+        // EUR debt subtotal of -9,000 rendered in EUR's own currency formatting,
+        // plus the marker. Critically: never coerced into a "$" figure. (The exact
+        // symbol — "€" vs "EUR" — is locale-dependent, so assert the *absence* of $
+        // and the dominant-currency pick rather than a brittle symbol literal.)
+        #expect(text.hasSuffix("+"))
+        #expect(!text.contains("$"))
+        // The figure equals EUR's native formatting of the dominant subtotal.
+        let expectedFigure = Formatters.currency(dominant!.amount, in: CurrencyCode("EUR"), format: .compact)
+        #expect(text == expectedFigure + "+")
+    }
+
+    @Test("Single-USD menu-bar text is byte-identical to the legacy formatter (no regression)")
+    func menuBarSingleUSDByteIdentical() {
+        let accounts = [
+            depository(name: "US Checking", current: 5_000, currency: "USD"),
+            depository(name: "US Savings", current: 3_000, currency: "USD"),
+            credit(name: "US Card", current: 800, limit: 3_000, currency: "USD"),
+        ]
+
+        for format in [CurrencyFormat.compact, .full, .abbreviated] {
+            let glanceText = MenuBarSummary.text(
+                mode: .netWorth,
+                accounts: accounts,
+                transactions: [],
+                currencyFormat: format
+            )
+            // Legacy behavior: a single scalar net-cash figure in USD via the
+            // pre-multi-currency formatter path.
+            let legacy = Formatters.currency(
+                MenuBarSummary.netCash(from: accounts),
+                format: format
+            )
+            #expect(glanceText == legacy)
+            #expect(!glanceText.hasSuffix("+")) // no mixed-currency marker for single-currency
+            // Spoken value also equals the visible single figure for VoiceOver.
+            let spoken = MenuBarSummary.accessibleValueText(
+                mode: .netWorth,
+                accounts: accounts,
+                transactions: [],
+                currencyFormat: format
+            )
+            #expect(spoken.contains(legacy))
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## What & why

#668 (AND-643 multi-currency) made the **dashboard** currency-honest, but the
**menu-bar glance** still degraded a mixed-currency balance to the literal
`"By currency"` — no number at all. Single-currency users were unaffected, but a
user whose accounts span multiple currencies got a useless glance. This finishes
the wiring so the constrained menu-bar surface shows an honest, currency-aware
figure without ever fabricating a cross-currency `$` total.

## Change

All in `PlaidBarCore` (pure, `Sendable`, tested) plus the menu-bar text path:

- **`MultiCurrencyBalancePresentation.glance(from:format:privacyMaskEnabled:)`** (new)
  - All accounts share **one** currency (or a real conversion exists) → returns
    the single figure verbatim. Single-USD output is **byte-identical** to before
    (`Formatters.currency(amount, in: .usd, …)` collapses to the legacy
    `Formatters.currency(amount, …)` path).
  - Accounts span **multiple** currencies with no offline rate → shows the
    **dominant** currency's subtotal (largest by absolute value) in that
    currency's own symbol, plus a non-color `"+"` marker
    (`multiCurrencyMarker`) signalling other currencies exist. **No fabricated
    cross-currency `$` sum**, no invented cloud FX.
  - Carries an accessibility label naming the figure as the dominant-currency
    subtotal and noting the others are shown separately (never meaning-by-color).
- **`MenuBarSummary.text`** routes `netWorth`/`netCash`/`totalCash` through
  `glance(…).text` instead of `displayText`.
- **`MenuBarSummary.accessibleValueText`** (new) returns the glance's spoken
  label for balance modes (plain `text` otherwise); `AppState.menuBarAccessibleValueText`
  threads it into `menuBarAccessibilityLabel` so VoiceOver doesn't read a bare
  `"€1,200+"` whose `+` and currency are visual-only. Same app-lock / Privacy
  Mask masking as `menuBarText`.

Additive: a single-currency user (and the masked/locked/empty states) sees
byte-identical prior behavior. The dashboard `headline`/`subtotalRows`/`displayText`
APIs are untouched.

## Testing

Exact commands (run with the sandbox disabled per repo setup):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (strict concurrency, warnings-as-errors)

swift test --filter MultiCurrencyTests
# → Test run with 25 tests passed (4 new)

swift test --filter MenuBar
# → Test run with 37 tests passed (announcement/glance/review goldens intact)

swift test --filter PlaidBarCoreTests
# → Test run with 2089 tests passed

git diff --check
# → clean
```

New tests in `MultiCurrencyTests`:
- single-USD menu-bar text byte-identical to the legacy formatter across
  `.compact`/`.full`/`.abbreviated`, with no `"+"` marker;
- mixed-currency picks the dominant subtotal + `"+"` marker + correct symbol and
  emits no wrong `$` (no `7,000` blind sum);
- dominant pick is by **absolute** magnitude (a large negative-debt subtotal wins);
- VoiceOver label present, names the dominant subtotal, discloses the others.

## Links

Closes AND-643 (menu-bar follow-up to #668).

## Follow-ups

- If/when an offline FX source is wired into the menu-bar path, the `.converted`
  branch already routes through `glance` and will show a single disclosed
  approximate total instead of the dominant-subtotal fallback — no further glance
  change needed.
