### PR TITLE
feat(budgeting): rebalance — redistribute budget within a fixed total (AND-549)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/BudgetRebalancePlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetRebalancePlanner.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+/// Pure, deterministic budget **rebalance** math for budgeting v2
+/// (AND-549 — deferred epic AND-524).
+///
+/// ## What this adds on top of AND-546 / AND-548
+///
+/// AND-546 persists ``MonthlyBudgetV2`` rows keyed by `(month, category)`; AND-548
+/// (``RolloverBudgetPlanner`` / ``MonthlyBudgetEditor``) adds the per-month carry
+/// math and immutability-aware editing. This planner is Copilot's **Rebalance**:
+/// move budget *from* an under-spent category *to* an over-spent one **within a
+/// single month, keeping that month's total budget constant**. It only ever
+/// reshuffles the existing `monthlyLimit` values for one month — it never changes
+/// the sum, never touches spend, and never edits a frozen historical month.
+///
+/// ## The invariant (AC 1)
+///
+/// A rebalance moves an amount `X` from a source category to a destination
+/// category for one `month`:
+///
+/// ```text
+/// source.monthlyLimit -= X
+/// dest.monthlyLimit   += X
+/// ```
+///
+/// so the month's total budget (`Σ monthlyLimit` over that month's rows) is
+/// **provably unchanged** — every applied move is `+X` and `−X` on the same total.
+/// ``apply(_:to:asOf:)`` enforces this exactly; ``BudgetRebalanceMove/amount`` is
+/// validated `> 0`, finite, and `<= source.monthlyLimit` so a source can never go
+/// negative and the conservation holds bit-for-bit.
+///
+/// ## Suggestions (AC 2)
+///
+/// ``suggestRebalances(...)`` proposes moves from categories with a **surplus**
+/// (limit comfortably above the month's override-aware spend) toward categories
+/// **trending over** (spend already above, or projected to exceed, the limit). It
+/// is greedy and total-preserving: it pulls only from real surplus and gives only
+/// what closes a real overage, so applying every suggestion leaves the month total
+/// unchanged. Suggestions are read-only proposals — nothing is mutated until the
+/// user applies a move.
+///
+/// ## Undo (AC 3)
+///
+/// Every applied ``BudgetRebalanceMove`` has an exact inverse
+/// (``BudgetRebalanceMove/inverse``: swap source/dest, same amount). Re-applying
+/// the inverse restores the pre-move limits **byte-for-byte**, so a rebalance is
+/// fully undoable and the dashboard reflects either state immediately (the result
+/// is just a new ``BudgetingV2Schema`` the read model re-renders from).
+///
+/// ## Determinism
+///
+/// Like ``RolloverBudgetPlanner`` and ``CategoryBudgetPlanner``, there is no hidden
+/// `Date()`: editability is gated by the explicit `asOf` month key, and spend is
+/// supplied by the caller (typically via
+/// ``CategoryBudgetPlanner/overrideAwareSpend(transactions:month:metadata:rules:calendar:)``).
+/// Every result is reproducible in `PlaidBarCore` unit tests.
+public enum BudgetRebalancePlanner {
+
+    // MARK: - Move
+
+    /// A single total-preserving rebalance: move `amount` of budget from
+    /// `sourceCategoryId` to `destinationCategoryId` for `month`. Pure value type;
+    /// `Sendable`. This is also the **undo token** — keep it to reverse the move via
+    /// ``inverse``.
+    public struct BudgetRebalanceMove: Codable, Sendable, Hashable, Identifiable {
+        /// The `YYYY-MM` month this move applies to. A rebalance is always within one
+        /// month so the month total is conserved.
+        public let month: String
+        /// The category budget is pulled *from* (``BudgetCategoryV2/id``).
+        public let sourceCategoryId: String
+        /// The category budget is pushed *to* (``BudgetCategoryV2/id``).
+        public let destinationCategoryId: String
+        /// The amount moved, in the account's display currency. Always `> 0`;
+        /// direction is encoded by source/destination, not by sign.
+        public let amount: Double
+
+        /// Stable identity — one move per `(month, source→dest, amount)`.
+        public var id: String {
+            "\(month)|\(sourceCategoryId)>\(destinationCategoryId)|\(amount)"
+        }
+
+        public init(
+            month: String,
+            sourceCategoryId: String,
+            destinationCategoryId: String,
+            amount: Double
+        ) {
+            self.month = month
+            self.sourceCategoryId = sourceCategoryId
+            self.destinationCategoryId = destinationCategoryId
+            self.amount = amount
+        }
+
+        /// The exact inverse move — swap source and destination, same amount. Applying
+        /// a move then its inverse restores the original limits byte-for-byte, which is
+        /// how undo (AC 3) round-trips losslessly.
+        public var inverse: BudgetRebalanceMove {
+            BudgetRebalanceMove(
+                month: month,
+                sourceCategoryId: destinationCategoryId,
+                destinationCategoryId: sourceCategoryId,
+                amount: amount
+            )
+        }
+    }
+
+    // MARK: - Apply result
+
+    /// Outcome of applying a rebalance move: the (possibly unchanged) schema, whether
+    /// the move applied, and — when it applied — the undo token to reverse it.
+    /// `applied == false` means the move was rejected (frozen month, missing/invalid
+    /// row, or an amount that would push the source negative) and the schema is
+    /// byte-identical to the input.
+    public struct ApplyResult: Sendable, Hashable {
+        public let schema: BudgetingV2Schema
+        public let applied: Bool
+        /// The token to undo this move, present only when `applied`. Re-apply it via
+        /// ``BudgetRebalancePlanner/apply(_:to:asOf:)`` to restore the prior limits.
+        public let undo: BudgetRebalanceMove?
+
+        public init(schema: BudgetingV2Schema, applied: Bool, undo: BudgetRebalanceMove?) {
+            self.schema = schema
+            self.applied = applied
+            self.undo = undo
+        }
+    }
+
+    // MARK: - Apply (AC 1 + AC 3)
+
+    /// Apply a total-preserving rebalance `move` to `schema` for `move.month`,
+    /// validating the conservation invariant and historical immutability.
+    ///
+    /// The move is rejected (no-op, `applied == false`, schema byte-identical) when:
+    /// - `move.month` is frozen history as of `asOf`
+    ///   (``RolloverBudgetPlanner/isMonthEditable(_:asOf:)``);
+    /// - source and destination are the same category (a no-op move);
+    /// - `amount` is not finite or not `> 0`;
+    /// - either category has no budget row for `month` (you can only move budget
+    ///   between two *budgeted* categories — there is no limit to pull from or a
+    ///   well-defined limit to add to otherwise);
+    /// - `amount` exceeds the source row's `monthlyLimit` (a source limit can never
+    ///   go negative — that would break conservation against a clamped floor).
+    ///
+    /// On success the source row's limit drops by `amount` and the destination's
+    /// rises by `amount`, so the month total is unchanged, and the returned
+    /// ``ApplyResult/undo`` is the inverse move.
+    ///
+    /// - Parameters:
+    ///   - move: the rebalance to apply.
+    ///   - schema: the current v2 snapshot.
+    ///   - asOf: the current `YYYY-MM` (injected "now") gating editability.
+    public static func apply(
+        _ move: BudgetRebalanceMove,
+        to schema: BudgetingV2Schema,
+        asOf: String
+    ) -> ApplyResult {
+        guard
+            RolloverBudgetPlanner.isMonthEditable(move.month, asOf: asOf),
+            move.sourceCategoryId != move.destinationCategoryId,
+            move.amount.isFinite,
+            move.amount > 0
+        else {
+            return ApplyResult(schema: schema, applied: false, undo: nil)
+        }
+
+        // Both endpoints must already be budgeted for the month.
+        guard
+            let sourceRow = row(in: schema, month: move.month, categoryId: move.sourceCategoryId),
+            let destinationRow = row(
+                in: schema, month: move.month, categoryId: move.destinationCategoryId
+            )
+        else {
+            return ApplyResult(schema: schema, applied: false, undo: nil)
+        }
+
+        // Conservation guard: the source limit can never go negative.
+        guard move.amount <= sourceRow.monthlyLimit else {
+            return ApplyResult(schema: schema, applied: false, undo: nil)
+        }
+
+        let updatedSource = MonthlyBudgetV2(
+            month: sourceRow.month,
+            categoryId: sourceRow.categoryId,
+            monthlyLimit: sourceRow.monthlyLimit - move.amount,
+            rollover: sourceRow.rollover
+        )
+        let updatedDestination = MonthlyBudgetV2(
+            month: destinationRow.month,
+            categoryId: destinationRow.categoryId,
+            monthlyLimit: destinationRow.monthlyLimit + move.amount,
+            rollover: destinationRow.rollover
+        )
+
+        var budgets = schema.budgets.filter { budget in
+            !(budget.month == move.month
+                && (budget.categoryId == move.sourceCategoryId
+                    || budget.categoryId == move.destinationCategoryId))
+        }
+        budgets.append(updatedSource)
+        budgets.append(updatedDestination)
+        budgets.sort { lhs, rhs in
+            lhs.month != rhs.month ? lhs.month < rhs.month : lhs.categoryId < rhs.categoryId
+        }
+
+        return ApplyResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true,
+            undo: move.inverse
+        )
+    }
+
+    // MARK: - Suggestions (AC 2)
+
+    /// A proposed rebalance plus the surplus/overage context that justified it, so
+    /// the UI can explain *why* (never communicate the source/destination roles by
+    /// color alone). Pure value type; `Sendable`.
+    public struct RebalanceSuggestion: Sendable, Hashable, Identifiable {
+        /// The total-preserving move this suggestion would apply.
+        public let move: BudgetRebalanceMove
+        /// The source category's surplus before the move (`limit - spend`, `> 0`).
+        public let sourceSurplus: Double
+        /// The destination category's overage before the move (`spend - limit`,
+        /// `> 0`) — how far over it is trending.
+        public let destinationOverage: Double
+
+        public var id: String { move.id }
+
+        public init(
+            move: BudgetRebalanceMove,
+            sourceSurplus: Double,
+            destinationOverage: Double
+        ) {
+            self.move = move
+            self.sourceSurplus = sourceSurplus
+            self.destinationOverage = destinationOverage
+        }
+    }
+
+    /// Default share of a category's surplus a single suggestion is willing to pull,
+    /// leaving a cushion so a "surplus" category isn't drained to the bone. `0.5`
+    /// keeps half the headroom in place.
+    public static let defaultMaxSurplusFraction = 0.5
+
+    /// Suggest total-preserving rebalances for `month`: pull from categories with a
+    /// **surplus** (limit comfortably above spend) toward categories **trending
+    /// over** (spend above limit).
+    ///
+    /// Greedy and conservation-safe by construction: each suggested move pulls only
+    /// from real surplus (capped at ``defaultMaxSurplusFraction`` of the source's
+    /// headroom, configurable) and gives only what closes the destination's overage,
+    /// so applying every suggestion never changes the month total. Sources are spent
+    /// most-surplus-first; destinations are filled most-over-first; ties break by
+    /// category id for determinism.
+    ///
+    /// - Parameters:
+    ///   - schema: the current v2 snapshot (its `month` rows define the limits).
+    ///   - month: the `YYYY-MM` to rebalance.
+    ///   - spendByCategory: override-aware net spend per category id for `month`
+    ///     (typically from ``CategoryBudgetPlanner/overrideAwareSpend(transactions:month:metadata:rules:calendar:)``,
+    ///     keyed by ``BudgetCategoryV2/id``). A missing category is treated as `0`
+    ///     spend (pure surplus).
+    ///   - asOf: the current `YYYY-MM`; suggestions are only produced for an editable
+    ///     month (a frozen month yields none).
+    ///   - maxSurplusFraction: the share of a source's surplus a single suggestion may
+    ///     pull. Defaults to ``defaultMaxSurplusFraction``.
+    /// - Returns: suggested moves, destination-overage-first; empty when there is no
+    ///   surplus, no overage, or the month is frozen.
+    public static func suggestRebalances(
+        in schema: BudgetingV2Schema,
+        month: String,
+        spendByCategory: [String: Double],
+        asOf: String,
+        maxSurplusFraction: Double = defaultMaxSurplusFraction
+    ) -> [RebalanceSuggestion] {
+        guard
+            RolloverBudgetPlanner.isMonthEditable(month, asOf: asOf),
+            maxSurplusFraction.isFinite,
+            maxSurplusFraction > 0
+        else { return [] }
+
+        let monthRows = schema.budgets.filter { $0.month == month && $0.monthlyLimit > 0 }
+        guard !monthRows.isEmpty else { return [] }
+
+        // Sources: categories under budget, ranked by how much we may pull (a cushion
+        // share of the surplus). Destinations: categories over budget, ranked by how
+        // far over. Both deterministic (amount desc, then category id asc).
+        var sources: [(categoryId: String, available: Double)] = []
+        var destinations: [(categoryId: String, overage: Double)] = []
+
+        for row in monthRows {
+            let spend = spendByCategory[row.categoryId] ?? 0
+            let remaining = row.monthlyLimit - spend
+            if remaining > 0 {
+                // Pull at most a fraction of the surplus, but never more than the limit.
+                let pullable = min(remaining * maxSurplusFraction, row.monthlyLimit)
+                if pullable > 0 {
+                    sources.append((row.categoryId, pullable))
+                }
+            } else if remaining < 0 {
+                destinations.append((row.categoryId, -remaining))
+            }
+        }
+
+        guard !sources.isEmpty, !destinations.isEmpty else { return [] }
+
+        sources.sort { lhs, rhs in
+            lhs.available != rhs.available
+                ? lhs.available > rhs.available
+                : lhs.categoryId < rhs.categoryId
+        }
+        destinations.sort { lhs, rhs in
+            lhs.overage != rhs.overage
+                ? lhs.overage > rhs.overage
+                : lhs.categoryId < rhs.categoryId
+        }
+
+        // Original surplus/overage for the suggestion's explanatory context, captured
+        // before the greedy walk consumes the running pools.
+        var sourceSurplusById: [String: Double] = [:]
+        for source in sources { sourceSurplusById[source.categoryId] = source.available }
+        var destinationOverageById: [String: Double] = [:]
+        for destination in destinations {
+            destinationOverageById[destination.categoryId] = destination.overage
+        }
+
+        var suggestions: [RebalanceSuggestion] = []
+        var sourceIndex = 0
+        var remainingBySource = sources.map(\.available)
+        var remainingNeedByDest = destinations.map(\.overage)
+
+        for destinationIndex in destinations.indices {
+            var need = remainingNeedByDest[destinationIndex]
+            let destinationId = destinations[destinationIndex].categoryId
+
+            while need > 0, sourceIndex < sources.count {
+                let available = remainingBySource[sourceIndex]
+                let sourceId = sources[sourceIndex].categoryId
+
+                // A source can't fund its own overage (it's a source *because* it has
+                // surplus, so it never appears as a destination) — no self-move guard
+                // needed beyond the available pool. Skip a drained source.
+                guard available > 0 else { sourceIndex += 1; continue }
+
+                let move = min(available, need)
+                suggestions.append(
+                    RebalanceSuggestion(
+                        move: BudgetRebalanceMove(
+                            month: month,
+                            sourceCategoryId: sourceId,
+                            destinationCategoryId: destinationId,
+                            amount: move
+                        ),
+                        sourceSurplus: sourceSurplusById[sourceId] ?? move,
+                        destinationOverage: destinationOverageById[destinationId] ?? move
+                    )
+                )
+                remainingBySource[sourceIndex] = available - move
+                need -= move
+                if remainingBySource[sourceIndex] <= 0 { sourceIndex += 1 }
+            }
+
+            remainingNeedByDest[destinationIndex] = need
+            if sourceIndex >= sources.count { break }
+        }
+
+        return suggestions
+    }
+
+    // MARK: - Totals (invariant helper)
+
+    /// The total budget for `month`: `Σ monthlyLimit` over that month's rows. Exposed
+    /// so callers (and tests) can assert the rebalance invariant — this value is
+    /// unchanged by every ``apply(_:to:asOf:)`` that applied.
+    public static func monthTotal(in schema: BudgetingV2Schema, month: String) -> Double {
+        schema.budgets.reduce(0) { partial, budget in
+            budget.month == month ? partial + budget.monthlyLimit : partial
+        }
+    }
+
+    // MARK: - Internals
+
+    /// The budget row for `(month, categoryId)` in `schema`, or `nil` if the category
+    /// is not budgeted that month. Last-wins on a malformed duplicate, matching
+    /// ``MonthlyBudgetEditor``'s upsert contract.
+    static func row(
+        in schema: BudgetingV2Schema,
+        month: String,
+        categoryId: String
+    ) -> MonthlyBudgetV2? {
+        schema.budgets.last { $0.month == month && $0.categoryId == categoryId }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/MonthlyBudgetEditor.swift
+++ b/Sources/PlaidBarCore/Utilities/MonthlyBudgetEditor.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Pure, deterministic per-month budget editing for budgeting v2 (AND-548).
+///
+/// The carry math lives in ``RolloverBudgetPlanner``; this is the small companion
+/// that *mutates the stored set* of ``MonthlyBudgetV2`` rows while enforcing the
+/// AC's immutability rule: **historical months are frozen, the current and future
+/// months are editable**. Every entry point returns a new ``BudgetingV2Schema``
+/// (value semantics) and leaves the input untouched, so it stays `Sendable` and
+/// trivially testable — no hidden `Date()`; "now" is the explicit `asOf` month key.
+///
+/// Editing a frozen historical month is rejected by returning the schema unchanged
+/// (a no-op), so a stale UI action can never rewrite history. Whether a month is
+/// editable is decided by ``RolloverBudgetPlanner/isMonthEditable(_:asOf:)`` — the
+/// single source of truth shared with the editor's enable/disable state.
+public enum MonthlyBudgetEditor {
+
+    /// The outcome of an edit attempt: the (possibly unchanged) schema plus whether
+    /// the edit was applied. `applied == false` means the target month was frozen
+    /// history and the schema is byte-identical to the input.
+    public struct EditResult: Sendable, Hashable {
+        public let schema: BudgetingV2Schema
+        public let applied: Bool
+
+        public init(schema: BudgetingV2Schema, applied: Bool) {
+            self.schema = schema
+            self.applied = applied
+        }
+    }
+
+    /// Upsert a per-month limit (and rollover flag) for one category, but only when
+    /// `month` is editable as of `asOf` (current or future). A frozen historical
+    /// month is a no-op.
+    ///
+    /// - Parameters:
+    ///   - schema: the current v2 snapshot.
+    ///   - categoryId: the ``BudgetCategoryV2/id`` to budget. Must exist in the
+    ///     schema's category table; an unknown id is rejected (no-op) so a budget can
+    ///     never reference a missing category.
+    ///   - month: the `YYYY-MM` month to set.
+    ///   - monthlyLimit: the new limit. A non-finite or negative value is rejected
+    ///     (no-op) — a budget limit is `>= 0`.
+    ///   - rollover: whether this month's remainder carries into the next month.
+    ///   - asOf: the current `YYYY-MM` (injected "now").
+    /// - Returns: the updated schema and whether the edit applied.
+    public static func setBudget(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        month: String,
+        monthlyLimit: Double,
+        rollover: Bool,
+        asOf: String
+    ) -> EditResult {
+        guard
+            RolloverBudgetPlanner.isMonthEditable(month, asOf: asOf),
+            monthlyLimit.isFinite,
+            monthlyLimit >= 0,
+            schema.category(id: categoryId) != nil
+        else {
+            return EditResult(schema: schema, applied: false)
+        }
+
+        let updatedRow = MonthlyBudgetV2(
+            month: month,
+            categoryId: categoryId,
+            monthlyLimit: monthlyLimit,
+            rollover: rollover
+        )
+
+        var budgets = schema.budgets.filter {
+            !($0.month == month && $0.categoryId == categoryId)
+        }
+        budgets.append(updatedRow)
+        budgets.sort { lhs, rhs in
+            lhs.month != rhs.month ? lhs.month < rhs.month : lhs.categoryId < rhs.categoryId
+        }
+
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+
+    /// Remove a category's budget for `month`, but only when `month` is editable as
+    /// of `asOf`. A frozen historical month is a no-op. Removing a row that doesn't
+    /// exist still reports `applied == true` (the post-state is "no budget for that
+    /// month", which is what was asked) but leaves the schema otherwise equal.
+    public static func removeBudget(
+        in schema: BudgetingV2Schema,
+        categoryId: String,
+        month: String,
+        asOf: String
+    ) -> EditResult {
+        guard RolloverBudgetPlanner.isMonthEditable(month, asOf: asOf) else {
+            return EditResult(schema: schema, applied: false)
+        }
+        let budgets = schema.budgets.filter {
+            !($0.month == month && $0.categoryId == categoryId)
+        }
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+
+    /// Seed the next month's budget rows from the current month's: every category
+    /// budgeted in `fromMonth` gets the same limit and rollover flag in
+    /// `nextMonthKey(fromMonth)`, unless that next month already has a row for the
+    /// category (existing rows win — never clobber a user's forward edit). Only
+    /// applies when the destination month is editable as of `asOf`.
+    ///
+    /// This is the "carry the budget template forward" convenience the per-month
+    /// editor uses so a user doesn't re-enter every limit each month; the envelope
+    /// *value* carry is separate (``RolloverBudgetPlanner``).
+    public static func rolloverTemplateToNextMonth(
+        in schema: BudgetingV2Schema,
+        fromMonth: String,
+        asOf: String
+    ) -> EditResult {
+        guard
+            let nextMonth = RolloverBudgetPlanner.nextMonthKey(fromMonth),
+            RolloverBudgetPlanner.isMonthEditable(nextMonth, asOf: asOf)
+        else {
+            return EditResult(schema: schema, applied: false)
+        }
+
+        let existingNextKeys = Set(
+            schema.budgets
+                .filter { $0.month == nextMonth }
+                .map(\.categoryId)
+        )
+        let template = schema.budgets.filter { $0.month == fromMonth }
+        guard !template.isEmpty else { return EditResult(schema: schema, applied: false) }
+
+        var budgets = schema.budgets
+        var addedAny = false
+        for row in template where !existingNextKeys.contains(row.categoryId) {
+            budgets.append(
+                MonthlyBudgetV2(
+                    month: nextMonth,
+                    categoryId: row.categoryId,
+                    monthlyLimit: row.monthlyLimit,
+                    rollover: row.rollover
+                )
+            )
+            addedAny = true
+        }
+        guard addedAny else { return EditResult(schema: schema, applied: false) }
+
+        budgets.sort { lhs, rhs in
+            lhs.month != rhs.month ? lhs.month < rhs.month : lhs.categoryId < rhs.categoryId
+        }
+        return EditResult(
+            schema: BudgetingV2Schema(
+                schemaVersion: schema.schemaVersion,
+                groups: schema.groups,
+                categories: schema.categories,
+                budgets: budgets
+            ),
+            applied: true
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/RolloverBudgetPlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/RolloverBudgetPlanner.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// Pure, deterministic per-month budget + rollover ("envelope carry") planning
+/// for budgeting v2 (AND-548 — deferred epic AND-524).
+///
+/// ## What this adds on top of AND-546
+///
+/// The merged v2 schema (AND-546) already persists ``MonthlyBudgetV2`` rows keyed
+/// by `(month, category)` with a per-row `rollover` flag. The *foundation only
+/// stores* those fields. This planner is the **math**: given a category's
+/// chronological budget rows and that category's per-month spend, it computes the
+/// envelope carry — the unspent (or overspent) remainder of each month rolled into
+/// the next month's available amount when rollover is enabled for that month.
+///
+/// ## Carry-forward rule
+///
+/// For one category, walking its months in chronological order, with `carryIn`
+/// seeded to `0` for the first month:
+///
+/// ```text
+/// available = monthlyLimit + carryIn
+/// spent     = override-aware net spend for the month  (signed; refunds net in)
+/// remaining = available - spent
+/// carryOut  = (this month's row.rollover) ? remaining : 0
+/// ```
+///
+/// `carryOut` feeds the next chronological month's `carryIn`. The carry is a true
+/// **envelope**: a positive `remaining` (under budget) *adds* to next month, and a
+/// negative `remaining` (over budget) *subtracts* from it — overspend carries too,
+/// matching the issue's "unspent **or** overspend" rule. A gap month with no
+/// budget row breaks the chain (there is no envelope to carry through), so a later
+/// month starts fresh from its own limit.
+///
+/// ## Per-category opt-out
+///
+/// Rollover is opt-in per `(month, category)` via the row's `rollover` flag, so a
+/// category opts out simply by having `rollover == false` on its rows — that month
+/// keeps `carryOut == 0` and the next month starts from its bare limit. A whole
+/// category can be opted out in one call with ``optedOutCategoryIds``, which forces
+/// `carryOut == 0` for every one of its months regardless of the row flag (the
+/// UI's per-category toggle); the stored rows are never mutated.
+///
+/// ## Historical immutability
+///
+/// The planner is read-only — it never edits a row. Whether a month is *editable*
+/// is a policy the UI enforces; ``isMonthEditable(_:asOf:calendar:)`` encodes it
+/// (only the current month and the future are editable; past months are frozen
+/// history). The carry math itself reads every month, past and present, so a frozen
+/// historical month still contributes its remainder to the carry.
+///
+/// ## Determinism
+///
+/// Like ``CategoryBudgetPlanner`` and ``SafeToSpendCalculator``, every entry point
+/// takes an explicit `Calendar` (and, where "now" matters, an explicit `asOf`
+/// month key) — there is no hidden `Date()`. Results are fully reproducible in
+/// `PlaidBarCore` unit tests.
+public enum RolloverBudgetPlanner {
+
+    // MARK: - Per-month result
+
+    /// The resolved budget for a single `(category, month)` after applying the
+    /// envelope carry. Pure value type; `Sendable`.
+    public struct MonthResult: Sendable, Hashable {
+        /// The budgeted month, `YYYY-MM`.
+        public let month: String
+        /// The v2 category id (``BudgetCategoryV2/id``).
+        public let categoryId: String
+        /// The month's own stored limit (``MonthlyBudgetV2/monthlyLimit``).
+        public let baseLimit: Double
+        /// Remainder carried *into* this month from the prior month's envelope.
+        /// `0` for the first month in the chain, for a month whose predecessor had
+        /// rollover off, or after a gap. Can be negative (carried overspend).
+        public let carriedIn: Double
+        /// Effective spending power this month: `baseLimit + carriedIn`.
+        public let available: Double
+        /// Override-aware net spend booked against this category this month.
+        public let spent: Double
+        /// What's left after spend: `available - spent`. Negative when overspent.
+        public let remaining: Double
+        /// Remainder carried *out* of this month into the next: `remaining` when
+        /// rollover is active for this month, else `0`.
+        public let carriedOut: Double
+        /// Whether rollover was active for this month (row flag on, category not
+        /// globally opted out). Surfaced so the UI can label the carry without
+        /// re-deriving it (never communicate the on/off state by color alone).
+        public let rolloverActive: Bool
+
+        public init(
+            month: String,
+            categoryId: String,
+            baseLimit: Double,
+            carriedIn: Double,
+            spent: Double,
+            rolloverActive: Bool
+        ) {
+            self.month = month
+            self.categoryId = categoryId
+            self.baseLimit = baseLimit
+            self.carriedIn = carriedIn
+            self.available = baseLimit + carriedIn
+            self.spent = spent
+            self.remaining = (baseLimit + carriedIn) - spent
+            self.carriedOut = rolloverActive ? ((baseLimit + carriedIn) - spent) : 0
+            self.rolloverActive = rolloverActive
+        }
+
+        /// Stable identity — one result per `(month, category)`, matching
+        /// ``MonthlyBudgetV2/id``.
+        public var id: String { "\(month)|\(categoryId)" }
+    }
+
+    // MARK: - Carry-forward over one category's months
+
+    /// Resolve the envelope carry across `budgets` for **one** category, in
+    /// chronological month order.
+    ///
+    /// - Parameters:
+    ///   - budgets: this category's ``MonthlyBudgetV2`` rows (any order; the planner
+    ///     sorts by month). Rows for other categories are ignored. Duplicate months
+    ///     for the category collapse to the last one seen after sort (a malformed
+    ///     input degrades, never crashes).
+    ///   - spendByMonth: override-aware net spend per `YYYY-MM` for this category
+    ///     (typically derived from ``CategoryBudgetPlanner/overrideAwareSpend(transactions:month:metadata:rules:calendar:)``).
+    ///     A missing month is treated as `0` spend.
+    ///   - categoryId: the category these budgets belong to (used to filter
+    ///     `budgets` and to ignore the global opt-out check). Pass the
+    ///     ``BudgetCategoryV2/id``.
+    ///   - optedOut: when `true`, this category is globally opted out of rollover —
+    ///     every month's `carryOut` is forced to `0` regardless of its row flag.
+    /// - Returns: one ``MonthResult`` per budgeted month, in chronological order.
+    public static func resolveCarry(
+        budgets: [MonthlyBudgetV2],
+        spendByMonth: [String: Double],
+        categoryId: String,
+        optedOut: Bool = false
+    ) -> [MonthResult] {
+        // Only this category's rows; collapse dup months (last wins) and sort
+        // chronologically — `YYYY-MM` sorts lexicographically in date order.
+        var rowByMonth: [String: MonthlyBudgetV2] = [:]
+        for budget in budgets where budget.categoryId == categoryId {
+            rowByMonth[budget.month] = budget
+        }
+        let months = rowByMonth.keys.sorted()
+        guard !months.isEmpty else { return [] }
+
+        var results: [MonthResult] = []
+        results.reserveCapacity(months.count)
+
+        var carryIn = 0.0
+        var previousMonth: String?
+
+        for month in months {
+            // A non-contiguous gap breaks the envelope: there's no budget row in the
+            // intervening month(s) to carry through, so the chain restarts here.
+            if let previousMonth, !Self.isImmediateSuccessor(previousMonth, of: month) {
+                carryIn = 0
+            }
+
+            guard let row = rowByMonth[month] else { continue }
+            let spent = spendByMonth[month] ?? 0
+            // Rollover is active only when the row opts in AND the category isn't
+            // globally opted out by the caller's per-category toggle.
+            let rolloverActive = row.rollover && !optedOut
+
+            let result = MonthResult(
+                month: month,
+                categoryId: categoryId,
+                baseLimit: row.monthlyLimit,
+                carriedIn: carryIn,
+                spent: spent,
+                rolloverActive: rolloverActive
+            )
+            results.append(result)
+
+            carryIn = result.carriedOut
+            previousMonth = month
+        }
+        return results
+    }
+
+    /// Resolve the envelope carry for **every** category present in `budgets`,
+    /// returning each category's chronological ``MonthResult`` chain keyed by
+    /// category id. A convenience fan-out over ``resolveCarry(budgets:spendByMonth:categoryId:optedOut:)``.
+    ///
+    /// - Parameters:
+    ///   - budgets: all ``MonthlyBudgetV2`` rows (mixed categories/months).
+    ///   - spendByMonthByCategory: override-aware net spend keyed
+    ///     `categoryId → (YYYY-MM → spend)`.
+    ///   - optedOutCategoryIds: category ids globally opted out of rollover (the
+    ///     per-category toggle); their `carryOut` is forced to `0` every month.
+    public static func resolveCarryByCategory(
+        budgets: [MonthlyBudgetV2],
+        spendByMonthByCategory: [String: [String: Double]],
+        optedOutCategoryIds: Set<String> = []
+    ) -> [String: [MonthResult]] {
+        let categoryIds = Set(budgets.map(\.categoryId))
+        var out: [String: [MonthResult]] = [:]
+        out.reserveCapacity(categoryIds.count)
+        for categoryId in categoryIds {
+            out[categoryId] = resolveCarry(
+                budgets: budgets,
+                spendByMonth: spendByMonthByCategory[categoryId] ?? [:],
+                categoryId: categoryId,
+                optedOut: optedOutCategoryIds.contains(categoryId)
+            )
+        }
+        return out
+    }
+
+    // MARK: - Historical immutability policy
+
+    /// Whether `month` (`YYYY-MM`) is editable as of `asOf` (`YYYY-MM`). The current
+    /// month and any future month are editable; a past month is frozen history.
+    ///
+    /// This is the policy behind the AC "historical months immutable, current
+    /// editable" — the planner exposes it so a single source of truth gates the
+    /// editor UI. The carry math itself still reads frozen months (their stored
+    /// remainder rolls forward); only *editing* a frozen month is disallowed.
+    ///
+    /// A malformed `month` or `asOf` key returns `false` (fail closed — never let a
+    /// bad key make a historical month look editable).
+    public static func isMonthEditable(_ month: String, asOf: String) -> Bool {
+        guard Self.isCanonicalMonthKey(month), Self.isCanonicalMonthKey(asOf) else {
+            return false
+        }
+        return month >= asOf
+    }
+
+    // MARK: - Month-key arithmetic
+
+    /// The `YYYY-MM` month key for the month after `month`, or `nil` for a malformed
+    /// key. Deterministic — pure string arithmetic on the canonical key, so it needs
+    /// no `Calendar` and matches the lexicographic ordering the rest of the app sorts
+    /// months by.
+    public static func nextMonthKey(_ month: String) -> String? {
+        guard let (year, monthValue) = parseMonthKey(month) else { return nil }
+        let next = monthValue == 12 ? (year + 1, 1) : (year, monthValue + 1)
+        return formatMonthKey(year: next.0, month: next.1)
+    }
+
+    /// The `YYYY-MM` month key for the month before `month`, or `nil` for a
+    /// malformed key.
+    public static func previousMonthKey(_ month: String) -> String? {
+        guard let (year, monthValue) = parseMonthKey(month) else { return nil }
+        let prev = monthValue == 1 ? (year - 1, 12) : (year, monthValue - 1)
+        return formatMonthKey(year: prev.0, month: prev.1)
+    }
+
+    /// The `YYYY-MM` month key for the month containing `date` in `calendar`. The one
+    /// entry point that consults a date — and only via an explicit injected
+    /// `Calendar`, so "now" stays testable.
+    public static func monthKey(for date: Date, calendar: Calendar) -> String? {
+        let components = calendar.dateComponents([.year, .month], from: date)
+        guard let year = components.year, let month = components.month else { return nil }
+        return formatMonthKey(year: year, month: month)
+    }
+
+    // MARK: - Internals
+
+    /// Whether `candidate` is exactly the month after `month` (`YYYY-MM`). Used to
+    /// detect a contiguous chain vs. a gap that resets the carry.
+    static func isImmediateSuccessor(_ month: String, of candidate: String) -> Bool {
+        nextMonthKey(month) == candidate
+    }
+
+    /// Fast structural check that `value` is a canonical `YYYY-MM` month key with an
+    /// in-range month (`01`…`12`). Mirrors `Formatters.isCanonicalTransactionDateKey`
+    /// for the month bucket.
+    static func isCanonicalMonthKey(_ value: String) -> Bool {
+        parseMonthKey(value) != nil
+    }
+
+    /// Parse a canonical `YYYY-MM` key into `(year, month)`, or `nil` when malformed
+    /// (wrong length/shape, non-numeric, month out of `1...12`).
+    static func parseMonthKey(_ value: String) -> (year: Int, month: Int)? {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              parts[0].count == 4,
+              parts[1].count == 2,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              (1...12).contains(month)
+        else { return nil }
+        return (year, month)
+    }
+
+    /// Format `(year, month)` back into a zero-padded canonical `YYYY-MM` key.
+    static func formatMonthKey(year: Int, month: Int) -> String {
+        let yearPart = String(format: "%04d", year)
+        let monthPart = String(format: "%02d", month)
+        return "\(yearPart)-\(monthPart)"
+    }
+}

--- a/Tests/PlaidBarCoreTests/BudgetRebalancePlannerTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetRebalancePlannerTests.swift
@@ -1,0 +1,383 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Budget rebalance — redistribute budget within a fixed total (AND-549 — deferred
+/// epic AND-524).
+///
+/// Every test is deterministic: budget rows and per-category spend are supplied
+/// directly, and "now" is an explicit `YYYY-MM` key — never wall-clock `Date()`.
+/// Covers the conservation invariant (move $X from A to B, total unchanged),
+/// rejection of moves that would break conservation or edit a frozen month,
+/// surplus→overage suggestions, and lossless undo (a move then its inverse restores
+/// the schema byte-for-byte).
+@Suite("Budget rebalance planner — total-preserving redistribution (AND-549)")
+struct BudgetRebalancePlannerTests {
+
+    private let food = SpendingCategory.foodAndDrink.rawValue
+    private let shopping = SpendingCategory.shopping.rawValue
+    private let travel = SpendingCategory.travel.rawValue
+    private let asOf = "2026-06"
+
+    // MARK: - Schema fixtures
+
+    /// A v2 schema seeded with the closed taxonomy (via the AND-546 migration seed)
+    /// plus the supplied month budgets.
+    private func schema(_ budgets: [MonthlyBudgetV2]) -> BudgetingV2Schema {
+        let seeded = BudgetingV2Migration.seed()
+        return BudgetingV2Schema(
+            groups: seeded.groups,
+            categories: seeded.categories,
+            budgets: budgets
+        )
+    }
+
+    private func budget(
+        _ month: String,
+        _ category: String,
+        _ limit: Double,
+        rollover: Bool = false
+    ) -> MonthlyBudgetV2 {
+        MonthlyBudgetV2(month: month, categoryId: category, monthlyLimit: limit, rollover: rollover)
+    }
+
+    private func move(
+        _ month: String,
+        from source: String,
+        to destination: String,
+        _ amount: Double
+    ) -> BudgetRebalancePlanner.BudgetRebalanceMove {
+        BudgetRebalancePlanner.BudgetRebalanceMove(
+            month: month,
+            sourceCategoryId: source,
+            destinationCategoryId: destination,
+            amount: amount
+        )
+    }
+
+    // MARK: - AC 1: move $X from A to B, total unchanged
+
+    @Test("Applying a move shifts X from source to destination")
+    func applyShiftsBudget() {
+        let start = schema([
+            budget("2026-06", food, 500),
+            budget("2026-06", shopping, 300),
+        ])
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 100),
+            to: start,
+            asOf: asOf
+        )
+
+        #expect(result.applied)
+        let foodRow = BudgetRebalancePlanner.row(in: result.schema, month: "2026-06", categoryId: food)
+        let shoppingRow = BudgetRebalancePlanner.row(
+            in: result.schema, month: "2026-06", categoryId: shopping
+        )
+        #expect(foodRow?.monthlyLimit == 400)
+        #expect(shoppingRow?.monthlyLimit == 400)
+    }
+
+    @Test("Month total is invariant under any applied rebalance")
+    func totalIsInvariant() {
+        let start = schema([
+            budget("2026-06", food, 500),
+            budget("2026-06", shopping, 300),
+            budget("2026-06", travel, 200),
+        ])
+        let totalBefore = BudgetRebalancePlanner.monthTotal(in: start, month: "2026-06")
+        #expect(totalBefore == 1000)
+
+        // Two chained moves; total must hold after each.
+        let after1 = BudgetRebalancePlanner.apply(
+            move("2026-06", from: travel, to: food, 150), to: start, asOf: asOf
+        )
+        #expect(after1.applied)
+        #expect(BudgetRebalancePlanner.monthTotal(in: after1.schema, month: "2026-06") == totalBefore)
+
+        let after2 = BudgetRebalancePlanner.apply(
+            move("2026-06", from: shopping, to: food, 75), to: after1.schema, asOf: asOf
+        )
+        #expect(after2.applied)
+        #expect(BudgetRebalancePlanner.monthTotal(in: after2.schema, month: "2026-06") == totalBefore)
+    }
+
+    @Test("A move that exactly drains the source is allowed and conserves the total")
+    func drainSourceToZero() {
+        let start = schema([
+            budget("2026-06", food, 200),
+            budget("2026-06", shopping, 100),
+        ])
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 200), to: start, asOf: asOf
+        )
+        #expect(result.applied)
+        #expect(
+            BudgetRebalancePlanner.row(in: result.schema, month: "2026-06", categoryId: food)?
+                .monthlyLimit == 0
+        )
+        #expect(
+            BudgetRebalancePlanner.row(in: result.schema, month: "2026-06", categoryId: shopping)?
+                .monthlyLimit == 300
+        )
+        #expect(BudgetRebalancePlanner.monthTotal(in: result.schema, month: "2026-06") == 300)
+    }
+
+    @Test("Rollover flags and other months are untouched by a rebalance")
+    func unrelatedRowsUntouched() {
+        let start = schema([
+            budget("2026-06", food, 500, rollover: true),
+            budget("2026-06", shopping, 300),
+            budget("2026-07", food, 500), // different month, must not move
+        ])
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 100), to: start, asOf: asOf
+        )
+        #expect(result.applied)
+        // Rollover flag preserved on the mutated source.
+        #expect(
+            BudgetRebalancePlanner.row(in: result.schema, month: "2026-06", categoryId: food)?
+                .rollover == true
+        )
+        // July untouched.
+        #expect(
+            BudgetRebalancePlanner.row(in: result.schema, month: "2026-07", categoryId: food)?
+                .monthlyLimit == 500
+        )
+        #expect(BudgetRebalancePlanner.monthTotal(in: result.schema, month: "2026-07") == 500)
+    }
+
+    // MARK: - Rejected moves (no-op, conservation preserved)
+
+    @Test("A move larger than the source limit is rejected (source can't go negative)")
+    func rejectOverdraw() {
+        let start = schema([
+            budget("2026-06", food, 100),
+            budget("2026-06", shopping, 100),
+        ])
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 150), to: start, asOf: asOf
+        )
+        #expect(!result.applied)
+        #expect(result.undo == nil)
+        #expect(result.schema == start) // byte-identical
+    }
+
+    @Test("Editing a frozen historical month is rejected")
+    func rejectFrozenMonth() {
+        let start = schema([
+            budget("2026-01", food, 500),
+            budget("2026-01", shopping, 300),
+        ])
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-01", from: food, to: shopping, 100), to: start, asOf: asOf
+        )
+        #expect(!result.applied)
+        #expect(result.schema == start)
+    }
+
+    @Test("A move where either endpoint is unbudgeted that month is rejected")
+    func rejectMissingRow() {
+        let start = schema([budget("2026-06", food, 500)]) // shopping has no row
+        let result = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 100), to: start, asOf: asOf
+        )
+        #expect(!result.applied)
+        #expect(result.schema == start)
+    }
+
+    @Test("Self-move and non-positive / non-finite amounts are rejected")
+    func rejectDegenerate() {
+        let start = schema([
+            budget("2026-06", food, 500),
+            budget("2026-06", shopping, 300),
+        ])
+        // Same source and destination.
+        #expect(
+            !BudgetRebalancePlanner.apply(
+                move("2026-06", from: food, to: food, 50), to: start, asOf: asOf
+            ).applied
+        )
+        // Zero amount.
+        #expect(
+            !BudgetRebalancePlanner.apply(
+                move("2026-06", from: food, to: shopping, 0), to: start, asOf: asOf
+            ).applied
+        )
+        // Negative amount.
+        #expect(
+            !BudgetRebalancePlanner.apply(
+                move("2026-06", from: food, to: shopping, -50), to: start, asOf: asOf
+            ).applied
+        )
+        // Non-finite amount.
+        #expect(
+            !BudgetRebalancePlanner.apply(
+                move("2026-06", from: food, to: shopping, .infinity), to: start, asOf: asOf
+            ).applied
+        )
+    }
+
+    // MARK: - AC 3: undo round-trips losslessly
+
+    @Test("Applying a move then its undo restores the schema byte-for-byte")
+    func undoRoundTrips() {
+        let start = schema([
+            budget("2026-06", food, 500, rollover: true),
+            budget("2026-06", shopping, 300),
+            budget("2026-06", travel, 120),
+        ])
+        let forward = BudgetRebalancePlanner.apply(
+            move("2026-06", from: food, to: shopping, 137.5), to: start, asOf: asOf
+        )
+        #expect(forward.applied)
+        let undoToken = try! #require(forward.undo)
+
+        let restored = BudgetRebalancePlanner.apply(undoToken, to: forward.schema, asOf: asOf)
+        #expect(restored.applied)
+        // The schema after undo equals the original (rows + limits + flags).
+        #expect(restored.schema == start)
+    }
+
+    @Test("The undo token is the exact inverse of the move")
+    func undoTokenIsInverse() {
+        let m = move("2026-06", from: food, to: shopping, 80)
+        #expect(m.inverse.sourceCategoryId == shopping)
+        #expect(m.inverse.destinationCategoryId == food)
+        #expect(m.inverse.amount == 80)
+        #expect(m.inverse.month == "2026-06")
+        #expect(m.inverse.inverse == m) // double inverse is identity
+    }
+
+    // MARK: - AC 2: suggestions from surplus toward over-trending
+
+    @Test("Suggests pulling from a surplus category toward an over-trending one")
+    func suggestsSurplusTowardOverage() {
+        let start = schema([
+            budget("2026-06", food, 400),     // over: spent 500
+            budget("2026-06", shopping, 400), // surplus: spent 100
+        ])
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-06",
+            spendByCategory: [food: 500, shopping: 100],
+            asOf: asOf
+        )
+
+        #expect(!suggestions.isEmpty)
+        let first = suggestions[0]
+        #expect(first.move.sourceCategoryId == shopping) // the under-spent one funds
+        #expect(first.move.destinationCategoryId == food) // the over-trending one receives
+        #expect(first.move.amount > 0)
+        // Surplus = 400 - 100 = 300; default cushion pulls at most half → 150.
+        #expect(first.move.amount <= 150)
+        // The destination overage context is the food shortfall (500 - 400 = 100).
+        #expect(first.destinationOverage == 100)
+    }
+
+    @Test("Applying all suggestions preserves the month total")
+    func applyingSuggestionsConservesTotal() {
+        let start = schema([
+            budget("2026-06", food, 300),     // over by 200 (spent 500)
+            budget("2026-06", shopping, 600), // surplus 500 (spent 100)
+            budget("2026-06", travel, 200),   // over by 50 (spent 250)
+        ])
+        let spend = [food: 500.0, shopping: 100.0, travel: 250.0]
+        let totalBefore = BudgetRebalancePlanner.monthTotal(in: start, month: "2026-06")
+
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start, month: "2026-06", spendByCategory: spend, asOf: asOf
+        )
+        #expect(!suggestions.isEmpty)
+
+        var current = start
+        for suggestion in suggestions {
+            let result = BudgetRebalancePlanner.apply(suggestion.move, to: current, asOf: asOf)
+            #expect(result.applied)
+            current = result.schema
+        }
+        // Total unchanged after applying every suggestion.
+        #expect(BudgetRebalancePlanner.monthTotal(in: current, month: "2026-06") == totalBefore)
+    }
+
+    @Test("No suggestions when nothing is over budget")
+    func noOverageNoSuggestions() {
+        let start = schema([
+            budget("2026-06", food, 500),
+            budget("2026-06", shopping, 500),
+        ])
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-06",
+            spendByCategory: [food: 100, shopping: 100], // both under
+            asOf: asOf
+        )
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("No suggestions when there is no surplus to pull from")
+    func noSurplusNoSuggestions() {
+        let start = schema([
+            budget("2026-06", food, 400),     // over
+            budget("2026-06", shopping, 300), // also over
+        ])
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-06",
+            spendByCategory: [food: 500, shopping: 400],
+            asOf: asOf
+        )
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("A frozen month yields no suggestions")
+    func frozenMonthNoSuggestions() {
+        let start = schema([
+            budget("2026-01", food, 400),
+            budget("2026-01", shopping, 400),
+        ])
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-01",
+            spendByCategory: [food: 500, shopping: 100],
+            asOf: asOf
+        )
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("Suggestions are ranked destination-overage-first, then deterministic")
+    func suggestionsRankedDeterministically() {
+        // Two over categories: travel over by 300, food over by 100. Travel should
+        // be funded first (bigger overage).
+        let start = schema([
+            budget("2026-06", food, 200),     // over by 100
+            budget("2026-06", travel, 200),   // over by 300
+            budget("2026-06", shopping, 2000), // big surplus (spent 0)
+        ])
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-06",
+            spendByCategory: [food: 300, travel: 500, shopping: 0],
+            asOf: asOf
+        )
+        #expect(suggestions.count >= 1)
+        #expect(suggestions[0].move.destinationCategoryId == travel)
+    }
+
+    @Test("Suggestions are stable across runs (pure, deterministic)")
+    func suggestionsStable() {
+        let start = schema([
+            budget("2026-06", food, 300),
+            budget("2026-06", shopping, 600),
+            budget("2026-06", travel, 200),
+        ])
+        let spend = [food: 500.0, shopping: 100.0, travel: 250.0]
+        let a = BudgetRebalancePlanner.suggestRebalances(
+            in: start, month: "2026-06", spendByCategory: spend, asOf: asOf
+        )
+        let b = BudgetRebalancePlanner.suggestRebalances(
+            in: start, month: "2026-06", spendByCategory: spend, asOf: asOf
+        )
+        #expect(a == b)
+    }
+}

