### PR TITLE
fix: gate debounced glance snapshot saves

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4334,7 +4334,10 @@ final class AppState {
             await debouncer.schedule(snapshot) { snapshot in
                 let changed: Bool
                 do {
-                    changed = try GlanceSnapshotStore.saveIfChanged(snapshot)
+                    changed = try await MainActor.run {
+                        guard self.glanceSnapshotWriteGeneration == generation else { return false }
+                        return try GlanceSnapshotStore.saveIfChanged(snapshot)
+                    }
                 } catch {
                     // A genuine write failure was previously indistinguishable
                     // from the "no change" skip below. Surface it (no balance

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -189,6 +189,34 @@ struct PlaidBarTests {
         #expect(!commitWindow.contains("Task.detached"))
     }
 
+    @Test("Glance snapshot save re-checks generation inside debounced operation")
+    func glanceSnapshotDebouncedCommitIsGenerationGatedBeforeSave() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appStateSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/AppState.swift"),
+            encoding: .utf8
+        )
+        let methodRange = try #require(appStateSource.range(of: "private func writeGlanceSnapshot"))
+        let method = String(appStateSource[methodRange.lowerBound...].prefix(4_500))
+        let operationRange = try #require(method.range(of: "await debouncer.schedule(snapshot)"))
+        let methodAfterOperationStarts = String(method[operationRange.lowerBound...])
+        let generationGuard = try #require(
+            methodAfterOperationStarts.range(of: "guard self.glanceSnapshotWriteGeneration == generation else { return false }")
+        )
+        let saveCall = try #require(
+            methodAfterOperationStarts.range(of: "return try GlanceSnapshotStore.saveIfChanged(snapshot)")
+        )
+        let commitWindow = String(methodAfterOperationStarts[generationGuard.upperBound..<saveCall.lowerBound])
+
+        #expect(generationGuard.upperBound < saveCall.lowerBound)
+        #expect(
+            String(methodAfterOperationStarts[..<generationGuard.lowerBound])
+                .contains("changed = try await MainActor.run")
+        )
+        #expect(!commitWindow.contains("await"))
+        #expect(!commitWindow.contains("scheduler.sleep"))
+    }
+
     @Test("Foundation Models availability uses the public framework gate (AND-656)")
     func foundationModelsProbeUsesPublicFrameworkGate() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)


### PR DESCRIPTION
## Summary
- re-checks glanceSnapshotWriteGeneration inside the debounced glance snapshot operation before saving
- keeps the generation check and save on MainActor so clear/demo-entry paths cannot interleave between the check and file write
- adds a source-structure regression test for the debounced save guard

Closes #704
Linear: AND-720

## Test Plan
- python3 source assertion for debounced generation guard before saveIfChanged
- git diff --check
- xcrun swiftc -parse -parse-as-library Sources/PlaidBar/App/AppState.swift
- xcrun swiftc -parse -parse-as-library Tests/PlaidBarTests/PlaidBarTests.swift
- swift test --filter glanceSnapshotDebouncedCommitIsGenerationGatedBeforeSave (blocked by pre-existing FoundationModelsMacros plugin errors on this host)