### PR TITLE
fix(recurring): quiet repeated "Low confidence" tags to one subtle cue (AND-729)

### DIFF
--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -241,18 +241,19 @@ private struct FlagBadge: View {
     }
 }
 
+/// A quiet, icon-only "low confidence" cue (AND-729). The full "Low confidence"
+/// text capsule, repeated on every estimated row, read as a wall of hedges and
+/// competed with the actionable attention flags. Reduced to a single subtle
+/// glyph with the wording on hover: the actionable ``FlagBadge``s stay loud
+/// (text + capsule), while the confidence caveat recedes. The glyph shape — not
+/// color — carries the cue, and the row's accessibility label still voices "low
+/// confidence" (never color alone, ACCESSIBILITY.md).
 private struct LowConfidenceBadge: View {
     var body: some View {
-        Label {
-            Text(RecurringConfidenceLevel.low.label)
-        } icon: {
-            Image(systemName: RecurringConfidenceLevel.low.iconName)
-        }
-        .font(.caption2.weight(.medium))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, Spacing.xs)
-        .padding(.vertical, Spacing.chipVertical)
-        .background(.quinary, in: Capsule())
-        .lineLimit(1)
+        Image(systemName: RecurringConfidenceLevel.low.iconName)
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.tertiary)
+            .help(RecurringConfidenceLevel.low.label)
+            .accessibilityHidden(true)
     }
 }


### PR DESCRIPTION
From the 2026-06-26 UI review — [AND-729](https://linear.app/andeslab/issue/AND-729).

The **"Low confidence" text capsule** rendered on *every* estimated recurring row (Dashboard "Recurring", Planning "Commitments", and the popover flyout — all via `RecurringObligationsSection`) read as a wall of hedges and competed visually with the genuinely-actionable attention flags ("Forgotten?", price-up).

**Change:** reduce the confidence caveat to a single subtle glyph (`exclamationmark.circle`, tertiary) with the wording on `.help()` hover. The actionable `FlagBadge`s keep their loud text+capsule treatment, so attention states stand out and the estimate caveat recedes.

**Accessibility preserved:** the glyph shape (not color) carries the cue, and the row's accessibility label still voices "low confidence" — never color alone (ACCESSIBILITY.md).

## Verification
- Presentation-only; no Core logic changed.
- Strict-concurrency gate clean; full `swift test` **2632 passed**.
- Render-confirmed on Dashboard + Planning; the recurring list reads markedly calmer (text capsules → one quiet icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)