### PR TITLE
fix(alerts): category-budget alert re-fires on band re-entry (AND-663)

### DIFF
--- a/Sources/PlaidBarCore/Utilities/CategoryBudgetAlertEvaluator.swift
+++ b/Sources/PlaidBarCore/Utilities/CategoryBudgetAlertEvaluator.swift
@@ -16,9 +16,11 @@ import Foundation
 /// The de-dup contract (see ``NotificationTriggerSelection``) keys an alert on
 /// *category + month + band*, so a category fires **once** when it enters
 /// `nearing` and **once more** if it later escalates to `over` — but not on every
-/// refresh while it sits in the same band. Crossing `under → nearing → over` is
-/// monotonic within a month, so this models the "near or exceed" requirement
-/// without storing prior spend.
+/// refresh while it sits in the same band. This evaluator stays stateless; the
+/// notification layer treats the alert as a stateful band condition that clears
+/// when the band goes inactive (``NotificationTriggerKind/clearsWhenResolved``),
+/// so a refund or recategorization that drops spend out of a band re-arms it and
+/// a later re-crossing fires again within the same month (AND-663).
 ///
 /// ## Privacy
 /// This type emits no amounts — only the category and its band. The notification

--- a/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
+++ b/Sources/PlaidBarCore/Utilities/NotificationTriggerSelection.swift
@@ -79,17 +79,22 @@ public enum NotificationTriggerKind: String, Codable, CaseIterable, Sendable {
 
     public var clearsWhenResolved: Bool {
         switch self {
+        // A category-budget alert is a *stateful* band condition, like
+        // highUtilization/lowBalance: it auto-resolves when its band is no longer
+        // active. Spend is not monotonic within a month — a refund or
+        // recategorization can drop a category's month-to-date spend back below a
+        // band it had crossed. Clearing the delivered key when the band goes
+        // inactive re-arms it, so re-entering the same band later that month fires
+        // a fresh alert instead of being suppressed for the rest of the month
+        // (AND-663). While spend sits inside a band the key stays active, so it is
+        // never resolved and never re-fires — no in-band spam.
         case .itemError, .providerOutage, .loginRequired, .syncStale, .highUtilization, .lowBalance,
-             .recurringChargeChanged, .recurringChargeDueSoon:
+             .recurringChargeChanged, .recurringChargeDueSoon, .categoryBudgetAlert:
             true
         // A crossed watchlist threshold is a one-shot like largeTransaction:
         // the spend already happened, so it should not auto-clear when the
-        // month-to-date sum later changes. A category-budget alert is keyed on
-        // its band, and within a month spend only climbs (under → nearing →
-        // over), so a delivered band-crossing should likewise not auto-resolve —
-        // each higher band carries its own one-shot key.
-        case .largeTransaction, .recurringChargeDetected, .merchantWatch, .categoryWatch,
-             .categoryBudgetAlert:
+        // month-to-date sum later changes.
+        case .largeTransaction, .recurringChargeDetected, .merchantWatch, .categoryWatch:
             false
         }
     }
@@ -530,10 +535,13 @@ public enum NotificationTriggerSelection {
     /// Decision for a budgeted category crossing its `nearing`/`over` band
     /// (AND-642).
     ///
-    /// De-dup grain: `category + month + band`. Within a month spend climbs
-    /// monotonically (under → nearing → over), so a category fires once when it
+    /// De-dup grain: `category + month + band`. A category fires once when it
     /// nears its limit and once more if it exceeds — never on every refresh while
     /// it sits in the same band, and the next month re-arms with a new month key.
+    /// Because this kind ``NotificationTriggerKind/clearsWhenResolved``, a band
+    /// also re-arms *within* the month: if a refund or recategorization drops
+    /// spend back below a band, the delivered key clears, so re-crossing into that
+    /// same band fires a fresh alert rather than being suppressed (AND-663).
     ///
     /// ## Privacy
     /// The body never carries an amount **and never names the category**. A

--- a/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift
@@ -168,7 +168,8 @@ struct CategoryBudgetAlertEvaluatorTests {
             deliveredDedupKeys: [nearingKey!]
         )
         #expect(repeated.decisions.filter { $0.kind == .categoryBudgetAlert }.isEmpty)
-        // A one-shot band crossing does not auto-resolve when it stays put.
+        // The band is still active, so the delivered key is not resolved while the
+        // category sits in the same band — no in-band spam, no premature re-arm.
         #expect(repeated.resolvedDedupKeys.isEmpty)
 
         // Now it crosses into over: a distinct band key fires even though the
@@ -185,6 +186,53 @@ struct CategoryBudgetAlertEvaluatorTests {
         let overDecisions = escalated.decisions.filter { $0.kind == .categoryBudgetAlert }
         #expect(overDecisions.count == 1)
         #expect(overDecisions.first?.dedupKey != nearingKey)
+    }
+
+    @Test("A category re-fires after a refund drops it out of a band and it re-enters that band (AND-663)")
+    func refireAfterRefundDropsOutOfBand() {
+        // 1. Spend crosses into the nearing band → the alert fires.
+        let nearingPresentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 90),  // nearing (0.90)
+        ])
+        let first = NotificationTriggerSelection.evaluate(
+            budgetPresentation: nearingPresentation, now: fixedNow, calendar: utcCalendar
+        )
+        let nearingKey = first.decisions.first { $0.kind == .categoryBudgetAlert }?.dedupKey
+        #expect(nearingKey != nil)
+
+        // 2. A refund (or recategorization) drops month-to-date spend below the
+        // band: the band is no longer active, so the delivered key must RESOLVE,
+        // re-arming the alert for a future re-crossing. Before the fix this kind
+        // was sticky (clearsWhenResolved == false), so the key was never cleared
+        // and step 3 stayed suppressed for the rest of the month.
+        let refundedPresentation = CategoryBudgetPresentation(items: [
+            item(.foodAndDrink, limit: 100, spent: 40),  // under (0.40)
+        ])
+        let refunded = NotificationTriggerSelection.evaluate(
+            budgetPresentation: refundedPresentation,
+            now: fixedNow,
+            calendar: utcCalendar,
+            deliveredDedupKeys: [nearingKey!]
+        )
+        #expect(refunded.decisions.filter { $0.kind == .categoryBudgetAlert }.isEmpty)
+        #expect(refunded.resolvedDedupKeys.contains(nearingKey!))
+
+        // 3. Spend climbs back into the SAME nearing band. The caller removes
+        // resolved keys from its delivered set (see NotificationService), so we
+        // model that here: the second crossing produces a fresh alert. Before the
+        // fix the key was never resolved in step 2, so it stayed delivered and
+        // this crossing was suppressed for the rest of the month.
+        var delivered: Set<String> = [nearingKey!]
+        delivered.subtract(refunded.resolvedDedupKeys)
+        let reEntered = NotificationTriggerSelection.evaluate(
+            budgetPresentation: nearingPresentation,
+            now: fixedNow,
+            calendar: utcCalendar,
+            deliveredDedupKeys: delivered
+        )
+        let reEnteredDecisions = reEntered.decisions.filter { $0.kind == .categoryBudgetAlert }
+        #expect(reEnteredDecisions.count == 1)
+        #expect(reEnteredDecisions.first?.dedupKey == nearingKey)
     }
 
     @Test("Disabling the budget-alert family suppresses its decisions")


