### PR TITLE
refactor(core): consolidate destination hero-metric detail copy into Core

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -261,7 +261,10 @@ struct AccountsDestinationView: View {
             label: "Net worth",
             value: metricValue(for: netWorthAggregation, masked: masked),
             systemImage: "chart.line.uptrend.xyaxis",
-            detail: metricDetail(for: netWorthAggregation, fallback: accountCountDetail(summary.accountCount)),
+            detail: MultiCurrencyBalancePresentation.metricDetail(
+                from: netWorthAggregation,
+                fallback: AccountPresentation.accountCountDetail(summary.accountCount)
+            ),
             accent: SemanticColors.brand
         )
 
@@ -270,7 +273,10 @@ struct AccountsDestinationView: View {
             label: "Total assets",
             value: metricValue(for: assetsAggregation, masked: masked),
             systemImage: "banknote",
-            detail: metricDetail(for: assetsAggregation, fallback: "Cash and savings on hand"),
+            detail: MultiCurrencyBalancePresentation.metricDetail(
+                from: assetsAggregation,
+                fallback: "Cash and savings on hand"
+            ),
             accent: SemanticColors.positive
         )
 
@@ -279,15 +285,14 @@ struct AccountsDestinationView: View {
             label: "Total debt",
             value: metricValue(for: debtAggregation, masked: masked),
             systemImage: "creditcard",
-            detail: metricDetail(for: debtAggregation, fallback: "Credit and loan balances"),
+            detail: MultiCurrencyBalancePresentation.metricDetail(
+                from: debtAggregation,
+                fallback: "Credit and loan balances"
+            ),
             accent: summary.totalDebt > 0 ? SemanticColors.warning : .secondary
         )
 
         return [netWorth, assets, debt]
-    }
-
-    private func accountCountDetail(_ count: Int) -> String {
-        count == 1 ? "Across 1 account" : "Across \(count) accounts"
     }
 
     private func metricValue(for aggregation: CurrencyAggregation, masked: Bool) -> String {
@@ -296,11 +301,6 @@ struct AccountsDestinationView: View {
             format: .compact,
             privacyMaskEnabled: masked
         )
-    }
-
-    private func metricDetail(for aggregation: CurrencyAggregation, fallback: String) -> String {
-        let headline = MultiCurrencyBalancePresentation.headline(from: aggregation, format: .compact)
-        return headline.formattedTotal == nil ? headline.disclosure : fallback
     }
 
     // MARK: - Selection (shared NavigationState.selectedAccountID)

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -319,7 +319,10 @@ struct DashboardDestinationView: View {
                 privacyMaskEnabled: masked
             ),
             systemImage: "chart.line.uptrend.xyaxis",
