### PR TITLE
refactor(core): consolidate duplicated percent-from-share formatter into Core

### DIFF
--- a/Sources/PlaidBar/Views/BalanceCompositionBar.swift
+++ b/Sources/PlaidBar/Views/BalanceCompositionBar.swift
@@ -81,10 +81,6 @@ struct AnimatedBalanceCompositionBar: View {
     }
 
     private func segmentAccessibility(_ segment: BalanceCompositionBarSegment) -> String {
-        "\(segment.title), \(segment.accessibilityValueText), \(percentText(segment.share)) of balance mix"
+        "\(segment.title), \(segment.accessibilityValueText), \(Formatters.percentFromShare(segment.share)) of balance mix"
     }
-}
-
-private func percentText(_ share: Double) -> String {
-    "\(Int((share * 100).rounded()))%"
 }

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -472,14 +472,14 @@ private struct WealthMixLegendRow: View {
                 .rollingTabularNumber(compactValue, reduceMotion: reduceMotion)
                 .lineLimit(1)
 
-            Text(percentText(segment.share))
+            Text(Formatters.percentFromShare(segment.share))
                 .microText()
                 .foregroundStyle(.secondary)
-                .rollingTabularNumber(percentText(segment.share), reduceMotion: reduceMotion)
+                .rollingTabularNumber(Formatters.percentFromShare(segment.share), reduceMotion: reduceMotion)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(
-            "\(segment.title): \(PrivacyMaskPresentation.currency(segment.value, format: .full, isEnabled: privacyMaskEnabled)), \(percentText(segment.share))"
+            "\(segment.title): \(PrivacyMaskPresentation.currency(segment.value, format: .full, isEnabled: privacyMaskEnabled)), \(Formatters.percentFromShare(segment.share))"
         )
     }
 }
@@ -801,8 +801,4 @@ private func cashflowText(_ amount: Double, format: CurrencyFormat) -> String {
         return "-\(Formatters.currency(abs(amount), format: format))"
     }
     return Formatters.currency(0, format: format)
-}
-
-private func percentText(_ share: Double) -> String {
-    "\(Int((share * 100).rounded()))%"
 }

--- a/Sources/PlaidBarCore/Utilities/Formatters.swift
+++ b/Sources/PlaidBarCore/Utilities/Formatters.swift
@@ -229,4 +229,12 @@ public enum Formatters {
     public static func percent(_ value: Double, decimals: Int = 1) -> String {
         String(format: "%.\(decimals)f%%", value)
     }
+
+    /// Format a fractional share (`0...1`) as a whole-number percent string, e.g. `0.4267` → `"43%"`.
+    /// Rounds to the nearest whole percent (half away from zero) with no decimal places — used for
+    /// compact composition/segment share labels. Unlike ``percent(_:decimals:)``, the input is a
+    /// fraction, not an already-scaled percentage value.
+    public static func percentFromShare(_ share: Double) -> String {
+        "\(Int((share * 100).rounded()))%"
+    }
 }

--- a/Tests/PlaidBarCoreTests/FormattersTests.swift
+++ b/Tests/PlaidBarCoreTests/FormattersTests.swift
@@ -151,4 +151,17 @@ struct FormattersTests {
     func relativeDate() {
         #expect(!Formatters.relativeDate(Date().addingTimeInterval(-3_600)).isEmpty)
     }
+
+    @Test("percentFromShare renders a whole-number percent from a 0...1 fraction")
+    func percentFromShare() {
+        // Pins the exact output of the previously-inline percentText(_:) helpers.
+        #expect(Formatters.percentFromShare(0) == "0%")
+        #expect(Formatters.percentFromShare(1) == "100%")
+        #expect(Formatters.percentFromShare(0.5) == "50%")
+        // Rounds to the nearest whole percent.
+        #expect(Formatters.percentFromShare(0.4267) == "43%")
+        #expect(Formatters.percentFromShare(0.4234) == "42%")
+        // Half rounds away from zero (Double.rounded() default).
+        #expect(Formatters.percentFromShare(0.005) == "1%")
+    }
 }


### PR DESCRIPTION
## Summary

- `percentText(_ share: Double) -> String` was a **byte-identical private helper duplicated in two view files** (`BalanceCompositionBar.swift`, `WealthSummaryFlyout.swift`): a pure `0...1` fraction → whole-number percent `String` formatter with **no unit-test coverage**.
- Hoisted into `Formatters.percentFromShare(_:)` in `PlaidBarCore`, next to the existing `percent(_:decimals:)` (which takes an already-scaled percentage value — a distinct contract called out in the doc comment, so no overload ambiguity).
- Rerouted all four call sites, deleted both inline copies, added golden tests pinning the prior output.

Behavior-preserving: the extracted body is character-for-character identical to both deleted copies — `"\(Int((share * 100).rounded()))%"`.

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` (Step 13)
- Backlog slice: AppState/duplication → PlaidBarCore extraction (one cohesive pure-logic cluster)
- Scope note: one focused DRY extraction; no product-behavior change.

## Agent coordination

- Builder agent: Claude (scheduled refactor task)
- Builder branch/worktree: `refactor/auto-2026-06-27` in an isolated worktree off `origin/main`
- Reviewer/merge steward: Otto
- Coordination note: review only — no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Utilities/Formatters.swift` — add `percentFromShare(_:)`
- `Sources/PlaidBar/Views/BalanceCompositionBar.swift` — reroute call site, delete inline copy
- `Sources/PlaidBar/Views/WealthSummaryFlyout.swift` — reroute 3 call sites, delete inline copy
- `Tests/PlaidBarCoreTests/FormattersTests.swift` — golden tests (incl. rounding edge)

## Local gates

- [x] `git diff --check`
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean (the CI gate)
- [x] `swift test` — full suite **2654 passed** (incl. the sometimes-flaky LocalInsightModelRuntime test)
- [x] Demo app boot-smoke (`.build/debug/PlaidBar --demo`, ~9s) — no crash
- [x] Secret scan completed over the diff — clean (no real Plaid creds/tokens/IDs/balances)

## GitHub checks

- [ ] Required GitHub checks are green before merge.

## Privacy and safety impact

None. Pure presentation-string formatting consolidation; no data flow, storage, network, or masking-logic change. The percent string is computed identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)