### PR TITLE
fix(investments): page investment transactions

### DIFF
--- a/Sources/PlaidBarServer/Plaid/PlaidClient.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidClient.swift
@@ -31,7 +31,9 @@ protocol PlaidClientProtocol: Sendable {
     func getInvestmentTransactions(
         accessToken: String,
         startDate: String,
-        endDate: String
+        endDate: String,
+        count: Int,
+        offset: Int
     ) async throws -> PlaidInvestmentTransactionsResponse
 
     func syncTransactions(
@@ -61,7 +63,9 @@ extension PlaidClientProtocol {
     func getInvestmentTransactions(
         accessToken: String,
         startDate: String,
-        endDate: String
+        endDate: String,
+        count _: Int,
+        offset _: Int
     ) async throws -> PlaidInvestmentTransactionsResponse {
         PlaidInvestmentTransactionsResponse(
             accounts: [],
@@ -197,7 +201,9 @@ actor PlaidClient: PlaidClientProtocol {
     func getInvestmentTransactions(
         accessToken: String,
         startDate: String,
-        endDate: String
+        endDate: String,
+        count: Int,
+        offset: Int
     ) async throws -> PlaidInvestmentTransactionsResponse {
         let body = PlaidInvestmentTransactionsRequest(
             clientId: config.plaidClientId,
@@ -205,7 +211,7 @@ actor PlaidClient: PlaidClientProtocol {
             accessToken: accessToken,
             startDate: startDate,
             endDate: endDate,
-            options: .init(count: 250, offset: 0)
+            options: .init(count: count, offset: offset)
         )
         return try await post("/investments/transactions/get", body: body)
     }

--- a/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
@@ -55,17 +55,55 @@ struct InvestmentRoutes: Sendable {
         let perItem = try await BoundedConcurrency.map(items, limit: maxConcurrentItemRefreshes) { item -> [InvestmentTransactionDTO] in
             do {
                 let accessToken = try tokenStore.accessToken(for: item)
-                let response = try await plaidClient.getInvestmentTransactions(
+                let transactions = try await Self.paginatedInvestmentTransactions(
+                    plaidClient: plaidClient,
                     accessToken: accessToken,
                     startDate: startDate,
                     endDate: endDate
                 )
-                return response.investmentTransactions.map(Self.investmentTransactionDTO(from:))
+                return transactions.map(Self.investmentTransactionDTO(from:))
             } catch {
                 return []
             }
         }
         return try Self.jsonResponse(perItem.flatMap { $0 })
+    }
+
+    // MARK: - Mapping
+
+    static let investmentTransactionsPageSize = 250
+
+    static func paginatedInvestmentTransactions(
+        plaidClient: any PlaidClientProtocol,
+        accessToken: String,
+        startDate: String,
+        endDate: String,
+        pageSize: Int = investmentTransactionsPageSize
+    ) async throws -> [PlaidInvestmentTransaction] {
+        let count = max(1, pageSize)
+        var offset = 0
+        var transactions: [PlaidInvestmentTransaction] = []
+
+        while true {
+            let response = try await plaidClient.getInvestmentTransactions(
+                accessToken: accessToken,
+                startDate: startDate,
+                endDate: endDate,
+                count: count,
+                offset: offset
+            )
+            transactions.append(contentsOf: response.investmentTransactions)
+
+            if let total = response.totalInvestmentTransactions {
+                if transactions.count >= total || response.investmentTransactions.isEmpty {
+                    return transactions
+                }
+            } else if response.investmentTransactions.count < count {
+                return transactions
+            }
+
+            offset += response.investmentTransactions.count
+        }
     }
 
     // MARK: - Mapping

--- a/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
+++ b/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
@@ -9,6 +9,73 @@ import Testing
 /// account/liability mapping is validated.
 @Suite("Investment routes mapping")
 struct InvestmentRoutesTests {
+    private actor PaginatedInvestmentPlaidClient: PlaidClientProtocol {
+        private var responses: [PlaidInvestmentTransactionsResponse]
+        private var calls: [(count: Int, offset: Int)] = []
+
+        init(responses: [PlaidInvestmentTransactionsResponse]) {
+            self.responses = responses
+        }
+
+        func createLinkToken(
+            clientUserId _: String,
+            completionRedirectUri _: String
+        ) async throws -> PlaidLinkTokenResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func createUpdateLinkToken(
+            clientUserId _: String,
+            accessToken _: String,
+            completionRedirectUri _: String
+        ) async throws -> PlaidLinkTokenResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func getLinkToken(_: String) async throws -> PlaidLinkTokenGetResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func exchangePublicToken(_: String) async throws -> PlaidTokenExchangeResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func getAccounts(accessToken _: String) async throws -> PlaidAccountsResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func getBalances(accessToken _: String) async throws -> PlaidAccountsResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func getInvestmentTransactions(
+            accessToken _: String,
+            startDate _: String,
+            endDate _: String,
+            count: Int,
+            offset: Int
+        ) async throws -> PlaidInvestmentTransactionsResponse {
+            calls.append((count: count, offset: offset))
+            guard !responses.isEmpty else { throw PlaidError.invalidResponse }
+            return responses.removeFirst()
+        }
+
+        func syncTransactions(
+            accessToken _: String,
+            cursor _: String?
+        ) async throws -> PlaidTransactionsSyncResponse {
+            throw PlaidError.invalidResponse
+        }
+
+        func removeItem(accessToken _: String) async throws {
+            throw PlaidError.invalidResponse
+        }
+
+        func recordedCalls() -> [(count: Int, offset: Int)] {
+            calls
+        }
+    }
+
     private func item(id: String = "item-1") -> ItemModel {
         ItemModel(id: id, accessToken: "keychain:\(id)", institutionName: "Fidelity")
     }
@@ -80,6 +147,76 @@ struct InvestmentRoutesTests {
         )
         let result = InvestmentRoutes.investmentsResponse(from: response, item: item(), itemId: "item-1")
         #expect(result.accounts.first?.type == .other)
+    }
+
+    private func investmentTransaction(id: String) -> PlaidInvestmentTransaction {
+        PlaidInvestmentTransaction(
+            investmentTransactionId: id,
+            accountId: "acct_a",
+            securityId: "sec_vti",
+            date: "2026-06-01",
+            name: "Buy VTI",
+            quantity: 10,
+            price: 250,
+            amount: 2_500,
+            fees: 0,
+            type: "buy",
+            subtype: "buy",
+            isoCurrencyCode: "USD"
+        )
+    }
+
+    private func investmentTransactionsResponse(
+        ids: [String],
+        total: Int?
+    ) -> PlaidInvestmentTransactionsResponse {
+        PlaidInvestmentTransactionsResponse(
+            accounts: [],
+            securities: [],
+            investmentTransactions: ids.map(investmentTransaction(id:)),
+            totalInvestmentTransactions: total,
+            item: nil,
+            requestId: nil
+        )
+    }
+
+    @Test("Investment transactions page until the Plaid total is satisfied")
+    func paginatesInvestmentTransactionsUntilTotalIsSatisfied() async throws {
+        let client = PaginatedInvestmentPlaidClient(responses: [
+            investmentTransactionsResponse(ids: ["itx-1", "itx-2"], total: 3),
+            investmentTransactionsResponse(ids: ["itx-3"], total: 3),
+        ])
+
+        let transactions = try await InvestmentRoutes.paginatedInvestmentTransactions(
+            plaidClient: client,
+            accessToken: "keychain:item-1",
+            startDate: "2026-03-26",
+            endDate: "2026-06-24",
+            pageSize: 2
+        )
+
+        #expect(transactions.map(\.investmentTransactionId) == ["itx-1", "itx-2", "itx-3"])
+        #expect(await client.recordedCalls().map(\.offset) == [0, 2])
+        #expect(await client.recordedCalls().map(\.count) == [2, 2])
+    }
+
+    @Test("Investment transaction pagination stops on a short page when Plaid omits total")
+    func paginatesInvestmentTransactionsWithoutTotalUntilShortPage() async throws {
+        let client = PaginatedInvestmentPlaidClient(responses: [
+            investmentTransactionsResponse(ids: ["itx-1", "itx-2"], total: nil),
+            investmentTransactionsResponse(ids: ["itx-3"], total: nil),
+        ])
+
+        let transactions = try await InvestmentRoutes.paginatedInvestmentTransactions(
+            plaidClient: client,
+            accessToken: "keychain:item-1",
+            startDate: "2026-03-26",
+            endDate: "2026-06-24",
+            pageSize: 2
+        )
+
+        #expect(transactions.map(\.investmentTransactionId) == ["itx-1", "itx-2", "itx-3"])
+        #expect(await client.recordedCalls().map(\.offset) == [0, 2])
     }
 
     @Test("Investment transaction mapping carries the security, amount, and type")


### PR DESCRIPTION
## Summary

Fixes #680.

- pages Plaid `/investments/transactions/get` using `count`/`offset` instead of hard-coding `offset: 0`
- stops when `totalInvestmentTransactions` is satisfied, or on a short page when Plaid omits the total
- adds server tests for total-backed and total-less pagination behavior

## Privacy/security

- no Plaid credentials, access tokens, public tokens, raw Plaid payloads, account IDs, transaction IDs, balances, or local SQLite data are logged or moved into the SwiftUI app
- the app still talks only to the local PlaidBarServer API for Plaid-backed investment data

## Verification

- `git diff --check` — passed
- `swift build --target PlaidBarServerTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarServerTests' complete!`)
- `swift test --filter InvestmentRoutesTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked before running this test by unrelated existing `PlaidBarCacheTests` strict warnings/errors (`try` on non-throwing cache initializers and non-Sendable `CountingFileManager`)
- `swift test --filter InvestmentRoutesTests` — blocked before running by unrelated app-target FoundationModels macro/toolchain errors (`FoundationModelsMacros.GenerableMacro` plugin not found)

Linear: AND-659
Kanban: t_00a93eac
