### PR TITLE
refactor(cleanup): remove dead code surfaced by audit

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -3551,11 +3551,6 @@ final class AppState {
         UserDefaults.standard.set(data, forKey: Keys.categoryBudgetCache)
     }
 
-    private func loadCategoryBudgetCacheForActiveContext() {
-        guard let transactionCacheContext else { return }
-        loadCategoryBudgetCache(for: transactionCacheContext)
-    }
-
     private func loadCategoryBudgetCache(for context: TransactionCacheContext) {
         guard let data = UserDefaults.standard.data(forKey: Keys.categoryBudgetCache),
               let cache = try? JSONDecoder().decode(CategoryBudgetCache.self, from: data),

--- a/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
@@ -21,7 +21,6 @@ import SwiftUI
 /// components. The card + window ship complete without it.
 struct CategoryDashboardWindow: View {
     @Environment(AppState.self) private var appState
-    @Environment(\.openCategoryDashboard) private var openCategoryDashboard
 
     /// User-selected flat-table ordering. Stored as a small `Sendable` enum (a
     /// `[KeyPathComparator]` is not `Sendable`, so it cannot live in `@State` under

--- a/Sources/PlaidBar/Views/Charts/IncomeCategoryFlowChart.swift
+++ b/Sources/PlaidBar/Views/Charts/IncomeCategoryFlowChart.swift
@@ -98,7 +98,6 @@ struct IncomeCategoryFlowChart: View {
     /// VoiceOver amounts are masked; the flow geometry and labels still render.
     var isPrivacyMasked: Bool = false
 
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var revealFraction: CGFloat = 0
 

--- a/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
@@ -21,7 +21,6 @@ import SwiftUI
 /// a tight stack (AND-624).
 struct InsightsTrendsView: View {
     @Environment(AppState.self) private var appState
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     private var isMasked: Bool { appState.shouldMaskFinancialValues }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1257,10 +1257,6 @@ private struct LocalInsightsCard: View {
         appState.summary(for: .lastMonth)
     }
 
-    private var bullets: [String] {
-        Array(primarySummary?.generatedBullets.prefix(3) ?? [])
-    }
-
     private var receipt: LocalAIInsightReceipt {
         LocalAIInsightReceipt.make(
             summary: primarySummary,


### PR DESCRIPTION
## Summary

Pure dead-code removal surfaced by an automated static-analysis audit of the codebase. Every deletion was verified to have **no live call sites** before removal, and two false-positive candidates from the audit were excluded because they are referenced by tests (the deprecated `RecoveryAction.defaultTitle/defaultIconName` shims, pinned by `RecoveryActionTests`).

No behavior change. Strict-concurrency build (`-strict-concurrency=complete -warnings-as-errors`) and the full test suite (**2389 tests**) both pass — an unused-but-actually-referenced symbol would have failed the build.

## Removed

| Symbol | File | Why safe |
|--------|------|----------|
| `loadCategoryBudgetCacheForActiveContext()` | `Sources/PlaidBar/App/AppState.swift` | Private wrapper with zero callers; call sites use `loadCategoryBudgetCache(for:)` directly |
| `bullets` | `Sources/PlaidBar/Views/MainPopover.swift` | Unread computed property; the body renders `LocalAIInsightReceipt` |
| `@Environment openCategoryDashboard` | `Sources/PlaidBar/Views/CategoryDashboardWindow.swift` | Declared, never read |
| `@Environment colorScheme` | `Sources/PlaidBar/Views/Charts/IncomeCategoryFlowChart.swift` | Declared, never read (`reduceMotion` kept — it is used) |
| `@Environment reduceMotion` | `Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift` | Declared, never read (`reduceTransparency` kept) |

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → Build complete, no warnings
- `swift test` → 2389 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
