### PR TITLE
fix: green main — two tests left red by #685 (sync date contract + sticky sync clear)

### DIFF
--- a/Tests/PlaidBarCoreTests/SyncResponseTests.swift
+++ b/Tests/PlaidBarCoreTests/SyncResponseTests.swift
@@ -43,9 +43,43 @@ struct SyncResponseTests {
 
     @Test("Decoding reads present pending cursor fields")
     func decodePendingCursors() throws {
-        let json = #"{"added":[],"modified":[],"removed":[],"hasMore":true,"pendingCursors":{"item-1":"c1"},"pendingCursorUpdatedAts":{"item-1":1800000100}}"#
-        let response = try JSONDecoder().decode(SyncResponse.self, from: Data(json.utf8))
+        // The wire contract for cursor-update timestamps is ISO-8601 date
+        // strings: the server encodes `SyncResponse` with an `.iso8601`
+        // `JSONEncoder` (TransactionRoutes) and the app's `ServerClient`
+        // decodes with an `.iso8601` `JSONDecoder`. Decode the way production
+        // does so this test exercises the real round-trip rather than the
+        // default `.deferredToDate` reference-date strategy.
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_100)
+        let json = #"""
+        {"added":[],"modified":[],"removed":[],"hasMore":true,"pendingCursors":{"item-1":"c1"},"pendingCursorUpdatedAts":{"item-1":"2027-01-15T08:01:40Z"}}
+        """#
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let response = try decoder.decode(SyncResponse.self, from: Data(json.utf8))
         #expect(response.pendingCursors["item-1"] == "c1")
-        #expect(response.pendingCursorUpdatedAts["item-1"] == Date(timeIntervalSince1970: 1_800_000_100))
+        #expect(response.pendingCursorUpdatedAts["item-1"] == updatedAt)
+    }
+
+    @Test("Cursor update times round-trip losslessly through the ISO-8601 wire contract")
+    func cursorUpdatedAtsRoundTripISO8601() throws {
+        // Mirrors the production encode/decode pair: server encodes the response
+        // with `.iso8601`, the app decodes with `.iso8601`. The timestamp must
+        // survive the round-trip so a committed cursor's observation time is
+        // preserved (the basis of #685's "pending until cursor commit" clear).
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_100)
+        let original = SyncResponse(
+            added: [],
+            modified: [],
+            removed: [],
+            hasMore: false,
+            pendingCursors: ["item-1": "c1"],
+            pendingCursorUpdatedAts: ["item-1": updatedAt]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SyncResponse.self, from: try encoder.encode(original))
+        #expect(decoded.pendingCursorUpdatedAts["item-1"] == updatedAt)
     }
 }

--- a/Tests/PlaidBarServerTests/WebhookDefectAndVerifierTests.swift
+++ b/Tests/PlaidBarServerTests/WebhookDefectAndVerifierTests.swift
@@ -109,11 +109,12 @@ struct WebhookDefectAndVerifierTests {
         }
     }
 
-    @Test("Sticky sync signal clears once the item refresh advances past it")
-    func stickySyncClearsAfterRefresh() async throws {
+    @Test("Sticky sync signal clears once the committed cursor advances past it")
+    func stickySyncClearsAfterCursorCommit() async throws {
         try await Self.withStatusStores { tokenStore, billingStore, eventStore, config in
             // Events dated "now" sit after the item's creation `updatedAt`, so the
-            // sync is pending; a later refresh bumps `updatedAt` past them.
+            // sync is pending until a transaction-sync cursor commit advances past
+            // them.
             let syncAt = Date()
             _ = try await eventStore.record(Self.signal(
                 hash: "sync-2",
@@ -137,9 +138,20 @@ struct WebhookDefectAndVerifierTests {
             )
             #expect(try #require(try await statusRoutes.statusSnapshot(includeItems: true).itemStatuses?.first).needsSync)
 
-            // Item refresh advances updatedAt to a fresh now, past the sync event.
-            try await Task.sleep(for: .milliseconds(20))
+            // A status-only write bumps `items.updated_at`, but per #685 the sync
+            // signal is driven by the committed *cursor* time, not the item row —
+            // so a non-sync status change alone must NOT clear a pending sync.
             try await tokenStore.updateItemStatus(id: "item-webhook", status: ItemConnectionStatus.connected.rawValue)
+            #expect(try #require(try await statusRoutes.statusSnapshot(includeItems: true).itemStatuses?.first).needsSync)
+
+            // Committing a transaction-sync cursor whose observation time is past
+            // the sync event is what clears the sticky signal (the cursor-commit
+            // boundary owns the clear, AND-667 / #685).
+            try await tokenStore.saveSyncCursorIfItemExists(
+                itemId: "item-webhook",
+                cursor: "cursor-after-sync",
+                updatedAt: syncAt.addingTimeInterval(2)
+            )
             let refreshed = try await statusRoutes.statusSnapshot(includeItems: true)
             #expect(!(try #require(refreshed.itemStatuses?.first).needsSync))
         }


### PR DESCRIPTION
## Summary

`main` (d2abcf07) was red: a full `swift test` had **2 deterministic failures**, both left behind by **#685** ("keep sync-needed pending until cursor commit"). Both are fixed on the **test side** — each old assertion contradicted #685's *intended* behavior; the production code is correct and unchanged. Full suite is now green (**2562 passed, 0 failures**).

## Root cause

**Failure 1 — `SyncResponseTests.decodePendingCursors`** (added by #685)
The test decoded a bare numeric `pendingCursorUpdatedAts` (`{"item-1":1800000100}`) with a **default** `JSONDecoder()` and asserted epoch-1970 semantics (`Date(timeIntervalSince1970: 1_800_000_100)` ≈ 2027-01-15). But #685 itself established the wire contract as **ISO-8601 date strings**, symmetrically:
- Server **encodes** `SyncResponse` with `encoder.dateEncodingStrategy = .iso8601` (`TransactionRoutes.swift`).
- App `ServerClient` **decodes** responses with `decoder.dateDecodingStrategy = .iso8601` and **encodes** commit requests with `.iso8601` (`ServerClient.swift:25-30`).
- Server **decodes** `SyncCursorCommitRequest` with `.iso8601` (`TransactionRoutes.decodeCommitRequest`), and #685's own commit message states: *"The app encodes `cursorUpdatedAts` as ISO-8601 strings (`ServerClient`'s encoder)."*

Under the *default* `.deferredToDate` strategy a bare number is `timeIntervalSinceReferenceDate` (2001-based), so `1800000100` decoded to **2058-01-15** vs the expected **2027-01-15** — a deterministic mismatch. The test used the wrong decoder **and** the wrong wire shape (a bare number is neither what production emits nor decodes).

**Failure 2 — `WebhookDefectAndVerifierTests."Sticky sync signal clears once the item refresh advances past it"`** (added by #670)
#685 changed the `needsPollingSync` clear condition in `StatusRoutes`:
```
- guard let lastSync = item.updatedAt else { return true }
- return lastSync < syncEvent.effectiveDate
+ guard let syncCursorUpdatedAt else { return true }
+ return syncCursorUpdatedAt < syncEvent.effectiveDate
```
The signal now clears off the **committed transaction sync cursor** time, **not** the item row's `updated_at` — deliberately, so a non-sync status-only webhook (`PENDING_EXPIRATION`) that bumps `items.updated_at` can no longer falsely clear a still-pending transaction sync. The #670 test still asserted the old behavior — that a bare `updateItemStatus` clears `needsSync` — so it went red. This is exactly the failure mode #685's `needsPollingSync` doc-comment warns against.

## The decision

Both old assertions are **stale** — they contradict #685's intended, shipped behavior. The fix is on the **test side** in both cases; no production code changed.

- **F1:** the round-trip is genuinely symmetric and lossless on `.iso8601` (server encode ↔ app decode). I rewrote `decodePendingCursors` to decode an ISO-8601 string with an `.iso8601` decoder exactly as production does (`2027-01-15T08:01:40Z` == `Date(timeIntervalSince1970: 1_800_000_100)`, confirmed against the reproduction output), and added an explicit **encode→decode round-trip** test (`cursorUpdatedAtsRoundTripISO8601`) that pins the symmetric ISO-8601 contract so a future coder-strategy drift is caught at the boundary.
- **F2:** I rewrote the test to assert the **intended** post-#685 behavior: a status-only write must **not** clear a pending sync, and committing a sync cursor whose observation time is past the sync event is what clears the sticky signal (via `saveSyncCursorIfItemExists(updatedAt:)`).

Verified client/server agree by reading both coders (`TransactionRoutes` encoder/decoder + `ServerClient` encoder/decoder all `.iso8601`) and by the new round-trip test.

## Design decisions

- No production behavior change — `SyncResponse`, `StatusRoutes.needsPollingSync`, and the coders are all untouched. This is purely making the tests assert the contract #685 actually shipped.
- Made the wire format **explicit** in the test (ISO-8601 string + `.iso8601` decoder) rather than relying on an implicit numeric strategy, matching the codebase convention (`BillingRoutes`/`ReviewRoutes`/`ServerClient` all use explicit `.iso8601`).
- Added a round-trip guard test so the symmetric contract is enforced, not just one decode direction.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **passes**.
- Reproduced both failures in isolation on clean `origin/main` first (F1: decoded `2058-01-15` vs `2027-01-15`; F2: `needsSync` still true after `updateItemStatus`). Not flakiness/order-dependence.
- After the fix, full (unfiltered) suite:

```
✔ Test run with 2562 tests passed after 0.871 seconds.
```

Zero failures, exit 0. (The `skipped` cases are Keychain-gated by design.)

## Linked issue

Linear AND — "main is red: two tests left failing by #685" — https://linear.app/andeslab/team/AND
Regression source: **#685** (`fix(webhooks): keep sync-needed pending until cursor commit`).

## Known limitations

- Both failures were *test*-side staleness, not product bugs — no runtime behavior changed, so no user-facing regression risk is being closed here beyond restoring a green gate.

## Follow-ups

- **CI gate does run `swift test` on PRs** (`.github/workflows/ci.yml`: `on.pull_request.branches: [main]`, step `Test → run: swift test` with `PLAIDBAR_TEST_KEYCHAIN=1`). So the config is correct; #685 nonetheless reached `main` red. Likely path: a required-check bypass / admin merge, or the recurring GitHub Actions billing block that has previously short-circuited CI in this repo (see prior CI-OAuth-gate notes). Worth confirming branch protection requires the `build` check to be **green** (not just present) before merge.
- Consider an encode/decode contract test colocated at the server boundary (not just in Core) so a future server-side coder change is caught even if Core tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
