### PR TITLE
fix(investments): holdings returns setup-state instead of misleading empty success (AND-661)

### DIFF
--- a/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
+++ b/Sources/PlaidBarServer/Middleware/SetupStateMiddleware.swift
@@ -43,7 +43,7 @@ struct SetupStateMiddleware<Context: RequestContext>: RouterMiddleware {
     /// credentials. Status and item readiness endpoints are deliberately
     /// absent: they serve local metadata that setup guidance relies on.
     static var plaidBackedPathPrefixes: [String] {
-        ["/api/link", "/api/accounts", "/api/transactions"]
+        ["/api/link", "/api/accounts", "/api/transactions", "/api/investments"]
     }
 
     static func isPlaidBackedPath(_ path: String) -> Bool {

--- a/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
@@ -35,10 +35,16 @@ struct InvestmentRoutes: Sendable {
                 let accessToken = try tokenStore.accessToken(for: item)
                 let response = try await plaidClient.getInvestmentHoldings(accessToken: accessToken)
                 return Self.investmentsResponse(from: response, item: item, itemId: itemId)
+            } catch PlaidError.credentialsNotConfigured {
+                // Setup state affects every item identically: surface the 503
+                // credential guidance (via `SetupStateMiddleware`) instead of
+                // swallowing it into a misleading empty-but-successful refresh.
+                // Mirrors `AccountRoutes`.
+                throw PlaidError.credentialsNotConfigured
             } catch {
-                // A missing `investments` scope (or any per-item failure) yields
-                // an empty contribution; the request still succeeds for items
-                // that do hold investments.
+                // A missing `investments` scope (or any other per-item failure)
+                // yields an empty contribution; the request still succeeds for
+                // items that do hold investments.
                 return InvestmentsResponse()
             }
         }
@@ -62,6 +68,10 @@ struct InvestmentRoutes: Sendable {
                     endDate: endDate
                 )
                 return transactions.map(Self.investmentTransactionDTO(from:))
+            } catch PlaidError.credentialsNotConfigured {
+                // Setup state surfaces the 503 credential guidance instead of an
+                // empty-but-successful refresh. Mirrors `AccountRoutes`.
+                throw PlaidError.credentialsNotConfigured
             } catch {
                 return []
             }

--- a/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
+++ b/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
@@ -344,13 +344,20 @@ struct InvestmentRoutesSetupStateTests {
         return headers
     }
 
