### PR TITLE
refactor(core): extract TransactionReviewStatus presentation copy to Core

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
@@ -118,7 +118,7 @@ struct TransactionInspectorView: View {
 
     private func statusBadges(_ row: TransactionWorkspace.Row) -> some View {
         HStack(spacing: Spacing.xs) {
-            badge(statusTitle(row.status), systemImage: statusGlyph(row.status), tint: statusColor(row.status))
+            badge(row.status.displayName, systemImage: row.status.glyphName, tint: statusColor(row.status))
             if row.transaction.pending {
                 badge("Pending", systemImage: "clock", tint: SemanticColors.pending)
             }
@@ -395,22 +395,6 @@ struct TransactionInspectorView: View {
     private func amountText(_ row: TransactionWorkspace.Row) -> String {
         let prefix = row.transaction.isIncome ? "+" : ""
         return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
-    }
-
-    private func statusTitle(_ status: TransactionReviewStatus) -> String {
-        switch status {
-        case .needsReview: "Needs review"
-        case .reviewed: "Reviewed"
-        case .ignored: "Ignored"
-        }
-    }
-
-    private func statusGlyph(_ status: TransactionReviewStatus) -> String {
-        switch status {
-        case .needsReview: "exclamationmark.circle"
-        case .reviewed: "checkmark.circle"
-        case .ignored: "minus.circle"
-        }
     }
 
     private func statusColor(_ status: TransactionReviewStatus) -> Color {

--- a/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
@@ -131,12 +131,12 @@ struct TransactionsTable: View {
 
     /// Review status — glyph + text, never color alone.
     private func statusCell(_ row: TransactionWorkspace.Row) -> some View {
-        Label(statusTitle(row.status), systemImage: statusGlyph(row.status))
+        Label(row.status.displayName, systemImage: row.status.glyphName)
             .font(.caption.weight(.medium))
             .labelStyle(.titleAndIcon)
             .foregroundStyle(statusColor(row.status))
             .lineLimit(1)
-            .accessibilityLabel("Status: \(statusTitle(row.status))")
+            .accessibilityLabel("Status: \(row.status.displayName)")
     }
 
     // MARK: - Context menu (single-row, via the existing review path)
@@ -197,22 +197,6 @@ struct TransactionsTable: View {
 
     private func categoryTitle(_ row: TransactionWorkspace.Row) -> String {
         (row.effectiveCategory ?? row.suggestedCategory)?.displayName ?? "Uncategorized"
-    }
-
-    private func statusTitle(_ status: TransactionReviewStatus) -> String {
-        switch status {
-        case .needsReview: "Needs review"
-        case .reviewed: "Reviewed"
-        case .ignored: "Ignored"
-        }
-    }
-
-    private func statusGlyph(_ status: TransactionReviewStatus) -> String {
-        switch status {
-        case .needsReview: "exclamationmark.circle"
-        case .reviewed: "checkmark.circle"
-        case .ignored: "minus.circle"
-        }
     }
 
     private func statusColor(_ status: TransactionReviewStatus) -> Color {

--- a/Sources/PlaidBarCore/Models/TransactionReview.swift
+++ b/Sources/PlaidBarCore/Models/TransactionReview.swift
@@ -1,9 +1,32 @@
 import Foundation
 
-public enum TransactionReviewStatus: String, Codable, Sendable, Equatable, Hashable {
+public enum TransactionReviewStatus: String, Codable, Sendable, CaseIterable, Equatable, Hashable {
     case needsReview
     case reviewed
     case ignored
+
+    /// Human-readable status label. Shared by the transactions table and the
+    /// transaction inspector so the two surfaces read identically; previously
+    /// duplicated as a private `statusTitle` switch in both views. Mirrors
+    /// `TransactionReviewReason.displayName`.
+    public var displayName: String {
+        switch self {
+        case .needsReview: "Needs review"
+        case .reviewed: "Reviewed"
+        case .ignored: "Ignored"
+        }
+    }
+
+    /// SF Symbol name for this status's badge glyph. The glyph is always a
+    /// redundant layer alongside `title`, never the sole carrier of meaning
+    /// (ACCESSIBILITY.md). Color encoding stays in the view layer.
+    public var glyphName: String {
+        switch self {
+        case .needsReview: "exclamationmark.circle"
+        case .reviewed: "checkmark.circle"
+        case .ignored: "minus.circle"
+        }
+    }
 }
 
 public enum TransactionReviewReason: String, Codable, Sendable, CaseIterable, Equatable, Hashable {

--- a/Tests/PlaidBarCoreTests/TransactionReviewStatusPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionReviewStatusPresentationTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import PlaidBarCore
+
+/// Pins the per-status presentation copy (`displayName`, `glyphName`) extracted
+/// from the transactions table + transaction inspector views into
+/// `TransactionReviewStatus`. Both surfaces previously carried byte-identical
+/// private `statusTitle`/`statusGlyph` switches; these are now the single
+/// source of truth. The strings drive what the user sees, so the golden values
+/// are asserted verbatim — any change is intentional and must update the test.
+@Suite struct TransactionReviewStatusPresentationTests {
+    @Test func displayNamePinsEveryCase() {
+        #expect(TransactionReviewStatus.needsReview.displayName == "Needs review")
+        #expect(TransactionReviewStatus.reviewed.displayName == "Reviewed")
+        #expect(TransactionReviewStatus.ignored.displayName == "Ignored")
+    }
+
+    @Test func glyphNamePinsEveryCase() {
+        #expect(TransactionReviewStatus.needsReview.glyphName == "exclamationmark.circle")
+        #expect(TransactionReviewStatus.reviewed.glyphName == "checkmark.circle")
+        #expect(TransactionReviewStatus.ignored.glyphName == "minus.circle")
+    }
+
+    /// Every status must yield a non-empty display name + glyph — guards against
+    /// a future case being added to the enum without presentation copy.
+    @Test func everyStatusHasNonEmptyPresentation() {
+        for status in TransactionReviewStatus.allCases {
+            #expect(!status.displayName.isEmpty)
+            #expect(!status.glyphName.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Two window-first views — `TransactionInspectorView` and `TransactionsTable` — each carried **byte-identical** private `statusTitle(_:)` and `statusGlyph(_:)` switches over `TransactionReviewStatus`.
- Moved them to `displayName` and `glyphName` computed properties on the `TransactionReviewStatus` enum in `PlaidBarCore` (the single source of truth), mirroring the existing `TransactionReviewReason.displayName`/`glyphName`/`explanation` pattern in the same file.
- Both call sites now delegate. The SwiftUI `Color`-returning `statusColor(_:)` deliberately **stays in the view layer** (color is presentation, never the sole carrier of meaning — ACCESSIBILITY.md), consistent with the prior `TransactionReviewReason` `tint(for:)` precedent (PR #653).
- Added `CaseIterable` so the new golden-string tests pin every case via `allCases`.

Behavior-preserving only — the extracted strings are byte-identical to both deleted copies. This is step 11 of the autonomous architecture-refactor loop (pure presentation logic → Core).

## Autonomous task IDs

- Task ID(s): autonomous architecture-refactor loop (no Linear issue)
- Backlog slice: AppState/view → PlaidBarCore pure-logic extraction (thesis: pure Sendable presentation logic belongs in Core)
- Scope note: one focused, behavior-preserving extraction

## Agent coordination

- Builder agent: Claude (scheduled vaultpeek-architecture-refactor task)
- Builder branch/worktree: `refactor/auto-2026-06-25` (worktree off `origin/main`)
- Reviewer/merge steward: Otto
- Coordination note: review only; no other agent should push to this branch

## Changed files

- `Sources/PlaidBarCore/Models/TransactionReview.swift` — add `displayName` + `glyphName` to `TransactionReviewStatus`; add `CaseIterable`
- `Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift` — delete private `statusTitle`/`statusGlyph`, delegate to enum
- `Sources/PlaidBar/Views/Destinations/TransactionsTable.swift` — same
- `Tests/PlaidBarCoreTests/TransactionReviewStatusPresentationTests.swift` — new golden-string tests (3)

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` clean (CI gate; all 3 targets)
- [x] `swift build` of server/shared covered by the strict full-package build above
- [x] Full `swift test` green — 2557 tests pass (incl. the sometimes-flaky LocalInsightModelRuntime test); new `TransactionReviewStatusPresentation` suite 3/3
- [x] Secret scan completed over the diff — none found

## GitHub checks

- [ ] Required GitHub checks are green before merge.
- [ ] `CI / build` is green before merge.
- [ ] `Claude Code Review / claude-review` is green before merge.
- [ ] `Codex Code Review / codex-review` is green before merge.

## Privacy and safety impact

None. Pure presentation-string extraction; no data flow, storage, network, or credential surface touched. Demo app booted 9s without crash.