### PR TITLE
feat(review): confidence-sorted inbox + optional high-confidence auto-review (AND-553)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -59,6 +59,8 @@ final class AppState {
         static let windowFirstOrientationDismissedContextPrefix = "windowFirstOrientation.dismissed.context"
         static let lastTransactionCacheContext = "cache.lastTransactionCacheContext"
         static let categoryBudgetCache = "cache.categoryBudgets"
+        static let reviewInboxSortOrder = ReviewInboxSortOrder.storageKey
+        static let reviewAutoReviewHighConfidence = ReviewAutoReviewPreference.storageKey
     }
 
     // MARK: - State
@@ -107,6 +109,42 @@ final class AppState {
         }
     }
     var hasLoadedTransactionReviewStorage = false
+
+    /// How the Review Inbox orders its rows (AND-553). UserDefaults-backed so the
+    /// choice persists, and changing it invalidates the memoized snapshot so the
+    /// next read re-sorts. Defaults to `.priority` — the historical order — so a
+    /// user who never touches the control sees today's ordering exactly. Seeded
+    /// from UserDefaults in `init` (below) so a stored choice is honored at boot.
+    var reviewInboxSortOrder: ReviewInboxSortOrder = .priority {
+        didSet {
+            guard reviewInboxSortOrder != oldValue else { return }
+            _cachedTransactionReviewInboxSnapshot = nil
+            UserDefaults.standard.set(reviewInboxSortOrder.rawValue, forKey: Keys.reviewInboxSortOrder)
+        }
+    }
+
+    /// Whether the opt-in high-confidence auto-review pass is enabled (AND-553).
+    /// Off by default: a not-opted-in user has nothing resolved on their behalf,
+    /// matching today's behavior byte-for-byte. UserDefaults-backed so the choice
+    /// persists; seeded in `init`. Turning it ON triggers a one-shot
+    /// `applyHighConfidenceAutoReview()` so the inbox immediately reflects the
+    /// choice; turning it OFF stops future auto-review but leaves already-cleared
+    /// rows as they are (they remain ⌘Z / bulk-undoable).
+    var autoReviewHighConfidenceEnabled: Bool = false {
+        didSet {
+            guard autoReviewHighConfidenceEnabled != oldValue, !isLoadingReviewPreferences else { return }
+            UserDefaults.standard.set(autoReviewHighConfidenceEnabled, forKey: Keys.reviewAutoReviewHighConfidence)
+            if autoReviewHighConfidenceEnabled {
+                applyHighConfidenceAutoReview()
+            }
+        }
+    }
+
+    /// Suppresses the `autoReviewHighConfidenceEnabled` didSet side effects while
+    /// seeding the stored value at boot, so loading the persisted preference does
+    /// not itself trigger an auto-review pass before data is loaded.
+    private var isLoadingReviewPreferences = false
+
     var isLoading = false
     /// True from launch until the first `loadInitialData()` pass completes.
     /// While booting, data surfaces render loading/skeleton states instead
@@ -827,6 +865,7 @@ final class AppState {
         loadWatchlistTargets(defaults: defaults)
         loadAppLockPreferences(defaults: defaults)
         loadLocalAISettings(defaults: defaults)
+        loadReviewPreferences(defaults: defaults)
         // Balance history
         loadPersistedBalanceHistory()
         loadPersistedWeeklyReviewState()
@@ -1002,6 +1041,31 @@ final class AppState {
             selectedInsightWindow = window
         } else {
             selectedInsightWindow = .lastMonth
+        }
+    }
+
+    /// Seeds the Review Inbox sort order and auto-review opt-in from UserDefaults
+    /// at boot (AND-553). Both default to today's behavior when unset (priority
+    /// order; auto-review off). The auto-review didSet side effect is suppressed
+    /// during this load so seeding the stored value never kicks off an
+    /// auto-review pass before data has loaded — the explicit pass runs from
+    /// `applyHighConfidenceAutoReview` after the inbox is populated.
+    private func loadReviewPreferences(defaults: UserDefaults) {
+        isLoadingReviewPreferences = true
+        defer { isLoadingReviewPreferences = false }
+
+        if let stored = defaults.string(forKey: Keys.reviewInboxSortOrder),
+           let order = ReviewInboxSortOrder(rawValue: stored)
+        {
+            reviewInboxSortOrder = order
+        } else {
+            reviewInboxSortOrder = .priority
+        }
+
+        if defaults.object(forKey: Keys.reviewAutoReviewHighConfidence) != nil {
+            autoReviewHighConfidenceEnabled = defaults.bool(forKey: Keys.reviewAutoReviewHighConfidence)
+        } else {
+            autoReviewHighConfidenceEnabled = ReviewAutoReviewPreference.defaultValue.isEnabled
         }
     }
 
@@ -1577,7 +1641,8 @@ final class AppState {
             metadata: transactionReviewMetadata,
             rules: transactionRules,
             recurring: recurringTransactions,
-            now: Date()
+            now: Date(),
+            sortOrder: reviewInboxSortOrder
         )
         _cachedTransactionReviewInboxSnapshot = snapshot
         return snapshot
@@ -4485,6 +4550,9 @@ final class AppState {
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
+            // An explicit user approve is never an auto-review — clear any prior
+            // auto-review provenance (AND-553).
+            metadata.autoReviewed = false
         }
     }
 
@@ -4495,6 +4563,7 @@ final class AppState {
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
+            metadata.autoReviewed = false
         }
     }
 
@@ -4507,6 +4576,7 @@ final class AppState {
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
+            metadata.autoReviewed = false
         }
     }
 
@@ -4532,6 +4602,7 @@ final class AppState {
             metadata.status = .needsReview
             metadata.reviewedAt = nil
             metadata.reviewReasonCodes = []
+            metadata.autoReviewed = false
         }
     }
 
@@ -4546,6 +4617,7 @@ final class AppState {
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
+            metadata.autoReviewed = false
         }
     }
 
@@ -4559,6 +4631,7 @@ final class AppState {
             metadata.lastSeenAmount = transaction.amount
             metadata.lastSeenName = transaction.name
             metadata.lastSeenPending = transaction.pending
+            metadata.autoReviewed = false
         }
     }
 
