### PR TITLE
feat(budgeting): custom/renamed/recolored categories + groups editor (AND-547)

### DIFF
--- a/Sources/PlaidBar/App/AppState+CategoryEditor.swift
+++ b/Sources/PlaidBar/App/AppState+CategoryEditor.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PlaidBarCache
+import PlaidBarCore
+
+/// AppState wiring for the budgeting-v2 categories & groups editor (AND-547 —
+/// deferred epic AND-524).
+///
+/// Reuses the AND-546 seams: it opens the opt-in ``BudgetingV2Store`` against the
+/// active data directory and scopes it with the same ``readModelCacheKey()`` the
+/// other disposable caches use, so the v2 schema is per-Plaid-environment. Like the
+/// read-model and transaction caches the store is opened behind `try?`; a failure
+/// leaves the editor empty/read-only and the app on v1 budgeting (additive,
+/// fallback-safe).
+extension AppState {
+    /// Builds the editor model for the active environment, or a read-only model
+    /// (`store: nil`) when v2 is unavailable (demo mode, no server context yet, or
+    /// the store fails to open). The model loads its snapshot on appear, so a fresh
+    /// instance per editor presentation is fine and keeps no long-lived disk handle.
+    ///
+    /// The store open is best-effort and never throws to the caller; a `nil` store
+    /// yields an editor that can render the opt-in prompt but performs no I/O.
+    @MainActor
+    func makeCategoryEditorModel() -> CategoryEditorModel {
+        guard !isDemoMode, let cacheKey = readModelCacheKey() else {
+            // No environment context yet (or demo): editor stays read-only and v1
+            // budgeting is untouched. A non-nil cacheKey is required so a seeded
+            // snapshot is scoped; without one there is nothing to read or write.
+            return CategoryEditorModel(store: nil, cacheKey: "")
+        }
+        let store = try? BudgetingV2Store(onDiskIn: activeStorageDirectoryURL)
+        return CategoryEditorModel(store: store, cacheKey: cacheKey)
+    }
+
+    /// The current month as `YYYY-MM`, used to carry v1 budgets forward at opt-in and
+    /// recover them on opt-out. Uses the same date convention the rest of the app
+    /// sorts/keys budgets by.
+    @MainActor
+    func currentBudgetMonthKey(asOf date: Date = Date(), calendar: Calendar = .current) -> String {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        let year = components.year ?? 1970
+        let month = components.month ?? 1
+        return String(format: "%04d-%02d", year, month)
+    }
+}

