### PR TITLE
fix(privacy): mask Local AI receipt metadata

### DIFF
--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -440,7 +440,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
             ? "Spending insight hidden while Privacy Mask is on"
             : PrivacyMaskPresentation.maskCurrencyTokens(in: redactedHeadline, isEnabled: privacyMaskEnabled)
         let confidence = confidenceText(for: input, availability: availability, privacyMaskEnabled: privacyMaskEnabled)
-        let reversibleActionCopy = reversibleActionCopy(for: input)
+        let reversibleActionCopy = reversibleActionCopy(for: input, privacyMaskEnabled: privacyMaskEnabled)
         let timeWindow = timeWindow(for: input)
         let accessibility = [
             "Local insight receipt.",
@@ -548,9 +548,16 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         }
     }
 
-    private static func reversibleActionCopy(for input: LocalAIActivitySummaryInput) -> String {
+    private static func reversibleActionCopy(
+        for input: LocalAIActivitySummaryInput,
+        privacyMaskEnabled: Bool
+    ) -> String {
         guard !input.categorySuggestions.isEmpty else {
             return "This receipt changes nothing. Review the source dashboard rows before taking action."
+        }
+
+        if privacyMaskEnabled {
+            return "Insight actions are hidden while Privacy Mask is on. Turn Privacy Mask off to review local-only actions."
         }
 
         return "Category hints are local overlays. Accepting or rejecting a hint is reversible and does not mutate raw Plaid records."

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -387,7 +387,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
             EvidenceChip(
                 id: "transactions",
                 label: "Source rows",
-                value: "\(input.current.transactionCount)",
+                value: privacyMaskEnabled ? PrivacyMaskPresentation.compactValue : "\(input.current.transactionCount)",
                 systemImage: "list.bullet.rectangle"
             ),
             EvidenceChip(
@@ -398,7 +398,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
             ),
         ]
 
-        if let topCategory = input.current.categoryTotals.first {
+        if !privacyMaskEnabled, let topCategory = input.current.categoryTotals.first {
             chips.append(EvidenceChip(
                 id: "top-category",
                 label: "Top category",
@@ -419,7 +419,7 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
             ))
         }
 
-        if !input.categorySuggestions.isEmpty {
+        if !privacyMaskEnabled, !input.categorySuggestions.isEmpty {
             chips.append(EvidenceChip(
                 id: "category-hints",
                 label: "Category hints",
@@ -436,8 +436,10 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         let redactedHeadline = redactKnownSourceIdentifiers(in: rawHeadline, input: input)
         // Mask any currency baked into the (possibly model-generated) headline so
         // Privacy Mask hides "$X expenses, $Y income…" like every other value.
-        let headline = PrivacyMaskPresentation.maskCurrencyTokens(in: redactedHeadline, isEnabled: privacyMaskEnabled)
-        let confidence = confidenceText(for: input, availability: availability)
+        let headline = privacyMaskEnabled
+            ? "Spending insight hidden while Privacy Mask is on"
+            : PrivacyMaskPresentation.maskCurrencyTokens(in: redactedHeadline, isEnabled: privacyMaskEnabled)
+        let confidence = confidenceText(for: input, availability: availability, privacyMaskEnabled: privacyMaskEnabled)
         let reversibleActionCopy = reversibleActionCopy(for: input)
         let timeWindow = timeWindow(for: input)
         let accessibility = [
@@ -485,8 +487,13 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
 
     private static func confidenceText(
         for input: LocalAIActivitySummaryInput,
-        availability: LocalAIAvailability
+        availability: LocalAIAvailability,
+        privacyMaskEnabled: Bool
     ) -> String {
+        if privacyMaskEnabled {
+            return "Confidence hidden while Privacy Mask is on."
+        }
+
         if availability.state != .available {
             return "Deterministic confidence: local summary only; no model runtime contributed."
         }

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -177,6 +177,9 @@ struct LocalAIInsightReceiptTests {
         #expect(!rendered.contains("7"))
         #expect(!rendered.contains("Food & Drink"))
         #expect(!rendered.contains("Category hints"))
+        #expect(!rendered.contains("local overlays"))
+        #expect(!rendered.contains("reversible"))
+        #expect(receipt.reversibleActionCopy == "Insight actions are hidden while Privacy Mask is on. Turn Privacy Mask off to review local-only actions.")
     }
 
     private static let disabledAvailability = LocalAIAvailability(

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptTests.swift
@@ -149,6 +149,36 @@ struct LocalAIInsightReceiptTests {
         #expect(!receipt.headline.contains("categoryEvidenceAccountSecret"))
     }
 
+    @Test("Privacy Mask withholds receipt counts, category details, and generated free text")
+    func privacyMaskWithholdsReceiptMetadata() {
+        let input = makeInput(transactionCount: 7, includeCategorySuggestion: true)
+        let summary = LocalAIActivitySummary(
+            window: .last7days,
+            availability: Self.disabledAvailability,
+            input: input,
+            generatedSummary: "Last 7D: 7 rows reviewed with Food & Drink as top category.",
+            generatedBullets: [],
+            evidence: input.evidence
+        )
+
+        let receipt = LocalAIInsightReceipt.make(
+            summary: summary,
+            availability: Self.disabledAvailability,
+            privacyMaskEnabled: true
+        )
+        let rendered = ([receipt.headline, receipt.confidence, receipt.accessibilitySummary] +
+            receipt.evidenceChips.flatMap { [$0.label, $0.value] })
+            .joined(separator: " ")
+
+        #expect(receipt.headline == "Spending insight hidden while Privacy Mask is on")
+        #expect(receipt.evidenceChips.first { $0.id == "transactions" }?.value == PrivacyMaskPresentation.compactValue)
+        #expect(!receipt.evidenceChips.contains { $0.id == "top-category" })
+        #expect(!receipt.evidenceChips.contains { $0.id == "category-hints" })
+        #expect(!rendered.contains("7"))
+        #expect(!rendered.contains("Food & Drink"))
+        #expect(!rendered.contains("Category hints"))
+    }
+
     private static let disabledAvailability = LocalAIAvailability(
         state: .disabled,
         detail: "No local AI runtime is configured. VaultPeek is using deterministic local summaries and category hints only."


### PR DESCRIPTION
## Summary

- Masks Local AI receipt source-row counts when Privacy Mask is enabled.
- Omits top-category and category-hint evidence chips while masked.
- Replaces generated/deterministic receipt headline and confidence copy with generic masked copy so visible and accessibility strings do not repeat behavioral finance metadata.
- Adds a focused Core regression test for the masked receipt path.

Fixes #712
Linear: AND-734
Kanban: t_2e4c9976

## Verification

- `git diff --check` — passed
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed
- `swift test --filter LocalAIInsightReceiptTests/privacyMaskWithholdsReceiptMetadata -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked before test execution by unrelated app-target FoundationModels macro/plugin errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found in FoundationModels* files).

## Privacy notes

No Plaid credentials, tokens, account IDs, transaction IDs, balances, local SQLite contents, prompts, or response bodies are moved or logged. This is a pure Core presentation change for masked display/accessibility copy.
