### PR TITLE
feat(budgeting): rules manager UI — list/edit/reorder/delete (AND-551)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4604,6 +4604,41 @@ final class AppState {
         persistReviewStorage()
     }
 
+    // MARK: - Rules management (AND-551)
+
+    /// Update (or insert) a categorization rule from the rules-manager surface.
+    ///
+    /// Routes through the pure `TransactionRuleManager.applyingEdit`, which
+    /// normalizes the rule's free-text fields and **preserves the existing rule's
+    /// `id` and `createdAt`** so an edit never silently re-ranks the rule relative
+    /// to its peers (conflict precedence is by `createdAt`). The change is undoable
+    /// (one ⌘Z restores the prior rule set) and persisted through the same serial
+    /// writer as every other review-storage mutation. Caches invalidate via
+    /// `transactionRules.didSet`.
+    ///
+    /// Editing a rule deliberately does **not** touch review metadata: re-running
+    /// the matcher over already-reviewed transactions is the resolver's job at
+    /// aggregation time, not a retroactive metadata rewrite here.
+    func updateTransactionRule(_ rule: TransactionRule) {
+        pushReviewUndoState()
+        transactionRules = TransactionRuleManager.applyingEdit(rule, to: transactionRules)
+        persistReviewStorage()
+    }
+
+    /// Delete a categorization rule from the rules-manager surface.
+    ///
+    /// Per AC #2, deleting a rule must **not** retroactively un-review past
+    /// transactions: this only drops the rule from the matcher set
+    /// (`TransactionRuleManager.deleting`), leaving every `.reviewed` /`.ignored`
+    /// metadata record exactly as it was. Undoable and persisted like every other
+    /// review mutation.
+    func deleteTransactionRule(id: UUID) {
+        guard transactionRules.contains(where: { $0.id == id }) else { return }
+        pushReviewUndoState()
+        transactionRules = TransactionRuleManager.deleting(ruleID: id, from: transactionRules)
+        persistReviewStorage()
+    }
+
     /// Marks a batch of inbox rows reviewed in a single, undoable step (AND-528).
     ///
     /// The blast radius — exactly which transaction ids resolve — is decided by the

