### PR TITLE
fix(privacy): mask Category Dashboard counts

### DIFF
--- a/Sources/PlaidBar/Views/CategoryDashboardCard.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardCard.swift
@@ -96,7 +96,7 @@ struct CategoryDashboardCard: View {
 
             Spacer(minLength: Spacing.sm)
 
-            if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted) {
+            if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted, privacyMaskEnabled: isMasked) {
                 Label(summary, systemImage: attentionIcon(model))
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(attentionTint(model))
@@ -174,7 +174,7 @@ struct CategoryDashboardCard: View {
             HStack(spacing: Spacing.xs) {
                 Label("Open dashboard", systemImage: "rectangle.expand.vertical")
                     .font(.caption.weight(.semibold))
-                if let overflow = model.overflowText {
+                if let overflow = model.overflowText(privacyMaskEnabled: isMasked) {
                     Text(overflow)
                         .microText()
                         .foregroundStyle(.secondary)
@@ -255,7 +255,7 @@ struct CategoryDashboardCard: View {
         }
         let total = isMasked ? PrivacyMaskPresentation.compactValue : model.totalSpentText
         var sentence = "Spending by category. \(total) spent this month."
-        if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted) {
+        if let summary = model.attentionSummary(isBudgeted: isAnyBudgeted, privacyMaskEnabled: isMasked) {
             sentence += " \(summary)."
         }
         return sentence

--- a/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
@@ -90,8 +90,17 @@ public struct CategoryDashboardCardModel: Sendable, Hashable {
     /// no row is budgeted (so the card omits the line rather than claiming "on
     /// track" for an unbudgeted month).
     public func attentionSummary(isBudgeted: Bool) -> String? {
+        attentionSummary(isBudgeted: isBudgeted, privacyMaskEnabled: false)
+    }
+
+    /// Privacy-aware budget-pressure copy for surfaces that may render while
+    /// Privacy Mask/App Lock is active. Exact over/nearing counts are behavioral
+    /// finance metadata, so the masked variant keeps the risk state without the
+    /// count.
+    public func attentionSummary(isBudgeted: Bool, privacyMaskEnabled: Bool) -> String? {
         guard isBudgeted else { return nil }
         if overBudgetCount == 0, nearingCount == 0 { return "On track" }
+        if privacyMaskEnabled { return "Budget attention hidden" }
         var parts: [String] = []
         if overBudgetCount > 0 { parts.append("\(overBudgetCount) over budget") }
         if nearingCount > 0 { parts.append("\(nearingCount) nearing") }
@@ -101,7 +110,13 @@ public struct CategoryDashboardCardModel: Sendable, Hashable {
     /// `"+N more"` overflow caption for the open-dashboard link, or `nil` when the
     /// card already shows every spending group.
     public var overflowText: String? {
+        overflowText(privacyMaskEnabled: false)
+    }
+
+    /// Privacy-aware overflow caption. The exact number of hidden spending groups
+    /// is behavioral finance metadata, so masked surfaces use generic copy.
+    public func overflowText(privacyMaskEnabled: Bool) -> String? {
         guard overflowCount > 0 else { return nil }
-        return "+\(overflowCount) more"
+        return privacyMaskEnabled ? "More categories" : "+\(overflowCount) more"
     }
 }

--- a/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
+++ b/Sources/PlaidBarCore/Models/CategoryDashboardCardModel.swift
@@ -100,7 +100,11 @@ public struct CategoryDashboardCardModel: Sendable, Hashable {
     public func attentionSummary(isBudgeted: Bool, privacyMaskEnabled: Bool) -> String? {
         guard isBudgeted else { return nil }
         if overBudgetCount == 0, nearingCount == 0 { return "On track" }
-        if privacyMaskEnabled { return "Budget attention hidden" }
+        if privacyMaskEnabled {
+            if overBudgetCount > 0, nearingCount > 0 { return "Over budget and nearing budget" }
+            if overBudgetCount > 0 { return "Over budget" }
+            return "Nearing budget"
+        }
         var parts: [String] = []
         if overBudgetCount > 0 { parts.append("\(overBudgetCount) over budget") }
         if nearingCount > 0 { parts.append("\(nearingCount) nearing") }

--- a/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
@@ -133,6 +133,34 @@ struct CategoryDashboardCardModelTests {
         #expect(model.attentionSummary(isBudgeted: false) == nil)
     }
 
+    @Test("attention summary masks exact over and nearing counts under Privacy Mask")
+    func attentionSummaryMasksCounts() {
+        let p = presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 250, limit: 200),
+            group(.shopping, leaf: .shopping, spent: 90, limit: 100),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p)
+
+        #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: true) == "Budget attention hidden")
+        #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: true)?.contains("1") != true)
+        #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: false) == "1 over budget · 1 nearing")
+    }
+
+    @Test("overflow text masks exact hidden category count under Privacy Mask")
+    func overflowTextMasksCount() {
+        let p = presentation([
+            group(.shopping, leaf: .shopping, spent: 100),
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 400),
+            group(.transportation, leaf: .transportation, spent: 250),
+            group(.entertainment, leaf: .entertainment, spent: 50),
+        ])
+        let model = CategoryDashboardCardModel(presentation: p, topGroupLimit: 2)
+
+        #expect(model.overflowText(privacyMaskEnabled: false) == "+2 more")
+        #expect(model.overflowText(privacyMaskEnabled: true) == "More categories")
+        #expect(model.overflowText(privacyMaskEnabled: true)?.contains("2") != true)
+    }
+
     @Test("currency code flows into the donut and headline formatting")
     func currencyCodeFlows() {
         let p = presentation([group(.foodAndDining, leaf: .foodAndDrink, spent: 300)])

--- a/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
+++ b/Tests/PlaidBarCoreTests/CategoryDashboardCardModelTests.swift
@@ -141,9 +141,22 @@ struct CategoryDashboardCardModelTests {
         ])
         let model = CategoryDashboardCardModel(presentation: p)
 
-        #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: true) == "Budget attention hidden")
+        #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: true) == "Over budget and nearing budget")
         #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: true)?.contains("1") != true)
         #expect(model.attentionSummary(isBudgeted: true, privacyMaskEnabled: false) == "1 over budget · 1 nearing")
+    }
+
+    @Test("attention summary preserves masked risk state without exact counts")
+    func attentionSummaryMasksCountsButPreservesRiskState() {
+        let overBudget = CategoryDashboardCardModel(presentation: presentation([
+            group(.foodAndDining, leaf: .foodAndDrink, spent: 250, limit: 200),
+        ]))
+        let nearing = CategoryDashboardCardModel(presentation: presentation([
+            group(.shopping, leaf: .shopping, spent: 90, limit: 100),
+        ]))
+
+        #expect(overBudget.attentionSummary(isBudgeted: true, privacyMaskEnabled: true) == "Over budget")
+        #expect(nearing.attentionSummary(isBudgeted: true, privacyMaskEnabled: true) == "Nearing budget")
     }
 
     @Test("overflow text masks exact hidden category count under Privacy Mask")


### PR DESCRIPTION
## Summary

- add privacy-aware Category Dashboard card-model copy for budget attention and overflow labels
- route the SwiftUI card header, open-dashboard affordance, and accessibility summary through the masked copy
- add Core regression coverage that keeps normal copy unchanged while withholding exact counts under Privacy Mask

Fixes #717

## Verification

- `git diff --check` — pass
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — pass
- `swift test --filter CategoryDashboardCardModelTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked before focused test execution by unrelated app-target FoundationModels macro/plugin resolution (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found) and unrelated `RoundingConsistencyTests.swift:152` redundant `#require` warning-as-error during broad test target compilation
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by unrelated `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152` redundant `#require` warning-as-error

## Privacy/Security

No Plaid credentials, tokens, raw IDs, transaction payloads, balances, prompts, or response bodies were moved. This is a local presentation-only Privacy Mask fix for count-bearing behavioral metadata.