### PR DESCRIPTION
## Summary

Category-budget alerts (AND-642) never re-fired once spend left an alert band and re-entered it within the same month. The notification kind set `clearsWhenResolved = false`, baking in the assumption that spend climbs monotonically within a month (`under → nearing → over`). Refunds and recategorization break that assumption: they can drop a category's month-to-date spend back below a band it had already crossed. Because the delivered dedup key (`category + month + band`) was never cleared, re-entry into the same band was de-duplicated for the rest of the month, so the user was **not** re-alerted on the second crossing.

This flips `categoryBudgetAlert` to `clearsWhenResolved = true`, making it a stateful band condition that re-arms when its band goes inactive.

## Architectural rationale

The fix reuses the existing resolution mechanism rather than inventing a new one. `NotificationTriggerSelection.evaluate` already computes `resolvedDedupKeys` for any delivered key whose kind `clearsWhenResolved` and whose family was evaluated this pass, **minus** the keys still active this pass. `NotificationService` removes resolved keys from its persisted delivered set, re-arming them. This is exactly how `highUtilization`, `lowBalance`, `syncStale`, etc. already behave: stateful conditions that clear when no longer active.

Conceptually, a category-budget alert *is* a stateful band condition (like credit utilization above a threshold), not a one-shot event (like a single large transaction). It was miscategorized in the original AND-642 implementation. The one-shot kinds (`largeTransaction`, `recurringChargeDetected`, `merchantWatch`, `categoryWatch`) stay `false` — the spend they describe already happened and should not auto-clear. The `CategoryBudgetAlertEvaluator` stays stateless and unchanged; only its classification in `clearsWhenResolved` moved.

