### PR TITLE
fix(webhooks): keep sync-needed pending until cursor commit

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2598,7 +2598,10 @@ final class AppState {
                     context: cacheContext
                 )
             }
-            try await serverClient.commitSyncCursors(batch.pendingCursors)
+            try await serverClient.commitSyncCursors(
+                batch.pendingCursors,
+                cursorUpdatedAts: batch.pendingCursorUpdatedAts
+            )
             lastSyncDate = Date()
             serverSyncedItemCount = statusItemCount
             await refreshItemStatuses()

--- a/Sources/PlaidBar/Services/ServerClient.swift
+++ b/Sources/PlaidBar/Services/ServerClient.swift
@@ -162,12 +162,12 @@ actor ServerClient {
         return try await get(url)
     }
 
-    func commitSyncCursors(_ cursors: [String: String]) async throws {
+    func commitSyncCursors(_ cursors: [String: String], cursorUpdatedAts: [String: Date] = [:]) async throws {
         guard !cursors.isEmpty else { return }
         guard let url = ServerEndpoint.transactionCursorCommitURL(baseURL: baseURL) else {
             throw ServerClientError.requestFailed
         }
-        try await post(url, body: SyncCursorCommitRequest(cursors: cursors))
+        try await post(url, body: SyncCursorCommitRequest(cursors: cursors, cursorUpdatedAts: cursorUpdatedAts))
     }
 
     func createLinkToken() async throws -> LinkResponse {

--- a/Sources/PlaidBarCore/Models/SyncResponse.swift
+++ b/Sources/PlaidBarCore/Models/SyncResponse.swift
@@ -7,19 +7,22 @@ public struct SyncResponse: Codable, Sendable {
     public let removed: [String]  // transaction IDs
     public let hasMore: Bool
     public let pendingCursors: [String: String]
+    public let pendingCursorUpdatedAts: [String: Date]
 
     public init(
         added: [TransactionDTO],
         modified: [TransactionDTO],
         removed: [String],
         hasMore: Bool,
-        pendingCursors: [String: String] = [:]
+        pendingCursors: [String: String] = [:],
+        pendingCursorUpdatedAts: [String: Date] = [:]
     ) {
         self.added = added
         self.modified = modified
         self.removed = removed
         self.hasMore = hasMore
         self.pendingCursors = pendingCursors
+        self.pendingCursorUpdatedAts = pendingCursorUpdatedAts
     }
 
     enum CodingKeys: String, CodingKey {
@@ -28,6 +31,7 @@ public struct SyncResponse: Codable, Sendable {
         case removed
         case hasMore
         case pendingCursors
+        case pendingCursorUpdatedAts
     }
 
     public init(from decoder: Decoder) throws {
@@ -37,13 +41,30 @@ public struct SyncResponse: Codable, Sendable {
         removed = try container.decode([String].self, forKey: .removed)
         hasMore = try container.decode(Bool.self, forKey: .hasMore)
         pendingCursors = try container.decodeIfPresent([String: String].self, forKey: .pendingCursors) ?? [:]
+        pendingCursorUpdatedAts = try container.decodeIfPresent(
+            [String: Date].self,
+            forKey: .pendingCursorUpdatedAts
+        ) ?? [:]
     }
 }
 
 public struct SyncCursorCommitRequest: Codable, Sendable {
     public let cursors: [String: String]
+    public let cursorUpdatedAts: [String: Date]
 
-    public init(cursors: [String: String]) {
+    public init(cursors: [String: String], cursorUpdatedAts: [String: Date] = [:]) {
         self.cursors = cursors
+        self.cursorUpdatedAts = cursorUpdatedAts
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cursors
+        case cursorUpdatedAts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cursors = try container.decode([String: String].self, forKey: .cursors)
+        cursorUpdatedAts = try container.decodeIfPresent([String: Date].self, forKey: .cursorUpdatedAts) ?? [:]
     }
 }

--- a/Sources/PlaidBarCore/Utilities/TransactionSyncBatch.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionSyncBatch.swift
@@ -3,15 +3,18 @@ import Foundation
 public struct TransactionSyncBatch: Sendable {
     public private(set) var transactions: [TransactionDTO]
     public private(set) var pendingCursors: [String: String]
+    public private(set) var pendingCursorUpdatedAts: [String: Date]
     public private(set) var hasChanges: Bool
 
     public init(
         transactions: [TransactionDTO],
         pendingCursors: [String: String] = [:],
+        pendingCursorUpdatedAts: [String: Date] = [:],
         hasChanges: Bool = false
     ) {
         self.transactions = transactions
         self.pendingCursors = pendingCursors
+        self.pendingCursorUpdatedAts = pendingCursorUpdatedAts
         self.hasChanges = hasChanges
     }
 
@@ -24,5 +27,6 @@ public struct TransactionSyncBatch: Sendable {
             }
         }
         pendingCursors.merge(response.pendingCursors) { _, latest in latest }
+        pendingCursorUpdatedAts.merge(response.pendingCursorUpdatedAts) { _, latest in latest }
     }
 }

--- a/Sources/PlaidBarServer/Routes/StatusRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/StatusRoutes.swift
@@ -72,6 +72,7 @@ struct StatusRoutes: Sendable {
     private func safeItemStatuses() async throws -> [ItemStatus] {
         let items = try await tokenStore.getAllItems()
         let webhookEvents = try await webhookEventStore?.latestEventsByItem() ?? [:]
+        let syncCursorUpdatedAts = try await tokenStore.syncCursorUpdatedAtsByItem()
         // The sync signal is read from a *separate*, sync-only projection so a
         // later non-sync webhook (e.g. PENDING_EXPIRATION) cannot mask an earlier
         // still-pending SYNC_UPDATES_AVAILABLE. The latest-overall event still
@@ -81,7 +82,8 @@ struct StatusRoutes: Sendable {
             Self.safeItemStatus(
                 from: $0,
                 webhookEvent: webhookEvents[$0.id ?? ""],
-                syncEvent: syncEvents[$0.id ?? ""]
+                syncEvent: syncEvents[$0.id ?? ""],
+                syncCursorUpdatedAt: syncCursorUpdatedAts[$0.id ?? ""]
             )
         }
     }
@@ -89,7 +91,8 @@ struct StatusRoutes: Sendable {
     private static func safeItemStatus(
         from item: ItemModel,
         webhookEvent: WebhookItemSignal? = nil,
-        syncEvent: WebhookItemSignal? = nil
+        syncEvent: WebhookItemSignal? = nil,
+        syncCursorUpdatedAt: Date? = nil
     ) -> ItemStatus {
         ItemStatus(
             id: item.id ?? "",
@@ -98,18 +101,22 @@ struct StatusRoutes: Sendable {
             lastSync: item.updatedAt,
             lastWebhookAt: webhookEvent?.effectiveDate,
             lastWebhookEvent: webhookEvent.map { "\($0.webhookType).\($0.webhookCode)" },
-            needsSync: Self.needsPollingSync(item: item, syncEvent: syncEvent)
+            needsSync: Self.needsPollingSync(syncEvent: syncEvent, syncCursorUpdatedAt: syncCursorUpdatedAt)
         )
     }
 
     /// Whether the item still has unconsumed sync work pending. Driven by the
     /// item's latest *sync-relevant* webhook (sticky — see
-    /// `WebhookEventStore.latestSyncEventsByItem`), cleared once the item's
-    /// `updatedAt` (its last refresh) advances past the sync event.
-    private static func needsPollingSync(item: ItemModel, syncEvent: WebhookItemSignal?) -> Bool {
+    /// `WebhookEventStore.latestSyncEventsByItem`), cleared once the committed
+    /// transaction sync cursor advances past the sync event. Item status-only
+    /// writes also update `items.updated_at`, so using the item row timestamp
+    /// here would incorrectly clear a pending transaction sync when a later
+    /// non-sync webhook such as `PENDING_EXPIRATION` only changed connection
+    /// status.
+    private static func needsPollingSync(syncEvent: WebhookItemSignal?, syncCursorUpdatedAt: Date?) -> Bool {
         guard let syncEvent else { return false }
-        guard let lastSync = item.updatedAt else { return true }
-        return lastSync < syncEvent.effectiveDate
+        guard let syncCursorUpdatedAt else { return true }
+        return syncCursorUpdatedAt < syncEvent.effectiveDate
     }
 
     static func includesItems(_ request: Request) -> Bool {

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -64,13 +64,18 @@ struct TransactionRoutes: Sendable {
             guard let nextCursor = result.nextCursor, !nextCursor.isEmpty else { return }
             cursors[result.itemId] = nextCursor
         }
+        let pendingCursorUpdatedAts = successfulResults.reduce(into: [String: Date]()) { updatedAts, result in
+            guard let nextCursor = result.nextCursor, !nextCursor.isEmpty, let cursorUpdatedAt = result.cursorUpdatedAt else { return }
+            updatedAts[result.itemId] = cursorUpdatedAt
+        }
 
         let syncResponse = SyncResponse(
             added: successfulResults.flatMap(\.added),
             modified: successfulResults.flatMap(\.modified),
             removed: successfulResults.flatMap(\.removed),
             hasMore: successfulResults.contains(where: \.hasMore),
-            pendingCursors: pendingCursors
+            pendingCursors: pendingCursors,
+            pendingCursorUpdatedAts: pendingCursorUpdatedAts
         )
 
         let data = try JSONEncoder().encode(syncResponse)
@@ -94,7 +99,8 @@ struct TransactionRoutes: Sendable {
             // resurrected for an item deleted mid-request.
             let persisted = try await tokenStore.saveSyncCursorIfItemExists(
                 itemId: itemId,
-                cursor: committableCursor
+                cursor: committableCursor,
+                updatedAt: commitRequest.cursorUpdatedAts[itemId] ?? Date()
             )
             guard persisted else {
                 throw HTTPError(.badRequest, message: "Cannot commit cursor for unknown item")
@@ -126,6 +132,7 @@ struct TransactionRoutes: Sendable {
         let removed: [String]
         let hasMore: Bool
         let nextCursor: String?
+        let cursorUpdatedAt: Date?
 
         static let skipped = ItemSyncResult(
             itemId: "",
@@ -135,7 +142,8 @@ struct TransactionRoutes: Sendable {
             modified: [],
             removed: [],
             hasMore: false,
-            nextCursor: nil
+            nextCursor: nil,
+            cursorUpdatedAt: nil
         )
     }
 
@@ -177,7 +185,8 @@ struct TransactionRoutes: Sendable {
                 modified: itemResult.modified,
                 removed: itemResult.removed,
                 hasMore: false,
-                nextCursor: itemResult.nextCursor
+                nextCursor: itemResult.nextCursor,
+                cursorUpdatedAt: itemResult.cursorUpdatedAt
             )
         } catch PlaidError.credentialsNotConfigured {
             // Setup state affects every item identically: surface the 503
@@ -196,7 +205,8 @@ struct TransactionRoutes: Sendable {
                 modified: [],
                 removed: [],
                 hasMore: false,
-                nextCursor: nil
+                nextCursor: nil,
+                cursorUpdatedAt: nil
             )
         }
     }
@@ -205,7 +215,13 @@ struct TransactionRoutes: Sendable {
         itemId: String,
         accessToken: String,
         persistedCursor: String?
-    ) async throws -> (added: [TransactionDTO], modified: [TransactionDTO], removed: [String], nextCursor: String?) {
+    ) async throws -> (
+        added: [TransactionDTO],
+        modified: [TransactionDTO],
+        removed: [String],
+        nextCursor: String?,
+        cursorUpdatedAt: Date?
+    ) {
         var mutationRestartCount = 0
 
         while true {
@@ -229,7 +245,13 @@ struct TransactionRoutes: Sendable {
         itemId: String,
         accessToken: String,
         persistedCursor: String?
-    ) async throws -> (added: [TransactionDTO], modified: [TransactionDTO], removed: [String], nextCursor: String?) {
+    ) async throws -> (
+        added: [TransactionDTO],
+        modified: [TransactionDTO],
+        removed: [String],
+        nextCursor: String?,
+        cursorUpdatedAt: Date?
+    ) {
         var cursor = persistedCursor
         var pageCount = 0
         var added: [TransactionDTO] = []
@@ -261,7 +283,7 @@ struct TransactionRoutes: Sendable {
             }
 
             guard response.hasMore else {
-                return (added, modified, removed, finalCursor)
+                return (added, modified, removed, finalCursor, finalCursor == nil ? nil : Date())
             }
         }
     }

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -78,7 +78,9 @@ struct TransactionRoutes: Sendable {
             pendingCursorUpdatedAts: pendingCursorUpdatedAts
         )
 
-        let data = try JSONEncoder().encode(syncResponse)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(syncResponse)
         return Response(
             status: .ok,
             headers: [.contentType: "application/json"],

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -93,7 +93,14 @@ struct TransactionRoutes: Sendable {
         request: Request,
         context: some RequestContext
     ) async throws -> HTTPResponse.Status {
-        let commitRequest = try await request.decode(as: SyncCursorCommitRequest.self, context: context)
+        // Decode with an explicit `.iso8601` strategy rather than the default
+        // context decoder. The app encodes `cursorUpdatedAts` as ISO-8601 date
+        // strings (`ServerClient`'s encoder), but the router's default
+        // `BasicRequestContext` decoder uses `.deferredToDate`, which would throw
+        // a `typeMismatch` on a populated map and fail the whole commit — leaving
+        // cursors unpersisted and `needsSync` permanently stuck. Mirrors the
+        // explicit-decoder convention in `BillingRoutes`/`ReviewRoutes`.
+        let commitRequest = try await Self.decodeCommitRequest(request)
         for (itemId, cursor) in commitRequest.cursors {
             guard let committableCursor = Self.normalizedCommittableCursor(cursor) else { continue }
             // Atomic existence-check + save: closes the TOCTOU between the
@@ -112,6 +119,23 @@ struct TransactionRoutes: Sendable {
     }
 
     // MARK: - Helpers
+
+    /// Upper bound for the small JSON cursor-commit payload.
+    private static let maxCommitBodyBytes = 256 * 1024
+
+    /// Decode a cursor-commit body with an explicit ISO-8601 date strategy so the
+    /// `cursorUpdatedAts` timestamps round-trip with what the app encoded.
+    private static func decodeCommitRequest(_ request: Request) async throws -> SyncCursorCommitRequest {
+        let buffer = try await request.body.collect(upTo: Self.maxCommitBodyBytes)
+        let data = Data(buffer: buffer)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(SyncCursorCommitRequest.self, from: data)
+        } catch {
+            throw HTTPError(.badRequest, message: "Malformed sync cursor commit")
+        }
+    }
 
     static func shouldFailSync(attemptedItemCount: Int, successfulItemCount: Int) -> Bool {
         attemptedItemCount > 0 && successfulItemCount == 0

--- a/Sources/PlaidBarServer/Storage/Database.swift
+++ b/Sources/PlaidBarServer/Storage/Database.swift
@@ -73,7 +73,7 @@ final class SyncCursorModel: Model, @unchecked Sendable {
     @Field(key: "cursor")
     var cursor: String
 
-    @Timestamp(key: "updated_at", on: .update)
+    @Field(key: "updated_at")
     var updatedAt: Date?
 
     init() {}

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -231,12 +231,14 @@ actor TokenStore {
         }
     }
 
-    func saveSyncCursor(itemId: String, cursor: String) async throws {
+    func saveSyncCursor(itemId: String, cursor: String, updatedAt: Date = Date()) async throws {
         if let existing = try await SyncCursorModel.find(itemId, on: fluent.db()) {
             existing.cursor = cursor
+            existing.updatedAt = updatedAt
             try await existing.save(on: fluent.db())
         } else {
             let model = SyncCursorModel(itemId: itemId, cursor: cursor)
+            model.updatedAt = updatedAt
             try await model.save(on: fluent.db())
         }
     }
@@ -248,12 +250,12 @@ actor TokenStore {
     /// the check and the save and resurrect a `sync_cursors` row for a gone
     /// item.
     @discardableResult
-    func saveSyncCursorIfItemExists(itemId: String, cursor: String) async throws -> Bool {
+    func saveSyncCursorIfItemExists(itemId: String, cursor: String, updatedAt: Date = Date()) async throws -> Bool {
         await acquireCursorWriteLock()
         let outcome: Result<Bool, Error>
         do {
             if try await ItemModel.find(itemId, on: fluent.db()) != nil {
-                try await saveSyncCursor(itemId: itemId, cursor: cursor)
+                try await saveSyncCursor(itemId: itemId, cursor: cursor, updatedAt: updatedAt)
                 outcome = .success(true)
             } else {
                 outcome = .success(false)

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -223,6 +223,14 @@ actor TokenStore {
         try await SyncCursorModel.find(itemId, on: fluent.db())?.cursor
     }
 
+    func syncCursorUpdatedAtsByItem() async throws -> [String: Date] {
+        let cursors = try await SyncCursorModel.query(on: fluent.db()).all()
+        return cursors.reduce(into: [String: Date]()) { result, cursor in
+            guard let itemId = cursor.id, let updatedAt = cursor.updatedAt else { return }
+            result[itemId] = updatedAt
+        }
+    }
+
     func saveSyncCursor(itemId: String, cursor: String) async throws {
         if let existing = try await SyncCursorModel.find(itemId, on: fluent.db()) {
             existing.cursor = cursor

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -1447,7 +1447,8 @@ struct PlaidBarCoreTests {
             modified: [],
             removed: [],
             hasMore: true,
-            pendingCursors: ["item_1": "cursor_page_1"]
+            pendingCursors: ["item_1": "cursor_page_1"],
+            pendingCursorUpdatedAts: ["item_1": Date(timeIntervalSince1970: 1)]
         ))
         batch.apply(SyncResponse(
             added: [
@@ -1458,7 +1459,11 @@ struct PlaidBarCoreTests {
             ],
             removed: ["remove", "new-page-1"],
             hasMore: false,
-            pendingCursors: ["item_1": "cursor_page_2", "item_2": "cursor_item_2"]
+            pendingCursors: ["item_1": "cursor_page_2", "item_2": "cursor_item_2"],
+            pendingCursorUpdatedAts: [
+                "item_1": Date(timeIntervalSince1970: 2),
+                "item_2": Date(timeIntervalSince1970: 3),
+            ]
         ))
 
         #expect(batch.hasChanges)
@@ -1466,6 +1471,10 @@ struct PlaidBarCoreTests {
         #expect(batch.transactions.first { $0.id == "modify" }?.amount == 35)
         #expect(Set(batch.transactions.map(\.id)).count == batch.transactions.count)
         #expect(batch.pendingCursors == ["item_1": "cursor_page_2", "item_2": "cursor_item_2"])
+        #expect(batch.pendingCursorUpdatedAts == [
+            "item_1": Date(timeIntervalSince1970: 2),
+            "item_2": Date(timeIntervalSince1970: 3),
+        ])
     }
 
     @Test("Transaction sync batch tracks cursors without marking empty pages changed")
@@ -1480,12 +1489,14 @@ struct PlaidBarCoreTests {
             modified: [],
             removed: [],
             hasMore: false,
-            pendingCursors: ["item_1": "cursor_empty"]
+            pendingCursors: ["item_1": "cursor_empty"],
+            pendingCursorUpdatedAts: ["item_1": Date(timeIntervalSince1970: 4)]
         ))
 
         #expect(!batch.hasChanges)
         #expect(batch.transactions == existing)
         #expect(batch.pendingCursors == ["item_1": "cursor_empty"])
+        #expect(batch.pendingCursorUpdatedAts == ["item_1": Date(timeIntervalSince1970: 4)])
     }
 
     @Test("Transaction sync batch treats equivalent non-empty deltas as unchanged")

--- a/Tests/PlaidBarCoreTests/SyncResponseTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncResponseTests.swift
@@ -4,16 +4,30 @@ import Testing
 
 @Suite("Sync response payloads")
 struct SyncResponseTests {
-    @Test("Sync cursor commit request carries its cursors")
+    @Test("Sync cursor commit request carries cursors and cursor update times")
     func commitRequest() {
-        let request = SyncCursorCommitRequest(cursors: ["item-1": "cursor-1"])
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_100)
+        let request = SyncCursorCommitRequest(
+            cursors: ["item-1": "cursor-1"],
+            cursorUpdatedAts: ["item-1": updatedAt]
+        )
         #expect(request.cursors["item-1"] == "cursor-1")
+        #expect(request.cursorUpdatedAts["item-1"] == updatedAt)
+    }
+
+    @Test("Decoding cursor commit request tolerates missing cursor update times")
+    func decodeCommitRequestWithoutCursorUpdatedAts() throws {
+        let json = #"{"cursors":{"item-1":"cursor-1"}}"#
+        let request = try JSONDecoder().decode(SyncCursorCommitRequest.self, from: Data(json.utf8))
+        #expect(request.cursors["item-1"] == "cursor-1")
+        #expect(request.cursorUpdatedAts.isEmpty)
     }
 
     @Test("Memberwise init defaults pending cursors to empty")
     func memberwiseInit() {
         let response = SyncResponse(added: [], modified: [], removed: [], hasMore: true)
         #expect(response.pendingCursors.isEmpty)
+        #expect(response.pendingCursorUpdatedAts.isEmpty)
         #expect(response.hasMore)
     }
 
@@ -22,14 +36,16 @@ struct SyncResponseTests {
         let json = #"{"added":[],"modified":[],"removed":["t1"],"hasMore":false}"#
         let response = try JSONDecoder().decode(SyncResponse.self, from: Data(json.utf8))
         #expect(response.pendingCursors.isEmpty)
+        #expect(response.pendingCursorUpdatedAts.isEmpty)
         #expect(response.hasMore == false)
         #expect(response.removed == ["t1"])
     }
 
-    @Test("Decoding reads a present pendingCursors field")
+    @Test("Decoding reads present pending cursor fields")
     func decodePendingCursors() throws {
-        let json = #"{"added":[],"modified":[],"removed":[],"hasMore":true,"pendingCursors":{"item-1":"c1"}}"#
+        let json = #"{"added":[],"modified":[],"removed":[],"hasMore":true,"pendingCursors":{"item-1":"c1"},"pendingCursorUpdatedAts":{"item-1":1800000100}}"#
         let response = try JSONDecoder().decode(SyncResponse.self, from: Data(json.utf8))
         #expect(response.pendingCursors["item-1"] == "c1")
+        #expect(response.pendingCursorUpdatedAts["item-1"] == Date(timeIntervalSince1970: 1_800_000_100))
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1091,12 +1091,26 @@ struct PlaidBarServerTests {
     }
 
     private static func decodeBody<T: Decodable>(_ response: Response) async throws -> T {
+        let data = try await responseData(response)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func decodeSyncBody(_ response: Response) async throws -> SyncResponse {
+        try decodeSyncData(try await responseData(response))
+    }
+
+    private static func decodeSyncData(_ data: Data) throws -> SyncResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(SyncResponse.self, from: data)
+    }
+
+    private static func responseData(_ response: Response) async throws -> Data {
         let collector = ResponseBodyCollector()
         let writer = CollectingResponseBodyWriter(collector: collector)
         try await response.body.write(writer)
         var buffer = await collector.collectedBuffer()
-        let data = buffer.readData(length: buffer.readableBytes) ?? Data()
-        return try JSONDecoder().decode(T.self, from: data)
+        return buffer.readData(length: buffer.readableBytes) ?? Data()
     }
 
     private static func responseString(_ response: Response) async throws -> String {
@@ -1790,7 +1804,7 @@ struct PlaidBarServerTests {
                 context: TestRequestContext(source: TestRequestContextSource())
             )
 
-            let sync: SyncResponse = try await Self.decodeBody(response)
+            let sync = try await Self.decodeSyncBody(response)
             #expect(sync.added.map(\.id) == ["tx-a", "tx-c"])
             #expect(sync.added.map(\.itemId) == ["item-a", "item-c"])
             #expect(sync.pendingCursors == ["item-a": "cursor-a", "item-c": "cursor-c"])
@@ -1838,7 +1852,8 @@ struct PlaidBarServerTests {
                 request: Self.makeRequest(path: "/api/transactions/sync"),
                 context: TestRequestContext(source: TestRequestContextSource())
             )
-            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+            let responseData = try await Self.responseData(httpResponse)
+            let response = try Self.decodeSyncData(responseData)
             let calls = await client.recordedSyncCalls()
 
             #expect(calls.map(\.accessToken) == [accessToken, accessToken])
@@ -1846,6 +1861,11 @@ struct PlaidBarServerTests {
             #expect(response.added.map(\.id) == ["tx-page-1", "tx-page-2"])
             #expect(response.hasMore == false)
             #expect(response.pendingCursors == [itemId: "cursor-2"])
+            let payload = try #require(try JSONSerialization.jsonObject(
+                with: responseData
+            ) as? [String: Any])
+            let cursorUpdatedAts = try #require(payload["pendingCursorUpdatedAts"] as? [String: String])
+            #expect(cursorUpdatedAts[itemId] != nil)
         }
     }
 
@@ -1894,7 +1914,7 @@ struct PlaidBarServerTests {
                 request: Self.makeRequest(path: "/api/transactions/sync"),
                 context: TestRequestContext(source: TestRequestContextSource())
             )
-            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+            let response = try await Self.decodeSyncBody(httpResponse)
             let calls = await client.recordedSyncCalls()
 
             #expect(calls.map(\.cursor) == ["persisted-cursor", "stale-cursor", "persisted-cursor", "fresh-cursor-1"])
@@ -1937,7 +1957,7 @@ struct PlaidBarServerTests {
                 request: Self.makeRequest(path: "/api/transactions/sync"),
                 context: TestRequestContext(source: TestRequestContextSource())
             )
-            let response: SyncResponse = try await Self.decodeBody(httpResponse)
+            let response = try await Self.decodeSyncBody(httpResponse)
 
             #expect(response.added.map(\.id) == ["ok-page"])
             #expect(response.pendingCursors == ["a-item-ok": "ok-cursor"])
@@ -2043,8 +2063,8 @@ struct PlaidBarServerTests {
                 context: TestRequestContext(source: TestRequestContextSource())
             )
 
-            let firstSync: SyncResponse = try await Self.decodeBody(try await first)
-            let secondSync: SyncResponse = try await Self.decodeBody(try await second)
+            let firstSync = try await Self.decodeSyncBody(try await first)
+            let secondSync = try await Self.decodeSyncBody(try await second)
 
             // Both callers observe the same coalesced result.
             #expect(firstSync.added.map(\.id) == ["tx-a"])

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -2026,6 +2026,67 @@ struct PlaidBarServerTests {
         }
     }
 
+    @Test("Cursor commit decodes ISO-8601 cursorUpdatedAts over the HTTP boundary")
+    func cursorCommitDecodesISO8601UpdatedAts() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plaidbar-cursor-commit-iso8601-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let databasePath = directory.appendingPathComponent("plaidbar-test.sqlite").path
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.cursor-commit-iso8601")
+        let client = DelayedRefreshPlaidClient(syncOutcomes: [:])
+
+        try await withTokenStore(databasePath: databasePath, logger: logger) { store, fluent in
+            try await ItemModel(
+                id: "item-a",
+                accessToken: "keychain:item-a",
+                institutionId: "ins-a",
+                institutionName: "Institution A"
+            ).save(on: fluent.db())
+            let route = TransactionRoutes(plaidClient: client, tokenStore: store, maxConcurrentItemRefreshes: 2)
+
+            // Mirror the real app client: ServerClient encodes the commit body —
+            // including the `cursorUpdatedAts` dates — with `.iso8601`. The server
+            // must decode that wire format. The router's default context decoder
+            // uses `.deferredToDate` and would throw a `typeMismatch` on these
+            // ISO-8601 date strings, so this drives the real HTTP decode boundary
+            // (regression guard for AND-667 cursor-commit decoding).
+            let cursorUpdatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+            let commit = SyncCursorCommitRequest(
+                cursors: ["item-a": "cursor-after-sync"],
+                cursorUpdatedAts: ["item-a": cursorUpdatedAt]
+            )
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let body = try encoder.encode(commit)
+            var headers = HTTPFields()
+            headers[.contentType] = "application/json"
+            let request = Request(
+                head: HTTPRequest(
+                    method: .post,
+                    scheme: nil,
+                    authority: nil,
+                    path: "/api/transactions/sync/cursors",
+                    headerFields: headers
+                ),
+                body: RequestBody(buffer: ByteBuffer(data: body))
+            )
+
+            let status = try await route.commitSyncCursors(
+                request: request,
+                context: TestRequestContext(source: TestRequestContextSource())
+            )
+
+            #expect(status == .ok)
+            #expect(try await store.getSyncCursor(itemId: "item-a") == "cursor-after-sync")
+            // The cursor's observation time round-trips intact, so a stale cursor
+            // committed after a newer sync webhook stays stale (the PR's intent).
+            let updatedAts = try await store.syncCursorUpdatedAtsByItem()
+            #expect(updatedAts["item-a"] == cursorUpdatedAt)
+        }
+    }
+
     @Test("Concurrent syncs for the same item coalesce onto a single Plaid pass")
     func concurrentItemSyncsCoalesce() async throws {
         let directory = FileManager.default.temporaryDirectory

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -207,9 +207,53 @@ struct WebhookReceiverTests {
             let pending = try await statusRoutes.statusSnapshot(includeItems: true)
             #expect(try #require(pending.itemStatuses?.first).needsSync)
 
-            try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            try await tokenStore.saveSyncCursor(itemId: "item-webhook", cursor: "cursor-after-sync")
             let refreshed = try await statusRoutes.statusSnapshot(includeItems: true)
             #expect(!((try #require(refreshed.itemStatuses?.first)).needsSync))
+        }
+    }
+
+    @Test("Status-changing webhook does not clear an earlier pending transaction sync")
+    func statusChangingWebhookDoesNotClearPendingTransactionSync() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            let signal = WebhookItemSignal(
+                itemId: "item-webhook",
+                webhookType: "TRANSACTIONS",
+                webhookCode: "SYNC_UPDATES_AVAILABLE",
+                requestId: "request-sync-before-status",
+                idempotencyHash: "sync-before-status-\(UUID().uuidString)",
+                eventAt: Date(timeIntervalSince1970: 1_800_000_000),
+                receivedAt: Date(timeIntervalSince1970: 1_800_000_000),
+                needsSync: true
+            )
+            _ = try await eventStore.record(signal)
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+            let pending = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(try #require(pending.itemStatuses?.first).needsSync)
+
+            let webhookRoute = WebhookRoutes(
+                verifier: StrictPlaidWebhookVerifier(signatureValidator: AcceptingSignatureValidator()),
+                tokenStore: tokenStore,
+                eventStore: eventStore,
+                now: { Date(timeIntervalSince1970: 1_800_000_600) }
+            )
+            let body = Self.payload(webhookCode: "PENDING_EXPIRATION", timestamp: "2027-01-15T08:10:00Z")
+            _ = try await webhookRoute.receive(
+                request: Self.request(body: body, jwt: Self.jwt(iat: 1_800_000_600, body: Data(body.utf8))),
+                context: WebhookTestContext(source: WebhookTestContextSource())
+            )
+
+            let afterStatusWebhook = try await statusRoutes.statusSnapshot(includeItems: true)
+            let item = try #require(afterStatusWebhook.itemStatuses?.first)
+            #expect(item.status == .pendingExpiration)
+            #expect(item.lastWebhookEvent == "ITEM.PENDING_EXPIRATION")
+            #expect(item.needsSync)
         }
     }
 

--- a/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookReceiverTests.swift
@@ -257,6 +257,48 @@ struct WebhookReceiverTests {
         }
     }
 
+
+    @Test("Stale cursor commit does not clear a newer pending transaction sync")
+    func staleCursorCommitDoesNotClearNewerPendingTransactionSync() async throws {
+        try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
+            let syncEventAt = Date(timeIntervalSince1970: 1_800_000_000)
+            let signal = WebhookItemSignal(
+                itemId: "item-webhook",
+                webhookType: "TRANSACTIONS",
+                webhookCode: "SYNC_UPDATES_AVAILABLE",
+                requestId: "request-sync-after-cursor",
+                idempotencyHash: "sync-after-cursor-\(UUID().uuidString)",
+                eventAt: syncEventAt,
+                receivedAt: syncEventAt,
+                needsSync: true
+            )
+            _ = try await eventStore.record(signal)
+
+            let statusRoutes = StatusRoutes(
+                tokenStore: tokenStore,
+                billingStore: billingStore,
+                webhookEventStore: eventStore,
+                config: config
+            )
+
+            try await tokenStore.saveSyncCursor(
+                itemId: "item-webhook",
+                cursor: "cursor-before-webhook",
+                updatedAt: syncEventAt.addingTimeInterval(-60)
+            )
+            let staleCommit = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(try #require(staleCommit.itemStatuses?.first).needsSync)
+
+            try await tokenStore.saveSyncCursor(
+                itemId: "item-webhook",
+                cursor: "cursor-after-webhook",
+                updatedAt: syncEventAt.addingTimeInterval(60)
+            )
+            let freshCommit = try await statusRoutes.statusSnapshot(includeItems: true)
+            #expect(!((try #require(freshCommit.itemStatuses?.first)).needsSync))
+        }
+    }
+
     @Test("Consent-repair webhook codes persist their modeled item status")
     func consentRepairWebhookCodesPersistModeledStatus() async throws {
         let scenarios: [(code: String, expected: ItemConnectionStatus)] = [


### PR DESCRIPTION
## Summary

- Keep `needsSync` sticky until the committed transaction sync cursor advances past the latest sync webhook.
- Stop using `items.updated_at` as the pending-sync clear signal, because status-only webhook handling also updates the item row timestamp.
- Add server regression coverage for a later `PENDING_EXPIRATION` webhook after `SYNC_UPDATES_AVAILABLE`.

Fixes #684
Linear: AND-667

## Verification

- `git diff --check`
- `swift build --target PlaidBarServerTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarServerTests' complete!`)

## Blocked broader/focused test execution

- `swift test --filter statusChangingWebhookDoesNotClearPendingTransactionSync -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` was blocked before this server test could run by unrelated existing `PlaidBarCacheTests` strict warnings/errors (`try` around non-throwing initializers and a non-Sendable test file manager).
- `swift test --filter statusChangingWebhookDoesNotClearPendingTransactionSync` was blocked before test execution by unrelated `FoundationModelsMacros.GenerableMacro` plugin resolution failures in app target files.

PR remediation update for https://github.com/ftchvs/VaultPeek/pull/685:

Added follow-up commit 5ba9633 (`fix(webhooks): preserve cursor observation time`) to address Codex review threads:
- Cursor commits now carry the server-observed cursor timestamp, so a cursor generated before a later `SYNC_UPDATES_AVAILABLE` webhook stays stale even if committed afterward.
- First-ever cursor commits now persist `sync_cursors.updated_at` explicitly instead of relying on `@Timestamp(on: .update)`.
- Added regression coverage for stale cursor commits and cursor timestamp payload compatibility.

Verification:
- `git diff --check`
- `swift build --target PlaidBarServerTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed.
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed.

GitHub review threads: re-audited and resolved (0 unresolved on PR #685). PR remains CLEAN; CI currently reports `claude` skipped.