### PR TITLE
feat(review): opt-in server-synced review state (AND-552)

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,14 @@ when the local app created the Hosted Link session.
 | `GET` | `/api/budgets` | List saved category budgets (display-safe monthly limits only) |
 | `PUT` | `/api/budgets/:category` | Upsert a category's monthly limit (body `{ "monthlyLimit": Double }`); income/transfer categories are rejected |
 | `DELETE` | `/api/budgets/:category` | Remove a category's budget |
+| `GET` | `/api/review` | Pull the opt-in synced review-state snapshot (overrides + rules); empty unless the user enabled server-synced review. Display-safe values only — no Plaid tokens |
+| `PUT` | `/api/review` | Upload a device review-state snapshot; the server merges it (per-record last-writer-wins) and returns the union. Opt-in only |
+| `DELETE` | `/api/review` | Clear all synced review state (opt-out / reset) |
+
+> `/api/review` is the **opt-in** server-synced review surface (AND-552). It is
+> off by default (`ServerSyncedReviewFeatureFlag`); with sync off nothing is sent
+> or stored and behavior is byte-identical to local-first. See `SECURITY.md` for
+> the trust-boundary change (the server then stores user category overrides).
 
 ## Roadmap
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,6 +108,32 @@ Use GitHub private vulnerability reporting if available, or contact the reposito
   Keychain support can store token bytes in SQLite under `PLAIDBAR_DATA_DIR`.
   To keep the derived cache and any fallback token rows on-device, point
   `PLAIDBAR_DATA_DIR` at a local, non-synced directory.
+- **Trust-boundary change — opt-in server-synced review state (AND-552).** By
+  default the local server **never** stores transaction *review state* — the
+  per-transaction overrides a user sets in the Review Inbox (chosen category,
+  merchant rename, transfer flag, budget exclusion, free-text note, review
+  status) and their categorization rules. That state is app-local JSON only.
+  AND-552 adds an **optional** multi-device sync that, *only when the user
+  explicitly opts in*, persists exactly that review state on the local server
+  (the `review_metadata` / `review_rules` SQLite tables, served by
+  `/api/review` behind the same bearer-token middleware as every other `/api`
+  route). This deliberately **expands the server's stored data surface beyond
+  Plaid limits and token references**: with sync on, the server SQLite holds the
+  user's category overrides, merchant renames, and notes — display-safe derived
+  values, **never** a Plaid token, access secret, or Keychain material. The
+  opt-in is gated by `ServerSyncedReviewFeatureFlag` (default **OFF**); with it
+  off — the default for a fresh install and every existing user — the app never
+  constructs or sends a review snapshot, the `/api/review` tables stay empty,
+  and behavior is byte-identical to before AND-552, so **no review data leaves
+  the device without explicit consent**. Like the read-model cache, the synced
+  tables live in the environment-scoped SQLite under `PLAIDBAR_DATA_DIR`
+  (default local `~/.vaultpeek/`), so pointing the data dir at a cloud-synced
+  folder can copy this review state off-device (see the `PLAIDBAR_DATA_DIR`
+  caveat above). Opting back out clears the server-side tables
+  (`DELETE /api/review`). Conflicting edits across devices resolve by per-record
+  last-writer-wins on each record's `updatedAt` clock
+  (`ReviewStateConflictResolver`), so a sync never invents a category the user
+  did not choose.
 - `/api/status` is authenticated and exposes readiness metadata: version,
   environment, credential availability, storage path, linked item count,
   synced item count, sync readiness, and last sync time. With the opt-in

--- a/Sources/PlaidBar/Services/ReviewSyncService.swift
+++ b/Sources/PlaidBar/Services/ReviewSyncService.swift
@@ -1,0 +1,69 @@
+import Foundation
+import PlaidBarCore
+
+/// Drives the **opt-in** sync of review state to the local server (AND-552 —
+/// deferred epic AND-524).
+///
+/// ## Strictly opt-in — the off path sends nothing
+///
+/// Every entry point first consults the injected `isEnabled` gate (wired to
+/// ``ServerSyncedReviewFeatureFlag``, default OFF). When syncing is **off** the
+/// service short-circuits and never touches the `ServerClient`, so a not-opted-in
+/// user's review state never leaves the device — behavior is byte-identical to
+/// before AND-552. Only an explicit, consent-gated opt-in turns this on.
+///
+/// ## What it does when on
+///
+/// - `pushAndMerge(local:)` uploads the device's snapshot and returns the server's
+///   merged union (per-record last-writer-wins via ``ReviewStateConflictResolver``,
+///   applied server-side), so the device converges in one round-trip.
+/// - `pull()` fetches the server's stored snapshot.
+/// - `disableSync()` clears the server's stored state when the user opts back out,
+///   so opting out also removes what was previously synced.
+///
+/// The service is a `Sendable` `actor` over the `ServerClient` actor; it holds no
+/// UI state. Callers (AppState) own the in-memory review metadata/rules and decide
+/// when to assemble a snapshot to push or how to apply a pulled one.
+actor ReviewSyncService {
+    private let serverClient: ServerClient
+    private let isEnabled: @Sendable () -> Bool
+
+    /// - Parameters:
+    ///   - serverClient: the authenticated localhost client.
+    ///   - isEnabled: the opt-in gate. Defaults to the live
+    ///     ``ServerSyncedReviewFeatureFlag`` resolution (CLI override → stored
+    ///     preference → OFF). Injected so tests drive both paths deterministically.
+    init(
+        serverClient: ServerClient,
+        isEnabled: @escaping @Sendable () -> Bool = { ServerSyncedReviewFeatureFlag.resolved() }
+    ) {
+        self.serverClient = serverClient
+        self.isEnabled = isEnabled
+    }
+
+    /// Whether server-synced review is currently enabled (the opt-in gate).
+    var syncEnabled: Bool { isEnabled() }
+
+    /// Upload `local` and return the server's merged snapshot — **only when opted
+    /// in**. Returns `nil` without making any request when syncing is off, so the
+    /// caller leaves its local state exactly as-is.
+    func pushAndMerge(local: ReviewStateSnapshotDTO) async throws -> ReviewStateSnapshotDTO? {
+        guard ReviewSyncGate.allowsNetwork(isOptedIn: isEnabled()) else { return nil }
+        return try await serverClient.putReviewState(local)
+    }
+
+    /// Pull the server's stored snapshot — **only when opted in**. Returns `nil`
+    /// without making any request when syncing is off.
+    func pull() async throws -> ReviewStateSnapshotDTO? {
+        guard ReviewSyncGate.allowsNetwork(isOptedIn: isEnabled()) else { return nil }
+        return try await serverClient.getReviewState()
+    }
+
+    /// Clear the server's stored review state (opt-out / reset). Unlike the read
+    /// and write paths this does **not** require the flag to be on — it is the
+    /// teardown a user runs *when disabling* sync, so it must work to remove what
+    /// was previously uploaded.
+    func disableSync() async throws {
+        try await serverClient.clearReviewState()
+    }
+}

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -126,6 +126,35 @@ actor ServerClient {
         try await delete(url)
     }
 
