### PR TITLE
fix: gate debounced glance snapshot commit

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4332,14 +4332,17 @@ final class AppState {
         Task { [snapshot, debouncer, generation] in
             guard self.glanceSnapshotWriteGeneration == generation else { return }
             await debouncer.schedule(snapshot) { snapshot in
-                // The debouncer intentionally delays before invoking this closure;
-                // a clear/demo-entry path can bump the generation and wipe App
-                // Group files during that delay. Re-check immediately before the
-                // commit so stale snapshots cannot republish after a clear (AND-720).
-                guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }
                 let changed: Bool
                 do {
-                    changed = try GlanceSnapshotStore.saveIfChanged(snapshot)
+                    changed = try await MainActor.run {
+                        // The debouncer intentionally delays before invoking this
+                        // closure; a clear/demo-entry path can bump the generation
+                        // and wipe App Group files during that delay. Re-check and
+                        // commit on the MainActor with no suspension between them so
+                        // stale snapshots cannot republish after a clear (AND-720).
+                        guard self.glanceSnapshotWriteGeneration == generation else { return false }
+                        return try GlanceSnapshotStore.saveIfChanged(snapshot)
+                    }
                 } catch {
                     // A genuine write failure was previously indistinguishable
                     // from the "no change" skip below. Surface it (no balance

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4332,6 +4332,11 @@ final class AppState {
         Task { [snapshot, debouncer, generation] in
             guard self.glanceSnapshotWriteGeneration == generation else { return }
             await debouncer.schedule(snapshot) { snapshot in
+                // The debouncer intentionally delays before invoking this closure;
+                // a clear/demo-entry path can bump the generation and wipe App
+                // Group files during that delay. Re-check immediately before the
+                // commit so stale snapshots cannot republish after a clear (AND-720).
+                guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }
                 let changed: Bool
                 do {
                     changed = try GlanceSnapshotStore.saveIfChanged(snapshot)

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -189,6 +189,25 @@ struct PlaidBarTests {
         #expect(!commitWindow.contains("Task.detached"))
     }
 
+    @Test("Glance snapshot debounced save re-checks generation immediately before commit")
+    func glanceSnapshotDebouncedSaveRechecksGenerationBeforeCommit() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appStateSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/AppState.swift"),
+            encoding: .utf8
+        )
+        let methodRange = try #require(appStateSource.range(of: "private func writeGlanceSnapshot"))
+        let method = String(appStateSource[methodRange.lowerBound...].prefix(6_000))
+        let scheduleCall = try #require(method.range(of: "await debouncer.schedule(snapshot)"))
+        let afterSchedule = String(method[scheduleCall.upperBound...])
+        let generationGuard = try #require(
+            afterSchedule.range(of: "guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }")
+        )
+        let saveCall = try #require(afterSchedule.range(of: "changed = try GlanceSnapshotStore.saveIfChanged(snapshot)"))
+
+        #expect(generationGuard.upperBound < saveCall.lowerBound)
+    }
+
     @Test("Foundation Models availability uses the public framework gate (AND-656)")
     func foundationModelsProbeUsesPublicFrameworkGate() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -201,11 +201,19 @@ struct PlaidBarTests {
         let scheduleCall = try #require(method.range(of: "await debouncer.schedule(snapshot)"))
         let afterSchedule = String(method[scheduleCall.upperBound...])
         let generationGuard = try #require(
-            afterSchedule.range(of: "guard await MainActor.run(body: { self.glanceSnapshotWriteGeneration == generation }) else { return }")
+            afterSchedule.range(of: "guard self.glanceSnapshotWriteGeneration == generation else { return false }")
         )
-        let saveCall = try #require(afterSchedule.range(of: "changed = try GlanceSnapshotStore.saveIfChanged(snapshot)"))
+        let saveCall = try #require(
+            afterSchedule.range(of: "return try GlanceSnapshotStore.saveIfChanged(snapshot)")
+        )
+        let commitWindow = String(afterSchedule[generationGuard.upperBound..<saveCall.lowerBound])
 
         #expect(generationGuard.upperBound < saveCall.lowerBound)
+        #expect(
+            String(afterSchedule[..<generationGuard.lowerBound])
+                .contains("changed = try await MainActor.run")
+        )
+        #expect(!commitWindow.contains("await"))
     }
 
     @Test("Foundation Models availability uses the public framework gate (AND-656)")


### PR DESCRIPTION
## Summary

- Re-check `glanceSnapshotWriteGeneration` inside the debounced glance snapshot operation immediately before `GlanceSnapshotStore.saveIfChanged`.
- Add a source-invariant regression test pinning the second generation guard after the debouncer schedule point.
- Keep the existing finance snapshot generation gate unchanged.

Fixes #704
Linear: AND-720
Kanban: t_a2c7734f

## Verification

- Ad-hoc source invariant — pass (`PASS: debounced glance save re-checks generation before saveIfChanged`).
- `git diff --check` — pass.
- `swift build --target PlaidBar -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by existing unrelated FoundationModels macro plugin availability in `Sources/PlaidBar/Services/FoundationModels*` (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found). AppState compiled before the blocker.
- `swift test --filter glanceSnapshotDebouncedSaveRechecksGenerationBeforeCommit -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by the same app-target/toolchain failure (`error: fatalError` after app/server test compilation); not claimed as a passed test run.

## Privacy / security

This is a system-surface privacy ordering hardening. No Plaid credentials, access tokens, public tokens, account IDs, transaction IDs, balances, raw Plaid payloads, prompts, response bodies, local SQLite contents, logs, or screenshots are exposed or moved.