--- a/Tests/PlaidBarCoreTests/MonthlyBudgetEditorTests.swift
+++ b/Tests/PlaidBarCoreTests/MonthlyBudgetEditorTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Per-month budget editing under the historical-immutability rule (AND-548).
+///
+/// "Now" is always an explicit `asOf` month key — no wall-clock `Date()`. Verifies
+/// the editor upserts/removes only on the current/future months, rejects edits to
+/// frozen historical months (no-op), validates inputs, and forward-seeds the budget
+/// template without clobbering existing forward edits.
+@Suite("Monthly budget editor — immutable history (AND-548)")
+struct MonthlyBudgetEditorTests {
+
+    private let food = SpendingCategory.foodAndDrink.rawValue
+    private let shopping = SpendingCategory.shopping.rawValue
+
+    /// A seeded (taxonomy-complete) schema with no budgets — the realistic starting
+    /// point after opt-in.
+    private func emptySchema() -> BudgetingV2Schema {
+        BudgetingV2Migration.seed()
+    }
+
+    // MARK: - Set on an editable month
+
+    @Test("Setting a budget on the current month applies and stores the row")
+    func setOnCurrentMonthApplies() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(),
+            categoryId: food,
+            month: "2026-06",
+            monthlyLimit: 500,
+            rollover: true,
+            asOf: "2026-06"
+        )
+        #expect(result.applied)
+        let row = result.schema.budgets.first { $0.month == "2026-06" && $0.categoryId == food }
+        #expect(row?.monthlyLimit == 500)
+        #expect(row?.rollover == true)
+    }
+
+    @Test("Setting a budget on a future month applies")
+    func setOnFutureMonthApplies() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(),
+            categoryId: food,
+            month: "2026-08",
+            monthlyLimit: 250,
+            rollover: false,
+            asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(result.schema.budgets.contains { $0.month == "2026-08" })
+    }
+
+    @Test("Re-setting the same month/category upserts (no duplicate row)")
+    func resetUpsertsInPlace() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 600, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let matching = schema.budgets.filter { $0.month == "2026-06" && $0.categoryId == food }
+        #expect(matching.count == 1)
+        #expect(matching.first?.monthlyLimit == 600)
+        #expect(matching.first?.rollover == false)
+    }
+
+    // MARK: - Historical immutability
+
+    @Test("Setting a budget on a past month is a no-op — history is frozen")
+    func setOnPastMonthIsNoOp() {
+        let before = emptySchema()
+        let result = MonthlyBudgetEditor.setBudget(
+            in: before,
+            categoryId: food,
+            month: "2026-05", // past relative to asOf
+            monthlyLimit: 500,
+            rollover: true,
+            asOf: "2026-06"
+        )
+        #expect(!result.applied)
+        #expect(result.schema == before) // byte-identical, nothing rewritten
+    }
+
+    @Test("Removing a budget from a past month is a no-op")
+    func removeFromPastMonthIsNoOp() {
+        // Build a schema that already holds a (frozen) historical budget.
+        let seeded = BudgetingV2Migration.seed(
+            carryingForward: [CategoryBudgetDTO(category: .foodAndDrink, monthlyLimit: 500)],
+            month: "2026-05"
+        )
+        let result = MonthlyBudgetEditor.removeBudget(
+            in: seeded, categoryId: food, month: "2026-05", asOf: "2026-06"
+        )
+        #expect(!result.applied)
+        #expect(result.schema == seeded) // the historical row survives
+    }
+
+    @Test("Removing a budget from the current month applies")
+    func removeFromCurrentMonthApplies() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        let result = MonthlyBudgetEditor.removeBudget(
+            in: schema, categoryId: food, month: "2026-06", asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(!result.schema.budgets.contains { $0.month == "2026-06" && $0.categoryId == food })
+    }
+
+    // MARK: - Input validation
+
+    @Test("A negative or non-finite limit is rejected (no-op)")
+    func invalidLimitRejected() {
+        let before = emptySchema()
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: -10, rollover: false, asOf: "2026-06"
+        ).applied)
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: .nan, rollover: false, asOf: "2026-06"
+        ).applied)
+        #expect(!MonthlyBudgetEditor.setBudget(
+            in: before, categoryId: food, month: "2026-06",
+            monthlyLimit: .infinity, rollover: false, asOf: "2026-06"
+        ).applied)
+    }
+
+    @Test("A zero limit is allowed (a deliberately zeroed envelope)")
+    func zeroLimitAllowed() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: food, month: "2026-06",
+            monthlyLimit: 0, rollover: false, asOf: "2026-06"
+        )
+        #expect(result.applied)
+        #expect(result.schema.budgets.first { $0.month == "2026-06" }?.monthlyLimit == 0)
+    }
+
+    @Test("An unknown category id is rejected — a budget can't reference a missing category")
+    func unknownCategoryRejected() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: "NOT_A_REAL_CATEGORY", month: "2026-06",
+            monthlyLimit: 100, rollover: false, asOf: "2026-06"
+        )
+        #expect(!result.applied)
+    }
+
+    @Test("A malformed asOf freezes everything (fail closed)")
+    func malformedAsOfFreezes() {
+        let result = MonthlyBudgetEditor.setBudget(
+            in: emptySchema(), categoryId: food, month: "2026-06",
+            monthlyLimit: 100, rollover: false, asOf: "bad"
+        )
+        #expect(!result.applied)
+    }
+
+    // MARK: - Forward template seeding
+
+    @Test("Forward-seeding copies the current month's budgets into the next month")
+    func forwardSeedCopiesTemplate() {
+        var schema = emptySchema()
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: shopping, month: "2026-06",
+            monthlyLimit: 300, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: schema, fromMonth: "2026-06", asOf: "2026-06"
+        )
+        #expect(result.applied)
+        let july = result.schema.budgets.filter { $0.month == "2026-07" }
+        #expect(july.count == 2)
+        #expect(july.first { $0.categoryId == food }?.monthlyLimit == 500)
+        #expect(july.first { $0.categoryId == food }?.rollover == true)
+        #expect(july.first { $0.categoryId == shopping }?.monthlyLimit == 300)
+    }
+
+    @Test("Forward-seeding never clobbers an existing forward edit")
+    func forwardSeedPreservesExistingNextMonth() {
+        var schema = emptySchema()
+        // Current month template.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        // A deliberate, different July edit already exists.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-07",
+            monthlyLimit: 999, rollover: false, asOf: "2026-06"
+        ).schema
+
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: schema, fromMonth: "2026-06", asOf: "2026-06"
+        )
+        // Nothing to add — July's food row already exists and must win.
+        #expect(!result.applied)
+        #expect(result.schema.budgets.first { $0.month == "2026-07" && $0.categoryId == food }?
+            .monthlyLimit == 999)
+    }
+
+    @Test("Forward-seeding is a no-op when the template month has no budgets")
+    func forwardSeedEmptyTemplateIsNoOp() {
+        let result = MonthlyBudgetEditor.rolloverTemplateToNextMonth(
+            in: emptySchema(), fromMonth: "2026-06", asOf: "2026-06"
+        )
+        #expect(!result.applied)
+    }
+
+    // MARK: - End-to-end: edit then resolve carry
+
+    @Test("Editing per-month budgets then resolving carry produces the expected envelope")
+    func editThenResolveCarry() {
+        var schema = emptySchema()
+        // June: $500 limit, rollover on.
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-06",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+        // July: $500 limit, rollover on (future month, editable).
+        schema = MonthlyBudgetEditor.setBudget(
+            in: schema, categoryId: food, month: "2026-07",
+            monthlyLimit: 500, rollover: true, asOf: "2026-06"
+        ).schema
+
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: schema.budgets,
+            spendByMonth: ["2026-06": 200], // $300 unspent rolls to July
+            categoryId: food
+        )
+        #expect(results.map(\.month) == ["2026-06", "2026-07"])
+        #expect(results[1].carriedIn == 300)
+        #expect(results[1].available == 800)
+    }
+}

