### PR TITLE
fix(ui): correct Safe-to-Spend confidence cue + align Insights period label

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -308,7 +308,7 @@ struct DashboardDestinationView: View {
             )
         let safeDetail = cashHeadline.formattedTotal == nil
             ? cashHeadline.disclosure
-            : "Through end of month · \(safeToSpend.confidence.label) confidence"
+            : safeToSpend.confidence.dashboardDetailCue
 
         let netWorth = HeroMetric(
             id: "netWorth",

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -10,10 +10,16 @@ public enum LocalAIInsightWindow: String, Codable, Sendable, CaseIterable, Hasha
     }
 
     /// Compact label for tight chrome (pills, evidence chips, prompt period line).
+    ///
+    /// `.lastMonth` reads "Last 30 days" — the same honest rolling-window label the
+    /// segmented selector uses (`longDisplayName`) — not "Last Month". The
+    /// deterministic summary sentence is built from this label while the picker
+    /// shows `longDisplayName`; they must agree so the user never reads a "Last
+    /// Month: …" summary under a "Last 30 days" control.
     public var displayName: String {
         switch self {
         case .last7days: "Last 7D"
-        case .lastMonth: "Last Month"
+        case .lastMonth: "Last 30 days"
         case .yearOverYear: "YoY"
         }
     }

--- a/Sources/PlaidBarCore/Models/SafeToSpend.swift
+++ b/Sources/PlaidBarCore/Models/SafeToSpend.swift
@@ -142,6 +142,15 @@ public enum SafeToSpendConfidence: String, Sendable, CaseIterable, Comparable, C
         }
     }
 