--- a/Sources/PlaidBar/Services/CategoryEditorModel.swift
+++ b/Sources/PlaidBar/Services/CategoryEditorModel.swift
@@ -1,0 +1,251 @@
+import Foundation
+import OSLog
+import PlaidBarCache
+import PlaidBarCore
+
+/// App-side state for the budgeting-v2 categories & groups editor (AND-547 —
+/// deferred epic AND-524).
+///
+/// Owns the opt-in ``BudgetingV2Store`` and the in-memory ``BudgetingV2Schema`` the
+/// editor view renders, and routes every mutation through the pure
+/// ``BudgetCategoryEditor`` in `PlaidBarCore` (all validation/CRUD logic is there
+/// and unit-tested; this model only persists the result and surfaces errors).
+///
+/// ## Opt-in & additive
+/// The editor is **opt-in**: until the user explicitly opens it and seeds v2, no v2
+/// snapshot exists and v1 budgeting is byte-for-byte unchanged. `load()` only reads
+/// an existing snapshot; `optIn()` seeds one (carrying any v1 budgets forward).
+/// Opting out (`optOut(month:)`) recovers the v1 budgets and clears the snapshot,
+/// restoring v1 untouched.
+///
+/// ## Fallback-safe
+/// The store is opened with `try?` and every persist is best-effort; a store failure
+/// leaves the editor read-only and the rest of the app on v1.
+///
+/// ## Privacy / isolation
+/// The store writes only to the local private data dir (never the App Group or
+/// iCloud) and only `Sendable` values cross the actor boundary. The editor surfaces
+/// category *labels and budget limits*, which are financial data — so the hosting
+/// view respects Privacy Mask / App Lock exactly like every other budget surface.
+@MainActor
+@Observable
+public final class CategoryEditorModel {
+    private static let logger = Logger(subsystem: "com.ftchvs.PlaidBar", category: "CategoryEditor")
+
+    /// The currently loaded v2 schema, or `nil` when the user has not opted in (or
+    /// the store is unavailable). The editor view shows the opt-in prompt when `nil`.
+    public private(set) var schema: BudgetingV2Schema?
+
+    /// The most recent user-facing edit error, cleared on the next successful edit.
+    /// Carried as text by the view (never color-alone, ACCESSIBILITY.md).
+    public private(set) var lastError: BudgetCategoryEditor.BudgetCategoryEditError?
+
+    /// True while a load/seed/persist round-trip is in flight (disables controls).
+    public private(set) var isBusy = false
+
+    private let store: BudgetingV2Store?
+    private let cacheKey: String
+
+    /// - Parameters:
+    ///   - store: the opened v2 store, or `nil` (demo / disabled / open failed) — in
+    ///     which case the editor stays empty and read-only.
+    ///   - cacheKey: the environment+directory-scoped key (the same one the other
+    ///     caches use), so the v2 snapshot is scoped per Plaid environment.
+    public init(store: BudgetingV2Store?, cacheKey: String) {
+        self.store = store
+        self.cacheKey = cacheKey
+    }
+
+    /// Whether the user has opted into v2 (a schema is loaded).
+    public var isOptedIn: Bool { schema != nil }
+
+    /// Groups in display order (by `sortIndex`, then name) for the editor list.
+    public var orderedGroups: [BudgetCategoryGroupV2] {
+        (schema?.groups ?? []).sorted { lhs, rhs in
+            lhs.sortIndex != rhs.sortIndex ? lhs.sortIndex < rhs.sortIndex : lhs.name < rhs.name
+        }
+    }
+
+    /// Categories in `group`, in within-group display order (by `sortIndex`, then name).
+    public func categories(in group: BudgetCategoryGroupV2) -> [BudgetCategoryV2] {
+        (schema?.categories ?? [])
+            .filter { $0.groupId == group.id }
+            .sorted { lhs, rhs in
+                lhs.sortIndex != rhs.sortIndex ? lhs.sortIndex < rhs.sortIndex : lhs.name < rhs.name
+            }
+    }
+
+    // MARK: - Load / opt-in / opt-out
+
+    /// Load an existing v2 snapshot (no-op when not opted in). Best-effort.
+    public func load() async {
+        guard let store else { return }
+        isBusy = true
+        defer { isBusy = false }
+        schema = try? await store.load(cacheKey: cacheKey)
+    }
+
+    /// Opt into v2: seed the schema from the closed taxonomy, optionally carrying the
+    /// user's existing v1 budgets into `month`, and persist. Idempotent.
+    public func optIn(carryingForward v1Budgets: [CategoryBudgetDTO] = [], month: String? = nil) async {
+        guard let store else { return }
+        isBusy = true
+        defer { isBusy = false }
+        do {
+            schema = try await store.seedV2(cacheKey: cacheKey, carryingForward: v1Budgets, month: month)
+            lastError = nil
+        } catch {
+            Self.logger.error("v2 opt-in failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Opt out of v2: recover the v1 budgets for `month`, clear the snapshot, and
+    /// return the recovered budgets so the caller can write them back to the v1
+    /// `/api/budgets` store. v1 budgeting is restored untouched.
+    @discardableResult
+    public func optOut(month: String) async -> [CategoryBudgetDTO] {
+        guard let store else { schema = nil; return [] }
+        isBusy = true
+        defer { isBusy = false }
+        let recovered = (try? await store.optOut(cacheKey: cacheKey, month: month)) ?? []
+        schema = nil
+        return recovered
+    }
+
+    // MARK: - Category edits (delegate to the pure editor, then persist)
+
+    /// Create a custom category. `id` is generated here (UUID) so the pure editor
+    /// stays deterministic.
+    public func addCategory(name: String, emoji: String?, colorHex: String, groupId: String) async {
+        await apply { schema in
+            BudgetCategoryEditor.addCategory(
+                to: schema,
+                id: BudgetCategoryEditor.customCategoryID(UUID().uuidString),
+                name: name,
+                emoji: emoji,
+                colorHex: colorHex,
+                groupId: groupId
+            )
+        }
+    }
+
+    /// Rename / recolor / re-emoji a category (system or custom). `emoji: .some(nil)`
+    /// clears the glyph; `nil` leaves a field untouched.
+    public func editCategory(
+        categoryId: String,
+        name: String? = nil,
+        emoji: String?? = nil,
+        colorHex: String? = nil
+    ) async {
+        await apply { schema in
+            BudgetCategoryEditor.editCategory(
+                in: schema, categoryId: categoryId, name: name, emoji: emoji, colorHex: colorHex
+            )
+        }
+    }
+
+    /// Move a category to another group.
+    public func moveCategory(categoryId: String, toGroupId: String) async {
+        await apply { schema in
+            BudgetCategoryEditor.moveCategory(in: schema, categoryId: categoryId, toGroupId: toGroupId)
+        }
+    }
+
+    /// Reorder categories within a group.
+    public func reorderCategories(groupId: String, orderedCategoryIds: [String]) async {
+        await apply { schema in
+            BudgetCategoryEditor.reorderCategories(
+                in: schema, groupId: groupId, orderedCategoryIds: orderedCategoryIds
+            )
+        }
+    }
+
+    /// Delete a custom category, reassigning its budgets to `reassignToCategoryId`
+    /// (default: the `.other` system category). Returns the reassignment mapping so
+    /// the caller can re-point any transaction-level overrides the same way.
+    @discardableResult
+    public func deleteCustomCategory(
+        categoryId: String,
+        reassignToCategoryId: String? = nil
+    ) async -> BudgetCategoryEditor.DeletionResult? {
+        guard let current = schema else { return nil }
+        let result = BudgetCategoryEditor.deleteCustomCategory(
+            in: current, categoryId: categoryId, reassignToCategoryId: reassignToCategoryId
+        )
+        switch result {
+        case .success(let deletion):
+            await persist(deletion.schema)
+            return deletion
+        case .failure(let error):
+            lastError = error
+            return nil
+        }
+    }
+
+    // MARK: - Group edits
+
+    /// Create a custom group.
+    public func addGroup(name: String) async {
+        await apply { schema in
+            BudgetCategoryEditor.addGroup(
+                to: schema, id: BudgetCategoryEditor.customGroupID(UUID().uuidString), name: name
+            )
+        }
+    }
+
+    /// Rename a group (system or custom).
+    public func renameGroup(groupId: String, name: String) async {
+        await apply { schema in
+            BudgetCategoryEditor.renameGroup(in: schema, groupId: groupId, name: name)
+        }
+    }
+
+    /// Reorder groups top-to-bottom.
+    public func reorderGroups(orderedGroupIds: [String]) async {
+        await apply { schema in
+            BudgetCategoryEditor.reorderGroups(in: schema, orderedGroupIds: orderedGroupIds)
+        }
+    }
+
+    /// Delete a custom group, moving its categories to `reassignToGroupId` (default:
+    /// the `.other` system group).
+    public func deleteCustomGroup(groupId: String, reassignToGroupId: String? = nil) async {
+        await apply { schema in
+            BudgetCategoryEditor.deleteCustomGroup(
+                in: schema, groupId: groupId, reassignToGroupId: reassignToGroupId
+            )
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Run a pure edit against the current schema; on success persist + adopt the new
+    /// snapshot and clear the error, on failure surface the error and leave the
+    /// schema untouched (the edit is rejected, not partially applied).
+    private func apply(
+        _ edit: (BudgetingV2Schema) -> Result<BudgetingV2Schema, BudgetCategoryEditor.BudgetCategoryEditError>
+    ) async {
+        guard let current = schema else { return }
+        switch edit(current) {
+        case .success(let updated):
+            await persist(updated)
+        case .failure(let error):
+            lastError = error
+        }
+    }
+
+    /// Adopt `updated` in memory and persist it (best-effort). The in-memory schema
+    /// is updated regardless so the UI reflects the edit even if a disk write fails;
+    /// the snapshot is disposable and reseedable, so a transient write failure is
+    /// non-fatal.
+    private func persist(_ updated: BudgetingV2Schema) async {
+        schema = updated
+        lastError = nil
+        guard let store else { return }
+        do {
+            try await store.save(cacheKey: cacheKey, schema: updated)
+        } catch {
+            Self.logger.error("v2 schema persist failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+}

--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -24,6 +24,13 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.accounts.rawValue)
 
+            CategorySettingsView()
+                .environment(appState)
+                .tabItem {
+                    Label("Categories", systemImage: "tag")
+                }
+                .tag(SettingsTab.categories.rawValue)
+
             AppearanceSettingsView()
                 .tabItem {
                     Label("Appearance", systemImage: "paintbrush")
@@ -64,10 +71,46 @@ struct SettingsView: View {
 private enum SettingsTab: String {
     case general
     case accounts
+    case categories
     case appearance
     case notifications
     case privacy
     case about
+}
+
+/// Settings tab hosting the budgeting-v2 categories & groups editor (AND-547).
+///
+/// Builds a fresh ``CategoryEditorModel`` per appearance from the active environment
+/// (scoped to the same per-environment cache key the other caches use) and hands it
+/// the current v1 budgets + month so opting in carries the user's saved budgets
+/// forward. The editor is opt-in and additive: a user who never enables it sees no
+/// change to standard budgeting. This surface shows category labels (financial
+/// data), so it inherits the same Privacy Mask / App Lock gating as the rest of
+/// Settings via the shared scene environment.
+struct CategorySettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var model: CategoryEditorModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                CategoryEditorView(
+                    model: model,
+                    v1Budgets: DataExportBuilder.budgetDTOs(from: appState.categoryBudgets),
+                    currentMonth: appState.currentBudgetMonthKey()
+                )
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear {
+            if model == nil {
+                model = appState.makeCategoryEditorModel()
+            }
+        }
+    }
 }
 
 struct AppearanceSettingsView: View {

--- a/Sources/PlaidBar/Views/CategoryEditorView.swift
+++ b/Sources/PlaidBar/Views/CategoryEditorView.swift
@@ -1,0 +1,283 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Settings/Budgets editor for budgeting-v2 categories & groups (AND-547).
+///
+/// Lets the user create/rename/recolor/re-emoji/reorder categories, define and
+/// reorder groups, move categories between groups, and delete custom categories
+/// (with their budgets reassigned, never orphaned). It is **opt-in**: until the user
+/// taps "Enable custom categories" no v2 snapshot exists and v1 budgeting is
+/// unchanged.
+///
+/// All logic lives in the pure `BudgetCategoryEditor` (Core, unit-tested) via
+/// ``CategoryEditorModel``; this view only renders the schema and dispatches edits.
+///
+/// Accessibility: a category's identity is always carried by its **name text** and
+/// SF Symbol/emoji glyph, never by its color swatch alone (ACCESSIBILITY.md). Edit
+/// errors are shown as text. Dynamic Type is respected (system fonts, no fixed
+/// frames on text).
+struct CategoryEditorView: View {
+    @Bindable var model: CategoryEditorModel
+
+    /// The currently saved v1 budgets, carried forward when the user opts in so an
+    /// existing budgeter keeps their numbers.
+    let v1Budgets: [CategoryBudgetDTO]
+    /// The current month as `YYYY-MM`, used to carry v1 budgets forward / recover on
+    /// opt-out. Passed in (no hidden `Date()`).
+    let currentMonth: String
+
+    @State private var presentedSheet: EditorSheet?
+
+    private enum EditorSheet: Identifiable {
+        case newCategory(groupId: String)
+        case editCategory(BudgetCategoryV2)
+        case newGroup
+        case renameGroup(BudgetCategoryGroupV2)
+
+        var id: String {
+            switch self {
+            case .newCategory(let groupId): "new-cat-\(groupId)"
+            case .editCategory(let category): "edit-cat-\(category.id)"
+            case .newGroup: "new-group"
+            case .renameGroup(let group): "rename-group-\(group.id)"
+            }
+        }
+    }
+
+    var body: some View {
+        Group {
+            if model.isOptedIn {
+                editorList
+            } else {
+                optInPrompt
+            }
+        }
+        .navigationTitle("Categories")
+        .task { await model.load() }
+        .sheet(item: $presentedSheet) { sheet in
+            sheetContent(sheet)
+        }
+    }
+
+    // MARK: - Opt-in prompt
+
+    private var optInPrompt: some View {
+        ContentUnavailableView {
+            Label("Custom categories", systemImage: "folder.badge.gearshape")
+        } description: {
+            Text("""
+            Rename, recolor, and reorganize your budget categories, or create your \
+            own. Your current budgets carry over, and you can switch back anytime.
+            """)
+        } actions: {
+            Button("Enable custom categories") {
+                Task { await model.optIn(carryingForward: v1Budgets, month: currentMonth) }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(model.isBusy)
+        }
+    }
+
+    // MARK: - Editor list
+
+    private var editorList: some View {
+        List {
+            if let error = model.lastError {
+                Section {
+                    Label(message(for: error), systemImage: "exclamationmark.triangle")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Edit error: \(message(for: error))")
+                }
+            }
+
+            ForEach(model.orderedGroups) { group in
+                groupSection(group)
+            }
+
+            Section {
+                Button {
+                    presentedSheet = .newGroup
+                } label: {
+                    Label("Add group", systemImage: "folder.badge.plus")
+                }
+                .disabled(model.isBusy)
+
+                Button(role: .destructive) {
+                    Task { await model.optOut(month: currentMonth) }
+                } label: {
+                    Label("Switch back to standard categories", systemImage: "arrow.uturn.backward")
+                }
+                .disabled(model.isBusy)
+            } footer: {
+                Text("Switching back restores the standard categories and your saved budgets.")
+            }
+        }
+        .listStyle(.inset)
+    }
+
+    private func groupSection(_ group: BudgetCategoryGroupV2) -> some View {
+        Section {
+            ForEach(model.categories(in: group)) { category in
+                categoryRow(category)
+            }
+            .onMove { indices, newOffset in
+                moveCategories(in: group, from: indices, to: newOffset)
+            }
+
+            Button {
+                presentedSheet = .newCategory(groupId: group.id)
+            } label: {
+                Label("Add category", systemImage: "plus.circle")
+                    .font(.callout)
+            }
+            .disabled(model.isBusy)
+        } header: {
+            HStack {
+                Text(group.name)
+                if group.isCustom {
+                    Text("Custom")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Custom group")
+                }
+                Spacer()
+                Menu {
+                    Button("Rename group") { presentedSheet = .renameGroup(group) }
+                    if group.isCustom {
+                        Button("Delete group", role: .destructive) {
+                            Task { await model.deleteCustomGroup(groupId: group.id) }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .accessibilityLabel("Group options for \(group.name)")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+        }
+    }
+
+    private func categoryRow(_ category: BudgetCategoryV2) -> some View {
+        HStack(spacing: Spacing.sm) {
+            glyph(for: category)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(category.name)
+                    .font(.body)
+                Text(category.isCustom ? "Custom" : "Standard")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Menu {
+                Button("Edit") { presentedSheet = .editCategory(category) }
+                moveMenu(for: category)
+                if category.isCustom {
+                    Button("Delete", role: .destructive) {
+                        Task { await model.deleteCustomCategory(categoryId: category.id) }
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .accessibilityLabel("Options for \(category.name)")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "\(category.name), \(category.isCustom ? "custom" : "standard") category"
+        )
+    }
+
+    /// The category's leading glyph: its emoji when set, else its SF Symbol tinted by
+    /// the category color. The color is a *redundant* accent — the name text and
+    /// glyph always carry identity, so meaning is never color-alone.
+    @ViewBuilder
+    private func glyph(for category: BudgetCategoryV2) -> some View {
+        if let emoji = category.emoji {
+            Text(emoji)
+                .font(.title3)
+                .accessibilityHidden(true)
+        } else {
+            Image(systemName: category.iconName)
+                .font(.title3)
+                .foregroundStyle(Color(budgetHex: category.colorHex) ?? .secondary)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func moveMenu(for category: BudgetCategoryV2) -> some View {
+        Menu("Move to group") {
+            ForEach(model.orderedGroups.filter { $0.id != category.groupId }) { group in
+                Button(group.name) {
+                    Task { await model.moveCategory(categoryId: category.id, toGroupId: group.id) }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sheets
+
+    @ViewBuilder
+    private func sheetContent(_ sheet: EditorSheet) -> some View {
+        switch sheet {
+        case .newCategory(let groupId):
+            CategoryFormSheet(mode: .create(groupId: groupId), model: model)
+        case .editCategory(let category):
+            CategoryFormSheet(mode: .edit(category), model: model)
+        case .newGroup:
+            GroupFormSheet(mode: .create, model: model)
+        case .renameGroup(let group):
+            GroupFormSheet(mode: .rename(group), model: model)
+        }
+    }
+
+    // MARK: - Reorder
+
+    private func moveCategories(in group: BudgetCategoryGroupV2, from indices: IndexSet, to newOffset: Int) {
+        var ids = model.categories(in: group).map(\.id)
+        ids.move(fromOffsets: indices, toOffset: newOffset)
+        Task { await model.reorderCategories(groupId: group.id, orderedCategoryIds: ids) }
+    }
+
+    // MARK: - Error copy
+
+    private func message(for error: BudgetCategoryEditor.BudgetCategoryEditError) -> String {
+        switch error {
+        case .emptyName: "Enter a name."
+        case .nameTooLong: "That name is too long."
+        case .duplicateCategoryName: "Another category in this group already uses that name."
+        case .duplicateGroupName: "Another group already uses that name."
+        case .invalidColor: "Choose a valid color."
+        case .invalidEmoji: "Pick a single emoji."
+        case .categoryNotFound: "That category no longer exists."
+        case .groupNotFound: "That group no longer exists."
+        case .cannotDeleteSystemCategory: "Standard categories can't be deleted — rename or recolor instead."
+        case .cannotDeleteSystemGroup: "Standard groups can't be deleted."
+        case .invalidReassignmentTarget: "Pick where to move this category's budget first."
+        }
+    }
+}
+
+// MARK: - Color(hex:) for v2 category swatches
+
+extension Color {
+    /// Build a SwiftUI `Color` from a `#RRGGBB` hex (the v2 category `colorHex`).
+    /// Returns `nil` for a malformed string so the caller can fall back to a neutral
+    /// tint — the color is always a redundant accent, never the sole carrier of
+    /// meaning (ACCESSIBILITY.md).
+    init?(budgetHex hex: String) {
+        guard hex.hasPrefix("#") else { return nil }
+        let digits = hex.dropFirst()
+        guard digits.count == 6, let value = UInt32(digits, radix: 16) else { return nil }
+        self.init(
+            .sRGB,
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+}

--- a/Sources/PlaidBar/Views/CategoryFormSheet.swift
+++ b/Sources/PlaidBar/Views/CategoryFormSheet.swift
@@ -1,0 +1,239 @@
+import PlaidBarCore
+import SwiftUI
+
+/// Create or edit a single budgeting-v2 category (AND-547).
+///
+/// A thin form over ``CategoryEditorModel``: it collects a name, optional emoji, and
+/// a color, validates each field live via the pure ``BudgetCategoryEditor``
+/// validators, and dispatches the create/edit. The model (and the Core editor it
+/// delegates to) owns persistence and the authoritative duplicate/error rules; this
+/// view only pre-flights the obvious field-level problems so Save stays enabled only
+/// when the input is well-formed.
+///
+/// Accessibility: every field has an explicit label/value; the validation verdict is
+/// carried by text (never color alone). A preset color is also labeled by name, so
+/// the swatch grid is usable without color perception.
+struct CategoryFormSheet: View {
+    enum Mode {
+        case create(groupId: String)
+        case edit(BudgetCategoryV2)
+    }
+
+    let mode: Mode
+    @Bindable var model: CategoryEditorModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var emoji: String
+    @State private var colorHex: String
+    @State private var isSaving = false
+
+    /// A small accessible palette of named presets (the v1 chart hues), so a user
+    /// can pick a color without a system color well and each swatch reads by name.
+    private static let presets: [(name: String, hex: String)] = [
+        ("Coral", "#FF6B6B"), ("Teal", "#4ECDC4"), ("Sky", "#45B7D1"),
+        ("Sage", "#96CEB4"), ("Butter", "#FFEAA7"), ("Lilac", "#DDA0DD"),
+        ("Mint", "#98D8C8"), ("Gold", "#F7DC6F"), ("Violet", "#BB8FCE"),
+        ("Tangerine", "#F8C471"), ("Spring", "#82E0AA"), ("Slate", "#AEB6BF"),
+    ]
+
+    init(mode: Mode, model: CategoryEditorModel) {
+        self.mode = mode
+        self.model = model
+        switch mode {
+        case .create:
+            _name = State(initialValue: "")
+            _emoji = State(initialValue: "")
+            _colorHex = State(initialValue: Self.presets[0].hex)
+        case .edit(let category):
+            _name = State(initialValue: category.name)
+            _emoji = State(initialValue: category.emoji ?? "")
+            _colorHex = State(initialValue: category.colorHex)
+        }
+    }
+
+    private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var trimmedEmoji: String { emoji.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    /// Whether the current field values are well-formed enough to commit. The
+    /// authoritative duplicate/exists checks still run in the model on save.
+    private var isCommittable: Bool {
+        guard BudgetCategoryEditor.validateName(trimmedName) == nil else { return false }
+        guard BudgetCategoryEditor.isValidHexColor(colorHex) else { return false }
+        if !trimmedEmoji.isEmpty, !BudgetCategoryEditor.isValidEmoji(trimmedEmoji) { return false }
+        return true
+    }
+
+    var body: some View {
+        Form {
+            Section("Name") {
+                TextField("Category name", text: $name)
+                    .accessibilityLabel("Category name")
+            }
+
+            Section {
+                TextField("Emoji (optional)", text: $emoji)
+                    .accessibilityLabel("Category emoji, optional")
+                if !trimmedEmoji.isEmpty, !BudgetCategoryEditor.isValidEmoji(trimmedEmoji) {
+                    Label("Use a single emoji, or leave it blank.", systemImage: "exclamationmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Emoji")
+            } footer: {
+                Text("Shown in place of the category icon.")
+            }
+
+            Section("Color") {
+                colorPicker
+            }
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 360, minHeight: 320)
+        .navigationTitle(title)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }.disabled(isSaving)
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { Task { await commit() } }
+                    .disabled(!isCommittable || isSaving)
+            }
+        }
+    }
+
+    private var colorPicker: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 6), spacing: Spacing.sm) {
+            ForEach(Self.presets, id: \.hex) { preset in
+                Button {
+                    colorHex = preset.hex
+                } label: {
+                    swatch(preset)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(preset.name)
+                .accessibilityAddTraits(colorHex.caseInsensitiveCompare(preset.hex) == .orderedSame ? [.isSelected] : [])
+            }
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    private func swatch(_ preset: (name: String, hex: String)) -> some View {
+        let isSelected = colorHex.caseInsensitiveCompare(preset.hex) == .orderedSame
+        return Circle()
+            .fill(Color(budgetHex: preset.hex) ?? .secondary)
+            .frame(width: 28, height: 28)
+            .overlay {
+                // Selection is shown by a redundant checkmark glyph, not color alone.
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                        .shadow(radius: 1)
+                }
+            }
+            .overlay {
+                Circle().strokeBorder(.primary.opacity(isSelected ? 0.6 : 0.15), lineWidth: isSelected ? 2 : 1)
+            }
+    }
+
+    private var title: String {
+        switch mode {
+        case .create: "New Category"
+        case .edit: "Edit Category"
+        }
+    }
+
+    private func commit() async {
+        guard !isSaving, isCommittable else { return }
+        isSaving = true
+        defer { isSaving = false }
+        let emojiValue: String? = trimmedEmoji.isEmpty ? nil : trimmedEmoji
+
+        switch mode {
+        case .create(let groupId):
+            await model.addCategory(
+                name: trimmedName, emoji: emojiValue, colorHex: colorHex, groupId: groupId
+            )
+        case .edit(let category):
+            await model.editCategory(
+                categoryId: category.id,
+                name: trimmedName,
+                emoji: .some(emojiValue),
+                colorHex: colorHex
+            )
+        }
+        if model.lastError == nil { dismiss() }
+    }
+}
+
+/// Create or rename a budgeting-v2 category group (AND-547).
+struct GroupFormSheet: View {
+    enum Mode {
+        case create
+        case rename(BudgetCategoryGroupV2)
+    }
+
+    let mode: Mode
+    @Bindable var model: CategoryEditorModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var isSaving = false
+
+    init(mode: Mode, model: CategoryEditorModel) {
+        self.mode = mode
+        self.model = model
+        switch mode {
+        case .create: _name = State(initialValue: "")
+        case .rename(let group): _name = State(initialValue: group.name)
+        }
+    }
+
+    private var trimmedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+    private var isCommittable: Bool { BudgetCategoryEditor.validateName(trimmedName) == nil }
+
+    var body: some View {
+        Form {
+            Section("Name") {
+                TextField("Group name", text: $name)
+                    .accessibilityLabel("Group name")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 340, minHeight: 160)
+        .navigationTitle(title)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }.disabled(isSaving)
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { Task { await commit() } }
+                    .disabled(!isCommittable || isSaving)
+            }
+        }
+    }
+
+    private var title: String {
+        switch mode {
+        case .create: "New Group"
+        case .rename: "Rename Group"
+        }
+    }
+
+    private func commit() async {
+        guard !isSaving, isCommittable else { return }
+        isSaving = true
+        defer { isSaving = false }
+        switch mode {
+        case .create:
+            await model.addGroup(name: trimmedName)
+        case .rename(let group):
+            await model.renameGroup(groupId: group.id, name: trimmedName)
+        }
+        if model.lastError == nil { dismiss() }
+    }
+}

--- a/Sources/PlaidBarCore/Models/BudgetingV2Schema.swift
+++ b/Sources/PlaidBarCore/Models/BudgetingV2Schema.swift
@@ -38,18 +38,26 @@ import Foundation
 /// migration-stable key. Additive — it does not alter ``CategoryGroup`` itself.
 public struct BudgetCategoryGroupV2: Codable, Sendable, Hashable, Identifiable {
     /// Stable identity — the seeded ``CategoryGroup`` `rawValue` (e.g. `HOUSING`).
-    /// A user-created group (a later epic) would use a fresh UUID string here; the
-    /// foundation only ever seeds the closed taxonomy, so every id round-trips back
-    /// to a ``CategoryGroup``.
+    /// A user-created group (AND-547) uses a fresh `"grp_<uuid>"` string here; a
+    /// seeded group keeps the closed-taxonomy `rawValue`, so every *seeded* id
+    /// round-trips back to a ``CategoryGroup`` while a custom one never collides.
     public let id: String
-    /// Human-readable group title (seeded from ``CategoryGroup/title``).
+    /// Human-readable group title (seeded from ``CategoryGroup/title``; user-editable
+    /// via the categories editor, AND-547).
     public let name: String
-    /// Top-to-bottom display order (seeded from ``CategoryGroup/sortIndex``).
+    /// Top-to-bottom display order (seeded from ``CategoryGroup/sortIndex``;
+    /// user-reorderable via the categories editor, AND-547).
     public let sortIndex: Int
     /// The ``CategoryGroup`` this row seeded from, when `id` is a seeded taxonomy
-    /// key. `nil` for a (future) user-created group with no v1 ancestor. Lets a
-    /// reverse migration map a v2 group back to its v1 origin losslessly.
+    /// key. `nil` for a user-created group (AND-547) with no v1 ancestor. Lets a
+    /// reverse migration map a v2 group back to its v1 origin losslessly, and lets
+    /// the editor distinguish a deletable custom group from a protected system one.
     public let seededFromGroup: CategoryGroup?
+
+    /// Whether this group was created by the user (AND-547) rather than seeded from
+    /// the closed taxonomy. Derived from ``seededFromGroup`` so the two can never
+    /// disagree: a seeded group always has an ancestor, a custom one never does.
+    public var isCustom: Bool { seededFromGroup == nil }
 
     public init(id: String, name: String, sortIndex: Int, seededFromGroup: CategoryGroup?) {
         self.id = id
@@ -79,49 +87,112 @@ public struct BudgetCategoryGroupV2: Codable, Sendable, Hashable, Identifiable {
 /// transaction — maps to its v2 row with no reclassification. `groupId` references
 /// the seeded ``BudgetCategoryGroupV2``.
 public struct BudgetCategoryV2: Codable, Sendable, Hashable, Identifiable {
-    /// Stable identity — the seeded ``SpendingCategory`` `rawValue`. A
-    /// user-created category (a later epic) would use a fresh UUID string; the
-    /// foundation only ever seeds the closed enum, so every id round-trips back to
-    /// a ``SpendingCategory`` via ``seededFromCategory``.
+    /// Stable identity — the seeded ``SpendingCategory`` `rawValue`. A user-created
+    /// category (AND-547) uses a fresh `"cat_<uuid>"` string; a seeded row keeps the
+    /// closed-enum `rawValue`, so every *seeded* id round-trips back to a
+    /// ``SpendingCategory`` via ``seededFromCategory`` while a custom one never
+    /// collides with — or shadows — a Plaid key.
     public let id: String
-    /// Display name (seeded from ``SpendingCategory/displayName``). User-editable in
-    /// a later epic; the foundation just carries the v1 name forward.
+    /// Display name (seeded from ``SpendingCategory/displayName``). User-renamable
+    /// via the categories editor (AND-547) for both system and custom rows.
     public let name: String
     /// SF Symbol for the category icon (seeded from ``SpendingCategory/iconName``).
     public let iconName: String
-    /// Parent group id (the seeded ``BudgetCategoryGroupV2/id``).
+    /// Optional user emoji glyph shown in place of (or alongside) ``iconName`` in
+    /// the editor and dashboard (AND-547). `nil` for a seeded row that the user has
+    /// not re-emoji'd, so a not-edited category renders exactly as v1 did.
+    /// Decoded as `nil` when absent, so a pre-AND-547 snapshot keeps the SF Symbol.
+    public let emoji: String?
+    /// Display color as a `#RRGGBB` hex string (seeded from
+    /// ``SpendingCategory/colorHex``). User-recolorable via the editor (AND-547).
+    /// Decoded as the seeded color (or a neutral fallback for a custom row) when
+    /// absent, so a pre-AND-547 snapshot keeps the v1 chart color.
+    public let colorHex: String
+    /// Parent group id (the seeded ``BudgetCategoryGroupV2/id``). User-movable
+    /// between groups via the editor (AND-547).
     public let groupId: String
+    /// Within-group display order (AND-547). Seeded rows default to `0` and fall
+    /// back to display-name ordering; the editor assigns explicit indices on
+    /// reorder. Decoded as `0` when absent so a pre-AND-547 snapshot is stable.
+    public let sortIndex: Int
     /// The ``SpendingCategory`` this row seeded from, preserving the exact v1
-    /// taxonomy link. `nil` only for a (future) user-created category with no v1
-    /// ancestor — never for a seeded row. Lets a reverse migration drop straight
-    /// back to the v1 enum key without a name lookup.
+    /// taxonomy link **even after a rename/recolor** — renaming a system category
+    /// never breaks its `systemKey → Plaid` mapping. `nil` only for a user-created
+    /// category (AND-547) with no v1 ancestor. Lets a reverse migration drop
+    /// straight back to the v1 enum key without a name lookup, and lets the editor
+    /// tell a deletable custom row from a protected system one.
     public let seededFromCategory: SpendingCategory?
+
+    /// Whether this category was created by the user (AND-547) rather than seeded
+    /// from the closed enum. Derived from ``seededFromCategory`` so a system row can
+    /// never be misclassified as deletable: a seeded row always has a v1 ancestor.
+    public var isCustom: Bool { seededFromCategory == nil }
 
     public init(
         id: String,
         name: String,
         iconName: String,
+        emoji: String? = nil,
+        colorHex: String,
         groupId: String,
+        sortIndex: Int = 0,
         seededFromCategory: SpendingCategory?
     ) {
         self.id = id
         self.name = name
         self.iconName = iconName
+        self.emoji = emoji
+        self.colorHex = colorHex
         self.groupId = groupId
+        self.sortIndex = sortIndex
         self.seededFromCategory = seededFromCategory
     }
 
     /// Seed a v2 category row from a ``SpendingCategory``, linking it to the group
-    /// the category rolls up into (``SpendingCategory/group``).
+    /// the category rolls up into (``SpendingCategory/group``) and carrying the v1
+    /// chart color forward so an unedited category is visually identical to v1.
     public init(seedingFrom category: SpendingCategory) {
         self.init(
             id: category.rawValue,
             name: category.displayName,
             iconName: category.iconName,
+            emoji: nil,
+            colorHex: category.colorHex,
             groupId: category.group.rawValue,
+            sortIndex: 0,
             seededFromCategory: category
         )
     }
+
+    // MARK: - Backward-compatible decoding
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, iconName, emoji, colorHex, groupId, sortIndex, seededFromCategory
+    }
+
+    /// Custom decoder so a snapshot written **before AND-547** (no `emoji` /
+    /// `colorHex` / `sortIndex` keys) still decodes: the new fields default rather
+    /// than throwing, keeping the v2 store self-healing and the upgrade additive.
+    /// A missing color falls back to the seeded ``SpendingCategory/colorHex`` when
+    /// the row links to one, else a neutral gray, so no row is ever color-less.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        iconName = try container.decode(String.self, forKey: .iconName)
+        emoji = try container.decodeIfPresent(String.self, forKey: .emoji)
+        groupId = try container.decode(String.self, forKey: .groupId)
+        sortIndex = try container.decodeIfPresent(Int.self, forKey: .sortIndex) ?? 0
+        let seeded = try container.decodeIfPresent(SpendingCategory.self, forKey: .seededFromCategory)
+        seededFromCategory = seeded
+        colorHex = try container.decodeIfPresent(String.self, forKey: .colorHex)
+            ?? seeded?.colorHex
+            ?? BudgetCategoryV2.neutralColorHex
+    }
+
+    /// Neutral fallback color for a custom row whose snapshot somehow omits one
+    /// (matches ``SpendingCategory/other`` so it reads as an unstyled category).
+    public static let neutralColorHex = "#BDC3C7"
 }
 
 // MARK: - Monthly budget (v2 — per-month + rollover)

--- a/Sources/PlaidBarCore/Utilities/BudgetCategoryEditor.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetCategoryEditor.swift
@@ -1,0 +1,621 @@
+import Foundation
+
+/// Pure, deterministic CRUD + validation for the budgeting-v2 categories &
+/// groups editor (AND-547 — deferred epic AND-524).
+///
+/// All the *logic* of the editor lives here as a stateless `enum` so it stays
+/// `Sendable`, has no hidden `Date()`/UUID/I/O (callers pass identity in), and is
+/// fully unit-testable in `PlaidBarCore`. The Settings/Budgets editor UI is a thin
+/// shell that calls these functions and persists the returned ``BudgetingV2Schema``
+/// snapshot via `PlaidBarCache.BudgetingV2Store`.
+///
+/// ## What it edits
+/// Every function takes the current ``BudgetingV2Schema`` and returns either a
+/// **new** schema (value semantics — the input is never mutated) or a
+/// ``BudgetCategoryEditError``. It covers the four AND-547 acceptance criteria:
+/// 1. **Create a custom category** with name + emoji + color + group.
+/// 2. **Rename / recolor / re-emoji** a category — including a *system* one —
+///    **without breaking its `systemKey → Plaid` mapping** (``seededFromCategory``
+///    is preserved verbatim; only presentation fields change).
+/// 3. **Create / rename / reorder groups** and **move categories between groups**.
+/// 4. **Delete a custom category**, **reassigning its budgets** to a fallback so no
+///    spend is orphaned (a seeded *system* category is never deletable).
+///
+/// ## v1-safety contract
+/// The editor only ever rewrites the **v2 snapshot** (an opt-in, disposable cache).
+/// It never touches ``SpendingCategory`` `rawValue`s, the v1 ``CategoryBudgetDTO``
+/// store, or `/api/budgets`. A user who has not opted into v2 never reaches this
+/// code, so v1 budgeting is byte-for-byte unchanged.
+public enum BudgetCategoryEditor {
+    // MARK: - Identity prefixes
+
+    /// Prefix for a user-created category id, e.g. `"cat_<uuid>"`. Keeps a custom id
+    /// from ever colliding with — or being mistaken for — a Plaid `rawValue`
+    /// (``SpendingCategory``), which is always uppercase letters/underscores.
+    public static let customCategoryIDPrefix = "cat_"
+    /// Prefix for a user-created group id, e.g. `"grp_<uuid>"`. Same rationale.
+    public static let customGroupIDPrefix = "grp_"
+
+    /// Build a stable custom-category id from a caller-supplied unique token (a UUID
+    /// string at the call site — kept out of this pure layer so it stays testable).
+    public static func customCategoryID(_ token: String) -> String {
+        customCategoryIDPrefix + token
+    }
+
+    /// Build a stable custom-group id from a caller-supplied unique token.
+    public static func customGroupID(_ token: String) -> String {
+        customGroupIDPrefix + token
+    }
+
+    // MARK: - Errors
+
+    /// Why an edit was rejected. Surfaced to the editor UI as a redundant
+    /// text-carried message (never color-alone, ACCESSIBILITY.md).
+    public enum BudgetCategoryEditError: Error, Sendable, Hashable {
+        /// The name was empty (after trimming) or only whitespace.
+        case emptyName
+        /// The name is too long (> ``maxNameLength`` characters).
+        case nameTooLong
+        /// Another category in the same group already uses this name (case-insensitive).
+        case duplicateCategoryName
+        /// Another group already uses this name (case-insensitive).
+        case duplicateGroupName
+        /// The color string is not a valid `#RRGGBB` hex.
+        case invalidColor
+        /// The emoji is not a single emoji grapheme.
+        case invalidEmoji
+        /// The referenced category id does not exist in the snapshot.
+        case categoryNotFound
+        /// The referenced group id does not exist in the snapshot.
+        case groupNotFound
+        /// A system (seeded) category cannot be deleted — only renamed/recolored.
+        case cannotDeleteSystemCategory
+        /// A system (seeded) group cannot be deleted.
+        case cannotDeleteSystemGroup
+        /// The target fallback for a delete-reassignment is missing or invalid.
+        case invalidReassignmentTarget
+    }
+
+    /// Longest allowed category / group name. Keeps the editor and dashboard rows
+    /// from overflowing; long enough for any real label.
+    public static let maxNameLength = 48
+
+    // MARK: - Create a custom category (AC 1)
+
+    /// Create a new **custom** category with a name, optional emoji, color, and
+    /// parent group, appended at the end of that group's order.
+    ///
+    /// - Parameters:
+    ///   - id: a fresh, unique id (build via ``customCategoryID(_:)`` at the call
+    ///     site so this layer stays UUID-free and deterministic).
+    ///   - name: display name; trimmed, must be non-empty, within ``maxNameLength``,
+    ///     and unique within `groupId` (case-insensitive).
+    ///   - emoji: optional single-emoji glyph; validated when present.
+    ///   - colorHex: `#RRGGBB` color; validated.
+    ///   - groupId: the parent group; must exist.
+    ///   - iconName: SF Symbol fallback shown when no emoji is set. Defaults to the
+    ///     neutral "tag" glyph.
+    /// - Returns: a new snapshot with the category added, or an error.
+    public static func addCategory(
+        to schema: BudgetingV2Schema,
+        id: String,
+        name: String,
+        emoji: String? = nil,
+        colorHex: String,
+        groupId: String,
+        iconName: String = "tag"
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let error = validateName(trimmedName) { return .failure(error) }
+        guard schema.group(id: groupId) != nil else { return .failure(.groupNotFound) }
+        if let error = validateColor(colorHex) { return .failure(error) }
+        if let emoji, let error = validateEmoji(emoji) { return .failure(error) }
+        if hasDuplicateCategoryName(in: schema, groupId: groupId, name: trimmedName, excluding: nil) {
+            return .failure(.duplicateCategoryName)
+        }
+
+        let nextIndex = nextCategorySortIndex(in: schema, groupId: groupId)
+        let category = BudgetCategoryV2(
+            id: id,
+            name: trimmedName,
+            iconName: iconName,
+            emoji: normalizedEmoji(emoji),
+            colorHex: normalizedColor(colorHex),
+            groupId: groupId,
+            sortIndex: nextIndex,
+            seededFromCategory: nil
+        )
+        var categories = schema.categories
+        categories.append(category)
+        return .success(schema.replacingCategories(categories))
+    }
+
+    // MARK: - Edit a category (rename / recolor / re-emoji) (AC 2)
+
+    /// Rename, recolor, and/or re-emoji a category — system **or** custom — without
+    /// touching its ``BudgetCategoryV2/seededFromCategory`` link, so a renamed
+    /// *system* category keeps its exact `systemKey → Plaid` mapping (every
+    /// already-categorized transaction still buckets to the same Plaid key; only the
+    /// label/color/glyph the user sees changes).
+    ///
+    /// `nil` fields leave the current value untouched; pass `emoji: .some(nil)` to
+    /// *clear* an emoji. Only the presentation fields are editable here — the id,
+    /// group membership, and seed link are immutable through this entrypoint (use
+    /// ``moveCategory(in:categoryId:toGroupId:)`` to change the group).
+    public static func editCategory(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        name: String? = nil,
+        emoji: String?? = nil,
+        colorHex: String? = nil
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        guard let existing = schema.category(id: categoryId) else {
+            return .failure(.categoryNotFound)
+        }
+
+        var newName = existing.name
+        if let name {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let error = validateName(trimmed) { return .failure(error) }
+            if hasDuplicateCategoryName(
+                in: schema, groupId: existing.groupId, name: trimmed, excluding: categoryId
+            ) {
+                return .failure(.duplicateCategoryName)
+            }
+            newName = trimmed
+        }
+
+        var newColor = existing.colorHex
+        if let colorHex {
+            if let error = validateColor(colorHex) { return .failure(error) }
+            newColor = normalizedColor(colorHex)
+        }
+
+        var newEmoji = existing.emoji
+        if let emoji {
+            if let emoji, let error = validateEmoji(emoji) { return .failure(error) }
+            newEmoji = normalizedEmoji(emoji)
+        }
+
+        let updated = BudgetCategoryV2(
+            id: existing.id,
+            name: newName,
+            iconName: existing.iconName,
+            emoji: newEmoji,
+            colorHex: newColor,
+            groupId: existing.groupId,
+            sortIndex: existing.sortIndex,
+            // Preserved verbatim — the rename/recolor never breaks the Plaid mapping.
+            seededFromCategory: existing.seededFromCategory
+        )
+        return .success(schema.replacingCategory(updated))
+    }
+
+    /// Reorder categories *within a single group* by supplying the desired
+    /// top-to-bottom id order. Ids not in `orderedCategoryIds` keep their relative
+    /// order after the listed ones; ids that don't belong to `groupId` are ignored.
+    public static func reorderCategories(
+        in schema: BudgetingV2Schema,
+        groupId: String,
+        orderedCategoryIds: [String]
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        guard schema.group(id: groupId) != nil else { return .failure(.groupNotFound) }
+
+        let inGroup = schema.categories.filter { $0.groupId == groupId }
+        let rank = Dictionary(
+            orderedCategoryIds.enumerated().map { ($0.element, $0.offset) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        // Stable order: listed ids by their given rank, then the rest by current
+        // sortIndex/name — so an incomplete list never drops a category.
+        let reordered = inGroup.sorted { lhs, rhs in
+            let lr = rank[lhs.id] ?? Int.max
+            let rr = rank[rhs.id] ?? Int.max
+            if lr != rr { return lr < rr }
+            if lhs.sortIndex != rhs.sortIndex { return lhs.sortIndex < rhs.sortIndex }
+            return lhs.name < rhs.name
+        }
+
+        var byId = Dictionary(schema.categories.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        for (index, category) in reordered.enumerated() {
+            byId[category.id] = category.withSortIndex(index)
+        }
+        let categories = schema.categories.map { byId[$0.id] ?? $0 }
+        return .success(schema.replacingCategories(categories))
+    }
+
+    /// Move a category to a different group, appending it at the end of the target
+    /// group's order. The category's id, name, color, emoji, and seed link are all
+    /// preserved — only the group membership and within-group order change.
+    public static func moveCategory(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        toGroupId: String
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        guard let existing = schema.category(id: categoryId) else {
+            return .failure(.categoryNotFound)
+        }
+        guard schema.group(id: toGroupId) != nil else { return .failure(.groupNotFound) }
+        guard existing.groupId != toGroupId else { return .success(schema) }
+
+        // A move can collide with a same-named category already in the target group.
+        if hasDuplicateCategoryName(
+            in: schema, groupId: toGroupId, name: existing.name, excluding: categoryId
+        ) {
+            return .failure(.duplicateCategoryName)
+        }
+
+        let moved = BudgetCategoryV2(
+            id: existing.id,
+            name: existing.name,
+            iconName: existing.iconName,
+            emoji: existing.emoji,
+            colorHex: existing.colorHex,
+            groupId: toGroupId,
+            sortIndex: nextCategorySortIndex(in: schema, groupId: toGroupId),
+            seededFromCategory: existing.seededFromCategory
+        )
+        return .success(schema.replacingCategory(moved))
+    }
+
+    // MARK: - Delete a custom category (AC 4 — reassign, never orphan)
+
+    /// The result of a delete: the new schema plus the id every budget that pointed
+    /// at the deleted category was reassigned to, so a caller can re-point any
+    /// transaction-level overrides the same way (no orphaned spend).
+    public struct DeletionResult: Sendable, Hashable {
+        /// The post-delete snapshot.
+        public let schema: BudgetingV2Schema
+        /// The deleted category's id.
+        public let deletedCategoryId: String
+        /// The category id that the deleted category's budgets (and the caller's
+        /// transaction overrides) were reassigned to.
+        public let reassignedToCategoryId: String
+
+        public init(schema: BudgetingV2Schema, deletedCategoryId: String, reassignedToCategoryId: String) {
+            self.schema = schema
+            self.deletedCategoryId = deletedCategoryId
+            self.reassignedToCategoryId = reassignedToCategoryId
+        }
+    }
+
+    /// Delete a **custom** category, **reassigning** any budgets that pointed at it
+    /// to `reassignToCategoryId` so no monthly budget — and, via the returned
+    /// mapping, no transaction's spend — is left orphaned. A *system* (seeded)
+    /// category cannot be deleted (it anchors the Plaid mapping); rename/recolor it
+    /// instead.
+    ///
+    /// When a month already has a budget for *both* the deleted and the target
+    /// category, the two limits are **summed** into the target so no budgeted dollar
+    /// silently disappears. If `reassignToCategoryId` is `nil`, spend is reassigned
+    /// to the closest system fallback — the `.other` seeded category — guaranteeing
+    /// a always-present, never-deletable home.
+    public static func deleteCustomCategory(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        reassignToCategoryId: String? = nil
+    ) -> Result<DeletionResult, BudgetCategoryEditError> {
+        guard let existing = schema.category(id: categoryId) else {
+            return .failure(.categoryNotFound)
+        }
+        guard existing.isCustom else { return .failure(.cannotDeleteSystemCategory) }
+
+        // Resolve the reassignment target. Default to the seeded `.other` category,
+        // which always exists and is never deletable.
+        let targetId = reassignToCategoryId ?? SpendingCategory.other.rawValue
+        guard targetId != categoryId else { return .failure(.invalidReassignmentTarget) }
+        guard schema.category(id: targetId) != nil else {
+            return .failure(.invalidReassignmentTarget)
+        }
+
+        // Reassign budgets: each (month, deletedCategory) budget is folded onto the
+        // (month, target) budget — summing limits when both exist so no budgeted
+        // amount is dropped.
+        var budgetsByKey = Dictionary(
+            schema.budgets.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for budget in schema.budgets where budget.categoryId == categoryId {
+            budgetsByKey.removeValue(forKey: budget.id)
+            let targetBudget = MonthlyBudgetV2(
+                month: budget.month,
+                categoryId: targetId,
+                monthlyLimit: budget.monthlyLimit,
+                rollover: budget.rollover
+            )
+            if let existingTarget = budgetsByKey[targetBudget.id] {
+                budgetsByKey[targetBudget.id] = MonthlyBudgetV2(
+                    month: existingTarget.month,
+                    categoryId: existingTarget.categoryId,
+                    monthlyLimit: existingTarget.monthlyLimit + budget.monthlyLimit,
+                    // Keep rollover on if either side wanted it.
+                    rollover: existingTarget.rollover || budget.rollover
+                )
+            } else {
+                budgetsByKey[targetBudget.id] = targetBudget
+            }
+        }
+
+        let categories = schema.categories.filter { $0.id != categoryId }
+        let budgets = budgetsByKey.values.sorted { lhs, rhs in
+            lhs.id < rhs.id
+        }
+        let newSchema = BudgetingV2Schema(
+            schemaVersion: schema.schemaVersion,
+            groups: schema.groups,
+            categories: categories,
+            budgets: budgets
+        )
+        return .success(
+            DeletionResult(
+                schema: newSchema,
+                deletedCategoryId: categoryId,
+                reassignedToCategoryId: targetId
+            )
+        )
+    }
+
+    // MARK: - Groups (AC 3)
+
+    /// Create a new **custom** group, appended at the end of the group order.
+    public static func addGroup(
+        to schema: BudgetingV2Schema,
+        id: String,
+        name: String
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let error = validateName(trimmed) { return .failure(error) }
+        if hasDuplicateGroupName(in: schema, name: trimmed, excluding: nil) {
+            return .failure(.duplicateGroupName)
+        }
+        let nextIndex = (schema.groups.map(\.sortIndex).max() ?? -1) + 1
+        let group = BudgetCategoryGroupV2(
+            id: id,
+            name: trimmed,
+            sortIndex: nextIndex,
+            seededFromGroup: nil
+        )
+        var groups = schema.groups
+        groups.append(group)
+        return .success(schema.replacingGroups(groups))
+    }
+
+    /// Rename a group (system or custom). The id and seed link are preserved, so a
+    /// renamed *system* group still maps back to its ``CategoryGroup`` on opt-out.
+    public static func renameGroup(
+        in schema: BudgetingV2Schema,
+        groupId: String,
+        name: String
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        guard let existing = schema.group(id: groupId) else { return .failure(.groupNotFound) }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let error = validateName(trimmed) { return .failure(error) }
+        if hasDuplicateGroupName(in: schema, name: trimmed, excluding: groupId) {
+            return .failure(.duplicateGroupName)
+        }
+        let updated = BudgetCategoryGroupV2(
+            id: existing.id,
+            name: trimmed,
+            sortIndex: existing.sortIndex,
+            seededFromGroup: existing.seededFromGroup
+        )
+        return .success(schema.replacingGroup(updated))
+    }
+
+    /// Reorder groups top-to-bottom by supplying the desired id order. Ids not in
+    /// `orderedGroupIds` keep their relative order after the listed ones.
+    public static func reorderGroups(
+        in schema: BudgetingV2Schema,
+        orderedGroupIds: [String]
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        let rank = Dictionary(
+            orderedGroupIds.enumerated().map { ($0.element, $0.offset) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let reordered = schema.groups.sorted { lhs, rhs in
+            let lr = rank[lhs.id] ?? Int.max
+            let rr = rank[rhs.id] ?? Int.max
+            if lr != rr { return lr < rr }
+            if lhs.sortIndex != rhs.sortIndex { return lhs.sortIndex < rhs.sortIndex }
+            return lhs.name < rhs.name
+        }
+        let groups = reordered.enumerated().map { index, group in
+            BudgetCategoryGroupV2(
+                id: group.id,
+                name: group.name,
+                sortIndex: index,
+                seededFromGroup: group.seededFromGroup
+            )
+        }
+        return .success(schema.replacingGroups(groups))
+    }
+
+    /// Delete a **custom** group, moving every category in it to `reassignToGroupId`
+    /// (or the seeded `.other` group by default) so no category — and therefore no
+    /// spend — is orphaned. A *system* (seeded) group cannot be deleted.
+    public static func deleteCustomGroup(
+        in schema: BudgetingV2Schema,
+        groupId: String,
+        reassignToGroupId: String? = nil
+    ) -> Result<BudgetingV2Schema, BudgetCategoryEditError> {
+        guard let existing = schema.group(id: groupId) else { return .failure(.groupNotFound) }
+        guard existing.isCustom else { return .failure(.cannotDeleteSystemGroup) }
+
+        let targetId = reassignToGroupId ?? CategoryGroup.other.rawValue
+        guard targetId != groupId else { return .failure(.invalidReassignmentTarget) }
+        guard schema.group(id: targetId) != nil else { return .failure(.invalidReassignmentTarget) }
+
+        // Move the group's categories to the target, appended after the target's
+        // current members so order stays deterministic.
+        var nextIndex = nextCategorySortIndex(in: schema, groupId: targetId)
+        let categories = schema.categories.map { category -> BudgetCategoryV2 in
+            guard category.groupId == groupId else { return category }
+            let moved = BudgetCategoryV2(
+                id: category.id,
+                name: category.name,
+                iconName: category.iconName,
+                emoji: category.emoji,
+                colorHex: category.colorHex,
+                groupId: targetId,
+                sortIndex: nextIndex,
+                seededFromCategory: category.seededFromCategory
+            )
+            nextIndex += 1
+            return moved
+        }
+        let groups = schema.groups.filter { $0.id != groupId }
+        return .success(
+            BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: groups,
+                categories: categories,
+                budgets: schema.budgets
+            )
+        )
+    }
+
+    // MARK: - Validation (public so the UI can pre-flight a field live)
+
+    /// `nil` when `trimmedName` is a legal label, else the reason it isn't. Expects
+    /// an already-trimmed string (the editor trims before calling so the live field
+    /// validates against the committed value).
+    public static func validateName(_ trimmedName: String) -> BudgetCategoryEditError? {
+        if trimmedName.isEmpty { return .emptyName }
+        if trimmedName.count > maxNameLength { return .nameTooLong }
+        return nil
+    }
+
+    /// `nil` when `colorHex` is a valid `#RRGGBB` (case-insensitive, leading `#`
+    /// required), else ``BudgetCategoryEditError/invalidColor``.
+    public static func validateColor(_ colorHex: String) -> BudgetCategoryEditError? {
+        isValidHexColor(colorHex) ? nil : .invalidColor
+    }
+
+    /// `nil` when `emoji` is exactly one emoji grapheme, else
+    /// ``BudgetCategoryEditError/invalidEmoji``.
+    public static func validateEmoji(_ emoji: String) -> BudgetCategoryEditError? {
+        isValidEmoji(emoji) ? nil : .invalidEmoji
+    }
+
+    /// Whether a string is a well-formed `#RRGGBB` hex color (6 hex digits after a
+    /// required `#`). Both cases accepted; normalized to uppercase on store.
+    public static func isValidHexColor(_ value: String) -> Bool {
+        guard value.hasPrefix("#") else { return false }
+        let hex = value.dropFirst()
+        guard hex.count == 6 else { return false }
+        return hex.allSatisfy(\.isHexDigit)
+    }
+
+    /// Whether a string is exactly one emoji grapheme (a single `Character` whose
+    /// scalars include an emoji). Rejects empty, multi-character, and plain-text
+    /// (non-emoji) input so the glyph stays a clean single symbol.
+    public static func isValidEmoji(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 1, let scalar = trimmed.unicodeScalars.first else { return false }
+        // A grapheme is an emoji when its first scalar is an emoji *and* it is
+        // presented as emoji (covers ZWJ sequences and modifier-bearing emoji,
+        // which keep `isEmoji` on the first scalar).
+        return scalar.properties.isEmoji && (scalar.value >= 0x203C || scalar.properties.isEmojiPresentation)
+    }
+
+    // MARK: - Normalization
+
+    /// Uppercase a valid `#RRGGBB` so stored colors compare equal regardless of the
+    /// case the user typed. Assumes ``isValidHexColor(_:)`` already passed.
+    static func normalizedColor(_ colorHex: String) -> String {
+        "#" + colorHex.dropFirst().uppercased()
+    }
+
+    /// Trim an emoji to its single grapheme; `nil` clears it.
+    static func normalizedEmoji(_ emoji: String?) -> String? {
+        guard let emoji else { return nil }
+        let trimmed = emoji.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // MARK: - Internals
+
+    /// Whether `name` collides with another category in `groupId` (case-insensitive),
+    /// ignoring `excluding` (the row being edited).
+    static func hasDuplicateCategoryName(
+        in schema: BudgetingV2Schema,
+        groupId: String,
+        name: String,
+        excluding: String?
+    ) -> Bool {
+        let needle = name.lowercased()
+        return schema.categories.contains { category in
+            category.groupId == groupId
+                && category.id != excluding
+                && category.name.lowercased() == needle
+        }
+    }
+
+    /// Whether `name` collides with another group (case-insensitive), ignoring
+    /// `excluding`.
+    static func hasDuplicateGroupName(
+        in schema: BudgetingV2Schema,
+        name: String,
+        excluding: String?
+    ) -> Bool {
+        let needle = name.lowercased()
+        return schema.groups.contains { group in
+            group.id != excluding && group.name.lowercased() == needle
+        }
+    }
+
+    /// The next within-group `sortIndex` for `groupId` (max + 1, or 0 when empty).
+    static func nextCategorySortIndex(in schema: BudgetingV2Schema, groupId: String) -> Int {
+        (schema.categories.filter { $0.groupId == groupId }.map(\.sortIndex).max() ?? -1) + 1
+    }
+}
+
+// MARK: - Schema value-replacement helpers
+
+extension BudgetCategoryV2 {
+    /// A copy with a new within-group order, all other fields preserved.
+    func withSortIndex(_ index: Int) -> BudgetCategoryV2 {
+        BudgetCategoryV2(
+            id: id,
+            name: name,
+            iconName: iconName,
+            emoji: emoji,
+            colorHex: colorHex,
+            groupId: groupId,
+            sortIndex: index,
+            seededFromCategory: seededFromCategory
+        )
+    }
+}
+
+extension BudgetingV2Schema {
+    /// A copy with `categories` replaced (groups/budgets/version unchanged).
+    func replacingCategories(_ categories: [BudgetCategoryV2]) -> BudgetingV2Schema {
+        BudgetingV2Schema(
+            schemaVersion: schemaVersion,
+            groups: groups,
+            categories: categories,
+            budgets: budgets
+        )
+    }
+
+    /// A copy with the category sharing `updated.id` replaced in place.
+    func replacingCategory(_ updated: BudgetCategoryV2) -> BudgetingV2Schema {
+        replacingCategories(categories.map { $0.id == updated.id ? updated : $0 })
+    }
+
+    /// A copy with `groups` replaced (categories/budgets/version unchanged).
+    func replacingGroups(_ groups: [BudgetCategoryGroupV2]) -> BudgetingV2Schema {
+        BudgetingV2Schema(
+            schemaVersion: schemaVersion,
+            groups: groups,
+            categories: categories,
+            budgets: budgets
+        )
+    }
+
+    /// A copy with the group sharing `updated.id` replaced in place.
+    func replacingGroup(_ updated: BudgetCategoryGroupV2) -> BudgetingV2Schema {
+        replacingGroups(groups.map { $0.id == updated.id ? updated : $0 })
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/BudgetingV2Migration.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetingV2Migration.swift
@@ -54,7 +54,11 @@ public enum BudgetingV2Migration {
 
         // Categories ordered by (group display order, then category display name)
         // so the seeded leaf table is deterministic and reads naturally under each
-        // group header.
+        // group header. Each leaf is stamped with an explicit within-group
+        // `sortIndex` (0-based, contiguous per group) so the editor (AND-547) has a
+        // stable starting order to reorder against, rather than every seeded row
+        // sharing index 0.
+        var perGroupNextIndex: [String: Int] = [:]
         let categories = SpendingCategory.allCases
             .sorted { lhs, rhs in
                 if lhs.group.sortIndex != rhs.group.sortIndex {
@@ -62,7 +66,22 @@ public enum BudgetingV2Migration {
                 }
                 return lhs.displayName < rhs.displayName
             }
-            .map(BudgetCategoryV2.init(seedingFrom:))
+            .map { category -> BudgetCategoryV2 in
+                let groupId = category.group.rawValue
+                let index = perGroupNextIndex[groupId, default: 0]
+                perGroupNextIndex[groupId] = index + 1
+                let seeded = BudgetCategoryV2(seedingFrom: category)
+                return BudgetCategoryV2(
+                    id: seeded.id,
+                    name: seeded.name,
+                    iconName: seeded.iconName,
+                    emoji: seeded.emoji,
+                    colorHex: seeded.colorHex,
+                    groupId: seeded.groupId,
+                    sortIndex: index,
+                    seededFromCategory: seeded.seededFromCategory
+                )
+            }
 
         // Carry v1 budgets forward only when both a non-empty set AND a target
         // month are supplied. A budget for a category that somehow isn't in the

--- a/Tests/PlaidBarCacheTests/BudgetingV2EditorStoreTests.swift
+++ b/Tests/PlaidBarCacheTests/BudgetingV2EditorStoreTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import PlaidBarCache
+@testable import PlaidBarCore
+
+/// Round-trip tests that an AND-547 *edited* schema (custom categories/groups with
+/// the new emoji/color/sortIndex fields) persists through ``BudgetingV2Store`` and
+/// reloads byte-for-byte equal — the editor model's persistence path.
+@Suite("Budgeting v2 editor store round-trip (AND-547)", .serialized)
+struct BudgetingV2EditorStoreTests {
+
+    @Test("an edited schema with a custom category + group survives save/load equal")
+    func editedSchemaRoundTrips() async throws {
+        let store = try BudgetingV2Store(inMemory: true)
+        let cacheKey = "sandbox|/x"
+
+        var schema = try await store.seedV2(cacheKey: cacheKey)
+
+        // Add a custom group + category, rename a system category, recolor it.
+        schema = try BudgetCategoryEditor.addGroup(
+            to: schema, id: BudgetCategoryEditor.customGroupID("g1"), name: "Side Projects"
+        ).get()
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema,
+            id: BudgetCategoryEditor.customCategoryID("c1"),
+            name: "Gig Income",
+            emoji: "💼",
+            colorHex: "#22AA88",
+            groupId: BudgetCategoryEditor.customGroupID("g1")
+        ).get()
+        schema = try BudgetCategoryEditor.editCategory(
+            in: schema,
+            categoryId: SpendingCategory.foodAndDrink.rawValue,
+            name: "Groceries",
+            colorHex: "#FF0000"
+        ).get()
+
+        try await store.save(cacheKey: cacheKey, schema: schema)
+        let loaded = try #require(try await store.load(cacheKey: cacheKey))
+        #expect(loaded == schema)
+
+        // Spot-check the new fields survived persistence.
+        let custom = try #require(loaded.category(id: BudgetCategoryEditor.customCategoryID("c1")))
+        #expect(custom.emoji == "💼")
+        #expect(custom.colorHex == "#22AA88")
+        #expect(custom.isCustom)
+        let renamed = try #require(loaded.category(id: SpendingCategory.foodAndDrink.rawValue))
+        #expect(renamed.name == "Groceries")
+        #expect(renamed.colorHex == "#FF0000")
+        // System mapping intact after rename+recolor+persist.
+        #expect(renamed.seededFromCategory == .foodAndDrink)
+    }
+
+    @Test("opting out after edits still recovers the carried-forward v1 budgets")
+    func optOutAfterEditsRecoversV1() async throws {
+        let store = try BudgetingV2Store(inMemory: true)
+        let cacheKey = "sandbox|/x"
+        let v1 = [CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500)]
+
+        var schema = try await store.seedV2(cacheKey: cacheKey, carryingForward: v1, month: "2026-06")
+        // Rename the system category the budget points at — the mapping must survive.
+        schema = try BudgetCategoryEditor.editCategory(
+            in: schema, categoryId: SpendingCategory.foodAndDrink.rawValue, name: "Groceries"
+        ).get()
+        try await store.save(cacheKey: cacheKey, schema: schema)
+
+        let recovered = try await store.optOut(cacheKey: cacheKey, month: "2026-06")
+        #expect(recovered.contains { $0.category == .foodAndDrink && $0.monthlyLimit == 500 })
+        // Opt-out clears the snapshot — v1 is back in effect.
+        #expect(try await store.isOptedIn(cacheKey: cacheKey) == false)
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetCategoryEditorTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetCategoryEditorTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Tests for the budgeting-v2 categories & groups editor (AND-547).
+///
+/// Verifies the four acceptance criteria as pure, view-free logic:
+/// 1. create a custom category with name + emoji + color + group;
+/// 2. rename/recolor a SYSTEM category without breaking its `systemKey → Plaid`
+///    mapping;
+/// 3. create/rename/reorder groups + move categories between groups;
+/// 4. deleting a custom category reassigns its budgets (no orphaned spend).
+@Suite("BudgetCategoryEditor")
+struct BudgetCategoryEditorTests {
+    /// A freshly seeded snapshot (no carried-forward budgets) — the editor's input.
+    private func seededSchema() -> BudgetingV2Schema {
+        BudgetingV2Migration.seed()
+    }
+
+    // MARK: - AC 1: create a custom category
+
+    @Test("addCategory creates a custom category with name + emoji + color + group")
+    func addCustomCategory() throws {
+        let schema = seededSchema()
+        let groupId = CategoryGroup.shopping.rawValue
+        let id = BudgetCategoryEditor.customCategoryID("hobbies-1")
+
+        let result = BudgetCategoryEditor.addCategory(
+            to: schema,
+            id: id,
+            name: "Hobbies",
+            emoji: "🎨",
+            colorHex: "#ff8800",
+            groupId: groupId
+        )
+        let updated = try result.get()
+
+        let created = try #require(updated.category(id: id))
+        #expect(created.name == "Hobbies")
+        #expect(created.emoji == "🎨")
+        #expect(created.colorHex == "#FF8800") // normalized to uppercase
+        #expect(created.groupId == groupId)
+        #expect(created.isCustom)
+        #expect(created.seededFromCategory == nil)
+        // Appended after the group's seeded members.
+        let inGroup = updated.categories.filter { $0.groupId == groupId }
+        #expect(created.sortIndex == (inGroup.map(\.sortIndex).max() ?? -1))
+        // Additive: every seeded category survives.
+        #expect(updated.categories.count == schema.categories.count + 1)
+    }
+
+    @Test("addCategory rejects an empty name, bad color, bad emoji, and unknown group")
+    func addCategoryValidation() {
+        let schema = seededSchema()
+        let groupId = CategoryGroup.shopping.rawValue
+
+        #expect(throwsEditError(.emptyName) {
+            try BudgetCategoryEditor.addCategory(
+                to: schema, id: "cat_x", name: "   ", colorHex: "#FF8800", groupId: groupId
+            ).get()
+        })
+        #expect(throwsEditError(.invalidColor) {
+            try BudgetCategoryEditor.addCategory(
+                to: schema, id: "cat_x", name: "Hobbies", colorHex: "FF8800", groupId: groupId
+            ).get()
+        })
+        #expect(throwsEditError(.invalidEmoji) {
+            try BudgetCategoryEditor.addCategory(
+                to: schema, id: "cat_x", name: "Hobbies", emoji: "ab",
+                colorHex: "#FF8800", groupId: groupId
+            ).get()
+        })
+        #expect(throwsEditError(.groupNotFound) {
+            try BudgetCategoryEditor.addCategory(
+                to: schema, id: "cat_x", name: "Hobbies", colorHex: "#FF8800", groupId: "nope"
+            ).get()
+        })
+    }
+
+    @Test("addCategory rejects a duplicate name within the same group, case-insensitively")
+    func addCategoryDuplicateName() throws {
+        var schema = seededSchema()
+        let groupId = CategoryGroup.shopping.rawValue
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: "cat_1", name: "Hobbies", colorHex: "#FF8800", groupId: groupId
+        ).get()
+
+        #expect(throwsEditError(.duplicateCategoryName) {
+            try BudgetCategoryEditor.addCategory(
+                to: schema, id: "cat_2", name: "hobbies", colorHex: "#00FF00", groupId: groupId
+            ).get()
+        })
+        // Same name in a *different* group is allowed.
+        let otherGroup = CategoryGroup.entertainment.rawValue
+        #expect((try? BudgetCategoryEditor.addCategory(
+            to: schema, id: "cat_3", name: "Hobbies", colorHex: "#00FF00", groupId: otherGroup
+        ).get()) != nil)
+    }
+
+    // MARK: - AC 2: rename/recolor a SYSTEM category preserves the Plaid mapping
+
+    @Test("editCategory renames/recolors a system category WITHOUT breaking the Plaid mapping")
+    func editSystemCategoryPreservesMapping() throws {
+        let schema = seededSchema()
+        let systemId = SpendingCategory.foodAndDrink.rawValue // "FOOD_AND_DRINK"
+
+        let updated = try BudgetCategoryEditor.editCategory(
+            in: schema,
+            categoryId: systemId,
+            name: "Groceries & Eats",
+            emoji: .some("🍜"),
+            colorHex: "#123abc"
+        ).get()
+
+        let edited = try #require(updated.category(id: systemId))
+        #expect(edited.name == "Groceries & Eats")
+        #expect(edited.emoji == "🍜")
+        #expect(edited.colorHex == "#123ABC")
+        // The id is unchanged AND the seed link is preserved verbatim — the
+        // systemKey → Plaid mapping is intact.
+        #expect(edited.id == systemId)
+        #expect(edited.seededFromCategory == .foodAndDrink)
+        #expect(!edited.isCustom)
+        // Reverse migration still recovers the v1 key for this renamed category.
+        let v1 = BudgetingV2Migration.reverseToV1Budgets(
+            updated.replacingCategory(edited).withBudget(
+                MonthlyBudgetV2(month: "2026-06", categoryId: systemId, monthlyLimit: 100)
+            ),
+            month: "2026-06"
+        )
+        #expect(v1.contains { $0.category == .foodAndDrink && $0.monthlyLimit == 100 })
+    }
+
+    @Test("editCategory with nil fields is a no-op for those fields; clearing an emoji works")
+    func editCategoryPartial() throws {
+        var schema = seededSchema()
+        let id = BudgetCategoryEditor.customCategoryID("c1")
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: id, name: "Hobbies", emoji: "🎨",
+            colorHex: "#FF8800", groupId: CategoryGroup.shopping.rawValue
+        ).get()
+
+        // Rename only: color + emoji untouched.
+        var updated = try BudgetCategoryEditor.editCategory(in: schema, categoryId: id, name: "Crafts").get()
+        var row = try #require(updated.category(id: id))
+        #expect(row.name == "Crafts")
+        #expect(row.emoji == "🎨")
+        #expect(row.colorHex == "#FF8800")
+
+        // Clear the emoji explicitly via .some(nil).
+        updated = try BudgetCategoryEditor.editCategory(in: updated, categoryId: id, emoji: .some(nil)).get()
+        row = try #require(updated.category(id: id))
+        #expect(row.emoji == nil)
+        #expect(row.name == "Crafts") // unchanged
+    }
+
+    @Test("editCategory rejects an unknown id and a duplicate name within the group")
+    func editCategoryValidation() throws {
+        var schema = seededSchema()
+        let groupId = CategoryGroup.shopping.rawValue
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: "cat_a", name: "Alpha", colorHex: "#FF8800", groupId: groupId
+        ).get()
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: "cat_b", name: "Beta", colorHex: "#00FF00", groupId: groupId
+        ).get()
+
+        #expect(throwsEditError(.categoryNotFound) {
+            try BudgetCategoryEditor.editCategory(in: schema, categoryId: "nope", name: "X").get()
+        })
+        #expect(throwsEditError(.duplicateCategoryName) {
+            try BudgetCategoryEditor.editCategory(in: schema, categoryId: "cat_b", name: "alpha").get()
+        })
+    }
+
+    @Test("reorderCategories reindexes within a group and never drops an unlisted id")
+    func reorderCategories() throws {
+        let schema = seededSchema()
+        let groupId = CategoryGroup.entertainment.rawValue
+        let original = schema.categories.filter { $0.groupId == groupId }.map(\.id)
+        #expect(original.count >= 2)
+
+        // Reverse just the first two; the rest must remain, in order, after them.
+        let reordered = Array(original.prefix(2).reversed())
+        let updated = try BudgetCategoryEditor.reorderCategories(
+            in: schema, groupId: groupId, orderedCategoryIds: reordered
+        ).get()
+
+        let resultIds = updated.categories
+            .filter { $0.groupId == groupId }
+            .sorted { $0.sortIndex < $1.sortIndex }
+            .map(\.id)
+        #expect(resultIds.prefix(2) == ArraySlice(reordered))
+        #expect(Set(resultIds) == Set(original)) // nothing dropped
+        // Indices are contiguous from 0.
+        let indices = updated.categories.filter { $0.groupId == groupId }.map(\.sortIndex).sorted()
+        #expect(indices == Array(0..<indices.count))
+    }
+
+    // MARK: - AC 3: groups CRUD + move categories between groups
+
+    @Test("addGroup / renameGroup / reorderGroups manage custom and system groups")
+    func groupCrud() throws {
+        var schema = seededSchema()
+        let originalGroupCount = schema.groups.count
+        let groupId = BudgetCategoryEditor.customGroupID("g1")
+
+        // Create.
+        schema = try BudgetCategoryEditor.addGroup(to: schema, id: groupId, name: "Side Projects").get()
+        let created = try #require(schema.group(id: groupId))
+        #expect(created.name == "Side Projects")
+        #expect(created.isCustom)
+        #expect(schema.groups.count == originalGroupCount + 1)
+
+        // Duplicate name rejected (system group "Housing").
+        #expect(throwsEditError(.duplicateGroupName) {
+            try BudgetCategoryEditor.addGroup(to: schema, id: "grp_x", name: "housing").get()
+        })
+
+        // Rename.
+        schema = try BudgetCategoryEditor.renameGroup(in: schema, groupId: groupId, name: "Hobbies").get()
+        #expect(schema.group(id: groupId)?.name == "Hobbies")
+
+        // Reorder: move the new group to the front.
+        let order = [groupId] + schema.groups.map(\.id).filter { $0 != groupId }
+        schema = try BudgetCategoryEditor.reorderGroups(in: schema, orderedGroupIds: order).get()
+        let sorted = schema.groups.sorted { $0.sortIndex < $1.sortIndex }
+        #expect(sorted.first?.id == groupId)
+        #expect(sorted.map(\.sortIndex) == Array(0..<sorted.count))
+    }
+
+    @Test("renameGroup preserves a system group's seed link for opt-out")
+    func renameSystemGroupPreservesSeed() throws {
+        let schema = seededSchema()
+        let groupId = CategoryGroup.housing.rawValue
+        let updated = try BudgetCategoryEditor.renameGroup(in: schema, groupId: groupId, name: "Home Base").get()
+        let group = try #require(updated.group(id: groupId))
+        #expect(group.name == "Home Base")
+        #expect(group.seededFromGroup == .housing)
+        #expect(!group.isCustom)
+    }
+
+    @Test("moveCategory relocates a category and appends it in the target group")
+    func moveCategory() throws {
+        let schema = seededSchema()
+        let categoryId = SpendingCategory.travel.rawValue // seeds into .entertainment
+        let originalGroup = try #require(schema.category(id: categoryId)).groupId
+        let target = CategoryGroup.shopping.rawValue
+        #expect(originalGroup != target)
+
+        let updated = try BudgetCategoryEditor.moveCategory(
+            in: schema, categoryId: categoryId, toGroupId: target
+        ).get()
+        let moved = try #require(updated.category(id: categoryId))
+        #expect(moved.groupId == target)
+        // Seed link preserved across a move — the Plaid mapping is intact.
+        #expect(moved.seededFromCategory == .travel)
+        // Appended at the end of the target group.
+        let targetIndices = updated.categories.filter { $0.groupId == target }.map(\.sortIndex)
+        #expect(moved.sortIndex == (targetIndices.max() ?? -1))
+    }
+
+    @Test("deleteCustomGroup moves its categories to the fallback group, never orphaning them")
+    func deleteCustomGroupReassigns() throws {
+        var schema = seededSchema()
+        let groupId = BudgetCategoryEditor.customGroupID("g1")
+        schema = try BudgetCategoryEditor.addGroup(to: schema, id: groupId, name: "Side").get()
+        let catId = BudgetCategoryEditor.customCategoryID("c1")
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: catId, name: "Gig", colorHex: "#FF8800", groupId: groupId
+        ).get()
+
+        let updated = try BudgetCategoryEditor.deleteCustomGroup(in: schema, groupId: groupId).get()
+        #expect(updated.group(id: groupId) == nil)
+        // The category survived and moved to the default fallback (.other).
+        let moved = try #require(updated.category(id: catId))
+        #expect(moved.groupId == CategoryGroup.other.rawValue)
+    }
+
+    @Test("a system group cannot be deleted")
+    func systemGroupNotDeletable() {
+        let schema = seededSchema()
+        #expect(throwsEditError(.cannotDeleteSystemGroup) {
+            try BudgetCategoryEditor.deleteCustomGroup(in: schema, groupId: CategoryGroup.housing.rawValue).get()
+        })
+    }
+
+    // MARK: - AC 4: delete a custom category reassigns its spend (no orphans)
+
+    @Test("deleteCustomCategory reassigns its budgets to the fallback, summing collisions")
+    func deleteCustomCategoryReassignsBudgets() throws {
+        var schema = seededSchema()
+        let groupId = CategoryGroup.shopping.rawValue
+        let customId = BudgetCategoryEditor.customCategoryID("c1")
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: customId, name: "Hobbies", colorHex: "#FF8800", groupId: groupId
+        ).get()
+
+        let fallback = SpendingCategory.shopping.rawValue
+        // The custom category has a budget; the fallback already has one in the same
+        // month — they must SUM so no budgeted dollar disappears.
+        schema = schema.withBudget(MonthlyBudgetV2(month: "2026-06", categoryId: customId, monthlyLimit: 80))
+        schema = schema.withBudget(MonthlyBudgetV2(month: "2026-06", categoryId: fallback, monthlyLimit: 120))
+        schema = schema.withBudget(MonthlyBudgetV2(month: "2026-07", categoryId: customId, monthlyLimit: 50))
+
+        let result = try BudgetCategoryEditor.deleteCustomCategory(
+            in: schema, categoryId: customId, reassignToCategoryId: fallback
+        ).get()
+
+        #expect(result.deletedCategoryId == customId)
+        #expect(result.reassignedToCategoryId == fallback)
+        #expect(result.schema.category(id: customId) == nil)
+        // No budget references the deleted category anymore.
+        #expect(!result.schema.budgets.contains { $0.categoryId == customId })
+        // June: 120 + 80 summed onto the fallback. July: 50 carried over.
+        let june = result.schema.budgets.first { $0.month == "2026-06" && $0.categoryId == fallback }
+        #expect(june?.monthlyLimit == 200)
+        let july = result.schema.budgets.first { $0.month == "2026-07" && $0.categoryId == fallback }
+        #expect(july?.monthlyLimit == 50)
+        // Total budgeted dollars are conserved across the delete.
+        let before = schema.budgets.map(\.monthlyLimit).reduce(0, +)
+        let after = result.schema.budgets.map(\.monthlyLimit).reduce(0, +)
+        #expect(before == after)
+    }
+
+    @Test("deleteCustomCategory defaults the reassignment target to the .other system category")
+    func deleteCustomCategoryDefaultFallback() throws {
+        var schema = seededSchema()
+        let customId = BudgetCategoryEditor.customCategoryID("c1")
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: customId, name: "Hobbies", colorHex: "#FF8800",
+            groupId: CategoryGroup.shopping.rawValue
+        ).get()
+        schema = schema.withBudget(MonthlyBudgetV2(month: "2026-06", categoryId: customId, monthlyLimit: 40))
+
+        let result = try BudgetCategoryEditor.deleteCustomCategory(in: schema, categoryId: customId).get()
+        #expect(result.reassignedToCategoryId == SpendingCategory.other.rawValue)
+        let moved = result.schema.budgets.first {
+            $0.month == "2026-06" && $0.categoryId == SpendingCategory.other.rawValue
+        }
+        #expect(moved?.monthlyLimit == 40)
+    }
+
+    @Test("a SYSTEM category cannot be deleted")
+    func systemCategoryNotDeletable() {
+        let schema = seededSchema()
+        #expect(throwsEditError(.cannotDeleteSystemCategory) {
+            try BudgetCategoryEditor.deleteCustomCategory(
+                in: schema, categoryId: SpendingCategory.foodAndDrink.rawValue
+            ).get()
+        })
+    }
+
+    @Test("deleteCustomCategory rejects reassigning to itself or a missing target")
+    func deleteCustomCategoryInvalidTarget() throws {
+        var schema = seededSchema()
+        let customId = BudgetCategoryEditor.customCategoryID("c1")
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema, id: customId, name: "Hobbies", colorHex: "#FF8800",
+            groupId: CategoryGroup.shopping.rawValue
+        ).get()
+
+        #expect(throwsEditError(.invalidReassignmentTarget) {
+            try BudgetCategoryEditor.deleteCustomCategory(
+                in: schema, categoryId: customId, reassignToCategoryId: customId
+            ).get()
+        })
+        #expect(throwsEditError(.invalidReassignmentTarget) {
+            try BudgetCategoryEditor.deleteCustomCategory(
+                in: schema, categoryId: customId, reassignToCategoryId: "ghost"
+            ).get()
+        })
+    }
+
+    // MARK: - Validation primitives
+
+    @Test("hex color validation accepts #RRGGBB only")
+    func hexColorValidation() {
+        #expect(BudgetCategoryEditor.isValidHexColor("#FF8800"))
+        #expect(BudgetCategoryEditor.isValidHexColor("#ff8800"))
+        #expect(!BudgetCategoryEditor.isValidHexColor("FF8800"))   // no #
+        #expect(!BudgetCategoryEditor.isValidHexColor("#FFF"))     // too short
+        #expect(!BudgetCategoryEditor.isValidHexColor("#GG8800"))  // non-hex
+        #expect(!BudgetCategoryEditor.isValidHexColor("#FF88000")) // too long
+    }
+
+    @Test("emoji validation accepts exactly one emoji grapheme")
+    func emojiValidation() {
+        #expect(BudgetCategoryEditor.isValidEmoji("🎨"))
+        #expect(BudgetCategoryEditor.isValidEmoji("👩‍🚀")) // ZWJ sequence is one grapheme
+        #expect(!BudgetCategoryEditor.isValidEmoji("ab"))   // plain text
+        #expect(!BudgetCategoryEditor.isValidEmoji("a"))    // single non-emoji
+        #expect(!BudgetCategoryEditor.isValidEmoji(""))     // empty
+        #expect(!BudgetCategoryEditor.isValidEmoji("🎨🎨")) // two
+    }
+
+    @Test("name length is bounded")
+    func nameLength() {
+        let long = String(repeating: "x", count: BudgetCategoryEditor.maxNameLength + 1)
+        #expect(BudgetCategoryEditor.validateName(long) == .nameTooLong)
+        let ok = String(repeating: "x", count: BudgetCategoryEditor.maxNameLength)
+        #expect(BudgetCategoryEditor.validateName(ok) == nil)
+    }
+
+    // MARK: - Additive / v1-safety guarantees
+
+    @Test("a freshly seeded snapshot carries v1 colors and contiguous within-group order")
+    func seedCarriesColorsAndOrder() {
+        let schema = seededSchema()
+        // Every seeded category keeps its v1 chart color.
+        for category in schema.categories {
+            #expect(category.colorHex == category.seededFromCategory?.colorHex)
+            #expect(!category.isCustom)
+        }
+        // Within each group the sortIndex is contiguous from 0.
+        for group in schema.groups {
+            let indices = schema.categories
+                .filter { $0.groupId == group.id }
+                .map(\.sortIndex)
+                .sorted()
+            #expect(indices == Array(0..<indices.count))
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Assert a throwing editor expression fails with exactly `expected`.
+    private func throwsEditError(
+        _ expected: BudgetCategoryEditor.BudgetCategoryEditError,
+        _ body: () throws -> Any
+    ) -> Bool {
+        do {
+            _ = try body()
+            return false
+        } catch let error as BudgetCategoryEditor.BudgetCategoryEditError {
+            return error == expected
+        } catch {
+            return false
+        }
+    }
+}
+
+// MARK: - Test-only schema convenience
+
+private extension BudgetingV2Schema {
+    /// A copy with one budget appended (replacing any existing budget for the same
+    /// (month, category) key).
+    func withBudget(_ budget: MonthlyBudgetV2) -> BudgetingV2Schema {
+        var byKey = Dictionary(budgets.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
+        byKey[budget.id] = budget
+        return BudgetingV2Schema(
+            schemaVersion: schemaVersion,
+            groups: groups,
+            categories: categories,
+            budgets: byKey.values.sorted { $0.id < $1.id }
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetingV2SchemaBackCompatTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetingV2SchemaBackCompatTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Backward-compatibility tests for the AND-547 additive schema fields
+/// (`emoji` / `colorHex` / `sortIndex` on ``BudgetCategoryV2``, `isCustom` derivation).
+///
+/// A v2 snapshot written **before** AND-547 has none of the new category keys. The
+/// custom decoder must default them rather than throw, so the opt-in v2 store stays
+/// self-healing and the upgrade is additive (a v2 user who opted in pre-AND-547
+/// keeps their snapshot and just gains the new presentation fields).
+@Suite("BudgetingV2Schema back-compat")
+struct BudgetingV2SchemaBackCompatTests {
+    private var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    @Test("a pre-AND-547 category JSON (no emoji/colorHex/sortIndex) still decodes")
+    func decodesLegacyCategory() throws {
+        // Exactly the shape AND-546 wrote: id/name/iconName/groupId/seededFromCategory.
+        let legacyJSON = """
+        {
+          "id": "FOOD_AND_DRINK",
+          "name": "Food & Drink",
+          "iconName": "fork.knife",
+          "groupId": "FOOD_AND_DINING",
+          "seededFromCategory": "FOOD_AND_DRINK"
+        }
+        """
+        let data = Data(legacyJSON.utf8)
+        let decoded = try decoder.decode(BudgetCategoryV2.self, from: data)
+
+        #expect(decoded.id == "FOOD_AND_DRINK")
+        #expect(decoded.emoji == nil) // defaulted
+        #expect(decoded.sortIndex == 0) // defaulted
+        // Missing color falls back to the seeded category's v1 chart color.
+        #expect(decoded.colorHex == SpendingCategory.foodAndDrink.colorHex)
+        #expect(decoded.seededFromCategory == .foodAndDrink)
+        #expect(!decoded.isCustom)
+    }
+
+    @Test("a legacy custom-ish row with no seed and no color falls back to neutral")
+    func decodesLegacyCustomNeutralColor() throws {
+        let legacyJSON = """
+        {
+          "id": "cat_legacy",
+          "name": "Legacy",
+          "iconName": "tag",
+          "groupId": "OTHER"
+        }
+        """
+        let decoded = try decoder.decode(BudgetCategoryV2.self, from: Data(legacyJSON.utf8))
+        #expect(decoded.colorHex == BudgetCategoryV2.neutralColorHex)
+        #expect(decoded.seededFromCategory == nil)
+        #expect(decoded.isCustom)
+    }
+
+    @Test("a full AND-547 snapshot round-trips through encode/decode unchanged")
+    func roundTripsNewSchema() throws {
+        var schema = BudgetingV2Migration.seed()
+        schema = try BudgetCategoryEditor.addCategory(
+            to: schema,
+            id: BudgetCategoryEditor.customCategoryID("c1"),
+            name: "Hobbies",
+            emoji: "🎨",
+            colorHex: "#FF8800",
+            groupId: CategoryGroup.shopping.rawValue
+        ).get()
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(schema)
+        let decoded = try decoder.decode(BudgetingV2Schema.self, from: data)
+        #expect(decoded == schema)
+    }
+
+    @Test("isCustom is purely derived — a seeded row is never custom, a fresh one always is")
+    func isCustomDerivation() {
+        let seeded = BudgetCategoryV2(seedingFrom: .shopping)
+        #expect(!seeded.isCustom)
+        let custom = BudgetCategoryV2(
+            id: "cat_x", name: "X", iconName: "tag", colorHex: "#FF8800",
+            groupId: "OTHER", seededFromCategory: nil
+        )
+        #expect(custom.isCustom)
+
+        let seededGroup = BudgetCategoryGroupV2(seedingFrom: .housing)
+        #expect(!seededGroup.isCustom)
+        let customGroup = BudgetCategoryGroupV2(id: "grp_x", name: "X", sortIndex: 99, seededFromGroup: nil)
+        #expect(customGroup.isCustom)
+    }
+}


### PR DESCRIPTION
## What & why

**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.** The maintainer authorized the deferred budgeting-v2 epic.

AND-547 adds the editor to create/rename/recolor/re-emoji/reorder categories and define/reorder groups, built on the **merged AND-546 schema** (#663, `199bca9` — persisted `Category`/`CategoryGroup`/`Budget(month, rollover)` tables + override-aware spend math). It is **additive and opt-in**: a user who does not enable custom categories sees **byte-identical** standard budgeting (no v2 snapshot is written, the v1 `/api/budgets` path is untouched, and opting out restores v1 losslessly).

## Change

**`PlaidBarCore` (pure, `Sendable`, unit-tested) — all logic lives here:**
- **`BudgetCategoryEditor`** — stateless CRUD/validation over a `BudgetingV2Schema` (value semantics; no hidden `Date()`/UUID/I/O — identity is passed in). Implements the four ACs:
  1. **Create a custom category** with name + emoji + color + group (custom ids are `cat_<uuid>` so they never collide with a Plaid `rawValue`).
  2. **Rename / recolor / re-emoji a SYSTEM category without breaking its `systemKey → Plaid` mapping** — `seededFromCategory` is preserved verbatim; only presentation fields change, so every already-categorized transaction still buckets to the same Plaid key.
  3. **Create / rename / reorder groups** and **move categories between groups**.
  4. **Delete a custom category, reassigning its budgets** to a fallback (default: the always-present `.other` system category), **summing** colliding month/category limits so no budgeted dollar disappears — **no orphaned spend**. The returned `DeletionResult` carries the `deleted → reassigned` mapping so a caller can re-point transaction-level overrides the same way. System categories/groups are never deletable.
- **`BudgetingV2Schema`** — additively extends `BudgetCategoryV2` with `emoji`, `colorHex`, and a within-group `sortIndex`, plus a derived `isCustom` on both category and group. A **custom decoder defaults the new keys**, so a v2 snapshot written *before* AND-547 still decodes (self-healing, no destructive reseed).
- **`BudgetingV2Migration.seed`** — stamps each seeded leaf with a contiguous per-group `sortIndex` so the editor has a stable starting order to reorder against.

**`PlaidBar` (app UI):**
- **`CategoryEditorModel`** (`@Observable @MainActor`) — owns the opt-in `BudgetingV2Store`, routes every mutation through `BudgetCategoryEditor`, persists best-effort (in-memory schema updates regardless so the UI reflects an edit even if a disk write fails — the snapshot is disposable). Opt-in carries v1 budgets forward; opt-out recovers them and clears the snapshot.
- **`CategoryEditorView` + `CategoryFormSheet`** — a new Settings **"Categories"** tab: opt-in prompt, per-group sections, drag-to-reorder, move-to-group, an accessible named-swatch color picker, and emoji field. Identity is always carried by **name + glyph, never color alone**; errors are text. Financial labels inherit the shared Privacy Mask / App Lock gating via the Settings scene.
- **`AppState+CategoryEditor`** — builds the model scoped to the active Plaid environment via the existing `readModelCacheKey()` seam, behind `try?` (a store failure leaves the editor read-only and the app on v1).

The server, Plaid client, and Keychain/localhost boundary are unchanged. No secrets touch the app/Core. Synthetic/demo data only.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors   # Build complete, 0 errors/warnings
swift test --filter BudgetCategoryEditorTests          # 20 passed (4 ACs + validation + additivity)
swift test --filter BudgetingV2SchemaBackCompatTests   # 4 passed (pre-AND-547 snapshot still decodes; round-trip)
swift test --filter BudgetingV2EditorStoreTests        # 2 passed (edited schema persists; opt-out recovers v1)
swift test --filter CategoryBudget --filter Budget     # 202 passed (no regression)
git diff --check                                       # clean
```

Key guarantees covered by tests: a renamed system category keeps `seededFromCategory`/Plaid key and still reverse-migrates to v1; deleting a custom category conserves total budgeted dollars (sums collisions); a pre-AND-547 snapshot decodes with the new fields defaulted; seeded categories keep their v1 chart colors and a contiguous per-group order.

## Links

Closes AND-547

## Follow-ups

- Wiring the `DeletionResult` reassignment mapping into the transaction-override store so a custom-category delete also re-points `TransactionReviewMetadata.userCategory` references (the pure mapping is returned and tested; the app-side re-point is a small additional seam, deferred to keep this diff scoped).
- Per-month budgets / rebalance / splits / rules manager / sync (AND-548…AND-553) continue to build on this editor + schema.