-    /// Wires the real `SetupStateMiddleware` (in `missingBoth` setup state) and
-    /// `InvestmentRoutes` behind the bearer-token middleware. `seedItem` controls
-    /// whether a linked item exists, so we exercise both the prefix gating (no
-    /// items: middleware blocks before the handler) and the handler re-throw
-    /// (one item: the credential-less Plaid call is reached and must propagate).
+    /// Wires the real `SetupStateMiddleware` and `InvestmentRoutes` behind the
+    /// bearer-token middleware. `seedItem` controls whether a linked item
+    /// exists; `credentialDiagnosis` controls whether the middleware's prefix
+    /// gate short-circuits.
+    ///
+    /// With `.missingBoth` (the default) the prefix gate blocks `/api/investments`
+    /// before the handler runs, so these tests exercise the *gating*. With
+    /// `.configured` the gate passes through to the handler, so the request
+    /// actually reaches the credential-less Plaid call — that is the only way to
+    /// exercise the handler's `catch PlaidError.credentialsNotConfigured`
+    /// re-throw and the middleware's *outer* catch-net that turns it into a 503.
     private func withInvestmentsAPI(
         seedItem: Bool,
+        credentialDiagnosis: CredentialSetupDiagnosis = .missingBoth,
         _ body: @Sendable (any TestClientProtocol) async throws -> Void
     ) async throws {
         let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.investments-setup")
@@ -379,7 +386,7 @@ struct InvestmentRoutesSetupStateTests {
             let api = router.group("api")
             api.add(middleware: APITokenMiddleware(authToken: apiToken))
             api.add(middleware: SetupStateMiddleware(
-                credentialDiagnosis: .missingBoth,
+                credentialDiagnosis: credentialDiagnosis,
                 plaidEnvironment: .sandbox
             ))
             InvestmentRoutes(
@@ -422,11 +429,12 @@ struct InvestmentRoutesSetupStateTests {
         }
     }
 
-    @Test("Holdings re-throws credentialsNotConfigured for a linked item instead of swallowing it into 200-empty")
-    func holdingsRethrowsCredentialsNotConfiguredForLinkedItem() async throws {
-        // With an item present the handler reaches the credential-less Plaid
-        // call; the regression is swallowing the error into an empty 200. The
-        // re-throw surfaces through the middleware catch-net as the setup 503.
+    @Test("Holdings stays 503 in setup state even when an item is already linked")
+    func holdingsGatedByMiddlewareWithLinkedItem() async throws {
+        // In `.missingBoth` the prefix gate short-circuits to 503 *before* the
+        // handler runs, regardless of whether an item is linked. This guards
+        // the prefix-gating only — it does NOT reach the handler re-throw (see
+        // `holdingsRethrowsCredentialsNotConfiguredWhenCredentialsConfigured`).
         try await withInvestmentsAPI(seedItem: true) { client in
             let response = try await client.execute(
                 uri: "/api/investments/holdings",
@@ -437,9 +445,48 @@ struct InvestmentRoutesSetupStateTests {
         }
     }
 
-    @Test("Investment transactions re-throw credentialsNotConfigured for a linked item instead of swallowing it into 200-empty")
-    func transactionsRethrowCredentialsNotConfiguredForLinkedItem() async throws {
+    @Test("Investment transactions stay 503 in setup state even when an item is already linked")
+    func transactionsGatedByMiddlewareWithLinkedItem() async throws {
         try await withInvestmentsAPI(seedItem: true) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/transactions",
+                method: .get,
+                headers: authHeaders
+            )
+            #expect(response.status == .serviceUnavailable)
+        }
+    }
+
+    // MARK: - Handler re-throw (true guard)
+    //
+    // The tests above all run with `.missingBoth`, so the prefix gate
+    // short-circuits before the handler executes — reverting *only* the
+    // handler's `catch PlaidError.credentialsNotConfigured` re-throw would leave
+    // them green. The two tests below set `.configured` so the prefix gate is
+    // bypassed and the request actually reaches the handler. With a linked item
+    // and a Plaid double that throws `credentialsNotConfigured`, the only path
+    // to a 503 is: handler re-throws → middleware's *outer* catch converts it.
+    // Remove the re-throw clause and the handler's `catch { return … }` swallows
+    // the error into a misleading 200-empty, so these tests go red — proving
+    // they genuinely guard the re-throw.
+
+    @Test("Holdings re-throws credentialsNotConfigured (reaching the handler) so a linked item surfaces 503, not 200-empty")
+    func holdingsRethrowsCredentialsNotConfiguredWhenCredentialsConfigured() async throws {
+        try await withInvestmentsAPI(seedItem: true, credentialDiagnosis: .configured) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/holdings",
+                method: .get,
+                headers: authHeaders
+            )
+            // Without the handler re-throw this would be `.ok` with an empty
+            // payload (the per-item `catch` swallows the error).
+            #expect(response.status == .serviceUnavailable)
+        }
+    }
+
+    @Test("Investment transactions re-throw credentialsNotConfigured (reaching the handler) so a linked item surfaces 503, not 200-empty")
+    func transactionsRethrowCredentialsNotConfiguredWhenCredentialsConfigured() async throws {
+        try await withInvestmentsAPI(seedItem: true, credentialDiagnosis: .configured) { client in
             let response = try await client.execute(
                 uri: "/api/investments/transactions",
                 method: .get,

--- a/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
+++ b/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
@@ -1,4 +1,10 @@
 import Foundation
+import FluentKit
+import FluentSQLiteDriver
+import Hummingbird
+import HummingbirdFluent
+import HummingbirdTesting
+import Logging
 @testable import PlaidBarCore
 @testable import PlaidBarServer
 import Testing
@@ -272,5 +278,174 @@ struct InvestmentRoutesTests {
         #expect(end == "2026-06-24")
         #expect(start == "2026-03-26")
         #expect(start < end)
+    }
+}
+
+/// Setup-state behavior for the Investments routes (AND-661, AND-644 follow-up).
+///
+/// With no Plaid credentials configured, holdings and investment transactions
+/// must surface the setup-state `503` (so the app shows the credential-guidance
+/// state) instead of a misleading empty-but-successful `200`. This mirrors how
+/// `AccountRoutes` is gated: the `SetupStateMiddleware` prefix list blocks the
+/// route before the handler runs, and — as a safety net for any item already
+/// linked — the handler re-throws `PlaidError.credentialsNotConfigured` rather
+/// than swallowing it into an empty contribution.
+@Suite("Investment routes setup state")
+struct InvestmentRoutesSetupStateTests {
+    private let apiToken = "local-investments-token"
+
+    /// A Plaid double whose investment calls fail as if credentials were never
+    /// configured — the exact error the real `PlaidClient` throws in setup state.
+    private struct CredentialLessPlaidClient: PlaidClientProtocol {
+        func createLinkToken(clientUserId _: String, completionRedirectUri _: String) async throws -> PlaidLinkTokenResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func createUpdateLinkToken(clientUserId _: String, accessToken _: String, completionRedirectUri _: String) async throws -> PlaidLinkTokenResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func getLinkToken(_: String) async throws -> PlaidLinkTokenGetResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func exchangePublicToken(_: String) async throws -> PlaidTokenExchangeResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func getAccounts(accessToken _: String) async throws -> PlaidAccountsResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func getBalances(accessToken _: String) async throws -> PlaidAccountsResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func getInvestmentHoldings(accessToken _: String) async throws -> PlaidHoldingsResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func getInvestmentTransactions(accessToken _: String, startDate _: String, endDate _: String, count _: Int, offset _: Int) async throws -> PlaidInvestmentTransactionsResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func syncTransactions(accessToken _: String, cursor _: String?) async throws -> PlaidTransactionsSyncResponse {
+            throw PlaidError.credentialsNotConfigured
+        }
+
+        func removeItem(accessToken _: String) async throws {
+            throw PlaidError.credentialsNotConfigured
+        }
+    }
+
+    private var authHeaders: HTTPFields {
+        var headers = HTTPFields()
+        headers[.authorization] = "Bearer \(apiToken)"
+        return headers
+    }
+
+    /// Wires the real `SetupStateMiddleware` (in `missingBoth` setup state) and
+    /// `InvestmentRoutes` behind the bearer-token middleware. `seedItem` controls
+    /// whether a linked item exists, so we exercise both the prefix gating (no
+    /// items: middleware blocks before the handler) and the handler re-throw
+    /// (one item: the credential-less Plaid call is reached and must propagate).
+    private func withInvestmentsAPI(
+        seedItem: Bool,
+        _ body: @Sendable (any TestClientProtocol) async throws -> Void
+    ) async throws {
+        let logger = Logger(label: "com.ftchvs.plaidbar-server-tests.investments-setup")
+        let fluent = Fluent(logger: logger)
+        fluent.databases.use(.sqlite(.memory), as: .sqlite)
+        await fluent.migrations.add(CreateItems())
+        await fluent.migrations.add(AddProviderToItems())
+        await fluent.migrations.add(AddOriginToItems())
+        await fluent.migrations.add(CreateSyncCursors())
+
+        var bodyError: Error?
+        do {
+            try await fluent.migrate()
+            if seedItem {
+                // A direct (non-`keychain:`) token resolves without Keychain, so
+                // `accessToken(for:)` succeeds and the credential-less Plaid call
+                // is the failure under test, not token resolution.
+                try await ItemModel(
+                    id: "item-1",
+                    accessToken: "plaintext-access-token",
+                    institutionName: "Fidelity"
+                ).save(on: fluent.db())
+            }
+
+            let router = Router()
+            let api = router.group("api")
+            api.add(middleware: APITokenMiddleware(authToken: apiToken))
+            api.add(middleware: SetupStateMiddleware(
+                credentialDiagnosis: .missingBoth,
+                plaidEnvironment: .sandbox
+            ))
+            InvestmentRoutes(
+                plaidClient: CredentialLessPlaidClient(),
+                tokenStore: TokenStore(fluent: fluent)
+            ).register(with: api)
+
+            let app = Application(router: router, logger: logger)
+            try await app.test(.router) { client in
+                try await body(client)
+            }
+        } catch {
+            bodyError = error
+        }
+        try await fluent.shutdown()
+        if let bodyError { throw bodyError }
+    }
+
+    @Test("Holdings returns 503 setup state (not 200-empty) when no items are linked")
+    func holdingsGatedByMiddlewareWithoutItems() async throws {
+        try await withInvestmentsAPI(seedItem: false) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/holdings",
+                method: .get,
+                headers: authHeaders
+            )
+            #expect(response.status == .serviceUnavailable)
+        }
+    }
+
+    @Test("Investment transactions return 503 setup state (not 200-empty) when no items are linked")
+    func transactionsGatedByMiddlewareWithoutItems() async throws {
+        try await withInvestmentsAPI(seedItem: false) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/transactions",
+                method: .get,
+                headers: authHeaders
+            )
+            #expect(response.status == .serviceUnavailable)
+        }
+    }
+
+    @Test("Holdings re-throws credentialsNotConfigured for a linked item instead of swallowing it into 200-empty")
+    func holdingsRethrowsCredentialsNotConfiguredForLinkedItem() async throws {
+        // With an item present the handler reaches the credential-less Plaid
+        // call; the regression is swallowing the error into an empty 200. The
+        // re-throw surfaces through the middleware catch-net as the setup 503.
+        try await withInvestmentsAPI(seedItem: true) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/holdings",
+                method: .get,
+                headers: authHeaders
+            )
+            #expect(response.status == .serviceUnavailable)
+        }
+    }
+
+    @Test("Investment transactions re-throw credentialsNotConfigured for a linked item instead of swallowing it into 200-empty")
+    func transactionsRethrowCredentialsNotConfiguredForLinkedItem() async throws {
+        try await withInvestmentsAPI(seedItem: true) { client in
+            let response = try await client.execute(
+                uri: "/api/investments/transactions",
+                method: .get,
+                headers: authHeaders
+            )
+            #expect(response.status == .serviceUnavailable)
+        }
     }
 }

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -903,6 +903,10 @@ struct PlaidBarServerTests {
         #expect(Middleware.isPlaidBackedPath("/api/accounts/item-1"))
         #expect(Middleware.isPlaidBackedPath("/api/transactions/sync"))
         #expect(Middleware.isPlaidBackedPath("/api/transactions/sync/cursors"))
+        // Investments (AND-661): holdings/transactions need credentials too, so
+        // setup state must gate them rather than returning an empty success.
+        #expect(Middleware.isPlaidBackedPath("/api/investments/holdings"))
+        #expect(Middleware.isPlaidBackedPath("/api/investments/transactions"))
 
         // Readiness metadata stays available so setup guidance can render.
         #expect(!Middleware.isPlaidBackedPath("/api/status"))


### PR DESCRIPTION
## Summary

`/api/investments/holdings` (and `/api/investments/transactions`) returned `200` with an empty payload when no Plaid credentials were configured, instead of the `503` setup state every other Plaid-backed route returns. The app then rendered a misleading *empty success* rather than the credential-guidance setup state. This is the AND-644 Investments follow-up.

Two defects, both mirrored from the correct `AccountRoutes` pattern:

1. The `investments` route prefix was **omitted from `SetupStateMiddleware.plaidBackedPathPrefixes`**, so with no items linked the per-item route skipped Plaid entirely and returned an empty `200`.
2. The handler **swallowed every per-item error, including `PlaidError.credentialsNotConfigured`**, so even an already-linked item could not surface the setup state.

## Architectural rationale (mirrors AccountRoutes)

`SetupStateMiddleware` maps the credential-less setup state to a clear `503` so clients can tell "server is up but awaiting credentials" apart from a real failure or a successful empty refresh. It does this with two layers, both of which `AccountRoutes` already uses and `InvestmentRoutes` was missing:

- **Prefix gating** — `plaidBackedPathPrefixes` blocks Plaid-backed paths before the handler runs, covering the no-items-linked case where the handler would otherwise return empty-but-`200`. Added `"/api/investments"` alongside `"/api/link"`, `"/api/accounts"`, `"/api/transactions"`.
- **Handler re-throw (safety net)** — for items already linked, the handler reaches the live Plaid call; `AccountRoutes` re-throws `PlaidError.credentialsNotConfigured` so the middleware's `catch` converts it to the `503`. `InvestmentRoutes` now re-throws it identically (in both `getHoldings` and `getInvestmentTransactions`) instead of folding it into an empty contribution.

## Design decisions

- **Re-throw `credentialsNotConfigured` in both handlers, not just holdings.** The same swallow-all `catch` and the same setup-state contract apply to investment transactions; fixing only holdings would leave `/api/investments/transactions` reporting an empty `200` in setup state. The prefix gate already covers both routes, so re-throwing in both keeps the handler-level safety net consistent with the gate.
- **Other per-item errors still yield an empty contribution.** A missing `investments` product scope (the common case for existing links) remains best-effort: it returns an empty `InvestmentsResponse`/`[]` so a scope gap on one item never fails the whole request. Only `credentialsNotConfigured` — which affects every item identically — propagates. This exactly mirrors `AccountRoutes.listLiabilities` / `refreshAccounts`.
- **Smallest correct change.** One prefix string + two `catch PlaidError.credentialsNotConfigured` clauses; no behavior change for the configured/happy path.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes (CI gate).
- `swift test` (full suite) — 2567 tests, 2 failures, both **pre-existing** and unrelated (fixed in pending PR #693): `SyncResponseTests` `decodePendingCursors` and `WebhookDefectAndVerifier` sticky-sync. **Zero new failures** from this change.
- Tests in `Tests/PlaidBarServerTests/`:
  - Extended `setupStateMiddlewareClassifiesPlaidBackedPaths` (in `PlaidBarServerTests`) to assert `/api/investments/holdings` and `/api/investments/transactions` are classified Plaid-backed.
  - `Investment routes setup state` suite (in `InvestmentRoutesTests`) wires the real `SetupStateMiddleware` + `InvestmentRoutes` through a `Router`/`Application.test`.

### Test-fidelity follow-up (true guard for the handler re-throw)

A review found that the original four setup-state tests all wired `SetupStateMiddleware` with `credentialDiagnosis: .missingBoth`. In that state the `/api/investments` **prefix gate short-circuits to `503` before the handler ever runs**, so the two `seedItem: true` tests that *claimed* to guard the handler re-throw did not: reverting **only** the handler's `catch PlaidError.credentialsNotConfigured` re-throw left all four green. The re-throw was effectively unguarded.

This follow-up commit:

- Parameterizes the suite's `withInvestmentsAPI` helper with `credentialDiagnosis` (default `.missingBoth`, so the existing prefix-gate tests are unchanged) and **renames** the prior `seedItem: true` tests to reflect that they guard the **prefix gate only**.
- Adds two **true-guard** tests (`holdingsRethrowsCredentialsNotConfiguredWhenCredentialsConfigured`, `transactionsRethrowCredentialsNotConfiguredWhenCredentialsConfigured`) with `credentialDiagnosis: .configured`. With credentials present the prefix gate is bypassed, so a linked item actually reaches the credential-less Plaid double — the only path to `503` is then the handler re-throw → the middleware's *outer* `catch`.
- **Red-on-revert verified:** reverting *only* the two handler `catch PlaidError.credentialsNotConfigured` clauses turns these two new tests red (handler swallows the error → `200 OK` empty instead of `503`), while the four `.missingBoth` tests stay green — proving the new tests genuinely guard the re-throw. Production code is unchanged by this commit (the revert was reverted).

## Linked issue

- AND-661 (Medium) — AND-644 Investments follow-up
- https://linear.app/andeslab/issue/AND-661

## Known limitations

- The behavioral suite drives a credential-less `PlaidClientProtocol` double rather than a live Plaid call, so it asserts the server-side contract (status code surfaced to the app), not Plaid's own error wire format.
- The "one linked item" path uses a direct (non-`keychain:`) stored token so token resolution succeeds without macOS Keychain, keeping the test deterministic and Keychain-independent.

## Follow-ups

- None required. The investment-transactions pagination cap is explicitly **out of scope** — already handled by AND-659 / PR #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
