### PR TITLE
feat(dashboard): surface top goal progress on the Dashboard (AND-730)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -161,15 +161,18 @@ struct DashboardDestinationView: View {
         .accessibilityElement(children: .contain)
     }
 
-    /// The right/secondary **Money & insights** column — three cards: recurring
-    /// obligations, the category dashboard, and the local-insight teaser (plus the
-    /// first-run snapshot when present, which is transient). Each re-hosted card
-    /// self-cards, so they are mounted directly under the column banner.
+    /// The right/secondary **Money & insights** column — recurring obligations, the
+    /// savings-goals glance (AND-730), the category dashboard, and the local-insight
+    /// teaser (plus the first-run snapshot when present, which is transient). Each
+    /// re-hosted card self-cards, so they are mounted directly under the column
+    /// banner.
     private var secondaryColumn: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.lg) {
             columnHeader("Money & insights", systemImage: "chart.pie")
 
             DashboardRecurringCard(onOpen: { openRoute(.planning(section: .recurring)) })
+
+            DashboardGoalsCard(onOpen: { openRoute(.goals()) })
 
             CategoryDashboardCard(inWindow: true)
 

--- a/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
@@ -1,0 +1,205 @@
+import PlaidBarCore
+import SwiftUI
+
+/// The window-first **Dashboard** savings-goals glance card (AND-730).
+///
+/// Goals were previously invisible until you navigated to the Goals workspace.
+/// This card surfaces the top few goals — name, a labeled progress bar, the
+/// saved-of-target figure, and the percent — directly on the dashboard's
+/// "Money & insights" column, with an **Open Goals** affordance that deep-links to
+/// ``RouteDestination/goals``.
+///
+/// Surface only — every figure is the pure, Core-tested ``Goal`` /
+/// ``DashboardGoalsPreview`` math (`fractionComplete`, `percentComplete`,
+/// `pace(asOf:)`, the top-N ordering); persistence is the same local-first
+/// ``GoalsStore`` the Goals workspace reads, so the two can never disagree. The
+/// card lazily triggers `loadIfNeeded()` on appear (the dashboard does not
+/// otherwise touch goals storage).
+///
+/// When there are **no goals**, it shows a quiet "set a savings goal" empty
+/// affordance with an Open Goals action rather than self-hiding, so the dashboard
+/// grid keeps a uniform card rather than a hole and offers a next step. (Note:
+/// `--demo` seeds no goals today — AND-732 — so the demo render shows this empty
+/// state, which is expected.)
+///
+/// Progress is always carried by **text + the bar**, never color alone
+/// (ACCESSIBILITY.md); amounts honor Privacy Mask (`PrivacyMaskPresentation`).
+/// **Flag-OFF inert:** reached only inside the window-first dashboard; the
+/// popover never instantiates it.
+struct DashboardGoalsCard: View {
+    @Environment(AppState.self) private var appState
+    /// Deep-links to the Goals workspace.
+    let onOpen: () -> Void
+
+    private var store: GoalsStore { appState.goalsStore }
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
+
+    var body: some View {
+        WindowSection("Goals", systemImage: "target") {
+            openButton
+        } content: {
+            if !store.hasLoaded {
+                loadingState
+            } else if store.goals.isEmpty {
+                emptyState
+            } else {
+                let preview = DashboardGoalsPreview.make(from: store.goals)
+                VStack(alignment: .leading, spacing: WindowMetrics.md) {
+                    ForEach(preview.goals) { goal in
+                        DashboardGoalRow(goal: goal, isMasked: isMasked)
+                    }
+                    if let overflow = preview.overflowLabel {
+                        Button(action: onOpen) {
+                            Text("+ \(overflow)")
+                                .windowSupportingText()
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens the Goals workspace to see all goals.")
+                    }
+                }
+                .accessibilityElement(children: .contain)
+            }
+        }
+        .task { await store.loadIfNeeded() }
+        .accessibilityElement(children: .contain)
+    }
+
+    /// The header "Open Goals" affordance — routes to the Goals workspace.
+    private var openButton: some View {
+        Button(action: onOpen) {
+            Label("Open Goals", systemImage: "arrow.up.right")
+                .labelStyle(.titleAndIcon)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help("Open the Goals workspace")
+        .accessibilityHint("Opens the Goals workspace.")
+    }
+
+    private var loadingState: some View {
+        ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, minHeight: 60)
+            .accessibilityLabel("Loading goals")
+    }
+
+    /// A quiet empty affordance — a prompt + an Open Goals action — rather than a
+    /// broken/blank card or a self-hide that would leave a hole in the grid.
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            Label("Set a savings goal", systemImage: "flag.checkered")
+                .windowDataText()
+            Text("Track a target like an emergency fund and watch your progress here.")
+                .windowSupportingText()
+                .fixedSize(horizontal: false, vertical: true)
+            Button(action: onOpen) {
+                Label("Open Goals", systemImage: "plus")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Goals. Set a savings goal to track your progress. Opens the Goals workspace.")
+    }
+}
+
+// MARK: - Compact goal row
+
+/// A compact dashboard goal row: the goal name + percent on one line, a labeled
+/// progress bar, and the saved-of-target figure with the pace verdict. Meaning is
+/// carried by text + the bar, never color alone (ACCESSIBILITY.md); amounts honor
+/// Privacy Mask.
+private struct DashboardGoalRow: View {
+    let goal: Goal
+    let isMasked: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
+                Image(systemName: goal.linkedCategory?.iconName ?? "flag.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20)
+                    .accessibilityHidden(true)
+                Text(goal.name)
+                    .windowCardTitle()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                Spacer(minLength: WindowMetrics.sm)
+                Text(percent(goal.percentComplete))
+                    .font(.subheadline.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(.primary)
+            }
+
+            progressBar
+
+            HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
+                Text("\(currency(goal.contributedAmount)) of \(currency(goal.targetAmount))")
+                    .windowSupportingText()
+                    .lineLimit(1)
+                Spacer(minLength: WindowMetrics.sm)
+                paceLabel
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var progressBar: some View {
+        if isMasked {
+            ProgressView()
+                .progressViewStyle(.linear)
+                .tint(.secondary)
+                .accessibilityHidden(true)
+        } else {
+            ProgressView(value: goal.fractionComplete)
+                .progressViewStyle(.linear)
+                .tint(goal.isComplete ? SemanticColors.positive : SemanticColors.brand)
+                .accessibilityHidden(true)
+        }
+    }
+
+    @ViewBuilder
+    private var paceLabel: some View {
+        let pace = goal.pace(asOf: Date())
+        if goal.isComplete {
+            Label("Funded", systemImage: "checkmark.seal.fill")
+                .windowSupportingText()
+        } else if pace != .noDeadline {
+            Label(pace.label, systemImage: pace.systemImage)
+                .windowSupportingText()
+        }
+    }
+
+    private var accessibilityLabel: String {
+        var parts = ["\(goal.name), \(percent(goal.percentComplete)) funded"]
+        parts.append("\(currency(goal.contributedAmount)) of \(currency(goal.targetAmount))")
+        if goal.isComplete {
+            parts.append("Funded")
+        } else {
+            let pace = goal.pace(asOf: Date())
+            if pace != .noDeadline { parts.append(pace.label) }
+        }
+        return parts.joined(separator: ". ")
+    }
+
+    private func currency(_ amount: Double) -> String {
+        PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: isMasked, style: .compact)
+    }
+
+    private func percent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview {
+    DashboardGoalsCard(onOpen: {})
+        .environment(AppState())
+        .padding()
+        .frame(width: 360)
+}
+#endif

--- a/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
+++ b/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A read-only, **dashboard-scale** preview of the user's savings ``Goal``s
+/// (AND-730).
+///
+/// The Goals workspace owns the full list; the Dashboard only needs a compact
+/// glance — the top few goals most worth seeing, plus a hint of how many more are
+/// tracked. This pure value type performs that selection so the dashboard card
+/// stays a thin surface and the "which goals lead" ordering is unit-tested at the
+/// Core layer (CLAUDE.md: shared logic lives in `PlaidBarCore`).
+///
+/// Ordering surfaces the goals that most reward a glance: **behind-pace goals
+/// first** (they need attention), then in-progress goals **closest to their
+/// target** (the satisfying almost-there ones), with funded goals last. Ties fall
+/// back to the same newest-first ordering the Goals list uses, so the dashboard
+/// and the workspace never feel arbitrary relative to each other.
+public struct DashboardGoalsPreview: Sendable, Equatable {
+    /// The featured goals, already ordered and capped to the requested limit.
+    public let goals: [Goal]
+    /// The total number of goals the user has (before capping), so the card can
+    /// say "+N more".
+    public let totalGoalCount: Int
+    /// How many goals are not shown in `goals` (`totalGoalCount - goals.count`).
+    public let overflowCount: Int
+
+    public init(goals: [Goal], totalGoalCount: Int, overflowCount: Int) {
+        self.goals = goals
+        self.totalGoalCount = totalGoalCount
+        self.overflowCount = overflowCount
+    }
+
+    /// True when there are no goals to preview — the dashboard shows the quiet
+    /// "set a savings goal" empty affordance in that case.
+    public var isEmpty: Bool { totalGoalCount == 0 }
+
+    /// "+N more goal(s)" footer copy when goals overflow the cap, else `nil`.
+    /// Grammatically pluralized so the card never reads "1 more goals".
+    public var overflowLabel: String? {
+        guard overflowCount > 0 else { return nil }
+        return overflowCount == 1 ? "1 more goal" : "\(overflowCount) more goals"
+    }
+
+    /// The default number of goals the dashboard features.
+    public static let defaultLimit = 3
+
+    /// Build a dashboard preview from the full goal list, evaluating pace `asOf` a
+    /// reference date and capping at `limit` featured goals.
+    public static func make(
+        from goals: [Goal],
+        limit: Int = defaultLimit,
+        asOf now: Date = Date()
+    ) -> DashboardGoalsPreview {
+        let cap = max(limit, 0)
+        let ranked = goals.sorted { lhs, rhs in
+            let l = priority(of: lhs, asOf: now)
+            let r = priority(of: rhs, asOf: now)
+            if l != r { return l < r }
+            // Within the same bucket, the more-complete goal leads (closest to
+            // target for in-progress; both 1.0 for funded — falls through to date).
+            if lhs.fractionComplete != rhs.fractionComplete {
+                return lhs.fractionComplete > rhs.fractionComplete
+            }
+            // Stable tie-break: newest-created first, then name, then id — matching
+            // the Goals list's display order.
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt > rhs.createdAt }
+            if lhs.name != rhs.name { return lhs.name < rhs.name }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+        let featured = Array(ranked.prefix(cap))
+        return DashboardGoalsPreview(
+            goals: featured,
+            totalGoalCount: goals.count,
+            overflowCount: max(goals.count - featured.count, 0)
+        )
+    }
+
+    /// Lower sorts earlier: behind-pace (0) lead, then in-progress (1), then funded
+    /// (2). Behind goals need attention; funded ones are done, so they sit last.
+    private static func priority(of goal: Goal, asOf now: Date) -> Int {
+        if goal.isComplete { return 2 }
+        return goal.pace(asOf: now) == .behind ? 0 : 1
+    }
+}

--- a/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Dashboard goals preview (AND-730)")
+struct DashboardGoalsPreviewTests {
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+    private func day(_ n: Int) -> Date { base.addingTimeInterval(Double(n) * 86_400) }
+
+    @Test("Empty goal list previews as empty")
+    func empty() {
+        let preview = DashboardGoalsPreview.make(from: [], asOf: base)
+        #expect(preview.isEmpty)
+        #expect(preview.goals.isEmpty)
+        #expect(preview.totalGoalCount == 0)
+        #expect(preview.overflowCount == 0)
+    }
+
+    @Test("Caps the featured goals at the limit and reports the overflow")
+    func capsAndReportsOverflow() {
+        let goals = (0..<5).map { i in
+            Goal(name: "G\(i)", targetAmount: 1000, contributedAmount: Double(i) * 100, createdAt: day(i))
+        }
+        let preview = DashboardGoalsPreview.make(from: goals, limit: 3, asOf: base)
+        #expect(preview.goals.count == 3)
+        #expect(preview.totalGoalCount == 5)
+        #expect(preview.overflowCount == 2)
+        #expect(!preview.isEmpty)
+    }
+
+    @Test("Fewer goals than the limit reports no overflow")
+    func noOverflowWhenFew() {
+        let goals = [
+            Goal(name: "A", targetAmount: 1000, contributedAmount: 250, createdAt: day(0)),
+            Goal(name: "B", targetAmount: 2000, contributedAmount: 500, createdAt: day(1)),
+        ]
+        let preview = DashboardGoalsPreview.make(from: goals, limit: 3, asOf: base)
+        #expect(preview.goals.count == 2)
+        #expect(preview.totalGoalCount == 2)
+        #expect(preview.overflowCount == 0)
+    }
+
+    @Test("Behind-pace goals are surfaced ahead of comfortable ones")
+    func behindFirst() {
+        // A: on track (no deadline). B: behind pace. C: funded.
+        let onTrack = Goal(name: "A", targetAmount: 1000, contributedAmount: 100, createdAt: day(0))
+        let behind = Goal(
+            name: "B",
+            targetAmount: 1000,
+            targetDate: day(100),
+            contributedAmount: 50,
+            createdAt: day(0)
+        )
+        let funded = Goal(name: "C", targetAmount: 500, contributedAmount: 500, createdAt: day(0))
+        let preview = DashboardGoalsPreview.make(from: [onTrack, behind, funded], limit: 1, asOf: day(50))
+        #expect(preview.goals.first?.name == "B")
+    }
+
+    @Test("Overflow label pluralizes the remaining count")
+    func overflowLabel() {
+        let one = DashboardGoalsPreview(goals: [], totalGoalCount: 4, overflowCount: 1)
+        #expect(one.overflowLabel == "1 more goal")
+        let many = DashboardGoalsPreview(goals: [], totalGoalCount: 6, overflowCount: 3)
+        #expect(many.overflowLabel == "3 more goals")
+        let none = DashboardGoalsPreview(goals: [], totalGoalCount: 0, overflowCount: 0)
+        #expect(none.overflowLabel == nil)
+    }
+}

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1376,6 +1376,39 @@ struct PlaidBarTests {
         #expect(popover.contains("Text(summary.captionText)"))
         #expect(popover.contains(".accessibilityLabel(summary.accessibilityLabel)"))
     }
+
+    @Test("Dashboard surfaces a Goals glance card that routes to Goals and masks amounts (AND-730)")
+    func dashboardGoalsCardWiring() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let dashboard = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift"),
+            encoding: .utf8
+        )
+        let card = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift"),
+            encoding: .utf8
+        )
+
+        // The dashboard mounts the goals glance card and deep-links it to the Goals
+        // workspace (not an in-place inspector — the 2-column dashboard has none).
+        #expect(dashboard.contains("DashboardGoalsCard(onOpen: { openRoute(.goals()) })"))
+
+        // The card reads the same local-first store the Goals workspace uses and the
+        // Core-tested top-N preview, so the two surfaces can never disagree.
+        #expect(card.contains("appState.goalsStore"))
+        #expect(card.contains("DashboardGoalsPreview.make(from: store.goals)"))
+        #expect(card.contains("await store.loadIfNeeded()"))
+
+        // Progress is carried by text + the bar; the percent runs through the
+        // mask-aware helper, never the raw "%"-interpolated figure.
+        #expect(!card.contains(#"\(goal.percentComplete)%"#))
+        #expect(card.contains("percent(goal.percentComplete)"))
+        #expect(card.contains("isMasked: isMasked"))
+
+        // An empty goal list shows the quiet affordance, not a blank/broken card.
+        #expect(card.contains("Set a savings goal"))
+        #expect(card.contains("Open Goals"))
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.


### PR DESCRIPTION
## What

Goals were invisible from the Dashboard — you had to navigate into the Goals workspace to see any progress. This adds a compact **Goals** glance card to the Dashboard's "Money & insights" column (part 3 of AND-730).

The card features the top 1–3 goals, each with:
- name + a labeled progress bar
- saved-of-target figure + percent
- the on-track / behind / funded pace verdict

…plus an **Open Goals** affordance (header button + an "+N more goals" footer when goals overflow the cap) that deep-links to `RouteDestination.goals`.

When the user has **no goals**, it shows a quiet "Set a savings goal" empty affordance with an Open Goals action — not a blank/broken card.

## How

- **`DashboardGoalsPreview`** (PlaidBarCore, pure + unit-tested): selects and caps the top-N goals and reports overflow. Ordering surfaces what's worth a glance — **behind-pace first**, then in-progress **closest to target**, funded last — reusing the existing `Goal` progress math (`fractionComplete` / `percentComplete` / `pace(asOf:)`). No new model logic in the view.
- **`DashboardGoalsCard`** (app): a thin surface mounted in the dashboard's secondary column. Reads the **same local-first `GoalsStore`** the Goals workspace uses (lazy `loadIfNeeded()` on appear), so the two surfaces can never disagree.

## Accessibility / privacy

- Progress is carried by **text + the bar**, never color alone (ACCESSIBILITY.md). The percent runs through the mask-aware helper.
- Amounts honor **Privacy Mask** (`PrivacyMaskPresentation`); the bar reads indeterminate when masked.
- Flag-OFF inert: only instantiated inside the window-first dashboard.

## Tests

- TDD `DashboardGoalsPreviewTests` (cap/overflow, behind-first ordering, pluralized overflow copy, empty).
- Source-invariant `dashboardGoalsCardWiring` test asserts the dashboard mounts the card, routes to `.goals()`, reads the shared store/preview, masks the percent, and offers the empty affordance.
- Strict-concurrency gate green; full `swift test` green (2638 tests). Window-first render exits 0; the dashboard card renders in the demo's expected empty state.

## Note

`--demo` seeds no goals today (AND-732), so the demo render shows the empty state — expected. No demo-goal seeding is added here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)