-            detail: metricDetail(for: netWorthAggregation, fallback: accountCountDetail(summary.accountCount)),
+            detail: MultiCurrencyBalancePresentation.metricDetail(
+                from: netWorthAggregation,
+                fallback: AccountPresentation.accountCountDetail(summary.accountCount)
+            ),
             accent: SemanticColors.brand,
             provenance: FigureProvenance.netWorth(
                 accounts: appState.accounts,
@@ -352,15 +355,6 @@ struct DashboardDestinationView: View {
         )
 
         return [netWorth, safe, spend]
-    }
-
-    private func accountCountDetail(_ count: Int) -> String {
-        count == 1 ? "Across 1 account" : "Across \(count) accounts"
-    }
-
-    private func metricDetail(for aggregation: CurrencyAggregation, fallback: String) -> String {
-        let headline = MultiCurrencyBalancePresentation.headline(from: aggregation, format: .compact)
-        return headline.formattedTotal == nil ? headline.disclosure : fallback
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 public enum AccountPresentation {
+    /// Pluralized "Across N accounts" detail copy. Pure presentation string used
+    /// as the contextual fallback under a net-worth hero metric when a single
+    /// converted total is available.
+    public static func accountCountDetail(_ count: Int) -> String {
+        count == 1 ? "Across 1 account" : "Across \(count) accounts"
+    }
+
     public static func isDebt(_ account: AccountDTO) -> Bool {
         account.type == .credit || account.type == .loan
     }

--- a/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
@@ -114,6 +114,21 @@ public enum MultiCurrencyBalancePresentation {
         return perCurrency.isEmpty ? "By currency" : perCurrency
     }
 
+    /// Secondary detail copy for a hero metric backed by a currency aggregation.
+    /// When the aggregation has no single converted total — mixed, unpriceable
+    /// currencies — surface the honest per-currency ``Headline/disclosure``;
+    /// otherwise defer to the caller's contextual `fallback` copy. Mirrors the
+    /// inline detail logic the dashboard and accounts destinations each spelled
+    /// out verbatim. The disclosure is format-independent, so this intentionally
+    /// takes no `format`: the `.compact` headline matches the prior inline call.
+    public static func metricDetail(
+        from aggregation: CurrencyAggregation,
+        fallback: String
+    ) -> String {
+        let headline = headline(from: aggregation, format: .compact)
+        return headline.formattedTotal == nil ? headline.disclosure : fallback
+    }
+
     /// Formats per-currency subtotals as display rows. `privacyMaskEnabled`
     /// suppresses the figure but keeps the currency identity visible (you can see
     /// you have EUR without seeing how much).

--- a/Tests/PlaidBarCoreTests/DestinationMetricDetailPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/DestinationMetricDetailPresentationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// Pins the hero-metric detail copy that the Dashboard and Accounts destinations
+/// previously each spelled out inline (byte-identical private `metricDetail` and
+/// `accountCountDetail` helpers, now consolidated into Core). Golden strings are
+/// the verbatim prior output so the extraction stays behavior-preserving.
+@Suite("Destination hero-metric detail copy")
+struct DestinationMetricDetailPresentationTests {
+    // MARK: - AccountPresentation.accountCountDetail
+
+    @Test("Account-count detail pluralizes, singular for exactly one account")
+    func accountCountDetailPluralization() {
+        #expect(AccountPresentation.accountCountDetail(0) == "Across 0 accounts")
+        #expect(AccountPresentation.accountCountDetail(1) == "Across 1 account")
+        #expect(AccountPresentation.accountCountDetail(2) == "Across 2 accounts")
+        #expect(AccountPresentation.accountCountDetail(42) == "Across 42 accounts")
+    }
+
+    // MARK: - MultiCurrencyBalancePresentation.metricDetail
+
+    @Test("Single-currency aggregation has a converted total, so the fallback copy wins")
+    func metricDetailReturnsFallbackWhenTotalAvailable() {
+        let aggregation = CurrencyAggregation.aggregate([(amount: 100, currency: .usd)])
+        // A single resolved currency yields an exact headline total, so the
+        // contextual fallback copy is surfaced verbatim.
+        #expect(
+            MultiCurrencyBalancePresentation.metricDetail(
+                from: aggregation,
+                fallback: "Across 3 accounts"
+            ) == "Across 3 accounts"
+        )
+    }
+
+    @Test("Mixed, unpriceable currencies surface the honest disclosure instead of the fallback")
+    func metricDetailReturnsDisclosureWhenNoTotal() {
+        let aggregation = CurrencyAggregation.aggregate([
+            (amount: 100, currency: .usd),
+            (amount: 200, currency: CurrencyCode("EUR")),
+        ])
+        let detail = MultiCurrencyBalancePresentation.metricDetail(
+            from: aggregation,
+            fallback: "Across 2 accounts"
+        )
+        // No conversion source → no single total → the per-currency disclosure
+        // replaces the fallback. Pinned to the prior inline output verbatim.
+        #expect(detail == "Multiple currencies — no conversion rates available. Shown per currency below.")
+        #expect(detail != "Across 2 accounts")
+    }
+}


### PR DESCRIPTION
## Summary

Two byte-identical pure helpers lived inline in **both** sibling destination views (`DashboardDestinationView`, `AccountsDestinationView`) and were untested. This consolidates them into `PlaidBarCore` next to their existing presentation siblings, routes all call sites, and deletes the duplicated copies. Behavior-preserving.

- `MultiCurrencyBalancePresentation.metricDetail(from:fallback:)` — return the honest per-currency `Headline.disclosure` when an aggregation has no single converted total, else the caller's contextual fallback copy. The Core method hardcodes the `.compact` headline the inline callers used (the returned disclosure is format-independent, so no `format` knob is exposed).
- `AccountPresentation.accountCountDetail(_:)` — pluralized "Across N accounts".

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` pass (2026-06-26)
- Backlog slice: AppState/duplication reduction — pure presentation logic → Core (continues #686, #699, #653, #524)
- Scope note: one focused behavior-preserving extraction; no product behavior change.

## Agent coordination

- Builder agent: Claude (autonomous refactor loop)
- Builder branch/worktree: `refactor/auto-2026-06-26` in a throwaway worktree off `origin/main`
- Reviewer/merge steward: Otto
- Coordination note: review only — no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift` — add `metricDetail(from:fallback:)`
- `Sources/PlaidBarCore/Utilities/AccountPresentation.swift` — add `accountCountDetail(_:)`
- `Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift` — route 1 call site, delete 2 inline copies
- `Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift` — route 3 call sites, delete 2 inline copies (`metricValue` untouched)
- `Tests/PlaidBarCoreTests/DestinationMetricDetailPresentationTests.swift` — new golden tests

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` clean (CI gate)
- [x] `swift test` — full suite **2629 tests green** (incl. the occasionally-flaky LocalInsight timeout test); new suite 3/3
- [x] Demo app boot-smoke: `.build/debug/PlaidBar --demo` alive 9s, no crash
- [x] Secret scan completed (source + tests)

## Privacy and safety impact

- [x] Only synthetic data in tests (USD/EUR aggregations, no real balances/IDs)
- [x] No real Plaid credentials, tokens, account IDs, or balances
- [x] Preserves the local-first boundary — pure presentation-logic move, no new surfaces
- [x] User-facing copy unchanged (byte-identical detail strings)

## UI and accessibility checks

- [x] No UI/behavior change — the detail strings rendered are identical to before; accessibility/color semantics unchanged.

## Merge safety

- [x] Final diff reviewed for secrets, private data, scope creep — clean
- [x] Adversarial reviewer confirmed behavior-preserved (byte-by-byte vs deleted inline copies), 0 must-fix; both nits applied (dropped inert `format` param, removed a tautological assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)