+    // MARK: - Opt-in server-synced review state (AND-552)
+
+    /// Pull the server's stored review-state snapshot. Only called when the user
+    /// has enabled `ServerSyncedReviewFeatureFlag` (default OFF); a not-opted-in
+    /// app never reaches this.
+    func getReviewState() async throws -> ReviewStateSnapshotDTO {
+        guard let url = ServerEndpoint.reviewStateURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await get(url)
+    }
+
+    /// Upload the device's review-state snapshot and return the server's merged
+    /// union (per-record last-writer-wins). Opt-in only.
+    func putReviewState(_ snapshot: ReviewStateSnapshotDTO) async throws -> ReviewStateSnapshotDTO {
+        guard let url = ServerEndpoint.reviewStateURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        return try await put(url, body: snapshot)
+    }
+
+    /// Clear all synced review state on the server (opt-out / reset). Opt-in only.
+    func clearReviewState() async throws {
+        guard let url = ServerEndpoint.reviewStateURL(baseURL: baseURL) else {
+            throw ServerClientError.requestFailed
+        }
+        try await delete(url)
+    }
+
     func syncTransactions(itemId: String? = nil) async throws -> SyncResponse {
         guard let url = ServerEndpoint.transactionSyncURL(baseURL: baseURL, itemId: itemId) else {
             throw ServerClientError.requestFailed

--- a/Sources/PlaidBarCore/Models/ReviewSyncDTO.swift
+++ b/Sources/PlaidBarCore/Models/ReviewSyncDTO.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Wire DTOs for the **opt-in** server-synced review state (AND-552 — deferred
+/// epic AND-524).
+///
+/// ## What this is (and is not)
+///
+/// Today the transaction review state — the per-transaction overrides in
+/// ``TransactionReviewMetadata`` (user category, merchant rename, transfer flag,
+/// budget exclusion, note, status) plus the user's ``TransactionRule`` set — is
+/// **app-local JSON only**; the local server never sees it. AND-552 adds an
+/// *optional* multi-device sync of exactly that state through a new `/api/review`
+/// table, gated by the ``ServerSyncedReviewFeatureFlag`` (default **OFF**).
+///
+/// These DTOs are the on-the-wire shape the app pushes to / pulls from the local
+/// server when, and only when, the user has explicitly opted in. They are
+/// `Sendable` value types living in `PlaidBarCore` so both the app's sync client
+/// and the server's route/store share one contract.
+///
+/// ## Trust-boundary note
+///
+/// A synced record stores **user category overrides** (and merchant renames,
+/// notes, etc.) on the local server's SQLite — state the server otherwise never
+/// holds. That expansion is documented in `SECURITY.md`. It happens only on
+/// explicit opt-in; with the flag OFF nothing here is ever constructed or sent,
+/// so the not-opted-in user's behavior is byte-identical to today.
+
+// MARK: - Per-record sync envelopes
+
+/// One synced review-metadata record: the full ``TransactionReviewMetadata`` plus
+/// the `updatedAt` timestamp that drives last-writer-wins conflict resolution.
+///
+/// The metadata's own `reviewedAt` marks *when the user reviewed the charge*, not
+/// *when this record was last written*, so it cannot order concurrent edits. A
+/// dedicated monotonic `updatedAt` (set by the writer on every change) is the LWW
+/// clock: the record with the newer `updatedAt` wins a conflict on the same id.
+public struct ReviewMetadataRecordDTO: Codable, Sendable, Equatable, Identifiable {
+    /// Stable identity — the transaction id the metadata belongs to (mirrors
+    /// ``TransactionReviewMetadata/id``).
+    public var id: String { metadata.id }
+    /// The full review metadata for this transaction.
+    public let metadata: TransactionReviewMetadata
+    /// LWW clock: when this record was last written on the originating device.
+    public let updatedAt: Date
+
+    public init(metadata: TransactionReviewMetadata, updatedAt: Date) {
+        self.metadata = metadata
+        self.updatedAt = updatedAt
+    }
+}
+
+/// One synced categorization-rule record: the full ``TransactionRule`` plus the
+/// `updatedAt` LWW clock. The rule's own `createdAt` orders creation, not edits,
+/// so `updatedAt` is carried separately for conflict resolution.
+public struct ReviewRuleRecordDTO: Codable, Sendable, Equatable, Identifiable {
+    /// Stable identity — the rule's UUID (mirrors ``TransactionRule/id``).
+    public var id: UUID { rule.id }
+    /// The full categorization rule.
+    public let rule: TransactionRule
+    /// LWW clock: when this rule was last written on the originating device.
+    public let updatedAt: Date
+
+    public init(rule: TransactionRule, updatedAt: Date) {
+        self.rule = rule
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - Snapshot (request + response payloads)
+
+/// The full opt-in review-state snapshot exchanged with `/api/review`.
+///
+/// `GET /api/review` returns the server's current snapshot; `PUT /api/review`
+/// uploads the device's snapshot and returns the **merged** result (the server
+/// resolves conflicts via ``ReviewStateConflictResolver`` and echoes the union
+/// back so the device converges in one round-trip). Both directions use this one
+/// shape so the contract is symmetric.
+public struct ReviewStateSnapshotDTO: Codable, Sendable, Equatable {
+    /// Schema version so a future shape change reads older snapshots as a miss
+    /// rather than a hard decode failure (mirrors ``BudgetingV2Schema``).
+    public static let currentSchemaVersion = 1
+
+    /// The schema version this snapshot was written with.
+    public let schemaVersion: Int
+    /// All synced per-transaction review metadata records.
+    public let metadata: [ReviewMetadataRecordDTO]
+    /// All synced categorization-rule records.
+    public let rules: [ReviewRuleRecordDTO]
+
+    public init(
+        schemaVersion: Int = ReviewStateSnapshotDTO.currentSchemaVersion,
+        metadata: [ReviewMetadataRecordDTO],
+        rules: [ReviewRuleRecordDTO]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.metadata = metadata
+        self.rules = rules
+    }
+
+    /// An empty snapshot (no synced records) at the current schema version.
+    public static var empty: ReviewStateSnapshotDTO {
+        ReviewStateSnapshotDTO(metadata: [], rules: [])
+    }
+
+    /// Whether this snapshot matches the current schema version.
+    public var isCurrentSchema: Bool {
+        schemaVersion == Self.currentSchemaVersion
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ReviewStateConflictResolver.swift
+++ b/Sources/PlaidBarCore/Utilities/ReviewStateConflictResolver.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Pure, deterministic **last-writer-wins** conflict resolution for the opt-in
+/// server-synced review state (AND-552).
+///
+/// ## Why LWW (and not per-field merge)
+///
+/// A single review record (the override on one transaction, or one rule) is the
+/// unit a user edits atomically — they pick a category, rename a merchant, mark a
+/// transfer. Merging two concurrent edits to the *same* record field-by-field
+/// would manufacture a third state the user never chose (e.g. device A's category
+/// with device B's merchant rename), which is more surprising than simply keeping
+/// the most recent deliberate edit. So conflict resolution is **per-record LWW**,
+/// keyed on each record's monotonic `updatedAt`: for a given id, the record with
+/// the newer timestamp wins; ties break deterministically so the merge is a pure
+/// function of its inputs (no clock, no I/O, no randomness) and fully testable.
+///
+/// Distinct ids never conflict — they are unioned. So this is "merge the two
+/// snapshots, and where both sides carry the same id, keep the newer write."
+///
+/// ## Where it runs
+///
+/// The local server runs `merge(...)` when a device `PUT`s its snapshot: it folds
+/// the upload into the stored snapshot and returns the union, so every device
+/// converges to the same set in one round-trip. The app can run the same function
+/// locally to reconcile a pulled snapshot against unsynced local edits before
+/// writing them back — same rule on both sides, by construction.
+public enum ReviewStateConflictResolver {
+    // MARK: - Snapshot merge
+
+    /// Merge two review-state snapshots with per-record last-writer-wins.
+    ///
+    /// For each id present in either side: if only one side has it, that record is
+    /// kept; if both do, the record with the newer `updatedAt` wins (ties resolve
+    /// to `incoming`, treating the upload as the latest deliberate write). The
+    /// result is ordered deterministically (metadata by transaction id, rules by
+    /// rule UUID string) so two devices that converge produce byte-identical
+    /// snapshots.
+    ///
+    /// - Parameters:
+    ///   - base: the existing snapshot (e.g. the server's stored state).
+    ///   - incoming: the newly uploaded snapshot (the device's state).
+    /// - Returns: the merged snapshot at the current schema version.
+    public static func merge(
+        base: ReviewStateSnapshotDTO,
+        incoming: ReviewStateSnapshotDTO
+    ) -> ReviewStateSnapshotDTO {
+        let mergedMetadata = mergeMetadata(base: base.metadata, incoming: incoming.metadata)
+        let mergedRules = mergeRules(base: base.rules, incoming: incoming.rules)
+        return ReviewStateSnapshotDTO(metadata: mergedMetadata, rules: mergedRules)
+    }
+
+    // MARK: - Record merges
+
+    /// Per-record LWW merge of two metadata record lists, keyed on transaction id,
+    /// returned sorted by id.
+    public static func mergeMetadata(
+        base: [ReviewMetadataRecordDTO],
+        incoming: [ReviewMetadataRecordDTO]
+    ) -> [ReviewMetadataRecordDTO] {
+        var byId = Dictionary(base.map { ($0.id, $0) }, uniquingKeysWith: newerMetadata)
+        for record in incoming {
+            if let existing = byId[record.id] {
+                byId[record.id] = newerMetadata(existing, record)
+            } else {
+                byId[record.id] = record
+            }
+        }
+        return byId.values.sorted { $0.id < $1.id }
+    }
+
+    /// Per-record LWW merge of two rule record lists, keyed on rule UUID, returned
+    /// sorted by the UUID's string form for a stable order.
+    public static func mergeRules(
+        base: [ReviewRuleRecordDTO],
+        incoming: [ReviewRuleRecordDTO]
+    ) -> [ReviewRuleRecordDTO] {
+        var byId = Dictionary(base.map { ($0.id, $0) }, uniquingKeysWith: newerRule)
+        for record in incoming {
+            if let existing = byId[record.id] {
+                byId[record.id] = newerRule(existing, record)
+            } else {
+                byId[record.id] = record
+            }
+        }
+        return byId.values.sorted { $0.id.uuidString < $1.id.uuidString }
+    }
+
+    // MARK: - Pairwise winner (the LWW rule)
+
+    /// The winner of a same-id metadata conflict: the newer `updatedAt`. On an
+    /// exact tie the **second** argument wins, so when called as
+    /// `newerMetadata(existing, incoming)` the freshly uploaded write is treated
+    /// as the latest deliberate edit. Deterministic given its inputs.
+    static func newerMetadata(
+        _ lhs: ReviewMetadataRecordDTO,
+        _ rhs: ReviewMetadataRecordDTO
+    ) -> ReviewMetadataRecordDTO {
+        rhs.updatedAt >= lhs.updatedAt ? rhs : lhs
+    }
+
+    /// The winner of a same-id rule conflict: the newer `updatedAt`, with the
+    /// second argument winning an exact tie (see ``newerMetadata(_:_:)``).
+    static func newerRule(
+        _ lhs: ReviewRuleRecordDTO,
+        _ rhs: ReviewRuleRecordDTO
+    ) -> ReviewRuleRecordDTO {
+        rhs.updatedAt >= lhs.updatedAt ? rhs : lhs
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ReviewSyncAssembler.swift
+++ b/Sources/PlaidBarCore/Utilities/ReviewSyncAssembler.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure assembly/flatten helpers for the opt-in review sync (AND-552).
+///
+/// AppState owns the in-memory review state (`[TransactionReviewMetadata]` +
+/// `[TransactionRule]`); these helpers turn that into the ``ReviewStateSnapshotDTO``
+/// wire shape to push, and fold a server snapshot back into the plain in-memory
+/// arrays. They live in `PlaidBarCore` (not the `@main` app target) so they are
+/// `Sendable` and unit-testable without a server.
+public enum ReviewSyncAssembler {
+    /// Build a wire snapshot from in-memory review metadata + rules, stamping each
+    /// record with `updatedAt` as its last-writer-wins clock. One `updatedAt` is
+    /// applied to every record in a single push — the device writes its review
+    /// state atomically (see `ReviewStorageWriter`), so all records in one upload
+    /// share that write's timestamp. Records are sorted (metadata by transaction
+    /// id, rules by UUID) so two devices that converge produce identical snapshots.
+    public static func snapshot(
+        metadata: [TransactionReviewMetadata],
+        rules: [TransactionRule],
+        updatedAt: Date
+    ) -> ReviewStateSnapshotDTO {
+        ReviewStateSnapshotDTO(
+            metadata: metadata
+                .map { ReviewMetadataRecordDTO(metadata: $0, updatedAt: updatedAt) }
+                .sorted { $0.id < $1.id },
+            rules: rules
+                .map { ReviewRuleRecordDTO(rule: $0, updatedAt: updatedAt) }
+                .sorted { $0.id.uuidString < $1.id.uuidString }
+        )
+    }
+
+    /// Flatten a wire snapshot back into the plain in-memory review metadata + rules
+    /// AppState holds (dropping the per-record sync clocks). Metadata is returned in
+    /// transaction-id order and rules in UUID order so a converged device renders a
+    /// stable list.
+    public static func localState(
+        from snapshot: ReviewStateSnapshotDTO
+    ) -> (metadata: [TransactionReviewMetadata], rules: [TransactionRule]) {
+        let metadata = snapshot.metadata
+            .sorted { $0.id < $1.id }
+            .map(\.metadata)
+        let rules = snapshot.rules
+            .sorted { $0.id.uuidString < $1.id.uuidString }
+            .map(\.rule)
+        return (metadata, rules)
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ReviewSyncGate.swift
+++ b/Sources/PlaidBarCore/Utilities/ReviewSyncGate.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Pure decision for whether an opt-in review-sync operation may touch the network
+/// (AND-552).
+///
+/// The app's `ReviewSyncService` is in the (untestable) `@main` app target, so the
+/// security-critical "**when not opted in, send nothing**" rule lives here as a
+/// pure `Sendable` predicate that the service delegates to — the same pattern as
+/// ``ReviewStoragePersistencePolicy`` keeping the demo-mode persistence guard out
+/// of the app target. The decision is a function of the opt-in flag alone, so it
+/// is exhaustively unit-testable without a server or a running app.
+public enum ReviewSyncGate {
+    /// What a sync entry point is allowed to do for the current opt-in state.
+    public enum Action: Sendable, Equatable {
+        /// Syncing is enabled — the caller may perform the network operation.
+        case proceed
+        /// Syncing is disabled — the caller must do nothing and leave local state
+        /// untouched. **No review data leaves the device.**
+        case skip
+    }
+
+    /// The action for a read/write sync operation given whether the user has opted
+    /// in. `false` ⇒ ``Action/skip`` (the default, local-first path) so a
+    /// not-opted-in user never makes a request.
+    public static func action(isOptedIn: Bool) -> Action {
+        isOptedIn ? .proceed : .skip
+    }
+
+    /// Whether a read/write sync operation may run. Convenience over
+    /// ``action(isOptedIn:)`` for a simple `guard`.
+    public static func allowsNetwork(isOptedIn: Bool) -> Bool {
+        action(isOptedIn: isOptedIn) == .proceed
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerEndpoint.swift
@@ -57,6 +57,14 @@ public enum ServerEndpoint {
         url(baseURL: baseURL, path: "/api/budgets/\(percentEncodedPathComponent(categoryId))")
     }
 
+    /// `/api/review` — opt-in server-synced review state (AND-552). `GET` pulls the
+    /// stored snapshot; `PUT` uploads a device snapshot and gets the merged union
+    /// back; `DELETE` clears the synced state (opt-out). Only reached when the user
+    /// has enabled ``ServerSyncedReviewFeatureFlag``.
+    public static func reviewStateURL(baseURL: String) -> URL? {
+        url(baseURL: baseURL, path: "/api/review")
+    }
+
     private static func percentEncodedPathComponent(_ value: String) -> String {
         var allowed = CharacterSet.urlPathAllowed
         allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")

--- a/Sources/PlaidBarCore/Utilities/ServerSyncedReviewFeatureFlag.swift
+++ b/Sources/PlaidBarCore/Utilities/ServerSyncedReviewFeatureFlag.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Opt-in feature flag gating **server-synced review state** (AND-552 — deferred
+/// epic AND-524).
+///
+/// VaultPeek is local-first: the transaction review state (per-transaction
+/// overrides + categorization rules) lives in app-local JSON and the local server
+/// never sees it. AND-552 lets a user *optionally* sync that state across their
+/// own devices through the local server's new `/api/review` table. Because that
+/// expands what the server stores (it would hold the user's category overrides,
+/// merchant renames, and notes), it is **strictly opt-in**.
+///
+/// ## Default OFF — additive, byte-identical when not opted in
+///
+/// `defaultValue` is **`false`**. With the flag off (the default for a fresh
+/// install and every existing user who never enables it), the app never
+/// constructs or sends a review snapshot and the server route is simply unused —
+/// behavior is byte-identical to before AND-552, and **no review data leaves the
+/// device**. Only an explicit, consent-gated opt-in (the Settings toggle) turns
+/// syncing on.
+///
+/// The resolution rule is pure and lives in `PlaidBarCore` so it is `Sendable`,
+/// testable without launching the app, and mirrors ``WindowFirstFeatureFlag``.
+public enum ServerSyncedReviewFeatureFlag {
+    /// `UserDefaults` key persisting the user's opt-in. Absent ⇒ OFF (default).
+    public static let storageKey = "featureFlag.serverSyncedReview"
+
+    /// CLI override (QA aid, mirrors `--window-first`): `--server-synced-review
+    /// on|off|true|false|1|0`. Lets a QA/test pass exercise the opt-in path
+    /// without leaving a durable preference behind. Wins over the stored
+    /// preference when present and parseable.
+    public static let commandLineFlag = "--server-synced-review"
+
+    /// The flag's default when neither a CLI override nor a stored preference is
+    /// present. **OFF** — local-first stays the product; syncing review state to
+    /// the server requires explicit consent.
+    public static let defaultValue = false
+
+    /// Pure resolution: CLI override (if parseable) wins, else the stored
+    /// preference, else `defaultValue` (OFF). No I/O — every input is passed in,
+    /// so the whole policy is unit-testable. `cliOverrideRaw` is the raw string
+    /// that followed `--server-synced-review` (or `nil` when the flag was absent).
+    public static func resolve(
+        cliOverrideRaw: String?,
+        storedValue: Bool?
+    ) -> Bool {
+        if let parsed = parse(cliOverrideRaw) {
+            return parsed
+        }
+        if let storedValue {
+            return storedValue
+        }
+        return defaultValue
+    }
+
+    /// Parses a CLI override token into a bool, or `nil` when it is absent or not
+    /// a recognized on/off spelling — an unparseable value never silently enables
+    /// syncing (the caller falls through to the stored preference / OFF default).
+    public static func parse(_ raw: String?) -> Bool? {
+        guard let token = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !token.isEmpty else {
+            return nil
+        }
+        switch token {
+        case "on", "true", "yes", "1":
+            return true
+        case "off", "false", "no", "0":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    /// Resolves the live flag from the CLI arguments and a `UserDefaults` store.
+    /// Defaults to the process arguments and `.standard`; both are injectable so
+    /// tests drive the wrapper without touching real global state.
+    public static func resolved(
+        arguments: [String] = CommandLine.arguments,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        resolve(
+            cliOverrideRaw: CommandLineOptions.value(for: commandLineFlag, in: arguments),
+            storedValue: defaults.object(forKey: storageKey) == nil
+                ? nil
+                : defaults.bool(forKey: storageKey)
+        )
+    }
+}

--- a/Sources/PlaidBarServer/App.swift
+++ b/Sources/PlaidBarServer/App.swift
@@ -53,12 +53,14 @@ struct PlaidBarServer: AsyncParsableCommand {
         await fluent.migrations.add(CreateCategoryBudgets())
         await fluent.migrations.add(CreateBillingSubscriptions())
         await fluent.migrations.add(CreateWebhookEvents())
+        await fluent.migrations.add(CreateReviewState())
         try await fluent.migrate()
         try ServerConfig.enforcePrivateSQLiteStorePermissions(at: serverConfig.databasePath)
 
         let plaidClient = PlaidClient(config: serverConfig)
         let tokenStore = TokenStore(fluent: fluent, logger: logger)
         let budgetStore = BudgetStore(fluent: fluent)
+        let reviewStateStore = ReviewStateStore(fluent: fluent)
         let billingStore = BillingSubscriptionStore(fluent: fluent)
         let webhookEventStore = WebhookEventStore(fluent: fluent)
         do {
@@ -119,6 +121,11 @@ struct PlaidBarServer: AsyncParsableCommand {
         )
             .register(with: api)
         BudgetRoutes(budgetStore: budgetStore)
+            .register(with: api)
+        // Opt-in server-synced review state (AND-552). The route is always wired,
+        // but only an app that has enabled `ServerSyncedReviewFeatureFlag`
+        // (default OFF) ever calls it, so the synced tables stay empty otherwise.
+        ReviewRoutes(reviewStateStore: reviewStateStore)
             .register(with: api)
         BillingRoutes(
             billingStore: billingStore,

--- a/Sources/PlaidBarServer/Routes/ReviewRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/ReviewRoutes.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Hummingbird
+import NIOCore
+import PlaidBarCore
+
+/// `/api/review` — opt-in server-synced review state (AND-552, deferred epic
+/// AND-524). Registered under the same `APITokenMiddleware`-guarded group as the
+/// other API routes, so every call requires the bearer token.
+///
+/// ## Strictly opt-in
+/// The route always exists, but it is only *exercised* by an app that has enabled
+/// ``ServerSyncedReviewFeatureFlag`` (default OFF). A not-opted-in app never calls
+/// it, so the synced tables stay empty and behavior is byte-identical to before
+/// AND-552 — no review data leaves the device without explicit consent.
+///
+/// ## Endpoints
+/// - `GET /api/review` — pull the stored snapshot (empty when never synced).
+/// - `PUT /api/review` — upload a device snapshot; the server merges it into the
+///   stored state with per-record last-writer-wins
+///   (``ReviewStateConflictResolver``) and returns the merged union so the device
+///   converges in one round-trip.
+/// - `DELETE /api/review` — clear all synced review state (opt-out / reset).
+///
+/// ## Data surface
+/// The stored snapshot holds **user category overrides, merchant renames, notes,
+/// and categorization rules** — display-safe derived values, never a Plaid token.
+/// This is the only place the server persists review state; the trust-boundary
+/// change is documented in `SECURITY.md`.
+struct ReviewRoutes: Sendable {
+    let reviewStateStore: ReviewStateStore
+
+    /// Reject uploads larger than this so a single `PUT` cannot balloon the local
+    /// SQLite store. The synced state is small (overrides + rules), so 4 MiB is a
+    /// generous ceiling that still fails closed on a malformed/huge body.
+    static let maxUploadBytes = 4 * 1024 * 1024
+
+    func register(with group: RouterGroup<some RequestContext>) {
+        group.group("review")
+            .get(use: getSnapshot)
+            .put(use: putSnapshot)
+            .delete(use: deleteSnapshot)
+    }
+
+    @Sendable
+    func getSnapshot(request: Request, context: some RequestContext) async throws -> Response {
+        let snapshot = try await reviewStateStore.snapshot()
+        return try Self.jsonResponse(snapshot)
+    }
+
+    @Sendable
+    func putSnapshot(request: Request, context: some RequestContext) async throws -> Response {
+        let body = try await request.body.collect(upTo: Self.maxUploadBytes)
+        let incoming = try Self.decodeSnapshot(body)
+        let merged = try await reviewStateStore.merge(incoming: incoming)
+        return try Self.jsonResponse(merged)
+    }
+
+    @Sendable
+    func deleteSnapshot(request: Request, context: some RequestContext) async throws -> HTTPResponse.Status {
+        try await reviewStateStore.clearAll()
+        return .noContent
+    }
+
+    // MARK: - Validation (pure, testable without a request context)
+
+    /// Decode and validate an uploaded snapshot. Rejects an unparseable body and a
+    /// snapshot tagged with an unknown (newer) schema version — failing closed
+    /// rather than silently persisting a shape this server cannot round-trip.
+    static func decodeSnapshot(_ buffer: ByteBuffer) throws -> ReviewStateSnapshotDTO {
+        var buffer = buffer
+        let data = buffer.readData(length: buffer.readableBytes) ?? Data()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot: ReviewStateSnapshotDTO
+        do {
+            snapshot = try decoder.decode(ReviewStateSnapshotDTO.self, from: data)
+        } catch {
+            throw HTTPError(.badRequest, message: "Malformed review snapshot")
+        }
+        guard snapshot.schemaVersion <= ReviewStateSnapshotDTO.currentSchemaVersion else {
+            throw HTTPError(
+                .badRequest,
+                message: "Unsupported review snapshot schema version \(snapshot.schemaVersion)"
+            )
+        }
+        return snapshot
+    }
+
+    static func jsonResponse(_ value: some Encodable) throws -> Response {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(data: data))
+        )
+    }
+}

--- a/Sources/PlaidBarServer/Storage/ReviewStateModel.swift
+++ b/Sources/PlaidBarServer/Storage/ReviewStateModel.swift
@@ -1,0 +1,107 @@
+import FluentKit
+import Foundation
+
+// MARK: - Review state models (Fluent) — opt-in server-synced review (AND-552)
+
+/// One synced **review-metadata** record: the per-transaction override the user
+/// set in the Review Inbox (category, merchant rename, transfer flag, budget
+/// exclusion, note, status), persisted only when the user opts into server-synced
+/// review (AND-552 — deferred epic AND-524).
+///
+/// The row id is the transaction id, so a transaction has at most one synced
+/// review record and an upsert is a primary-key lookup. The metadata itself is
+/// stored as a JSON blob (`payload`) of the `Sendable` `ReviewMetadataRecordDTO`
+/// so the schema does not have to mirror every override field as a column — the
+/// shared `PlaidBarCore` DTO is the contract. `updated_at` is the explicit
+/// last-writer-wins clock the conflict resolver orders on (distinct from any
+/// Fluent auto-timestamp).
+///
+/// ## Trust boundary
+/// This row holds **user category overrides and merchant renames** — display-safe
+/// derived state, never a Plaid token or access secret — and exists only after an
+/// explicit opt-in. The expanded server data surface is documented in
+/// `SECURITY.md`.
+final class ReviewMetadataModel: Model, @unchecked Sendable {
+    static let schema = "review_metadata"
+
+    @ID(custom: "transaction_id", generatedBy: .user)
+    var id: String?
+
+    /// JSON-encoded `ReviewMetadataRecordDTO` (the override payload + its clock).
+    @Field(key: "payload")
+    var payload: String
+
+    /// Last-writer-wins clock, mirrored out of the payload into a column so the
+    /// store can order/query without decoding every row.
+    @Field(key: "updated_at")
+    var updatedAt: Date
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(transactionId: String, payload: String, updatedAt: Date) {
+        self.id = transactionId
+        self.payload = payload
+        self.updatedAt = updatedAt
+    }
+}
+
+/// One synced **categorization rule** record (AND-552). The row id is the rule's
+/// UUID string; the full `ReviewRuleRecordDTO` is stored as a JSON `payload`, with
+/// `updated_at` mirrored out as the LWW clock. Same opt-in / trust-boundary
+/// contract as ``ReviewMetadataModel``.
+final class ReviewRuleModel: Model, @unchecked Sendable {
+    static let schema = "review_rules"
+
+    @ID(custom: "rule_id", generatedBy: .user)
+    var id: String?
+
+    /// JSON-encoded `ReviewRuleRecordDTO`.
+    @Field(key: "payload")
+    var payload: String
+
+    @Field(key: "updated_at")
+    var updatedAt: Date
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(ruleId: String, payload: String, updatedAt: Date) {
+        self.id = ruleId
+        self.payload = payload
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - Migration
+
+/// Creates the two opt-in review-sync tables (AND-552). Additive: the migration
+/// only creates new tables, never touching `items`, `category_budgets`, or any
+/// existing schema, so an installed server that never receives an opted-in `PUT`
+/// keeps these tables empty and behaves exactly as before.
+struct CreateReviewState: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("review_metadata")
+            .field("transaction_id", .string, .identifier(auto: false))
+            .field("payload", .string, .required)
+            .field("updated_at", .datetime, .required)
+            .field("created_at", .datetime)
+            .create()
+
+        try await database.schema("review_rules")
+            .field("rule_id", .string, .identifier(auto: false))
+            .field("payload", .string, .required)
+            .field("updated_at", .datetime, .required)
+            .field("created_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("review_rules").delete()
+        try await database.schema("review_metadata").delete()
+    }
+}

--- a/Sources/PlaidBarServer/Storage/ReviewStateStore.swift
+++ b/Sources/PlaidBarServer/Storage/ReviewStateStore.swift
@@ -1,0 +1,143 @@
+import FluentKit
+import Foundation
+import HummingbirdFluent
+import PlaidBarCore
+
+/// Local persistence for the **opt-in** server-synced review state (AND-552 —
+/// deferred epic AND-524).
+///
+/// Mirrors `BudgetStore`: an `actor` over the same Fluent/SQLite store so writes
+/// are serialized and the database stays single-writer. It persists the user's
+/// review overrides and categorization rules — display-safe derived values only
+/// (no Plaid tokens or access secrets), and only ever populated after an explicit
+/// client opt-in. With no opted-in client these tables stay empty.
+///
+/// ## Conflict resolution
+/// A device upload is folded into the stored snapshot with per-record
+/// last-writer-wins (``ReviewStateConflictResolver``): for a given transaction id
+/// or rule id, the record with the newer `updatedAt` survives; distinct ids are
+/// unioned. The merged union is returned so the uploading device converges in one
+/// round-trip.
+actor ReviewStateStore {
+    private let fluent: Fluent
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fluent: Fluent) {
+        self.fluent = fluent
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    // MARK: - Read
+
+    /// The full stored review-state snapshot. Rows whose JSON payload no longer
+    /// decodes against the current DTO (e.g. a future schema change) are skipped
+    /// rather than surfaced as garbage, mirroring `BudgetStore.allBudgets()`.
+    /// Metadata is returned sorted by transaction id and rules by rule id, so the
+    /// snapshot is deterministic.
+    func snapshot() async throws -> ReviewStateSnapshotDTO {
+        let metadataRows = try await ReviewMetadataModel.query(on: fluent.db()).all()
+        let ruleRows = try await ReviewRuleModel.query(on: fluent.db()).all()
+
+        let metadata = metadataRows
+            .compactMap { row -> ReviewMetadataRecordDTO? in
+                guard let data = row.payload.data(using: .utf8) else { return nil }
+                return try? decoder.decode(ReviewMetadataRecordDTO.self, from: data)
+            }
+            .sorted { $0.id < $1.id }
+
+        let rules = ruleRows
+            .compactMap { row -> ReviewRuleRecordDTO? in
+                guard let data = row.payload.data(using: .utf8) else { return nil }
+                return try? decoder.decode(ReviewRuleRecordDTO.self, from: data)
+            }
+            .sorted { $0.id.uuidString < $1.id.uuidString }
+
+        return ReviewStateSnapshotDTO(metadata: metadata, rules: rules)
+    }
+
+    // MARK: - Merge upload (LWW)
+
+    /// Fold `incoming` into the stored snapshot with per-record last-writer-wins,
+    /// persist the merged result, and return it. Idempotent: re-uploading the same
+    /// snapshot yields the same stored state. A row only changes on disk when the
+    /// incoming record actually wins its id, so a redundant upload is cheap.
+    @discardableResult
+    func merge(incoming: ReviewStateSnapshotDTO) async throws -> ReviewStateSnapshotDTO {
+        let base = try await snapshot()
+        let merged = ReviewStateConflictResolver.merge(base: base, incoming: incoming)
+
+        try await upsertMetadata(merged.metadata, previous: base.metadata)
+        try await upsertRules(merged.rules, previous: base.rules)
+
+        return merged
+    }
+
+    // MARK: - Opt-out / reset
+
+    /// Remove all synced review state (opt-out, or a local-data reset). Safe to
+    /// call when nothing is stored. Leaves every other table untouched.
+    func clearAll() async throws {
+        try await ReviewMetadataModel.query(on: fluent.db()).delete()
+        try await ReviewRuleModel.query(on: fluent.db()).delete()
+    }
+
+    // MARK: - Private
+
+    private func upsertMetadata(
+        _ merged: [ReviewMetadataRecordDTO],
+        previous: [ReviewMetadataRecordDTO]
+    ) async throws {
+        let previousById = Dictionary(previous.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        for record in merged {
+            // Skip rows the merge left identical to what is already stored.
+            if previousById[record.id] == record { continue }
+            let payload = try jsonString(record)
+            if let existing = try await ReviewMetadataModel.find(record.id, on: fluent.db()) {
+                existing.payload = payload
+                existing.updatedAt = record.updatedAt
+                try await existing.save(on: fluent.db())
+            } else {
+                try await ReviewMetadataModel(
+                    transactionId: record.id,
+                    payload: payload,
+                    updatedAt: record.updatedAt
+                ).save(on: fluent.db())
+            }
+        }
+    }
+
+    private func upsertRules(
+        _ merged: [ReviewRuleRecordDTO],
+        previous: [ReviewRuleRecordDTO]
+    ) async throws {
+        let previousById = Dictionary(previous.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        for record in merged {
+            if previousById[record.id] == record { continue }
+            let key = record.id.uuidString
+            let payload = try jsonString(record)
+            if let existing = try await ReviewRuleModel.find(key, on: fluent.db()) {
+                existing.payload = payload
+                existing.updatedAt = record.updatedAt
+                try await existing.save(on: fluent.db())
+            } else {
+                try await ReviewRuleModel(
+                    ruleId: key,
+                    payload: payload,
+                    updatedAt: record.updatedAt
+                ).save(on: fluent.db())
+            }
+        }
+    }
+
+    private func jsonString(_ value: some Encodable) throws -> String {
+        let data = try encoder.encode(value)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tests/PlaidBarCoreTests/ReviewStateSyncTests.swift
+++ b/Tests/PlaidBarCoreTests/ReviewStateSyncTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Opt-in server-synced review state — pure Core logic (AND-552).
+///
+/// Covers the last-writer-wins conflict resolver, the wire DTO JSON contract, and
+/// the opt-in feature flag (default OFF). The route/store CRUD lives in the server
+/// test target; the app-side gate ("opt-out sends nothing") lives in the app test
+/// target.
+@Suite("Server-synced review state — Core (AND-552)")
+struct ReviewStateSyncTests {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func metadataRecord(
+        id: String,
+        category: SpendingCategory?,
+        updatedAt: Date
+    ) -> ReviewMetadataRecordDTO {
+        ReviewMetadataRecordDTO(
+            metadata: TransactionReviewMetadata(
+                id: id,
+                status: .reviewed,
+                userCategory: category
+            ),
+            updatedAt: updatedAt
+        )
+    }
+
+    private func ruleRecord(
+        id: UUID,
+        merchantContains: String,
+        category: SpendingCategory?,
+        updatedAt: Date
+    ) -> ReviewRuleRecordDTO {
+        ReviewRuleRecordDTO(
+            rule: TransactionRule(
+                id: id,
+                matchMerchantContains: merchantContains,
+                category: category,
+                createdAt: epoch
+            ),
+            updatedAt: updatedAt
+        )
+    }
+
+    // MARK: - LWW: distinct ids are unioned
+
+    @Test("Distinct ids never conflict — both survive the merge")
+    func distinctIdsUnioned() {
+        let base = ReviewStateSnapshotDTO(
+            metadata: [metadataRecord(id: "tx-a", category: .foodAndDrink, updatedAt: epoch)],
+            rules: []
+        )
+        let incoming = ReviewStateSnapshotDTO(
+            metadata: [metadataRecord(id: "tx-b", category: .shopping, updatedAt: epoch)],
+            rules: []
+        )
+
+        let merged = ReviewStateConflictResolver.merge(base: base, incoming: incoming)
+        #expect(merged.metadata.map(\.id) == ["tx-a", "tx-b"])
+        #expect(merged.metadata.first { $0.id == "tx-a" }?.metadata.userCategory == .foodAndDrink)
+        #expect(merged.metadata.first { $0.id == "tx-b" }?.metadata.userCategory == .shopping)
+    }
+
+    // MARK: - LWW: newer write wins same id
+
+    @Test("Same id — the record with the newer updatedAt wins")
+    func newerWriteWinsSameId() {
+        let older = metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)
+        let newer = metadataRecord(
+            id: "tx-1",
+            category: .shopping,
+            updatedAt: epoch.addingTimeInterval(60)
+        )
+
+        // Newer arriving as the upload wins.
+        let mergedForward = ReviewStateConflictResolver.merge(
+            base: ReviewStateSnapshotDTO(metadata: [older], rules: []),
+            incoming: ReviewStateSnapshotDTO(metadata: [newer], rules: [])
+        )
+        #expect(mergedForward.metadata.count == 1)
+        #expect(mergedForward.metadata.first?.metadata.userCategory == .shopping)
+
+        // And it still wins when it is already the stored side (older uploaded).
+        let mergedReverse = ReviewStateConflictResolver.merge(
+            base: ReviewStateSnapshotDTO(metadata: [newer], rules: []),
+            incoming: ReviewStateSnapshotDTO(metadata: [older], rules: [])
+        )
+        #expect(mergedReverse.metadata.count == 1)
+        #expect(mergedReverse.metadata.first?.metadata.userCategory == .shopping)
+    }
+
+    @Test("Exact updatedAt tie resolves to the incoming (latest deliberate) write")
+    func tieResolvesToIncoming() {
+        let stored = metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)
+        let uploaded = metadataRecord(id: "tx-1", category: .entertainment, updatedAt: epoch)
+
+        let merged = ReviewStateConflictResolver.merge(
+            base: ReviewStateSnapshotDTO(metadata: [stored], rules: []),
+            incoming: ReviewStateSnapshotDTO(metadata: [uploaded], rules: [])
+        )
+        #expect(merged.metadata.first?.metadata.userCategory == .entertainment)
+    }
+
+    @Test("Rules merge by UUID with the same LWW rule")
+    func rulesMergeByUUID() {
+        let ruleId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let older = ruleRecord(id: ruleId, merchantContains: "Old", category: .foodAndDrink, updatedAt: epoch)
+        let newer = ruleRecord(
+            id: ruleId,
+            merchantContains: "New",
+            category: .shopping,
+            updatedAt: epoch.addingTimeInterval(120)
+        )
+        let otherId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let other = ruleRecord(id: otherId, merchantContains: "Other", category: .travel, updatedAt: epoch)
+
+        let merged = ReviewStateConflictResolver.merge(
+            base: ReviewStateSnapshotDTO(metadata: [], rules: [older, other]),
+            incoming: ReviewStateSnapshotDTO(metadata: [], rules: [newer])
+        )
+        #expect(merged.rules.count == 2)
+        let winning = merged.rules.first { $0.id == ruleId }
+        #expect(winning?.rule.matchMerchantContains == "New")
+        #expect(winning?.rule.category == .shopping)
+        #expect(merged.rules.contains { $0.id == otherId })
+    }
+
+    // MARK: - Determinism
+
+    @Test("Merge is deterministic and order-independent in its result set")
+    func mergeDeterministicOrdering() {
+        let a = metadataRecord(id: "tx-c", category: .shopping, updatedAt: epoch)
+        let b = metadataRecord(id: "tx-a", category: .foodAndDrink, updatedAt: epoch)
+        let c = metadataRecord(id: "tx-b", category: .travel, updatedAt: epoch)
+
+        let merged = ReviewStateConflictResolver.merge(
+            base: ReviewStateSnapshotDTO(metadata: [a, b], rules: []),
+            incoming: ReviewStateSnapshotDTO(metadata: [c], rules: [])
+        )
+        // Sorted by transaction id, independent of input order.
+        #expect(merged.metadata.map(\.id) == ["tx-a", "tx-b", "tx-c"])
+    }
+
+    @Test("Re-merging an identical snapshot is idempotent")
+    func mergeIdempotent() {
+        let snapshot = ReviewStateSnapshotDTO(
+            metadata: [metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)],
+            rules: [
+                ruleRecord(
+                    id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                    merchantContains: "Coffee",
+                    category: .foodAndDrink,
+                    updatedAt: epoch
+                ),
+            ]
+        )
+        let once = ReviewStateConflictResolver.merge(base: snapshot, incoming: snapshot)
+        let twice = ReviewStateConflictResolver.merge(base: once, incoming: snapshot)
+        #expect(once == snapshot)
+        #expect(twice == once)
+    }
+
+    // MARK: - Wire DTO JSON contract
+
+    @Test("Snapshot round-trips through its documented JSON contract")
+    func snapshotJSONRoundTrip() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = ReviewStateSnapshotDTO(
+            metadata: [metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)],
+            rules: [
+                ruleRecord(
+                    id: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+                    merchantContains: "Starbucks",
+                    category: .foodAndDrink,
+                    updatedAt: epoch
+                ),
+            ]
+        )
+        let data = try encoder.encode(snapshot)
+        let decoded = try decoder.decode(ReviewStateSnapshotDTO.self, from: data)
+        #expect(decoded == snapshot)
+        #expect(decoded.schemaVersion == ReviewStateSnapshotDTO.currentSchemaVersion)
+    }
+
+    @Test("Empty snapshot is current-schema and carries no records")
+    func emptySnapshot() {
+        let empty = ReviewStateSnapshotDTO.empty
+        #expect(empty.metadata.isEmpty)
+        #expect(empty.rules.isEmpty)
+        #expect(empty.isCurrentSchema)
+    }
+
+    // MARK: - Opt-in flag (default OFF)
+
+    @Test("Server-synced review is OFF by default")
+    func flagDefaultsOff() {
+        #expect(ServerSyncedReviewFeatureFlag.defaultValue == false)
+        // No CLI override, no stored preference ⇒ OFF.
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: nil) == false)
+    }
+
+    @Test("Stored opt-in and CLI override turn syncing on; unparseable never enables")
+    func flagResolution() {
+        // Stored preference honored when no CLI override.
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: true) == true)
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: false) == false)
+        // CLI override wins over the stored preference.
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: "on", storedValue: false) == true)
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: "off", storedValue: true) == false)
+        // Unparseable token falls through to the stored value / default — never
+        // silently enabling.
+        #expect(ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: "maybe", storedValue: nil) == false)
+        #expect(ServerSyncedReviewFeatureFlag.parse("garbage") == nil)
+    }
+
+    // MARK: - Sync gate (opt-out sends nothing)
+
+    @Test("When NOT opted in, the sync gate skips — no network, nothing leaves the device")
+    func gateSkipsWhenNotOptedIn() {
+        #expect(ReviewSyncGate.action(isOptedIn: false) == .skip)
+        #expect(ReviewSyncGate.allowsNetwork(isOptedIn: false) == false)
+    }
+
+    @Test("When opted in, the sync gate proceeds")
+    func gateProceedsWhenOptedIn() {
+        #expect(ReviewSyncGate.action(isOptedIn: true) == .proceed)
+        #expect(ReviewSyncGate.allowsNetwork(isOptedIn: true) == true)
+    }
+
+    @Test("The gate's default (flag OFF) skips — local-first end to end")
+    func gateDefaultSkips() {
+        // Compose the actual gate decision over the actual default flag value:
+        // a fresh install with no preference must skip.
+        let defaultDecision = ReviewSyncGate.allowsNetwork(
+            isOptedIn: ServerSyncedReviewFeatureFlag.resolve(cliOverrideRaw: nil, storedValue: nil)
+        )
+        #expect(defaultDecision == false)
+    }
+
+    // MARK: - Assembler round-trip
+
+    @Test("Assembler builds a stamped snapshot and flattens it back losslessly")
+    func assemblerRoundTrip() {
+        let metadata = [
+            TransactionReviewMetadata(id: "tx-b", status: .reviewed, userCategory: .shopping),
+            TransactionReviewMetadata(id: "tx-a", status: .ignored, userCategory: .foodAndDrink),
+        ]
+        let rules = [
+            TransactionRule(
+                id: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!,
+                matchMerchantContains: "Coffee",
+                category: .foodAndDrink,
+                createdAt: epoch
+            ),
+        ]
+        let snapshot = ReviewSyncAssembler.snapshot(metadata: metadata, rules: rules, updatedAt: epoch)
+        // Every record stamped with the one push timestamp, sorted by id.
+        #expect(snapshot.metadata.map(\.id) == ["tx-a", "tx-b"])
+        #expect(snapshot.metadata.allSatisfy { $0.updatedAt == epoch })
+
+        let flattened = ReviewSyncAssembler.localState(from: snapshot)
+        #expect(flattened.metadata.map(\.id) == ["tx-a", "tx-b"])
+        #expect(flattened.metadata.first?.userCategory == .foodAndDrink)
+        #expect(flattened.rules.first?.matchMerchantContains == "Coffee")
+    }
+}

--- a/Tests/PlaidBarServerTests/ReviewStateStoreTests.swift
+++ b/Tests/PlaidBarServerTests/ReviewStateStoreTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+import FluentKit
+import FluentSQLiteDriver
+import Hummingbird
+import HummingbirdFluent
+import HummingbirdTesting
+import Logging
+@testable import PlaidBarCore
+@testable import PlaidBarServer
+import Testing
+
+/// Opt-in server-synced review state — store + `/api/review` route (AND-552).
+@Suite("Server-synced review state persistence (AND-552)")
+struct ReviewStateStoreTests {
+    private let apiToken = "local-review-token"
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Fixtures
+
+    private func metadataRecord(
+        id: String,
+        category: SpendingCategory?,
+        updatedAt: Date
+    ) -> ReviewMetadataRecordDTO {
+        ReviewMetadataRecordDTO(
+            metadata: TransactionReviewMetadata(id: id, status: .reviewed, userCategory: category),
+            updatedAt: updatedAt
+        )
+    }
+
+    private func ruleRecord(
+        id: UUID,
+        merchantContains: String,
+        category: SpendingCategory?,
+        updatedAt: Date
+    ) -> ReviewRuleRecordDTO {
+        ReviewRuleRecordDTO(
+            rule: TransactionRule(
+                id: id,
+                matchMerchantContains: merchantContains,
+                category: category,
+                createdAt: epoch
+            ),
+            updatedAt: updatedAt
+        )
+    }
+
+    // MARK: - Harnesses (mirror CategoryBudgetStoreTests)
+
+    private func withReviewStore(_ body: (ReviewStateStore) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-review-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("review.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.review")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateReviewState())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            try await body(ReviewStateStore(fluent: fluent))
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    private func withReviewAPI(_ body: @Sendable (any TestClientProtocol) async throws -> Void) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-review-api-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("review.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.review-api")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.file(databasePath)), as: .sqlite)
+        await fluent.migrations.add(CreateReviewState())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+
+            let router = Router()
+            let api = router.group("api")
+            api.add(middleware: APITokenMiddleware(authToken: apiToken))
+            ReviewRoutes(reviewStateStore: ReviewStateStore(fluent: fluent))
+                .register(with: api)
+
+            let app = Application(router: router, logger: logger)
+            try await app.test(.router) { client in
+                try await body(client)
+            }
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    private var authorizedJSONHeaders: HTTPFields {
+        var headers = HTTPFields()
+        headers[.authorization] = "Bearer \(apiToken)"
+        headers[.contentType] = "application/json"
+        return headers
+    }
+
+    private func encode(_ snapshot: ReviewStateSnapshotDTO) throws -> ByteBuffer {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return ByteBuffer(data: try encoder.encode(snapshot))
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from response: TestResponse) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var body = response.body
+        let data = body.readData(length: body.readableBytes) ?? Data()
+        return try decoder.decode(T.self, from: data)
+    }
+
+    // MARK: - Store
+
+    @Test("An empty store returns an empty snapshot")
+    func emptyStore() async throws {
+        try await withReviewStore { store in
+            let snapshot = try await store.snapshot()
+            #expect(snapshot.metadata.isEmpty)
+            #expect(snapshot.rules.isEmpty)
+        }
+    }
+
+    @Test("Merge persists records and round-trips them sorted")
+    func mergeRoundTrips() async throws {
+        try await withReviewStore { store in
+            let ruleId = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+            let uploaded = ReviewStateSnapshotDTO(
+                metadata: [
+                    metadataRecord(id: "tx-b", category: .shopping, updatedAt: epoch),
+                    metadataRecord(id: "tx-a", category: .foodAndDrink, updatedAt: epoch),
+                ],
+                rules: [ruleRecord(id: ruleId, merchantContains: "Coffee", category: .foodAndDrink, updatedAt: epoch)]
+            )
+            let merged = try await store.merge(incoming: uploaded)
+            #expect(merged.metadata.map(\.id) == ["tx-a", "tx-b"])
+
+            let reloaded = try await store.snapshot()
+            #expect(reloaded.metadata.map(\.id) == ["tx-a", "tx-b"])
+            #expect(reloaded.rules.map(\.id) == [ruleId])
+            #expect(reloaded.metadata.first?.metadata.userCategory == .foodAndDrink)
+        }
+    }
+
+    @Test("Merge applies last-writer-wins on a conflicting transaction id")
+    func mergeLastWriterWins() async throws {
+        try await withReviewStore { store in
+            try await store.merge(incoming: ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)],
+                rules: []
+            ))
+            // A newer write to the same id replaces it.
+            try await store.merge(incoming: ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .shopping, updatedAt: epoch.addingTimeInterval(60))],
+                rules: []
+            ))
+            let snapshot = try await store.snapshot()
+            #expect(snapshot.metadata.count == 1)
+            #expect(snapshot.metadata.first?.metadata.userCategory == .shopping)
+
+            // An older write to the same id does NOT clobber the newer stored one.
+            try await store.merge(incoming: ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .travel, updatedAt: epoch)],
+                rules: []
+            ))
+            let afterStale = try await store.snapshot()
+            #expect(afterStale.metadata.first?.metadata.userCategory == .shopping)
+        }
+    }
+
+    @Test("clearAll removes all synced review state (opt-out)")
+    func clearAllRemovesEverything() async throws {
+        try await withReviewStore { store in
+            try await store.merge(incoming: ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)],
+                rules: [ruleRecord(
+                    id: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
+                    merchantContains: "X",
+                    category: .shopping,
+                    updatedAt: epoch
+                )]
+            ))
+            try await store.clearAll()
+            let snapshot = try await store.snapshot()
+            #expect(snapshot.metadata.isEmpty)
+            #expect(snapshot.rules.isEmpty)
+            // Idempotent: clearing an empty store does not throw.
+            try await store.clearAll()
+        }
+    }
+
+    // MARK: - Route contract
+
+    @Test("GET /api/review starts empty after the migration")
+    func apiGetStartsEmpty() async throws {
+        try await withReviewAPI { client in
+            let response = try await client.execute(uri: "/api/review", method: .get, headers: authorizedJSONHeaders)
+            #expect(response.status == .ok)
+            let snapshot = try decode(ReviewStateSnapshotDTO.self, from: response)
+            #expect(snapshot.metadata.isEmpty)
+            #expect(snapshot.rules.isEmpty)
+        }
+    }
+
+    @Test("PUT/GET/DELETE /api/review round-trips and merges via the wired route")
+    func apiRoundTripContract() async throws {
+        try await withReviewAPI { client in
+            let upload = ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .foodAndDrink, updatedAt: epoch)],
+                rules: []
+            )
+            let put = try await client.execute(
+                uri: "/api/review",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encode(upload)
+            )
+            #expect(put.status == .ok)
+            let merged = try decode(ReviewStateSnapshotDTO.self, from: put)
+            #expect(merged.metadata.first?.metadata.userCategory == .foodAndDrink)
+
+            // A second device PUT with a newer write to the same id wins via LWW.
+            let upload2 = ReviewStateSnapshotDTO(
+                metadata: [metadataRecord(id: "tx-1", category: .shopping, updatedAt: epoch.addingTimeInterval(120))],
+                rules: []
+            )
+            let put2 = try await client.execute(
+                uri: "/api/review",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: try encode(upload2)
+            )
+            let merged2 = try decode(ReviewStateSnapshotDTO.self, from: put2)
+            #expect(merged2.metadata.first?.metadata.userCategory == .shopping)
+
+            let get = try await client.execute(uri: "/api/review", method: .get, headers: authorizedJSONHeaders)
+            let persisted = try decode(ReviewStateSnapshotDTO.self, from: get)
+            #expect(persisted.metadata.first?.metadata.userCategory == .shopping)
+
+            let delete = try await client.execute(uri: "/api/review", method: .delete, headers: authorizedJSONHeaders)
+            #expect(delete.status == .noContent)
+
+            let getAfter = try await client.execute(uri: "/api/review", method: .get, headers: authorizedJSONHeaders)
+            let cleared = try decode(ReviewStateSnapshotDTO.self, from: getAfter)
+            #expect(cleared.metadata.isEmpty)
+        }
+    }
+
+    @Test("/api/review requires the bearer token")
+    func apiRequiresAuth() async throws {
+        try await withReviewAPI { client in
+            let response = try await client.execute(uri: "/api/review", method: .get)
+            #expect(response.status == .unauthorized)
+        }
+    }
+
+    @Test("PUT /api/review rejects a malformed body")
+    func apiRejectsMalformedBody() async throws {
+        try await withReviewAPI { client in
+            let response = try await client.execute(
+                uri: "/api/review",
+                method: .put,
+                headers: authorizedJSONHeaders,
+                body: ByteBuffer(string: "{ not valid json")
+            )
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    // MARK: - Pure decode validation
+
+    @Test("decodeSnapshot rejects an unsupported (newer) schema version")
+    func decodeRejectsFutureSchema() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let future = ReviewStateSnapshotDTO(
+            schemaVersion: ReviewStateSnapshotDTO.currentSchemaVersion + 1,
+            metadata: [],
+            rules: []
+        )
+        let buffer = ByteBuffer(data: try encoder.encode(future))
+        #expect(throws: (any Error).self) { try ReviewRoutes.decodeSnapshot(buffer) }
+    }
+}


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.** The maintainer authorized re-opening this cloud surface, approved **only as strictly opt-in**.

