### PR TITLE
fix(privacy): mask account removal dialog copy

### DIFF
--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -117,7 +117,7 @@ struct AccountDetailFlyout: View {
         .accessibilityElement(children: .contain)
         .accessibilityLabel(summary.accessibilityLabel(privacyMaskEnabled: appState.shouldMaskFinancialValues))
         .confirmationDialog(
-            "Remove \(institutionRemovalName)?",
+            removalDialogTitle,
             isPresented: $isConfirmingAccountRemoval,
             titleVisibility: .visible
         ) {
@@ -126,9 +126,7 @@ struct AccountDetailFlyout: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text(
-                "This disconnects the linked Plaid institution and removes \(institutionAccountCountText) plus \(institutionTransactionCountText) from VaultPeek. It does not close any bank account."
-            )
+            Text(removalDialogMessage)
         }
     }
 
@@ -479,24 +477,37 @@ struct AccountDetailFlyout: View {
 
     // MARK: Removal copy
 
+    private var removalDialogTitle: String {
+        AccountPresentation.removalDialogTitle(
+            institutionName: institutionRemovalName,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
+        )
+    }
+
+    private var removalDialogMessage: String {
+        AccountPresentation.removalDialogMessage(
+            linkedAccountCount: institutionAccountCount,
+            cachedTransactionCount: institutionTransactionCount,
+            privacyMaskEnabled: appState.shouldMaskFinancialValues
+        )
+    }
+
     private var institutionRemovalName: String {
         itemConnectionStatus?.institutionName ?? AccountPresentation.displayName(for: account)
     }
 
-    private var institutionAccountCountText: String {
-        let count = max(appState.accounts.count { $0.itemId == account.itemId }, 1)
-        return count == 1 ? "1 linked account" : "\(count) linked accounts"
+    private var institutionAccountCount: Int {
+        max(appState.accounts.count { $0.itemId == account.itemId }, 1)
     }
 
-    private var institutionTransactionCountText: String {
+    private var institutionTransactionCount: Int {
         // The dialog message is evaluated as part of the panel body, so gate
         // the full transaction scan on the dialog actually being presented.
-        guard isConfirmingAccountRemoval else { return "0 cached local transactions" }
+        guard isConfirmingAccountRemoval else { return 0 }
         let institutionAccountIds = Set(
             appState.accounts.filter { $0.itemId == account.itemId }.map(\.id)
         )
-        let count = appState.transactions.count { institutionAccountIds.contains($0.accountId) }
-        return count == 1 ? "1 cached local transaction" : "\(count) cached local transactions"
+        return appState.transactions.count { institutionAccountIds.contains($0.accountId) }
     }
 }
 

--- a/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountPresentation.swift
@@ -8,6 +8,30 @@ public enum AccountPresentation {
         count == 1 ? "Across 1 account" : "Across \(count) accounts"
     }
 
+    public static func removalDialogTitle(
+        institutionName: String,
+        privacyMaskEnabled: Bool = false
+    ) -> String {
+        privacyMaskEnabled ? "Remove linked institution?" : "Remove \(institutionName)?"
+    }
+
+    public static func removalDialogMessage(
+        linkedAccountCount: Int,
+        cachedTransactionCount: Int,
+        privacyMaskEnabled: Bool = false
+    ) -> String {
+        if privacyMaskEnabled {
+            return "This disconnects the linked Plaid institution and removes its linked accounts plus cached local transactions from VaultPeek. It does not close any bank account."
+        }
+
+        let accountCount = max(linkedAccountCount, 1)
+        let accountText = accountCount == 1 ? "1 linked account" : "\(accountCount) linked accounts"
+        let transactionText = cachedTransactionCount == 1
+            ? "1 cached local transaction"
+            : "\(cachedTransactionCount) cached local transactions"
+        return "This disconnects the linked Plaid institution and removes \(accountText) plus \(transactionText) from VaultPeek. It does not close any bank account."
+    }
+
     public static func isDebt(_ account: AccountDTO) -> Bool {
         account.type == .credit || account.type == .loan
     }

--- a/Tests/PlaidBarCoreTests/AccountRemovalPresentationTests.swift
+++ b/Tests/PlaidBarCoreTests/AccountRemovalPresentationTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import PlaidBarCore
+
+@Suite("Account removal presentation")
+struct AccountRemovalPresentationTests {
+    @Test("Unmasked removal dialog names the institution and exact local removal counts")
+    func unmaskedCopyPreservesExplicitWarning() {
+        #expect(
+            AccountPresentation.removalDialogTitle(
+                institutionName: "Acme Bank",
+                privacyMaskEnabled: false
+            ) == "Remove Acme Bank?"
+        )
+
+        #expect(
+            AccountPresentation.removalDialogMessage(
+                linkedAccountCount: 2,
+                cachedTransactionCount: 47,
+                privacyMaskEnabled: false
+            ) == "This disconnects the linked Plaid institution and removes 2 linked accounts plus 47 cached local transactions from VaultPeek. It does not close any bank account."
+        )
+    }
+
+    @Test("Masked removal dialog withholds institution names and exact counts")
+    func maskedCopyWithholdsPrivateDetails() {
+        let title = AccountPresentation.removalDialogTitle(
+            institutionName: "Acme Bank",
+            privacyMaskEnabled: true
+        )
+        let message = AccountPresentation.removalDialogMessage(
+            linkedAccountCount: 2,
+            cachedTransactionCount: 47,
+            privacyMaskEnabled: true
+        )
+
+        #expect(title == "Remove linked institution?")
+        #expect(!title.contains("Acme Bank"))
+        #expect(!message.contains("Acme Bank"))
+        #expect(!message.contains("2 linked accounts"))
+        #expect(!message.contains("47 cached local transactions"))
+        #expect(message.contains("linked accounts"))
+        #expect(message.contains("cached local transactions"))
+    }
+
+    @Test("Unmasked removal dialog clamps linked account count to one")
+    func unmaskedCopyClampsMissingAccountCount() {
+        #expect(
+            AccountPresentation.removalDialogMessage(
+                linkedAccountCount: 0,
+                cachedTransactionCount: 1,
+                privacyMaskEnabled: false
+            ).contains("1 linked account plus 1 cached local transaction")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- fixes the account removal confirmation dialog so Privacy Mask uses generic linked-institution copy instead of institution/account names
- withholds exact linked-account and cached-local-transaction counts while masked
- preserves the current explicit destructive warning copy when unmasked
- adds Core regression coverage for masked/unmasked removal dialog copy

Fixes #737
Linear: AND-974
Kanban: t_e9c78376

## Verification

- `swift build --target PlaidBarCoreTests` ✅
  - Built the new `AccountRemovalPresentationTests.swift` target code successfully.
  - Existing unrelated warning remains in `Tests/PlaidBarCoreTests/RoundingConsistencyTests.swift:152` about redundant `#require` (tracked separately by #734 / AND-973 / PR #735).
- `git diff --check` ✅
- Ad-hoc committed verification ✅
  - Temp script: `/var/folders/lk/g3jh81xn5mjc9mrv_bq640wr0000gn/T/hermes-verify-committed-removal-dialog-qx2205bp.py` (removed after run)
  - Verified exact committed file set, clean worktree, committed diff whitespace, helper/flyout/test invariants.

## Known broad-gate blocker

- `swift test --filter AccountRemovalPresentationTests` is blocked before the focused test can execute because the app target compiles unrelated FoundationModels macro/plugin code and this environment cannot find `FoundationModelsMacros.GenerableMacro` / `GuideMacro`.
- `swift test --skip-build --filter AccountRemovalPresentationTests` is also blocked because SwiftPM did not create the full `PlaidBarPackageTests.xctest` bundle after the scoped target build.