--- a/Tests/PlaidBarCoreTests/RolloverBudgetPlannerTests.swift
+++ b/Tests/PlaidBarCoreTests/RolloverBudgetPlannerTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Per-month budgets + rollover ("envelope carry") math (AND-548 — deferred epic
+/// AND-524).
+///
+/// Every test is deterministic: budget rows and per-month spend are supplied
+/// directly, and "now" is an explicit `YYYY-MM` key or an injected UTC `Calendar`
+/// — never wall-clock `Date()`. Covers carry-forward of unspent and overspend,
+/// per-category opt-out (row flag + global toggle), gap/boundary resets, the
+/// historical-immutability policy, month-key arithmetic, and the additive guarantee
+/// that an empty/unbudgeted input yields no carry.
+@Suite("Rollover budget planner — per-month carry-forward (AND-548)")
+struct RolloverBudgetPlannerTests {
+
+    private let food = SpendingCategory.foodAndDrink.rawValue
+
+    private func budget(
+        _ month: String,
+        _ limit: Double,
+        rollover: Bool,
+        category: String? = nil
+    ) -> MonthlyBudgetV2 {
+        MonthlyBudgetV2(
+            month: month,
+            categoryId: category ?? food,
+            monthlyLimit: limit,
+            rollover: rollover
+        )
+    }
+
+    // MARK: - Carry of unspent (positive remainder)
+
+    @Test("Unspent remainder of a rollover month adds to the next month's available")
+    func unspentCarriesForward() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        // Spent $300 in Jan → $200 unspent carries into Feb.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 300, "2026-02": 0],
+            categoryId: food
+        )
+
+        #expect(results.count == 2)
+        let jan = results[0]
+        #expect(jan.carriedIn == 0)
+        #expect(jan.available == 500)
+        #expect(jan.remaining == 200)
+        #expect(jan.carriedOut == 200)
+
+        let feb = results[1]
+        #expect(feb.carriedIn == 200)
+        #expect(feb.available == 700) // 500 limit + 200 carried
+        #expect(feb.remaining == 700)
+        #expect(feb.carriedOut == 700)
+    }
+
+    @Test("Carry compounds across three contiguous rollover months")
+    func carryCompoundsAcrossMonths() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true),
+            budget("2026-02", 100, rollover: true),
+            budget("2026-03", 100, rollover: true),
+        ]
+        // Spend nothing — each month's full limit should pile up.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.map(\.available) == [100, 200, 300])
+        #expect(results.map(\.carriedOut) == [100, 200, 300])
+    }
+
+    // MARK: - Carry of overspend (negative remainder)
+
+    @Test("Overspend carries as a negative remainder, reducing next month's available")
+    func overspendCarriesForward() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        // Spent $650 in Jan → -$150 overspend carries into Feb.
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 650],
+            categoryId: food
+        )
+        let jan = results[0]
+        #expect(jan.remaining == -150)
+        #expect(jan.carriedOut == -150)
+
+        let feb = results[1]
+        #expect(feb.carriedIn == -150)
+        #expect(feb.available == 350) // 500 - 150 overspend
+    }
+
+    // MARK: - Per-category opt-out (row flag)
+
+    @Test("A month with rollover off carries nothing; the next month starts from its bare limit")
+    func rolloverOffBreaksCarry() {
+        let budgets = [
+            budget("2026-01", 500, rollover: false), // opted out this month
+            budget("2026-02", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 100], // $400 unspent — but not carried
+            categoryId: food
+        )
+        #expect(results[0].rolloverActive == false)
+        #expect(results[0].carriedOut == 0)
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500) // bare limit, no carry
+    }
+
+    // MARK: - Per-category opt-out (global toggle)
+
+    @Test("Global per-category opt-out forces every month's carry to zero, even with row flag on")
+    func globalOptOutForcesZeroCarry() {
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-02", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 100],
+            categoryId: food,
+            optedOut: true
+        )
+        #expect(results.allSatisfy { !$0.rolloverActive })
+        #expect(results.allSatisfy { $0.carriedOut == 0 })
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500)
+    }
+
+    @Test("resolveCarryByCategory honors the opted-out category set independently per category")
+    func optOutSetIsPerCategory() {
+        let dining = SpendingCategory.foodAndDrink.rawValue
+        let shopping = SpendingCategory.shopping.rawValue
+        let budgets = [
+            budget("2026-01", 200, rollover: true, category: dining),
+            budget("2026-02", 200, rollover: true, category: dining),
+            budget("2026-01", 300, rollover: true, category: shopping),
+            budget("2026-02", 300, rollover: true, category: shopping),
+        ]
+        let byCategory = RolloverBudgetPlanner.resolveCarryByCategory(
+            budgets: budgets,
+            spendByMonthByCategory: [
+                dining: ["2026-01": 50],   // $150 unspent
+                shopping: ["2026-01": 50], // $250 unspent
+            ],
+            optedOutCategoryIds: [shopping] // only shopping opted out
+        )
+        // Dining carries: Feb available = 200 + 150 = 350.
+        #expect(byCategory[dining]?[1].available == 350)
+        // Shopping opted out: Feb available stays the bare 300.
+        #expect(byCategory[shopping]?[1].available == 300)
+        #expect(byCategory[shopping]?.allSatisfy { !$0.rolloverActive } == true)
+    }
+
+    // MARK: - Month boundaries
+
+    @Test("Carry crosses a year boundary (Dec → Jan)")
+    func carryCrossesYearBoundary() {
+        let budgets = [
+            budget("2025-12", 400, rollover: true),
+            budget("2026-01", 400, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2025-12": 100], // $300 unspent
+            categoryId: food
+        )
+        #expect(results[1].month == "2026-01")
+        #expect(results[1].carriedIn == 300)
+        #expect(results[1].available == 700)
+    }
+
+    @Test("A gap month (no budget row) resets the carry — a later month starts fresh")
+    func gapResetsCarry() {
+        // Jan and March budgeted; Feb has no row → the envelope can't carry through.
+        let budgets = [
+            budget("2026-01", 500, rollover: true),
+            budget("2026-03", 500, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: ["2026-01": 0], // $500 unspent in Jan
+            categoryId: food
+        )
+        #expect(results.count == 2)
+        #expect(results[0].month == "2026-01")
+        #expect(results[1].month == "2026-03")
+        // March does NOT inherit January's $500 across the missing February.
+        #expect(results[1].carriedIn == 0)
+        #expect(results[1].available == 500)
+    }
+
+    @Test("Unsorted input is resolved in chronological order")
+    func inputIsSortedChronologically() {
+        let budgets = [
+            budget("2026-03", 100, rollover: true),
+            budget("2026-01", 100, rollover: true),
+            budget("2026-02", 100, rollover: true),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.map(\.month) == ["2026-01", "2026-02", "2026-03"])
+        #expect(results.map(\.available) == [100, 200, 300])
+    }
+
+    @Test("Rows for other categories are ignored")
+    func otherCategoryRowsIgnored() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true, category: food),
+            budget("2026-01", 999, rollover: true, category: SpendingCategory.shopping.rawValue),
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.count == 1)
+        #expect(results[0].baseLimit == 100)
+    }
+
+    @Test("Empty budgets yield no results — an unbudgeted category has no carry (additive)")
+    func emptyBudgetsYieldNoCarry() {
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: [],
+            spendByMonth: ["2026-01": 100],
+            categoryId: food
+        )
+        #expect(results.isEmpty)
+    }
+
+    @Test("Missing spend for a month is treated as zero")
+    func missingSpendIsZero() {
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: [budget("2026-01", 250, rollover: true)],
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results[0].spent == 0)
+        #expect(results[0].remaining == 250)
+        #expect(results[0].carriedOut == 250)
+    }
+
+    @Test("Duplicate month rows collapse to the last one (degrades, never crashes)")
+    func duplicateMonthCollapses() {
+        let budgets = [
+            budget("2026-01", 100, rollover: true),
+            budget("2026-01", 200, rollover: true), // dup month, last wins
+        ]
+        let results = RolloverBudgetPlanner.resolveCarry(
+            budgets: budgets,
+            spendByMonth: [:],
+            categoryId: food
+        )
+        #expect(results.count == 1)
+        #expect(results[0].baseLimit == 200)
+    }
+
+    // MARK: - Historical immutability policy
+
+    @Test("Current and future months are editable; past months are frozen")
+    func editabilityPolicy() {
+        #expect(RolloverBudgetPlanner.isMonthEditable("2026-06", asOf: "2026-06")) // current
+        #expect(RolloverBudgetPlanner.isMonthEditable("2026-07", asOf: "2026-06")) // future
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-05", asOf: "2026-06")) // past
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2025-12", asOf: "2026-01")) // past, prior year
+    }
+
+    @Test("A malformed month key is never editable (fail closed)")
+    func malformedMonthNotEditable() {
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-13", asOf: "2026-06"))
+        #expect(!RolloverBudgetPlanner.isMonthEditable("nope", asOf: "2026-06"))
+        #expect(!RolloverBudgetPlanner.isMonthEditable("2026-06", asOf: "garbage"))
+    }
+
+    // MARK: - Month-key arithmetic
+
+    @Test("nextMonthKey / previousMonthKey roll across month and year boundaries")
+    func monthKeyArithmetic() {
+        #expect(RolloverBudgetPlanner.nextMonthKey("2026-01") == "2026-02")
+        #expect(RolloverBudgetPlanner.nextMonthKey("2026-12") == "2027-01")
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-01") == "2025-12")
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-03") == "2026-02")
+        #expect(RolloverBudgetPlanner.nextMonthKey("bad") == nil)
+        #expect(RolloverBudgetPlanner.previousMonthKey("2026-00") == nil)
+    }
+
+    @Test("monthKey(for:calendar:) derives the bucket from an injected calendar (no wall clock)")
+    func monthKeyFromInjectedCalendar() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        // 2026-06-13T12:00:00Z
+        let date = Date(timeIntervalSince1970: 1_781_352_000)
+        #expect(RolloverBudgetPlanner.monthKey(for: date, calendar: calendar) == "2026-06")
+    }
+}


