### PR TITLE
fix(privacy): mask Dashboard Goals metadata

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
@@ -140,7 +140,9 @@ private struct DashboardGoalRow: View {
                     .windowSupportingText()
                     .lineLimit(1)
                 Spacer(minLength: WindowMetrics.sm)
-                paceLabel
+                if !isMasked {
+                    paceLabel
+                }
             }
         }
         .accessibilityElement(children: .ignore)
@@ -177,11 +179,13 @@ private struct DashboardGoalRow: View {
     private var accessibilityLabel: String {
         var parts = ["\(title), \(percent(goal.percentComplete)) funded"]
         parts.append("\(currency(goal.contributedAmount)) of \(currency(goal.targetAmount))")
-        if goal.isComplete {
-            parts.append("Funded")
-        } else {
-            let pace = goal.pace(asOf: Date())
-            if pace != .noDeadline { parts.append(pace.label) }
+        if !isMasked {
+            if goal.isComplete {
+                parts.append("Funded")
+            } else {
+                let pace = goal.pace(asOf: Date())
+                if pace != .noDeadline { parts.append(pace.label) }
+            }
         }
         return parts.joined(separator: ". ")
     }

--- a/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
@@ -48,9 +48,9 @@ struct DashboardGoalsCard: View {
                     ForEach(preview.goals) { goal in
                         DashboardGoalRow(goal: goal, isMasked: isMasked)
                     }
-                    if let overflow = preview.overflowLabel {
+                    if let overflow = preview.displayOverflowLabel(isMasked: isMasked) {
                         Button(action: onOpen) {
-                            Text("+ \(overflow)")
+                            Text(isMasked ? overflow : "+ \(overflow)")
                                 .windowSupportingText()
                         }
                         .buttonStyle(.plain)
@@ -123,7 +123,7 @@ private struct DashboardGoalRow: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 20)
                     .accessibilityHidden(true)
-                Text(goal.name)
+                Text(title)
                     .windowCardTitle()
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
@@ -175,7 +175,7 @@ private struct DashboardGoalRow: View {
     }
 
     private var accessibilityLabel: String {
-        var parts = ["\(goal.name), \(percent(goal.percentComplete)) funded"]
+        var parts = ["\(title), \(percent(goal.percentComplete)) funded"]
         parts.append("\(currency(goal.contributedAmount)) of \(currency(goal.targetAmount))")
         if goal.isComplete {
             parts.append("Funded")
@@ -184,6 +184,10 @@ private struct DashboardGoalRow: View {
             if pace != .noDeadline { parts.append(pace.label) }
         }
         return parts.joined(separator: ". ")
+    }
+
+    private var title: String {
+        DashboardGoalsPreview.displayTitle(for: goal, isMasked: isMasked)
     }
 
     private func currency(_ amount: Double) -> String {

--- a/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardGoalsCard.swift
@@ -118,7 +118,7 @@ private struct DashboardGoalRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.sm) {
-                Image(systemName: goal.linkedCategory?.iconName ?? "flag.fill")
+                Image(systemName: DashboardGoalsPreview.displayIconName(for: goal, isMasked: isMasked))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .frame(width: 20)

--- a/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
+++ b/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
@@ -45,6 +45,11 @@ public struct DashboardGoalsPreview: Sendable, Equatable {
     /// dashboard must not render them while masked.
     public static let maskedGoalTitle = "Goal hidden"
 
+    /// Generic goal icon used while Privacy Mask is active. A linked category icon
+    /// can reveal goal intent (for example travel, medical, or home), so masked
+    /// dashboard rows keep a neutral flag glyph.
+    public static let maskedGoalIconName = "flag.fill"
+
     /// Generic overflow copy used while Privacy Mask is active. The exact hidden
     /// goal count is metadata, so the dashboard keeps the route affordance without
     /// exposing `overflowCount`.
@@ -53,6 +58,11 @@ public struct DashboardGoalsPreview: Sendable, Equatable {
     /// Dashboard-safe title copy for a featured goal.
     public static func displayTitle(for goal: Goal, isMasked: Bool) -> String {
         isMasked ? maskedGoalTitle : goal.name
+    }
+
+    /// Dashboard-safe SF Symbol for a featured goal.
+    public static func displayIconName(for goal: Goal, isMasked: Bool) -> String {
+        isMasked ? maskedGoalIconName : (goal.linkedCategory?.iconName ?? maskedGoalIconName)
     }
 
     /// Dashboard-safe overflow copy. Unmasked copy preserves the existing

--- a/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
+++ b/Sources/PlaidBarCore/Models/DashboardGoalsPreview.swift
@@ -40,6 +40,28 @@ public struct DashboardGoalsPreview: Sendable, Equatable {
         return overflowCount == 1 ? "1 more goal" : "\(overflowCount) more goals"
     }
 
+    /// Generic goal title used while Privacy Mask is active. Goal names can carry
+    /// real-world plan metadata ("House down payment", "Medical fund"), so the
+    /// dashboard must not render them while masked.
+    public static let maskedGoalTitle = "Goal hidden"
+
+    /// Generic overflow copy used while Privacy Mask is active. The exact hidden
+    /// goal count is metadata, so the dashboard keeps the route affordance without
+    /// exposing `overflowCount`.
+    public static let maskedOverflowLabel = "More goals"
+
+    /// Dashboard-safe title copy for a featured goal.
+    public static func displayTitle(for goal: Goal, isMasked: Bool) -> String {
+        isMasked ? maskedGoalTitle : goal.name
+    }
+
+    /// Dashboard-safe overflow copy. Unmasked copy preserves the existing
+    /// pluralized "+N more" semantics; masked copy withholds the exact count.
+    public func displayOverflowLabel(isMasked: Bool) -> String? {
+        guard overflowCount > 0 else { return nil }
+        return isMasked ? Self.maskedOverflowLabel : overflowLabel
+    }
+
     /// The default number of goals the dashboard features.
     public static let defaultLimit = 3
 

--- a/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
@@ -65,4 +65,15 @@ struct DashboardGoalsPreviewTests {
         let none = DashboardGoalsPreview(goals: [], totalGoalCount: 0, overflowCount: 0)
         #expect(none.overflowLabel == nil)
     }
+
+    @Test("Privacy Mask withholds dashboard goal names and exact overflow counts")
+    func privacyMaskWithholdsMetadata() {
+        let goal = Goal(name: "Emergency Fund", targetAmount: 1000, contributedAmount: 500, createdAt: base)
+        let preview = DashboardGoalsPreview(goals: [goal], totalGoalCount: 4, overflowCount: 3)
+
+        #expect(DashboardGoalsPreview.displayTitle(for: goal, isMasked: false) == "Emergency Fund")
+        #expect(DashboardGoalsPreview.displayTitle(for: goal, isMasked: true) == "Goal hidden")
+        #expect(preview.displayOverflowLabel(isMasked: false) == "3 more goals")
+        #expect(preview.displayOverflowLabel(isMasked: true) == "More goals")
+    }
 }

--- a/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
+++ b/Tests/PlaidBarCoreTests/DashboardGoalsPreviewTests.swift
@@ -66,13 +66,21 @@ struct DashboardGoalsPreviewTests {
         #expect(none.overflowLabel == nil)
     }
 
-    @Test("Privacy Mask withholds dashboard goal names and exact overflow counts")
+    @Test("Privacy Mask withholds dashboard goal names, linked category icons, and exact overflow counts")
     func privacyMaskWithholdsMetadata() {
-        let goal = Goal(name: "Emergency Fund", targetAmount: 1000, contributedAmount: 500, createdAt: base)
+        let goal = Goal(
+            name: "Emergency Fund",
+            targetAmount: 1000,
+            linkedCategory: .healthAndFitness,
+            contributedAmount: 500,
+            createdAt: base
+        )
         let preview = DashboardGoalsPreview(goals: [goal], totalGoalCount: 4, overflowCount: 3)
 
         #expect(DashboardGoalsPreview.displayTitle(for: goal, isMasked: false) == "Emergency Fund")
         #expect(DashboardGoalsPreview.displayTitle(for: goal, isMasked: true) == "Goal hidden")
+        #expect(DashboardGoalsPreview.displayIconName(for: goal, isMasked: false) == SpendingCategory.healthAndFitness.iconName)
+        #expect(DashboardGoalsPreview.displayIconName(for: goal, isMasked: true) == "flag.fill")
         #expect(preview.displayOverflowLabel(isMasked: false) == "3 more goals")
         #expect(preview.displayOverflowLabel(isMasked: true) == "More goals")
     }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1489,6 +1489,13 @@ struct PlaidBarTests {
         #expect(card.contains("percent(goal.percentComplete)"))
         #expect(card.contains("isMasked: isMasked"))
 
+        // Masking also suppresses derived pace/status metadata. A goal being
+        // funded/behind pace is computed from private target/contributed amounts
+        // and dates, so visible and VoiceOver strings must not keep appending it
+        // after the mask turns on.
+        #expect(card.contains("if !isMasked {\n                    paceLabel\n                }"))
+        #expect(card.contains("if !isMasked {\n            if goal.isComplete {"))
+
         // An empty goal list shows the quiet affordance, not a blank/broken card.
         #expect(card.contains("Set a savings goal"))
         #expect(card.contains("Open Goals"))


### PR DESCRIPTION
## Summary
- masks Dashboard Goals row titles while Privacy Mask/App Lock masking is active using Core presentation helpers
- replaces exact masked overflow counts with count-free `More goals` while preserving unmasked `N more goals`
- adds focused Core regression coverage for masked dashboard goal titles and overflow labels

Fixes #730
Linear: AND-971
Kanban: t_c4f9ce4a

## Verification
- `git diff --check` — pass
- `swift build --target PlaidBarCore` — pass (`Build of target: 'PlaidBarCore' complete!`)
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked by unrelated existing strict test helper error in `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152` (`#require` redundant because `summary.remaining` is non-optional)
- `swift test --filter DashboardGoalsPreviewTests/privacyMaskWithholdsMetadata` — blocked before execution by unrelated app-target FoundationModels macro/plugin errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found)

## Risk
- Scoped to Dashboard Goals presentation and Core copy helpers only.
- Does not touch Plaid/server/token storage or any cloud/private-data flow.
