### PR TITLE
fix: reload Control Center on privacy snapshot changes

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PlaidBarCore
 import PlaidBarCache
+import AppIntents
 import Combine
 import OSLog
 import WidgetKit
@@ -4244,6 +4245,7 @@ final class AppState {
             Task {
                 await clearGlanceSnapshot()
                 await MainActor.run {
+                    ControlCenter.shared.reloadAllControls()
                     WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
                 }
             }
@@ -4296,6 +4298,7 @@ final class AppState {
                 }
                 guard changed else { return }
                 await MainActor.run {
+                    ControlCenter.shared.reloadAllControls()
                     WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
                 }
             }
@@ -4382,11 +4385,13 @@ final class AppState {
         // Drop the display-only Spotlight account index on the same reset /
         // data-wipe path so removed-account names don't linger in search (AND-513).
         AccountSpotlightIndexer.clear()
-        // Tell WidgetKit to drop the already-issued timeline entry so the widget
-        // surface stops showing pre-clear balances immediately. This covers
-        // every clear path — the explicit reset/data-wipe (`resetLocalData`) and
-        // removing the last institution — not just the empty-accounts write
-        // branch, which previously reloaded on its own (AND-385 Codex review).
+        // Tell WidgetKit/Control Center to drop the already-issued timeline/control
+        // entries so system surfaces stop showing pre-clear balances immediately.
+        // This covers every clear path — the explicit reset/data-wipe
+        // (`resetLocalData`) and removing the last institution — not just the
+        // empty-accounts write branch, which previously reloaded on its own
+        // (AND-385 Codex review).
+        ControlCenter.shared.reloadAllControls()
         WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
     }
 
@@ -4397,6 +4402,7 @@ final class AppState {
         try? GlanceSnapshotStore.clear()
         try? AppGroupSnapshotStore.clear()
         AccountSpotlightIndexer.clear()
+        ControlCenter.shared.reloadAllControls()
         WidgetCenter.shared.reloadTimelines(ofKind: "PlaidBarGlanceWidget")
     }
 

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -166,6 +166,7 @@ struct PlaidBarTests {
         #expect(glanceMakeBlock.contains("isMasked: systemSurfaceMaskEnabled"))
         #expect(!glanceMakeBlock.contains("isMasked: shouldMaskFinancialValues"))
         #expect(appStateSource.contains("queued OFF command must restore the"))
+        #expect(appStateSource.contains("ControlCenter.shared.reloadAllControls()"))
         #expect(appStateSource.contains("clearPublishedSystemSnapshotsForDemoEntry()"))
     }
 


### PR DESCRIPTION
## Summary

- Reload Control Center controls whenever the app-side glance/system snapshot writer publishes or clears a snapshot.
- Keep widget timeline reload behavior unchanged while making in-app Privacy Mask/App Lock transitions consistent with the Widget extension's privacy-mask intent.
- Add a source-invariant regression assertion covering the app-side Control Center reload seam.

Fixes #687
Linear: AND-668

## Rebase onto AND-670 concurrency hardening (#698)

This branch was based on old `main`. It has been merged up to current `main` (including #698, the AppState/cache concurrency hardening). The `AppState.swift` reload sites were placed so they coexist with #698's restructuring:

- The empty-accounts clear branch, `clearGlanceSnapshot()`, and `clearPublishedSystemSnapshotsForDemoEntry()` reload Control Center alongside their existing `WidgetCenter.shared.reloadTimelines(...)`.
- The glance-snapshot-write reload sits **inside** #698's generation guard (`guard self.glanceSnapshotWriteGeneration == generation else { return }`) and after its `guard changed else { return }`, so it fires only on a write that wins the generation race and actually changes the snapshot. It does **not** defeat the generation guard — a stale in-flight write returns early before reaching the reload.
- #698's single-flight `refreshDashboard` / `performRefreshDashboard` and the generation-gated `writeFinanceSnapshot(updatedAt:generation:)` are preserved unchanged.
- The `PlaidBarTests.swift` merge is additive: #688's Control-Center-reload source-invariant and #698's `financeSnapshotCommitIsGenerationGatedBeforeSave` are both retained.

## Verification (real, full suite — supersedes the prior "blocked" notes)

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **PASS** (`Build complete!`, exit 0). The FoundationModels-macro / PlaidBarCacheTests strict-concurrency errors mentioned earlier did not reproduce; the clean build was previously blocked only by the SwiftPM-under-sandbox quirk.
- `swift test` (full suite, **no filter**) — **PASS: `Test run with 2595 tests passed`, 0 failures** (only environment-gated Keychain tests self-skip, as on `main`).
- `swift test --filter privacyMaskControlPathsRedactEveryPublishedSystemSurface` — PASS (asserts the Control Center reload source-invariant).
- `swift test --filter financeSnapshotCommitIsGenerationGatedBeforeSave` — PASS (#698 invariant intact).
- `git diff --check` — clean; no conflict markers.

## Privacy / security

Local system-surface refresh only. No Plaid credentials, access tokens, public tokens, account IDs, transaction IDs, balances, raw Plaid payloads, prompts, response bodies, or local SQLite contents are moved into the app/docs/tests/artifacts.