### PR DESCRIPTION
**DEFERRED v2 (AND-524 epic) — re-opens scope cut from v1.**

> Stacked on **AND-548** (per-month budgets). PR base is `feat/and-548-per-month-budgets`; this PR's own diff is the two new rebalance files. Review/merge AND-548 first.

## What & why

Copilot's **Rebalance**: move budget from an under-spent category to an over-spent one **while keeping that month's total budget constant**. Closes AND-549, the next dependent of the merged AND-546 schema (`MonthlyBudgetV2(month, categoryId, monthlyLimit, rollover)`) after AND-548's per-month rows. Purely additive `PlaidBarCore` math — no existing file is touched, so a v1 / not-opted-in user keeps **byte-identical** behavior.

## Change

New `BudgetRebalancePlanner` (pure, `Sendable`, deterministic — no hidden `Date()`):

- **`apply(_:to:asOf:)`** — moves `$X` from a source category to a destination for one month: source limit `−X`, destination limit `+X`, so the month total (`Σ monthlyLimit`) is **provably unchanged** (AC 1). Rejected as a no-op (schema byte-identical) when the month is frozen history (`RolloverBudgetPlanner.isMonthEditable`), the endpoints match, the amount is non-finite/non-positive, either endpoint is unbudgeted that month, or the amount exceeds the source limit (a source can never go negative).
- **`suggestRebalances(...)`** — proposes moves from categories with a **surplus** (limit above override-aware spend, pulling at most a cushion fraction of the headroom) toward categories **trending over** (spend above limit) (AC 2). Greedy and conservation-safe: applying every suggestion never changes the month total. Deterministic ranking (destination-overage-first, ties by category id); a frozen month yields none.
- **Undo** (AC 3) — every `BudgetRebalanceMove` has an exact `inverse`; the `ApplyResult` returns it as the undo token. Re-applying it restores the pre-move limits **byte-for-byte**, so a rebalance is fully undoable and the dashboard re-renders from the returned `BudgetingV2Schema` immediately.
- **`monthTotal(...)`** — exposed as the invariant helper callers/tests assert against.

