### PR TITLE
fix(server): terminal token-vault failure surfaces a reconnect path (AND-718)

### DIFF
--- a/Sources/PlaidBarServer/Routes/AccountRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/AccountRoutes.swift
@@ -161,10 +161,7 @@ struct AccountRoutes: Sendable {
                 // reporting a misleading per-item refresh failure.
                 throw PlaidError.credentialsNotConfigured
             } catch {
-                try await tokenStore.updateItemStatus(
-                    id: itemId,
-                    status: ItemStatusMapping.status(forAPIError: error).rawValue
-                )
+                try await tokenStore.updateItemStatus(id: itemId, forAPIError: error)
                 return AccountRefreshResult(attempted: true, succeeded: false, accounts: [])
             }
         }

--- a/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
+++ b/Sources/PlaidBarServer/Routes/ItemStatusMapping.swift
@@ -23,6 +23,19 @@ enum ItemStatusMapping {
         return status(forPlaidCode: errorCode) ?? .error
     }
 
+    /// Whether `error`/`status` represents a transient token-vault failure that
+    /// was downgraded to the non-actionable `.providerOutage` state (rather than
+    /// the hard `.error` reconnect lane). Callers use this to emit a diagnostic
+    /// log so an item parked in "we'll retry automatically" stays visible in the
+    /// field. The terminal `.invalidStoredToken` variant maps to `.error`, so it
+    /// is deliberately NOT reported here.
+    static func didDowngradeTokenVaultFailure(
+        _ error: Error,
+        toStatus status: ItemConnectionStatus
+    ) -> Bool {
+        error is PlaidTokenVaultError && status == .providerOutage
+    }
+
     static func status(forWebhookCode code: String, currentStatus: ItemConnectionStatus) -> ItemConnectionStatus? {
         let normalized = normalize(code)
         switch normalized {

--- a/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/TransactionRoutes.swift
@@ -219,10 +219,7 @@ struct TransactionRoutes: Sendable {
             // credential guidance instead of marking items errored.
             throw PlaidError.credentialsNotConfigured
         } catch {
-            try await tokenStore.updateItemStatus(
-                id: itemId,
-                status: ItemStatusMapping.status(forAPIError: error).rawValue
-            )
+            try await tokenStore.updateItemStatus(id: itemId, forAPIError: error)
             return ItemSyncResult(
                 itemId: itemId,
                 attempted: true,

--- a/Sources/PlaidBarServer/Storage/TokenStore.swift
+++ b/Sources/PlaidBarServer/Storage/TokenStore.swift
@@ -217,6 +217,23 @@ actor TokenStore {
         try await item.save(on: fluent.db())
     }
 
+    /// Maps a per-item refresh/sync failure to its connection status and persists
+    /// it. When a transient token-vault/Keychain failure is downgraded to the
+    /// non-actionable `.providerOutage` state, emit an item-id-only diagnostic so
+    /// an item parked in "we'll retry automatically" is findable in the field
+    /// (mirrors the best-effort `deleteItem` Keychain logging — the item id is an
+    /// opaque identifier, never token material). The terminal `.invalidStoredToken`
+    /// variant maps to the hard `.error` reconnect lane and is not logged here.
+    func updateItemStatus(id: String, forAPIError error: Error) async throws {
+        let status = ItemStatusMapping.status(forAPIError: error)
+        if ItemStatusMapping.didDowngradeTokenVaultFailure(error, toStatus: status) {
+            logger.warning(
+                "Token-vault failure for item \(id) downgraded to provider-outage (auto-retried): \(String(describing: error))"
+            )
+        }
+        try await updateItemStatus(id: id, status: status.rawValue)
+    }
+
     // MARK: - Sync Cursors
 
     func getSyncCursor(itemId: String) async throws -> String? {

--- a/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
+++ b/Tests/PlaidBarServerTests/PlaidBarServerTests.swift
@@ -1724,8 +1724,17 @@ struct PlaidBarServerTests {
 
         // Corrupt or empty token bytes are terminal from the item refresh path:
         // re-reading the same Keychain entry will keep throwing, so do not hide
-        // that recovery behind "we'll retry automatically".
-        #expect(ItemStatusMapping.status(forAPIError: PlaidTokenVaultError.invalidStoredToken) == .error)
+        // that recovery behind "we'll retry automatically" (AND-718). It must land
+        // in a state that surfaces a reconnect path.
+        let terminalStatus = ItemStatusMapping.status(forAPIError: PlaidTokenVaultError.invalidStoredToken)
+        #expect(terminalStatus == .error)
+        // Fail-on-revert: a regression to `.providerOutage` would silently strip
+        // the reconnect affordance. Assert it is NOT the transient lane, and that
+        // it satisfies the exact predicate the recovery UX keys off of
+        // (`WeeklyReview.needsReconnect`: `status == .error || needsUpdateMode`).
+        #expect(terminalStatus != .providerOutage)
+        #expect(terminalStatus.isProviderOutage == false)
+        #expect(terminalStatus == .error || terminalStatus.needsUpdateMode)
 
         // A genuine Plaid item error still maps to the hard `.error` state — the
         // transient special-case must not swallow real connection failures.
@@ -1739,6 +1748,46 @@ struct PlaidBarServerTests {
         // A non-Plaid, non-token-vault error remains a hard `.error` too.
         struct UnrelatedError: Error {}
         #expect(ItemStatusMapping.status(forAPIError: UnrelatedError()) == .error)
+    }
+
+    @Test("Only transient token-vault downgrades are flagged for the diagnostic log")
+    func itemStatusMappingFlagsTransientTokenVaultDowngradesForLogging() {
+        // The downgrade-diagnostic predicate (used to emit an item-id-only server
+        // log when a token-vault failure is parked in the auto-retried
+        // `.providerOutage` lane, AND-718) fires for every transient variant...
+        let transient: [PlaidTokenVaultError] = [
+            .keychainUnavailable,
+            .keychainLoadFailed(-25300),
+            .keychainSaveFailed(-34018),
+            .keychainDeleteFailed(-25300)
+        ]
+        for error in transient {
+            let status = ItemStatusMapping.status(forAPIError: error)
+            #expect(ItemStatusMapping.didDowngradeTokenVaultFailure(error, toStatus: status))
+        }
+
+        // ...but NOT for the terminal `.invalidStoredToken` variant — it maps to
+        // `.error`, so it is a reconnect, not a silent downgrade, and must not be
+        // mislabeled as an auto-retried outage in the logs.
+        let terminal = PlaidTokenVaultError.invalidStoredToken
+        #expect(
+            !ItemStatusMapping.didDowngradeTokenVaultFailure(
+                terminal,
+                toStatus: ItemStatusMapping.status(forAPIError: terminal)
+            )
+        )
+
+        // ...and never for a non-token-vault error, even if it lands on
+        // `.providerOutage` (a genuine Plaid-side outage code).
+        let providerOutage = PlaidError.apiError(
+            statusCode: 503,
+            errorType: "INSTITUTION_ERROR",
+            errorCode: "INSTITUTION_DOWN",
+            errorMessage: "synthetic outage"
+        )
+        let outageStatus = ItemStatusMapping.status(forAPIError: providerOutage)
+        #expect(outageStatus == .providerOutage)
+        #expect(!ItemStatusMapping.didDowngradeTokenVaultFailure(providerOutage, toStatus: outageStatus))
     }
 
     @Test("Webhook ERROR and repaired-with-new-accounts codes map correctly and preserve hard errors")


### PR DESCRIPTION
## Summary

Closes the last open corner of AND-718, a follow-up to AND-669 / #690.

**Important framing:** the core mapping fix AND-718 was filed against was *already present on `main`*. The issue (and the upstream review note) assumed the merged #690 landed a blanket `if error is PlaidTokenVaultError { return .providerOutage }` guard that swept `.invalidStoredToken` into the auto-retried `.providerOutage` lane. The version of #690 that actually merged (commit `52dfd598`) never did that — it already special-cases `.invalidStoredToken` → `.error` and maps only the four transient variants to `.providerOutage`, and the #690 test already split them. So the "perpetual retry / no reconnect path" bug does **not** exist in shipped code.

What was genuinely still missing is the issue's second bullet: a diagnostic log when a token-vault failure is downgraded to `.providerOutage`. This PR adds that, plus hardens the existing test assertions to be unambiguously fail-on-revert against the reconnect semantics.

## Which variants are terminal vs transient

`PlaidTokenVaultError` (`Sources/PlaidBarServer/Storage/PlaidTokenVault.swift`) has exactly five cases:

| Variant | Class | Maps to | Why |
|---|---|---|---|
| `invalidStoredToken` | **terminal** | `.error` | Thrown by `loadFromKeychain` when the stored bytes are present but empty/non-UTF8. Re-reading the same corrupt entry throws every time — it never self-heals, so it must surface a reconnect path. |
| `keychainUnavailable` | transient | `.providerOutage` | Device locked / Keychain temporarily unavailable — recovers on its own. |
| `keychainLoadFailed(_)` | transient | `.providerOutage` | A momentary `SecItemCopyMatching` failure (ACL prompt the background server can't satisfy, etc.). |
| `keychainSaveFailed(_)` | transient | `.providerOutage` | Momentary `SecItemAdd`/update failure. |
| `keychainDeleteFailed(_)` | transient | `.providerOutage` | Momentary `SecItemDelete` failure. |

`.error` is what surfaces a reconnect: `WeeklyReview.needsReconnect` is `status == .error || status.needsUpdateMode` (`Sources/PlaidBarCore/Models/WeeklyReview.swift:447`), driving the `.reconnectAccount` recovery action. `.providerOutage` is neither, so it stays in the non-actionable "we'll retry automatically" advisory lane. The current mapping is already correct on exactly this axis — no mapping change was needed.

## Design decisions

- **No mapping change.** `ItemStatusMapping.status(forAPIError:)` already classified all five variants correctly on `main`; touching it would be churn with no behavior delta. The PR leaves it as-is and only *adds* a pure predicate `didDowngradeTokenVaultFailure(_:toStatus:)` for the diagnostic.
- **Log at one chokepoint, item-id only.** Added `TokenStore.updateItemStatus(id:forAPIError:)`, which maps + persists + (only on a transient token-vault downgrade) logs `logger.warning("Token-vault failure for item <id> downgraded to provider-outage (auto-retried): …")`. This lives in `TokenStore` because it already owns the `Logger` and already logs item-id-only token-vault failures in `deleteItem` — same precedent, never logs token material. The two route catch sites (`AccountRoutes`, `TransactionRoutes`) now call this instead of mapping inline, so the diagnostic covers both refresh and sync paths with no duplication. The terminal `.invalidStoredToken` → `.error` case is deliberately **not** logged as a downgrade (it's a reconnect, not a silent park).
- **Other six `updateItemStatus(id:status:)` callers untouched** — the new overload is additive.

## Testing notes

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → **Build complete!** (CI gate, zero warnings/errors).
- `swift test` (full suite, not filtered) → **`Test run with 2596 tests passed`**, exit 0, **zero recorded issues / zero failures**. (The `✘ … skipped: "macOS Keychain accepts test writes"` lines are environment-gated Keychain-write tests, skipped on `main` too — not failures.)
- Strengthened `itemStatusMappingTreatsTokenVaultFailuresAsTransient`: the terminal assertion now also checks `!= .providerOutage`, `isProviderOutage == false`, and `status == .error || needsUpdateMode` (the exact `WeeklyReview.needsReconnect` predicate) — a revert to `.providerOutage` fails the test.
- New `itemStatusMappingFlagsTransientTokenVaultDowngradesForLogging`: the diagnostic predicate fires for all four transient variants, does **not** fire for terminal `.invalidStoredToken`, and does **not** fire for a non-token-vault `INSTITUTION_DOWN` error that also lands on `.providerOutage`.

## Linked issue

- AND-718 — https://linear.app/andeslab/issue/AND-718
- Follow-up to AND-669 / #690 (the transient-Keychain-failure fix).

## Known limitations

- The diagnostic is a `warning`-level log line, not a metric/counter; there's no aggregation of repeated downgrades for a single item across refreshes.
- The issue's alternative suggestion (a bounded retry budget that escalates `.providerOutage` → `.error` after N consecutive failures) is intentionally not implemented — for genuinely-transient Keychain hiccups, auto-retry without escalation is the desired AND-669 behavior, and the only non-self-healing variant (`invalidStoredToken`) already routes straight to `.error`.

## Follow-ups

- None required for AND-718. If field logs later show a transient variant getting *stuck* (a Keychain failure that is effectively permanent on some hardware), the retry-budget escalation is the natural next step — but that should be driven by real data, not pre-emptively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
