### PR TITLE
feat(window): persist & restore primary window frame + appearance-before-first-paint test (AND-593)

### DIFF
--- a/Sources/PlaidBar/App/MainWindowFrameAutosaver.swift
+++ b/Sources/PlaidBar/App/MainWindowFrameAutosaver.swift
@@ -1,0 +1,62 @@
+import AppKit
+import SwiftUI
+
+/// Persists and restores the window-first primary `Window`'s position and size
+/// across relaunch (AND-593).
+///
+/// SwiftUI's declarative `Window` scene gives no `NSWindowController` and no
+/// hook for the host window's frame, so — exactly like ``PopoverLeadingEdgeAnchor``
+/// and the legacy AppKit window controllers (`CategoryDashboardWindowController`,
+/// `ReviewTableWindowController`, `DetachedDashboardWindowController`, which all
+/// set a `frameAutosaveName`) — this reaches the real `NSWindow` through a tiny
+/// `NSViewRepresentable` bridge and applies a stable
+/// ``NSWindow/setFrameAutosaveName(_:)`` once. AppKit then writes the frame to
+/// `UserDefaults` whenever the user moves/resizes the window and restores it on
+/// the next launch. `.defaultSize` only supplies the *first-ever* frame; the
+/// autosave name is what makes the choice durable.
+///
+/// Hosted in a zero-size `.background` view so it never participates in layout.
+/// The name is applied on `viewDidMoveToWindow` (when the host first acquires a
+/// window) and is idempotent: setting the same autosave name twice is harmless,
+/// so repeated SwiftUI re-layout / re-host passes cannot corrupt the saved frame.
+///
+/// Flag-OFF safety: the primary `Window` only opens behind `WindowFirstFeatureFlag`
+/// (`.defaultLaunchBehavior(.suppressed)`, gated opener), so this bridge is never
+/// mounted on the popover-first escape-hatch path and activation/restoration
+/// behavior there is byte-identical to before.
+struct MainWindowFrameAutosaver: NSViewRepresentable {
+    /// Stable, app-wide-unique autosave key for the primary window's frame.
+    let autosaveName: String
+
+    func makeNSView(context: Context) -> AutosaverHostView {
+        let view = AutosaverHostView()
+        view.autosaveName = autosaveName
+        return view
+    }
+
+    func updateNSView(_ nsView: AutosaverHostView, context: Context) {
+        nsView.autosaveName = autosaveName
+        nsView.applyIfPossible()
+    }
+
+    /// Zero-size host that applies the autosave name as soon as it has a window.
+    /// `viewDidMoveToWindow` fires once the representable is attached to the real
+    /// window hierarchy, which is exactly when the `NSWindow` exists to configure.
+    final class AutosaverHostView: NSView {
+        var autosaveName: String?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            applyIfPossible()
+        }
+
+        /// Applies the autosave name to the host window once it is available.
+        /// Idempotent: AppKit no-ops when the name is unchanged, so this is safe to
+        /// call from both `viewDidMoveToWindow` and `updateNSView`.
+        func applyIfPossible() {
+            guard let window, let autosaveName,
+                  window.frameAutosaveName != autosaveName else { return }
+            window.setFrameAutosaveName(autosaveName)
+        }
+    }
+}

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -46,6 +46,13 @@ struct PlaidBarApp: App {
     /// AND-591). Shared by the scene declaration and the
     /// `openWindow(id:)` affordances so they never drift.
     private static let mainWindowID = "main"
+    /// Stable frame-autosave name for the primary workspace `Window` (AND-593).
+    /// Applied once to the underlying `NSWindow` via ``MainWindowFrameAutosaver``
+    /// so AppKit persists the window's position+size to `UserDefaults` and restores
+    /// it across relaunch. Distinct from the legacy detached/Category/Review window
+    /// autosave names (`VaultPeekCategoryDashboard` etc.) so each window keeps its
+    /// own remembered frame.
+    private static let mainWindowFrameAutosaveName = "VaultPeekMainWindow"
     /// Window-first hybrid opt-in (`WindowFirstFeatureFlag`, default OFF). Resolved
     /// once at launch from the CLI override / stored preference. While OFF the
     /// "Open VaultPeek" affordance never targets the `Window` scene, so the app
@@ -543,6 +550,18 @@ struct PlaidBarApp: App {
                 // the window-first flag), so flag-OFF behavior is unchanged.
                 .onAppear { windowActivationPolicy.onWindowAppear() }
                 .onDisappear { windowActivationPolicy.onWindowDisappear() }
+                // Persist + restore the window's position/size across relaunch
+                // (AND-593). SwiftUI's declarative `Window` exposes no frame-origin
+                // hook, so — like `PopoverLeadingEdgeAnchor` and the legacy AppKit
+                // window controllers — reach the real `NSWindow` and apply a stable
+                // `frameAutosaveName` once; AppKit then writes the frame to
+                // `UserDefaults` and restores it on the next launch. Hosted in a
+                // zero-size `.background` representable so it never affects layout.
+                // Only reached when the window opens (behind the window-first flag),
+                // so flag-OFF behavior is unchanged.
+                .background(
+                    MainWindowFrameAutosaver(autosaveName: Self.mainWindowFrameAutosaveName)
+                )
                 // Liquid Glass on chrome only: the window
                 // background is the ultra-thin material; data surfaces inside stay
                 // opaque. Under Reduce Transparency (system setting or the reduced

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -111,6 +111,91 @@ struct PlaidBarTests {
         #expect(modifierBlock.contains("appState.dismissWindowFirstOrientation()"))
     }
 
+    // MARK: - Primary window frame restoration (AND-593)
+
+    /// AND-593: the primary window-first `Window`'s position/size must persist and
+    /// restore across relaunch. Asserts the restoration wiring is present on the
+    /// `Window` scene: a stable frame-autosave name is applied to the primary
+    /// NSWindow (AppKit then persists+restores the frame via UserDefaults). The
+    /// app target is not in the unit-test binary, so this string-matches the
+    /// scene source — the repo's established pattern for app-target wiring.
+    @Test("Primary window frame is persisted/restored via a stable autosave name (AND-593)")
+    func primaryWindowFrameAutosaveIsWired() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/PlaidBarApp.swift"),
+            encoding: .utf8
+        )
+        let autosaverSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/MainWindowFrameAutosaver.swift"),
+            encoding: .utf8
+        )
+
+        // A stable autosave name keyed to the primary window, distinct from the
+        // legacy detached/Category/Review window names, drives AppKit's automatic
+        // frame persistence + restore.
+        #expect(appSource.contains("mainWindowFrameAutosaveName"))
+        #expect(appSource.contains(#""VaultPeekMainWindow""#))
+
+        // The restoration bridge calls `setFrameAutosaveName` on the discovered
+        // primary NSWindow — the one API that makes AppKit persist+restore the
+        // frame across relaunch.
+        #expect(autosaverSource.contains("setFrameAutosaveName"))
+        #expect(autosaverSource.contains(": NSViewRepresentable"))
+
+        // The autosaver is attached to the primary `Window` scene root, so the
+        // wiring actually reaches the window (not just declared in isolation). The
+        // attachment lives between the `Window(` declaration and its scene
+        // modifiers (`.defaultLaunchBehavior`), so search that span.
+        let windowRange = try #require(appSource.range(of: #"Window("VaultPeek", id: Self.mainWindowID)"#))
+        let sceneModifiersRange = try #require(
+            appSource.range(of: ".defaultLaunchBehavior(.suppressed)", range: windowRange.upperBound..<appSource.endIndex)
+        )
+        let windowBlock = String(appSource[windowRange.lowerBound..<sceneModifiersRange.lowerBound])
+        #expect(windowBlock.contains("MainWindowFrameAutosaver(autosaveName: Self.mainWindowFrameAutosaveName)"))
+    }
+
+    /// AND-593: appearance must be set **before first window paint** so the first
+    /// frame renders in the chosen Light/Dark with no flash. Asserts the ordering
+    /// structurally: the single authoritative `NSApp.appearance` writer
+    /// (`applyStoredAppearance()`) is invoked in the synchronous shell `init()` —
+    /// which runs before any scene `body` is built — and that the `init` applies it
+    /// ahead of constructing `AppState`/declaring scenes.
+    @Test("Stored appearance is applied in init before the window scene paints (AND-593)")
+    func appearanceIsAppliedBeforeFirstWindowPaint() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/PlaidBarApp.swift"),
+            encoding: .utf8
+        )
+
+        // The appearance applier lives in the synchronous `init()` (runs before
+        // SwiftUI builds any scene `body`), so the first paint already carries the
+        // chosen appearance.
+        let initRange = try #require(appSource.range(of: "init() {"))
+        let initBlock = String(appSource[initRange.lowerBound...].prefix(1_500))
+        let appearanceApply = try #require(initBlock.range(of: "Self.applyStoredAppearance()"))
+
+        // Ordering: appearance is applied before `AppState` is constructed (the
+        // state that backs every scene's content), so nothing paints first.
+        let stateConstruction = try #require(initBlock.range(of: "let state = AppState()"))
+        #expect(appearanceApply.upperBound < stateConstruction.lowerBound)
+
+        // The applier itself targets `NSApplication.appearance` — the only API that
+        // cascades the theme to chrome + AppKit materials before first paint, not
+        // just SwiftUI content.
+        let applierRange = try #require(appSource.range(of: "private static func applyStoredAppearance()"))
+        let applierBlock = String(appSource[applierRange.lowerBound...].prefix(600))
+        #expect(applierBlock.contains("AppAppearance.applyToNSApp("))
+
+        // And the primary window scene folds into that same single writer rather
+        // than introducing a second, competing setter that could flash a wrong
+        // first-paint theme.
+        let windowRange = try #require(appSource.range(of: #"Window("VaultPeek", id: Self.mainWindowID)"#))
+        let windowBlock = String(appSource[windowRange.lowerBound...].prefix(2_500))
+        #expect(windowBlock.contains(".appliesAppAppearance()"))
+    }
+
     @Test("Window-first Goals and Planning mask amount-derived progress while Privacy Mask is active")
     func windowFirstGoalsProgressUsesPrivacyMask() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)