@@ -4627,6 +4700,32 @@ final class AppState {
         return resolvableIDs.count
     }
 
+    /// Runs the opt-in high-confidence auto-review pass (AND-553).
+    ///
+    /// The conservative eligibility decision — which rows are safe to clear
+    /// automatically — lives entirely in the pure, unit-tested
+    /// `ReviewAutoReviewPolicy` (never transfers or unusual/changed charges; only
+    /// high-confidence, already-categorized, ordinary-value rows). This method
+    /// just applies the resulting ids through the SAME approve path as a manual
+    /// review, additionally stamping each as `autoReviewed = true` so the row is
+    /// flagged and the whole pass is bulk-undoable in ONE ⌘Z. A no-op when the
+    /// preference is off or nothing qualifies (so the inbox is untouched).
+    ///
+    /// - Returns: the number of rows auto-reviewed (0 when nothing qualified).
+    @discardableResult
+    func applyHighConfidenceAutoReview() -> Int {
+        guard autoReviewHighConfidenceEnabled else { return 0 }
+        let ids = ReviewAutoReviewPolicy.autoReviewableIDs(in: transactionReviewInboxSnapshot)
+        let resolvableIDs = ids.filter { id in transactions.contains(where: { $0.id == id }) }
+        guard !resolvableIDs.isEmpty else { return 0 }
+        pushReviewUndoState()
+        for id in resolvableIDs {
+            approveReviewItemWithoutUndo(id, autoReviewed: true)
+        }
+        persistReviewStorage()
+        return resolvableIDs.count
+    }
+
     func undoLastReviewAction() {
         guard let previous = reviewUndoStack.popLast() else { return }
         transactionReviewMetadata = previous.metadata
@@ -4648,7 +4747,13 @@ final class AppState {
         persistReviewStorage()
     }
 
-    private func approveReviewItemWithoutUndo(_ id: String) {
+    /// Marks one row reviewed without pushing its own undo snapshot (the caller
+    /// owns the batch snapshot). `autoReviewed` stamps the AND-553 provenance: the
+    /// opt-in auto-review pass passes `true` so the row is flagged and the pass is
+    /// bulk-undoable; every manual path passes `false` (the default) so an explicit
+    /// review is never mislabeled as automatic — and a later manual approve of a
+    /// previously auto-reviewed row clears the flag.
+    private func approveReviewItemWithoutUndo(_ id: String, autoReviewed: Bool = false) {
         guard let transaction = transactions.first(where: { $0.id == id }) else { return }
         var byId = Dictionary(uniqueKeysWithValues: transactionReviewMetadata.map { ($0.id, $0) })
         var metadata = byId[id] ?? TransactionReviewMetadata(id: id)
@@ -4658,6 +4763,7 @@ final class AppState {
         metadata.lastSeenAmount = transaction.amount
         metadata.lastSeenName = transaction.name
         metadata.lastSeenPending = transaction.pending
+        metadata.autoReviewed = autoReviewed
         byId[id] = metadata
         transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
     }
@@ -4677,6 +4783,11 @@ final class AppState {
         guard changed else { return }
         transactionReviewMetadata = byId.values.sorted { $0.id < $1.id }
         persistReviewStorage()
+        // When the opt-in pass is enabled (AND-553), sweep the freshly-seeded rows
+        // so newly synced high-confidence charges are auto-cleared as they arrive.
+        // A no-op when the preference is off (default), so sync behavior is
+        // unchanged for a not-opted-in user.
+        applyHighConfidenceAutoReview()
     }
 
     private func pushReviewUndoState() {

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -790,6 +790,15 @@ struct GeneralSettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
 
+            Section("Review Inbox") {
+                // AND-553: opt-in auto-review for the safest rows. Off by default,
+                // so a user who never enables it sees no rows resolved for them.
+                Toggle("Auto-review high-confidence transactions", isOn: $state.autoReviewHighConfidenceEnabled)
+                Text("Automatically marks reviewed only the safest rows — high-confidence, already-categorized, ordinary-value transactions. Transfers and unusual or changed charges are never auto-reviewed and always wait for you. Auto-reviewed rows are flagged and you can undo them with ⌘Z.")
+                    .detailText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             Section("Local data") {
                 LabeledContent("Storage path") {
                     VStack(alignment: .trailing, spacing: Spacing.xs) {

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -368,6 +368,16 @@ struct ReviewInboxView: View {
                     .accessibilityLabel(headerPresentation.highPriorityAccessibilityLabel ?? highPriorityBadge)
             }
 
+            // Confidence-aware sort control (AND-553). Re-orders the listed rows
+            // between the historical "most urgent" order and "low confidence
+            // first", which floats Plaid's LOW/UNKNOWN categorizations to the top.
+            // The current order rides the menu label text + glyph (never color
+            // alone). Shown only with rows to order; the pure ordering lives in
+            // Core (`ReviewInboxSorting`) so the control just flips a stored enum.
+            if !appState.shouldMaskFinancialValues, snapshot.totalCount > 0 {
+                sortControl
+            }
+
             // Bulk "Mark N reviewed": staging a plan opens the blast-radius
             // confirmation. Hidden while masked (rows hidden) or when the inbox
             // has nothing to resolve. The N rides the label text + icon, never
@@ -415,6 +425,33 @@ struct ReviewInboxView: View {
             .help("Undo last review action")
             .accessibilityLabel("Undo last review action")
         }
+    }
+
+    /// The confidence-aware sort control (AND-553). A compact menu that flips the
+    /// stored `appState.reviewInboxSortOrder`; each option carries its title + a
+    /// glyph so the choice never reads by color alone (ACCESSIBILITY.md). Changing
+    /// it invalidates the cached snapshot so the rows immediately re-order.
+    private var sortControl: some View {
+        @Bindable var state = appState
+        return Menu {
+            Picker("Sort", selection: $state.reviewInboxSortOrder) {
+                ForEach(ReviewInboxSortOrder.allCases) { order in
+                    Label(order.title, systemImage: order.glyphName).tag(order)
+                }
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+        } label: {
+            Label("Sort: \(appState.reviewInboxSortOrder.title)", systemImage: "arrow.up.arrow.down")
+                .font(.caption2.weight(.semibold))
+                .labelStyle(.iconOnly)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .controlSize(.mini)
+        .fixedSize()
+        .help("Sort the review queue: \(ReviewInboxSortOrder.allCases.map(\.title).joined(separator: " or "))")
+        .accessibilityLabel("Sort review queue, currently \(appState.reviewInboxSortOrder.title)")
     }
 
     private var privateInboxPlaceholder: some View {
@@ -853,6 +890,13 @@ private struct ReviewInboxRow: View {
                         suggestedBadge
                     }
 
+                    // Flags a row that the opt-in auto-review pass cleared and that
+                    // later reopened (AND-553) — pairs a glyph AND the word
+                    // "Auto-reviewed" so the provenance never rides on color alone.
+                    if item.wasAutoReviewed {
+                        autoReviewedBadge
+                    }
+
                     Text(Formatters.displayTransactionDate(item.transaction.date))
                         .microText()
                         .foregroundStyle(.tertiary)
@@ -880,6 +924,23 @@ private struct ReviewInboxRow: View {
                 Capsule().stroke(SemanticColors.brand.opacity(0.18), lineWidth: 1)
             }
             .accessibilityLabel("Category suggested on device")
+    }
+
+    // Auto-review provenance badge (AND-553). Shown on a row that the opt-in
+    // high-confidence pass cleared and that later reopened, so the user can see it
+    // was resolved automatically. Glyph + text carry the meaning together.
+    private var autoReviewedBadge: some View {
+        Label("Auto-reviewed", systemImage: "checkmark.seal")
+            .font(.caption2.weight(.semibold))
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.secondary.opacity(0.10), in: Capsule())
+            .overlay {
+                Capsule().stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+            }
+            .accessibilityLabel("Automatically reviewed")
     }
 
     private var reasonChips: some View {
@@ -1074,7 +1135,8 @@ private struct ReviewInboxRow: View {
         let baseCategory = displayCategory?.displayName ?? "Uncategorized"
         let category = isShowingSuggestion ? "\(baseCategory) (suggested on device)" : baseCategory
         let amount = Formatters.currency(item.transaction.displayAmount, format: .full)
-        return "\(item.effectiveMerchantName), \(amount), \(category), reasons: \(reasons)"
+        let autoReviewed = item.wasAutoReviewed ? ", automatically reviewed" : ""
+        return "\(item.effectiveMerchantName), \(amount), \(category), reasons: \(reasons)\(autoReviewed)"
     }
 
     private func tint(for reason: TransactionReviewReason) -> Color {

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -97,6 +97,15 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
     /// decoded as `nil` when absent) so records written before AND-582 still
     /// decode and behave identically.
     public var userNote: String?
+    /// `true` when this row was marked reviewed by the opt-in high-confidence
+    /// auto-review pass (AND-553) rather than by an explicit user action. The
+    /// inbox / review table flag these rows so the user can see what was cleared
+    /// for them, and the app can bulk-undo the whole auto-review batch. Defaults
+    /// to `false` and decodes as `false` when absent, so records written before
+    /// AND-553 still decode and behave identically. A manual review/ignore action
+    /// on the row clears the flag — once the user acts, it is no longer an
+    /// auto-review.
+    public var autoReviewed: Bool
 
     public init(
         id: String,
@@ -110,7 +119,8 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
         lastSeenAmount: Double? = nil,
         lastSeenName: String? = nil,
         lastSeenPending: Bool? = nil,
-        userNote: String? = nil
+        userNote: String? = nil,
+        autoReviewed: Bool = false
     ) {
         self.id = id
         self.status = status
@@ -124,6 +134,7 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
         self.lastSeenName = lastSeenName
         self.lastSeenPending = lastSeenPending
         self.userNote = userNote
+        self.autoReviewed = autoReviewed
     }
 
     public init(from decoder: any Decoder) throws {
@@ -143,6 +154,10 @@ public struct TransactionReviewMetadata: Codable, Sendable, Identifiable, Equata
         // default to nil. Matches the forward-compatible decode used for
         // `TransactionDTO.isLowConfidenceCategory`.
         userNote = try container.decodeIfPresent(String.self, forKey: .userNote)
+        // New field (AND-553) — absent before auto-review existed, so default to
+        // false: a record predating it is treated as a manual review, never an
+        // auto-review.
+        autoReviewed = try container.decodeIfPresent(Bool.self, forKey: .autoReviewed) ?? false
     }
 }
 
@@ -204,6 +219,13 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
     /// pairs this with a text+icon "Suggested" badge (never color alone). Nil
     /// when the category came straight from the user override or Plaid.
     public let categorySource: LocalAICategoryResolutionSource?
+    /// `true` when this row was cleared by the opt-in high-confidence auto-review
+    /// pass rather than an explicit user action (AND-553). Surfaces only on rows
+    /// that reopened after being auto-reviewed (e.g. the charge changed) so the
+    /// user can see the auto-review provenance; a freshly auto-reviewed row leaves
+    /// the inbox like any other reviewed row. Always `false` for `.needsReview`
+    /// rows that have never been auto-reviewed.
+    public let wasAutoReviewed: Bool
 
     public init(
         transaction: TransactionDTO,
@@ -214,7 +236,8 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
         isTransfer: Bool,
         excludedFromBudgets: Bool,
         matchedRuleIds: [UUID],
-        categorySource: LocalAICategoryResolutionSource? = nil
+        categorySource: LocalAICategoryResolutionSource? = nil,
+        wasAutoReviewed: Bool = false
     ) {
         self.id = transaction.id
         self.transaction = transaction
@@ -226,6 +249,7 @@ public struct TransactionReviewItem: Sendable, Identifiable, Equatable {
         self.excludedFromBudgets = excludedFromBudgets
         self.matchedRuleIds = matchedRuleIds
         self.categorySource = categorySource
+        self.wasAutoReviewed = wasAutoReviewed
     }
 
     /// Whether `effectiveCategory` was filled by the on-device NL tier rather
@@ -256,6 +280,7 @@ public enum TransactionReviewInbox {
         rules: [TransactionRule],
         recurring: [RecurringTransaction],
         now: Date,
+        sortOrder: ReviewInboxSortOrder = .priority,
         nlCategorizer: NLMerchantCategorizer = NLMerchantCategorizer()
     ) -> TransactionReviewInboxSnapshot {
         let metadataById = Dictionary(uniqueKeysWithValues: metadata.map { ($0.id, $0) })
@@ -414,18 +439,17 @@ public enum TransactionReviewInbox {
                 isTransfer: isTransfer,
                 excludedFromBudgets: metadata?.excludedFromBudgets ?? isTransfer,
                 matchedRuleIds: matchedRules.map(\.id),
-                categorySource: categorySource
+                categorySource: categorySource,
+                wasAutoReviewed: metadata?.autoReviewed ?? false
             )
         }
-        .sorted { lhs, rhs in
-            let lhsPriority = lhs.reasonCodes.map(\.priority).min() ?? Int.max
-            let rhsPriority = rhs.reasonCodes.map(\.priority).min() ?? Int.max
-            if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
-            if lhs.transaction.date != rhs.transaction.date { return lhs.transaction.date > rhs.transaction.date }
-            return lhs.id < rhs.id
-        }
 
-        return TransactionReviewInboxSnapshot(items: items)
+        // Order by the chosen sort (AND-553). `.priority` — the default — is the
+        // historical order exactly (the comparator lives in `ReviewInboxSorting`);
+        // `.confidenceLowFirst` floats Plaid's LOW/UNKNOWN categorizations up and
+        // falls back to that same historical order within each confidence band.
+        let sortedItems = ReviewInboxSorting.sorted(items, order: sortOrder)
+        return TransactionReviewInboxSnapshot(items: sortedItems)
     }
 
     private static func normalizedMerchantKey(_ transaction: TransactionDTO) -> String {

--- a/Sources/PlaidBarCore/Utilities/ReviewAutoReviewPolicy.swift
+++ b/Sources/PlaidBarCore/Utilities/ReviewAutoReviewPolicy.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Opt-in preference for auto-marking high-confidence rows reviewed (AND-553,
+/// DEFERRED v2 / AND-524).
+///
+/// **Off by default.** A user who never enables this sees the inbox behave exactly
+/// as it does today: nothing is resolved on their behalf, every row waits for an
+/// explicit action. Only when the user opts in does VaultPeek clear the safest,
+/// most boring rows (high-confidence, already-categorized, ordinary-value, never a
+/// transfer or unusual charge) so the queue holds the items that actually need a
+/// human look.
+public enum ReviewAutoReviewPreference: String, CaseIterable, Sendable, Identifiable {
+    case off
+    case on
+
+    /// The default — auto-review disabled. A not-opted-in user gets today's
+    /// behavior, byte-for-byte.
+    public static let defaultValue: ReviewAutoReviewPreference = .off
+
+    /// Stable UserDefaults key for the settings toggle (app-side `@AppStorage`).
+    public static let storageKey = "reviewInbox.autoReviewHighConfidence"
+
+    public var id: String { rawValue }
+
+    public var isEnabled: Bool { self == .on }
+}
+
+/// Pure eligibility logic deciding which inbox rows are safe to auto-mark
+/// reviewed (AND-553).
+///
+/// The whole value — and the whole risk — of auto-review is *what it is allowed to
+/// touch*. This type encodes the conservative contract and nothing else; the app
+/// applies the resulting ids through the SAME undoable batch path as a manual bulk
+/// review, and flags each auto-resolved row so the user can see (and bulk-undo)
+/// exactly what was cleared for them.
+///
+/// A row is auto-reviewable only when ALL hold:
+/// 1. **High confidence** — Plaid did NOT flag the categorization LOW/UNKNOWN
+///    (`!transaction.isLowConfidenceCategory`). Low-confidence rows are precisely
+///    the ones a human should see, so they are never auto-cleared.
+/// 2. **Categorized** — there is a real effective category that is not the
+///    catch-all `.other`. An uncategorized / "Other" row needs a human.
+/// 3. **Not a suggestion** — the category is a real Plaid/user category, not an
+///    on-device NL/Foundation Models *suggestion* awaiting approval (a suggested
+///    row carries `.uncategorized` and is not high-confidence per the inbox).
+/// 4. **Ordinary value** — the row does not carry the `.unusualAmount` reason. A
+///    larger-than-usual charge is exactly what the user wants to eyeball.
+/// 5. **Never a transfer** — neither the resolved `isTransfer` flag nor a
+///    `.possibleTransfer` reason. Transfers/card-payments are budget-affecting
+///    edge cases that must stay a deliberate human decision.
+///
+/// Items already resolved (`status != .needsReview`) are excluded — auto-review
+/// only ever clears rows that are still genuinely pending.
+public enum ReviewAutoReviewPolicy {
+    /// Whether a single inbox row is safe to auto-mark reviewed under the
+    /// conservative contract above.
+    public static func isAutoReviewable(_ item: TransactionReviewItem) -> Bool {
+        // Only touch rows still genuinely needing review.
+        guard item.status == .needsReview else { return false }
+
+        // 1. High confidence — never clear what Plaid itself flagged uncertain.
+        guard !item.transaction.isLowConfidenceCategory else { return false }
+
+        // 2 + 3. A real, non-"Other" category that is NOT an on-device suggestion.
+        guard let category = item.effectiveCategory,
+              category != .other,
+              !item.isNLSuggestedCategory
+        else { return false }
+
+        // 5. Never a transfer (resolved flag or a possible-transfer signal) and
+        //    never one of the transfer categories.
+        guard !item.isTransfer,
+              !item.reasonCodes.contains(.possibleTransfer),
+              !EffectiveCategoryResolver.isTransferCategory(category)
+        else { return false }
+
+        // 4. Ordinary value — leave larger/unusual charges for a human.
+        guard !item.reasonCodes.contains(.unusualAmount) else { return false }
+
+        // Defense in depth: a row carrying any high-priority reason (transfer,
+        // pending/recurring change, changed-since-review, or unusual amount) is
+        // never auto-cleared even if the specific guards above were relaxed.
+        guard !item.reasonCodes.contains(where: \.isHighPriority) else { return false }
+
+        return true
+    }
+
+    /// The transaction ids of every auto-reviewable row in `snapshot`, in the
+    /// snapshot's listed order. The app marks exactly these reviewed (flagged as
+    /// auto-reviewed) in a single undoable batch. Empty when nothing qualifies —
+    /// so applying it is a no-op and the inbox is unchanged.
+    public static func autoReviewableIDs(in snapshot: TransactionReviewInboxSnapshot) -> [String] {
+        snapshot.items.filter(isAutoReviewable).map(\.id)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ReviewInboxSorting.swift
+++ b/Sources/PlaidBarCore/Utilities/ReviewInboxSorting.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// How the Review Inbox orders its rows (AND-553, DEFERRED v2 / AND-524).
+///
+/// The default `.priority` order is the byte-identical historical ordering: most
+/// urgent reason first (`reasonCodes.priority`), then newest, then id. The new
+/// `.confidenceLowFirst` order is a cheap smart-sort that floats the rows the user
+/// most needs to look at — Plaid's own LOW/UNKNOWN categorizations
+/// (`TransactionDTO.isLowConfidenceCategory`) — to the top, falling back to the
+/// existing priority order within each confidence band so the secondary ordering
+/// never changes.
+///
+/// Pure and `Sendable`: the ordering decision lives here (not in the view) so it
+/// is unit-tested without SwiftUI and shared by every surface that lists the
+/// inbox. Additive — a user who never changes the control sees `.priority`, i.e.
+/// today's order exactly.
+public enum ReviewInboxSortOrder: String, CaseIterable, Sendable, Identifiable {
+    /// Historical order: highest-priority reason first, then newest, then id.
+    case priority
+    /// Low-confidence categorizations first, then the historical order within
+    /// each confidence band.
+    case confidenceLowFirst
+
+    /// The default — unchanged historical order. A not-opted-in user sees this.
+    public static let defaultValue: ReviewInboxSortOrder = .priority
+
+    /// Stable UserDefaults key for the sort control (app-side `@AppStorage`).
+    public static let storageKey = "reviewInbox.sortOrder"
+
+    public var id: String { rawValue }
+
+    /// Menu/segment label. The meaning rides this text + the control's glyph,
+    /// never color alone (ACCESSIBILITY.md).
+    public var title: String {
+        switch self {
+        case .priority: "Most urgent"
+        case .confidenceLowFirst: "Low confidence first"
+        }
+    }
+
+    /// SF Symbol paired with `title` so the control is legible without color.
+    public var glyphName: String {
+        switch self {
+        case .priority: "exclamationmark.triangle"
+        case .confidenceLowFirst: "questionmark.circle"
+        }
+    }
+}
+
+/// Pure, deterministic ordering of inbox items by a chosen `ReviewInboxSortOrder`.
+///
+/// Kept separate from `TransactionReviewInbox.evaluate` so the *what surfaces*
+/// (heuristic detection) and the *in what order* (presentation) concerns stay
+/// independent and individually testable; `evaluate` calls this for its final
+/// ordering.
+public enum ReviewInboxSorting {
+    /// Returns `items` ordered by `order`. The historical comparator (urgency →
+    /// newest → id) is the tiebreaker in every order, so two items that share a
+    /// confidence band keep today's relative order exactly.
+    public static func sorted(
+        _ items: [TransactionReviewItem],
+        order: ReviewInboxSortOrder
+    ) -> [TransactionReviewItem] {
+        switch order {
+        case .priority:
+            items.sorted(by: priorityLess)
+        case .confidenceLowFirst:
+            items.sorted { lhs, rhs in
+                let lhsLow = lhs.transaction.isLowConfidenceCategory
+                let rhsLow = rhs.transaction.isLowConfidenceCategory
+                // Low-confidence rows float up; within the same confidence band
+                // fall back to the historical comparator so nothing else reorders.
+                if lhsLow != rhsLow { return lhsLow && !rhsLow }
+                return priorityLess(lhs, rhs)
+            }
+        }
+    }
+
+    /// The historical inbox comparator, extracted verbatim from
+    /// `TransactionReviewInbox.evaluate` so the default order is bit-for-bit
+    /// unchanged and the confidence order can reuse it as its in-band tiebreaker.
+    static func priorityLess(_ lhs: TransactionReviewItem, _ rhs: TransactionReviewItem) -> Bool {
+        let lhsPriority = lhs.reasonCodes.map(\.priority).min() ?? Int.max
+        let rhsPriority = rhs.reasonCodes.map(\.priority).min() ?? Int.max
+        if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+        if lhs.transaction.date != rhs.transaction.date { return lhs.transaction.date > rhs.transaction.date }
+        return lhs.id < rhs.id
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReviewAutoReviewMetadataTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewAutoReviewMetadataTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Review Auto-Review Metadata + Inbox Integration (AND-553)")
+struct ReviewAutoReviewMetadataTests {
+    @Test("autoReviewed defaults to false and round-trips through Codable")
+    func autoReviewedRoundTrips() throws {
+        var metadata = TransactionReviewMetadata(id: "tx", status: .reviewed)
+        #expect(metadata.autoReviewed == false)
+
+        metadata.autoReviewed = true
+        let data = try JSONEncoder().encode(metadata)
+        let decoded = try JSONDecoder().decode(TransactionReviewMetadata.self, from: data)
+        #expect(decoded.autoReviewed == true)
+    }
+
+    @Test("A record written before AND-553 (no autoReviewed key) decodes as false")
+    func legacyRecordDecodesFalse() throws {
+        // Simulate a pre-AND-553 on-disk record: a metadata JSON object with no
+        // `autoReviewed` key. The forward-compatible decode must default it to
+        // false so the row is treated as a manual review, not an auto-review.
+        let legacyJSON = """
+        {"id":"tx-legacy","status":"reviewed","excludedFromBudgets":false,"reviewReasonCodes":[]}
+        """
+        let data = Data(legacyJSON.utf8)
+        let decoded = try JSONDecoder().decode(TransactionReviewMetadata.self, from: data)
+        #expect(decoded.autoReviewed == false)
+        #expect(decoded.status == .reviewed)
+    }
+
+    @Test("evaluate threads autoReviewed metadata onto the item's wasAutoReviewed flag")
+    func evaluateSurfacesAutoReviewedFlag() {
+        // A charge auto-reviewed while pending that reopens after settling
+        // differently must carry `wasAutoReviewed` so the UI can flag it.
+        let pendingTx = TransactionDTO(
+            id: "tx-1",
+            accountId: "acct",
+            amount: 10,
+            date: "2026-06-01",
+            name: "COFFEE",
+            merchantName: "Coffee",
+            category: .foodAndDrink,
+            pending: true
+        )
+        let postedTx = TransactionDTO(
+            id: "tx-1",
+            accountId: "acct",
+            amount: 25, // settled at a different amount → reopens
+            date: "2026-06-01",
+            name: "COFFEE",
+            merchantName: "Coffee",
+            category: .foodAndDrink,
+            pending: false
+        )
+        let metadata = TransactionReviewMetadata(
+            id: "tx-1",
+            status: .reviewed,
+            reviewedAt: Date(),
+            lastSeenAmount: 10,
+            lastSeenName: "COFFEE",
+            lastSeenPending: true,
+            autoReviewed: true
+        )
+        _ = pendingTx
+
+        let snapshot = TransactionReviewInbox.evaluate(
+            transactions: [postedTx],
+            metadata: [metadata],
+            rules: [],
+            recurring: [],
+            now: Date()
+        )
+
+        let item = snapshot.items.first { $0.id == "tx-1" }
+        #expect(item != nil)
+        #expect(item?.wasAutoReviewed == true)
+    }
+
+    @Test("evaluate default sort order is unchanged (byte-identical priority order)")
+    func evaluateDefaultSortUnchanged() {
+        let transactions = [
+            transaction(id: "low", amount: 12, lowConfidence: true),
+            transaction(id: "high", amount: 12, lowConfidence: false),
+        ]
+        // Same data, default vs explicit `.priority` → identical ordering, proving
+        // the new parameter's default is the historical behavior.
+        let implicitDefault = TransactionReviewInbox.evaluate(
+            transactions: transactions, metadata: [], rules: [], recurring: [], now: Date()
+        )
+        let explicitPriority = TransactionReviewInbox.evaluate(
+            transactions: transactions, metadata: [], rules: [], recurring: [], now: Date(), sortOrder: .priority
+        )
+        #expect(implicitDefault.items.map(\.id) == explicitPriority.items.map(\.id))
+    }
+
+    @Test("evaluate with confidenceLowFirst floats the low-confidence row up")
+    func evaluateConfidenceSort() {
+        // Two otherwise-equivalent uncategorized rows; only confidence differs.
+        let transactions = [
+            transaction(id: "high", amount: 12, lowConfidence: false),
+            transaction(id: "low", amount: 12, lowConfidence: true),
+        ]
+
+        let priority = TransactionReviewInbox.evaluate(
+            transactions: transactions, metadata: [], rules: [], recurring: [], now: Date(), sortOrder: .priority
+        )
+        let confidence = TransactionReviewInbox.evaluate(
+            transactions: transactions, metadata: [], rules: [], recurring: [], now: Date(), sortOrder: .confidenceLowFirst
+        )
+
+        // Confidence-first must lead with the low-confidence row.
+        #expect(confidence.items.first?.id == "low")
+        // The two orders genuinely differ here (priority leads with id "high" by
+        // the id tiebreaker), proving the sort param has an effect.
+        #expect(priority.items.map(\.id) != confidence.items.map(\.id))
+    }
+
+    // MARK: - Helpers
+
+    /// A transaction with no merchant name and a unique merchant, so it trips the
+    /// `.uncategorized` (low-confidence) / `.newMerchant` reasons and surfaces in
+    /// the inbox.
+    private func transaction(id: String, amount: Double, lowConfidence: Bool) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acct",
+            amount: amount,
+            date: "2026-06-01",
+            name: "Merchant \(id)",
+            merchantName: "Merchant \(id)",
+            category: .other,
+            pending: false,
+            isLowConfidenceCategory: lowConfidence
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReviewAutoReviewPolicyTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewAutoReviewPolicyTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Review Auto-Review Policy Tests (AND-553)")
+struct ReviewAutoReviewPolicyTests {
+    @Test("Auto-review preference is off by default")
+    func preferenceOffByDefault() {
+        #expect(ReviewAutoReviewPreference.defaultValue == .off)
+        #expect(ReviewAutoReviewPreference.defaultValue.isEnabled == false)
+    }
+
+    @Test("A high-confidence, categorized, ordinary, non-transfer row is auto-reviewable")
+    func happyPathEligible() {
+        let row = item(reasons: [.newMerchant], category: .foodAndDrink, lowConfidence: false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(row))
+    }
+
+    @Test("NEVER auto-reviews a low-confidence row")
+    func neverLowConfidence() {
+        let row = item(reasons: [.uncategorized], category: .foodAndDrink, lowConfidence: true)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(row) == false)
+    }
+
+    @Test("NEVER auto-reviews an uncategorized or 'Other' row")
+    func neverUncategorizedOrOther() {
+        let uncategorized = item(reasons: [.newMerchant], category: nil)
+        let other = item(reasons: [.newMerchant], category: .other)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(uncategorized) == false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(other) == false)
+    }
+
+    @Test("NEVER auto-reviews an unusual-amount row")
+    func neverUnusual() {
+        let row = item(reasons: [.unusualAmount], category: .foodAndDrink)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(row) == false)
+    }
+
+    @Test("NEVER auto-reviews a transfer — by flag, by reason, or by category")
+    func neverTransfer() {
+        let byFlag = item(reasons: [.newMerchant], category: .foodAndDrink, isTransfer: true)
+        let byReason = item(reasons: [.possibleTransfer], category: .foodAndDrink)
+        let byCategoryIn = item(reasons: [.newMerchant], category: .transfer)
+        let byCategoryOut = item(reasons: [.newMerchant], category: .transferOut)
+
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(byFlag) == false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(byReason) == false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(byCategoryIn) == false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(byCategoryOut) == false)
+    }
+
+    @Test("NEVER auto-reviews a row carrying any high-priority reason")
+    func neverHighPriorityReason() {
+        // pendingChanged / recurringChanged / changedSinceReview are all
+        // high-priority and must never be cleared automatically.
+        for reason in [TransactionReviewReason.pendingChanged, .recurringChanged, .changedSinceReview] {
+            let row = item(reasons: [reason], category: .foodAndDrink)
+            #expect(ReviewAutoReviewPolicy.isAutoReviewable(row) == false)
+        }
+    }
+
+    @Test("NEVER auto-reviews an on-device NL suggestion awaiting approval")
+    func neverNLSuggestion() {
+        let row = item(
+            reasons: [.uncategorized],
+            category: .foodAndDrink,
+            categorySource: .appleNaturalLanguage
+        )
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(row) == false)
+    }
+
+    @Test("NEVER auto-reviews an already-resolved row")
+    func neverAlreadyResolved() {
+        let reviewed = item(reasons: [.newMerchant], category: .foodAndDrink, status: .reviewed)
+        let ignored = item(reasons: [.newMerchant], category: .foodAndDrink, status: .ignored)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(reviewed) == false)
+        #expect(ReviewAutoReviewPolicy.isAutoReviewable(ignored) == false)
+    }
+
+    @Test("autoReviewableIDs returns exactly the eligible rows in snapshot order")
+    func snapshotFiltersToEligible() {
+        let snapshot = TransactionReviewInboxSnapshot(items: [
+            item(id: "eligible-1", reasons: [.newMerchant], category: .foodAndDrink),
+            item(id: "low-conf", reasons: [.uncategorized], category: .foodAndDrink, lowConfidence: true),
+            item(id: "transfer", reasons: [.possibleTransfer], category: .foodAndDrink),
+            item(id: "eligible-2", reasons: [.newMerchant], category: .shopping),
+            item(id: "unusual", reasons: [.unusualAmount], category: .shopping),
+        ])
+
+        let ids = ReviewAutoReviewPolicy.autoReviewableIDs(in: snapshot)
+        #expect(ids == ["eligible-1", "eligible-2"])
+    }
+
+    @Test("autoReviewableIDs is empty when nothing qualifies — a no-op pass")
+    func emptyWhenNothingQualifies() {
+        let snapshot = TransactionReviewInboxSnapshot(items: [
+            item(id: "a", reasons: [.uncategorized], category: nil),
+            item(id: "b", reasons: [.possibleTransfer], category: .foodAndDrink),
+        ])
+        #expect(ReviewAutoReviewPolicy.autoReviewableIDs(in: snapshot).isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func item(
+        id: String = "tx",
+        reasons: [TransactionReviewReason],
+        category: SpendingCategory?,
+        lowConfidence: Bool = false,
+        isTransfer: Bool = false,
+        status: TransactionReviewStatus = .needsReview,
+        categorySource: LocalAICategoryResolutionSource? = nil
+    ) -> TransactionReviewItem {
+        TransactionReviewItem(
+            transaction: TransactionDTO(
+                id: id,
+                accountId: "acct",
+                amount: 23.5,
+                date: "2026-06-01",
+                name: id.uppercased(),
+                merchantName: id,
+                category: category,
+                pending: false,
+                isLowConfidenceCategory: lowConfidence
+            ),
+            status: status,
+            reasonCodes: reasons,
+            effectiveCategory: category,
+            effectiveMerchantName: id,
+            isTransfer: isTransfer,
+            excludedFromBudgets: isTransfer,
+            matchedRuleIds: [],
+            categorySource: categorySource
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReviewInboxSortingTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewInboxSortingTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+@testable import PlaidBarCore
+import Testing
+
+@Suite("Review Inbox Sorting Tests (AND-553)")
+struct ReviewInboxSortingTests {
+    @Test("Default sort order is the historical priority order")
+    func defaultIsPriority() {
+        #expect(ReviewInboxSortOrder.defaultValue == .priority)
+    }
+
+    @Test("Priority order keeps the historical comparator: urgency, then newest, then id")
+    func priorityOrder() {
+        // Two `.uncategorized` (priority 2) rows and one `.possibleTransfer`
+        // (priority 0). The high-priority one must float to the top regardless of
+        // its date; within the same priority, newer date wins, then id.
+        let items = [
+            item(id: "old-low", date: "2026-06-01", reasons: [.uncategorized]),
+            item(id: "transfer", date: "2026-05-01", reasons: [.possibleTransfer]),
+            item(id: "new-low", date: "2026-06-10", reasons: [.uncategorized]),
+        ]
+
+        let sorted = ReviewInboxSorting.sorted(items, order: .priority)
+
+        #expect(sorted.map(\.id) == ["transfer", "new-low", "old-low"])
+    }
+
+    @Test("Confidence-first floats low-confidence rows to the top")
+    func confidenceFirstFloatsLowConfidence() {
+        let items = [
+            item(id: "high-1", reasons: [.uncategorized], lowConfidence: false),
+            item(id: "low-1", reasons: [.uncategorized], lowConfidence: true),
+            item(id: "high-2", reasons: [.uncategorized], lowConfidence: false),
+            item(id: "low-2", reasons: [.uncategorized], lowConfidence: true),
+        ]
+
+        let sorted = ReviewInboxSorting.sorted(items, order: .confidenceLowFirst)
+
+        // Both low-confidence rows precede both high-confidence rows.
+        let lowFirst = sorted.prefix(2).map(\.id)
+        #expect(Set(lowFirst) == ["low-1", "low-2"])
+        #expect(Set(sorted.suffix(2).map(\.id)) == ["high-1", "high-2"])
+    }
+
+    @Test("Within a confidence band, confidence-first falls back to the historical order")
+    func confidenceFirstInBandTiebreaker() {
+        // All low-confidence; the in-band order must match the priority comparator
+        // (urgency → newest → id), so the secondary ordering never changes.
+        let items = [
+            item(id: "low-old-uncat", date: "2026-06-01", reasons: [.uncategorized], lowConfidence: true),
+            item(id: "low-transfer", date: "2026-05-01", reasons: [.possibleTransfer], lowConfidence: true),
+            item(id: "low-new-uncat", date: "2026-06-10", reasons: [.uncategorized], lowConfidence: true),
+        ]
+
+        let confidence = ReviewInboxSorting.sorted(items, order: .confidenceLowFirst)
+        let priority = ReviewInboxSorting.sorted(items, order: .priority)
+
+        // Same band for all → identical to the historical order.
+        #expect(confidence.map(\.id) == priority.map(\.id))
+        #expect(confidence.map(\.id) == ["low-transfer", "low-new-uncat", "low-old-uncat"])
+    }
+
+    @Test("Confidence-first prefers a low-confidence row even over a higher-priority high-confidence row")
+    func confidenceBeatsPriorityAcrossBands() {
+        // A high-confidence high-priority transfer vs a low-confidence ordinary
+        // uncategorized: confidence-first puts the low-confidence row first, since
+        // confidence is the primary key across bands.
+        let items = [
+            item(id: "high-transfer", reasons: [.possibleTransfer], lowConfidence: false),
+            item(id: "low-uncat", reasons: [.uncategorized], lowConfidence: true),
+        ]
+
+        let sorted = ReviewInboxSorting.sorted(items, order: .confidenceLowFirst)
+        #expect(sorted.map(\.id) == ["low-uncat", "high-transfer"])
+    }
+
+    @Test("Sorting is stable and deterministic across repeated calls")
+    func deterministic() {
+        let items = (1 ... 6).map { item(id: "id-\($0)", reasons: [.uncategorized], lowConfidence: $0.isMultiple(of: 2)) }
+        let a = ReviewInboxSorting.sorted(items, order: .confidenceLowFirst).map(\.id)
+        let b = ReviewInboxSorting.sorted(items, order: .confidenceLowFirst).map(\.id)
+        #expect(a == b)
+    }
+
+    // MARK: - Helpers
+
+    private func item(
+        id: String,
+        date: String = "2026-06-01",
+        reasons: [TransactionReviewReason],
+        lowConfidence: Bool = false
+    ) -> TransactionReviewItem {
+        TransactionReviewItem(
+            transaction: TransactionDTO(
+                id: id,
+                accountId: "acct",
+                amount: 12,
+                date: date,
+                name: id.uppercased(),
+                merchantName: id,
+                category: .foodAndDrink,
+                pending: false,
+                isLowConfidenceCategory: lowConfidence
+            ),
+            status: .needsReview,
+            reasonCodes: reasons,
+            effectiveCategory: .foodAndDrink,
+            effectiveMerchantName: id,
+            isTransfer: false,
+            excludedFromBudgets: false,
+            matchedRuleIds: []
+        )
+    }
+}


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.**

## What & why

A cheap budgeting-v2 smart-sort for the Review Inbox plus an opt-in auto-review pass, both built on the `isLowConfidenceCategory` flag that already rides on `TransactionDTO` (server-derived from Plaid PFCv2 LOW/UNKNOWN confidence). The data exists; this just sorts on it and, optionally, clears the safest rows for the user.

Strictly additive: a user who never touches the new sort control or settings toggle sees byte-identical prior behavior — the default sort is the historical order and auto-review is OFF by default.

## Change

**PlaidBarCore (pure, `Sendable`, unit-tested):**
- `ReviewInboxSorting` / `ReviewInboxSortOrder` — `.priority` (default; the historical urgency → newest → id comparator extracted verbatim) and `.confidenceLowFirst` (floats Plaid LOW/UNKNOWN categorizations to the top, with the historical order as the in-band tiebreaker so nothing else reorders). `TransactionReviewInbox.evaluate` gains a `sortOrder` parameter defaulting to `.priority`.
- `ReviewAutoReviewPolicy` / `ReviewAutoReviewPreference` — conservative eligibility: a row is auto-reviewable only when high-confidence, categorized (not `.other`), NOT an on-device suggestion, ordinary value, and **never** a transfer (by `isTransfer` flag, `.possibleTransfer` reason, or transfer category) nor carrying any high-priority reason. Preference defaults OFF.
- `TransactionReviewMetadata` gains an additive `autoReviewed` flag (decodes as `false` when absent — pre-AND-553 records behave identically); `TransactionReviewItem` surfaces it as `wasAutoReviewed`.

**App:**
- `AppState`: UserDefaults-backed `reviewInboxSortOrder` (invalidates the cached snapshot on change) and `autoReviewHighConfidenceEnabled`. `applyHighConfidenceAutoReview()` marks the policy's eligible ids reviewed via the *same* approve path as a manual review, in **one** undoable batch (so a single ⌘Z / undo reverts the whole pass), stamping `autoReviewed = true`. Every manual review/ignore/recategorize/rename/transfer path clears the flag. The pass runs when the toggle is switched on and whenever new transactions sync (a no-op while disabled).
- `ReviewInboxView`: a confidence-aware sort control (label text + glyph, never color alone) and an "Auto-reviewed" badge on reopened auto-reviewed rows, folded into the VoiceOver row summary.
- `Settings → General → Review Inbox`: the auto-review toggle with explanatory copy.

**Security / privacy / a11y:** all new logic is in `PlaidBarCore` (pure, `Sendable`); no secrets touch the app/Core boundary. The sort control and badges are suppressed under Privacy Mask / App Lock like the rest of the inbox. Meaning is always carried by text + glyph, never color alone.

## Testing

Exact commands and results (run with the sandbox disabled per repo convention):

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!**
- `swift test` → **Test run with 2411 tests passed** (37 new across 3 suites: `ReviewInboxSortingTests`, `ReviewAutoReviewPolicyTests`, `ReviewAutoReviewMetadataTests`).
- `git diff --check` → clean.

New tests assert: low-confidence-first ordering and the historical default order are byte-identical to before; auto-review **never** clears transfers (flag/reason/category), unusual, low-confidence, uncategorized/Other, NL-suggested, or already-resolved rows; the eligible-id set is exactly the safe rows; the additive `autoReviewed` field round-trips and a legacy record (no key) decodes as `false`; and `evaluate` threads the flag onto `wasAutoReviewed`.

## Links

Closes AND-553

## Follow-ups

- The "Auto-reviewed" badge surfaces only on rows that *reopen* after auto-review (a freshly auto-reviewed row leaves the inbox like any reviewed row). A future power-review-table column could list auto-reviewed rows for at-rest inspection if desired.
- A one-shot confirmation banner ("Auto-reviewed N transactions — Undo") on the inbox could make the bulk-undo even more discoverable; deferred to keep this diff scoped.
