### PR TITLE
fix(currency): render money figures consistently across surfaces (AND-731)

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift
@@ -252,7 +252,14 @@ struct AccountsDestinationView: View {
     private var heroMetrics: [HeroMetric] {
         let masked = appState.shouldMaskFinancialValues
         let summary = wealthSummary
-        let netWorthAggregation = MultiCurrencyBalancePresentation.netWorth(accounts: appState.accounts)
+        // Net worth is derived from the *rounded* assets and debt at the hero's own
+        // `.compact` precision (AND-731) so the displayed trio reconciles on screen:
+        // displayed net worth == displayed assets − displayed debt. The plain
+        // `netWorth` aggregation rounds independently and could read $1 off its parts.
+        let netWorthAggregation = MultiCurrencyBalancePresentation.reconciledNetWorth(
+            accounts: appState.accounts,
+            format: .compact
+        )
         let assetsAggregation = MultiCurrencyBalancePresentation.totalAssets(accounts: appState.accounts)
         let debtAggregation = MultiCurrencyBalancePresentation.totalDebt(accounts: appState.accounts)
 

--- a/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift
@@ -157,7 +157,11 @@ struct BudgetsDestinationView: View {
             remainingTile = HeroMetric(
                 id: "remaining",
                 label: summary.isAggregateOver ? "Over budget" : "Left this month",
-                value: heroCurrency(abs(remaining), masked: masked),
+                // AND-731: the same `summary.remaining` figure also appears in the
+                // status panel rendered at `.full` ("$247.79"). Render the hero at
+                // the same precision here so one labeled value never reads as two
+                // different numbers ("$248" vs "$247.79") on the same screen.
+                value: reconciledHeroCurrency(abs(remaining), masked: masked),
                 systemImage: summary.isAggregateOver ? "exclamationmark.triangle.fill" : "checkmark.circle",
                 detail: summary.remainingDetail,
                 accent: summary.isAggregateOver ? SemanticColors.negative : SemanticColors.positive
@@ -180,6 +184,16 @@ struct BudgetsDestinationView: View {
     /// uses, so the two destinations' headline numbers read identically.
     private func heroCurrency(_ amount: Double, masked: Bool) -> String {
         PrivacyMaskPresentation.currency(amount, format: .compact, isEnabled: masked)
+    }
+
+    /// Hero currency for a figure that **also** appears elsewhere on this screen
+    /// (the "Left this month" / "Over budget" remaining value, shown again in the
+    /// status panel). Rendered at `.full` to match the panel's `currency(_:)` exactly
+    /// (AND-731) so a single labeled value never reads as two different numbers
+    /// ("$248" vs "$247.79"). Other hero tiles (Budgeted, Spent) are not duplicated,
+    /// so they keep the compact `heroCurrency`.
+    private func reconciledHeroCurrency(_ amount: Double, masked: Bool) -> String {
+        PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: masked, style: .compact)
     }
 
     /// Masked-aware currency for the flat table's money columns — matches the

--- a/Sources/PlaidBarCore/Utilities/Formatters.swift
+++ b/Sources/PlaidBarCore/Utilities/Formatters.swift
@@ -4,6 +4,19 @@ public enum CurrencyFormat: String, Sendable {
     case full       // $12,450.32
     case abbreviated // $12.4K
     case compact    // $12,450
+
+    /// Number of fraction digits this format renders. The single source of truth
+    /// for the rounding-consistency policy (AND-731): a figure shown twice on one
+    /// screen, or an aggregate derived from displayed parts, must round to the same
+    /// precision so the on-screen numbers reconcile. `abbreviated` collapses to a
+    /// K/M magnitude with no meaningful cents, so it shares the whole-unit
+    /// precision of `compact`.
+    public var displayFractionDigits: Int {
+        switch self {
+        case .full: return 2
+        case .compact, .abbreviated: return 0
+        }
+    }
 }
 
 public enum Formatters {
@@ -26,6 +39,16 @@ public enum Formatters {
         f.maximumFractionDigits = 0
         return f
     }()
+
+    /// Rounds `amount` to the precision `format` will *display* (AND-731). Use this
+    /// when an aggregate must reconcile with its displayed parts (e.g. net worth ==
+    /// displayed assets − displayed debt): round each part with this first, derive
+    /// the aggregate from the rounded parts, then format — so the on-screen figures
+    /// add up even though the underlying doubles carry sub-cent precision.
+    public static func displayRounded(_ amount: Double, format: CurrencyFormat) -> Double {
+        let scale = pow(10.0, Double(format.displayFractionDigits))
+        return (amount * scale).rounded() / scale
+    }
 
     public static func currency(_ amount: Double, format: CurrencyFormat = .full, currencyCode: String = "USD") -> String {
         switch format {

--- a/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/MultiCurrencyBalancePresentation.swift
@@ -49,6 +49,57 @@ public enum MultiCurrencyBalancePresentation {
         )
     }
 
+    /// Net worth whose **displayed** figure reconciles with the displayed assets
+    /// and debt at the same `format` (AND-731).
+    ///
+    /// Plain ``netWorth(accounts:…)`` sums signed balances at full precision, so its
+    /// rounded display (e.g. `$60,104`) can differ by a cent's worth of rounding
+    /// from `displayedAssets − displayedDebt` (e.g. `$66,162 − $6,057 = $60,105`) —
+    /// three independent rounding passes that don't add up on screen. This variant
+    /// rounds each per-currency asset and debt subtotal to the format's display
+    /// precision *first*, then forms net = roundedAssets − roundedDebt per currency,
+    /// so the three on-screen numbers always reconcile. The cross-currency converted
+    /// total (if any) is likewise rebuilt from these rounded subtotals.
+    ///
+    /// Use this for the Accounts/Dashboard hero trio where all three are shown
+    /// together; the unrounded ``netWorth`` remains correct for menu-bar glances and
+    /// any single-figure surface that does not also display its parts.
+    public static func reconciledNetWorth(
+        accounts: [AccountDTO],
+        format: CurrencyFormat,
+        reportingCurrency: CurrencyCode = .usd,
+        conversionSource: any CurrencyConversionSource = NoConversionSource()
+    ) -> CurrencyAggregation {
+        let assets = totalAssets(
+            accounts: accounts,
+            reportingCurrency: reportingCurrency,
+            conversionSource: conversionSource
+        )
+        let debt = totalDebt(
+            accounts: accounts,
+            reportingCurrency: reportingCurrency,
+            conversionSource: conversionSource
+        )
+
+        var roundedByCurrency: [CurrencyCode: Double] = [:]
+        for subtotal in assets.subtotals {
+            roundedByCurrency[subtotal.currency, default: 0]
+                += Formatters.displayRounded(subtotal.amount, format: format)
+        }
+        for subtotal in debt.subtotals {
+            // Debt subtotals are positive magnitudes; net worth subtracts them.
+            roundedByCurrency[subtotal.currency, default: 0]
+                -= Formatters.displayRounded(subtotal.amount, format: format)
+        }
+
+        let entries = roundedByCurrency.map { (amount: $0.value, currency: $0.key) }
+        return CurrencyAggregation.aggregate(
+            entries,
+            reportingCurrency: reportingCurrency,
+            conversionSource: conversionSource
+        )
+    }
+
     public static func totalCash(
         accounts: [AccountDTO],
         reportingCurrency: CurrencyCode = .usd,

--- a/Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift
+++ b/Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+/// AND-731: a money figure must render identically across surfaces, and an
+/// aggregate shown next to its parts must reconcile with those displayed parts.
+/// Two concrete invariants are pinned here:
+///   (a) displayed net worth == displayed assets − displayed debt (Accounts hero);
+///   (b) the Budgets "Left this month" figure is the same Core value, so the hero
+///       and the status panel render the identical number.
+@Suite("Rounding consistency across surfaces (AND-731)")
+struct RoundingConsistencyTests {
+    // MARK: - (a) Accounts net worth reconciles with its displayed parts
+
+    /// Representative single-currency balances chosen so that *independent* rounding
+    /// of net worth, assets, and debt visibly disagrees: assets 66,161.60 → "$66,162",
+    /// debt 6,057.40 → "$6,057", but net 60,104.20 → "$60,104" ≠ 66,162 − 6,057 =
+    /// 60,105. The reconciled net worth must read "$60,105".
+    @Test("Displayed net worth equals displayed assets − displayed debt (the $1-off case)")
+    func reconciledNetWorthMatchesDisplayedParts() {
+        let accounts = [
+            depository(name: "Checking", current: 66_161.60, currency: "USD"),
+            credit(name: "Card", current: 6_057.40, limit: 10_000, currency: "USD"),
+        ]
+
+        let assets = MultiCurrencyBalancePresentation.totalAssets(accounts: accounts)
+        let debt = MultiCurrencyBalancePresentation.totalDebt(accounts: accounts)
+        let reconciledNet = MultiCurrencyBalancePresentation.reconciledNetWorth(
+            accounts: accounts,
+            format: .compact
+        )
+
+        let assetsText = MultiCurrencyBalancePresentation.displayText(from: assets, format: .compact)
+        let debtText = MultiCurrencyBalancePresentation.displayText(from: debt, format: .compact)
+        let netText = MultiCurrencyBalancePresentation.displayText(from: reconciledNet, format: .compact)
+
+        // Sanity: the parts round as the ticket describes.
+        #expect(assetsText == "$66,162")
+        #expect(debtText == "$6,057")
+
+        // The reconciled net worth equals displayed assets − displayed debt ($60,105),
+        // not the independently-rounded $60,104.
+        #expect(netText == "$60,105")
+
+        // And it does NOT equal the naive independent rounding, proving the fix bites.
+        let naiveNet = MultiCurrencyBalancePresentation.netWorth(accounts: accounts)
+        let naiveText = MultiCurrencyBalancePresentation.displayText(from: naiveNet, format: .compact)
+        #expect(naiveText == "$60,104")
+        #expect(netText != naiveText)
+    }
+
+    /// The reconciliation must hold for a sweep of representative balances: for every
+    /// case, the displayed net worth string equals (displayed assets − displayed debt)
+    /// re-rendered at the same precision.
+    @Test("Net worth reconciles with parts across a representative sweep")
+    func reconciledNetWorthHoldsAcrossSweep() {
+        let cases: [(assets: Double, debt: Double)] = [
+            (66_161.60, 6_057.40),
+            (1_000.50, 0.49),
+            (12_345.67, 2_345.12),
+            (999.99, 999.49),
+            (0, 250.75),
+            (5_000, 0),
+        ]
+
+        for sweep in cases {
+            let accounts = [
+                depository(name: "Cash", current: sweep.assets, currency: "USD"),
+                credit(name: "Card", current: sweep.debt, limit: 100_000, currency: "USD"),
+            ]
+            let assets = MultiCurrencyBalancePresentation.totalAssets(accounts: accounts)
+            let debt = MultiCurrencyBalancePresentation.totalDebt(accounts: accounts)
+            let net = MultiCurrencyBalancePresentation.reconciledNetWorth(accounts: accounts, format: .compact)
+
+            let displayedAssets = Formatters.displayRounded(
+                assets.subtotals.first?.amount ?? 0, format: .compact
+            )
+            let displayedDebt = Formatters.displayRounded(
+                debt.subtotals.first?.amount ?? 0, format: .compact
+            )
+            let expectedNetText = Formatters.currency(displayedAssets - displayedDebt, format: .compact)
+            let actualNetText = MultiCurrencyBalancePresentation.displayText(from: net, format: .compact)
+
+            #expect(
+                actualNetText == expectedNetText,
+                "assets \(sweep.assets), debt \(sweep.debt): net \(actualNetText) != \(expectedNetText)"
+            )
+        }
+    }
+
+    /// Reconciliation also holds at `.full` precision (used where heroes show cents),
+    /// guarding against a future surface that pairs all three at full precision.
+    @Test("Net worth reconciles with parts at full precision too")
+    func reconciledNetWorthHoldsAtFullPrecision() {
+        let accounts = [
+            depository(name: "Cash", current: 1_000.555, currency: "USD"),
+            credit(name: "Card", current: 250.554, limit: 5_000, currency: "USD"),
+        ]
+        let assets = MultiCurrencyBalancePresentation.totalAssets(accounts: accounts)
+        let debt = MultiCurrencyBalancePresentation.totalDebt(accounts: accounts)
+        let net = MultiCurrencyBalancePresentation.reconciledNetWorth(accounts: accounts, format: .full)
+
+        let displayedAssets = Formatters.displayRounded(assets.subtotals.first?.amount ?? 0, format: .full)
+        let displayedDebt = Formatters.displayRounded(debt.subtotals.first?.amount ?? 0, format: .full)
+        let expected = Formatters.currency(displayedAssets - displayedDebt, format: .full)
+        let actual = MultiCurrencyBalancePresentation.displayText(from: net, format: .full)
+        #expect(actual == expected)
+    }
+
+    // MARK: - Formatters.displayRounded policy
+
+    @Test("displayRounded rounds to the format's display precision")
+    func displayRoundedPrecision() {
+        // Compact/abbreviated → whole units.
+        #expect(Formatters.displayRounded(248.49, format: .compact) == 248)
+        #expect(Formatters.displayRounded(247.79, format: .compact) == 248)
+        #expect(Formatters.displayRounded(247.79, format: .abbreviated) == 248)
+        // Full → cents.
+        #expect(Formatters.displayRounded(247.794, format: .full) == 247.79)
+        #expect(Formatters.displayRounded(247.795, format: .full) == 247.80)
+    }
+
+    @Test("CurrencyFormat advertises its display fraction digits")
+    func formatFractionDigits() {
+        #expect(CurrencyFormat.full.displayFractionDigits == 2)
+        #expect(CurrencyFormat.compact.displayFractionDigits == 0)
+        #expect(CurrencyFormat.abbreviated.displayFractionDigits == 0)
+    }
+
+    // MARK: - (b) Budgets "Left this month" is one Core value shown twice
+
+    /// The Budgets hero "Left this month" tile and the status panel's "Left this
+    /// month" line both render `BudgetsStatusSummary.Summary.remaining`. There is a
+    /// single Core source for the figure, so once both surfaces format it at the same
+    /// precision they read identically. Pin that the value is single-sourced and that
+    /// formatting it at the surfaces' shared `.full` precision yields one number.
+    @Test("Budgets 'Left this month' is a single Core figure formatted identically")
+    func budgetsRemainingIsSingleSourced() {
+        // A budgeted total of 1,000 with 752.21 spent → 247.79 remaining: the exact
+        // figure from the ticket, where compact ("$248") and full ("$247.79") differ.
+        let summary = BudgetsStatusSummary.Summary(
+            health: .onTrack,
+            overBudgetCount: 0,
+            nearingCount: 0,
+            budgetedCount: 3,
+            trackedCount: 5,
+            totalSpent: 900.00,
+            budgetedSpent: 752.21,
+            totalLimit: 1_000.00
+        )
+
+        let remaining = try? #require(summary.remaining)
+        #expect(remaining != nil)
+        guard let remaining else { return }
+        #expect(abs(remaining - 247.79) < 0.0001)
+        #expect(!summary.isAggregateOver)
+
+        // Both surfaces render at `.full` (the status panel's precision, which the
+        // hero now matches), so the figure is one number on the whole screen.
+        let heroText = PrivacyMaskPresentation.currency(
+            abs(remaining), format: .full, isEnabled: false, style: .compact
+        )
+        let panelText = PrivacyMaskPresentation.currency(
+            abs(remaining), format: .full, isEnabled: false, style: .compact
+        )
+        #expect(heroText == panelText)
+        #expect(heroText.contains("247.79"))
+    }
+
+    // MARK: - Helpers
+
+    private func depository(name: String, current: Double, currency: String) -> AccountDTO {
+        AccountDTO(
+            id: name,
+            itemId: "item",
+            name: name,
+            type: .depository,
+            balances: BalanceDTO(available: current, current: current, isoCurrencyCode: currency)
+        )
+    }
+
+    private func credit(name: String, current: Double, limit: Double, currency: String) -> AccountDTO {
+        AccountDTO(
+            id: name,
+            itemId: "item",
+            name: name,
+            type: .credit,
+            balances: BalanceDTO(current: current, limit: limit, isoCurrencyCode: currency)
+        )
+    }
+}

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1313,6 +1313,37 @@ struct PlaidBarTests {
         #expect(accounts.contains("visibleAccounts.map(\\.id)"))
     }
 
+    /// Source-invariant guard for AND-731: a money figure must render identically
+    /// across surfaces. The Accounts hero must derive net worth from the *rounded*
+    /// assets and debt (`reconciledNetWorth`) so the displayed trio reconciles
+    /// (displayed net worth == displayed assets − displayed debt), and the Budgets
+    /// hero's duplicated "Left this month" value must render at the same `.full`
+    /// precision the status panel uses, not a divergent `.compact`. The `@main` app
+    /// target isn't unit-testable, so this string-matches the wiring; the numeric
+    /// behavior is proven in `RoundingConsistencyTests`.
+    @Test("Money figures reconcile across surfaces (AND-731)")
+    func moneyFiguresReconcileAcrossSurfaces() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let accounts = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/AccountsDestinationView.swift"),
+            encoding: .utf8
+        )
+        let budgets = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/BudgetsDestinationView.swift"),
+            encoding: .utf8
+        )
+
+        // Accounts net worth hero is reconciled from the rounded parts, not summed
+        // independently.
+        #expect(accounts.contains("MultiCurrencyBalancePresentation.reconciledNetWorth("))
+        #expect(!accounts.contains("MultiCurrencyBalancePresentation.netWorth(accounts: appState.accounts)"))
+
+        // Budgets "Left this month" hero renders at full precision to match the
+        // status panel's `currency(_:)` (which uses `.full`).
+        #expect(budgets.contains("reconciledHeroCurrency(abs(remaining), masked: masked)"))
+        #expect(budgets.contains("PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: masked, style: .compact)"))
+    }
+
     /// Source-invariant guard for AND-671: each activity-heatmap cell must carry a
     /// per-cell textual affordance (`.help` + `.accessibilityLabel`) so the day's
     /// meaning never rides on tint/opacity alone (ACCESSIBILITY.md). Both window


### PR DESCRIPTION
## Summary

AND-731: a given money figure must render identically across surfaces, and an aggregate shown next to its parts must reconcile with those displayed parts. Fixes two concrete inconsistencies.

### 1. Budgets "Left this month" showed two roundings on one screen
The hero rendered the same `BudgetsStatusSummary.remaining` value with `.compact` (e.g. `$248`) while the status panel rendered it with `.full` (`$247.79`) — one labeled value reading as two different numbers on the same screen. The remaining hero now renders at `.full`, matching the status panel's `currency(_:)` exactly. Budgeted/Spent heroes are not duplicated elsewhere, so they keep the compact hero style.

### 2. Accounts net worth was off by $1 from its parts
Net Worth, Total Assets, and Total Debt were each rounded independently, so the displayed net worth could differ from displayed assets − displayed debt (e.g. `$66,162 − $6,057 = $60,105` but net rendered `$60,104`). New `MultiCurrencyBalancePresentation.reconciledNetWorth(accounts:format:)` rounds each per-currency asset/debt subtotal to the display precision **first**, then forms net = roundedAssets − roundedDebt, so the on-screen trio reconciles. The unrounded `netWorth` aggregation is retained for single-figure surfaces (menu-bar glance, Dashboard) that don't display the parts.

## Policy

Single-sourced in `Formatters`: `CurrencyFormat.displayFractionDigits` + `Formatters.displayRounded(_:format:)` define the one rounding precision per format. Heroes/glances MAY round, but a figure shown twice on one screen must match, and an aggregate must reconcile with its displayed parts.

## Tests (TDD)

- Core `RoundingConsistencyTests`:
  - (a) displayed net worth == displayed assets − displayed debt across a representative sweep, including the exact `$1`-off case from the ticket;
  - (b) the Budgets "Left this month" figure is single-sourced (`BudgetsStatusSummary.remaining`) and formats identically at the surfaces' shared `.full` precision;
  - `displayRounded` / `displayFractionDigits` precision pins.
- Source-invariant test in `PlaidBarTests` pins the `@main` app-target wiring (`reconciledNetWorth` for Accounts net worth; full-precision remaining hero for Budgets).

## Verification

- Strict gate green: `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`.
- Full suite green: `swift test` — 2639 tests passed.
- `--render-window-first` exited 0; window-accounts.png + window-budgets.png written for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)