### PR TITLE
fix(privacy): mask recurring row details

### DIFF
--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -168,10 +168,16 @@ private struct RecurringObligationRow: View {
     private var merchantNameLabel: some View {
         switch scale {
         case .popover:
-            Text(item.merchantName).font(.subheadline)
+            Text(displayMerchantName).font(.subheadline)
         case .window:
-            Text(item.merchantName).windowBodyText()
+            Text(displayMerchantName).windowBodyText()
         }
+    }
+
+    private var displayMerchantName: String {
+        privacyMaskEnabled
+            ? StrongMaskFormatter.merchantName(item.merchantName)
+            : item.merchantName
     }
 
     /// Expected amount — popover `.subheadline` semibold, window tabular
@@ -191,13 +197,19 @@ private struct RecurringObligationRow: View {
     /// `windowFigureCaption` so the sub-label reads at the window's caption scale.
     @ViewBuilder
     private var detailLabel: some View {
-        let text = "\(item.frequency.displayName) · next \(Formatters.displayTransactionDate(item.nextExpectedDate))"
+        let text = "\(item.frequency.displayName) · next \(displayNextExpectedDate)"
         switch scale {
         case .popover:
             Text(text).microText()
         case .window:
             Text(text).windowFigureCaption()
         }
+    }
+
+    private var displayNextExpectedDate: String {
+        privacyMaskEnabled
+            ? StrongMaskFormatter.date(item.nextExpectedDate)
+            : Formatters.displayTransactionDate(item.nextExpectedDate)
     }
 
     /// Deterministic flag order so badges don't reshuffle between renders.
@@ -207,10 +219,10 @@ private struct RecurringObligationRow: View {
 
     private var accessibilityLabel: String {
         var parts = [
-            item.merchantName,
+            displayMerchantName,
             item.frequency.displayName,
             "expected \(PrivacyMaskPresentation.currency(item.expectedAmount, format: .full, isEnabled: privacyMaskEnabled))",
-            "next \(Formatters.displayTransactionDate(item.nextExpectedDate))",
+            "next \(displayNextExpectedDate)",
         ]
         parts.append(contentsOf: orderedFlags.map(\.accessibilityDescription))
         if item.confidenceLevel == .low { parts.append("low confidence") }

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1148,6 +1148,26 @@ struct PlaidBarTests {
         #expect(cache.count == 2, "no eviction when every cached id is still in the inbox")
     }
 
+    // MARK: - Recurring obligations Privacy Mask source invariants
+
+    @Test("Recurring obligations mask merchant and due-date detail copy while private")
+    func recurringObligationsMaskMerchantAndDueDateCopy() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let recurringSource = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/RecurringObligationsSection.swift"),
+            encoding: .utf8
+        )
+
+        #expect(recurringSource.contains("private var displayMerchantName: String"))
+        #expect(recurringSource.contains("StrongMaskFormatter.merchantName(item.merchantName)"))
+        #expect(recurringSource.contains("Text(displayMerchantName)"))
+        #expect(recurringSource.contains("private var displayNextExpectedDate: String"))
+        #expect(recurringSource.contains("StrongMaskFormatter.date(item.nextExpectedDate)"))
+        #expect(recurringSource.contains("let text = \"\\(item.frequency.displayName) · next \\(displayNextExpectedDate)\""))
+        #expect(recurringSource.contains("displayMerchantName,\n            item.frequency.displayName"))
+        #expect(recurringSource.contains("\"next \\(displayNextExpectedDate)\""))
+    }
+
     // MARK: - Window-scale shared sub-components + unified search (AND-625)
 
     /// Source-invariant guard for AND-625 part (1): the shared sub-components that


### PR DESCRIPTION
## Summary

- masks recurring row merchant names via `StrongMaskFormatter.merchantName` when Privacy Mask/App Lock is active
- masks recurring row next expected dates via `StrongMaskFormatter.date` when private
- reuses the masked merchant/date strings in the row accessibility label so VoiceOver does not expose the real details
- adds a source-invariant regression guard for the app-target recurring row privacy seam

Fixes #732

Linear: AND-972

## Verification

- `git diff --check`
- `python3` source invariant: `source invariant OK: recurring visible and accessibility merchant/date paths use StrongMaskFormatter while private`
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → `Build of target: 'PlaidBarCore' complete!`

Blocked canonical focused test:

- `swift test --filter recurringObligationsMaskMerchantAndDueDateCopy -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` failed before the filtered test executed because the current toolchain cannot load `FoundationModelsMacros.GenerableMacro` / `GuideMacro` for unrelated app-target FoundationModels categorizer/insight files. The command reached app-target compilation and compiled `PlaidBar RecurringObligationsSection.swift` before failing in those unrelated macro-backed files.

## Privacy / security

Local UI/VoiceOver disclosure only. This change does not move Plaid credentials, access tokens, public tokens, raw Plaid payloads, account IDs, transaction IDs, balances, SQLite data, prompts, or response bodies into the app/docs/tests/artifacts.
