### PR TITLE
fix(local-ai): align insight window summary labels

### DIFF
--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -9,18 +9,17 @@ public enum LocalAIInsightWindow: String, Codable, Sendable, CaseIterable, Hasha
         rawValue
     }
 
-    /// Compact label for tight chrome (pills, evidence chips, prompt period line).
+    /// User-facing label for tight chrome (pills, evidence chips, prompt period line).
     ///
-    /// `.lastMonth` reads "Last 30 days" — the same honest rolling-window label the
-    /// segmented selector uses (`longDisplayName`) — not "Last Month". The
-    /// deterministic summary sentence is built from this label while the picker
-    /// shows `longDisplayName`; they must agree so the user never reads a "Last
-    /// Month: …" summary under a "Last 30 days" control.
+    /// These labels intentionally match `longDisplayName`. The deterministic
+    /// summary sentence is built from this label while the picker shows
+    /// `longDisplayName`; they must agree so the user never reads an abbreviated
+    /// summary headline under a full picker control.
     public var displayName: String {
         switch self {
-        case .last7days: "Last 7D"
+        case .last7days: "Last 7 days"
         case .lastMonth: "Last 30 days"
-        case .yearOverYear: "YoY"
+        case .yearOverYear: "Year over year"
         }
     }
 

--- a/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightsModelTests.swift
@@ -42,16 +42,14 @@ struct LocalAIInsightsModelTests {
 
     // MARK: - Window labels
 
-    @Test("Each window has a distinct compact, long, and accessibility label")
+    @Test("Each window has expected display, long, and accessibility labels")
     func windowLabels() {
-        #expect(LocalAIInsightWindow.last7days.displayName == "Last 7D")
-        // `.lastMonth` uses the honest rolling-window label "Last 30 days" (not
-        // "Last Month"): the deterministic summary sentence is built from
-        // `displayName`, while the segmented picker shows `longDisplayName`. They
-        // must agree, so the user never reads "Last Month: …" under a "Last 30
-        // days" control.
+        #expect(LocalAIInsightWindow.last7days.displayName == "Last 7 days")
+        // `displayName` feeds deterministic summary headlines, while the
+        // segmented picker shows `longDisplayName`. They must agree, so the user
+        // never reads an abbreviated summary under a full picker label.
         #expect(LocalAIInsightWindow.lastMonth.displayName == "Last 30 days")
-        #expect(LocalAIInsightWindow.yearOverYear.displayName == "YoY")
+        #expect(LocalAIInsightWindow.yearOverYear.displayName == "Year over year")
 
         #expect(LocalAIInsightWindow.last7days.longDisplayName == "Last 7 days")
         #expect(LocalAIInsightWindow.lastMonth.longDisplayName == "Last 30 days")
@@ -62,19 +60,23 @@ struct LocalAIInsightsModelTests {
         #expect(LocalAIInsightWindow.yearOverYear.accessibilityName == "Year over year")
     }
 
-    @Test("The summary-sentence label agrees with the picker label for .lastMonth")
-    func lastMonthSummaryAgreesWithPicker() {
+    @Test("The summary-sentence labels agree with picker labels for every window")
+    func summaryLabelsAgreeWithPickerForEveryWindow() {
         // Bug guard: the segmented control reads `longDisplayName` and the
-        // deterministic summary sentence reads `displayName`. For `.lastMonth`
-        // they must say the same thing so the period the user picks matches the
+        // deterministic summary sentence reads `displayName`. They must say the
+        // same thing for every window so the period the user picks matches the
         // period the summary names.
-        let window = LocalAIInsightWindow.lastMonth
-        #expect(window.displayName == window.longDisplayName)
+        for window in LocalAIInsightWindow.allCases {
+            #expect(window.displayName == window.longDisplayName)
 
-        let input = Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
-        let text = LocalAIDeterministicSummary.summaryText(for: input)
-        #expect(text.hasPrefix("\(window.longDisplayName):"))
-        #expect(!text.contains("Last Month"))
+            let input = Self.makeInput(window: window, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
+            let text = LocalAIDeterministicSummary.summaryText(for: input)
+            #expect(text.hasPrefix("\(window.longDisplayName):"))
+        }
+        let monthText = LocalAIDeterministicSummary.summaryText(
+            for: Self.makeInput(window: .lastMonth, expenseTotal: 1200, incomeTotal: 3000, net: 1800)
+        )
+        #expect(!monthText.contains("Last Month"))
 
         // SF Symbols pair text with a shape so the selector never rides on color
         // alone, and the three symbols are distinct.


### PR DESCRIPTION
## Summary
- Align LocalAIInsightWindow.displayName with longDisplayName for Last 7 days and Year over year
- Expand deterministic summary regression coverage across every insight window

Closes #720
Linear: AND-733

## Test plan
- PASS: git diff --check
- PASS: swift build --target PlaidBarCoreTests
- BLOCKED: swift test --filter LocalAIInsightsModelTests (unrelated local toolchain/package build failure: FoundationModels macro plugin not found while building PlaidBar app target)