### PR TITLE
fix(insights): align Local AI period labels

### DIFF
--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -9,18 +9,18 @@ public enum LocalAIInsightWindow: String, Codable, Sendable, CaseIterable, Hasha
         rawValue
     }
 
-    /// Compact label for tight chrome (pills, evidence chips, prompt period line).
+    /// Display label for chrome, evidence chips, and the deterministic prompt
+    /// period line.
     ///
-    /// `.lastMonth` reads "Last 30 days" — the same honest rolling-window label the
-    /// segmented selector uses (`longDisplayName`) — not "Last Month". The
-    /// deterministic summary sentence is built from this label while the picker
-    /// shows `longDisplayName`; they must agree so the user never reads a "Last
-    /// Month: …" summary under a "Last 30 days" control.
+    /// These labels intentionally match `longDisplayName`: the deterministic
+    /// summary sentence is built from this label while the picker shows
+    /// `longDisplayName`; they must agree so the user never reads an abbreviated
+    /// summary under a fuller selected-window control.
     public var displayName: String {
         switch self {
-        case .last7days: "Last 7D"
+        case .last7days: "Last 7 days"
         case .lastMonth: "Last 30 days"
-        case .yearOverYear: "YoY"
+        case .yearOverYear: "Year over year"
         }
     }
 

--- a/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
@@ -42,16 +42,11 @@ struct LocalAIInsightsModelTests {
 
     // MARK: - Window labels
 
-    @Test("Each window has a distinct compact, long, and accessibility label")
+    @Test("Each window has full display, long, and accessibility labels")
     func windowLabels() {
-        #expect(LocalAIInsightWindow.last7days.displayName == "Last 7D")
-        // `.lastMonth` uses the honest rolling-window label "Last 30 days" (not
-        // "Last Month"): the deterministic summary sentence is built from
-        // `displayName`, while the segmented picker shows `longDisplayName`. They
-        // must agree, so the user never reads "Last Month: …" under a "Last 30
-        // days" control.
+        #expect(LocalAIInsightWindow.last7days.displayName == "Last 7 days")
         #expect(LocalAIInsightWindow.lastMonth.displayName == "Last 30 days")
-        #expect(LocalAIInsightWindow.yearOverYear.displayName == "YoY")
+        #expect(LocalAIInsightWindow.yearOverYear.displayName == "Year over year")
 
         #expect(LocalAIInsightWindow.last7days.longDisplayName == "Last 7 days")
         #expect(LocalAIInsightWindow.lastMonth.longDisplayName == "Last 30 days")
@@ -62,19 +57,20 @@ struct LocalAIInsightsModelTests {
         #expect(LocalAIInsightWindow.yearOverYear.accessibilityName == "Year over year")
     }
 
-    @Test("The summary-sentence label agrees with the picker label for .lastMonth")
-    func lastMonthSummaryAgreesWithPicker() {
+    @Test("Summary-sentence labels agree with picker labels for every window")
+    func summaryLabelsAgreeWithPickerLabels() {
         // Bug guard: the segmented control reads `longDisplayName` and the
-        // deterministic summary sentence reads `displayName`. For `.lastMonth`
-        // they must say the same thing so the period the user picks matches the
-        // period the summary names.
-        let window = LocalAIInsightWindow.lastMonth
-        #expect(window.displayName == window.longDisplayName)
+        // deterministic summary sentence reads `displayName`. They must say the
+        // same thing so the period the user picks matches the period the summary
+        // names across every local-AI insights window.
+        for window in LocalAIInsightWindow.allCases {
+            #expect(window.displayName == window.longDisplayName)
 
-        let input = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
-        let text = LocalAIDeterministicSummary.summaryText(for: input)
-        #expect(text.hasPrefix("\(window.longDisplayName):"))
-        #expect(!text.contains("Last Month"))
+            let input = Self.makeInput(window: window, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
+            let text = LocalAIDeterministicSummary.summaryText(for: input)
+            #expect(text.hasPrefix("\(window.longDisplayName):"))
+        }
+        #expect(!LocalAIDeterministicSummary.summaryText(for: Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)).contains("Last Month"))
 
         // SF Symbols pair text with a shape so the selector never rides on color
         // alone, and the three symbols are distinct.

--- a/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalInsightModelPromptTests.swift
@@ -125,17 +125,22 @@ struct LocalInsightModelPromptTests {
         #expect(!prompt.contains("Versus"))
     }
 
-    @Test("Comparison wording is window-aware (7d / 30d / YoY phrase differently)")
+    @Test("Comparison wording and period line are window-aware (7d / 30d / YoY phrase differently)")
     func windowAwareComparisonPhrasing() {
         let last7 = LocalInsightPromptBuilder.make(from: input(window: .last7days)).user
+        #expect(last7.contains("Period: Last 7 days"))
         #expect(last7.contains("Versus the prior 7 days"))
+        #expect(!last7.contains("Last 7D"))
         #expect(!last7.contains("a year ago"))
 
         let lastMonth = LocalInsightPromptBuilder.make(from: input(window: .lastMonth)).user
+        #expect(lastMonth.contains("Period: Last 30 days"))
         #expect(lastMonth.contains("Versus the prior 30 days"))
 
         let yoy = LocalInsightPromptBuilder.make(from: input(window: .yearOverYear)).user
+        #expect(yoy.contains("Period: Year over year"))
         #expect(yoy.contains("Versus the same period a year ago"))
+        #expect(!yoy.contains("YoY"))
         #expect(!yoy.contains("prior 30 days"))
         #expect(!yoy.contains("prior 7 days"))
     }


### PR DESCRIPTION
## Summary
- align `LocalAIInsightWindow.displayName` with `longDisplayName` for every insights window
- extend Local AI insight summary regression coverage to iterate all windows
- pin prompt period-line copy for Last 7 days / Last 30 days / Year over year and reject the old `Last 7D` / `YoY` drift

Fixes #720
Linear: AND-733
Kanban: t_a86ea658

## Verification
- `git diff --check` — passed
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarCore' complete!`)
- ad-hoc source invariant — passed (`labels/prompt/tests cover Last 7 days, Last 30 days, and Year over year without Last 7D/YoY drift`)

## Blocked broader/focused Swift test
- `swift test --filter LocalAIInsightsModelTests/windowLabels -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` fails before the filtered test executes due to unrelated app-target FoundationModels macro/plugin resolution errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found).
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` is blocked by unrelated `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152` redundant `#require` under warnings-as-errors.