## Design decisions

- **Avoiding re-alert spam while in-band:** `resolvedDedupKeys` is `clearableDeliveredKeys.subtracting(activeDedupKeys)`. While spend sits inside a band, that band's key is re-emitted into `activeDedupKeys` every pass, so it is subtracted out and never resolved — and it stays in the delivered set, so the decision is filtered out. The alert resolves and re-arms **only** when the band is genuinely no longer active. No change to in-band behavior; the existing `dedupEscalation` test (same band on repeated refresh → no new decision, `resolvedDedupKeys` empty) still passes unchanged.
- **Per-band grain preserved:** the dedup key is still `category + month + band`, so `nearing` and `over` are independent. Escalation `nearing → over` still fires a distinct alert; de-escalation `over → nearing` resolves the `over` key so a later re-cross of `over` fires again. This is the desired "re-entry fires fresh" behavior, applied per band.
- **Minimal change:** a single `case` move in the `clearsWhenResolved` switch plus doc-comment corrections (the old comments asserted the now-falsified monotonic premise). No signature, storage, or evaluator changes.

## Testing notes

Exact commands and results (run with the sandbox disabled per repo quirk):

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (CI strict-concurrency gate, 0 warnings/errors).
- `swift test --filter CategoryBudgetAlertEvaluatorTests` → **13 tests passed** (includes the new regression test).
- `swift test --filter NotificationTriggerEvaluationTests` → **9 tests passed** (no regression from the `clearsWhenResolved` change).

New test: `refireAfterRefundDropsOutOfBand` in `Tests/PlaidBarCoreTests/CategoryBudgetAlertEvaluatorTests.swift`. It simulates: spend crosses into `nearing` (alert fires) → refund drops spend to `under` (delivered key **resolves**; the caller drops it) → spend rises back into `nearing` (alert fires **again**, same key). Verified it **fails before** the fix (all three assertions fail: the key is never resolved and the re-cross is suppressed) and **passes after** — confirmed by stashing only the core change and re-running.

## Linked issue

- AND-663 (Low) — https://linear.app/andeslab/issue/AND-663

## Known limitations

- Resolution is recompute-driven, not event-driven: the alert re-arms on the **next** trigger evaluation after spend leaves the band, not the instant a refund posts. Matches every other stateful trigger in this file.
- The dedup key carries no spend value, so a tiny dip below the band boundary and back (e.g. 100.5% → 99.5% → 100.5% across two evaluation passes) counts as a genuine re-crossing and re-fires. This is intentional and consistent with the per-band model; if it proves noisy in practice, a hysteresis margin on the band boundary would be the follow-up.
- The 1,000-key cap and per-month re-arm in `NotificationService` are unchanged.

## Follow-ups

- Consider band-boundary hysteresis if real-world refund noise causes flapping near a boundary (out of scope here; no evidence yet).
- The broader `clearsWhenResolved` semantics could be documented once on the enum rather than per-case; not done here to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)