### PR TITLE
fix(privacy): clear Review Inbox bulk dialog when masked

### DIFF
--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -168,6 +168,12 @@ struct ReviewInboxView: View {
                 // which rows resolve before confirming — never a bare count.
                 Text(plan.blastRadiusDescription())
             }
+            // Privacy Mask / App Lock can engage while the bulk confirmation is
+            // staged. The cached plan's dialog title/message include exact counts
+            // and blast-radius details, so drop it as soon as masking begins.
+            .onChange(of: appState.shouldMaskFinancialValues) { _, masked in
+                if masked { bulkReviewPlan = nil }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- clears a staged Review Inbox bulk-review confirmation when Privacy Mask/App Lock turns on
- matches the existing `ReviewTableWindow` privacy behavior so cached bulk count/blast-radius details cannot remain behind a masked placeholder

Fixes #723

Linear: AND-762

## Verification

- RED source invariant before fix: failed with `ReviewInboxView lacks mask-change clearing hook for bulkReviewPlan`
- `git diff --check` — passed
- source invariant after fix — passed (`ReviewInboxView clears staged bulk dialog on Privacy Mask/App Lock transition`)
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarCore' complete!`)

## Blocked broader gate

- `swift build --target PlaidBar -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` is blocked by unrelated app-target FoundationModels macro/plugin errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found) in `FoundationModelsIncomeCategorizer`, `FoundationModelsInsightModel`, and `FoundationModelsMerchantCategorizer`. The command reached compilation of `Sources/PlaidBar/Views/ReviewInboxView.swift`, but the target exits non-zero due to those unrelated macro failures.

## Privacy boundary

Local UI disclosure fix only. No Plaid secrets, provider tokens, account IDs, transaction IDs, balances, raw payloads, prompts, or response bodies were added to app/docs/tests.