### PR TITLE
fix(budgeting): rebalance can target zero-limit destination categories (AND-672)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/BudgetRebalancePlanner.swift
+++ b/Sources/PlaidBarCore/Utilities/BudgetRebalancePlanner.swift
@@ -283,12 +283,19 @@ public enum BudgetRebalancePlanner {
             maxSurplusFraction > 0
         else { return [] }
 
-        let monthRows = schema.budgets.filter { $0.month == month && $0.monthlyLimit > 0 }
+        let monthRows = schema.budgets.filter { $0.month == month }
         guard !monthRows.isEmpty else { return [] }
 
         // Sources: categories under budget, ranked by how much we may pull (a cushion
         // share of the surplus). Destinations: categories over budget, ranked by how
         // far over. Both deterministic (amount desc, then category id asc).
+        //
+        // The zero-limit exclusion applies to *sources only* — you can't pull budget
+        // from a category that has none, and `pullable` below is naturally `0` when
+        // `monthlyLimit == 0`. A zero-limit category is still a legitimate
+        // *destination*: a brand-new or just-zeroed category that is overspent
+        // (`spend > 0`, so `remaining < 0`) must be eligible to receive a share, or
+        // "redistribute within a fixed total" silently drops it (AND-672).
         var sources: [(categoryId: String, available: Double)] = []
         var destinations: [(categoryId: String, overage: Double)] = []
 
@@ -297,6 +304,7 @@ public enum BudgetRebalancePlanner {
             let remaining = row.monthlyLimit - spend
             if remaining > 0 {
                 // Pull at most a fraction of the surplus, but never more than the limit.
+                // `0` when the limit is `0`, so a zero-limit row is never a source.
                 let pullable = min(remaining * maxSurplusFraction, row.monthlyLimit)
                 if pullable > 0 {
                     sources.append((row.categoryId, pullable))

--- a/Tests/PlaidBarCoreTests/BudgetRebalancePlannerTests.swift
+++ b/Tests/PlaidBarCoreTests/BudgetRebalancePlannerTests.swift
@@ -300,6 +300,44 @@ struct BudgetRebalancePlannerTests {
         #expect(BudgetRebalancePlanner.monthTotal(in: current, month: "2026-06") == totalBefore)
     }
 
+    @Test("A zero-limit overspent category is an eligible rebalance destination (AND-672)")
+    func zeroLimitDestinationReceivesShare() {
+        // `travel` was just zeroed (limit 0) but already has spend, so it is
+        // overspent and a legitimate destination. `shopping` carries the surplus.
+        let start = schema([
+            budget("2026-06", shopping, 600), // surplus: spent 100 → headroom 500
+            budget("2026-06", travel, 0),     // zero-limit but overspent (spent 90)
+        ])
+        let totalBefore = BudgetRebalancePlanner.monthTotal(in: start, month: "2026-06")
+        #expect(totalBefore == 600)
+
+        let suggestions = BudgetRebalancePlanner.suggestRebalances(
+            in: start,
+            month: "2026-06",
+            spendByCategory: [shopping: 100, travel: 90],
+            asOf: asOf
+        )
+
+        // (a) The zero-limit category must receive a positive share — not be dropped.
+        #expect(!suggestions.isEmpty)
+        let toTravel = suggestions.filter { $0.move.destinationCategoryId == travel }
+        #expect(!toTravel.isEmpty)
+        #expect(toTravel.allSatisfy { $0.move.amount > 0 })
+        #expect(toTravel.contains { $0.move.sourceCategoryId == shopping })
+
+        // (b) Applying every suggestion keeps the month total invariant.
+        var current = start
+        for suggestion in suggestions {
+            let result = BudgetRebalancePlanner.apply(suggestion.move, to: current, asOf: asOf)
+            #expect(result.applied)
+            current = result.schema
+        }
+        #expect(BudgetRebalancePlanner.monthTotal(in: current, month: "2026-06") == totalBefore)
+        // The once-zero-limit destination now holds a positive limit.
+        let travelRow = BudgetRebalancePlanner.row(in: current, month: "2026-06", categoryId: travel)
+        #expect((travelRow?.monthlyLimit ?? 0) > 0)
+    }
+
     @Test("No suggestions when nothing is over budget")
     func noOverageNoSuggestions() {
         let start = schema([


### PR DESCRIPTION
## Summary

The budget **rebalance** suggester (`suggestRebalances` in `BudgetRebalancePlanner`, AND-549) silently dropped destination categories whose current `monthlyLimit` is `0`. A brand-new or just-zeroed category that is overspent could therefore never **receive** redistributed budget from a rebalance — surprising for a feature framed as "redistribute within a fixed total."

The candidate pre-filter (`schema.budgets.filter { $0.month == month && $0.monthlyLimit > 0 }`) excluded every zero-limit row **before** the source/destination split. That exclusion is correct for the **source** side (you can't pull budget from a category that has none) but wrong for the **destination** side.

This change applies the zero-limit exclusion to **sources only**, making a zero-limit overspent category an eligible destination again. The month-total invariant is preserved.

## Architectural rationale

Pure, deterministic logic stays in `PlaidBarCore` (`Sources/PlaidBarCore/Utilities/BudgetRebalancePlanner.swift`), per the project's "shared logic in Core" convention — no view or route is touched. The fix is a one-line filter relaxation plus comments; the source/destination ranking, greedy walk, and conservation guarantees are unchanged.

The source side stays safe **by construction**, not by an explicit re-filter: the source branch computes `pullable = min(remaining * maxSurplusFraction, monthlyLimit)`, which is `0` when `monthlyLimit == 0`, and is gated behind `if pullable > 0`. So a zero-limit row can never become a source. Only the destination branch (`remaining < 0`) newly sees zero-limit overspent rows.

## Design decisions

- **Smallest behavior-correct change.** Relaxed the pre-filter from `month && limit > 0` to `month`, rather than restructuring the source/destination loop. The existing `if pullable > 0` guard already enforces the source-side zero-limit exclusion, so no redundant guard was added.
- **Invariant untouched.** `apply(_:to:asOf:)` already supports a zero-limit destination (`destination.monthlyLimit + amount`) and rejects any move that would push a source negative. Every applied move remains `+X`/`-X` on the same month total, so `monthTotal` is provably unchanged.
- **No new public surface.** Signature, defaults, and determinism (ranking by amount desc, then category id asc) are all preserved; the 17 existing AND-549 tests still pass unchanged.

## Testing notes

Exact commands and results (run with the sandbox disabled per repo quirk):

```
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
# → Build complete! (CI strict-concurrency gate passes)

swift test --filter "zeroLimitDestinationReceivesShare"
# → 1 test passed (after fix)

swift test --filter "BudgetRebalancePlannerTests"
# → Test run with 18 tests passed (17 existing + 1 new)
```

**Fails-before / passes-after confirmation:** with the source fix stashed (pre-fix code) but the new test present, `swift test --filter "zeroLimitDestinationReceivesShare"` **failed** with 4 issues — the zero-limit `travel` destination was dropped and `suggestions` came back empty. Restoring the fix makes it pass. This proves the AND-549 suite was previously blind to the drop (its suggestion tests pin neither destination count nor redistributed amount for a zero-limit target).

New test: `zeroLimitDestinationReceivesShare` — rebalances into a set that includes a zero-limit overspent category and asserts (a) it receives a positive share and (b) the grand total is invariant after applying every suggestion.

## Linked issue

- AND-672 — https://linear.app/andeslab/issue/AND-672

## Known limitations

- The new test exercises a single zero-limit overspent destination plus one surplus source. It does not fan out across many zero-limit destinations competing for a constrained surplus; the existing greedy ordering already covers multi-destination ranking, so this was kept minimal and focused on the dropped-destination regression.
- This only affects **suggestions**. `apply` already handled zero-limit destinations correctly, so no apply-path behavior changed.

## Follow-ups

- The broader AND-549 suggestion suite could pin redistributed amount and destination count more tightly (the weakness that hid this bug) — a small hardening pass, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)