### PR TITLE
refactor(core): consolidate Local AI receipt provenance lines into Core

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift
@@ -65,7 +65,7 @@ struct DashboardLocalInsightCard: View {
                 }
 
                 VStack(alignment: .leading, spacing: WindowMetrics.xs) {
-                    ForEach(Array(detailLines(receipt).enumerated()), id: \.offset) { _, detail in
+                    ForEach(Array(receipt.detailLines.enumerated()), id: \.offset) { _, detail in
                         HStack(alignment: .top, spacing: WindowMetrics.sm) {
                             Image(systemName: "circle.fill")
                                 .font(.system(size: 5))
@@ -118,15 +118,6 @@ struct DashboardLocalInsightCard: View {
         case .disabled, .checking: AppearanceTextColors.secondary
         case .unavailable: SemanticColors.warning
         }
-    }
-
-    private func detailLines(_ receipt: LocalAIInsightReceipt) -> [String] {
-        var lines = [receipt.confidence]
-        if let unavailableState = receipt.unavailableState {
-            lines.append(unavailableState)
-        }
-        lines.append(contentsOf: receipt.limitations.prefix(2))
-        return Array(lines.prefix(3))
     }
 
     private func evidenceChip(_ chip: LocalAIInsightReceipt.EvidenceChip) -> some View {

--- a/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift
@@ -367,7 +367,7 @@ struct InsightsAIInsightView: View {
         VStack(alignment: .leading, spacing: WindowMetrics.xs) {
             provenanceBullet(receipt.confidence)
 
-            if !secondaryProvenanceLines.isEmpty {
+            if !receipt.secondaryProvenanceLines.isEmpty {
                 Button {
                     withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
                         showProvenanceDetails.toggle()
@@ -388,7 +388,7 @@ struct InsightsAIInsightView: View {
 
                 if showProvenanceDetails {
                     VStack(alignment: .leading, spacing: WindowMetrics.xs) {
-                        ForEach(Array(secondaryProvenanceLines.enumerated()), id: \.offset) { _, line in
+                        ForEach(Array(receipt.secondaryProvenanceLines.enumerated()), id: \.offset) { _, line in
                             provenanceBullet(line)
                         }
                     }
@@ -410,17 +410,6 @@ struct InsightsAIInsightView: View {
                 .windowSupportingText()
                 .fixedSize(horizontal: false, vertical: true)
         }
-    }
-
-    /// The collapsible secondary lines: the runtime-unavailable note and up to two
-    /// limitations. Excludes the always-visible confidence cue.
-    private var secondaryProvenanceLines: [String] {
-        var lines: [String] = []
-        if let unavailableState = receipt.unavailableState {
-            lines.append(unavailableState)
-        }
-        lines.append(contentsOf: receipt.limitations.prefix(2))
-        return Array(lines.prefix(3))
     }
 
     private var footer: some View {

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1300,7 +1300,7 @@ private struct LocalInsightsCard: View {
             }
 
             VStack(alignment: .leading, spacing: 3) {
-                ForEach(Array(receiptDetailLines.enumerated()), id: \.offset) { _, detail in
+                ForEach(Array(receipt.detailLines.enumerated()), id: \.offset) { _, detail in
                     HStack(alignment: .top, spacing: 6) {
                         Circle()
                             .fill(Color.secondary.opacity(0.58))
@@ -1343,15 +1343,6 @@ private struct LocalInsightsCard: View {
         .glassSurface(.inset)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(receipt.accessibilitySummary)
-    }
-
-    private var receiptDetailLines: [String] {
-        var lines = [receipt.confidence]
-        if let unavailableState = receipt.unavailableState {
-            lines.append(unavailableState)
-        }
-        lines.append(contentsOf: receipt.limitations.prefix(2))
-        return Array(lines.prefix(3))
     }
 
     private var footerText: String {

--- a/Sources/PlaidBarCore/Models/LocalAIInsights.swift
+++ b/Sources/PlaidBarCore/Models/LocalAIInsights.swift
@@ -373,6 +373,36 @@ public struct LocalAIInsightReceipt: Equatable, Sendable {
         self.accessibilitySummary = accessibilitySummary
     }
 
+    /// The provenance detail lines rendered beneath a receipt on the compact
+    /// glance surfaces (the Dashboard insight card and the menu-bar popover):
+    /// the confidence cue first, then the runtime-unavailable note when present,
+    /// then up to two limitations — the whole list capped at three lines. Pure
+    /// presentation over the receipt's own fields; the receipt is built
+    /// already-masked upstream, so this is mask-agnostic.
+    public var detailLines: [String] {
+        var lines = [confidence]
+        if let unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
+    /// The collapsible *secondary* provenance lines used where the confidence
+    /// cue is rendered separately (the Insights AI surface): the
+    /// runtime-unavailable note when present, then up to two limitations, capped
+    /// at three. Distinct from ``detailLines`` — here the three-line cap
+    /// excludes the confidence cue, so the two are not simply related by
+    /// prepending `confidence`.
+    public var secondaryProvenanceLines: [String] {
+        var lines: [String] = []
+        if let unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
     public static func make(
         summary: LocalAIActivitySummary?,
         availability: LocalAIAvailability,

--- a/Tests/PlaidBarCoreTests/LocalAIInsightReceiptDetailLinesTests.swift
+++ b/Tests/PlaidBarCoreTests/LocalAIInsightReceiptDetailLinesTests.swift
@@ -1,0 +1,131 @@
+import Testing
+@testable import PlaidBarCore
+
+/// Pins the pure provenance-line composition consolidated into
+/// ``LocalAIInsightReceipt`` from three byte-identical/near-identical inline
+/// copies (Dashboard insight card, menu-bar popover, Insights AI surface).
+///
+/// `detailLines` and `secondaryProvenanceLines` are deliberately distinct: the
+/// three-line cap on `detailLines` *includes* the leading confidence cue, while
+/// the cap on `secondaryProvenanceLines` applies to the secondary lines alone —
+/// so the two are **not** related by simply prepending `confidence`.
+@Suite struct LocalAIInsightReceiptDetailLinesTests {
+    /// Builds a receipt whose only fields that matter to line composition are
+    /// `confidence`, `limitations`, and `unavailableState`. The rest are inert.
+    private func receipt(
+        confidence: String = "High confidence",
+        limitations: [String] = [],
+        unavailableState: String? = nil
+    ) -> LocalAIInsightReceipt {
+        LocalAIInsightReceipt(
+            title: "Title",
+            headline: "Headline",
+            evidenceChips: [],
+            timeWindow: "Last 30 days",
+            localOnlyBadge: "On-device",
+            confidence: confidence,
+            limitations: limitations,
+            unavailableState: unavailableState,
+            reversibleActionCopy: "Reversible",
+            accessibilitySummary: "Summary"
+        )
+    }
+
+    // The verbatim original inline expressions, used as behavior-preservation
+    // oracles so the extraction is proven identical, not merely plausible.
+    private func detailLinesOracle(_ r: LocalAIInsightReceipt) -> [String] {
+        var lines = [r.confidence]
+        if let unavailableState = r.unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: r.limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
+    private func secondaryOracle(_ r: LocalAIInsightReceipt) -> [String] {
+        var lines: [String] = []
+        if let unavailableState = r.unavailableState {
+            lines.append(unavailableState)
+        }
+        lines.append(contentsOf: r.limitations.prefix(2))
+        return Array(lines.prefix(3))
+    }
+
+    // MARK: - detailLines (confidence-prepended, whole list capped at 3)
+
+    @Test func detailLinesConfidenceOnly() {
+        #expect(receipt().detailLines == ["High confidence"])
+    }
+
+    @Test func detailLinesConfidencePlusLimitations() {
+        let r = receipt(limitations: ["lim1", "lim2"])
+        #expect(r.detailLines == ["High confidence", "lim1", "lim2"])
+    }
+
+    @Test func detailLinesCapsLimitationsAtTwo() {
+        // Three limitations: prefix(2) keeps two, then the overall prefix(3)
+        // keeps confidence + those two.
+        let r = receipt(limitations: ["lim1", "lim2", "lim3"])
+        #expect(r.detailLines == ["High confidence", "lim1", "lim2"])
+    }
+
+    @Test func detailLinesUnavailableDropsSecondLimitation() {
+        // Differentiator: confidence + unavailable + two limitations is four
+        // entries; the three-line cap drops the *last* limitation.
+        let r = receipt(limitations: ["lim1", "lim2"], unavailableState: "Model offline")
+        #expect(r.detailLines == ["High confidence", "Model offline", "lim1"])
+    }
+
+    @Test func detailLinesUnavailableNoLimitations() {
+        let r = receipt(unavailableState: "Model offline")
+        #expect(r.detailLines == ["High confidence", "Model offline"])
+    }
+
+    // MARK: - secondaryProvenanceLines (no confidence, capped at 3)
+
+    @Test func secondaryEmptyWhenNothingSecondary() {
+        #expect(receipt().secondaryProvenanceLines == [])
+    }
+
+    @Test func secondaryUnavailablePlusTwoLimitations() {
+        let r = receipt(limitations: ["lim1", "lim2"], unavailableState: "Model offline")
+        #expect(r.secondaryProvenanceLines == ["Model offline", "lim1", "lim2"])
+    }
+
+    @Test func secondaryCapsLimitationsAtTwo() {
+        let r = receipt(limitations: ["lim1", "lim2", "lim3"])
+        #expect(r.secondaryProvenanceLines == ["lim1", "lim2"])
+    }
+
+    @Test func secondaryUnavailableOnly() {
+        let r = receipt(unavailableState: "Model offline")
+        #expect(r.secondaryProvenanceLines == ["Model offline"])
+    }
+
+    // MARK: - The two are genuinely distinct (cap interaction)
+
+    @Test func detailLinesAreNotConfidencePlusSecondary() {
+        // With unavailable + two limitations, detailLines has three entries but
+        // [confidence] + secondaryProvenanceLines would have four — proving the
+        // caps interact differently and both members are needed.
+        let r = receipt(limitations: ["lim1", "lim2"], unavailableState: "Model offline")
+        #expect(r.detailLines != [r.confidence] + r.secondaryProvenanceLines)
+    }
+
+    // MARK: - Behavior-preservation oracle sweep
+
+    @Test func matchesVerbatimOriginalsAcrossCombinations() {
+        let confidences = ["High confidence", ""]
+        let limitationSets: [[String]] = [[], ["a"], ["a", "b"], ["a", "b", "c"]]
+        let unavailables: [String?] = [nil, "Offline"]
+        for c in confidences {
+            for lims in limitationSets {
+                for u in unavailables {
+                    let r = receipt(confidence: c, limitations: lims, unavailableState: u)
+                    #expect(r.detailLines == detailLinesOracle(r))
+                    #expect(r.secondaryProvenanceLines == secondaryOracle(r))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Three inline copies of the "compose provenance detail lines from a `LocalAIInsightReceipt`" logic lived in the app layer. Consolidated them into two pure, `Sendable` computed properties on `LocalAIInsightReceipt` in **PlaidBarCore**, where they are unit-testable:
  - `detailLines` — confidence cue first, then the runtime-unavailable note, then up to two limitations, the whole list capped at three. Replaced `detailLines(_:)` in `DashboardLocalInsightCard` and `receiptDetailLines` in `MainPopover` (byte-identical to each other).
  - `secondaryProvenanceLines` — same shape without the confidence cue (rendered separately on the Insights surface), capped at three. Replaced the inline property in `InsightsAIInsightView`.
- The two properties are **deliberately distinct**: the three-line cap includes the confidence line for `detailLines` but not for `secondaryProvenanceLines`, so they are not related by simply prepending `confidence`.
- Behavior-preserving. No product behavior changes; the composition is mask-agnostic (the receipt is built already-masked upstream).

## Autonomous task IDs

- Task ID(s): scheduled `vaultpeek-architecture-refactor` pass (2026-07-01)
- Backlog slice: PlaidBarCore extraction — pure presentation logic out of the app layer
- Scope note: one focused, behavior-preserving extraction

## Agent coordination

- Builder agent: Claude (Opus 4.8), autonomous refactor loop
- Builder branch/worktree: `refactor/auto-2026-07-01`
- Reviewer/merge steward: Otto
- Coordination note: review-only; no other agent should push to this branch

## Changed files

- `Sources/PlaidBarCore/Models/LocalAIInsights.swift` — add `detailLines` + `secondaryProvenanceLines`
- `Sources/PlaidBar/Views/Destinations/DashboardLocalInsightCard.swift` — reroute, delete inline copy
- `Sources/PlaidBar/Views/MainPopover.swift` — reroute, delete inline copy
- `Sources/PlaidBar/Views/Destinations/InsightsAIInsightView.swift` — reroute (2 sites), delete inline copy
- `Tests/PlaidBarCoreTests/LocalAIInsightReceiptDetailLinesTests.swift` — new (verbatim-original oracle sweep + cap-interaction edge case)

## Local gates

- [x] `git diff --check` (clean)
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` (CI gate — clean, 59s)
- [x] `swift test` — full suite green, **2664 tests passed** (incl. the flaky `LocalInsightModelRuntime` timeout test, passed this run)
- [x] Demo app boot-smoke: `.build/debug/PlaidBar --demo` ran ~9s, no crash
- [x] Secret scan completed (no secrets; only false-positive match was a doc comment containing "masked")

## GitHub checks

- [ ] Required GitHub checks green before merge.

## Privacy and safety impact

- [x] Used only synthetic data in the new tests.
- [x] No real Plaid credentials, tokens, account IDs, or balances.
- [x] Preserves the local-first boundary — no backend, telemetry, or cloud AI introduced; pure refactor.
- [x] User-facing copy unchanged.

## Merge safety

- [x] Final diff reviewed for secrets, private data, and scope creep — clean, additive + deletions only.
- [x] No other agent is mutating this branch/worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)