### PR TITLE
fix(a11y): activity heatmap cells carry per-cell label/help (AND-671)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -43,7 +43,7 @@ struct DashboardActivityHeatmapCard: View {
             if appState.shouldMaskFinancialValues || reduceTransparency {
                 heatmapTextAlternative(layout: layout)
             } else {
-                DashboardYearHeatmapGrid(layout: layout)
+                DashboardYearHeatmapGrid(layout: layout, isPrivacyMasked: appState.shouldMaskFinancialValues)
             }
         }
         .loadingRedaction(appState.loadState(for: .activityHeatmap))
@@ -449,6 +449,12 @@ private struct DashboardOverviewFallback: View {
 /// under Privacy Mask / Reduce Transparency before reaching this view.
 struct DashboardYearHeatmapGrid: View {
     let layout: SpendingHeatmapLayout
+    /// Whether Privacy Mask is active. The parent only renders this grid when
+    /// masking is OFF (the masked branch shows a text alternative), so this is
+    /// `false` in practice — but it is threaded honestly into the per-cell label
+    /// source so the affordance never leaks a value if the grid is ever shown
+    /// while masked (defense in depth; single Core label source).
+    var isPrivacyMasked: Bool = false
 
     /// Gap between cells. A touch wider than the glance grid's 2pt so the larger
     /// cells read as a clean lattice at desk distance.
@@ -546,9 +552,16 @@ struct DashboardYearHeatmapGrid: View {
     private func cellView(for day: SpendingHeatmapDay?, size: CGFloat) -> some View {
         if let day {
             let intensity = SpendingHeatmap.cellIntensity(for: day, peakValue: layout.peakValue)
+            // Per-cell textual affordance: the cell's meaning otherwise rides on
+            // tint/opacity alone (ACCESSIBILITY.md). The label is the single Core
+            // source (date + masked value + count), so pointer-hover and VoiceOver
+            // get the same sentence and Privacy Mask is honored (AND-671).
+            let label = SpendingHeatmap.cellLabel(for: day, mode: layout.mode, isPrivacyMasked: isPrivacyMasked)
             RoundedRectangle(cornerRadius: Radius.control)
                 .fill(Color.primary.opacity(0.10 + 0.62 * intensity))
                 .frame(width: size, height: size)
+                .help(label)
+                .accessibilityLabel(label)
         } else {
             RoundedRectangle(cornerRadius: Radius.control)
                 .fill(.clear)

--- a/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
@@ -109,7 +109,7 @@ struct InsightsTrendsView: View {
                     // information without relying on color or translucency.
                     heatmapTextAlternative(layout: layout)
                 } else {
-                    InsightsActivityHeatmapGrid(layout: layout)
+                    InsightsActivityHeatmapGrid(layout: layout, isPrivacyMasked: isMasked)
                 }
             }
             .loadingRedaction(appState.loadState(for: .activityHeatmap))
@@ -165,6 +165,12 @@ struct InsightsTrendsView: View {
 /// this view is shown only when neither is active.
 struct InsightsActivityHeatmapGrid: View {
     let layout: SpendingHeatmapLayout
+    /// Whether Privacy Mask is active. The parent only renders this grid when
+    /// masking is OFF (the masked branch shows a text alternative), so this is
+    /// `false` in practice — but it is threaded honestly into the per-cell label
+    /// source so the affordance never leaks a value if the grid is ever shown
+    /// while masked (defense in depth; single Core label source).
+    var isPrivacyMasked: Bool = false
 
     private let spacing: CGFloat = 3
     /// Desk-distance cell bounds — larger than the popover's 5...9pt glance cells so
@@ -207,9 +213,16 @@ struct InsightsActivityHeatmapGrid: View {
     private func cellView(for day: SpendingHeatmapDay?, size: CGFloat) -> some View {
         if let day {
             let intensity = SpendingHeatmap.cellIntensity(for: day, peakValue: layout.peakValue)
+            // Per-cell textual affordance: the cell's meaning otherwise rides on
+            // tint/opacity alone (ACCESSIBILITY.md). The label is the single Core
+            // source (date + masked value + count), so pointer-hover and VoiceOver
+            // get the same sentence and Privacy Mask is honored (AND-671).
+            let label = SpendingHeatmap.cellLabel(for: day, mode: layout.mode, isPrivacyMasked: isPrivacyMasked)
             RoundedRectangle(cornerRadius: Radius.cell)
                 .fill(Color.primary.opacity(0.12 + 0.6 * intensity))
                 .frame(width: size, height: size)
+                .help(label)
+                .accessibilityLabel(label)
         } else {
             RoundedRectangle(cornerRadius: Radius.cell)
                 .fill(.clear)

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1063,7 +1063,7 @@ private struct BalanceActivityHeatmap: View {
 
     @ViewBuilder
     private func focusedDayCaption(for layout: SpendingHeatmapLayout) -> some View {
-        if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout), !isInitialLoad {
+        if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues), !isInitialLoad {
             HStack(spacing: 4) {
                 Image(systemName: "calendar")
                     .font(.system(size: 9, weight: .semibold))

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -954,6 +954,7 @@ private struct BalanceActivityHeatmap: View {
                                             peakValue: layout.peakValue,
                                             mode: layout.mode,
                                             size: cell,
+                                            isPrivacyMasked: appState.shouldMaskFinancialValues,
                                             isSelected: selectedDay == day.date,
                                             focusBinding: $focusedDay,
                                             reduceMotion: reduceMotion,
@@ -1185,6 +1186,11 @@ private struct BalanceHeatmapCell: View {
     let peakValue: Double
     let mode: SpendingHeatmapMode
     let size: CGFloat
+    /// Unlike the window grids, the popover heatmap renders its interactive cells
+    /// even while Privacy Mask is on, so the per-cell help/label MUST mask the
+    /// amount here (it would otherwise leak the day's value on hover / to
+    /// VoiceOver). Same single Core label source (AND-671).
+    var isPrivacyMasked: Bool = false
     var isSelected: Bool = false
     var focusBinding: FocusState<String?>.Binding
     var reduceMotion: Bool = false
@@ -1221,7 +1227,7 @@ private struct BalanceHeatmapCell: View {
     }
 
     private var helpText: String {
-        SpendingHeatmap.cellLabel(for: day, mode: mode)
+        SpendingHeatmap.cellLabel(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)
     }
 
     static func fillColor(intensity: Double, value: Double, mode: SpendingHeatmapMode) -> Color {

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -257,7 +257,16 @@ public enum SpendingHeatmap {
     /// Signed, mode-aware amount string for a single day (e.g. "$120.00" for
     /// spend, "+$300.00" / "-$75.00" for net cashflow). Single source of truth
     /// for both the cell label and the focused-day caption.
-    public static func amountText(for day: SpendingHeatmapDay, mode: SpendingHeatmapMode) -> String {
+    ///
+    /// When `isPrivacyMasked` is `true` the whole amount token — sign prefix
+    /// included — collapses to `••••` so a per-cell label/help never leaks the
+    /// day's value while Privacy Mask is on (ACCESSIBILITY.md / SECURITY.md).
+    public static func amountText(
+        for day: SpendingHeatmapDay,
+        mode: SpendingHeatmapMode,
+        isPrivacyMasked: Bool = false
+    ) -> String {
+        guard !isPrivacyMasked else { return PrivacyMaskPresentation.compactValue }
         switch mode {
         case .spending:
             return Formatters.currency(day.value, format: .full)
@@ -273,9 +282,17 @@ public enum SpendingHeatmap {
         "\(day.transactionCount) transaction\(day.transactionCount == 1 ? "" : "s")"
     }
 
-    /// Full cell label / pointer-help sentence for a single day.
-    public static func cellLabel(for day: SpendingHeatmapDay, mode: SpendingHeatmapMode) -> String {
-        "\(Formatters.displayTransactionDate(day.date)): \(amountText(for: day, mode: mode)) across \(transactionText(for: day))"
+    /// Full cell label / pointer-help sentence for a single day. The date and
+    /// transaction count are always present; the amount honors `isPrivacyMasked`
+    /// (shown as `••••` when masked) so the per-cell `.help`/`.accessibilityLabel`
+    /// affordance carries the cell's meaning textually without leaking the value
+    /// while Privacy Mask is on. Single source of truth for every heatmap surface.
+    public static func cellLabel(
+        for day: SpendingHeatmapDay,
+        mode: SpendingHeatmapMode,
+        isPrivacyMasked: Bool = false
+    ) -> String {
+        "\(Formatters.displayTransactionDate(day.date)): \(amountText(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)) across \(transactionText(for: day))"
     }
 
     /// Summary for the focused-day caption. Returns `nil` when nothing is

--- a/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
+++ b/Sources/PlaidBarCore/Models/SpendingHeatmap.swift
@@ -299,9 +299,17 @@ public enum SpendingHeatmap {
     /// selected (the caller shows the range total instead) or when the selected
     /// day key is not present in the layout (stale selection after a data or
     /// range change). Reuses the layout's already-derived `days`.
+    ///
+    /// When `isPrivacyMasked` is `true` the amount token — in both the inline
+    /// `captionText` and the VoiceOver `accessibilityLabel` — collapses to
+    /// `••••` (reusing `amountText`/`cellLabel`'s mask behavior) while the date
+    /// and the non-financial transaction count remain, so the focused-day
+    /// caption never leaks the selected day's value visually or to VoiceOver
+    /// while Privacy Mask is on (ACCESSIBILITY.md / SECURITY.md).
     public static func focusedDaySummary(
         for selectedDay: String?,
-        in layout: SpendingHeatmapLayout
+        in layout: SpendingHeatmapLayout,
+        isPrivacyMasked: Bool = false
     ) -> SpendingHeatmapFocusSummary? {
         guard let selectedDay,
               let day = layout.days.first(where: { $0.date == selectedDay })
@@ -310,14 +318,14 @@ public enum SpendingHeatmap {
         }
 
         let dateText = Formatters.displayTransactionDate(day.date)
-        let amount = amountText(for: day, mode: layout.mode)
+        let amount = amountText(for: day, mode: layout.mode, isPrivacyMasked: isPrivacyMasked)
         let count = transactionText(for: day)
         return SpendingHeatmapFocusSummary(
             dateText: dateText,
             amountText: amount,
             transactionText: count,
             captionText: "\(dateText) · \(amount) · \(count)",
-            accessibilityLabel: cellLabel(for: day, mode: layout.mode)
+            accessibilityLabel: cellLabel(for: day, mode: layout.mode, isPrivacyMasked: isPrivacyMasked)
         )
     }
 

--- a/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
@@ -83,4 +83,56 @@ struct HeatmapFocusSummaryTests {
         #expect(parts?[1] == summary?.amountText)
         #expect(parts?[2] == summary?.transactionText)
     }
+
+    // MARK: - Per-cell label masking (AND-671)
+
+    private let spendDay = SpendingHeatmapDay(date: "2026-01-01", value: 120, transactionCount: 3)
+    private let zeroDay = SpendingHeatmapDay(date: "2026-01-03", value: 0, transactionCount: 0)
+
+    @Test("Unmasked cell label shows the date, real amount, and count")
+    func cellLabelUnmaskedShowsValue() {
+        let label = SpendingHeatmap.cellLabel(for: spendDay, mode: .spending)
+
+        #expect(label.contains("3 transactions"))
+        #expect(label.contains(SpendingHeatmap.amountText(for: spendDay, mode: .spending)))
+        // The real currency amount is present, not the mask token.
+        #expect(label.contains("$"))
+        #expect(!label.contains(PrivacyMaskPresentation.compactValue))
+    }
+
+    @Test("Masked cell label hides the amount but keeps the date and count")
+    func cellLabelMaskedHidesAmountOnly() {
+        let label = SpendingHeatmap.cellLabel(for: spendDay, mode: .spending, isPrivacyMasked: true)
+
+        // Amount is withheld …
+        #expect(label.contains(PrivacyMaskPresentation.compactValue))
+        #expect(!label.contains("$"))
+        #expect(!label.contains("120"))
+        // … but the structural date and the (non-financial) transaction count remain,
+        // so the cell still carries meaning textually for hover / VoiceOver.
+        #expect(label.contains("3 transactions"))
+        let datePrefix = Formatters.displayTransactionDate(spendDay.date)
+        #expect(label.contains(datePrefix))
+    }
+
+    @Test("Masked net-cashflow amount drops the sign prefix entirely (no +/- leak)")
+    func cellLabelMaskedNetCashflowDropsSignPrefix() {
+        // -300 stored → income → would render with a "+" prefix unmasked. Masked,
+        // the whole token (prefix included) must collapse to the mask glyph.
+        let incomeDay = SpendingHeatmapDay(date: "2026-01-02", value: -300, transactionCount: 1)
+        let masked = SpendingHeatmap.amountText(for: incomeDay, mode: .netCashflow, isPrivacyMasked: true)
+
+        #expect(masked == PrivacyMaskPresentation.compactValue)
+        #expect(!masked.contains("+"))
+        #expect(!masked.contains("-"))
+    }
+
+    @Test("Masked zero/empty day still hides the $0 amount and keeps a zero count")
+    func cellLabelMaskedZeroDay() {
+        let label = SpendingHeatmap.cellLabel(for: zeroDay, mode: .spending, isPrivacyMasked: true)
+
+        #expect(label.contains(PrivacyMaskPresentation.compactValue))
+        #expect(!label.contains("$"))
+        #expect(label.contains("0 transactions"))
+    }
 }

--- a/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
+++ b/Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift
@@ -135,4 +135,64 @@ struct HeatmapFocusSummaryTests {
         #expect(!label.contains("$"))
         #expect(label.contains("0 transactions"))
     }
+
+    // MARK: - Focused-day caption masking (AND-671 follow-up)
+
+    @Test("Unmasked focused-day summary still shows the real amount in both surfaces")
+    func focusedSummaryUnmaskedShowsValue() {
+        let summary = SpendingHeatmap.focusedDaySummary(for: "2026-01-01", in: layout(mode: .spending))
+
+        #expect(summary != nil)
+        #expect(summary?.captionText.contains("$") == true)
+        #expect(summary?.accessibilityLabel.contains("$") == true)
+        #expect(summary?.captionText.contains(PrivacyMaskPresentation.compactValue) == false)
+        #expect(summary?.accessibilityLabel.contains(PrivacyMaskPresentation.compactValue) == false)
+    }
+
+    @Test("Masked focused-day summary hides the amount in caption AND VoiceOver label, keeps date + count")
+    func focusedSummaryMaskedHidesAmountInBothSurfaces() {
+        let summary = SpendingHeatmap.focusedDaySummary(
+            for: "2026-01-01",
+            in: layout(mode: .spending),
+            isPrivacyMasked: true
+        )
+
+        #expect(summary != nil)
+
+        // The amount token is withheld from BOTH the visual caption and the
+        // VoiceOver accessibility label — the live `Text(summary.captionText)`
+        // and `.accessibilityLabel(summary.accessibilityLabel)` in MainPopover
+        // must never render the real value while Privacy Mask is on.
+        #expect(summary?.amountText == PrivacyMaskPresentation.compactValue)
+        #expect(summary?.captionText.contains(PrivacyMaskPresentation.compactValue) == true)
+        #expect(summary?.accessibilityLabel.contains(PrivacyMaskPresentation.compactValue) == true)
+        #expect(summary?.captionText.contains("$") == false)
+        #expect(summary?.accessibilityLabel.contains("$") == false)
+        #expect(summary?.captionText.contains("120") == false)
+        #expect(summary?.accessibilityLabel.contains("120") == false)
+
+        // … but the structural date and the non-financial transaction count stay,
+        // so the focused-day caption still carries meaning when masked.
+        let datePrefix = Formatters.displayTransactionDate("2026-01-01")
+        #expect(summary?.transactionText == "3 transactions")
+        #expect(summary?.captionText.contains(datePrefix) == true)
+        #expect(summary?.captionText.contains("3 transactions") == true)
+        #expect(summary?.accessibilityLabel.contains(datePrefix) == true)
+        #expect(summary?.accessibilityLabel.contains("3 transactions") == true)
+    }
+
+    @Test("Masked focused-day net-cashflow summary drops the sign prefix (no +/- leak)")
+    func focusedSummaryMaskedNetCashflowDropsSignPrefix() {
+        // 2026-01-02 stored -300 → income → would render with a "+" prefix
+        // unmasked; masked, the whole token (prefix included) collapses.
+        let summary = SpendingHeatmap.focusedDaySummary(
+            for: "2026-01-02",
+            in: layout(mode: .netCashflow),
+            isPrivacyMasked: true
+        )
+
+        #expect(summary?.amountText == PrivacyMaskPresentation.compactValue)
+        #expect(summary?.captionText.contains("+") == false)
+        #expect(summary?.accessibilityLabel.contains("+") == false)
+    }
 }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1195,6 +1195,39 @@ struct PlaidBarTests {
         #expect(accounts.contains(".onChange(of: filteredAccounts.map(\\.id))"))
         #expect(accounts.contains("visibleAccounts.map(\\.id)"))
     }
+
+    /// Source-invariant guard for AND-671: each activity-heatmap cell must carry a
+    /// per-cell textual affordance (`.help` + `.accessibilityLabel`) so the day's
+    /// meaning never rides on tint/opacity alone (ACCESSIBILITY.md). Both window
+    /// grids (`DashboardYearHeatmapGrid`, `InsightsActivityHeatmapGrid`) source the
+    /// label from the single masked Core helper `SpendingHeatmap.cellLabel`. The
+    /// `@main` app target isn't unit-testable, so this string-matches the wiring.
+    @Test("Activity heatmap cells attach per-cell .help/.accessibilityLabel from masked Core label (AND-671)")
+    func activityHeatmapCellsCarryPerCellLabel() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let dashboard = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift"),
+            encoding: .utf8
+        )
+        let insights = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift"),
+            encoding: .utf8
+        )
+
+        // Both window grids: per-cell help + accessibility label, single-sourced from
+        // the mask-aware Core label (date + masked value + count).
+        for source in [dashboard, insights] {
+            #expect(source.contains("SpendingHeatmap.cellLabel(for: day, mode: layout.mode, isPrivacyMasked: isPrivacyMasked)"))
+            #expect(source.contains(".help(label)"))
+            #expect(source.contains(".accessibilityLabel(label)"))
+            // The grid threads the real mask state in, rather than hardcoding a value.
+            #expect(source.contains("var isPrivacyMasked: Bool = false"))
+        }
+
+        // Call sites pass the live Privacy Mask state into each grid.
+        #expect(dashboard.contains("DashboardYearHeatmapGrid(layout: layout, isPrivacyMasked: appState.shouldMaskFinancialValues)"))
+        #expect(insights.contains("InsightsActivityHeatmapGrid(layout: layout, isPrivacyMasked: isMasked)"))
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1228,6 +1228,37 @@ struct PlaidBarTests {
         #expect(dashboard.contains("DashboardYearHeatmapGrid(layout: layout, isPrivacyMasked: appState.shouldMaskFinancialValues)"))
         #expect(insights.contains("InsightsActivityHeatmapGrid(layout: layout, isPrivacyMasked: isMasked)"))
     }
+
+    /// Source-invariant guard for the AND-671 follow-up: the popover heatmap
+    /// (`MainPopover.swift`) renders its interactive cells AND the focused-day
+    /// caption *while Privacy Mask is on*, so both must source their text from the
+    /// mask-aware Core helpers with the live `appState.shouldMaskFinancialValues`
+    /// threaded in — otherwise the per-cell hover/VoiceOver label or the selected
+    /// day's caption would leak the real value. The `@main` app target isn't
+    /// unit-testable, so this string-matches the wiring so it can't be dropped.
+    @Test("Popover heatmap cell help and focused-day caption thread the live Privacy Mask state (AND-671)")
+    func popoverHeatmapMasksCellHelpAndFocusedCaption() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let popover = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/MainPopover.swift"),
+            encoding: .utf8
+        )
+
+        // Per-cell hover/VoiceOver label is sourced from the mask-aware Core label,
+        // and the cell is constructed with the live Privacy Mask state.
+        #expect(popover.contains("SpendingHeatmap.cellLabel(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)"))
+        #expect(popover.contains("var isPrivacyMasked: Bool = false"))
+        #expect(popover.contains("isPrivacyMasked: appState.shouldMaskFinancialValues"))
+
+        // Focused-day caption: the summary (whose captionText drives the visual
+        // Text and whose accessibilityLabel drives the VoiceOver label) is built
+        // with the live mask flag, so a selected cell never leaks its value.
+        #expect(popover.contains(
+            "SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues)"
+        ))
+        #expect(popover.contains("Text(summary.captionText)"))
+        #expect(popover.contains(".accessibilityLabel(summary.accessibilityLabel)"))
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.


### PR DESCRIPTION
## Summary

The year activity heatmap rendered each day's intensity through cell **tint/opacity alone**, with no per-cell hover `help` or accessibility label — so the per-day value was conveyed by a visual channel only (violates ACCESSIBILITY.md: never convey meaning by color/opacity alone). The surface-level VoiceOver summary and the Reduce-Transparency / Privacy-Mask text alternative already existed; this fills the missing **per-cell** affordance.

Each cell in both window grids now carries a textual `.help(...)` (pointer hover) and `.accessibilityLabel(...)` (VoiceOver) derived from the existing `SpendingHeatmap.cellLabel` — date + value + transaction count — with the value **masked under Privacy Mask**.

> **Follow-up (adversarial-review fix, 2nd commit):** the first commit masked only the per-cell `.help`/`.accessibilityLabel`. The same popover view (`BalanceActivityHeatmap`) also renders the **focused-day caption** (`focusedDayCaption(for:)`) from `SpendingHeatmap.focusedDaySummary`, which built its `captionText` (shown via `Text`) and `accessibilityLabel` (announced to VoiceOver) from an **un-masked** amount. Selecting a heatmap cell while Privacy Mask was on therefore still leaked the real value — both visually and to VoiceOver (the cell's onSelect→toggleSelection has no mask guard, so it is reachable live). The second commit closes that remaining half by threading the live mask flag into `focusedDaySummary` too. The header total and the audio graph were already mask-gated; the popover heatmap is now consistent.

## Architectural rationale (single-sourced masked label)

- The per-cell sentence is single-sourced from `PlaidBarCore`'s `SpendingHeatmap.cellLabel`, not a new view-local formatter, so every heatmap surface stays consistent.
- `cellLabel` (and the underlying `amountText`) gained an `isPrivacyMasked` parameter (default `false`, preserving all existing call sites). When masked, the **whole amount token — sign prefix included — collapses to `••••`** (`PrivacyMaskPresentation.compactValue`), while the structural date and the non-financial transaction count remain. This keeps the cell meaningful textually without ever leaking the value.
- `focusedDaySummary` gained the same `isPrivacyMasked` parameter (2nd commit) and threads it into its internal `amountText`/`cellLabel` calls, so its `captionText` and `accessibilityLabel` reuse the exact same mask-collapse path — no new masking logic.
- The two window grids (`DashboardYearHeatmapGrid`, `InsightsActivityHeatmapGrid`) take an `isPrivacyMasked` stored property and thread the live `appState.shouldMaskFinancialValues` in from their call sites, rather than hardcoding a literal.

## Design decisions

- **Both AND-671 surfaces fixed** (`DashboardOverviewColumn.swift`, `InsightsTrendsView.swift`). These grids are only rendered when masking is OFF (the masked branch shows a text alternative), so the flag is `false` in practice — but it's threaded honestly so the affordance is correct by construction if the grid is ever shown while masked (defense in depth).
- **Popover `BalanceHeatmapCell` moved onto the masked source too.** It already had per-cell `.help`/`.accessibilityLabel` (the precedent for this fix) but sourced an **unmasked** `cellLabel`, and unlike the window grids it *does* render its interactive cells while Privacy Mask is on — so its hover/VoiceOver text was a real value leak. Single-line fix onto the same Core source closes it.
- **Popover focused-day caption moved onto the masked source too (2nd commit).** Same popover view, same live-while-masked reachability: `focusedDayCaption(for:)` renders `Text(summary.captionText)` and `.accessibilityLabel(summary.accessibilityLabel)` unconditionally, so a selected cell's value leaked visually and to VoiceOver under Privacy Mask. The `MainPopover` call site now passes `appState.shouldMaskFinancialValues` into `focusedDaySummary`, so both surfaces collapse the amount to `••••`.
- The `ChartAudioGraph.heatmap` caller computes `amountText` only inside its *non-masked* branch (the masked branch already drops the amount and keeps date + count), so it was already safe and is left unchanged.
- Amount-only masking (date + count stay visible) mirrors the existing focused-day caption / audio-graph masking semantics in this codebase.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes (CI gate).
- Full `swift test`: **2570 tests, 2 failures**, both pre-existing and unrelated to this change — `SyncResponseTests` "Decoding reads present pending cursor fields" and `WebhookDefectAndVerifierTests` "Sticky sync signal clears once the item refresh advances past it" — i.e. exactly the two failures being addressed by the green-main fix in #693. **Zero new failures** from this branch. (Remaining `✘`-glyph lines in the run are Keychain `skipped:` cases, not failures.)
- New tests:
  - `Tests/PlaidBarCoreTests/HeatmapFocusSummaryTests.swift` — per-cell masking (4 cases): unmasked label shows the real amount; **Privacy Mask on** hides the amount (`$`/digits gone, `••••` present) but keeps date + count; masked net-cashflow drops the `+/-` sign prefix entirely; masked zero/empty day still hides `$0` and keeps a zero count. **Focused-day caption masking (2nd commit, 3 cases):** unmasked summary still shows the real amount in both `captionText` and `accessibilityLabel`; **masked** summary hides the amount in **both** surfaces (`$`/digits gone, `••••` present) while keeping date + count; masked net-cashflow caption drops the sign prefix.
  - `Tests/PlaidBarTests/PlaidBarTests.swift` — `activityHeatmapCellsCarryPerCellLabel`: source-invariant guard that both window grids attach `.help(label)` + `.accessibilityLabel(label)` from the mask-aware Core `cellLabel`, declare the `isPrivacyMasked` property, and that both call sites pass the live mask state. **`popoverHeatmapMasksCellHelpAndFocusedCaption` (2nd commit):** source-invariant guard that `MainPopover.swift` threads `isPrivacyMasked`/`shouldMaskFinancialValues` into **both** the popover cell help and the `focusedDaySummary` caption call site (and that `Text(summary.captionText)` / `.accessibilityLabel(summary.accessibilityLabel)` derive from the now-masked summary), so the popover flag-threading can't be silently dropped. These are the regression guards for the `@main` (non-unit-testable) view wiring.
- No existing source-invariant assertion string-matched the heatmap lines that changed (verified by grep), so nothing else needed updating.

## Linked issue

AND-671 (Medium, Accessibility) — https://linear.app/andeslab/issue/AND-671

## Known limitations

- The window grids never render while masked (parent shows a text alternative), so the masked window-cell path is reachable only via the Core unit test, not the live window UI today — the wiring is defensive/future-proof. The popover cell **and the popover focused-day caption** are where masking is exercised live.
- Source-invariant tests assert wiring strings, not rendered AX output (the `@main` app target isn't unit-testable); they string-match the exact `.help(label)` / `.accessibilityLabel(label)` / `focusedDaySummary(...)` lines, so an intentional rename of those will require updating the test alongside the view.

## Follow-ups

- None required. If the legacy popover is removed (Stage 2, AND-598…600), the `BalanceHeatmapCell` masking line and the focused-day-caption masking go away with it; the Core `cellLabel(isPrivacyMasked:)` / `focusedDaySummary(isPrivacyMasked:)` sources stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