## What & why

VaultPeek is local-first: the transaction **review state** — the per-transaction overrides a user sets in the Review Inbox (chosen category, merchant rename, transfer flag, budget exclusion, free-text note, review status) plus their categorization rules — is app-local JSON only, and the local server never sees it. AND-552 adds an **optional** multi-device sync of exactly that state through a new `/api/review` surface so a user can carry their review work across their own machines.

This re-opens a cloud surface, so it is **strictly opt-in**. With the toggle OFF (the default for a fresh install and every existing user), the app never constructs or sends a review snapshot, the new tables stay empty, and behavior is **byte-identical** to before AND-552 — nothing leaves the device without explicit consent.

## Change

Built on the merged AND-546 schema/security split; no Plaid/Keychain/localhost boundary changed.

- **PlaidBarCore (pure, Sendable):**
  - `ReviewSyncDTO` — `ReviewStateSnapshotDTO` + per-record envelopes (`ReviewMetadataRecordDTO`, `ReviewRuleRecordDTO`), each carrying an `updatedAt` LWW clock. Schema-versioned like `BudgetingV2Schema`.
  - `ReviewStateConflictResolver` — **conflict resolution = per-record last-writer-wins** keyed on `updatedAt`: distinct ids are unioned; for the same id the newer write wins (tie → the upload). Pure and deterministic, so a merge never invents a category the user did not pick (that's why LWW per-record, not per-field).
  - `ServerSyncedReviewFeatureFlag` — the opt-in flag, **default OFF** (mirrors `WindowFirstFeatureFlag`; `--server-synced-review on|off` CLI/QA override).
  - `ReviewSyncGate` — the pure "opt-out ⇒ skip, no network" decision, kept in Core so the security-critical off-path is unit-testable (the app target is `@main`/untestable).
  - `ReviewSyncAssembler` — in-memory review state ⇄ wire snapshot. `ServerEndpoint.reviewStateURL`.
- **PlaidBarServer:** `ReviewMetadataModel` / `ReviewRuleModel` Fluent models + **additive** `CreateReviewState` migration (creates two new tables, touches nothing existing); `ReviewStateStore` actor (`snapshot` / LWW `merge` / `clearAll`); `ReviewRoutes` (`GET`/`PUT`/`DELETE /api/review`) behind the **existing `APITokenMiddleware`**, with a 4 MiB body cap and a schema-version reject. Wired in `App.swift`.
- **PlaidBar app:** `ServerClient` review CRUD; `ReviewSyncService` gated through `ReviewSyncGate`, so the off path makes no request.
- **Docs:** `SECURITY.md` trust-boundary entry (the server stores user category overrides/renames/notes — display-safe, never a Plaid token — only when enabled; opt-out clears it); README Server API Reference rows for `/api/review`.

## Testing

Exact commands and results (Swift commands run with the sandbox disabled, per repo memory):

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete** (the only warning is the pre-existing, unrelated `async-http-client` unused-dependency note).
- `swift test --filter "ReviewStateSyncTests" --filter "ReviewStateStoreTests"` → **23 tests passed**. Covers: LWW (distinct-id union, newer-wins both directions, tie→incoming, idempotent re-merge, deterministic ordering); wire-DTO JSON round-trip; opt-in flag default OFF + resolution; **sync gate skips when not opted in (opt-out sends nothing)**; assembler round-trip; store CRUD; `/api/review` PUT/GET/DELETE merge round-trip through the wired route; auth-required; malformed-body + future-schema reject.
- `swift test` (full suite) → **2412 tests passed** (server target 194, core target 2100, all green — assembler move + service add caused no regression).
- `git diff --check` → clean.

## Links

Closes AND-552.

## Follow-ups

- Wire `ReviewSyncService` into `AppState`'s review-action path + a Settings opt-in toggle with a consent prompt (the gate, client, and assembler are in place; the AppState/Settings UI hookup is the remaining glue and a natural sibling of AND-553's rules-manager UI).
- Optional: a periodic/background `pull` + local-vs-server reconciliation pass for near-real-time multi-device convergence (today convergence happens on the next explicit push/pull).
