### PR TITLE
refactor(core): consolidate transaction signed-amount text into Core

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift
@@ -392,9 +392,11 @@ struct TransactionInspectorView: View {
 
     // MARK: - Formatting
 
+    // The inspector withholds its entire body under Privacy Mask / App Lock
+    // (see `isMasked` / `maskedPlaceholder`), so the amount is only ever rendered
+    // unmasked here.
     private func amountText(_ row: TransactionWorkspace.Row) -> String {
-        let prefix = row.transaction.isIncome ? "+" : ""
-        return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
+        row.signedAmountText(isMasked: false)
     }
 
     private func statusColor(_ status: TransactionReviewStatus) -> Color {

--- a/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
+++ b/Sources/PlaidBar/Views/Destinations/TransactionsTable.swift
@@ -185,9 +185,7 @@ struct TransactionsTable: View {
     // MARK: - Formatting helpers
 
     private func amountText(_ row: TransactionWorkspace.Row) -> String {
-        if isMasked { return "••••" }
-        let prefix = row.transaction.isIncome ? "+" : ""
-        return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
+        row.signedAmountText(isMasked: isMasked)
     }
 
     private func amountColor(_ row: TransactionWorkspace.Row) -> Color {

--- a/Sources/PlaidBarCore/Utilities/TransactionWorkspace.swift
+++ b/Sources/PlaidBarCore/Utilities/TransactionWorkspace.swift
@@ -337,6 +337,17 @@ public extension TransactionWorkspace {
         public var hasNote: Bool {
             !(note?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         }
+
+        /// Signed, privacy-mask-aware amount string for the Amount column and the
+        /// inspector. Income carries a leading `+`; an outflow is unsigned. Withheld
+        /// under mask as the shared compact placeholder. Shared by `TransactionsTable`
+        /// and `TransactionInspectorView` (the inspector gates its whole body on the
+        /// mask separately, so it always calls this unmasked).
+        public func signedAmountText(isMasked: Bool) -> String {
+            if isMasked { return PrivacyMaskPresentation.compactValue }
+            let prefix = transaction.isIncome ? "+" : ""
+            return "\(prefix)\(Formatters.currency(transaction.displayAmount, format: .full))"
+        }
     }
 }
 

--- a/Tests/PlaidBarCoreTests/TransactionRowAmountTextTests.swift
+++ b/Tests/PlaidBarCoreTests/TransactionRowAmountTextTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import PlaidBarCore
+import Testing
+
+/// Pins the exact output of `TransactionWorkspace.Row.signedAmountText(isMasked:)`,
+/// extracted from byte-identical inline copies in `TransactionsTable` and
+/// `TransactionInspectorView`. The reference strings are composed from
+/// `Formatters.currency(_:format:)` (the repo convention for `.full` amounts,
+/// which keeps the assertion locale-robust) so the test guarantees the helper
+/// reproduces the prior inline expression exactly.
+@Suite("Transaction Row Amount Text")
+struct TransactionRowAmountTextTests {
+    private func tx(_ id: String, amount: Double) -> TransactionDTO {
+        TransactionDTO(
+            id: id,
+            accountId: "acc1",
+            amount: amount,
+            date: "2026-06-10",
+            name: "Coffee Shop",
+            merchantName: "Coffee Shop",
+            category: .foodAndDrink,
+            pending: false
+        )
+    }
+
+    private func row(amount: Double) -> TransactionWorkspace.Row {
+        let rows = TransactionWorkspace.rows(
+            transactions: [tx("a", amount: amount)],
+            metadata: [],
+            rules: []
+        )
+        return rows[0]
+    }
+
+    // The original inline expression, reproduced verbatim, as the behavior oracle.
+    private func reference(_ row: TransactionWorkspace.Row) -> String {
+        let prefix = row.transaction.isIncome ? "+" : ""
+        return "\(prefix)\(Formatters.currency(row.transaction.displayAmount, format: .full))"
+    }
+
+    @Test("An outflow renders unsigned at full precision")
+    func outflowIsUnsigned() {
+        let r = row(amount: 50) // Plaid: positive = money out
+        #expect(r.signedAmountText(isMasked: false) == Formatters.currency(50, format: .full))
+        #expect(r.signedAmountText(isMasked: false) == reference(r))
+        #expect(!r.signedAmountText(isMasked: false).hasPrefix("+"))
+    }
+
+    @Test("Income carries a leading plus over the unsigned magnitude")
+    func incomeIsSigned() {
+        let r = row(amount: -120) // Plaid: negative = money in
+        #expect(r.transaction.isIncome)
+        #expect(r.signedAmountText(isMasked: false) == "+\(Formatters.currency(120, format: .full))")
+        #expect(r.signedAmountText(isMasked: false) == reference(r))
+    }
+
+    @Test("Masking withholds the amount as the shared compact placeholder")
+    func maskedWithholdsAmount() {
+        let r = row(amount: 50)
+        #expect(r.signedAmountText(isMasked: true) == PrivacyMaskPresentation.compactValue)
+        #expect(r.signedAmountText(isMasked: true) == "••••")
+    }
+
+    @Test("Masking wins over the income sign")
+    func maskedIncomeStillWithheld() {
+        let r = row(amount: -120)
+        #expect(r.signedAmountText(isMasked: true) == PrivacyMaskPresentation.compactValue)
+    }
+
+    @Test("Helper reproduces the prior inline expression across signs")
+    func matchesReferenceAcrossSigns() {
+        // `-0.0` is intentional: IEEE-754 `-0.0 < 0` is false, so it resolves to an
+        // unsigned zero — both the helper and the oracle treat it identically.
+        for amount in [50.0, -120.0, 0.0, -0.0, 1_234.56, -9_999.99] {
+            let r = row(amount: amount)
+            #expect(r.signedAmountText(isMasked: false) == reference(r))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The Transaction Workspace's signed-amount string was spelled **byte-for-byte** in two SwiftUI views — `TransactionsTable.amountText` and `TransactionInspectorView.amountText` — each rebuilding `isIncome ? "+" : ""` + `Formatters.currency(displayAmount, format: .full)`, with the table also hardcoding the `"••••"` mask literal.
- `TransactionWorkspace.Row` already documents itself as *"shared by both the table column rendering and the inspector"* — the formatting belongs there. Added a pure `Row.signedAmountText(isMasked:)` to PlaidBarCore (mask placeholder via `PrivacyMaskPresentation.compactValue`, identical to the old literal) and routed both call sites.
- The inspector gates its whole body on the mask before the amount renders, so it calls the helper unmasked (`isMasked: false`) — behavior-preserving; documented inline.
- New Swift Testing suite pins the exact prior output via an oracle composed from the original inline expression (locale-robust per repo convention).

Behavior-preserving only; no product behavior changes.

## Autonomous task IDs

- Task ID(s): autonomous architecture-refactor pass (Step 14)
- Backlog slice: ongoing PlaidBarCore extraction (pure logic out of views) — follows #707/#719
- Scope note: one focused DRY extraction; the pre-existing non-USD currency-code gap in both originals is intentionally left unchanged (changing it would alter behavior).

## Agent coordination

- Builder agent: Claude (scheduled `vaultpeek-architecture-refactor`)
- Builder branch/worktree: `refactor/auto-2026-06-28` in an isolated `$TMPDIR` worktree off `origin/main`
- Reviewer/merge steward: Felipe / Otto
- Coordination note: review only — no other agent should push to this branch.

## Changed files

- `Sources/PlaidBarCore/Utilities/TransactionWorkspace.swift` — add pure `Row.signedAmountText(isMasked:)`
- `Sources/PlaidBar/Views/Destinations/TransactionsTable.swift` — route to Core
- `Sources/PlaidBar/Views/Destinations/TransactionInspectorView.swift` — route to Core (unmasked; body already mask-gated)
- `Tests/PlaidBarCoreTests/TransactionRowAmountTextTests.swift` — new suite pinning prior output

## Local gates

- [x] `git diff --check` (clean)
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (CI gate; clean, 62s)
- [x] Server/shared target builds (covered by the all-target strict build above)
- [x] `swift test` — full suite **2658 green** (incl. the flaky LocalInsight timeout test, passed this run)
- [x] Secret scan completed over the diff (no secrets; tests use synthetic fixtures only)

## Privacy and safety impact

- [x] Only synthetic fixtures used in tests; no real Plaid data.
- [x] No real credentials, tokens, account IDs, exports, or balances.
- [x] Preserves the local-first boundary — pure presentation refactor, no backend/telemetry/sync.
- [x] User-facing copy unchanged.

## Reviewer local-first and secret-exposure checklist

- [x] No real secrets/tokens/IDs/exports/balances introduced.
- [x] No new status/diagnostic/logging surfaces; mask handling preserved (placeholder unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)