Accessibility/privacy: pure value types, no UI in this PR; `RebalanceSuggestion` carries explicit `sourceSurplus` / `destinationOverage` context so a future UI can label source/destination roles without relying on color alone. Spend is supplied by the caller (typically `CategoryBudgetPlanner.overrideAwareSpend`), so Privacy Mask / App Lock gating stays at the surfaces that render it.

## Testing

Exact commands and results:

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (no warnings/errors)

swift test --filter BudgetRebalancePlannerTests
# → 17 tests passed

swift test --filter RolloverBudgetPlannerTests --filter MonthlyBudgetEditorTests
# → 31 tests passed (stacked AND-548 suites, no regression)

git diff --check
# → clean
```

The 17 new tests cover: the conservation invariant under chained moves, drain-to-zero, rejection of overdraw / frozen / missing-row / degenerate (self-move, zero, negative, non-finite) moves, lossless undo round-trip + double-inverse identity, surplus→overage suggestions, applying-all-suggestions conserves the total, no-overage / no-surplus / frozen yields none, and deterministic stable ranking. All deterministic (explicit `asOf` month key + caller-supplied spend; synthetic data only).

## Links

Closes AND-549.

## Follow-ups

- Wire `BudgetRebalancePlanner` into the Budgets workspace surface (apply/undo affordance + suggestion chips) — UI epic, separate PR.
- Persist applied moves through `PlaidBarCache.BudgetingV2Store` so a rebalance survives relaunch (the math here is store-agnostic by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
