### PR TITLE
fix(demo): seed goals fixtures

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -2786,6 +2786,11 @@ final class AppState {
             // only; restore the user's real saved watchlist (or empty) so demo
             // Starbucks/Shopping targets never fire against real data.
             loadWatchlistTargets(defaults: .standard)
+            // Same for goals: loadDemoData() installs synthetic savings goals in
+            // the shared GoalsStore and marks it loaded. Restore/reload the user's
+            // local-first goals before the real flow can render or persist through
+            // the Goals workspace.
+            await goalsStore.restoreAfterDemo()
             // Demo fixtures may have been published to the shared App Group before
             // the demo guards landed, or by an older build; wipe both the glance and
             // finance snapshots (and the Spotlight account index) on demo exit so a

--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -4590,6 +4590,7 @@ final class AppState {
             DemoFixtures.demoBudgets().map { ($0.category, $0.monthlyLimit) },
             uniquingKeysWith: { first, _ in first }
         )
+        goalsStore.loadDemoGoals(DemoFixtures.demoGoals())
         balanceHistory = DemoFixtures.balanceHistory()
         // Seed demo watchlist nudges (AND-501) so the Settings Watchlists section
         // is populated and the evaluator fires against the demo transactions.

--- a/Sources/PlaidBar/Services/GoalsStore.swift
+++ b/Sources/PlaidBar/Services/GoalsStore.swift
@@ -67,6 +67,15 @@ final class GoalsStore {
         hasLoaded = true
     }
 
+    /// Replaces the in-memory list with synthetic demo fixtures without touching
+    /// the user's persisted `goals.json`. Demo mode should be useful on a clean
+    /// machine, but it must never overwrite local-first user data.
+    func loadDemoGoals(_ demoGoals: [Goal]) {
+        goals = Self.sortedForDisplay(demoGoals)
+        errorMessage = nil
+        hasLoaded = true
+    }
+
     // MARK: - CRUD (each mutation persists)
 
     /// Adds a new goal and persists. Returns the stored goal (with its id).

--- a/Sources/PlaidBar/Services/GoalsStore.swift
+++ b/Sources/PlaidBar/Services/GoalsStore.swift
@@ -31,6 +31,14 @@ final class GoalsStore {
 
     private let cache: LocalDataCacheService
     private let directoryProvider: @MainActor () -> URL
+    private var preDemoSnapshot: GoalsSnapshot?
+    private var isShowingDemoGoals = false
+
+    private struct GoalsSnapshot {
+        let goals: [Goal]
+        let hasLoaded: Bool
+        let errorMessage: String?
+    }
 
     /// - Parameters:
     ///   - cache: the local JSON cache actor. Default constructs its own so the
@@ -71,9 +79,43 @@ final class GoalsStore {
     /// the user's persisted `goals.json`. Demo mode should be useful on a clean
     /// machine, but it must never overwrite local-first user data.
     func loadDemoGoals(_ demoGoals: [Goal]) {
+        if preDemoSnapshot == nil {
+            preDemoSnapshot = GoalsSnapshot(
+                goals: goals,
+                hasLoaded: hasLoaded,
+                errorMessage: errorMessage
+            )
+        }
+        isShowingDemoGoals = true
         goals = Self.sortedForDisplay(demoGoals)
         errorMessage = nil
         hasLoaded = true
+    }
+
+    /// Restores the real local-first goals after leaving demo mode. If goals had
+    /// already loaded before demo entry, restore that in-memory snapshot; otherwise
+    /// reload from disk so the demo fixture list cannot keep `loadIfNeeded()` from
+    /// reaching the user's saved `goals.json`.
+    func restoreAfterDemo() async {
+        let snapshot = preDemoSnapshot
+        preDemoSnapshot = nil
+        isShowingDemoGoals = false
+        guard let snapshot else {
+            hasLoaded = false
+            await reload()
+            return
+        }
+
+        if snapshot.hasLoaded {
+            goals = snapshot.goals
+            hasLoaded = true
+            errorMessage = snapshot.errorMessage
+        } else {
+            goals = []
+            errorMessage = nil
+            hasLoaded = false
+            await reload()
+        }
     }
 
     // MARK: - CRUD (each mutation persists)
@@ -111,6 +153,11 @@ final class GoalsStore {
     // MARK: - Persistence
 
     private func persist() async {
+        guard !isShowingDemoGoals else {
+            errorMessage = nil
+            return
+        }
+
         let snapshot = goals
         let directory = directoryProvider()
         do {

--- a/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
@@ -18,9 +18,7 @@ import SwiftUI
 ///
 /// When there are **no goals**, it shows a quiet "set a savings goal" empty
 /// affordance with an Open Goals action rather than self-hiding, so the dashboard
-/// grid keeps a uniform card rather than a hole and offers a next step. (Note:
-/// `--demo` seeds no goals today — AND-732 — so the demo render shows this empty
-/// state, which is expected.)
+/// grid keeps a uniform card rather than a hole and offers a next step.
 ///
 /// Progress is always carried by **text + the bar**, never color alone
 /// (ACCESSIBILITY.md); amounts honor Privacy Mask (`PrivacyMaskPresentation`).

--- a/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
+++ b/Sources/PlaidBarCore/Utilities/DemoFixtures.swift
@@ -176,6 +176,52 @@ public enum DemoFixtures {
         ]
     }
 
+    /// Synthetic savings goals so `--demo` shows the Goals destination and
+    /// Dashboard goals card as a populated, evaluable surface instead of a
+    /// first-run empty prompt (AND-732). These are in-memory fixtures only; they
+    /// never touch Plaid or the user's persisted `goals.json`.
+    public static func demoGoals(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [Goal] {
+        func daysFromNow(_ days: Int) -> Date {
+            calendar.date(byAdding: .day, value: days, to: now) ?? now
+        }
+        func daysAgo(_ days: Int) -> Date {
+            calendar.date(byAdding: .day, value: -days, to: now) ?? now
+        }
+
+        return [
+            Goal(
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000B1")!,
+                name: "Emergency fund",
+                targetAmount: 12_000,
+                targetDate: daysFromNow(180),
+                linkedCategory: .billsAndUtilities,
+                contributedAmount: 4_800,
+                createdAt: daysAgo(90)
+            ),
+            Goal(
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000B2")!,
+                name: "Tahoe weekend",
+                targetAmount: 1_200,
+                targetDate: daysFromNow(45),
+                linkedCategory: .travel,
+                contributedAmount: 950,
+                createdAt: daysAgo(30)
+            ),
+            Goal(
+                id: UUID(uuidString: "00000000-0000-0000-0000-0000000000B3")!,
+                name: "New laptop",
+                targetAmount: 2_500,
+                targetDate: daysFromNow(120),
+                linkedCategory: .shopping,
+                contributedAmount: 700,
+                createdAt: daysAgo(60)
+            ),
+        ]
+    }
+
     /// Current-month-anchored spend rows used **only** to score `demoBudgets`
     /// against `CategoryBudgetPlanner` in `--demo`.
     ///

--- a/Tests/PlaidBarCoreTests/DemoReviewBudgetContinuityTests.swift
+++ b/Tests/PlaidBarCoreTests/DemoReviewBudgetContinuityTests.swift
@@ -46,6 +46,22 @@ struct DemoReviewBudgetContinuityTests {
 
     // MARK: - Dashboard builds over the real demo fixtures
 
+    /// Demo mode must populate the goals surfaces, not just the Plaid-derived
+    /// dashboard fixtures. The fixtures stay Core-local and synthetic, then
+    /// `AppState.loadDemoData` loads them into the app-local `GoalsStore` without
+    /// persisting over real user goals.
+    @Test("Demo fixtures provide savings goals for dashboard and Goals workspace")
+    func demoFixturesProvideGoals() {
+        let goals = DemoFixtures.demoGoals(now: referenceDate, calendar: calendar)
+        let preview = DashboardGoalsPreview.make(from: goals, asOf: referenceDate)
+
+        #expect(goals.count >= 3, "demo goals should populate the full goals surface")
+        #expect(!preview.isEmpty, "demo dashboard goals preview should not be empty")
+        #expect(preview.goals.count == min(goals.count, DashboardGoalsPreview.defaultLimit))
+        #expect(Set(goals.map(\.id)).count == goals.count, "demo goal ids must be stable and unique")
+        #expect(goals.allSatisfy { $0.targetAmount > 0 && $0.contributedAmount > 0 })
+    }
+
     /// The Category Dashboard card / window builds its rollup from the main demo
     /// transactions (where the seeded overrides live) plus the seeded budgets,
     /// metadata, and rules. It must be non-empty and internally consistent so the

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1493,6 +1493,26 @@ struct PlaidBarTests {
         #expect(card.contains("Set a savings goal"))
         #expect(card.contains("Open Goals"))
     }
+
+    @Test("Demo goals never persist over real local-first goals")
+    func demoGoalsStayInMemoryOnlyAndRestoreOnExit() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let appState = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/App/AppState.swift"),
+            encoding: .utf8
+        )
+        let store = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Services/GoalsStore.swift"),
+            encoding: .utf8
+        )
+
+        #expect(store.contains("private var preDemoSnapshot: GoalsSnapshot?"))
+        #expect(store.contains("private var isShowingDemoGoals = false"))
+        #expect(store.contains("func restoreAfterDemo() async"))
+        #expect(store.contains("guard !isShowingDemoGoals else"))
+        #expect(appState.contains("goalsStore.loadDemoGoals(DemoFixtures.demoGoals())"))
+        #expect(appState.contains("await goalsStore.restoreAfterDemo()"))
+    }
 }
 
 /// Deterministic `FMMerchantCategorizing` stub for the categorization-tier tests.


### PR DESCRIPTION
## Summary

- adds synthetic `DemoFixtures.demoGoals` fixtures for clean-machine demo mode
- loads those goals into `GoalsStore` in memory during `AppState.loadDemoData()` without touching persisted `goals.json`
- adds a Core continuity test proving demo goals populate the Dashboard/Goals preview path

Fixes #728. Linear: AND-732.

## Verification

- `git diff --check` — passed
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarCore' complete!`)
- `swift test --filter DemoReviewBudgetContinuityTests.demoFixturesProvideGoals -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked before test execution by existing app-target FoundationModels macro/plugin resolution errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found)
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by an unrelated existing strict Swift Testing diagnostic in `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152` (`#require` redundant)
- source-invariant check — confirmed `demoGoals` exists, app demo mode calls `goalsStore.loadDemoGoals(DemoFixtures.demoGoals())`, `loadDemoGoals` does not call `cache.saveGoals`, and the stale comment saying demo seeds no goals is removed

## Privacy / local-first

All new data is synthetic demo fixture content. The demo load path is in-memory only and does not send Plaid data, call cloud AI, or overwrite the user's local persisted goals.