### PR TITLE
test(core): pin currency/investments correctness invariants (AND-665)

### DIFF
--- a/Tests/PlaidBarCoreTests/InvestmentHoldingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/InvestmentHoldingsPresentationTests.swift
@@ -185,6 +185,43 @@ struct InvestmentHoldingsPresentationTests {
         #expect(summary.totalGainText == nil)
     }
 
+    @Test("Summary mixes basis and no-basis holdings: market value spans all, gain spans basis-only (AND-665)")
+    func summaryMixedCostBasis() {
+        // Three scoped holdings; only VTI and Cash report a cost basis, AAPL does
+        // not. This pins the asymmetry at InvestmentHoldingsPresentation.swift
+        // lines 235-249: totalMarketValue covers EVERY holding, while totalGain is
+        // computed over ONLY the basis-reporting holdings (their market value minus
+        // their basis). AAPL's $10,000 market value contributes to the total but is
+        // excluded from the gain numerator so value and basis stay comparable.
+        let mixed = [
+            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 90, institutionValue: 22_500, costBasis: 18_000),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 50, institutionValue: 10_000, costBasis: nil),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_cash", quantity: 2_800, institutionValue: 2_800, costBasis: 2_800),
+        ]
+        let summary = InvestmentHoldingsPresentation.summary(
+            holdings: mixed,
+            accountId: "acct_a",
+            privacyMaskEnabled: false
+        )
+
+        // Count and market value span ALL three holdings, including the basisless AAPL.
+        #expect(summary.holdingsCount == 3)
+        #expect(summary.totalMarketValue == 35_300) // 22_500 + 10_000 + 2_800
+
+        // Cost basis sums only the two holdings that report it.
+        #expect(summary.totalCostBasis == 20_800) // 18_000 + 2_800
+
+        // Gain numerator = market value of the BASIS holdings only (22_500 + 2_800),
+        // minus the cost basis. AAPL's 10_000 is intentionally NOT in the numerator,
+        // so the gain is 4_500 — NOT 14_500 (which a naive totalMarketValue - basis
+        // would wrongly produce by counting AAPL's unbacked market value as gain).
+        #expect(summary.totalGain == 4_500) // (22_500 + 2_800) - 20_800
+        #expect(summary.totalGain != 35_300 - 20_800) // guards against the naive formula
+        #expect(summary.gainDirection == .gain)
+        #expect(summary.totalMarketValueText == "$35,300.00")
+        #expect(summary.totalGainText == "+$4,500.00")
+    }
+
     @Test("Summary masks value and gain under Privacy Mask")
     func summaryPrivacyMask() {
         let summary = InvestmentHoldingsPresentation.summary(

--- a/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
+++ b/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
@@ -114,6 +114,35 @@ struct MultiCurrencyTests {
         #expect(rates.rate(from: CurrencyCode("CHF"), to: .usd) == nil)
     }
 
+    @Test("Static rate table returns nil when the target currency's stored rate is zero (AND-665)")
+    func staticConversionZeroTargetRateIsNil() {
+        // Exercises the divide-by-zero guard at CurrencyAggregation.swift line 75
+        // (`toInBase != 0`). A currency stored with a 0 base rate would otherwise
+        // produce a division by zero when used as the conversion target; the guard
+        // must yield nil so callers fall back to per-currency subtotals rather than
+        // an infinite/NaN figure.
+        let rates = StaticCurrencyConversionRates(
+            base: .usd,
+            unitsOfBasePerCurrency: [
+                CurrencyCode("EUR"): 1.08,
+                CurrencyCode("ZRO"): 0, // pathological: priced at 0 units of base
+            ]
+        )
+
+        // Converting TO the zero-rate currency divides by zero → guarded to nil.
+        #expect(rates.rate(from: .usd, to: CurrencyCode("ZRO")) == nil)
+        #expect(rates.rate(from: CurrencyCode("EUR"), to: CurrencyCode("ZRO")) == nil)
+        // And convert(...) propagates that nil rather than producing an Inf/NaN amount.
+        #expect(rates.convert(100, from: .usd, to: CurrencyCode("ZRO")) == nil)
+
+        // The guard is scoped to the *target*: converting FROM the zero-rate currency
+        // is well-defined (numerator 0) and stays priced, so a real foreign target is
+        // still handled rather than over-guarded.
+        #expect(rates.rate(from: CurrencyCode("ZRO"), to: .usd) == 0)
+        // Identity still prices at 1 even for the zero-rate currency.
+        #expect(rates.rate(from: CurrencyCode("ZRO"), to: CurrencyCode("ZRO")) == 1)
+    }
+
     @Test("NoConversionSource prices only identity")
     func noConversionSource() {
         let source = NoConversionSource()


### PR DESCRIPTION
## Summary

Adds two `PlaidBarCore` Swift Testing regressions that pin recently-added math whose key invariants were unpinned, so a future refactor can no longer silently change them. **Test-only — no production code changed.** Both invariants behave exactly as intended today; these tests lock in that behavior.

## What's pinned

### 1. Investment summary with partial cost basis
`Sources/PlaidBarCore/Utilities/InvestmentHoldingsPresentation.swift:235-249`. `totalGain` is computed over **only** the holdings that report a cost basis, while `totalMarketValue` covers **all** holdings. The all-with-basis (`summaryRollup`) and none-with-basis (`summaryWithoutCostBasis`) edges were already covered; the **mixed** case was the gap.

New test `summaryMixedCostBasis` uses 3 scoped holdings — VTI (mv 22,500 / basis 18,000), AAPL (mv 10,000 / **no basis**), Cash (mv 2,800 / basis 2,800) — and asserts the values derived from the actual formula:

- `totalMarketValue` = 22,500 + 10,000 + 2,800 = **35,300** (all holdings, incl. basisless AAPL).
- `totalCostBasis` = 18,000 + 2,800 = **20,800** (only the two basis holdings).
- `totalGain` = (22,500 + 2,800) − 20,800 = **4,500** — the gain numerator is the market value of the **basis holdings only**; AAPL's 10,000 is excluded.

Why this matters: a naive `totalMarketValue − totalCostBasis` would give 35,300 − 20,800 = **14,500**, wrongly counting AAPL's unbacked market value as gain. The test explicitly asserts `totalGain == 4_500` and `totalGain != 35_300 - 20_800` to guard that regression.

### 2. Currency conversion zero-rate guard
`Sources/PlaidBarCore/Utilities/CurrencyAggregation.swift:71-81`. `StaticCurrencyConversionRates.rate(from:to:)` guards with `toInBase != 0` to avoid a divide-by-zero when the **target** currency is stored at a 0 base rate; on a zero target it returns `nil` so callers fall back to per-currency subtotals instead of an Inf/NaN figure. That guard branch was unexercised.

New test `staticConversionZeroTargetRateIsNil` builds a table with `ZRO` priced at `0` units of base and asserts:

- `rate(from: .usd, to: ZRO) == nil` and `rate(from: EUR, to: ZRO) == nil` (target rate 0 → guarded).
- `convert(100, from: .usd, to: ZRO) == nil` (the nil rate propagates — no Inf/NaN amount).
- `rate(from: ZRO, to: .usd) == 0` (guard is scoped to the **target**; converting *from* the zero-rate currency is well-defined, numerator 0).
- `rate(from: ZRO, to: ZRO) == 1` (identity still prices at 1).

## Testing notes

- CI gate: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passes.
- New tests run green (`summaryMixedCostBasis`, `staticConversionZeroTargetRateIsNil`).
- Full `swift test`: 2563 tests, the **only** 2 failures are the pre-existing #693 ones — `SyncResponseTests` "Decoding reads present pending cursor fields" (`decodePendingCursors`, a date-bomb) and `WebhookDefectAndVerifier` "Sticky sync signal clears…". **Zero new failures.**

## Linked issue

AND-665 — https://linear.app/andeslab/issue/AND-665

## Known limitations

- Pure-value assertions only (counts/amounts/`nil`); no UI/rendering path is exercised. The two invariants live in `PlaidBarCore` reductions with no I/O, which is the intended test surface.
- The two #693 full-suite failures are untouched here (separate issue).

## Follow-ups

- None required. If the mixed-basis gain semantics ever change intentionally, update `summaryMixedCostBasis` alongside the production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)