### PR TITLE
test(core): fix strict rounding test gate

### DIFF
--- a/Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift
+++ b/Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift
@@ -149,9 +149,10 @@ struct RoundingConsistencyTests {
             totalLimit: 1_000.00
         )
 
-        let remaining = try? #require(summary.remaining)
-        #expect(remaining != nil)
-        guard let remaining else { return }
+        guard let remaining = summary.remaining else {
+            Issue.record("Expected budgeted summary to expose a remaining amount")
+            return
+        }
         #expect(abs(remaining - 247.79) < 0.0001)
         #expect(!summary.isAggregateOver)
 


### PR DESCRIPTION
## Summary

- Fixes the strict Swift Testing macro failure in `RoundingConsistencyTests` by replacing the redundant `try? #require(summary.remaining)` with an explicit optional guard and `Issue.record` failure path.
- Keeps the rounding regression assertion behavior unchanged while allowing `PlaidBarCoreTests` to compile under warnings-as-errors.

Fixes #734
Linear: AND-973
Kanban: t_843e905c

## Verification

- `git diff --check`
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` → passed (`Build of target: 'PlaidBarCoreTests' complete!`, exit 0)

## Broader gate note

- `swift test --filter RoundingConsistencyTests` is still blocked before test execution by the existing app-target FoundationModels macro/plugin issue (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found in `Sources/PlaidBar/Services/FoundationModels*`). This is unrelated to the touched Core test file and matches the known filtered app-target SwiftPM blocker pattern.
