### PR TITLE
fix(currency): complete multi-currency migration on remaining surfaces (AND-660)

### DIFF
--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -43,7 +43,15 @@ struct WealthSummaryFlyout: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: Spacing.lg) {
-                    WealthMetricGrid(presentation: presentation, privacyMaskEnabled: privacyMaskEnabled)
+                    WealthMetricGrid(
+                        presentation: presentation,
+                        // Per-currency assets/debt (AND-660): the tiles render a
+                        // per-currency breakdown for a mixed portfolio rather than
+                        // summing scalar Doubles across currencies under one `$`.
+                        assetsAggregation: MultiCurrencyBalancePresentation.totalAssets(accounts: appState.accounts),
+                        debtAggregation: MultiCurrencyBalancePresentation.totalDebt(accounts: appState.accounts),
+                        privacyMaskEnabled: privacyMaskEnabled
+                    )
                         .loadingRedaction(appState.loadState(for: .summaryCards))
                         .scrollEdgeDepth(reduceMotion: reduceMotion)
 
@@ -141,14 +149,14 @@ struct WealthSummaryFlyout: View {
         _ presentation: WealthSummaryPresentation,
         privacyMaskEnabled: Bool
     ) -> some View {
-        let netWorthText = PrivacyMaskPresentation.currency(
-            presentation.netWorth,
+        // Net worth is grouped per currency (AND-660), mirroring the Dashboard
+        // hero: a mixed-currency portfolio shows a per-currency breakdown, never a
+        // fabricated `$` total. Single-currency text is byte-identical to before.
+        let netWorthAggregation = MultiCurrencyBalancePresentation.netWorth(accounts: appState.accounts)
+        let netWorthText = MultiCurrencyBalancePresentation.displayText(
+            from: netWorthAggregation,
             format: .full,
-            isEnabled: privacyMaskEnabled,
-            // Masked hero shows dots (consistent with every other value),
-            // not the word "Private". The `.hero` word is reserved for the
-            // VoiceOver label below and the menu-bar title.
-            style: .compact
+            privacyMaskEnabled: privacyMaskEnabled
         )
         return VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(alignment: .firstTextBaseline) {
@@ -189,12 +197,13 @@ struct WealthSummaryFlyout: View {
         _ presentation: WealthSummaryPresentation,
         privacyMaskEnabled: Bool
     ) -> String {
-        let netWorth = PrivacyMaskPresentation.currency(
-            presentation.netWorth,
+        // Speak net worth per currency (AND-660): a mixed-currency portfolio
+        // names each currency rather than reading a fabricated `$` figure.
+        let netWorth = MultiCurrencyBalancePresentation.headline(
+            from: MultiCurrencyBalancePresentation.netWorth(accounts: appState.accounts),
             format: .full,
-            isEnabled: privacyMaskEnabled,
-            style: .hero
-        )
+            privacyMaskEnabled: privacyMaskEnabled
+        ).accessibilityLabel
         let netCashflow = privacyMaskEnabled
             ? PrivacyMaskPresentation.compactValue
             : cashflowText(presentation.cashflow.net, format: .full)
@@ -282,6 +291,11 @@ private struct WealthSyncPill: View {
 private struct WealthMetricGrid: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let presentation: WealthSummaryPresentation
+    /// Per-currency assets/debt aggregations (AND-660). The displayed figure comes
+    /// from these — a mixed-currency portfolio shows a per-currency breakdown
+    /// instead of a fabricated single-`$` scalar.
+    let assetsAggregation: CurrencyAggregation
+    let debtAggregation: CurrencyAggregation
     let privacyMaskEnabled: Bool
 
     private var columns: [GridItem] {
@@ -291,11 +305,23 @@ private struct WealthMetricGrid: View {
         ]
     }
 
+    private func aggregatedValue(_ aggregation: CurrencyAggregation) -> String {
+        MultiCurrencyBalancePresentation.displayText(
+            from: aggregation,
+            format: .compact,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+    }
+
     var body: some View {
+        // `presentation.totalDebt` stays the source of the yes/no "has debt" cue
+        // (tint + detail copy); it is currency-agnostic so a boolean over it is
+        // safe even when the displayed figure is per-currency.
+        let hasDebt = presentation.totalDebt > 0
         LazyVGrid(columns: columns, alignment: .leading, spacing: Spacing.sm) {
             WealthMetricTile(
                 title: "Assets",
-                value: PrivacyMaskPresentation.currency(presentation.totalAssets, format: .compact, isEnabled: privacyMaskEnabled),
+                value: aggregatedValue(assetsAggregation),
                 detail: "\(presentation.accountCount) accounts",
                 systemImage: "building.columns.fill",
                 reduceMotion: reduceMotion
@@ -303,10 +329,10 @@ private struct WealthMetricGrid: View {
 
             WealthMetricTile(
                 title: "Debt",
-                value: PrivacyMaskPresentation.currency(presentation.totalDebt, format: .compact, isEnabled: privacyMaskEnabled),
-                detail: presentation.totalDebt > 0 ? "Credit and loans" : "No debt synced",
+                value: aggregatedValue(debtAggregation),
+                detail: hasDebt ? "Credit and loans" : "No debt synced",
                 systemImage: "creditcard.fill",
-                tint: presentation.totalDebt > 0 ? SemanticColors.creditDebt : AppearanceTextColors.secondary,
+                tint: hasDebt ? SemanticColors.creditDebt : AppearanceTextColors.secondary,
                 reduceMotion: reduceMotion
             )
         }
@@ -672,14 +698,23 @@ private struct WealthCreditSection: View {
         _ summary: WealthSummaryPresentation.CreditUtilizationSummary,
         format: CurrencyFormat
     ) -> String {
-        PrivacyMaskPresentation.currency(summary.usedCredit, format: format, isEnabled: privacyMaskEnabled)
+        // Render used/limit in the utilization's own currency (AND-660): the
+        // headline ratio is per-currency, so a EUR card's figures read as EUR,
+        // not a fabricated `$`.
+        PrivacyMaskPresentation.value(
+            Formatters.currency(summary.usedCredit, in: summary.currency, format: format),
+            isEnabled: privacyMaskEnabled
+        )
     }
 
     private func limitValue(
         _ summary: WealthSummaryPresentation.CreditUtilizationSummary,
         format: CurrencyFormat
     ) -> String {
-        PrivacyMaskPresentation.currency(summary.totalLimit, format: format, isEnabled: privacyMaskEnabled)
+        PrivacyMaskPresentation.value(
+            Formatters.currency(summary.totalLimit, in: summary.currency, format: format),
+            isEnabled: privacyMaskEnabled
+        )
     }
 
     private func tint(_ summary: WealthSummaryPresentation.CreditUtilizationSummary) -> Color {

--- a/Sources/PlaidBarCore/Models/FigureProvenance.swift
+++ b/Sources/PlaidBarCore/Models/FigureProvenance.swift
@@ -119,6 +119,7 @@ public struct FigureProvenance: Equatable, Sendable {
                     id: "net-worth-source-\(index)",
                     for: row.0,
                     amount: row.1,
+                    currency: row.0.balances.currency,
                     privacyMaskEnabled: privacyMaskEnabled
                 )
             }
@@ -197,9 +198,10 @@ public struct FigureProvenance: Equatable, Sendable {
     /// Provenance for the credit-utilization figure
     /// (`WealthSummaryPresentation.CreditUtilizationSummary`).
     ///
-    /// Utilization is used credit over total limit across credit-card accounts.
-    /// This lists the credit accounts as sources and notes that accounts without a
-    /// known limit contribute used balance but cannot contribute a denominator.
+    /// Utilization is used credit over total limit for one credit-card currency.
+    /// This lists the scoped credit accounts as sources and notes that accounts
+    /// without a known limit contribute used balance but cannot contribute a
+    /// denominator.
     public static func creditUtilization(
         summary: WealthSummaryPresentation.CreditUtilizationSummary,
         creditAccounts: [AccountDTO],
@@ -207,9 +209,12 @@ public struct FigureProvenance: Equatable, Sendable {
         privacyMaskEnabled: Bool = false,
         now: Date = Date()
     ) -> FigureProvenance {
-        let withoutLimit = creditAccounts.count { ($0.balances.limit ?? 0) <= 0 }
+        let scopedCreditAccounts = creditAccounts.filter {
+            $0.balances.currency == summary.currency
+        }
+        let withoutLimit = scopedCreditAccounts.count { ($0.balances.limit ?? 0) <= 0 }
 
-        let sources = creditAccounts
+        let sources = scopedCreditAccounts
             .sorted { abs($0.balances.current ?? 0) > abs($1.balances.current ?? 0) }
             .prefix(maxSourceRows)
             .enumerated()
@@ -218,6 +223,7 @@ public struct FigureProvenance: Equatable, Sendable {
                     id: "credit-utilization-source-\(index)",
                     for: account,
                     amount: abs(account.balances.current ?? 0),
+                    currency: summary.currency,
                     privacyMaskEnabled: privacyMaskEnabled,
                     forceCreditGlyph: true
                 )
@@ -227,14 +233,17 @@ public struct FigureProvenance: Equatable, Sendable {
         if withoutLimit > 0 {
             exclusions.append("\(withoutLimit) card\(withoutLimit == 1 ? "" : "s") without a reported limit contribute used balance but not total limit.")
         }
-        if creditAccounts.count > maxSourceRows {
-            exclusions.append("Showing the \(maxSourceRows) largest of \(creditAccounts.count) credit cards.")
+        if summary.isMultiCurrency {
+            exclusions.append("Reports the highest-utilization \(summary.currency.rawValue) credit group; other credit currencies are tracked separately, not pooled into this ratio.")
+        }
+        if scopedCreditAccounts.count > maxSourceRows {
+            exclusions.append("Showing the \(maxSourceRows) largest of \(scopedCreditAccounts.count) \(summary.currency.rawValue) credit cards.")
         }
         exclusions.append("Based on the balance and limit each bank last reported.")
 
         let derivation = privacyMaskEnabled
-            ? "Balance used divided by total limit across your credit cards."
-            : "Balance used divided by total limit across your credit cards (\(summary.statusLabel))."
+            ? "Balance used divided by total limit for your \(summary.currency.rawValue) credit cards."
+            : "Balance used divided by total limit for your \(summary.currency.rawValue) credit cards (\(summary.statusLabel))."
 
         return make(
             figureTitle: "Credit utilization",
@@ -301,6 +310,7 @@ public struct FigureProvenance: Equatable, Sendable {
         id: String,
         for account: AccountDTO,
         amount: Double,
+        currency: CurrencyCode,
         privacyMaskEnabled: Bool,
         forceCreditGlyph: Bool = false
     ) -> Source {
@@ -308,10 +318,10 @@ public struct FigureProvenance: Equatable, Sendable {
         let label = account.name + suffix
         let value = privacyMaskEnabled
             ? PrivacyMaskPresentation.compactValue
-            : Formatters.currency(amount, format: .compact)
+            : Formatters.currency(amount, in: currency, format: .compact)
         let spokenValue = privacyMaskEnabled
             ? "balance hidden while Privacy Mask is on"
-            : "balance \(Formatters.currency(amount, format: .full))"
+            : "balance \(Formatters.currency(amount, in: currency, format: .full))"
         let glyph = forceCreditGlyph ? "creditcard" : account.type.provenanceGlyph
         return Source(
             id: id,

--- a/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
+++ b/Sources/PlaidBarCore/Models/FinanceSnapshot.swift
@@ -107,9 +107,15 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
     public let currencySubtotals: [CurrencySubtotal]
     /// Upcoming recurring bills within the look-ahead window, soonest first.
     public let nextRecurringBills: [UpcomingBill]
-    /// Aggregate credit utilization percent (0–100), nil when no credit limit
-    /// is known.
+    /// Credit utilization percent (0–100), nil when no credit limit is known.
+    /// For mixed-currency credit cards, this is the highest single-currency
+    /// utilization, not a pooled cross-currency denominator.
     public let creditUtilization: Double?
+    /// Currency backing ``creditUtilization`` when known.
+    public let creditUtilizationCurrency: CurrencyCode?
+    /// True when ``creditUtilization`` reports one highest-utilization currency
+    /// group while other credit-card currencies also exist.
+    public let creditUtilizationIsMultiCurrency: Bool
     /// ISO currency code for the headline figures (best-effort; "USD" default).
     public let isoCurrencyCode: String
     /// When the snapshot was produced.
@@ -141,6 +147,8 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         currencySubtotals: [CurrencySubtotal] = [],
         nextRecurringBills: [UpcomingBill],
         creditUtilization: Double?,
+        creditUtilizationCurrency: CurrencyCode? = nil,
+        creditUtilizationIsMultiCurrency: Bool = false,
         isoCurrencyCode: String = "USD",
         generatedAt: Date,
         isMasked: Bool,
@@ -155,6 +163,8 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         self.currencySubtotals = currencySubtotals
         self.nextRecurringBills = nextRecurringBills
         self.creditUtilization = creditUtilization
+        self.creditUtilizationCurrency = creditUtilizationCurrency
+        self.creditUtilizationIsMultiCurrency = creditUtilizationIsMultiCurrency
         self.isoCurrencyCode = isoCurrencyCode
         self.generatedAt = generatedAt
         self.isMasked = isMasked
@@ -169,7 +179,8 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
     // empty defaults, so an upgrade never fails to read a pre-AND-586 snapshot.
     private enum CodingKeys: String, CodingKey {
         case safeToSpend, totalBalance, accountBalances, nextRecurringBills
-        case currencySubtotals, creditUtilization, isoCurrencyCode, generatedAt, isMasked
+        case currencySubtotals, creditUtilization, creditUtilizationCurrency
+        case creditUtilizationIsMultiCurrency, isoCurrencyCode, generatedAt, isMasked
         case periodSpending, topSpendingCategories
         case safeToSpendConfidence, safeToSpendHorizonEnd
     }
@@ -182,6 +193,8 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         currencySubtotals = try container.decodeIfPresent([CurrencySubtotal].self, forKey: .currencySubtotals) ?? []
         nextRecurringBills = try container.decode([UpcomingBill].self, forKey: .nextRecurringBills)
         creditUtilization = try container.decodeIfPresent(Double.self, forKey: .creditUtilization)
+        creditUtilizationCurrency = try container.decodeIfPresent(CurrencyCode.self, forKey: .creditUtilizationCurrency)
+        creditUtilizationIsMultiCurrency = try container.decodeIfPresent(Bool.self, forKey: .creditUtilizationIsMultiCurrency) ?? false
         isoCurrencyCode = try container.decodeIfPresent(String.self, forKey: .isoCurrencyCode) ?? "USD"
         generatedAt = try container.decode(Date.self, forKey: .generatedAt)
         isMasked = try container.decode(Bool.self, forKey: .isMasked)
@@ -269,5 +282,16 @@ public struct FinanceSnapshot: Codable, Sendable, Equatable {
         )
         .map { "\($0.currency.rawValue) \($0.formattedAmount)" }
         .joined(separator: ", ")
+    }
+
+    public var creditUtilizationScopeLabel: String? {
+        guard creditUtilizationIsMultiCurrency,
+              let creditUtilizationCurrency
+        else { return nil }
+
+        if creditUtilizationCurrency.isResolved {
+            return "\(creditUtilizationCurrency.rawValue) credit-card group"
+        }
+        return "credit-card group without a reported currency"
     }
 }

--- a/Sources/PlaidBarCore/Models/InvestmentDTO.swift
+++ b/Sources/PlaidBarCore/Models/InvestmentDTO.swift
@@ -104,6 +104,14 @@ public struct HoldingDTO: Codable, Sendable, Equatable, Identifiable {
         guard let costBasis else { return nil }
         return marketValue - costBasis
     }
+
+    /// Normalized currency identity for this holding's market value/cost basis.
+    /// Wraps the raw Plaid `iso_currency_code`; an absent/empty code resolves to
+    /// ``CurrencyCode/unknown`` (never silently assumed to be USD), so a EUR
+    /// position is grouped and rendered as EUR rather than mislabeled `$`.
+    public var currency: CurrencyCode {
+        CurrencyCode(isoCurrencyCode)
+    }
 }
 
 /// A buy/sell/dividend/fee event inside an investment account, from Plaid

--- a/Sources/PlaidBarCore/Utilities/ControlValuePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/ControlValuePresentation.swift
@@ -124,9 +124,12 @@ public enum ControlValuePresentation {
             )
         }
         let formatted = Formatters.percent(percent, decimals: 0)
+        let accessibility = snapshot.creditUtilizationScopeLabel.map {
+            "Credit utilization \(formatted), highest in the \($0)"
+        } ?? "Credit utilization \(formatted)"
         return ControlValueDisplay(
             value: formatted,
-            accessibilityLabel: "Credit utilization \(formatted)",
+            accessibilityLabel: accessibility,
             systemImage: "creditcard",
             isWithheld: false
         )

--- a/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceIntentQueries.swift
@@ -143,6 +143,9 @@ public enum FinanceIntentQueries {
             return .message("No credit cards with a known limit are linked.")
         }
         let formatted = Formatters.percent(percent)
+        if let scope = snapshot.creditUtilizationScopeLabel {
+            return .value(percent, spokenDialog: "Your highest credit utilization is \(formatted) in the \(scope).")
+        }
         return .value(percent, spokenDialog: "Your credit utilization is \(formatted).")
     }
 

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 ///   used to build `accountBalances`), matching the intent's "spendable balance
 ///   across linked accounts" — not net worth.
 /// - `creditUtilization` ← ``WealthSummaryPresentation`` credit-utilization rule
-///   (recomputed from the same depository/credit balances)
+///   (same worst single-currency group and scope metadata)
 /// - `nextRecurringBills` ← the supplied recurring streams, filtered to dated
 ///   outflows within the horizon and sorted soonest-first.
 public enum FinanceSnapshotBuilder {
@@ -81,7 +81,8 @@ public enum FinanceSnapshotBuilder {
             calendar: calendar
         )
 
-        let utilization = creditUtilizationPercent(from: accounts)
+        let utilizationGroups = MenuBarSummary.creditUtilizationByCurrency(from: accounts)
+        let utilization = utilizationGroups.first
 
         let spending = monthToDateSpending(
             transactions: transactions,
@@ -119,7 +120,9 @@ public enum FinanceSnapshotBuilder {
             accountBalances: accountBalances,
             currencySubtotals: currencySubtotals,
             nextRecurringBills: bills,
-            creditUtilization: utilization,
+            creditUtilization: utilization?.percent,
+            creditUtilizationCurrency: utilization?.currency,
+            creditUtilizationIsMultiCurrency: utilizationGroups.count > 1,
             isoCurrencyCode: currencyCode,
             generatedAt: generatedAt,
             isMasked: isMasked,
@@ -216,14 +219,4 @@ public enum FinanceSnapshotBuilder {
         }
     }
 
-    // MARK: - Credit utilization
-
-    /// Credit utilization (0–100), nil when no credit limit is known. **Per
-    /// currency** as of AND-660: the worst single-currency utilization, never a
-    /// cross-currency pooled ratio. This figure feeds the local-AI snapshot, so a
-    /// fabricated cross-currency denominator must never reach an insight prompt.
-    /// Same rule as ``WealthSummaryPresentation`` (`MenuBarSummary.creditUtilization`).
-    private static func creditUtilizationPercent(from accounts: [AccountDTO]) -> Double? {
-        MenuBarSummary.creditUtilization(from: accounts)
-    }
 }

--- a/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnapshotBuilder.swift
@@ -218,17 +218,12 @@ public enum FinanceSnapshotBuilder {
 
     // MARK: - Credit utilization
 
-    /// Aggregate credit utilization (0–100), nil when no credit limit is known.
-    /// Same rule as ``WealthSummaryPresentation`` (`used / limit * 100`).
+    /// Credit utilization (0–100), nil when no credit limit is known. **Per
+    /// currency** as of AND-660: the worst single-currency utilization, never a
+    /// cross-currency pooled ratio. This figure feeds the local-AI snapshot, so a
+    /// fabricated cross-currency denominator must never reach an insight prompt.
+    /// Same rule as ``WealthSummaryPresentation`` (`MenuBarSummary.creditUtilization`).
     private static func creditUtilizationPercent(from accounts: [AccountDTO]) -> Double? {
-        let creditBalances = accounts
-            .filter { $0.type == .credit }
-            .map(\.balances)
-
-        let totalLimit = creditBalances.reduce(0) { $0 + max($1.limit ?? 0, 0) }
-        guard totalLimit > 0 else { return nil }
-
-        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
-        return (usedCredit / totalLimit) * 100
+        MenuBarSummary.creditUtilization(from: accounts)
     }
 }

--- a/Sources/PlaidBarCore/Utilities/FinanceSnippetPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/FinanceSnippetPresentation.swift
@@ -309,9 +309,12 @@ public enum FinanceSnippetPresentation {
         let clamped = min(max(percent, 0), 100)
         let isHigh = percent >= warningThreshold
         let formatted = Formatters.percent(percent)
-        let a11y = isHigh
-            ? "Credit utilization \(formatted). High — above your \(Formatters.percent(warningThreshold)) warning level."
-            : "Credit utilization \(formatted)."
+        var a11y = snapshot.creditUtilizationScopeLabel.map {
+            "Credit utilization \(formatted). Highest in the \($0)."
+        } ?? "Credit utilization \(formatted)."
+        if isHigh {
+            a11y += " High — above your \(Formatters.percent(warningThreshold)) warning level."
+        }
 
         return CreditUtilizationModel(
             percentText: formatted,

--- a/Sources/PlaidBarCore/Utilities/Formatters.swift
+++ b/Sources/PlaidBarCore/Utilities/Formatters.swift
@@ -78,14 +78,20 @@ public enum Formatters {
         let sign = amount < 0 ? "-" : ""
         let magnitude = abs(amount)
         let symbol = currencyCode == "USD" ? "$" : currencyCode
+        // A symbol that is the bare currency code (e.g. `EUR`) — rather than a
+        // glyph like `$` — needs a separator so it does not run into the
+        // magnitude as `EUR1.2K`. Use a non-breaking space so the figure never
+        // wraps between the code and the number. `$` (and the unknown-currency
+        // empty symbol) keep no separator, so USD output is byte-identical.
+        let separator = (symbol.isEmpty || symbol == "$") ? "" : "\u{00A0}"
 
         switch magnitude {
         case 1_000_000...:
-            return "\(sign)\(symbol)\(String(format: "%.1fM", magnitude / 1_000_000))"
+            return "\(sign)\(symbol)\(separator)\(String(format: "%.1fM", magnitude / 1_000_000))"
         case 1_000...:
-            return "\(sign)\(symbol)\(String(format: "%.1fK", magnitude / 1_000))"
+            return "\(sign)\(symbol)\(separator)\(String(format: "%.1fK", magnitude / 1_000))"
         default:
-            return "\(sign)\(symbol)\(String(format: "%.0f", magnitude))"
+            return "\(sign)\(symbol)\(separator)\(String(format: "%.0f", magnitude))"
         }
     }
 

--- a/Sources/PlaidBarCore/Utilities/InvestmentHoldingsPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/InvestmentHoldingsPresentation.swift
@@ -100,6 +100,15 @@ public enum InvestmentHoldingsPresentation {
     /// basis, and the aggregate unrealized gain with a directional cue.
     public struct Summary: Sendable, Equatable {
         public let holdingsCount: Int
+        /// Per-currency aggregation of the holdings' market values (AND-660). The
+        /// source of truth for the displayed total: mixed currencies stay grouped
+        /// here and never collapse into a single fabricated `$` figure.
+        public let marketValueAggregation: CurrencyAggregation
+        /// Scalar sum of every holding's market value, *regardless of currency*.
+        /// Retained only as the net-worth inclusion input (callers fold investment
+        /// value into a USD net worth today); it is **not** a display figure and
+        /// must not be rendered with a `$` when ``marketValueAggregation`` is
+        /// multi-currency. Prefer ``totalMarketValueText`` for display.
         public let totalMarketValue: Double
         public let totalCostBasis: Double?
         public let totalGain: Double?
@@ -108,8 +117,13 @@ public enum InvestmentHoldingsPresentation {
         public let totalGainText: String?
         public let accessibilityLabel: String
 
+        /// True when the holdings span more than one currency, so the displayed
+        /// total is a per-currency breakdown rather than a single headline figure.
+        public var isMultiCurrency: Bool { marketValueAggregation.isMultiCurrency }
+
         public init(
             holdingsCount: Int,
+            marketValueAggregation: CurrencyAggregation,
             totalMarketValue: Double,
             totalCostBasis: Double?,
             totalGain: Double?,
@@ -119,6 +133,7 @@ public enum InvestmentHoldingsPresentation {
             accessibilityLabel: String
         ) {
             self.holdingsCount = holdingsCount
+            self.marketValueAggregation = marketValueAggregation
             self.totalMarketValue = totalMarketValue
             self.totalCostBasis = totalCostBasis
             self.totalGain = totalGain
@@ -188,18 +203,22 @@ public enum InvestmentHoldingsPresentation {
             ? PrivacyMaskPresentation.compactValue
             : "\(formatQuantity(holding.quantity)) shares"
 
-        let marketValueText = PrivacyMaskPresentation.currency(
-            holding.marketValue,
-            isEnabled: privacyMaskEnabled
-        )
+        // Render the value/gain in the holding's *own* currency so a EUR
+        // position never reads as `$` (AND-660). Masked figures still collapse to
+        // the placeholder; only the unmasked path threads the currency.
+        let currency = holding.currency
+        let marketValueText = privacyMaskEnabled
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(holding.marketValue, in: currency)
 
         let gain = holding.unrealizedGain
         let gainDirection = gain.map(Direction.of)
-        let gainText: String? = gain.map { signedCurrency($0, masked: privacyMaskEnabled) }
+        let gainText: String? = gain.map { signedCurrency($0, in: currency, masked: privacyMaskEnabled) }
 
         let accessibilityLabel = holdingAccessibilityLabel(
             name: name,
             ticker: ticker,
+            currency: currency,
             marketValue: holding.marketValue,
             quantity: holding.quantity,
             gain: gain,
@@ -232,6 +251,12 @@ public enum InvestmentHoldingsPresentation {
     ) -> Summary {
         let scoped = accountId.map { id in holdings.filter { $0.accountId == id } } ?? holdings
 
+        // Group market value per currency so a mixed EUR/USD portfolio never
+        // collapses into a single fabricated `$` scalar (AND-660). The scalar
+        // `totalMarketValue` remains for net-worth inclusion only.
+        let marketValueAggregation = CurrencyAggregation.aggregate(
+            scoped.map { (amount: $0.marketValue, currency: $0.currency) }
+        )
         let totalMarketValue = scoped.reduce(0) { $0 + $1.marketValue }
 
         // Cost basis is summable only over the holdings that actually report it.
@@ -243,7 +268,13 @@ public enum InvestmentHoldingsPresentation {
             : basisHoldings.reduce(0) { $0 + ($1.costBasis ?? 0) }
 
         // Gain aggregates over the same basis-reporting holdings so value and
-        // basis stay comparable.
+        // basis stay comparable. Grouped per currency so a EUR gain and a USD
+        // gain are never summed into a meaningless cross-currency number.
+        let gainAggregation: CurrencyAggregation? = basisHoldings.isEmpty
+            ? nil
+            : CurrencyAggregation.aggregate(
+                basisHoldings.map { (amount: $0.marketValue - ($0.costBasis ?? 0), currency: $0.currency) }
+            )
         let totalGain: Double? = totalCostBasis.map { basis in
             basisHoldings.reduce(0) { $0 + $1.marketValue } - basis
         }
@@ -251,23 +282,65 @@ public enum InvestmentHoldingsPresentation {
 
         return Summary(
             holdingsCount: scoped.count,
+            marketValueAggregation: marketValueAggregation,
             totalMarketValue: totalMarketValue,
             totalCostBasis: totalCostBasis,
             totalGain: totalGain,
             gainDirection: direction,
-            totalMarketValueText: PrivacyMaskPresentation.currency(
-                totalMarketValue,
-                isEnabled: privacyMaskEnabled
+            totalMarketValueText: marketValueText(
+                from: marketValueAggregation,
+                privacyMaskEnabled: privacyMaskEnabled
             ),
-            totalGainText: totalGain.map { signedCurrency($0, masked: privacyMaskEnabled) },
+            totalGainText: gainAggregation.map {
+                gainText(from: $0, privacyMaskEnabled: privacyMaskEnabled)
+            },
             accessibilityLabel: summaryAccessibilityLabel(
                 holdingsCount: scoped.count,
-                totalMarketValue: totalMarketValue,
-                totalGain: totalGain,
+                marketValueAggregation: marketValueAggregation,
+                gainAggregation: gainAggregation,
                 direction: direction,
                 privacyMaskEnabled: privacyMaskEnabled
             )
         )
+    }
+
+    /// Display text for the rolled-up market value. Single currency (or a
+    /// priceable conversion) renders one figure; mixed unpriceable currencies
+    /// render a per-currency breakdown, never a fabricated `$` total (AND-660).
+    private static func marketValueText(
+        from aggregation: CurrencyAggregation,
+        privacyMaskEnabled: Bool
+    ) -> String {
+        let headline = MultiCurrencyBalancePresentation.headline(
+            from: aggregation,
+            format: .full,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+        if let total = headline.formattedTotal { return total }
+        return MultiCurrencyBalancePresentation.subtotalRows(
+            from: aggregation,
+            format: .full,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+        .map(\.formattedAmount)
+        .joined(separator: " · ")
+    }
+
+    /// Sign-prefixed display text for the rolled-up unrealized gain. Single
+    /// currency renders one signed figure; mixed currencies render a per-currency
+    /// list so EUR and USD gains are never summed (AND-660).
+    private static func gainText(
+        from aggregation: CurrencyAggregation,
+        privacyMaskEnabled: Bool
+    ) -> String {
+        if privacyMaskEnabled { return PrivacyMaskPresentation.compactValue }
+        if let single = aggregation.singleCurrency,
+           let subtotal = aggregation.subtotals.first {
+            return signedCurrency(subtotal.amount, in: single, masked: false)
+        }
+        return aggregation.subtotals
+            .map { signedCurrency($0.amount, in: $0.currency, masked: false) }
+            .joined(separator: " · ")
     }
 
     /// The total market value of all supplied holdings — the figure that should
@@ -319,16 +392,22 @@ public enum InvestmentHoldingsPresentation {
 
     /// A sign-prefixed currency string so the direction reads textually even in
     /// monochrome / for VoiceOver — never relying on color. Masked under Privacy
-    /// Mask.
-    static func signedCurrency(_ amount: Double, masked: Bool) -> String {
+    /// Mask. Rendered in `currency`'s own native format (AND-660) so a EUR gain
+    /// shows as EUR, not `$`.
+    static func signedCurrency(_ amount: Double, in currency: CurrencyCode, masked: Bool) -> String {
+        if masked { return PrivacyMaskPresentation.compactValue }
         // Uses the typographic U+2212 MINUS SIGN (not ASCII hyphen-minus) for a
-        // negative gain — preserved exactly via the `minusGlyph` knob.
-        Formatters.signedCurrency(amount, format: .full, minusGlyph: "\u{2212}", masked: masked)
+        // negative gain, and the holding's native currency for the magnitude.
+        let magnitude = Formatters.currency(abs(amount), in: currency, format: .full)
+        if amount > 0 { return "+\(magnitude)" }
+        if amount < 0 { return "\u{2212}\(magnitude)" }
+        return magnitude
     }
 
     private static func holdingAccessibilityLabel(
         name: String,
         ticker: String?,
+        currency: CurrencyCode,
         marketValue: Double,
         quantity: Double,
         gain: Double?,
@@ -344,17 +423,17 @@ public enum InvestmentHoldingsPresentation {
         }
 
         parts.append("\(formatQuantity(quantity)) shares")
-        parts.append("worth \(Formatters.currency(marketValue))")
+        parts.append("worth \(Formatters.currency(marketValue, in: currency))")
         if let gain, let gainDirection {
-            parts.append("\(gainDirection.spokenWord) \(Formatters.currency(abs(gain)))")
+            parts.append("\(gainDirection.spokenWord) \(Formatters.currency(abs(gain), in: currency))")
         }
         return parts.joined(separator: ", ")
     }
 
     private static func summaryAccessibilityLabel(
         holdingsCount: Int,
-        totalMarketValue: Double,
-        totalGain: Double?,
+        marketValueAggregation: CurrencyAggregation,
+        gainAggregation: CurrencyAggregation?,
         direction: Direction,
         privacyMaskEnabled: Bool
     ) -> String {
@@ -362,9 +441,22 @@ public enum InvestmentHoldingsPresentation {
         if privacyMaskEnabled {
             return "\(positions), value hidden while Privacy Mask is on"
         }
-        var label = "\(positions), total value \(Formatters.currency(totalMarketValue))"
-        if let totalGain {
-            label += ", \(direction.spokenWord) \(Formatters.currency(abs(totalGain)))"
+        // Name the total per currency so VoiceOver never speaks a fabricated `$`
+        // figure for a mixed-currency portfolio (AND-660).
+        let valueText = marketValueText(from: marketValueAggregation, privacyMaskEnabled: false)
+        var label = "\(positions), total value \(valueText)"
+        if let gainAggregation {
+            // Single currency keeps the prior "<direction> <amount>" phrasing; a
+            // mixed-currency gain reads as a per-currency list.
+            if let single = gainAggregation.singleCurrency,
+               let subtotal = gainAggregation.subtotals.first {
+                label += ", \(Direction.of(subtotal.amount).spokenWord) \(Formatters.currency(abs(subtotal.amount), in: single))"
+            } else {
+                let perCurrency = gainAggregation.subtotals
+                    .map { "\(Direction.of($0.amount).spokenWord) \(Formatters.currency(abs($0.amount), in: $0.currency))" }
+                    .joined(separator: ", ")
+                label += ", \(perCurrency)"
+            }
         }
         return label
     }

--- a/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/MenuBarSummary.swift
@@ -64,16 +64,76 @@ public enum MenuBarSummary {
             .reduce(0) { $0 + AccountPresentation.displayBalance(for: $1) }
     }
 
+    /// A credit-utilization figure scoped to a *single* currency. Used credit and
+    /// total limit are only ever summed within one currency, so the ratio is
+    /// always meaningful (AND-660). Pooling a EUR balance against a USD limit — the
+    /// pre-AND-660 bug — produced a fabricated denominator and an arbitrary ratio
+    /// that fed alerts, App Intents, and AI insights.
+    public struct CurrencyUtilization: Sendable, Equatable {
+        public let currency: CurrencyCode
+        public let usedCredit: Double
+        public let totalLimit: Double
+        public let percent: Double
+
+        public init(currency: CurrencyCode, usedCredit: Double, totalLimit: Double, percent: Double) {
+            self.currency = currency
+            self.usedCredit = usedCredit
+            self.totalLimit = totalLimit
+            self.percent = percent
+        }
+    }
+
+    /// Per-currency credit utilization: groups credit-card accounts by their own
+    /// currency and computes used/limit/percent *within* each currency, never
+    /// across currencies (AND-660). Only currencies whose cards report a positive
+    /// total limit are included (a denominator of 0 yields no meaningful ratio).
+    /// Sorted by descending utilization, then currency, so the worst (most
+    /// alert-worthy) currency is first and ties are deterministic.
+    public static func creditUtilizationByCurrency(from accounts: [AccountDTO]) -> [CurrencyUtilization] {
+        var usedByCurrency: [CurrencyCode: Double] = [:]
+        var limitByCurrency: [CurrencyCode: Double] = [:]
+
+        for account in accounts where account.type == .credit {
+            let currency = account.balances.currency
+            // A negative/garbage limit cannot anchor a denominator; clamp at 0 so
+            // a stray value never inflates or deflates the ratio.
+            limitByCurrency[currency, default: 0] += max(account.balances.limit ?? 0, 0)
+            usedByCurrency[currency, default: 0] += abs(account.balances.current ?? 0)
+        }
+
+        return limitByCurrency
+            .compactMap { currency, totalLimit -> CurrencyUtilization? in
+                guard totalLimit > 0 else { return nil }
+                let usedCredit = usedByCurrency[currency] ?? 0
+                return CurrencyUtilization(
+                    currency: currency,
+                    usedCredit: usedCredit,
+                    totalLimit: totalLimit,
+                    percent: (usedCredit / totalLimit) * 100
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.percent != rhs.percent { return lhs.percent > rhs.percent }
+                return lhs.currency < rhs.currency
+            }
+    }
+
+    /// The single utilization currency-group that best represents the user's
+    /// credit risk: the **highest** per-currency utilization (AND-660). This is
+    /// the figure surfaced as the headline and the one that decides whether the
+    /// high-utilization alert fires — so a maxed-out EUR card still trips the
+    /// threshold even when a large USD limit would dilute a pooled ratio.
+    /// Returns `nil` when no currency reports a positive total limit.
+    public static func worstCreditUtilization(from accounts: [AccountDTO]) -> CurrencyUtilization? {
+        creditUtilizationByCurrency(from: accounts).first
+    }
+
+    /// Headline credit-utilization percentage. **Per-currency** as of AND-660: the
+    /// worst single-currency utilization, never a cross-currency pooled ratio.
+    /// A same-currency portfolio is byte-identical to the pre-AND-660 value
+    /// (one currency group → the old `used / limit`).
     public static func creditUtilization(from accounts: [AccountDTO]) -> Double? {
-        let creditBalances = accounts
-            .filter { $0.type == .credit }
-            .map(\.balances)
-
-        let totalLimit = creditBalances.reduce(0) { $0 + ($1.limit ?? 0) }
-        guard totalLimit > 0 else { return nil }
-
-        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
-        return (usedCredit / totalLimit) * 100
+        worstCreditUtilization(from: accounts)?.percent
     }
 
     /// Highest single-card utilization (used/limit) across all credit cards,

--- a/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
@@ -96,11 +96,22 @@ public enum MultiCurrencyBalancePresentation {
         format: CurrencyFormat = .full,
         privacyMaskEnabled: Bool = false
     ) -> String {
-        headline(
+        let headline = headline(
             from: aggregation,
             format: format,
             privacyMaskEnabled: privacyMaskEnabled
-        ).formattedTotal ?? "By currency"
+        )
+        if let total = headline.formattedTotal { return total }
+        if privacyMaskEnabled { return PrivacyMaskPresentation.compactValue }
+
+        let perCurrency = subtotalRows(
+            from: aggregation,
+            format: format,
+            privacyMaskEnabled: privacyMaskEnabled
+        )
+        .map(\.formattedAmount)
+        .joined(separator: " · ")
+        return perCurrency.isEmpty ? "By currency" : perCurrency
     }
 
     /// Formats per-currency subtotals as display rows. `privacyMaskEnabled`

--- a/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/WealthSummaryPresentation.swift
@@ -29,19 +29,33 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         public let totalLimit: Double
         public let statusLabel: String
         public let exceedsThreshold: Bool
+        /// The currency the headline `usedCredit`/`totalLimit`/`percent` are scoped
+        /// to (AND-660). Utilization is computed within one currency, never pooled
+        /// across currencies, so these figures must be rendered in this currency —
+        /// not a fabricated `$`.
+        public let currency: CurrencyCode
+        /// True when credit cards span more than one currency, so this summary
+        /// reports the *worst* single currency while others exist. The flyout/
+        /// provenance surface this so the headline is not mistaken for a portfolio-
+        /// wide ratio.
+        public let isMultiCurrency: Bool
 
         public init(
             percent: Double,
             usedCredit: Double,
             totalLimit: Double,
             statusLabel: String,
-            exceedsThreshold: Bool
+            exceedsThreshold: Bool,
+            currency: CurrencyCode = .usd,
+            isMultiCurrency: Bool = false
         ) {
             self.percent = percent
             self.usedCredit = usedCredit
             self.totalLimit = totalLimit
             self.statusLabel = statusLabel
             self.exceedsThreshold = exceedsThreshold
+            self.currency = currency
+            self.isMultiCurrency = isMultiCurrency
         }
     }
 
@@ -252,25 +266,27 @@ public struct WealthSummaryPresentation: Sendable, Equatable {
         from accounts: [AccountDTO],
         threshold: Double
     ) -> CreditUtilizationSummary? {
-        let creditBalances = accounts
-            .filter { $0.type == .credit }
-            .map(\.balances)
-
-        let totalLimit = creditBalances.reduce(0) { $0 + max($1.limit ?? 0, 0) }
-        guard totalLimit > 0 else { return nil }
-
-        let usedCredit = creditBalances.reduce(0) { $0 + abs($1.current ?? 0) }
-        let percent = (usedCredit / totalLimit) * 100
+        // Utilization is computed PER CURRENCY (AND-660): used credit and total
+        // limit are only ever summed within one currency, so the ratio is always
+        // meaningful. The headline reports the *worst* single currency — the
+        // alert-correct choice, so a maxed-out EUR card still trips the threshold
+        // even when a large USD limit would dilute a (formerly pooled) ratio.
+        let groups = MenuBarSummary.creditUtilizationByCurrency(from: accounts)
+        guard let worst = groups.first else { return nil }
 
         return CreditUtilizationSummary(
-            percent: percent,
-            usedCredit: usedCredit,
-            totalLimit: totalLimit,
+            percent: worst.percent,
+            usedCredit: worst.usedCredit,
+            totalLimit: worst.totalLimit,
             statusLabel: AccountPresentation.utilizationStatusLabel(
-                for: percent,
+                for: worst.percent,
                 threshold: threshold
             ),
-            exceedsThreshold: percent >= threshold
+            // A high-utilization in ANY currency exceeds the threshold — pooling
+            // can no longer hide a maxed card behind a large foreign limit.
+            exceedsThreshold: groups.contains { $0.percent >= threshold },
+            currency: worst.currency,
+            isMultiCurrency: groups.count > 1
         )
     }
 

--- a/Sources/PlaidBarServer/Plaid/PlaidModels.swift
+++ b/Sources/PlaidBarServer/Plaid/PlaidModels.swift
@@ -294,6 +294,7 @@ struct PlaidHolding: Decodable, Sendable {
     let institutionValue: Double?
     let costBasis: Double?
     let isoCurrencyCode: String?
+    var unofficialCurrencyCode: String? = nil
 }
 
 struct PlaidSecurity: Decodable, Sendable {
@@ -303,6 +304,7 @@ struct PlaidSecurity: Decodable, Sendable {
     let type: String?
     let closePrice: Double?
     let isoCurrencyCode: String?
+    var unofficialCurrencyCode: String? = nil
 }
 
 struct PlaidInvestmentTransactionsResponse: Decodable, Sendable {
@@ -327,6 +329,7 @@ struct PlaidInvestmentTransaction: Decodable, Sendable {
     let type: String?
     let subtype: String?
     let isoCurrencyCode: String?
+    var unofficialCurrencyCode: String? = nil
 }
 
 struct PlaidTransactionsSyncResponse: Decodable, Sendable {

--- a/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
+++ b/Sources/PlaidBarServer/Routes/InvestmentRoutes.swift
@@ -140,6 +140,7 @@ struct InvestmentRoutes: Sendable {
                     current: account.balances.current,
                     limit: account.balances.limit,
                     isoCurrencyCode: account.balances.isoCurrencyCode
+                        ?? account.balances.unofficialCurrencyCode
                 ),
                 institutionName: item.institutionName
             )
@@ -153,6 +154,7 @@ struct InvestmentRoutes: Sendable {
                 institutionValue: holding.institutionValue,
                 costBasis: holding.costBasis,
                 isoCurrencyCode: holding.isoCurrencyCode
+                    ?? holding.unofficialCurrencyCode
             )
         }
         let securities = response.securities.map { security in
@@ -163,6 +165,7 @@ struct InvestmentRoutes: Sendable {
                 type: security.type,
                 closePrice: security.closePrice,
                 isoCurrencyCode: security.isoCurrencyCode
+                    ?? security.unofficialCurrencyCode
             )
         }
         return InvestmentsResponse(accounts: accounts, holdings: holdings, securities: securities)
@@ -182,6 +185,7 @@ struct InvestmentRoutes: Sendable {
             type: plaid.type,
             subtype: plaid.subtype,
             isoCurrencyCode: plaid.isoCurrencyCode
+                ?? plaid.unofficialCurrencyCode
         )
     }
 

--- a/Tests/PlaidBarCoreTests/ControlValuePresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/ControlValuePresentationTests.swift
@@ -64,6 +64,21 @@ struct ControlValuePresentationTests {
         #expect(display.systemImage == "creditcard")
     }
 
+    @Test("Mixed-currency credit utilization accessibility names the scoped currency")
+    func mixedCurrencyUtilizationNamesScope() {
+        let display = ControlValuePresentation.creditUtilization(
+            from: snapshot(
+                creditUtilization: 90,
+                creditUtilizationCurrency: CurrencyCode("EUR"),
+                creditUtilizationIsMultiCurrency: true
+            )
+        )
+
+        #expect(display.value == Formatters.percent(90, decimals: 0))
+        #expect(display.accessibilityLabel.contains("highest"))
+        #expect(display.accessibilityLabel.contains("EUR"))
+    }
+
     @Test("Masked credit utilization withholds the percent")
     func maskedUtilizationIsWithheld() {
         let display = ControlValuePresentation.creditUtilization(from: snapshot(creditUtilization: 73, isMasked: true))
@@ -98,6 +113,8 @@ struct ControlValuePresentationTests {
         safeToSpend: Double = 1_000,
         totalBalance: Double = 5_000,
         creditUtilization: Double? = 20,
+        creditUtilizationCurrency: CurrencyCode? = nil,
+        creditUtilizationIsMultiCurrency: Bool = false,
         isMasked: Bool = false
     ) -> FinanceSnapshot {
         FinanceSnapshot(
@@ -108,6 +125,8 @@ struct ControlValuePresentationTests {
             ],
             nextRecurringBills: [],
             creditUtilization: creditUtilization,
+            creditUtilizationCurrency: creditUtilizationCurrency,
+            creditUtilizationIsMultiCurrency: creditUtilizationIsMultiCurrency,
             generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
             isMasked: isMasked
         )

--- a/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
+++ b/Tests/PlaidBarCoreTests/FigureProvenanceTests.swift
@@ -154,8 +154,8 @@ struct FigureProvenanceTests {
             exceedsThreshold: false
         )
         let creditAccounts = [
-            AccountDTO(id: "card_a", itemId: "item", name: "Cashback Card", type: .credit, balances: BalanceDTO(current: -1_200, limit: 5_000)),
-            AccountDTO(id: "card_b", itemId: "item", name: "Store Card", type: .credit, balances: BalanceDTO(current: -50)), // no limit
+            AccountDTO(id: "card_a", itemId: "item", name: "Cashback Card", type: .credit, balances: BalanceDTO(current: -1_200, limit: 5_000, isoCurrencyCode: "USD")),
+            AccountDTO(id: "card_b", itemId: "item", name: "Store Card", type: .credit, balances: BalanceDTO(current: -50, isoCurrencyCode: "USD")), // no limit
         ]
 
         let provenance = FigureProvenance.creditUtilization(
@@ -175,6 +175,39 @@ struct FigureProvenanceTests {
         #expect(provenance.derivation.contains("Healthy"))
     }
 
+    @Test("Credit-utilization provenance is scoped to the headline currency")
+    func creditUtilizationProvenanceScopesToHeadlineCurrency() {
+        let summary = WealthSummaryPresentation.CreditUtilizationSummary(
+            percent: 90,
+            usedCredit: 900,
+            totalLimit: 1_000,
+            statusLabel: "High",
+            exceedsThreshold: true,
+            currency: CurrencyCode("EUR"),
+            isMultiCurrency: true
+        )
+        let creditAccounts = [
+            AccountDTO(id: "usd_card", itemId: "item", name: "USD Card", type: .credit, balances: BalanceDTO(current: -1_000, limit: 10_000, isoCurrencyCode: "USD")),
+            AccountDTO(id: "eur_card", itemId: "item", name: "EUR Card", type: .credit, balances: BalanceDTO(current: -900, limit: 1_000, isoCurrencyCode: "EUR")),
+            AccountDTO(id: "eur_store", itemId: "item", name: "EUR Store Card", type: .credit, balances: BalanceDTO(current: -25, isoCurrencyCode: "EUR")),
+        ]
+
+        let provenance = FigureProvenance.creditUtilization(
+            summary: summary,
+            creditAccounts: creditAccounts,
+            freshness: nil
+        )
+
+        #expect(provenance.sources.count == 2)
+        #expect(provenance.sources.contains { $0.label.contains("EUR Card") })
+        #expect(provenance.sources.contains { $0.label.contains("EUR Store Card") })
+        #expect(!provenance.sources.contains { $0.label.contains("USD Card") })
+        #expect(provenance.sources.allSatisfy { !($0.value?.contains("$") ?? false) })
+        #expect(provenance.sources.contains { $0.value?.contains("900") ?? false })
+        #expect(provenance.derivation.contains("EUR"))
+        #expect(provenance.exclusions.contains { $0.contains("not pooled") })
+    }
+
     @Test("Masked credit-utilization derivation drops the status label and amounts")
     func maskedCreditUtilizationHidesValues() {
         let summary = WealthSummaryPresentation.CreditUtilizationSummary(
@@ -185,7 +218,7 @@ struct FigureProvenanceTests {
             exceedsThreshold: true
         )
         let creditAccounts = [
-            AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -4_400, limit: 5_000)),
+            AccountDTO(id: "card", itemId: "item", name: "Card", type: .credit, balances: BalanceDTO(current: -4_400, limit: 5_000, isoCurrencyCode: "USD")),
         ]
 
         let provenance = FigureProvenance.creditUtilization(

--- a/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceAppIntentsPackageTests.swift
@@ -263,6 +263,21 @@ struct FinanceAppIntentsPackageTests {
         #expect(model.accessibilityLabel.lowercased().contains("high"))
     }
 
+    @Test("Mixed-currency credit-utilization snippet names the scoped currency")
+    func creditUtilizationSnippetNamesMixedCurrencyScope() {
+        let model = FinanceSnippetPresentation.creditUtilization(
+            from: snapshot(
+                creditUtilization: 90,
+                creditUtilizationCurrency: CurrencyCode("EUR"),
+                creditUtilizationIsMultiCurrency: true
+            )
+        )
+
+        #expect(model.percentText == Formatters.percent(90))
+        #expect(model.accessibilityLabel.contains("Highest"))
+        #expect(model.accessibilityLabel.contains("EUR"))
+    }
+
     @Test("Utilization over 100% clamps the gauge fraction to 1")
     func creditUtilizationSnippetClampsAbove100() {
         let model = FinanceSnippetPresentation.creditUtilization(from: snapshot(creditUtilization: 130))
@@ -294,6 +309,8 @@ struct FinanceAppIntentsPackageTests {
         totalBalance: Double = 5_000,
         bills: [FinanceSnapshot.UpcomingBill] = [],
         creditUtilization: Double? = 20,
+        creditUtilizationCurrency: CurrencyCode? = nil,
+        creditUtilizationIsMultiCurrency: Bool = false,
         isMasked: Bool = false,
         periodSpending: Double = 0,
         categories: [FinanceSnapshot.CategorySpend] = [],
@@ -308,6 +325,8 @@ struct FinanceAppIntentsPackageTests {
             ],
             nextRecurringBills: bills,
             creditUtilization: creditUtilization,
+            creditUtilizationCurrency: creditUtilizationCurrency,
+            creditUtilizationIsMultiCurrency: creditUtilizationIsMultiCurrency,
             generatedAt: asOf,
             isMasked: isMasked,
             periodSpending: periodSpending,

--- a/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceIntentQueriesTests.swift
@@ -117,6 +117,23 @@ struct FinanceIntentQueriesTests {
         #expect(dialog.contains("utilization"))
     }
 
+    @Test("Mixed-currency credit utilization names the scoped currency")
+    func creditUtilizationMixedCurrencyDialogNamesScope() {
+        guard case let .value(value, dialog) = FinanceIntentQueries.creditUtilization(
+            from: snapshot(
+                creditUtilization: 90,
+                creditUtilizationCurrency: CurrencyCode("EUR"),
+                creditUtilizationIsMultiCurrency: true
+            )
+        ) else {
+            Issue.record("Expected .value")
+            return
+        }
+        #expect(value == 90)
+        #expect(dialog.contains("highest"))
+        #expect(dialog.contains("EUR"))
+    }
+
     @Test("Credit utilization without a known limit reports a message")
     func creditUtilizationWithoutLimitReportsMessage() {
         guard case .message = FinanceIntentQueries.creditUtilization(from: snapshot(creditUtilization: nil)) else {
@@ -228,6 +245,8 @@ struct FinanceIntentQueriesTests {
         totalBalance: Double = 5_000,
         bills: [FinanceSnapshot.UpcomingBill] = [],
         creditUtilization: Double? = 20,
+        creditUtilizationCurrency: CurrencyCode? = nil,
+        creditUtilizationIsMultiCurrency: Bool = false,
         isMasked: Bool = false,
         periodSpending: Double = 0,
         categories: [FinanceSnapshot.CategorySpend] = [],
@@ -242,6 +261,8 @@ struct FinanceIntentQueriesTests {
             currencySubtotals: currencySubtotals,
             nextRecurringBills: bills,
             creditUtilization: creditUtilization,
+            creditUtilizationCurrency: creditUtilizationCurrency,
+            creditUtilizationIsMultiCurrency: creditUtilizationIsMultiCurrency,
             generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
             isMasked: isMasked,
             periodSpending: periodSpending,

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
@@ -109,6 +109,8 @@ struct FinanceSnapshotBuilderTests {
             generatedAt: asOf
         )
         #expect(snapshot.creditUtilization == 90)
+        #expect(snapshot.creditUtilizationCurrency == CurrencyCode("EUR"))
+        #expect(snapshot.creditUtilizationIsMultiCurrency)
         // Guard against regression to the pooled denominator.
         #expect(snapshot.creditUtilization != 1_900 / 11_000 * 100)
     }

--- a/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
+++ b/Tests/PlaidBarCoreTests/FinanceSnapshotBuilderTests.swift
@@ -93,6 +93,26 @@ struct FinanceSnapshotBuilderTests {
         #expect(!snapshot.isEmpty)
     }
 
+    // AND-660 #3: the AI/insight snapshot's utilization must be per-currency, so a
+    // fabricated cross-currency ratio never reaches a local-insight prompt.
+    @Test("Snapshot credit utilization is per-currency, never a pooled cross-currency ratio (AND-660)")
+    func snapshotUtilizationIsPerCurrency() {
+        // USD 10% + EUR 90%. Pooling would be ~17.3%; per-currency reports the
+        // worst (EUR 90%).
+        let snapshot = FinanceSnapshotBuilder.make(
+            accounts: [
+                credit(name: "USD Card", current: 1_000, limit: 10_000, currency: "USD"),
+                credit(name: "EUR Card", current: 900, limit: 1_000, currency: "EUR"),
+            ],
+            recurringTransactions: [],
+            isMasked: false,
+            generatedAt: asOf
+        )
+        #expect(snapshot.creditUtilization == 90)
+        // Guard against regression to the pooled denominator.
+        #expect(snapshot.creditUtilization != 1_900 / 11_000 * 100)
+    }
+
     @Test("Upcoming bills include dated outflows in-window and exclude income")
     func upcomingBillsFilterToOutflowsInWindow() throws {
         // asOf is 2026-05-29; end-of-month horizon is 2026-05-31. Build dated
@@ -247,13 +267,13 @@ struct FinanceSnapshotBuilderTests {
         )
     }
 
-    private func credit(name: String, current: Double, limit: Double) -> AccountDTO {
+    private func credit(name: String, current: Double, limit: Double, currency: String? = nil) -> AccountDTO {
         AccountDTO(
             id: "acct-\(name)",
             itemId: "item-1",
             name: name,
             type: .credit,
-            balances: BalanceDTO(current: current, limit: limit)
+            balances: BalanceDTO(current: current, limit: limit, isoCurrencyCode: currency)
         )
     }
 

--- a/Tests/PlaidBarCoreTests/FormattersTests.swift
+++ b/Tests/PlaidBarCoreTests/FormattersTests.swift
@@ -18,7 +18,15 @@ struct FormattersTests {
     func nonUsdCurrency() {
         #expect(!Formatters.currency(1_000, format: .full, currencyCode: "EUR").isEmpty)
         #expect(!Formatters.currency(1_000, format: .compact, currencyCode: "EUR").isEmpty)
-        #expect(Formatters.currency(1_500, format: .abbreviated, currencyCode: "EUR") == "EUR1.5K")
+        // AND-660 #4: an abbreviated non-USD figure separates the currency-code
+        // symbol from the magnitude with a non-breaking space (U+00A0) so it does
+        // not read as `EUR1.5K`. USD (the `$` glyph) keeps no separator.
+        #expect(Formatters.currency(1_500, format: .abbreviated, currencyCode: "EUR") == "EUR\u{00A0}1.5K")
+        #expect(Formatters.currency(2_400_000, format: .abbreviated, currencyCode: "GBP") == "GBP\u{00A0}2.4M")
+        #expect(Formatters.currency(-3_000, format: .abbreviated, currencyCode: "JPY") == "-JPY\u{00A0}3.0K")
+        #expect(Formatters.currency(750, format: .abbreviated, currencyCode: "CAD") == "CAD\u{00A0}750")
+        // USD stays byte-identical to the pre-AND-660 output (no separator).
+        #expect(Formatters.currency(1_500, format: .abbreviated, currencyCode: "USD") == "$1.5K")
     }
 
     @Test("Percent formats with the requested precision")

--- a/Tests/PlaidBarCoreTests/InvestmentHoldingsPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/InvestmentHoldingsPresentationTests.swift
@@ -9,12 +9,15 @@ struct InvestmentHoldingsPresentationTests {
         SecurityDTO(id: "sec_cash", name: "Cash Sweep", tickerSymbol: nil, type: "cash", closePrice: 1),
     ]
 
+    // These fixtures are USD positions; the `$` assertions below depend on the
+    // currency being explicit (AND-660 — an absent code resolves to the unknown
+    // bucket, which renders the bare number, not `$`).
     private func holdings() -> [HoldingDTO] {
         [
-            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 90, institutionPrice: 250, institutionValue: 22_500, costBasis: 18_000),
-            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 50, institutionPrice: 200, institutionValue: 10_000, costBasis: 11_500),
-            HoldingDTO(accountId: "acct_a", securityId: "sec_cash", quantity: 2_800, institutionPrice: 1, institutionValue: 2_800, costBasis: 2_800),
-            HoldingDTO(accountId: "acct_b", securityId: "sec_vti", quantity: 4, institutionPrice: 250, institutionValue: 1_000, costBasis: 900),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 90, institutionPrice: 250, institutionValue: 22_500, costBasis: 18_000, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 50, institutionPrice: 200, institutionValue: 10_000, costBasis: 11_500, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_cash", quantity: 2_800, institutionPrice: 1, institutionValue: 2_800, costBasis: 2_800, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_b", securityId: "sec_vti", quantity: 4, institutionPrice: 250, institutionValue: 1_000, costBasis: 900, isoCurrencyCode: "USD"),
         ]
     }
 
@@ -194,9 +197,9 @@ struct InvestmentHoldingsPresentationTests {
         // their basis). AAPL's $10,000 market value contributes to the total but is
         // excluded from the gain numerator so value and basis stay comparable.
         let mixed = [
-            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 90, institutionValue: 22_500, costBasis: 18_000),
-            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 50, institutionValue: 10_000, costBasis: nil),
-            HoldingDTO(accountId: "acct_a", securityId: "sec_cash", quantity: 2_800, institutionValue: 2_800, costBasis: 2_800),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 90, institutionValue: 22_500, costBasis: 18_000, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 50, institutionValue: 10_000, costBasis: nil, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_cash", quantity: 2_800, institutionValue: 2_800, costBasis: 2_800, isoCurrencyCode: "USD"),
         ]
         let summary = InvestmentHoldingsPresentation.summary(
             holdings: mixed,
@@ -274,9 +277,80 @@ struct InvestmentHoldingsPresentationTests {
 
     @Test("Signed currency uses an explicit sign so direction reads without color")
     func signedCurrencyText() {
-        #expect(InvestmentHoldingsPresentation.signedCurrency(250, masked: false) == "+$250.00")
-        #expect(InvestmentHoldingsPresentation.signedCurrency(-250, masked: false) == "−$250.00")
-        #expect(InvestmentHoldingsPresentation.signedCurrency(0, masked: false) == "$0.00")
-        #expect(InvestmentHoldingsPresentation.signedCurrency(250, masked: true) == PrivacyMaskPresentation.compactValue)
+        #expect(InvestmentHoldingsPresentation.signedCurrency(250, in: .usd, masked: false) == "+$250.00")
+        #expect(InvestmentHoldingsPresentation.signedCurrency(-250, in: .usd, masked: false) == "−$250.00")
+        #expect(InvestmentHoldingsPresentation.signedCurrency(0, in: .usd, masked: false) == "$0.00")
+        #expect(InvestmentHoldingsPresentation.signedCurrency(250, in: .usd, masked: true) == PrivacyMaskPresentation.compactValue)
+    }
+
+    // AND-660 #1: a holding/portfolio in a non-USD currency must render and
+    // aggregate in that currency — never collapsed into a fabricated `$` total.
+    @Test("Signed currency renders the holding's own currency, not $")
+    func signedCurrencyNonUSD() {
+        // EUR renders as the bare code + native formatting (no `$`).
+        let eurGain = InvestmentHoldingsPresentation.signedCurrency(250, in: CurrencyCode("EUR"), masked: false)
+        #expect(eurGain.hasPrefix("+"))
+        #expect(!eurGain.contains("$"))
+
+        let eurLoss = InvestmentHoldingsPresentation.signedCurrency(-250, in: CurrencyCode("EUR"), masked: false)
+        #expect(eurLoss.hasPrefix("\u{2212}")) // typographic minus, not ASCII hyphen
+        #expect(!eurLoss.contains("$"))
+    }
+
+    @Test("Single-currency EUR holding renders value and gain in EUR, never $")
+    func rowsRenderNativeCurrency() {
+        let eurHoldings = [
+            HoldingDTO(accountId: "acct_eu", securityId: "sec_vti", quantity: 4, institutionPrice: 250, institutionValue: 1_000, costBasis: 900, isoCurrencyCode: "EUR"),
+        ]
+        let rows = InvestmentHoldingsPresentation.rows(
+            forAccount: "acct_eu",
+            holdings: eurHoldings,
+            securities: securities,
+            privacyMaskEnabled: false
+        )
+        #expect(rows.count == 1)
+        // The market value and gain render in EUR — never a dollar glyph. `.full`
+        // uses the locale currency symbol (€), so the contract is "no `$`", which
+        // mirrors the established MultiCurrencyTests formatter assertions.
+        #expect(!(rows.first?.marketValueText.contains("$") ?? true))
+        #expect(!(rows.first?.gainText?.contains("$") ?? true))
+        #expect(rows.first?.marketValueText.contains("1,000") ?? false)
+    }
+
+    @Test("Mixed EUR/USD portfolio never collapses into one fabricated $ total (AND-660)")
+    func summaryMixedCurrencyDoesNotCollapse() {
+        // Two USD positions + one EUR position. The naive (buggy) behavior summed
+        // all three market values into a single scalar and labeled it `$`. With
+        // the AND-660 fix the summary groups per currency and the displayed total
+        // names both currencies — never a lone `$` figure pretending EUR is USD.
+        let mixed = [
+            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 40, institutionPrice: 250, institutionValue: 10_000, costBasis: 9_000, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_aapl", quantity: 25, institutionPrice: 200, institutionValue: 5_000, costBasis: 4_000, isoCurrencyCode: "USD"),
+            HoldingDTO(accountId: "acct_a", securityId: "sec_vti", quantity: 8, institutionPrice: 250, institutionValue: 2_000, costBasis: 1_800, isoCurrencyCode: "EUR"),
+        ]
+        let summary = InvestmentHoldingsPresentation.summary(
+            holdings: mixed,
+            accountId: "acct_a",
+            privacyMaskEnabled: false
+        )
+
+        // The aggregation keeps both currencies — it is multi-currency and its
+        // per-currency subtotals carry both USD (15,000) and EUR (2,000).
+        #expect(summary.isMultiCurrency)
+        #expect(summary.marketValueAggregation.subtotals.count == 2)
+        let byCurrency = Dictionary(
+            uniqueKeysWithValues: summary.marketValueAggregation.subtotals.map { ($0.currency, $0.amount) }
+        )
+        #expect(byCurrency[CurrencyCode("USD")] == 15_000)
+        #expect(byCurrency[CurrencyCode("EUR")] == 2_000)
+
+        // The DISPLAYED total is a per-currency breakdown (e.g. "€2,000.00 ·
+        // $15,000.00") — NOT a single `$17,000` figure (the old cross-currency
+        // collapse). With no conversion source the headline is unavailable, so both
+        // currencies are listed; the USD subtotal keeps its `$`, EUR its own symbol.
+        #expect(summary.totalMarketValueText.contains("15,000"))
+        #expect(summary.totalMarketValueText.contains("2,000"))
+        #expect(summary.totalMarketValueText.contains("·")) // per-currency separator
+        #expect(summary.totalMarketValueText != "$17,000.00")
     }
 }

--- a/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
+++ b/Tests/PlaidBarCoreTests/MultiCurrencyTests.swift
@@ -311,6 +311,30 @@ struct MultiCurrencyTests {
         #expect(unavailable.disclosure.lowercased().contains("per currency"))
     }
 
+    @Test("Display text renders per-currency amounts when no conversion total exists")
+    func displayTextFallsBackToPerCurrencyAmounts() {
+        let aggregation = CurrencyAggregation.aggregate([
+            (amount: 5_000, currency: .usd),
+            (amount: 2_000, currency: CurrencyCode("EUR")),
+        ])
+
+        let text = MultiCurrencyBalancePresentation.displayText(
+            from: aggregation,
+            format: .compact
+        )
+        #expect(text.contains("5,000"))
+        #expect(text.contains("2,000"))
+        #expect(text.contains("·"))
+        #expect(text != "By currency")
+
+        let masked = MultiCurrencyBalancePresentation.displayText(
+            from: aggregation,
+            format: .compact,
+            privacyMaskEnabled: true
+        )
+        #expect(masked == PrivacyMaskPresentation.compactValue)
+    }
+
     @Test("Menu bar shows the dominant currency's subtotal (no fabricated $ sum) for mixed currencies")
     func menuBarMixedCurrencyShowsDominantSubtotal() {
         // USD subtotal 5,000 dominates the EUR 2,000 subtotal by absolute value.

--- a/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/WealthSummaryPresentationTests.swift
@@ -50,16 +50,86 @@ struct WealthSummaryPresentationTests {
     func computesCreditUtilization() {
         let presentation = makePresentation(
             accounts: [
-                AccountDTO(id: "card-a", itemId: "item-a", name: "Card A", type: .credit, balances: BalanceDTO(current: -400, limit: 1_000)),
-                AccountDTO(id: "card-b", itemId: "item-b", name: "Card B", type: .credit, balances: BalanceDTO(current: -200, limit: 1_000)),
+                AccountDTO(id: "card-a", itemId: "item-a", name: "Card A", type: .credit, balances: BalanceDTO(current: -400, limit: 1_000, isoCurrencyCode: "USD")),
+                AccountDTO(id: "card-b", itemId: "item-b", name: "Card B", type: .credit, balances: BalanceDTO(current: -200, limit: 1_000, isoCurrencyCode: "USD")),
             ],
             creditUtilizationThreshold: 25
         )
 
+        // Two USD cards stay pooled WITHIN USD (single currency), so the ratio is
+        // unchanged from the pre-AND-660 behavior — per-currency only changes
+        // mixed-currency portfolios.
         #expect(presentation.creditUtilization?.usedCredit == 600)
         #expect(presentation.creditUtilization?.totalLimit == 2_000)
         #expect(presentation.creditUtilization?.percent == 30)
         #expect(presentation.creditUtilization?.statusLabel == "Warning")
+        #expect(presentation.creditUtilization?.exceedsThreshold == true)
+        #expect(presentation.creditUtilization?.currency == CurrencyCode("USD"))
+        #expect(presentation.creditUtilization?.isMultiCurrency == false)
+    }
+
+    // AND-660 #3 (highest stakes): used credit and limits must NEVER pool across
+    // currencies. A USD card at 10% utilization and a EUR card at 90% must report
+    // the WORST single-currency ratio (90% / EUR), not a fabricated cross-currency
+    // pooled number — and the threshold must still fire on the maxed EUR card.
+    @Test("Credit utilization is per-currency: USD+EUR mix does not pool into one ratio (AND-660)")
+    func creditUtilizationPerCurrency() {
+        // USD: 1,000 used of 10,000 limit = 10%.
+        // EUR: 900 used of 1,000 limit = 90%.
+        // Pooling (the old bug) would give (1,900 / 11,000) ≈ 17.3% — UNDER a 30%
+        // threshold, silently hiding the maxed EUR card. Per-currency must surface
+        // the 90% EUR group and trip the threshold.
+        let accounts = [
+            AccountDTO(id: "usd-card", itemId: "item-a", name: "USD Card", type: .credit, balances: BalanceDTO(current: -1_000, limit: 10_000, isoCurrencyCode: "USD")),
+            AccountDTO(id: "eur-card", itemId: "item-b", name: "EUR Card", type: .credit, balances: BalanceDTO(current: -900, limit: 1_000, isoCurrencyCode: "EUR")),
+        ]
+        let presentation = makePresentation(accounts: accounts, creditUtilizationThreshold: 30)
+
+        let util = presentation.creditUtilization
+        // Headline reports the worst currency group: EUR at 90%, NOT the ~17.3%
+        // pooled ratio.
+        #expect(util?.percent == 90)
+        #expect(util?.currency == CurrencyCode("EUR"))
+        #expect(util?.usedCredit == 900)
+        #expect(util?.totalLimit == 1_000)
+        #expect(util?.isMultiCurrency == true)
+        // The maxed EUR card trips the threshold even though a pooled ratio would
+        // have stayed under it.
+        #expect(util?.exceedsThreshold == true)
+        // Guard against regression to the pooled denominator/numerator.
+        #expect(util?.totalLimit != 11_000)
+        #expect(util?.usedCredit != 1_900)
+
+        // The shared menu-bar/alert path (feeds AttentionQueue → notifications +
+        // App Intents) must report the same worst-currency figure, NOT ~17.3%.
+        #expect(MenuBarSummary.creditUtilization(from: accounts) == 90)
+
+        // The per-currency groups expose BOTH currencies, each with its own
+        // self-consistent used/limit (never cross-currency summed).
+        let groups = MenuBarSummary.creditUtilizationByCurrency(from: accounts)
+        #expect(groups.count == 2)
+        #expect(groups.first?.currency == CurrencyCode("EUR")) // worst is first
+        #expect(groups.first?.percent == 90)
+        let usd = groups.first { $0.currency == CurrencyCode("USD") }
+        #expect(usd?.percent == 10)
+        #expect(usd?.usedCredit == 1_000)
+        #expect(usd?.totalLimit == 10_000)
+    }
+
+    @Test("Per-currency utilization keeps a low foreign card from inflating a high domestic one")
+    func creditUtilizationPerCurrencyDoesNotMaskGoodCard() {
+        // USD: 9,000 used of 10,000 = 90% (the worst). EUR: 100 used of 5,000 = 2%.
+        // Per-currency reports USD 90%; a naive pool would have been
+        // (9,100 / 15,000) ≈ 60.7%, understating the maxed USD card.
+        let presentation = makePresentation(
+            accounts: [
+                AccountDTO(id: "usd-card", itemId: "item-a", name: "USD Card", type: .credit, balances: BalanceDTO(current: -9_000, limit: 10_000, isoCurrencyCode: "USD")),
+                AccountDTO(id: "eur-card", itemId: "item-b", name: "EUR Card", type: .credit, balances: BalanceDTO(current: -100, limit: 5_000, isoCurrencyCode: "EUR")),
+            ],
+            creditUtilizationThreshold: 30
+        )
+        #expect(presentation.creditUtilization?.percent == 90)
+        #expect(presentation.creditUtilization?.currency == CurrencyCode("USD"))
         #expect(presentation.creditUtilization?.exceedsThreshold == true)
     }
 

--- a/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
+++ b/Tests/PlaidBarServerTests/InvestmentRoutesTests.swift
@@ -138,6 +138,42 @@ struct InvestmentRoutesTests {
         #expect(result.securities.contains { $0.tickerSymbol == "VTI" })
     }
 
+    @Test("Investment mapping preserves unofficial currencies when ISO is absent")
+    func mapsUnofficialInvestmentCurrencies() {
+        let response = PlaidHoldingsResponse(
+            accounts: [
+                PlaidAccount(
+                    accountId: "acct_crypto",
+                    balances: PlaidBalances(available: nil, current: 0.5, limit: nil, isoCurrencyCode: nil, unofficialCurrencyCode: "XBT"),
+                    mask: nil,
+                    name: "Crypto Brokerage",
+                    officialName: nil,
+                    type: "investment",
+                    subtype: "crypto exchange"
+                ),
+            ],
+            holdings: [
+                PlaidHolding(accountId: "acct_crypto", securityId: "sec_btc", quantity: 0.5, institutionPrice: 60_000, institutionValue: 30_000, costBasis: 20_000, isoCurrencyCode: nil, unofficialCurrencyCode: "XBT"),
+            ],
+            securities: [
+                PlaidSecurity(securityId: "sec_btc", name: "Bitcoin", tickerSymbol: "BTC", type: "cryptocurrency", closePrice: 60_000, isoCurrencyCode: nil, unofficialCurrencyCode: "XBT"),
+            ],
+            item: nil,
+            requestId: "req-crypto"
+        )
+
+        let result = InvestmentRoutes.investmentsResponse(
+            from: response,
+            item: item(),
+            itemId: "item-1"
+        )
+
+        #expect(result.accounts.first?.balances.isoCurrencyCode == "XBT")
+        #expect(result.holdings.first?.isoCurrencyCode == "XBT")
+        #expect(result.holdings.first?.currency == CurrencyCode("XBT"))
+        #expect(result.securities.first?.isoCurrencyCode == "XBT")
+    }
+
     @Test("An unknown Plaid account type maps to .other rather than crashing")
     func unknownAccountTypeFallsBack() {
         var response = holdingsResponse()
@@ -246,6 +282,29 @@ struct InvestmentRoutesTests {
         #expect(dto.securityId == "sec_vti")
         #expect(dto.amount == 2_500)
         #expect(dto.type == "buy")
+    }
+
+    @Test("Investment transaction mapping preserves unofficial currency")
+    func mapsInvestmentTransactionUnofficialCurrency() {
+        let plaid = PlaidInvestmentTransaction(
+            investmentTransactionId: "itx-crypto",
+            accountId: "acct_crypto",
+            securityId: "sec_btc",
+            date: "2026-06-01",
+            name: "Buy BTC",
+            quantity: 0.1,
+            price: 60_000,
+            amount: 6_000,
+            fees: nil,
+            type: "buy",
+            subtype: "buy",
+            isoCurrencyCode: nil,
+            unofficialCurrencyCode: "XBT"
+        )
+
+        let dto = InvestmentRoutes.investmentTransactionDTO(from: plaid)
+
+        #expect(dto.isoCurrencyCode == "XBT")
     }
 
     @Test("Merge de-duplicates accounts and securities by id across items")


### PR DESCRIPTION
## Summary

Completes the AND-660 multi-currency migration on the four surfaces AND-643 left behind. These are **correctness** fixes: the prior code summed scalar `Double` amounts across currencies and labeled the result `$`, feeding wrong figures into the menu-bar glance, the Wealth Summary flyout, the high-utilization alert (AttentionQueue → notifications + App Intents), and the local-AI insight snapshot. All four surfaces now reuse the existing AND-643 infrastructure (`CurrencyAggregation`, `MultiCurrencyBalancePresentation`, the in-currency `Formatters` overloads). A single-currency portfolio is byte-identical to before; only genuinely mixed-currency data changes.

## Per-surface breakdown

### 1. Investment holdings rendered + summed as USD
- **Wrong before:** every holding's market value and unrealized gain were rendered with a hardcoded USD formatter, and the account summary summed all market values into one scalar `Double` shown with `$`. A EUR position read as dollars; a mixed portfolio collapsed into a fabricated cross-currency total.
- **Fix:** each holding carries its own `CurrencyCode` (`HoldingDTO.currency`) and renders in it. The summary groups market value and gain per currency via `CurrencyAggregation`. Mixed portfolios show a per-currency breakdown (headline, gain, and VoiceOver label); the scalar `totalMarketValue` is retained only as the net-worth inclusion input and documented as non-display.
- **What number changes:** a `€2,000 + $15,000` portfolio now displays `€2,000.00 · $15,000.00` instead of a single `$17,000.00`.

### 2. Wealth Summary flyout
- **Wrong before:** the net-worth hero, Assets/Debt tiles, and credit used/limit figures read scalar `Double`s summed across currencies and rendered them with a hardcoded `$`.
- **Fix:** mirrors the Dashboard (AND-643) — computes net-worth/assets/debt aggregations from the accounts via `MultiCurrencyBalancePresentation` and renders through `displayText`/`headline`. The credit section renders used/limit in the utilization's own currency.
- **What number changes:** a mixed-currency net worth shows a per-currency breakdown (VoiceOver speaks each currency) instead of one `$` figure. No `PlaidBarCore`/server/Keychain changes.

### 3. Credit utilization pooled across currencies (highest stakes)
- **Wrong before:** used credit and limits were summed across **all** credit cards regardless of currency — dividing a EUR balance by a USD limit. The ratio was meaningless and the derived `exceedsThreshold` flag (which feeds the high-utilization alert and the AI snapshot) could silently hide a maxed-out foreign card behind a large domestic limit.
- **Fix:** utilization is computed **per currency** — used and limit are only ever summed within one currency. The single canonical helper `MenuBarSummary.creditUtilizationByCurrency` groups credit accounts by their own currency; the headline reports the **worst** single-currency group, and the alert fires if **any** currency exceeds the threshold. All three pooled call sites — `WealthSummaryPresentation` (display + provenance), `MenuBarSummary` (menu bar + alert), and `FinanceSnapshotBuilder` (AI snapshot) — route through it. `CreditUtilizationSummary` gains `currency` + `isMultiCurrency`.
- **What number changes:** a USD card at 10% (1,000/10,000) plus a EUR card at 90% (900/1,000) used to pool to **~17.3%** (1,900/11,000) — under a 30% threshold, hiding the maxed EUR card. It now reports **90% (EUR)** and trips the threshold. The headline scopes `usedCredit`/`totalLimit` to the worst currency (900 / 1,000 EUR), never the pooled 1,900 / 11,000.

### 4. Abbreviated non-USD format separator
- **Wrong before:** the abbreviated format concatenated a bare currency code onto the magnitude, so a non-USD figure read as `EUR1.2K`.
- **Fix:** insert a non-breaking space (`U+00A0`) between a currency-code symbol and the number → `EUR 1.2K`, never wrapping. The `$` glyph (and the unknown-currency empty symbol) keep no separator.
- **What number changes:** `EUR1.5K` → `EUR 1.5K`; `$1.5K` unchanged.

## Architectural rationale

Reuses the AND-643 infrastructure rather than inventing parallel logic: `CurrencyCode` (never silently assumes USD; absent code → `unknown` bucket), `CurrencyAggregation` (per-currency subtotals + best-effort offline conversion, falling back to subtotals-only — no cloud FX), `MultiCurrencyBalancePresentation` (`netWorth`/`totalAssets`/`totalDebt` + `headline`/`displayText`), and `Formatters.currency(_, in:)`. The flyout migration mirrors the Dashboard's `MultiCurrencyBalancePresentation.netWorth(...)` call pattern exactly. Per-currency utilization is single-sourced in `MenuBarSummary` so the menu bar, flyout, alert, and AI snapshot can never drift.

## Testing notes

Full strict gate `swift build --build-tests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`: the **only** remaining errors are pre-existing, in three `PlaidBarCacheTests` files (`CacheStoreOpenRobustnessTests`, `ReadModelCacheClearRaceTests`, `TransactionCacheClearRaceTests`) — out of scope, fixed by a separate PR (#702 / AND-721). **Zero** strict-concurrency errors or warnings in any file this PR touches.

`swift test` (full, no filter): **2619 tests passed, 0 failures** (exit 0). New tests: mixed EUR/USD holdings do not collapse into one `$` total; single-currency EUR holding renders in EUR; `signedCurrency` renders the holding's own currency; per-currency utilization (USD 10% + EUR 90% → reports 90% EUR, not pooled ~17.3%, and trips the threshold); a low foreign card cannot dilute a maxed domestic one; per-currency snapshot utilization for the AI path; abbreviated non-USD separator (GBP/JPY/CAD). Existing investment + utilization fixtures migrated to explicit `isoCurrencyCode: "USD"` to keep asserting `$`. `FormattersTests` line ~21 updated to the non-breaking-space output. Source-invariant `PlaidBarTests` (app target, 72 tests) unaffected and green.

## Linked issue

AND-660 — https://linear.app/andeslab/issue/AND-660. Not a duplicate of #673 (the AND-643 menu-bar-glance follow-up); this finishes the remaining surfaces that #673 did not touch.

## Known limitations

- Cross-currency conversion still relies on the offline `StaticCurrencyConversionRates` stub; with the default `NoConversionSource`, mixed-currency totals degrade to per-currency subtotals (by design — no cloud FX). Conversion is not enabled on these surfaces here; they show per-currency breakdowns when mixed.
- Credit utilization reports the **worst** single currency as the headline; the flyout does not yet enumerate every currency's utilization (the worst is the alert-relevant one). `isMultiCurrency` is exposed for a future multi-row treatment.
- `.full`/`.compact` non-USD figures render the locale currency symbol (e.g. `€`), while `.abbreviated` renders the code (e.g. `EUR 1.2K`) — consistent with the existing `Formatters` behavior.

## Follow-ups

- Enumerate per-currency credit utilization rows in the flyout when `isMultiCurrency` (currently worst-only headline).
- Consider a user-selectable reporting currency + an opt-in offline rate table so mixed portfolios can show a converted headline with disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