### PR DESCRIPTION
## Summary

Completes the remaining slice of **AND-593** — *"Authoritative appearance owner + window restoration (no first-paint flash)"*. The authoritative `NSApp.appearance` owner already shipped with Epic 1 (AND-620); this PR delivers the two residual pieces:

1. **Window position/size persist and restore across relaunch.** There was no `frameAutosaveName` / restoration wiring anywhere in the window scene (verified on `main`). This adds `MainWindowFrameAutosaver`, a zero-size `NSViewRepresentable` that reaches the declarative `Window`'s real `NSWindow` — mirroring the established `PopoverLeadingEdgeAnchor` bridge and the legacy AppKit window controllers (`CategoryDashboardWindowController` et al., which already set a `frameAutosaveName`) — and applies a stable `setFrameAutosaveName("VaultPeekMainWindow")` once. AppKit then writes the frame to `UserDefaults` on move/resize and restores it on the next launch. It's attached to the primary `Window` scene root next to the existing activation-policy bridge.

2. **A launch test asserting appearance is set before first window paint.** Added a source-invariant test (the PlaidBar app target isn't in the unit-test binary) asserting `applyStoredAppearance()` runs inside the synchronous shell `init()` *before* `AppState`/scene construction, that it targets `NSApplication.appearance`, and that the primary window folds into that single authoritative writer.

## Acceptance criteria addressed

- [x] Window position/size persist and restore across relaunch — stable `frameAutosaveName` on the primary `NSWindow`.
- [x] A launch test asserts appearance is set before first window paint — ordering pinned structurally (`applyStoredAppearance()` precedes `AppState()` in `init()`).
- [x] No theme flash on launch (already DONE via AND-620; ordering now regression-pinned).

## Design notes

- The autosaver is **idempotent** (no-ops when the name is unchanged) and **flag-gated**: the primary `Window` only opens behind `WindowFirstFeatureFlag` (`.defaultLaunchBehavior(.suppressed)` + gated opener), so the popover-first escape-hatch path is byte-identical to before.
- `.defaultSize` only supplies the *first-ever* frame; the autosave name is what makes the user's choice durable. `.restorationBehavior(.automatic)` (already present) and the explicit autosave name are complementary — the explicit wiring is what the acceptance criterion calls for and what the test pins.
- The autosave name `"VaultPeekMainWindow"` is distinct from the legacy detached/Category/Review window names so each window keeps its own remembered frame.

## Test evidence

- Strict CI gate: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — **Build complete** (clean).
- Full suite: `swift test` — **2628 tests passed**, 0 failures.
- TDD: the frame-autosave test was written first and observed failing (red) before the implementation landed; the appearance-ordering test pins already-shipped wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)