### PR TITLE
feat(budgeting): transaction splits — one transaction into N category allocations (AND-550)

### DIFF
--- a/Sources/PlaidBarCore/Models/TransactionSplit.swift
+++ b/Sources/PlaidBarCore/Models/TransactionSplit.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Splitting a single transaction into N category allocations (AND-550).
+///
+/// ## What this is (and the v1-safety contract)
+///
+/// A **child-allocation** model layered *additively* on top of ``TransactionDTO``.
+/// The parent transaction is never mutated, re-keyed, or removed: a split is a
+/// separate, opt-in record keyed by the parent's `transaction_id`. A user who
+/// does **not** split anything has no ``TransactionSplit`` records, so every
+/// consumer of transaction spend (budgets, summaries, review, exports, charts)
+/// sees byte-identical prior behavior. This is the deferred budgeting-v2 (AND-524)
+/// re-opening of scope that AND-399 explicitly cut.
+///
+/// A split divides the parent's signed amount (Plaid convention: positive = money
+/// out, negative = money in) into ``TransactionSplitAllocation`` parts. Each part
+/// carries its **own** budget category and its **own** budget-exclude flag, so a
+/// `$150` Target run can be `$90` Groceries + `$60` Home, or one part can be
+/// excluded from budgets while the rest counts. The defining **sum invariant** is
+/// that the parts' signed amounts sum back to the parent amount (within a cent),
+/// so splitting never creates or destroys money — it only re-attributes it.
+///
+/// ## Why a value type in `PlaidBarCore`
+///
+/// Pure, `Sendable`, no I/O, no hidden `Date()`. The split-aware spend math
+/// (``TransactionSplitResolver``) and every aggregation that reads it stay
+/// testable and shared across processes, per the project's "logic in Core"
+/// doctrine. Persistence (the app-only `PlaidBarCache` store) and the editor UI
+/// are separate, later surfaces — this file is the model + the sum invariant.
+
+// MARK: - Allocation (one category slice of a split)
+
+/// One slice of a split transaction: a signed amount attributed to a single
+/// budget category, with its own budget-exclusion flag.
+///
+/// Each allocation has a stable `id` so the editor can address an individual part
+/// (rename its category, toggle its exclude flag, change its amount) without
+/// reordering the rest. The `amount` is **signed**, in the parent's currency, and
+/// follows the same Plaid convention as ``TransactionDTO/amount`` (positive =
+/// money out). For a normal expense the parts are positive and sum to the
+/// positive parent amount; the model does not assume a sign so a refund (negative
+/// parent) splits the same way.
+public struct TransactionSplitAllocation: Codable, Sendable, Hashable, Identifiable {
+    /// Stable identity for this allocation row, independent of its position in the
+    /// split. A fresh UUID by default so a newly-added part never collides with an
+    /// existing one.
+    public let id: UUID
+    /// The budget category this slice is attributed to. The parent's own
+    /// ``TransactionDTO/category`` is ignored once a split exists — each part
+    /// declares its own bucket.
+    public let category: SpendingCategory
+    /// The signed amount of this slice, in the parent's currency (Plaid
+    /// convention: positive = money out). The parts' amounts must sum to the
+    /// parent amount (the split's sum invariant).
+    public let amount: Double
+    /// Whether this individual slice is excluded from budget/spend rollups. A
+    /// part can be excluded while its siblings still count — e.g. a reimbursable
+    /// line item carved out of a shared receipt. Defaults to `false` so an
+    /// allocation counts unless explicitly excluded.
+    public let excludedFromBudgets: Bool
+
+    public init(
+        id: UUID = UUID(),
+        category: SpendingCategory,
+        amount: Double,
+        excludedFromBudgets: Bool = false
+    ) {
+        self.id = id
+        self.category = category
+        self.amount = amount
+        self.excludedFromBudgets = excludedFromBudgets
+    }
+}
+
+// MARK: - Split (parent → N allocations)
+
+/// A transaction split: the parent transaction id plus the N allocations its
+/// amount is divided into.
+///
+/// Identity is the parent's `transaction_id` (one split per transaction), so a
+/// store can look a split up directly by the transaction it belongs to. The
+/// `expectedTotal` is the parent's signed amount captured at split time; the
+/// split is **valid** only when the allocations sum to it within a cent
+/// (``isBalanced(tolerance:)``) and there is at least one allocation. An empty or
+/// unbalanced split is treated as "no split" by the resolver, so a malformed
+/// record degrades to the parent's own category rather than dropping or
+/// double-counting the spend.
+public struct TransactionSplit: Codable, Sendable, Hashable, Identifiable {
+    /// Default balance tolerance in the parent's currency unit (one cent). Floating
+    /// point sums of currency parts can drift sub-cent; anything within this is
+    /// considered balanced. Mirrors the cent-level tolerances used elsewhere in the
+    /// review engine (e.g. `reviewedChargeChanged`'s `0.005` amount compare).
+    public static let balanceTolerance = 0.005
+
+    /// The parent ``TransactionDTO/id`` (Plaid `transaction_id`) this split divides.
+    public let transactionId: String
+    /// The parent's signed amount at the time the split was created — the value the
+    /// allocations must sum to. Persisting it (rather than re-reading the live
+    /// transaction) lets the resolver detect a stale split if the underlying charge
+    /// later changes amount.
+    public let expectedTotal: Double
+    /// The category allocations, in user-entered order. At least one for a valid
+    /// split.
+    public let allocations: [TransactionSplitAllocation]
+
+    /// Stable identity — one split per parent transaction.
+    public var id: String { transactionId }
+
+    public init(
+        transactionId: String,
+        expectedTotal: Double,
+        allocations: [TransactionSplitAllocation]
+    ) {
+        self.transactionId = transactionId
+        self.expectedTotal = expectedTotal
+        self.allocations = allocations
+    }
+
+    /// Convenience initializer that captures the parent's amount as the
+    /// `expectedTotal` directly from the transaction being split.
+    public init(splitting transaction: TransactionDTO, into allocations: [TransactionSplitAllocation]) {
+        self.init(
+            transactionId: transaction.id,
+            expectedTotal: transaction.amount,
+            allocations: allocations
+        )
+    }
+
+    /// The signed sum of every allocation's amount.
+    public var allocatedTotal: Double {
+        allocations.reduce(0) { $0 + $1.amount }
+    }
+
+    /// The signed gap between the parent amount and the allocated sum. Zero (within
+    /// tolerance) when the split balances; non-zero is the amount still
+    /// unallocated (positive) or over-allocated (negative). Exposed so an editor
+    /// can show "$10 left to allocate" without re-deriving the math.
+    public var unallocatedRemainder: Double {
+        expectedTotal - allocatedTotal
+    }
+
+    /// Whether the allocations sum to the parent amount within `tolerance` — the
+    /// split's defining sum invariant. An empty split is never balanced (a split
+    /// must have at least one part to be meaningful).
+    public func isBalanced(tolerance: Double = TransactionSplit.balanceTolerance) -> Bool {
+        guard !allocations.isEmpty else { return false }
+        return abs(unallocatedRemainder) <= tolerance
+    }
+
+    /// Whether this split may be applied: it has at least one allocation and it
+    /// balances to the parent amount. The resolver applies a split only when this
+    /// holds; otherwise it falls back to the parent transaction unchanged, so a
+    /// malformed split never corrupts spend totals. ``transactionId`` matching the
+    /// parent is the caller's responsibility (the resolver only applies a split it
+    /// looked up by that id).
+    public var isValid: Bool {
+        isBalanced()
+    }
+
+    // MARK: - Editing
+
+    /// Return a copy with `allocations` replaced, re-balancing against the same
+    /// `expectedTotal`. The editor uses this to add/remove/edit parts; validity is
+    /// re-derived from the new allocations via ``isValid``.
+    public func replacingAllocations(_ newAllocations: [TransactionSplitAllocation]) -> TransactionSplit {
+        TransactionSplit(
+            transactionId: transactionId,
+            expectedTotal: expectedTotal,
+            allocations: newAllocations
+        )
+    }
+
+    /// A two-way even split of `transaction` across two categories, used as a
+    /// sensible editor default / fixture seed. The first part takes any rounding
+    /// remainder so the two always sum to the parent exactly (the sum invariant
+    /// holds with no tolerance slack). Amounts are rounded to the cent.
+    public static func evenSplit(
+        of transaction: TransactionDTO,
+        between first: SpendingCategory,
+        and second: SpendingCategory
+    ) -> TransactionSplit {
+        let total = transaction.amount
+        let half = (total / 2 * 100).rounded() / 100
+        let remainder = (total - half)
+        return TransactionSplit(
+            splitting: transaction,
+            into: [
+                TransactionSplitAllocation(category: first, amount: remainder),
+                TransactionSplitAllocation(category: second, amount: half),
+            ]
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryBudgetPlanner.swift
@@ -112,7 +112,8 @@ public enum CategoryBudgetPlanner {
         calendar: Calendar = .current,
         areSuggested: Bool = false,
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = []
     ) -> CategoryBudgetPresentation {
         let positiveBudgets = budgets.filter { $0.value > 0 }
         guard
@@ -126,7 +127,8 @@ public enum CategoryBudgetPlanner {
             startKey: Formatters.transactionDateString(monthStart),
             endKey: Formatters.transactionDateString(nextMonthStart),
             metadata: metadata,
-            rules: rules
+            rules: rules,
+            splits: splits
         )
 
         let items = positiveBudgets
@@ -193,7 +195,8 @@ public enum CategoryBudgetPlanner {
         asOf date: Date,
         calendar: Calendar = .current,
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = []
     ) -> CategoryBudgetPresentation {
         let suggested = presentation(
             budgets: suggestedBudgets(from: transactions, asOf: date, calendar: calendar)
@@ -203,7 +206,8 @@ public enum CategoryBudgetPlanner {
             calendar: calendar,
             areSuggested: true,
             metadata: metadata,
-            rules: rules
+            rules: rules,
+            splits: splits
         )
 
         guard !explicitBudgets.isEmpty else { return suggested }
@@ -214,7 +218,8 @@ public enum CategoryBudgetPlanner {
             asOf: date,
             calendar: calendar,
             metadata: metadata,
-            rules: rules
+            rules: rules,
+            splits: splits
         )
         return merge(explicit: explicit, suggested: suggested)
     }
@@ -273,11 +278,18 @@ public enum CategoryBudgetPlanner {
     ///   - calendar: the calendar used to derive the month bounds (no hidden
     ///     `Date()`).
     /// - Returns: signed net spend per category for the month, override-aware.
+    /// - Parameter splits: per-transaction category splits (AND-550). **Defaults to
+    ///   empty**, preserving the un-split behavior exactly. When a transaction has a
+    ///   *valid* split here, its parent is replaced by its allocation rows — each
+    ///   bucketed by the allocation's own category and respecting the allocation's
+    ///   own exclude flag — so rollups count the **parts, not the parent**. A
+    ///   transaction with no (or a malformed) split is unchanged.
     public static func overrideAwareSpend(
         transactions: [TransactionDTO],
         month: String,
         metadata: [TransactionReviewMetadata] = [],
         rules: [TransactionRule] = [],
+        splits: [TransactionSplit] = [],
         calendar: Calendar = .current
     ) -> [SpendingCategory: Double] {
         guard
@@ -293,7 +305,8 @@ public enum CategoryBudgetPlanner {
             startKey: Formatters.transactionDateString(monthStart),
             endKey: Formatters.transactionDateString(nextMonthStart),
             metadata: metadata,
-            rules: rules
+            rules: rules,
+            splits: splits
         )
     }
 
@@ -341,16 +354,28 @@ public enum CategoryBudgetPlanner {
         startKey: String,
         endKey: String,
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = []
     ) -> [SpendingCategory: Double] {
+        let splitIndex = TransactionSplitResolver.index(splits)
+
         // Legacy path: no review state supplied → bucket by raw Plaid category.
+        // Still split-aware: a transaction with a valid split contributes its
+        // allocation rows (each by its own category, honoring its exclude flag)
+        // rather than one parent row. With no splits this is byte-identical to the
+        // pre-AND-550 loop.
         guard metadata != nil || rules != nil else {
             var totals: [SpendingCategory: Double] = [:]
             for transaction in transactions {
                 if transaction.date < startKey || transaction.date >= endKey { continue }
-                let category = transaction.category ?? .other
-                if excludedCategories.contains(category) { continue }
-                totals[category, default: 0] += transaction.amount
+                for row in TransactionSplitResolver.spendRows(
+                    for: transaction, splitsByTransactionId: splitIndex
+                ) {
+                    if row.isSplitExcluded { continue }
+                    let category = row.category ?? .other
+                    if excludedCategories.contains(category) { continue }
+                    totals[category, default: 0] += row.amount
+                }
             }
             return totals
         }
@@ -365,36 +390,53 @@ public enum CategoryBudgetPlanner {
         for transaction in transactions {
             if transaction.date < startKey || transaction.date >= endKey { continue }
 
-            // Carry pending-phase review metadata into the posted charge: Plaid
-            // re-posts a previously-pending charge under a new id that links back
-            // via `pendingTransactionId`. Prefer the transaction's own record;
-            // fall back to the carried-forward pending record (mirrors
-            // `TransactionReviewInbox.evaluate`).
-            let effectiveMetadata = metadataById[transaction.id]
-                ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
+            for row in TransactionSplitResolver.spendRows(
+                for: transaction, splitsByTransactionId: splitIndex
+            ) {
+                // A split allocation already declared its category and exclude flag
+                // explicitly when the user split the charge — so it bypasses the
+                // per-parent override/rule resolution and buckets by its own
+                // category. Income/transfer categories are still never counted.
+                if row.isSplitAllocation {
+                    if row.isSplitExcluded { continue }
+                    let category = row.category ?? .other
+                    if excludedCategories.contains(category) { continue }
+                    totals[category, default: 0] += row.amount
+                    continue
+                }
 
-            let resolution = EffectiveCategoryResolver.resolve(
-                transaction: transaction,
-                metadata: effectiveMetadata,
-                rules: activeRules
-            )
+                // Un-split row: the existing override-aware path, unchanged.
+                // Carry pending-phase review metadata into the posted charge: Plaid
+                // re-posts a previously-pending charge under a new id that links back
+                // via `pendingTransactionId`. Prefer the transaction's own record;
+                // fall back to the carried-forward pending record (mirrors
+                // `TransactionReviewInbox.evaluate`).
+                let effectiveMetadata = metadataById[transaction.id]
+                    ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
 
-            // Drop excluded rows (explicit user/rule exclusion or transfers).
-            if resolution.excludedFromBudgets || resolution.isTransfer { continue }
-            // No *confident* override/rule/Plaid category (the row is `.other`, has
-            // no Plaid category, or Plaid flagged it low/unknown). Per the spend
-            // precedence (user override → rule → raw Plaid → `.other`),
-            // such a row must **fall back** to its raw Plaid bucket — or `.other`
-            // when Plaid gave nothing — not vanish from totals. A display-only NL
-            // suggestion is still never counted here: it lives on
-            // `resolution.suggestedCategory`, not on the aggregation category, so an
-            // unapproved guess keeps the row in raw-Plaid/`.other` until approved.
-            let category = resolution.category ?? (transaction.category ?? .other)
-            // Income never counts as category spend even if it survived resolution
-            // (the resolver does not classify income as transfer/excluded).
-            if excludedCategories.contains(category) { continue }
+                let resolution = EffectiveCategoryResolver.resolve(
+                    transaction: transaction,
+                    metadata: effectiveMetadata,
+                    rules: activeRules
+                )
 
-            totals[category, default: 0] += transaction.amount
+                // Drop excluded rows (explicit user/rule exclusion or transfers).
+                if resolution.excludedFromBudgets || resolution.isTransfer { continue }
+                // No *confident* override/rule/Plaid category (the row is `.other`, has
+                // no Plaid category, or Plaid flagged it low/unknown). Per the spend
+                // precedence (user override → rule → raw Plaid → `.other`),
+                // such a row must **fall back** to its raw Plaid bucket — or `.other`
+                // when Plaid gave nothing — not vanish from totals. A display-only NL
+                // suggestion is still never counted here: it lives on
+                // `resolution.suggestedCategory`, not on the aggregation category, so an
+                // unapproved guess keeps the row in raw-Plaid/`.other` until approved.
+                let category = resolution.category ?? (transaction.category ?? .other)
+                // Income never counts as category spend even if it survived resolution
+                // (the resolver does not classify income as transfer/excluded).
+                if excludedCategories.contains(category) { continue }
+
+                totals[category, default: 0] += row.amount
+            }
         }
         return totals
     }

--- a/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/DataExportBuilder.swift
@@ -5,10 +5,11 @@ import Foundation
 /// AppKit, no I/O — string/Data math over Sendable DTOs, fully unit-testable.
 public enum DataExportBuilder {
     /// Bumped whenever the JSON envelope shape changes so importers can branch.
-    /// v2 adds the optional `budgets` array + `counts.budgets` (AND-645); the
-    /// new fields decode as empty/zero from a v1 file, so importers stay
+    /// v2 adds the optional `budgets` array + `counts.budgets` (AND-645); v3 adds
+    /// the optional `splits` array + `counts.splits` (AND-550). The new fields
+    /// decode as empty/zero from an older file, so importers stay
     /// backward-compatible.
-    public static let schemaVersion = 2
+    public static let schemaVersion = 3
 
     // MARK: - Masked-state gating (AND-645)
 
@@ -203,6 +204,37 @@ public enum DataExportBuilder {
             .sorted { $0.category.rawValue < $1.category.rawValue }
     }
 
+    /// CSV of transaction splits (AND-550). One row **per allocation**, so a split
+    /// transaction contributes N rows joined by the shared `transaction_id` — the
+    /// transactions CSV keeps its one-row-per-transaction contract while this file
+    /// carries the per-category breakdown. Rows are ordered by `transaction_id`
+    /// then allocation index for a deterministic, diff-able backup. `expected_total`
+    /// is the parent's signed amount the allocations must sum to (the invariant);
+    /// `amount` is the signed slice; `excluded_from_budgets` is the allocation's own
+    /// flag.
+    public static func splitsCSV(_ splits: [TransactionSplit]) -> String {
+        let header = row([
+            "transaction_id", "expected_total", "allocation_index",
+            "category", "category_name", "amount", "excluded_from_budgets",
+        ])
+        let rows = splits
+            .sorted { $0.transactionId < $1.transactionId }
+            .flatMap { split in
+                split.allocations.enumerated().map { index, allocation in
+                    row([
+                        split.transactionId,
+                        decimalString(split.expectedTotal),
+                        String(index),
+                        allocation.category.rawValue,
+                        allocation.category.displayName,
+                        decimalString(allocation.amount),
+                        allocation.excludedFromBudgets ? "true" : "false",
+                    ])
+                }
+            }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
     // MARK: - JSON
 
     /// Versioned, stable backup envelope: schemaVersion, exportedAt, environment,
@@ -218,12 +250,20 @@ public enum DataExportBuilder {
             public let transactions: Int
             public let balanceHistory: Int
             public let budgets: Int
+            public let splits: Int
 
-            public init(accounts: Int, transactions: Int, balanceHistory: Int, budgets: Int) {
+            public init(
+                accounts: Int,
+                transactions: Int,
+                balanceHistory: Int,
+                budgets: Int,
+                splits: Int = 0
+            ) {
                 self.accounts = accounts
                 self.transactions = transactions
                 self.balanceHistory = balanceHistory
                 self.budgets = budgets
+                self.splits = splits
             }
 
             public init(from decoder: any Decoder) throws {
@@ -233,6 +273,8 @@ public enum DataExportBuilder {
                 balanceHistory = try container.decode(Int.self, forKey: .balanceHistory)
                 // Absent in v1 envelopes → treat as zero.
                 budgets = try container.decodeIfPresent(Int.self, forKey: .budgets) ?? 0
+                // Absent in v1/v2 envelopes → treat as zero (AND-550).
+                splits = try container.decodeIfPresent(Int.self, forKey: .splits) ?? 0
             }
         }
 
@@ -244,6 +286,7 @@ public enum DataExportBuilder {
         public let transactions: [TransactionDTO]
         public let balanceHistory: [BalanceSnapshot]
         public let budgets: [CategoryBudgetDTO]
+        public let splits: [TransactionSplit]
 
         public init(
             schemaVersion: Int,
@@ -253,7 +296,8 @@ public enum DataExportBuilder {
             accounts: [AccountDTO],
             transactions: [TransactionDTO],
             balanceHistory: [BalanceSnapshot],
-            budgets: [CategoryBudgetDTO]
+            budgets: [CategoryBudgetDTO],
+            splits: [TransactionSplit] = []
         ) {
             self.schemaVersion = schemaVersion
             self.exportedAt = exportedAt
@@ -263,6 +307,7 @@ public enum DataExportBuilder {
             self.transactions = transactions
             self.balanceHistory = balanceHistory
             self.budgets = budgets
+            self.splits = splits
         }
 
         public init(from decoder: any Decoder) throws {
@@ -276,6 +321,8 @@ public enum DataExportBuilder {
             balanceHistory = try container.decode([BalanceSnapshot].self, forKey: .balanceHistory)
             // Absent in v1 envelopes → decode as no budgets.
             budgets = try container.decodeIfPresent([CategoryBudgetDTO].self, forKey: .budgets) ?? []
+            // Absent in v1/v2 envelopes → decode as no splits (AND-550).
+            splits = try container.decodeIfPresent([TransactionSplit].self, forKey: .splits) ?? []
         }
     }
 
@@ -284,12 +331,16 @@ public enum DataExportBuilder {
         transactions: [TransactionDTO],
         balanceHistory: [BalanceSnapshot],
         budgets: [CategoryBudgetDTO] = [],
+        splits: [TransactionSplit] = [],
         exportedAt: Date,
         environment: String? = nil
     ) -> Envelope {
         // Stable order: budgets are sorted by category raw value so the JSON
         // backup matches the CSV order and produces diff-able files.
         let orderedBudgets = budgets.sorted { $0.category.rawValue < $1.category.rawValue }
+        // Splits sorted by parent transaction id, matching `splitsCSV`, so the JSON
+        // and CSV exports stay diff-able and re-importable (AND-550).
+        let orderedSplits = splits.sorted { $0.transactionId < $1.transactionId }
         return Envelope(
             schemaVersion: schemaVersion,
             exportedAt: exportedAt,
@@ -298,12 +349,14 @@ public enum DataExportBuilder {
                 accounts: accounts.count,
                 transactions: transactions.count,
                 balanceHistory: balanceHistory.count,
-                budgets: orderedBudgets.count
+                budgets: orderedBudgets.count,
+                splits: orderedSplits.count
             ),
             accounts: accounts,
             transactions: transactions,
             balanceHistory: balanceHistory,
-            budgets: orderedBudgets
+            budgets: orderedBudgets,
+            splits: orderedSplits
         )
     }
 
@@ -312,6 +365,7 @@ public enum DataExportBuilder {
         transactions: [TransactionDTO],
         balanceHistory: [BalanceSnapshot],
         budgets: [CategoryBudgetDTO] = [],
+        splits: [TransactionSplit] = [],
         exportedAt: Date,
         environment: String? = nil
     ) throws -> Data {
@@ -320,6 +374,7 @@ public enum DataExportBuilder {
             transactions: transactions,
             balanceHistory: balanceHistory,
             budgets: budgets,
+            splits: splits,
             exportedAt: exportedAt,
             environment: environment
         )

--- a/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
@@ -91,6 +91,12 @@ public enum SpendingSummary {
                 ) {
                     if row.isSplitExcluded { continue }
                     let category = row.category ?? .other
+                    // Income/transfer split allocations are never spend — mirror
+                    // `CategoryBudgetPlanner.netSpendByCategory`'s `excludedCategories`
+                    // so a `.transfer`/`.income` allocation drops out of the summary.
+                    if CategoryBudgetPlanner.excludedCategories.contains(category) {
+                        continue
+                    }
                     // Use the magnitude so a split allocation matches the legacy
                     // `displayAmount` convention this summary uses.
                     totals[category, default: 0] += abs(row.amount)
@@ -116,6 +122,12 @@ public enum SpendingSummary {
                 if row.isSplitAllocation {
                     if row.isSplitExcluded { continue }
                     let category = row.category ?? .other
+                    // Income/transfer split allocations are never spend — mirror
+                    // `CategoryBudgetPlanner.netSpendByCategory`'s `excludedCategories`
+                    // so a `.transfer`/`.income` allocation drops out of the summary.
+                    if CategoryBudgetPlanner.excludedCategories.contains(category) {
+                        continue
+                    }
                     totals[category, default: 0] += abs(row.amount)
                     continue
                 }

--- a/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
@@ -32,7 +32,8 @@ public enum SpendingSummary {
         currentStart: String,
         previousStart: String,
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = []
     ) -> SpendingPeriodSummary {
         let currentExpenses = expenseTransactions(
             from: transactions,
@@ -47,7 +48,8 @@ public enum SpendingSummary {
         let categories = spendingByCategory(
             from: currentExpenses,
             metadata: metadata,
-            rules: rules
+            rules: rules,
+            splits: splits
         )
         let currentTotal = categories.reduce(0) { $0 + $1.1 }
         let previousTotal = previousExpenses.reduce(0) { $0 + $1.displayAmount }
@@ -71,16 +73,30 @@ public enum SpendingSummary {
     public static func spendingByCategory(
         from transactions: [TransactionDTO],
         metadata: [TransactionReviewMetadata]? = nil,
-        rules: [TransactionRule]? = nil
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = []
     ) -> [(SpendingCategory, Double)] {
         let expenses = expenseTransactions(from: transactions)
+        let splitIndex = TransactionSplitResolver.index(splits)
 
         // Legacy path: no review state supplied → bucket by raw Plaid category.
+        // Split-aware: a transaction with a valid split contributes its allocation
+        // rows (each by its own category, honoring its exclude flag). With no
+        // splits this is byte-identical to the pre-AND-550 grouping.
         guard metadata != nil || rules != nil else {
-            let grouped = Dictionary(grouping: expenses) { $0.category ?? .other }
-            return grouped.map { category, transactions in
-                (category, transactions.reduce(0) { $0 + $1.displayAmount })
-            }.sorted { $0.1 > $1.1 }
+            var totals: [SpendingCategory: Double] = [:]
+            for transaction in expenses {
+                for row in TransactionSplitResolver.spendRows(
+                    for: transaction, splitsByTransactionId: splitIndex
+                ) {
+                    if row.isSplitExcluded { continue }
+                    let category = row.category ?? .other
+                    // Use the magnitude so a split allocation matches the legacy
+                    // `displayAmount` convention this summary uses.
+                    totals[category, default: 0] += abs(row.amount)
+                }
+            }
+            return totals.map { ($0.key, $0.value) }.sorted { $0.1 > $1.1 }
         }
 
         let metadataById = Dictionary(
@@ -91,29 +107,44 @@ public enum SpendingSummary {
 
         var totals: [SpendingCategory: Double] = [:]
         for transaction in expenses {
-            // Carry pending-phase review metadata into the posted charge (mirrors
-            // `CategoryBudgetPlanner.netSpendByCategory`): prefer the transaction's
-            // own record, then the carried-forward pending record.
-            let effectiveMetadata = metadataById[transaction.id]
-                ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
+            for row in TransactionSplitResolver.spendRows(
+                for: transaction, splitsByTransactionId: splitIndex
+            ) {
+                // A split allocation already declared its category and exclude flag,
+                // so it bypasses per-parent override/rule resolution and buckets by
+                // its own category.
+                if row.isSplitAllocation {
+                    if row.isSplitExcluded { continue }
+                    let category = row.category ?? .other
+                    totals[category, default: 0] += abs(row.amount)
+                    continue
+                }
 
-            let resolution = EffectiveCategoryResolver.resolve(
-                transaction: transaction,
-                metadata: effectiveMetadata,
-                rules: activeRules
-            )
+                // Un-split row: the existing override-aware path, unchanged.
+                // Carry pending-phase review metadata into the posted charge (mirrors
+                // `CategoryBudgetPlanner.netSpendByCategory`): prefer the transaction's
+                // own record, then the carried-forward pending record.
+                let effectiveMetadata = metadataById[transaction.id]
+                    ?? transaction.pendingTransactionId.flatMap { metadataById[$0] }
 
-            // Drop excluded rows (explicit user/rule exclusion or transfers) — the
-            // override surface can re-classify a row as a transfer the raw Plaid
-            // category did not flag.
-            if resolution.excludedFromBudgets || resolution.isTransfer { continue }
+                let resolution = EffectiveCategoryResolver.resolve(
+                    transaction: transaction,
+                    metadata: effectiveMetadata,
+                    rules: activeRules
+                )
 
-            // Fall back to the raw Plaid bucket (or `.other`) when no confident
-            // override/rule/Plaid category resolved, matching the legacy bucket —
-            // a display-only NL suggestion is never counted (it lives on
-            // `resolution.suggestedCategory`, not on the aggregation category).
-            let category = resolution.category ?? (transaction.category ?? .other)
-            totals[category, default: 0] += transaction.displayAmount
+                // Drop excluded rows (explicit user/rule exclusion or transfers) — the
+                // override surface can re-classify a row as a transfer the raw Plaid
+                // category did not flag.
+                if resolution.excludedFromBudgets || resolution.isTransfer { continue }
+
+                // Fall back to the raw Plaid bucket (or `.other`) when no confident
+                // override/rule/Plaid category resolved, matching the legacy bucket —
+                // a display-only NL suggestion is never counted (it lives on
+                // `resolution.suggestedCategory`, not on the aggregation category).
+                let category = resolution.category ?? (transaction.category ?? .other)
+                totals[category, default: 0] += abs(row.amount)
+            }
         }
 
         return totals.map { ($0.key, $0.value) }.sorted { $0.1 > $1.1 }

--- a/Sources/PlaidBarCore/Utilities/TransactionSplitResolver.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionSplitResolver.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Expands transactions into split-aware **spend rows** (AND-550).
+///
+/// This is the single additive seam every spend consumer routes through to become
+/// split-aware. Given a transaction and (optionally) its ``TransactionSplit``, it
+/// emits one ``SpendRow`` per category allocation:
+///
+/// - **No split** (the common case): exactly **one** row, carrying the parent's
+///   own id / amount / category / date — byte-identical to the un-split transaction
+///   the consumer used before. This is the v1-safety guarantee: a user with no
+///   splits is unaffected across every consumer.
+/// - **A valid split**: one row **per allocation**, each with its own category,
+///   its own signed amount, and its own budget-exclude flag. The parent itself
+///   never appears as a row, so rollups count the **parts, not the parent**
+///   (the AC's invariant). Because a valid split's parts sum to the parent amount,
+///   the *total* spend is conserved — only the per-category attribution changes.
+/// - **A malformed split** (empty, or allocations that don't sum to the parent):
+///   treated as no split — the resolver falls back to the single parent row, so a
+///   bad record never drops or double-counts the charge. Editing/removing the
+///   split therefore restores the original automatically (no split → parent row).
+///
+/// Pure, `Sendable`, deterministic — no I/O, no hidden `Date()`. Aggregations
+/// (`CategoryBudgetPlanner`, `SpendingSummary`, exports, charts) call ``spendRows``
+/// instead of iterating raw transactions to inherit split-awareness with a default
+/// of "no splits = unchanged".
+public enum TransactionSplitResolver {
+    /// One unit of spend attribution after splits are applied: either a whole
+    /// (un-split) transaction or one allocation of a split. Carries the values an
+    /// aggregator needs — id, signed amount, category, date, the parent transaction
+    /// for further resolution (overrides/rules), and whether this row is excluded.
+    public struct SpendRow: Sendable, Equatable {
+        /// The originating transaction. For a split allocation this is the parent;
+        /// the allocation does not invent a synthetic transaction, so a consumer
+        /// that still needs the parent's merchant/name/override metadata can read it.
+        public let transaction: TransactionDTO
+        /// The signed amount attributed to this row (Plaid convention: positive =
+        /// money out). For an un-split transaction this equals `transaction.amount`;
+        /// for a split allocation it is the allocation's slice.
+        public let amount: Double
+        /// The budget category for this row. For an un-split transaction this is the
+        /// transaction's own ``TransactionDTO/category`` (which the aggregator may
+        /// still override via metadata/rules); for a split allocation it is the
+        /// allocation's declared category, which **supersedes** the parent category
+        /// and is not subject to per-parent recategorization (the user already chose
+        /// it explicitly when splitting).
+        public let category: SpendingCategory?
+        /// Whether this row was explicitly excluded from budgets at the **split**
+        /// level (the allocation's flag). An un-split row is never split-excluded
+        /// (`false`); its exclusion is still decided downstream by the override
+        /// resolver as before. A split allocation marked excluded drops out of
+        /// rollups regardless of category.
+        public let isSplitExcluded: Bool
+        /// Whether this row originated from a split allocation (vs. a whole
+        /// transaction). Lets a consumer that needs to *bypass* per-parent
+        /// override/rule resolution (because the split already declared the
+        /// category) branch on it.
+        public let isSplitAllocation: Bool
+        /// Stable identity for the row: the parent id for an un-split transaction,
+        /// or `"<txid>#<allocationUUID>"` for a split allocation, so per-row dedup /
+        /// addressing stays unique across a split's parts.
+        public let id: String
+
+        public init(
+            transaction: TransactionDTO,
+            amount: Double,
+            category: SpendingCategory?,
+            isSplitExcluded: Bool,
+            isSplitAllocation: Bool,
+            id: String
+        ) {
+            self.transaction = transaction
+            self.amount = amount
+            self.category = category
+            self.isSplitExcluded = isSplitExcluded
+            self.isSplitAllocation = isSplitAllocation
+            self.id = id
+        }
+
+        /// The row's date — always the parent transaction's date, so a split's
+        /// parts land in the same month/period as the original charge.
+        public var date: String { transaction.date }
+    }
+
+    /// Index a split list by its parent `transaction_id` for O(1) lookup during a
+    /// single aggregation pass. On a duplicate parent id the first split wins
+    /// (deterministic) — a store should never hold two splits for one transaction,
+    /// but the resolver stays total in case it does.
+    public static func index(_ splits: [TransactionSplit]) -> [String: TransactionSplit] {
+        Dictionary(splits.map { ($0.transactionId, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    /// Expand one transaction into its spend rows given a pre-built split index.
+    ///
+    /// Returns a single parent row when the transaction has no split, or an empty/
+    /// invalid split; otherwise one row per allocation. The `splitsByTransactionId`
+    /// index is built once by the caller (see ``index(_:)``) so a full pass stays
+    /// O(transactions + allocations).
+    public static func spendRows(
+        for transaction: TransactionDTO,
+        splitsByTransactionId: [String: TransactionSplit]
+    ) -> [SpendRow] {
+        guard let split = splitsByTransactionId[transaction.id], split.isValid else {
+            return [parentRow(for: transaction)]
+        }
+        return split.allocations.map { allocation in
+            SpendRow(
+                transaction: transaction,
+                amount: allocation.amount,
+                category: allocation.category,
+                isSplitExcluded: allocation.excludedFromBudgets,
+                isSplitAllocation: true,
+                id: "\(transaction.id)#\(allocation.id.uuidString)"
+            )
+        }
+    }
+
+    /// Expand a whole transaction list into split-aware spend rows. With an empty
+    /// `splits` argument (the default), this is exactly one row per transaction,
+    /// each equal to its parent — the byte-identical no-split path.
+    public static func spendRows(
+        from transactions: [TransactionDTO],
+        splits: [TransactionSplit] = []
+    ) -> [SpendRow] {
+        guard !splits.isEmpty else { return transactions.map(parentRow(for:)) }
+        let index = index(splits)
+        return transactions.flatMap { spendRows(for: $0, splitsByTransactionId: index) }
+    }
+
+    /// The single row for an un-split transaction: parent id, parent signed amount,
+    /// parent category, never split-excluded.
+    private static func parentRow(for transaction: TransactionDTO) -> SpendRow {
+        SpendRow(
+            transaction: transaction,
+            amount: transaction.amount,
+            category: transaction.category,
+            isSplitExcluded: false,
+            isSplitAllocation: false,
+            id: transaction.id
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/DataExportBuilderBudgetsTests.swift
+++ b/Tests/PlaidBarCoreTests/DataExportBuilderBudgetsTests.swift
@@ -106,7 +106,9 @@ struct DataExportBuilderBudgetsTests {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
-        #expect(envelope.schemaVersion == 2)
+        // Current envelope schema is 3 (AND-550 added the optional splits array);
+        // the budgets array from AND-645 is unchanged.
+        #expect(envelope.schemaVersion == 3)
         #expect(envelope.counts.budgets == 2)
         // Stable order: sorted by category raw value (FOOD_AND_DRINK first).
         #expect(envelope.budgets.map(\.category) == [.foodAndDrink, .transportation])

--- a/Tests/PlaidBarCoreTests/TransactionSplitTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionSplitTests.swift
@@ -1,0 +1,424 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Transaction splits — one transaction into N category allocations (AND-550).
+///
+/// Covers the model's sum invariant and validity, the resolver's additive
+/// expansion (no split → byte-identical single row; valid split → one row per
+/// part; malformed split → falls back to the parent), and split-aware spend across
+/// the budget/summary consumers — including that **rollups count the parts, not
+/// the parent**, that a per-part exclude flag is honored, and that removing the
+/// split restores the original totals.
+@Suite("Transaction splits (AND-550)")
+struct TransactionSplitTests {
+    private let calendar = Calendar(identifier: .gregorian)
+
+    private func tx(
+        _ id: String,
+        _ amount: Double,
+        _ date: String,
+        _ category: SpendingCategory?,
+        name: String = "Target"
+    ) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acct",
+            amount: amount,
+            date: date,
+            name: name,
+            category: category,
+            pending: false
+        )
+    }
+
+    // MARK: - Model: the sum invariant
+
+    @Test("A split whose parts sum to the parent amount is balanced and valid")
+    func balancedSplitIsValid() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60),
+            ]
+        )
+        #expect(split.allocatedTotal == 150)
+        #expect(split.unallocatedRemainder == 0)
+        #expect(split.isBalanced())
+        #expect(split.isValid)
+    }
+
+    @Test("A split whose parts do NOT sum to the parent amount is unbalanced and invalid")
+    func unbalancedSplitIsInvalid() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 40), // sums to 130
+            ]
+        )
+        #expect(split.allocatedTotal == 130)
+        #expect(split.unallocatedRemainder == 20)
+        #expect(!split.isBalanced())
+        #expect(!split.isValid)
+    }
+
+    @Test("Sub-cent float drift still balances within tolerance")
+    func subCentDriftBalances() {
+        // 100 / 3 thirds: 33.34 + 33.33 + 33.33 = 100.00 exactly here, but use a
+        // case that drifts: three 33.333… parts rounded.
+        let parent = tx("t1", 100, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 33.34),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 33.33),
+                TransactionSplitAllocation(category: .travel, amount: 33.33),
+            ]
+        )
+        #expect(split.isBalanced()) // within the one-cent tolerance
+        #expect(split.isValid)
+    }
+
+    @Test("An empty split is never balanced or valid")
+    func emptySplitIsInvalid() {
+        let split = TransactionSplit(transactionId: "t1", expectedTotal: 150, allocations: [])
+        #expect(!split.isBalanced())
+        #expect(!split.isValid)
+    }
+
+    @Test("evenSplit divides the parent exactly across two categories")
+    func evenSplitIsBalanced() {
+        let parent = tx("t1", 75.01, "2026-06-04", .shopping)
+        let split = TransactionSplit.evenSplit(of: parent, between: .foodAndDrink, and: .homeImprovement)
+        #expect(split.allocations.count == 2)
+        // The two parts sum back to the parent to the cent (the first part absorbs
+        // the rounding remainder).
+        #expect(abs(split.allocatedTotal - 75.01) < 0.005)
+        #expect(split.isValid)
+    }
+
+    @Test("A refund (negative parent) splits with negative parts")
+    func negativeParentSplits() {
+        let parent = tx("t1", -50, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: -30),
+                TransactionSplitAllocation(category: .homeImprovement, amount: -20),
+            ]
+        )
+        #expect(split.allocatedTotal == -50)
+        #expect(split.isValid)
+    }
+
+    // MARK: - Resolver: additive expansion
+
+    @Test("No split yields exactly one row identical to the parent")
+    func noSplitYieldsParentRow() throws {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let rows = TransactionSplitResolver.spendRows(from: [parent], splits: [])
+        #expect(rows.count == 1)
+        let row = try #require(rows.first)
+        #expect(row.id == "t1")
+        #expect(row.amount == 150)
+        #expect(row.category == .shopping)
+        #expect(!row.isSplitAllocation)
+        #expect(!row.isSplitExcluded)
+        #expect(row.date == "2026-06-04")
+    }
+
+    @Test("A valid split yields one row per allocation, none for the parent")
+    func validSplitYieldsAllocationRows() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60, excludedFromBudgets: true),
+            ]
+        )
+        let rows = TransactionSplitResolver.spendRows(from: [parent], splits: [split])
+        #expect(rows.count == 2)
+        let allAllocations = rows.allSatisfy { $0.isSplitAllocation }
+        #expect(allAllocations)
+        // Each row carries its own category + amount + exclude flag.
+        #expect(rows[0].category == .foodAndDrink)
+        #expect(rows[0].amount == 90)
+        #expect(!rows[0].isSplitExcluded)
+        #expect(rows[1].category == .homeImprovement)
+        #expect(rows[1].amount == 60)
+        #expect(rows[1].isSplitExcluded)
+        // Rows have unique ids namespaced under the parent.
+        #expect(Set(rows.map(\.id)).count == 2)
+        let allPrefixed = rows.allSatisfy { $0.id.hasPrefix("t1#") }
+        #expect(allPrefixed)
+    }
+
+    @Test("A malformed (unbalanced) split falls back to the single parent row")
+    func malformedSplitFallsBackToParent() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let badSplit = TransactionSplit(
+            splitting: parent,
+            into: [TransactionSplitAllocation(category: .foodAndDrink, amount: 90)] // 90 != 150
+        )
+        let rows = TransactionSplitResolver.spendRows(from: [parent], splits: [badSplit])
+        #expect(rows.count == 1)
+        #expect(rows[0].category == .shopping) // parent category, not the bad allocation
+        #expect(rows[0].amount == 150)
+        #expect(!rows[0].isSplitAllocation)
+    }
+
+    // MARK: - Split-aware spend: rollups count parts, not the parent
+
+    @Test("Override-aware spend buckets each allocation under its own category")
+    func splitSpendCountsParts() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60),
+            ]
+        )
+
+        let spend = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent],
+            month: "2026-06",
+            splits: [split],
+            calendar: calendar
+        )
+
+        // The parent's own SHOPPING bucket is gone; the two parts are counted.
+        #expect(spend[.shopping] == nil)
+        #expect(spend[.foodAndDrink] == 90)
+        #expect(spend[.homeImprovement] == 60)
+        // Total spend is conserved (the sum invariant): 90 + 60 == the parent 150.
+        #expect(spend.values.reduce(0, +) == 150)
+    }
+
+    @Test("A per-allocation exclude flag drops just that part, keeping the rest")
+    func splitAllocationExcludeIsHonored() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60, excludedFromBudgets: true),
+            ]
+        )
+
+        let spend = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent],
+            month: "2026-06",
+            splits: [split],
+            calendar: calendar
+        )
+
+        #expect(spend[.foodAndDrink] == 90)
+        // The excluded part contributes nothing, even though its category is valid.
+        #expect(spend[.homeImprovement] == nil)
+        #expect(spend.values.reduce(0, +) == 90)
+    }
+
+    @Test("A split into a transfer/income category never counts as spend")
+    func splitIntoExcludedCategoryDropsOut() {
+        let parent = tx("t1", 200, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 120),
+                TransactionSplitAllocation(category: .transfer, amount: 80), // own-account move
+            ]
+        )
+
+        let spend = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent],
+            month: "2026-06",
+            splits: [split],
+            calendar: calendar
+        )
+
+        #expect(spend[.foodAndDrink] == 120)
+        #expect(spend[.transfer] == nil) // transfers are never spend
+    }
+
+    // MARK: - Editing/removing a split restores the original
+
+    @Test("Removing the split restores the parent's original single-category spend")
+    func removingSplitRestoresOriginal() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60),
+            ]
+        )
+
+        // With the split, spend is split across two categories.
+        let withSplit = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent], month: "2026-06", splits: [split], calendar: calendar
+        )
+        #expect(withSplit[.shopping] == nil)
+
+        // Remove the split (pass none) → identical to never having split.
+        let withoutSplit = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent], month: "2026-06", splits: [], calendar: calendar
+        )
+        let original = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: [parent], month: "2026-06", calendar: calendar
+        )
+        #expect(withoutSplit == original)
+        #expect(withoutSplit[.shopping] == 150)
+        #expect(withoutSplit[.foodAndDrink] == nil)
+    }
+
+    @Test("replacingAllocations re-balances against the same expected total")
+    func replacingAllocationsRebalances() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [TransactionSplitAllocation(category: .foodAndDrink, amount: 150)]
+        )
+        #expect(split.isValid)
+        let edited = split.replacingAllocations([
+            TransactionSplitAllocation(category: .foodAndDrink, amount: 100),
+            TransactionSplitAllocation(category: .travel, amount: 50),
+        ])
+        #expect(edited.expectedTotal == 150)
+        #expect(edited.isValid)
+        #expect(edited.allocations.count == 2)
+    }
+
+    // MARK: - v1-safety: no split = byte-identical across consumers
+
+    @Test("With no splits, override-aware spend is byte-identical to the no-split call")
+    func noSplitSpendIsByteIdentical() {
+        let transactions = [
+            tx("t1", 150, "2026-06-04", .shopping),
+            tx("t2", 40, "2026-06-05", .foodAndDrink),
+            tx("t3", -1000, "2026-06-06", .income, name: "Payroll"),
+        ]
+        let metadata = [TransactionReviewMetadata(id: "t1", userCategory: .travel)]
+
+        let withEmptySplits = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: transactions, month: "2026-06", metadata: metadata, splits: [], calendar: calendar
+        )
+        let withoutSplitsParam = CategoryBudgetPlanner.overrideAwareSpend(
+            transactions: transactions, month: "2026-06", metadata: metadata, calendar: calendar
+        )
+        #expect(withEmptySplits == withoutSplitsParam)
+        // And the override still moves t1's spend (no split interferes).
+        #expect(withEmptySplits[.travel] == 150)
+        #expect(withEmptySplits[.foodAndDrink] == 40)
+        #expect(withEmptySplits[.income] == nil)
+    }
+
+    @Test("SpendingSummary.spendingByCategory is split-aware and unchanged without splits")
+    func summaryIsSplitAware() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60),
+            ]
+        )
+
+        // Without splits → one SHOPPING bucket of 150 (legacy).
+        let legacy = SpendingSummary.spendingByCategory(from: [parent])
+        #expect(legacy.count == 1)
+        #expect(legacy.first?.0 == .shopping)
+        #expect(legacy.first?.1 == 150)
+
+        // With the split → two buckets, parts counted, total conserved.
+        let split150 = SpendingSummary.spendingByCategory(from: [parent], splits: [split])
+        let byCategory = Dictionary(uniqueKeysWithValues: split150)
+        #expect(byCategory[.shopping] == nil)
+        #expect(byCategory[.foodAndDrink] == 90)
+        #expect(byCategory[.homeImprovement] == 60)
+        #expect(split150.reduce(0) { $0 + $1.1 } == 150)
+    }
+
+    // MARK: - Exports respect splits
+
+    @Test("splitsCSV emits one row per allocation, joined by transaction_id")
+    func splitsCSVEmitsPerAllocationRows() {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60, excludedFromBudgets: true),
+            ]
+        )
+        let csv = DataExportBuilder.splitsCSV([split])
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: true)
+        // header + 2 allocation rows
+        #expect(lines.count == 3)
+        #expect(lines[1].contains("t1"))
+        #expect(lines[1].contains("FOOD_AND_DRINK"))
+        #expect(lines[1].contains("90.00"))
+        #expect(lines[2].contains("HOME_IMPROVEMENT"))
+        #expect(lines[2].contains("true")) // the excluded flag
+    }
+
+    @Test("The JSON envelope carries splits and round-trips them")
+    func envelopeRoundTripsSplits() throws {
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .homeImprovement, amount: 60),
+            ]
+        )
+        let data = try DataExportBuilder.combinedJSON(
+            accounts: [],
+            transactions: [parent],
+            balanceHistory: [],
+            splits: [split],
+            exportedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(DataExportBuilder.Envelope.self, from: data)
+        #expect(envelope.schemaVersion == 3)
+        #expect(envelope.counts.splits == 1)
+        #expect(envelope.splits.count == 1)
+        #expect(envelope.splits.first?.transactionId == "t1")
+        #expect(envelope.splits.first?.allocations.count == 2)
+        #expect(envelope.splits.first?.isValid == true)
+    }
+
+    @Test("A v2 envelope without splits decodes as empty (backward compatible)")
+    func decodesV2EnvelopeWithoutSplits() throws {
+        // A schemaVersion-2 backup written before AND-550 has no `splits` key and no
+        // `counts.splits`. It must still decode cleanly with empty splits.
+        let legacyJSON = """
+        {
+          "schemaVersion": 2,
+          "exportedAt": "2026-06-24T00:00:00Z",
+          "environment": "sandbox",
+          "counts": { "accounts": 0, "transactions": 0, "balanceHistory": 0, "budgets": 0 },
+          "accounts": [],
+          "transactions": [],
+          "balanceHistory": [],
+          "budgets": []
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(
+            DataExportBuilder.Envelope.self,
+            from: Data(legacyJSON.utf8)
+        )
+        #expect(envelope.schemaVersion == 2)
+        #expect(envelope.splits.isEmpty)
+        #expect(envelope.counts.splits == 0)
+    }
+}

--- a/Tests/PlaidBarCoreTests/TransactionSplitTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionSplitTests.swift
@@ -344,6 +344,44 @@ struct TransactionSplitTests {
         #expect(split150.reduce(0) { $0 + $1.1 } == 150)
     }
 
+    @Test("A transfer/income split allocation is excluded from the summary (budget parity)")
+    func transferSplitAllocationIsExcludedFromSummary() {
+        // One purchase split into a real spend part, a transfer part, and an
+        // income part. Only the spend part should count — mirroring
+        // `CategoryBudgetPlanner.netSpendByCategory`, whose split branch drops
+        // `excludedCategories = [.income, .transfer, .transferOut]`.
+        let parent = tx("t1", 150, "2026-06-04", .shopping)
+        let split = TransactionSplit(
+            splitting: parent,
+            into: [
+                TransactionSplitAllocation(category: .foodAndDrink, amount: 90),
+                TransactionSplitAllocation(category: .transfer, amount: 40),
+                TransactionSplitAllocation(category: .income, amount: 20),
+            ]
+        )
+
+        // Legacy path (no metadata/rules): transfer/income allocations drop out.
+        let legacy = SpendingSummary.spendingByCategory(from: [parent], splits: [split])
+        let legacyByCategory = Dictionary(uniqueKeysWithValues: legacy)
+        #expect(legacyByCategory[.foodAndDrink] == 90)
+        #expect(legacyByCategory[.transfer] == nil)
+        #expect(legacyByCategory[.income] == nil)
+        #expect(legacy.reduce(0) { $0 + $1.1 } == 90)
+
+        // Override path (metadata supplied): same exclusion — the split
+        // allocation bypasses per-parent resolution but still drops transfers.
+        let override = SpendingSummary.spendingByCategory(
+            from: [parent],
+            metadata: [],
+            splits: [split]
+        )
+        let overrideByCategory = Dictionary(uniqueKeysWithValues: override)
+        #expect(overrideByCategory[.foodAndDrink] == 90)
+        #expect(overrideByCategory[.transfer] == nil)
+        #expect(overrideByCategory[.income] == nil)
+        #expect(override.reduce(0) { $0 + $1.1 } == 90)
+    }
+
     // MARK: - Exports respect splits
 
     @Test("splitsCSV emits one row per allocation, joined by transaction_id")


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.**

## What & why

AND-399 explicitly cut transaction splits from v1 as "invasive to the transaction model." This PR re-opens that scope under the deferred budgeting-v2 epic (AND-524): split a single transaction into N category allocations (e.g. a Target run = Groceries + Home), so spend lands in the right buckets instead of one catch-all category.

The hard constraint is **additivity**: this touches every consumer of `TransactionDTO` spend (budgets, summaries, exports), so a user who does not split anything must see **byte-identical** prior behavior. The implementation is a child-allocation model layered on top of the parent transaction — the parent is never mutated, re-keyed, or removed.

## Change

All logic lives in `PlaidBarCore` (pure, `Sendable`, no I/O, no hidden `Date()`):

- **Model — `Models/TransactionSplit.swift`**: `TransactionSplit` (keyed by parent `transaction_id`) + `TransactionSplitAllocation` (own category + own signed amount + own exclude flag). The defining **sum invariant** — allocations sum to the parent amount within a cent — is enforced by `isBalanced(tolerance:)` / `isValid`. An empty or unbalanced split is not valid.
- **Resolver — `Utilities/TransactionSplitResolver.swift`**: the single additive seam every spend consumer routes through. `spendRows(for:)` returns:
  - **no split** → exactly one parent row, byte-identical to today;
  - **valid split** → one row per allocation, so **rollups count the parts, not the parent** (total spend is conserved because the parts sum to the parent);
  - **malformed split** → falls back to the parent row, so **editing/removing a split restores the original** automatically.
- **Split-aware spend** (optional `splits:` param, defaults to empty):
  - `CategoryBudgetPlanner` — `overrideAwareSpend` / `presentation` / `mergedPresentation` / internal `netSpendByCategory`.
  - `SpendingSummary` — `spendingByCategory` / `periodSummary`.
  - A split allocation buckets by its **own** declared category (the user chose it explicitly when splitting, so it bypasses per-parent override/rule resolution), honors its own exclude flag, and never counts income/transfer categories.
- **Exports respect splits** — `DataExportBuilder.splitsCSV` (one row per allocation, joined by `transaction_id`; the transactions CSV keeps its one-row-per-transaction contract) and an additive `splits` array in the JSON envelope (`schemaVersion` bumped 2 → 3; decodes as empty from older backups).

Persistence (an app-only `PlaidBarCache` store) and the editor UI are intentionally out of scope here — this PR is the model + the split-aware spend math + exports, matching how AND-546 landed the schema foundation.

## Testing

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete!

swift test --filter TransactionSplitTests
# → Suite "Transaction splits (AND-550)" passed — 19 tests

swift test
# → Test run with 2408 tests passed

git diff --check
# → clean
```

New suite `TransactionSplitTests` covers: the sum invariant (balanced/unbalanced/empty/sub-cent drift/negative refund), resolver expansion (no-split single row, valid-split per-allocation rows, malformed fallback), split-aware spend (rollups count parts, total conserved, per-part exclude honored, transfer/income parts dropped), restore-on-remove, and v1-safety (no-split spend is byte-identical; legacy JSON envelope decodes with empty splits).

## Links

Closes AND-550

## Follow-ups

- Persistence: an opt-in `PlaidBarCache` split store (mirrors `BudgetingV2Store`) + wiring splits into the app's spend calls.
- Editor UI: a split sheet in the Transaction Workspace inspector (`evenSplit` is provided as a seed/default).
- Review engine: surface a split badge / route split rows through the Review Inbox display (the inbox already groups by raw category; a split-aware inbox view is a separate surface).
- Charts: thread `splits` into the dashboard chart aggregations that call `SpendingSummary`.
