### PR TITLE
fix(privacy): mask account pending counts

### DIFF
--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -99,7 +99,7 @@ public enum AccountPresentation {
         privacyMaskEnabled: Bool = false
     ) -> String {
         let mask = account.mask.map { privacyMaskEnabled ? " ••••" : " •••• \($0)" } ?? ""
-        let pending = pendingCount > 0 ? " • \(pendingCount) pending" : ""
+        let pending = pendingCount > 0 && !privacyMaskEnabled ? " • \(pendingCount) pending" : ""
         return "\(account.institutionName ?? account.type.rawValue.capitalized)\(mask) • \(connectionLabel)\(pending)"
     }
 
@@ -252,7 +252,7 @@ public enum AccountPresentation {
             components.append(connectionLabel)
         }
 
-        if pendingCount > 0 {
+        if pendingCount > 0 && !privacyMaskEnabled {
             components.append("\(pendingCount) pending transaction\(pendingCount == 1 ? "" : "s")")
         }
 

--- a/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/PrivacyMaskPresentationTests.swift
@@ -45,6 +45,7 @@ struct PrivacyMaskPresentationTests {
         #expect(AccountPresentation.dashboardRowSubtitle(
             for: account,
             connectionLabel: "Synced",
+            pendingCount: 3,
             privacyMaskEnabled: true
         ) == "Credit •••• • Synced")
         #expect(AccountPresentation.dashboardTrailingDetailText(
@@ -61,6 +62,7 @@ struct PrivacyMaskPresentationTests {
             for: account,
             amountText: "$1,250.00",
             connectionLabel: "Synced",
+            pendingCount: 3,
             privacyMaskEnabled: true
         )
         #expect(label.contains("Ending in 1234") == false)
@@ -71,6 +73,8 @@ struct PrivacyMaskPresentationTests {
         #expect(label.contains("Good") == false)
         #expect(label.contains("Warning") == false)
         #expect(label.contains("High") == false)
+        #expect(label.contains("3 pending") == false)
+        #expect(label.contains("pending transaction") == false)
     }
 
     @Test("Menu bar privacy mask preserves non-sensitive empty states")


### PR DESCRIPTION
## Summary

- Gate account-row pending-count copy on `!privacyMaskEnabled` in Core presentation.
- Add masked-mode regression coverage so visible subtitle and VoiceOver label withhold exact pending counts.

Fixes #726
Linear: AND-763
Kanban: t_eeacb58e

## Verification

- `git diff --check` — passed.
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed.
- Ad-hoc verification script `/var/folders/lk/g3jh81xn5mjc9mrv_bq640wr0000gn/T/hermes-verify-vaultpeek-pending-mask-zifwvung.py` — passed and was removed; checked the source/test privacy invariants plus `git diff --check`.

## Blocked broader gates

- `swift test --filter PrivacyMaskPresentationTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` did not reach the focused test because the app target fails first: `FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found in `Sources/PlaidBar/Services/FoundationModels*`.
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` compiled the touched tests but failed on an unrelated strict-concurrency/test macro warning in `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152`: redundant `#require` because `summary.remaining` is non-optional.