--- a/Sources/PlaidBar/Settings/RulesSettingsView.swift
+++ b/Sources/PlaidBar/Settings/RulesSettingsView.swift
@@ -1,0 +1,382 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Settings surface that lets the user manage categorization rules — list, edit,
+/// and delete the `TransactionRule`s that were previously create-only inline
+/// (AND-551, DEFERRED v2 / AND-524).
+///
+/// Thin renderer over `TransactionRuleManager`: that pure type owns the display
+/// order, the match/effect copy, and the conflict (shadowing) detection, so the
+/// view never re-derives "which rule wins". Mutations route through
+/// `AppState.updateTransactionRule` / `deleteTransactionRule`, which reuse the
+/// existing rule store and persistence path. Deleting a rule does **not**
+/// retroactively un-review past transactions (AC #2) — `AppState` leaves review
+/// metadata untouched.
+///
+/// Privacy: rule text (matchers, categories, renames) carries no balances or
+/// amounts, but the surface is still suppressed under Privacy Mask / App Lock as
+/// defense in depth, matching every other financial surface.
+struct RulesSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var editing: EditingRule?
+    @State private var pendingDeletion: TransactionRule?
+
+    private var rows: [TransactionRuleManager.RuleRow] {
+        TransactionRuleManager.rows(for: appState.transactionRules)
+    }
+
+    var body: some View {
+        Group {
+            if appState.shouldMaskFinancialValues {
+                maskedState
+            } else if rows.isEmpty {
+                emptyState
+            } else {
+                ruleList
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .sheet(item: $editing) { editingRule in
+            RuleEditorSheet(
+                draft: editingRule.rule,
+                isNew: editingRule.isNew,
+                onSave: { appState.updateTransactionRule($0) }
+            )
+        }
+        .confirmationDialog(
+            "Delete this rule?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            presenting: pendingDeletion
+        ) { rule in
+            Button("Delete Rule", role: .destructive) {
+                appState.deleteTransactionRule(id: rule.id)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { rule in
+            Text(
+                "Removes the “\(TransactionRuleManager.shortLabel(for: rule))” rule. Transactions you have already reviewed stay reviewed — deleting a rule never re-opens past transactions. New transactions will no longer match this rule."
+            )
+        }
+    }
+
+    // MARK: - List
+
+    private var ruleList: some View {
+        Form {
+            Section {
+                ForEach(rows) { row in
+                    RuleRowView(row: row) {
+                        editing = EditingRule(rule: row.rule, isNew: false)
+                    } onDelete: {
+                        pendingDeletion = row.rule
+                    }
+                }
+            } header: {
+                Text("Rules")
+            } footer: {
+                Text("Rules automatically recategorize, rename, mark as transfer, or exclude matching transactions. When two rules match the same transaction, the most recently created one wins for any field they both set; an overridden rule is flagged below.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section {
+                Button {
+                    editing = EditingRule(rule: TransactionRule(), isNew: true)
+                } label: {
+                    Label("Add Rule", systemImage: "plus")
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Empty / masked states
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Rules Yet", systemImage: "wand.and.stars")
+        } description: {
+            Text("Rules recategorize, rename, or exclude transactions automatically. Create one here, or from the Review inbox when you correct a transaction.")
+        } actions: {
+            Button {
+                editing = EditingRule(rule: TransactionRule(), isNew: true)
+            } label: {
+                Label("Add Rule", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var maskedState: some View {
+        ContentUnavailableView {
+            Label(
+                appState.isContentLocked ? "Locked" : "Hidden by Privacy Mask",
+                systemImage: appState.isContentLocked ? "lock" : "eye.slash"
+            )
+        } description: {
+            Text(
+                appState.isContentLocked
+                    ? "Unlock VaultPeek to manage your categorization rules."
+                    : "Turn off Privacy Mask to manage your categorization rules."
+            )
+        }
+    }
+}
+
+/// Identifies the rule being edited, distinguishing a brand-new draft (which
+/// `AppState` appends) from an edit of an existing rule (whose `id`/`createdAt` are
+/// preserved). `id` is the rule's id so the `.sheet(item:)` re-presents correctly.
+private struct EditingRule: Identifiable {
+    let rule: TransactionRule
+    let isNew: Bool
+    var id: UUID { rule.id }
+}
+
+// MARK: - Row
+
+private struct RuleRowView: View {
+    let row: TransactionRuleManager.RuleRow
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Text(row.matchDescription)
+                    .font(.callout.weight(.medium))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: Spacing.sm)
+
+                Button("Edit", action: onEdit)
+                    .controlSize(.small)
+
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                }
+                .controlSize(.small)
+                .accessibilityLabel("Delete rule")
+            }
+
+            if row.effects.isEmpty {
+                Text("No effect")
+                    .detailText()
+            } else {
+                effectChips
+            }
+
+            if row.isShadowed {
+                shadowWarning
+            }
+        }
+        .padding(.vertical, Spacing.xxs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double-tap Edit to change, or Delete to remove this rule.")
+    }
+
+    private var effectChips: some View {
+        // Wrapping rows of text+icon chips. Meaning is in the text; the icon and
+        // any tint are decoration only (ACCESSIBILITY.md). Reuses the shared
+        // wrapping layout from the Insights surface.
+        InsightsFlowLayout(spacing: Spacing.xs) {
+            ForEach(Array(row.effects.enumerated()), id: \.offset) { _, effect in
+                Label(effect.label, systemImage: effect.systemImage)
+                    .font(.caption.weight(.medium))
+                    .labelStyle(.titleAndIcon)
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, Spacing.chipVertical)
+                    .background(.quinary, in: Capsule())
+            }
+        }
+    }
+
+    private var shadowWarning: some View {
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+            ForEach(row.shadowedFields) { conflict in
+                Label {
+                    Text("\(conflict.field.displayName) is overridden by the “\(conflict.winningRuleLabel)” rule.")
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(SemanticColors.warning)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [row.matchDescription]
+        if row.effects.isEmpty {
+            parts.append("No effect")
+        } else {
+            parts.append(contentsOf: row.effects.map(\.label))
+        }
+        for conflict in row.shadowedFields {
+            parts.append("\(conflict.field.displayName) overridden by the \(conflict.winningRuleLabel) rule")
+        }
+        return parts.joined(separator: ". ")
+    }
+}
+
+// MARK: - Editor
+
+private struct RuleEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var matchMerchant: String
+    @State private var matchOriginalName: String
+    @State private var hasCategory: Bool
+    @State private var category: SpendingCategory
+    @State private var renameEnabled: Bool
+    @State private var renameTo: String
+    @State private var transferChoice: TriState
+    @State private var excludeChoice: TriState
+
+    private let originalRule: TransactionRule
+    let isNew: Bool
+    let onSave: (TransactionRule) -> Void
+
+    /// Three-state toggle for the optional `Bool?` rule fields: leave unset, set
+    /// true, or set false. Modeling them as `Bool?` (rather than a plain `Toggle`)
+    /// keeps the additive contract — a rule that never set transfer/exclusion is
+    /// stored exactly the same after a round-trip through the editor.
+    private enum TriState: String, CaseIterable, Identifiable {
+        case unset
+        case on
+        case off
+        var id: String { rawValue }
+        var title: String {
+            switch self {
+            case .unset: "No change"
+            case .on: "Yes"
+            case .off: "No"
+            }
+        }
+        var boolValue: Bool? {
+            switch self {
+            case .unset: nil
+            case .on: true
+            case .off: false
+            }
+        }
+        init(_ value: Bool?) {
+            switch value {
+            case .none: self = .unset
+            case .some(true): self = .on
+            case .some(false): self = .off
+            }
+        }
+    }
+
+    init(draft: TransactionRule, isNew: Bool, onSave: @escaping (TransactionRule) -> Void) {
+        self.originalRule = draft
+        self.isNew = isNew
+        self.onSave = onSave
+        _matchMerchant = State(initialValue: draft.matchMerchantContains ?? "")
+        _matchOriginalName = State(initialValue: draft.matchOriginalNameContains ?? "")
+        _hasCategory = State(initialValue: draft.category != nil)
+        _category = State(initialValue: draft.category ?? .foodAndDrink)
+        _renameEnabled = State(initialValue: (draft.merchantName?.isEmpty == false))
+        _renameTo = State(initialValue: draft.merchantName ?? "")
+        _transferChoice = State(initialValue: TriState(draft.isTransfer))
+        _excludeChoice = State(initialValue: TriState(draft.excludedFromBudgets))
+    }
+
+    private var composedRule: TransactionRule {
+        TransactionRule(
+            id: originalRule.id,
+            matchMerchantContains: matchMerchant,
+            matchOriginalNameContains: matchOriginalName,
+            category: hasCategory ? category : nil,
+            merchantName: renameEnabled ? renameTo : nil,
+            isTransfer: transferChoice.boolValue,
+            excludedFromBudgets: excludeChoice.boolValue,
+            createdAt: originalRule.createdAt
+        )
+    }
+
+    private var validationProblems: [TransactionRuleManager.ValidationProblem] {
+        TransactionRuleManager.validate(TransactionRuleManager.normalized(composedRule))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    TextField("Merchant contains", text: $matchMerchant, prompt: Text("e.g. Starbucks"))
+                    TextField("Description contains", text: $matchOriginalName, prompt: Text("e.g. SQ *"))
+                } header: {
+                    Text("Match when")
+                } footer: {
+                    Text("A transaction matches if either field is contained in its merchant or description (case-insensitive). Fill at least one.")
+                        .detailText()
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Section("Then") {
+                    Toggle("Set category", isOn: $hasCategory)
+                    if hasCategory {
+                        Picker("Category", selection: $category) {
+                            ForEach(SpendingCategory.allCases, id: \.self) { option in
+                                Label(option.displayName, systemImage: option.iconName).tag(option)
+                            }
+                        }
+                    }
+
+                    Toggle("Rename merchant", isOn: $renameEnabled)
+                    if renameEnabled {
+                        TextField("Display name", text: $renameTo, prompt: Text("e.g. Coffee"))
+                    }
+
+                    Picker("Mark as transfer", selection: $transferChoice) {
+                        ForEach(TriState.allCases) { Text($0.title).tag($0) }
+                    }
+
+                    Picker("Exclude from budgets", selection: $excludeChoice) {
+                        ForEach(TriState.allCases) { Text($0.title).tag($0) }
+                    }
+                }
+
+                if !validationProblems.isEmpty {
+                    Section {
+                        ForEach(validationProblems, id: \.self) { problem in
+                            Label {
+                                Text(problem.message)
+                            } icon: {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(SemanticColors.warning)
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button(isNew ? "Add Rule" : "Save") {
+                    onSave(composedRule)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .disabled(!validationProblems.isEmpty)
+            }
+            .padding(Spacing.md)
+        }
+        .frame(minWidth: 420, idealWidth: 460, minHeight: 420, idealHeight: 480)
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -30,6 +30,13 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.appearance.rawValue)
 
+            RulesSettingsView()
+                .environment(appState)
+                .tabItem {
+                    Label("Rules", systemImage: "wand.and.stars")
+                }
+                .tag(SettingsTab.rules.rawValue)
+
             NotificationSettingsView()
                 .environment(appState)
                 .tabItem {
@@ -65,6 +72,7 @@ private enum SettingsTab: String {
     case general
     case accounts
     case appearance
+    case rules
     case notifications
     case privacy
     case about

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -154,6 +154,7 @@ public enum SettingsRouteTab: String, CaseIterable, Sendable, Hashable, Codable 
     case general
     case accounts
     case appearance
+    case rules
     case notifications
     case privacy
     case about

--- a/Sources/PlaidBarCore/Utilities/TransactionRuleManager.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionRuleManager.swift
@@ -1,0 +1,408 @@
+import Foundation
+
+/// Pure, `Sendable` presentation + conflict logic for the rules-manager surface
+/// (AND-551, DEFERRED v2 / AND-524).
+///
+/// `TransactionRule`s are create-only inline in v1 (the Review Inbox's
+/// `createRule` / `InlineCategoryRulePrompt` path). This type is the pure half of
+/// the management surface: it turns the flat rule array into sorted, human-readable
+/// rows; describes each rule's *match* and *effect* in text (never color alone);
+/// detects and explains conflicts between rules; and resolves which rule actually
+/// governed a transaction (provenance). The app target's `RulesSettingsView` is a
+/// thin renderer over these decisions, and `AppState` owns the store mutations —
+/// so the meaning of "which rule wins" is defined in exactly one place and is
+/// unit-testable without the SwiftUI app target (CLAUDE.md).
+///
+/// ## Conflict-resolution doctrine (AC #4)
+/// When two rules both match a transaction and both set the *same* field
+/// (category, transfer, or budget exclusion), only one can win. The winner is the
+/// **most recently created** rule (`createdAt` descending; `id.uuidString` as the
+/// deterministic tiebreaker for equal timestamps). This is the *exact* precedence
+/// `EffectiveCategoryResolver.resolve` already applies to spend math — surfaced
+/// verbatim here so the UI's "this rule wins" explanation can never drift from what
+/// actually happens to a user's budgets. The losing rule is not deleted or hidden;
+/// it is flagged as *shadowed* on the conflicting field so the user can see and
+/// resolve it.
+///
+/// Privacy: every string this type produces is a rule's own matcher / category /
+/// effect text — never a balance, amount, account id, or transaction id. The view
+/// still suppresses the whole surface under Privacy Mask / App Lock as defense in
+/// depth, but nothing here is sensitive on its own.
+public enum TransactionRuleManager {
+    // MARK: - Sort
+
+    /// The canonical management ordering: newest-first by `createdAt`, with
+    /// `id.uuidString` as the deterministic tiebreaker. This mirrors the precedence
+    /// `EffectiveCategoryResolver` resolves by, so the first rule in the list is
+    /// also the highest-precedence one — "top of the list wins" reads true.
+    public static func sortedForDisplay(_ rules: [TransactionRule]) -> [TransactionRule] {
+        rules.sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt > rhs.createdAt }
+            return lhs.id.uuidString > rhs.id.uuidString
+        }
+    }
+
+    // MARK: - Effect description (AC #1)
+
+    /// The fields a rule can affect. Order matches how `RuleRow.effects` lists them.
+    public enum Effect: Sendable, Equatable {
+        /// Recategorize matches to a fixed category.
+        case category(SpendingCategory)
+        /// Rename the merchant shown for matches.
+        case merchant(String)
+        /// Mark matches as transfers (own-account moves).
+        case transfer(Bool)
+        /// Exclude matches from budget aggregation.
+        case excludeFromBudgets(Bool)
+
+        /// Text+icon label for the effect chip — meaning is always carried by the
+        /// text, never by the icon or any color (ACCESSIBILITY.md).
+        public var label: String {
+            switch self {
+            case .category(let category): "Categorize as \(category.displayName)"
+            case .merchant(let name): "Rename to \(name)"
+            case .transfer(let isTransfer): isTransfer ? "Mark as transfer" : "Not a transfer"
+            case .excludeFromBudgets(let excluded): excluded ? "Exclude from budgets" : "Include in budgets"
+            }
+        }
+
+        /// SF Symbol for the chip (chrome only — the `label` always accompanies it).
+        public var systemImage: String {
+            switch self {
+            case .category(let category): category.iconName
+            case .merchant: "character.cursor.ibeam"
+            case .transfer: "arrow.left.arrow.right"
+            case .excludeFromBudgets: "minus.circle"
+            }
+        }
+    }
+
+    /// The effects a single rule applies, in a stable display order. A rule that
+    /// sets no field (degenerate, e.g. carried forward from older data) yields an
+    /// empty array — the row then reads "No effect" so it is visible and deletable
+    /// rather than silently dead.
+    public static func effects(of rule: TransactionRule) -> [Effect] {
+        var result: [Effect] = []
+        if let category = rule.category { result.append(.category(category)) }
+        if let merchant = rule.merchantName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !merchant.isEmpty {
+            result.append(.merchant(merchant))
+        }
+        if let isTransfer = rule.isTransfer { result.append(.transfer(isTransfer)) }
+        if let excluded = rule.excludedFromBudgets { result.append(.excludeFromBudgets(excluded)) }
+        return result
+    }
+
+    /// Human-readable description of what a rule *matches on*. Mirrors
+    /// `TransactionRule.matches`: a merchant-contains token OR an original-name
+    /// token (case-insensitive). Returns a non-empty sentence even for a degenerate
+    /// rule so the row is never blank.
+    public static func matchDescription(of rule: TransactionRule) -> String {
+        var clauses: [String] = []
+        if let merchant = trimmedNonEmpty(rule.matchMerchantContains) {
+            clauses.append("merchant contains “\(merchant)”")
+        }
+        if let original = trimmedNonEmpty(rule.matchOriginalNameContains) {
+            clauses.append("description contains “\(original)”")
+        }
+        guard !clauses.isEmpty else { return "Matches nothing (no match text)" }
+        // The matcher is OR-combined in `TransactionRule.matches`, so describe it
+        // that way.
+        return "When " + clauses.joined(separator: " or ")
+    }
+
+    // MARK: - Rows (AC #1, #4)
+
+    /// A presentation row for one rule: the rule itself, its sorted display index,
+    /// its match/effect text, and any per-field shadowing caused by a
+    /// higher-precedence rule (AC #4). The view renders this directly.
+    public struct RuleRow: Sendable, Equatable, Identifiable {
+        public var id: UUID { rule.id }
+        public let rule: TransactionRule
+        public let matchDescription: String
+        public let effects: [Effect]
+        /// Conflicts where *another* rule out-ranks this one on a shared field, so
+        /// this rule's value for that field never takes effect. Empty when the rule
+        /// is fully effective. Drives the row's "shadowed" warning.
+        public let shadowedFields: [FieldConflict]
+
+        public init(
+            rule: TransactionRule,
+            matchDescription: String,
+            effects: [Effect],
+            shadowedFields: [FieldConflict]
+        ) {
+            self.rule = rule
+            self.matchDescription = matchDescription
+            self.effects = effects
+            self.shadowedFields = shadowedFields
+        }
+
+        /// Whether at least one of this rule's effects is overridden by a
+        /// higher-precedence rule.
+        public var isShadowed: Bool { !shadowedFields.isEmpty }
+    }
+
+    /// One field on which a lower-precedence rule is overridden by a winning rule.
+    public struct FieldConflict: Sendable, Equatable, Identifiable {
+        public enum Field: String, Sendable, Equatable {
+            case category
+            case transfer
+            case excludeFromBudgets
+
+            public var displayName: String {
+                switch self {
+                case .category: "Category"
+                case .transfer: "Transfer"
+                case .excludeFromBudgets: "Budget exclusion"
+                }
+            }
+        }
+
+        /// The field both rules try to set.
+        public let field: Field
+        /// The id of the rule that wins this field (most recently created).
+        public let winningRuleID: UUID
+        /// A short, privacy-safe label for the winning rule (its match text) so the
+        /// UI can say "overridden by the ‘Starbucks’ rule" without re-deriving it.
+        public let winningRuleLabel: String
+
+        public var id: String { "\(field.rawValue):\(winningRuleID.uuidString)" }
+
+        public init(field: Field, winningRuleID: UUID, winningRuleLabel: String) {
+            self.field = field
+            self.winningRuleID = winningRuleID
+            self.winningRuleLabel = winningRuleLabel
+        }
+    }
+
+    /// Build the full set of display rows in management order, each annotated with
+    /// any fields a higher-precedence overlapping rule shadows (AC #1 + #4).
+    ///
+    /// Two rules *overlap* when some transaction could match both — approximated
+    /// here, with no transactions in hand, by token containment between their
+    /// matchers (one matcher's token is a case-insensitive substring of the
+    /// other's, on the same axis). This is intentionally conservative: it catches
+    /// the real-world case (two "Amazon" rules, or "Amazon" vs "Amazon Prime") that
+    /// the spec calls out, without claiming certainty it can't have without the
+    /// transaction set. For a *given* transaction the exact winner is always
+    /// available via ``provenance(for:in:)``.
+    public static func rows(for rules: [TransactionRule]) -> [RuleRow] {
+        let ordered = sortedForDisplay(rules)
+        return ordered.map { rule in
+            RuleRow(
+                rule: rule,
+                matchDescription: matchDescription(of: rule),
+                effects: effects(of: rule),
+                shadowedFields: shadowedFields(for: rule, among: ordered)
+            )
+        }
+    }
+
+    /// The fields on which `rule` is overridden by a higher-precedence overlapping
+    /// rule. `ordered` must be `sortedForDisplay` output (newest-first), so any rule
+    /// *before* `rule` in it out-ranks `rule`.
+    private static func shadowedFields(
+        for rule: TransactionRule,
+        among ordered: [TransactionRule]
+    ) -> [FieldConflict] {
+        guard let index = ordered.firstIndex(where: { $0.id == rule.id }) else { return [] }
+        let higherPrecedence = ordered[..<index]
+        var conflicts: [FieldConflict] = []
+
+        func firstWinner(where setsField: (TransactionRule) -> Bool) -> TransactionRule? {
+            higherPrecedence.first { setsField($0) && overlaps(rule, $0) }
+        }
+
+        if rule.category != nil, let winner = firstWinner(where: { $0.category != nil }) {
+            conflicts.append(FieldConflict(
+                field: .category,
+                winningRuleID: winner.id,
+                winningRuleLabel: shortLabel(for: winner)
+            ))
+        }
+        if rule.isTransfer != nil, let winner = firstWinner(where: { $0.isTransfer != nil }) {
+            conflicts.append(FieldConflict(
+                field: .transfer,
+                winningRuleID: winner.id,
+                winningRuleLabel: shortLabel(for: winner)
+            ))
+        }
+        if rule.excludedFromBudgets != nil,
+           let winner = firstWinner(where: { $0.excludedFromBudgets != nil }) {
+            conflicts.append(FieldConflict(
+                field: .excludeFromBudgets,
+                winningRuleID: winner.id,
+                winningRuleLabel: shortLabel(for: winner)
+            ))
+        }
+        return conflicts
+    }
+
+    /// Whether two rules could plausibly match the same transaction, judged by
+    /// token containment on a shared matcher axis (merchant or original-name).
+    /// Conservative by design (see ``rows(for:)``).
+    static func overlaps(_ lhs: TransactionRule, _ rhs: TransactionRule) -> Bool {
+        if tokensOverlap(lhs.matchMerchantContains, rhs.matchMerchantContains) { return true }
+        if tokensOverlap(lhs.matchOriginalNameContains, rhs.matchOriginalNameContains) { return true }
+        return false
+    }
+
+    private static func tokensOverlap(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs = trimmedNonEmpty(lhs), let rhs = trimmedNonEmpty(rhs) else { return false }
+        return lhs.localizedCaseInsensitiveContains(rhs) || rhs.localizedCaseInsensitiveContains(lhs)
+    }
+
+    // MARK: - Provenance (AC #3)
+
+    /// Per-field provenance: which rule supplied the *effective* value of each
+    /// field for a given transaction, applying the real precedence. Exactly the
+    /// rule a user would point to and say "this is why my transaction is
+    /// categorized this way". `nil` for a field means no matching rule set it (the
+    /// value came from the user override or Plaid, not a rule).
+    public struct Provenance: Sendable, Equatable {
+        /// All rules that match the transaction, in precedence order (winner first).
+        public let matchingRules: [TransactionRule]
+        public let categoryRuleID: UUID?
+        public let transferRuleID: UUID?
+        public let excludeRuleID: UUID?
+
+        public init(
+            matchingRules: [TransactionRule],
+            categoryRuleID: UUID?,
+            transferRuleID: UUID?,
+            excludeRuleID: UUID?
+        ) {
+            self.matchingRules = matchingRules
+            self.categoryRuleID = categoryRuleID
+            self.transferRuleID = transferRuleID
+            self.excludeRuleID = excludeRuleID
+        }
+
+        /// Whether any rule matched the transaction at all.
+        public var hasMatch: Bool { !matchingRules.isEmpty }
+    }
+
+    /// Resolve which rule governs each field of `transaction`, using the same
+    /// newest-wins precedence as spend math (AC #3). The winning rule for a field
+    /// is the most-recently-created matching rule that sets that field — identical
+    /// to `EffectiveCategoryResolver.firstRuleValue` over the same sort.
+    public static func provenance(
+        for transaction: TransactionDTO,
+        in rules: [TransactionRule]
+    ) -> Provenance {
+        let matching = sortedForDisplay(rules.filter { $0.matches(transaction) })
+        return Provenance(
+            matchingRules: matching,
+            categoryRuleID: matching.first(where: { $0.category != nil })?.id,
+            transferRuleID: matching.first(where: { $0.isTransfer != nil })?.id,
+            excludeRuleID: matching.first(where: { $0.excludedFromBudgets != nil })?.id
+        )
+    }
+
+    // MARK: - Editing (AC #2)
+
+    /// Validate an edited rule before it is committed to the store. A rule must
+    /// have at least one non-empty matcher (otherwise it matches nothing) and at
+    /// least one effect (otherwise it does nothing). Returns the list of problems;
+    /// empty means valid.
+    public enum ValidationProblem: String, Sendable, Equatable {
+        case noMatcher
+        case noEffect
+
+        public var message: String {
+            switch self {
+            case .noMatcher: "Add match text (a merchant or description fragment) so the rule can match transactions."
+            case .noEffect: "Choose at least one effect (category, rename, transfer, or budget exclusion)."
+            }
+        }
+    }
+
+    public static func validate(_ rule: TransactionRule) -> [ValidationProblem] {
+        var problems: [ValidationProblem] = []
+        let hasMatcher = trimmedNonEmpty(rule.matchMerchantContains) != nil
+            || trimmedNonEmpty(rule.matchOriginalNameContains) != nil
+        if !hasMatcher { problems.append(.noMatcher) }
+        if effects(of: rule).isEmpty { problems.append(.noEffect) }
+        return problems
+    }
+
+    /// Apply an edit to a rule in `rules`, returning the new array. The edited
+    /// rule's `id` and `createdAt` are preserved (identity + precedence are stable
+    /// across an edit — editing must not silently re-rank a rule), and matcher /
+    /// effect fields are normalized (trimmed; empty → nil) so the stored rule and
+    /// what the user sees can't drift. A rule whose `id` is not present is appended,
+    /// supporting "edit or add" from one path. Returns `rules` unchanged when the
+    /// edit fails validation, with the problems surfaced separately by the caller.
+    public static func applyingEdit(
+        _ edited: TransactionRule,
+        to rules: [TransactionRule]
+    ) -> [TransactionRule] {
+        let normalized = normalized(edited)
+        var result = rules
+        if let index = result.firstIndex(where: { $0.id == normalized.id }) {
+            // Preserve the original creation time so an edit never silently changes
+            // the rule's precedence relative to its peers.
+            var carried = normalized
+            carried = TransactionRule(
+                id: result[index].id,
+                matchMerchantContains: normalized.matchMerchantContains,
+                matchOriginalNameContains: normalized.matchOriginalNameContains,
+                category: normalized.category,
+                merchantName: normalized.merchantName,
+                isTransfer: normalized.isTransfer,
+                excludedFromBudgets: normalized.excludedFromBudgets,
+                createdAt: result[index].createdAt
+            )
+            result[index] = carried
+        } else {
+            result.append(normalized)
+        }
+        return result
+    }
+
+    /// Remove the rule with `id`. Deleting a rule must NOT retroactively
+    /// un-review past transactions (AC #2): this only drops the rule from the
+    /// matcher set, so already-`.reviewed` transaction metadata is untouched. The
+    /// caller (`AppState`) deliberately does not mutate review metadata here.
+    public static func deleting(
+        ruleID id: UUID,
+        from rules: [TransactionRule]
+    ) -> [TransactionRule] {
+        rules.filter { $0.id != id }
+    }
+
+    /// Normalize a rule's free-text fields: trim whitespace and collapse empty
+    /// strings to `nil`, so a matcher of `"  "` becomes "no matcher" (caught by
+    /// validation) rather than an always-failing match, and a blank rename clears
+    /// rather than renaming to empty.
+    public static func normalized(_ rule: TransactionRule) -> TransactionRule {
+        TransactionRule(
+            id: rule.id,
+            matchMerchantContains: trimmedNonEmpty(rule.matchMerchantContains),
+            matchOriginalNameContains: trimmedNonEmpty(rule.matchOriginalNameContains),
+            category: rule.category,
+            merchantName: trimmedNonEmpty(rule.merchantName),
+            isTransfer: rule.isTransfer,
+            excludedFromBudgets: rule.excludedFromBudgets,
+            createdAt: rule.createdAt
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A short, privacy-safe label for a rule — its merchant matcher, else its
+    /// original-name matcher, else a stable fallback. Used in conflict copy.
+    public static func shortLabel(for rule: TransactionRule) -> String {
+        trimmedNonEmpty(rule.matchMerchantContains)
+            ?? trimmedNonEmpty(rule.matchOriginalNameContains)
+            ?? trimmedNonEmpty(rule.merchantName)
+            ?? "rule"
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionRuleManagerTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionRuleManagerTests.swift
@@ -1,0 +1,279 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Transaction Rule Manager Tests")
+struct TransactionRuleManagerTests {
+    // Fixed reference date so createdAt ordering is deterministic.
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func rule(
+        id: String,
+        merchant: String? = nil,
+        original: String? = nil,
+        category: SpendingCategory? = nil,
+        rename: String? = nil,
+        isTransfer: Bool? = nil,
+        excluded: Bool? = nil,
+        createdOffsetDays: Int = 0
+    ) -> TransactionRule {
+        TransactionRule(
+            id: UUID(uuidString: id)!,
+            matchMerchantContains: merchant,
+            matchOriginalNameContains: original,
+            category: category,
+            merchantName: rename,
+            isTransfer: isTransfer,
+            excludedFromBudgets: excluded,
+            createdAt: base.addingTimeInterval(Double(createdOffsetDays) * 86_400)
+        )
+    }
+
+    private func transaction(name: String, merchant: String?, category: SpendingCategory? = nil) -> TransactionDTO {
+        TransactionDTO(
+            id: "tx-\(name)",
+            accountId: "acc1",
+            amount: 12.34,
+            date: "2026-06-20",
+            name: name,
+            merchantName: merchant,
+            category: category,
+            pending: false
+        )
+    }
+
+    // MARK: - Sort / display order (AC #1)
+
+    @Test("Display order is newest createdAt first, with id tiebreaker")
+    func sortedNewestFirst() {
+        let older = rule(id: "00000000-0000-0000-0000-000000000001", merchant: "A", category: .shopping, createdOffsetDays: 0)
+        let newer = rule(id: "00000000-0000-0000-0000-000000000002", merchant: "B", category: .shopping, createdOffsetDays: 5)
+        let sorted = TransactionRuleManager.sortedForDisplay([older, newer])
+        #expect(sorted.map(\.id) == [newer.id, older.id])
+    }
+
+    @Test("Equal timestamps break ties deterministically by id descending")
+    func tiebreakById() {
+        let a = rule(id: "00000000-0000-0000-0000-00000000000A", merchant: "A", category: .shopping)
+        let b = rule(id: "00000000-0000-0000-0000-00000000000B", merchant: "B", category: .shopping)
+        let sorted = TransactionRuleManager.sortedForDisplay([a, b])
+        // "...B" > "...A" so B is first.
+        #expect(sorted.first?.id == b.id)
+    }
+
+    // MARK: - Effects + match copy (AC #1)
+
+    @Test("Effects list reflects every set field in stable order")
+    func effectsListed() {
+        let r = rule(
+            id: "00000000-0000-0000-0000-000000000010",
+            merchant: "Venmo",
+            category: .transfer,
+            rename: "Venmo Cashout",
+            isTransfer: true,
+            excluded: true
+        )
+        let effects = TransactionRuleManager.effects(of: r)
+        #expect(effects == [
+            .category(.transfer),
+            .merchant("Venmo Cashout"),
+            .transfer(true),
+            .excludeFromBudgets(true),
+        ])
+        #expect(effects[0].label == "Categorize as Transfer In")
+        #expect(effects[3].label == "Exclude from budgets")
+    }
+
+    @Test("A rule with no effect yields an empty effects list")
+    func noEffect() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000011", merchant: "Ghost")
+        #expect(TransactionRuleManager.effects(of: r).isEmpty)
+    }
+
+    @Test("Match description covers merchant and original-name as an OR clause")
+    func matchDescriptionOr() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000012", merchant: "Amazon", original: "AMZN")
+        let copy = TransactionRuleManager.matchDescription(of: r)
+        #expect(copy.contains("merchant contains"))
+        #expect(copy.contains("description contains"))
+        #expect(copy.contains(" or "))
+    }
+
+    @Test("Match description of a matcherless rule is non-empty")
+    func matchDescriptionEmpty() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000013", category: .shopping)
+        #expect(!TransactionRuleManager.matchDescription(of: r).isEmpty)
+    }
+
+    // MARK: - Conflict / shadowing (AC #4)
+
+    @Test("Newer overlapping rule shadows the older rule's category")
+    func newerShadowsOlder() {
+        let older = rule(id: "00000000-0000-0000-0000-000000000020", merchant: "Amazon", category: .shopping, createdOffsetDays: 0)
+        let newer = rule(id: "00000000-0000-0000-0000-000000000021", merchant: "Amazon", category: .entertainment, createdOffsetDays: 3)
+        let rows = TransactionRuleManager.rows(for: [older, newer])
+
+        // Newest first.
+        #expect(rows.first?.id == newer.id)
+        // The winner is fully effective.
+        #expect(rows.first?.isShadowed == false)
+        // The older rule is shadowed on category by the newer one.
+        let olderRow = rows.first { $0.id == older.id }
+        #expect(olderRow?.isShadowed == true)
+        #expect(olderRow?.shadowedFields.first?.field == .category)
+        #expect(olderRow?.shadowedFields.first?.winningRuleID == newer.id)
+        #expect(olderRow?.shadowedFields.first?.winningRuleLabel == "Amazon")
+    }
+
+    @Test("Non-overlapping rules never shadow each other")
+    func noOverlapNoShadow() {
+        let a = rule(id: "00000000-0000-0000-0000-000000000022", merchant: "Amazon", category: .shopping, createdOffsetDays: 0)
+        let b = rule(id: "00000000-0000-0000-0000-000000000023", merchant: "Starbucks", category: .foodAndDrink, createdOffsetDays: 3)
+        let rows = TransactionRuleManager.rows(for: [a, b])
+        #expect(rows.allSatisfy { !$0.isShadowed })
+    }
+
+    @Test("Shadowing is per-field: distinct fields do not conflict")
+    func perFieldShadowing() {
+        // Older sets category; newer sets only transfer. They overlap on merchant
+        // but touch different fields, so neither shadows the other.
+        let older = rule(id: "00000000-0000-0000-0000-000000000024", merchant: "Venmo", category: .shopping, createdOffsetDays: 0)
+        let newer = rule(id: "00000000-0000-0000-0000-000000000025", merchant: "Venmo", isTransfer: true, createdOffsetDays: 3)
+        let rows = TransactionRuleManager.rows(for: [older, newer])
+        #expect(rows.allSatisfy { !$0.isShadowed })
+    }
+
+    @Test("Token containment counts as overlap (Amazon vs Amazon Prime)")
+    func tokenContainmentOverlap() {
+        let broad = rule(id: "00000000-0000-0000-0000-000000000026", merchant: "Amazon", category: .shopping, createdOffsetDays: 3)
+        let specific = rule(id: "00000000-0000-0000-0000-000000000027", merchant: "Amazon Prime", category: .entertainment, createdOffsetDays: 0)
+        // broad is newer → it shadows the older specific rule on category.
+        let rows = TransactionRuleManager.rows(for: [broad, specific])
+        let specificRow = rows.first { $0.id == specific.id }
+        #expect(specificRow?.isShadowed == true)
+    }
+
+    // MARK: - Provenance (AC #3)
+
+    @Test("Provenance points each field at the most-recently-created matching rule")
+    func provenanceWinner() {
+        let older = rule(id: "00000000-0000-0000-0000-000000000030", merchant: "Amazon", category: .shopping, createdOffsetDays: 0)
+        let newer = rule(id: "00000000-0000-0000-0000-000000000031", merchant: "Amazon", category: .entertainment, createdOffsetDays: 3)
+        let tx = transaction(name: "AMAZON MKTPL", merchant: "Amazon")
+        let prov = TransactionRuleManager.provenance(for: tx, in: [older, newer])
+        #expect(prov.hasMatch)
+        #expect(prov.matchingRules.first?.id == newer.id)
+        #expect(prov.categoryRuleID == newer.id)
+    }
+
+    @Test("Provenance category matches EffectiveCategoryResolver's winning category")
+    func provenanceMatchesResolver() {
+        let older = rule(id: "00000000-0000-0000-0000-000000000032", merchant: "Amazon", category: .shopping, createdOffsetDays: 0)
+        let newer = rule(id: "00000000-0000-0000-0000-000000000033", merchant: "Amazon", category: .entertainment, createdOffsetDays: 3)
+        let tx = transaction(name: "AMAZON MKTPL", merchant: "Amazon")
+
+        let prov = TransactionRuleManager.provenance(for: tx, in: [older, newer])
+        let winningRule = prov.matchingRules.first { $0.id == prov.categoryRuleID }
+
+        let resolution = EffectiveCategoryResolver.resolve(transaction: tx, metadata: nil, rules: [older, newer])
+        // The rule the manager credits is the rule whose category the resolver applies.
+        #expect(winningRule?.category == resolution.category)
+        #expect(resolution.category == .entertainment)
+    }
+
+    @Test("Provenance has no match when no rule matches the transaction")
+    func provenanceNoMatch() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000034", merchant: "Amazon", category: .shopping)
+        let tx = transaction(name: "STARBUCKS 123", merchant: "Starbucks")
+        let prov = TransactionRuleManager.provenance(for: tx, in: [r])
+        #expect(!prov.hasMatch)
+        #expect(prov.categoryRuleID == nil)
+    }
+
+    // MARK: - Validation (AC #2 editing)
+
+    @Test("A rule with no matcher and no effect reports both problems")
+    func validateEmpty() {
+        let r = TransactionRule()
+        let problems = TransactionRuleManager.validate(r)
+        #expect(problems.contains(.noMatcher))
+        #expect(problems.contains(.noEffect))
+    }
+
+    @Test("Whitespace-only matcher counts as no matcher")
+    func validateWhitespaceMatcher() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000040", merchant: "   ", category: .shopping)
+        let problems = TransactionRuleManager.validate(TransactionRuleManager.normalized(r))
+        #expect(problems.contains(.noMatcher))
+        #expect(!problems.contains(.noEffect))
+    }
+
+    @Test("A complete rule validates with no problems")
+    func validateComplete() {
+        let r = rule(id: "00000000-0000-0000-0000-000000000041", merchant: "Amazon", category: .shopping)
+        #expect(TransactionRuleManager.validate(r).isEmpty)
+    }
+
+    // MARK: - Editing (AC #2)
+
+    @Test("Editing a rule preserves its id and createdAt so precedence is stable")
+    func editPreservesIdentity() {
+        let original = rule(id: "00000000-0000-0000-0000-000000000050", merchant: "Amazon", category: .shopping, createdOffsetDays: 7)
+        var edited = original
+        edited = TransactionRule(
+            id: original.id,
+            matchMerchantContains: "Amazon",
+            category: .entertainment,
+            // A caller might naively pass a fresh createdAt; applyingEdit must ignore it.
+            createdAt: base.addingTimeInterval(999_999)
+        )
+        let result = TransactionRuleManager.applyingEdit(edited, to: [original])
+        #expect(result.count == 1)
+        #expect(result[0].id == original.id)
+        #expect(result[0].createdAt == original.createdAt)
+        #expect(result[0].category == .entertainment)
+    }
+
+    @Test("Editing trims free-text fields")
+    func editNormalizes() {
+        let original = rule(id: "00000000-0000-0000-0000-000000000051", merchant: "Amazon", category: .shopping)
+        let edited = TransactionRule(
+            id: original.id,
+            matchMerchantContains: "  Amazon Fresh  ",
+            category: .shopping,
+            merchantName: "  Groceries  "
+        )
+        let result = TransactionRuleManager.applyingEdit(edited, to: [original])
+        #expect(result[0].matchMerchantContains == "Amazon Fresh")
+        #expect(result[0].merchantName == "Groceries")
+    }
+
+    @Test("Editing an unknown id appends a new rule")
+    func editAppendsNew() {
+        let existing = rule(id: "00000000-0000-0000-0000-000000000052", merchant: "Amazon", category: .shopping)
+        let fresh = rule(id: "00000000-0000-0000-0000-000000000053", merchant: "Costco", category: .shopping)
+        let result = TransactionRuleManager.applyingEdit(fresh, to: [existing])
+        #expect(result.count == 2)
+        #expect(result.contains { $0.id == fresh.id })
+    }
+
+    // MARK: - Deletion (AC #2)
+
+    @Test("Deleting removes only the targeted rule")
+    func deleteRemovesOnlyTarget() {
+        let a = rule(id: "00000000-0000-0000-0000-000000000060", merchant: "Amazon", category: .shopping)
+        let b = rule(id: "00000000-0000-0000-0000-000000000061", merchant: "Costco", category: .shopping)
+        let result = TransactionRuleManager.deleting(ruleID: a.id, from: [a, b])
+        #expect(result.map(\.id) == [b.id])
+    }
+
+    @Test("Deleting an absent id is a no-op")
+    func deleteAbsent() {
+        let a = rule(id: "00000000-0000-0000-0000-000000000062", merchant: "Amazon", category: .shopping)
+        let result = TransactionRuleManager.deleting(
+            ruleID: UUID(uuidString: "00000000-0000-0000-0000-0000000000FF")!,
+            from: [a]
+        )
+        #expect(result.count == 1)
+    }
+}


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.**

## What & why

`TransactionRule`s are create-only inline in v1 — the only way to make one is to correct a transaction in the Review inbox (`createRule` / `InlineCategoryRulePrompt`). Once created there was no way to see, change, or remove them. This adds a management surface so the user can audit and curate the rules quietly steering their categorization and budgets.

Builds directly on the merged AND-546 schema/override-aware spend math: the conflict-resolution doctrine here is the *exact* precedence `EffectiveCategoryResolver.resolve` already applies (most recently created matching rule wins per field), surfaced verbatim so the UI's "this rule wins" copy can never drift from what actually happens to budgets.

## Change

Pure logic in `PlaidBarCore` (Sendable, unit-tested), thin renderer + store mutators in the app — per CLAUDE.md.

- **`PlaidBarCore/Utilities/TransactionRuleManager.swift`** (new, pure):
  - `sortedForDisplay` / `rows` — newest-first display order (= precedence order).
  - `matchDescription` + `effects` — privacy-safe text for each rule's match and effect. Meaning is in the text; icons/tints are decoration only (ACCESSIBILITY.md).
  - `shadowedFields` / `overlaps` — per-field conflict detection (AC #4). When two overlapping rules set the same field, the most recently created wins; the loser is flagged "overridden by the X rule", never hidden or deleted.
  - `provenance(for:in:)` — the winning rule per field for a given transaction, identical to the resolver's `firstRuleValue` precedence (AC #3).
  - `validate` / `applyingEdit` / `deleting` — editing preserves `id` + `createdAt` so an edit never silently re-ranks a rule; deleting only drops the matcher.
- **`Sources/PlaidBar/App/AppState.swift`** — `updateTransactionRule` / `deleteTransactionRule`: reuse the existing `transactionRules` store and serial persistence writer, undoable via the existing review-undo stack. Deleting a rule deliberately does **not** touch review metadata, so already-reviewed transactions stay reviewed (AC #2).
- **`Sources/PlaidBar/Settings/RulesSettingsView.swift`** (new) + a new "Rules" tab in `SettingsView` — list (match + effect chips + conflict warnings), add/edit sheet with live validation, delete with a confirmation that explicitly states reviewed transactions are not re-opened. Suppressed under Privacy Mask / App Lock.
- **`Sources/PlaidBarCore/Models/Route.swift`** — added `rules` to `SettingsRouteTab` to keep deep-link tab parity with the app's `SettingsTab`.

**Additive / byte-identical for non-opted-in users:** a user with no rules sees an empty state and nothing new is written to disk; the existing inline create-path and spend math are unchanged.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (no errors, no warnings)

swift test --filter TransactionRuleManagerTests
# → Test run with 21 tests passed (display order, effects/match copy, per-field
#   shadowing incl. token-containment overlap, provenance — cross-checked against
#   EffectiveCategoryResolver — validation, edit identity/normalization, deletion)

swift test --filter EffectiveCategoryResolverTests --filter RouteDeepLinkTests --filter TransactionReviewInboxTests
# → Test run with 75 tests passed (no regression from Route / AppState edits)

git diff --check
# → clean
```

## Links

Closes AND-551

## Follow-ups

- A deep-link / button from the transaction inspector's existing provenance popover into the matching rule row in this manager (the `provenance` API is already in place for it).
- Reordering as an *explicit* precedence override (drag-to-rank) is intentionally out of scope here — precedence is `createdAt`-derived and an edit preserves it; a manual rank field would be a schema addition under the AND-524 epic.