+    /// Full detail cue for the Dashboard "Safe to spend" hero — the horizon
+    /// period text joined to `label`. `label` already reads as a complete phrase
+    /// ("On track", "Lower confidence", "Estimate only"), so this never appends
+    /// the literal word "confidence": doing so produced the duplicated "Lower
+    /// confidence confidence" and the ungrammatical "On track confidence".
+    public var dashboardDetailCue: String {
+        "Through end of month · \(label)"
+    }
+
     /// SF Symbol paired with `label` so the cue is never color-only.
     public var iconName: String {
         switch self {

--- a/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
@@ -45,7 +45,12 @@ struct LocalAIInsightsModelTests {
     @Test("Each window has a distinct compact, long, and accessibility label")
     func windowLabels() {
         #expect(LocalAIInsightWindow.last7days.displayName == "Last 7D")
-        #expect(LocalAIInsightWindow.lastMonth.displayName == "Last Month")
+        // `.lastMonth` uses the honest rolling-window label "Last 30 days" (not
+        // "Last Month"): the deterministic summary sentence is built from
+        // `displayName`, while the segmented picker shows `longDisplayName`. They
+        // must agree, so the user never reads "Last Month: …" under a "Last 30
+        // days" control.
+        #expect(LocalAIInsightWindow.lastMonth.displayName == "Last 30 days")
         #expect(LocalAIInsightWindow.yearOverYear.displayName == "YoY")
 
         #expect(LocalAIInsightWindow.last7days.longDisplayName == "Last 7 days")
@@ -55,6 +60,21 @@ struct LocalAIInsightsModelTests {
         #expect(LocalAIInsightWindow.last7days.accessibilityName == "Last 7 days")
         #expect(LocalAIInsightWindow.lastMonth.accessibilityName == "Last 30 days")
         #expect(LocalAIInsightWindow.yearOverYear.accessibilityName == "Year over year")
+    }
+
+    @Test("The summary-sentence label agrees with the picker label for .lastMonth")
+    func lastMonthSummaryAgreesWithPicker() {
+        // Bug guard: the segmented control reads `longDisplayName` and the
+        // deterministic summary sentence reads `displayName`. For `.lastMonth`
+        // they must say the same thing so the period the user picks matches the
+        // period the summary names.
+        let window = LocalAIInsightWindow.lastMonth
+        #expect(window.displayName == window.longDisplayName)
+
+        let input = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
+        let text = LocalAIDeterministicSummary.summaryText(for: input)
+        #expect(text.hasPrefix("\(window.longDisplayName):"))
+        #expect(!text.contains("Last Month"))
 
         // SF Symbols pair text with a shape so the selector never rides on color
         // alone, and the three symbols are distinct.
@@ -98,7 +118,7 @@ struct LocalAIInsightsModelTests {
     func deterministicSummaryHeadline() {
         let input = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
         let text = LocalAIDeterministicSummary.summaryText(for: input)
-        #expect(text.hasPrefix("Last Month:"))
+        #expect(text.hasPrefix("Last 30 days:"))
         #expect(text.contains("expenses"))
         #expect(text.contains("income"))
         #expect(text.contains("net cashflow"))

--- a/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
@@ -101,7 +101,7 @@ struct LocalInsightModelPromptTests {
     func includesDisplaySafeAggregates() {
         let prompt = LocalInsightPromptBuilder.make(from: input()).user
 
-        #expect(prompt.contains("Last Month"))
+        #expect(prompt.contains("Last 30 days"))
         #expect(prompt.contains("2026-05-13"))
         #expect(prompt.contains("18 transactions"))
         #expect(prompt.contains("Food & Drink"))

--- a/Tests/PlaidBarCoreTests/SafeToSpendModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SafeToSpendModelTests.swift
@@ -76,6 +76,26 @@ struct SafeToSpendModelTests {
         #expect(SafeToSpendConfidence.insufficientData.iconName == "questionmark.circle")
     }
 
+    @Test("Dashboard confidence cue prefixes the horizon and never duplicates 'confidence'")
+    func dashboardConfidenceCueGoldenStrings() {
+        // Golden strings: the cue is the horizon period text plus the label, with
+        // no trailing literal " confidence" — the label already reads as a full
+        // phrase, so appending the word produced "Lower confidence confidence" and
+        // the ungrammatical "On track confidence" / "Estimate only confidence".
+        #expect(SafeToSpendConfidence.insufficientData.dashboardDetailCue == "Through end of month · Estimate only")
+        #expect(SafeToSpendConfidence.lowConfidence.dashboardDetailCue == "Through end of month · Lower confidence")
+        #expect(SafeToSpendConfidence.ok.dashboardDetailCue == "Through end of month · On track")
+
+        // No cue may contain the word "confidence" twice (the original bug).
+        for confidence in SafeToSpendConfidence.allCases {
+            let occurrences = confidence.dashboardDetailCue
+                .lowercased()
+                .components(separatedBy: "confidence")
+                .count - 1
+            #expect(occurrences <= 1)
+        }
+    }
+
     // MARK: Horizon
 
     @Test("End-of-month horizon resolves to the month's final day")


### PR DESCRIPTION
These two front-end bugs came from a UI review of the window-first surfaces.

## Bug 1 (P1) — "confidence confidence" in the Dashboard "Safe to spend" hero
**Symptom:** the hero detail rendered "Through end of month · Lower confidence confidence" (duplicate) and the ungrammatical "On track confidence" / "Estimate only confidence". The hero detail is `.lineLimit(2)`, so it also visibly truncated.

**Root cause:** `DashboardDestinationView` appended a literal `" confidence"` to `SafeToSpendConfidence.label`, but `label` already returns full phrases ("Estimate only", "Lower confidence", "On track"). (`PlanningDestinationView` already used the correct pattern with no suffix.)

**Fix:** extracted the cue composition into a pure, `Sendable` `SafeToSpendConfidence.dashboardDetailCue` in `PlaidBarCore` returning `"Through end of month · <label>"`, and the Dashboard view now calls it (branch structure unchanged). 

**Test:** `SafeToSpendModelTests.dashboardConfidenceCueGoldenStrings` pins all three cases with golden strings and asserts no cue contains the word "confidence" twice — the test that would have caught the original bug.

## Bug 2 (P2) — Insights period label mismatch
**Symptom:** the segmented control showed "Last 30 days" while the summary sentence read "Last Month: …".

**Root cause:** the deterministic summary sentence is built from `LocalAIInsightWindow.displayName` ("Last Month") while the segmented picker uses `longDisplayName` ("Last 30 days").

**Fix:** standardized `.lastMonth.displayName` to the honest rolling-window label "Last 30 days" (matching the picker). No view renders `displayName` in a tight chip — the picker uses `longDisplayName` — and the label is only used in Core sentence/label contexts where "Last 30 days" fits, so there is no overflow risk.

**Test:** `LocalAIInsightsModelTests.lastMonthSummaryAgreesWithPicker` pins `displayName == longDisplayName` for `.lastMonth` and asserts the summary sentence prefixes "Last 30 days:" and never contains "Last Month". Updated the pre-existing pinned-label tests accordingly.

## Bug 3 (P2, conditional) — deferred
Seeding demo Goals/Alerts had no clean injection point:
- **Alerts** are computed: `AttentionQueue.evaluate` deliberately short-circuits to a single `healthyDemoRow` in demo mode (an intentional "all clear" design). Seeding fake alerts means overriding that Core decision — invasive.
- **Goals** go through `GoalsStore`, which persists every `add()` to the real `~/.vaultpeek/goals.json` and has no in-memory-only seed path. Seeding would write to the user's real data file or require new non-persisting plumbing / a store refactor.

Per the task's guidance, both were left for a follow-up issue rather than forced.

## Verification
- Strict gate: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — green
- Full suite: `swift test` — 2632 tests passed
- Visual: `--render-window-first` confirmed the Dashboard cue ("Through end of month · Lower confidence") and the Insights label agreement ("Last 30 days" control + "Last 30 days:" summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)