### PR TITLE
feat(design-tokens): add RawDesignTokens foundation (AND-980)

### DIFF
--- a/Sources/PlaidBarCore/Models/RawDesignTokens.swift
+++ b/Sources/PlaidBarCore/Models/RawDesignTokens.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// MARK: - Raw design tokens (Gate-0 doctrine, AND-979)
+//
+// Pure, `Sendable`, SwiftUI-free numeric values shared by the popover-scale
+// (`Sources/PlaidBar/Theme/DesignTokens.swift`) and window-scale
+// (`Sources/PlaidBar/Theme/WindowMetrics.swift`) token layers, following the
+// same Core-owns-the-value / app-bridges-to-SwiftUI split already used by
+// `AppAccentColor`/`AppAccentSwatch` (`AppearancePreferences.swift`) for the
+// resolved accent color. Colors stay `Color`-typed and app-target-only —
+// they are dynamic system colors that must resolve per-appearance / Increase
+// Contrast at draw time, not frozen RGB values — so only numerics move here.
+//
+// This is the additive first step of the redesign token migration: nothing
+// in the app target consumes these yet (Epic 1, AND-980). The window-scale
+// `WindowMetrics.md`/`.lg` (16/20) already numerically match `cardPadding`/
+// `cardGap` below; `RawRadius` is the one genuine numeric change (adopts the
+// redesign's clean 3-role ladder, replacing the app's two disagreeing
+// "panel" radii — `Radius.panel = 8` vs `SurfaceTokens.panelCornerRadius = 7`).
+
+/// The 8pt-grid spacing scale shared across popover and window surfaces.
+/// `cardGap` is strictly greater than `cardPadding` by design — separation
+/// between sibling cards comes from spacing, not from strokes or nested
+/// chrome, so a dense grid still reads as distinct surfaces.
+public enum RawSpacing: Sendable {
+    public static let xxs: Double = 2
+    public static let xs: Double = 4
+    public static let sm: Double = 8
+    public static let md: Double = 12
+    /// The one intra-card content inset. Matches `WindowMetrics.md` today.
+    public static let cardPadding: Double = 16
+    /// The one inter-card gap. Matches `WindowMetrics.lg` today. Always
+    /// greater than `cardPadding` — see `RawTokenInvariantTests`.
+    public static let cardGap: Double = 20
+    public static let xxl: Double = 32
+}
+
+/// The corner-radius ladder: three roles, no more. Adopts the redesign's
+/// scale, which also resolves the app's existing internal disagreement
+/// between `Radius.panel` (8) and `SurfaceTokens.panelCornerRadius` (7).
+public enum RawRadius: Sendable {
+    /// Heatmap cells, tiny chips.
+    public static let cell: Double = 3
+    /// Rows, buttons, hover washes, segmented filters, badges.
+    public static let control: Double = 7
+    /// Cards, panels, popover content, sheets.
+    public static let card: Double = 12
+}
+
+/// Fixed-frame sizes so a visual role renders at the same size everywhere.
+/// Values already match the app's existing `Sizing` enum — centralized here
+/// so both token layers read one source instead of two independently-tuned
+/// copies.
+public enum RawSizing: Sendable {
+    public static let iconInline: Double = 16
+    public static let iconNav: Double = 20
+    public static let iconChip: Double = 28
+    public static let statusDot: Double = 8
+    /// The macOS pointer-target floor for borderless glyph controls — not
+    /// the 44pt touch-input minimum, which would wreck desktop density.
+    public static let pointerTargetMin: Double = 28
+    public static let rowMinHeight: Double = 44
+}
+
+/// Raw animation durations/response values. `Animation` itself is a SwiftUI
+/// type and stays app-target-only (`MotionTokens.animation(_:reduceMotion:)`
+/// wraps these); only the numeric curve parameters live in Core so they can
+/// be asserted here without an app-target test dependency.
+public enum RawMotionDurations: Sendable {
+    /// Hover, press, chip toggles.
+    public static let micro: Double = 0.12
+    /// Selection, filter swaps, disclosure, banner entrances.
+    public static let standard: Double = 0.2
+    /// Spring response for drill-in/fly-out expansion.
+    public static let contentResponse: Double = 0.3
+    /// Spring damping fraction for drill-in/fly-out expansion.
+    public static let contentDamping: Double = 0.85
+    /// Once-per-appearance chart reveal.
+    public static let chartReveal: Double = 0.55
+}

--- a/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
+++ b/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
@@ -1,0 +1,107 @@
+import PlaidBarCore
+import Testing
+
+@Suite("Raw design token invariants (Gate-0 doctrine, AND-979)")
+struct RawDesignTokensTests {
+    // MARK: Spacing
+
+    @Test("Card gap exceeds card padding — separation comes from spacing, not chrome")
+    func cardGapExceedsCardPadding() {
+        #expect(RawSpacing.cardGap > RawSpacing.cardPadding)
+    }
+
+    @Test("Spacing scale is strictly ordered")
+    func spacingScaleOrdered() {
+        #expect(RawSpacing.xxs < RawSpacing.xs)
+        #expect(RawSpacing.xs < RawSpacing.sm)
+        #expect(RawSpacing.sm < RawSpacing.md)
+        #expect(RawSpacing.md < RawSpacing.cardPadding)
+        #expect(RawSpacing.cardPadding < RawSpacing.cardGap)
+        #expect(RawSpacing.cardGap < RawSpacing.xxl)
+    }
+
+    // MARK: Radius
+
+    @Test("Radius ladder is strictly ordered: cell < control < card")
+    func radiusLadderOrdered() {
+        #expect(RawRadius.cell < RawRadius.control)
+        #expect(RawRadius.control < RawRadius.card)
+    }
+
+    // MARK: Sizing
+
+    @Test("Pointer-target floor is the 28pt desktop minimum, not the 44pt touch minimum")
+    func pointerTargetIsDesktopFloor() {
+        #expect(RawSizing.pointerTargetMin == 28)
+        #expect(RawSizing.pointerTargetMin < RawSizing.rowMinHeight)
+    }
+
+    // MARK: Motion
+
+    @Test("Motion durations are non-negative and ordered micro < standard < chartReveal")
+    func motionDurationOrdering() {
+        #expect(RawMotionDurations.micro > 0)
+        #expect(RawMotionDurations.micro < RawMotionDurations.standard)
+        #expect(RawMotionDurations.standard < RawMotionDurations.chartReveal)
+        #expect(RawMotionDurations.contentDamping > 0 && RawMotionDurations.contentDamping < 1)
+    }
+}
+
+@Suite("Category color completeness + contrast (Gate-0 doctrine, AND-979)")
+struct CategoryColorContrastTests {
+    /// Every `SpendingCategory` case must define both a light- and dark-mode
+    /// hex, and no two categories may share the exact same light-mode hex
+    /// (they'd be visually indistinguishable in the donut/legend).
+    @Test("Every category has a light and dark hex, and light hexes are unique")
+    func categoryHexCompleteness() {
+        var seenLight: Set<String> = []
+        for category in SpendingCategory.allCases {
+            #expect(!category.colorHex.isEmpty)
+            #expect(!category.colorHexDark.isEmpty)
+            let (inserted, _) = seenLight.insert(category.colorHex)
+            #expect(inserted, "Duplicate light-mode hex for \(category): \(category.colorHex)")
+        }
+    }
+
+    /// WCAG 2.x contrast ratio between a category's dark-mode hex and the
+    /// app's dark content background (#1E1E1E, matching the documented dark
+    /// chart-palette fix). Guards the specific 5-category contrast bug
+    /// DESIGN.md documents as already fixed — regresses loudly if a future
+    /// edit reintroduces a low-contrast dark value instead of adding a hex
+    /// patch.
+    @Test("Category dark-mode hex clears 3:1 contrast against the dark chart background", arguments: SpendingCategory.allCases)
+    func categoryDarkContrast(category: SpendingCategory) {
+        let ratio = contrastRatio(category.colorHexDark, against: "#1E1E1E")
+        #expect(ratio >= 3.0, "\(category) colorHexDark contrast \(ratio) < 3:1 against dark background")
+    }
+
+    // MARK: - WCAG contrast math (pure, no SwiftUI)
+
+    private func contrastRatio(_ hexA: String, against hexB: String) -> Double {
+        let lumA = relativeLuminance(hexA)
+        let lumB = relativeLuminance(hexB)
+        let lighter = max(lumA, lumB)
+        let darker = min(lumA, lumB)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ hex: String) -> Double {
+        let (r, g, b) = rgbComponents(hex)
+        func channel(_ c: Double) -> Double {
+            c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+    }
+
+    private func rgbComponents(_ hex: String) -> (Double, Double, Double) {
+        var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        sanitized.removeAll { $0 == "#" }
+        guard sanitized.count == 6, let value = UInt32(sanitized, radix: 16) else {
+            return (0, 0, 0)
+        }
+        let r = Double((value >> 16) & 0xFF) / 255
+        let g = Double((value >> 8) & 0xFF) / 255
+        let b = Double(value & 0xFF) / 255
+        return (r, g, b)
+    }
+}


### PR DESCRIPTION
## Summary
- First additive increment of the redesign design-system migration (Gate-0 doctrine [AND-979](https://linear.app/andeslab/issue/AND-979), Epic 1 [AND-980](https://linear.app/andeslab/issue/AND-980)). Nothing in the app target consumes these tokens yet — zero visual diff.
- New `Sources/PlaidBarCore/Models/RawDesignTokens.swift`: pure, `Sendable`, SwiftUI-free `RawSpacing`/`RawRadius`/`RawSizing`/`RawMotionDurations`, mirroring the existing `SemanticColors.resolvedAccent(for:)` Core→SwiftUI bridge precedent. Colors stay `Color`-typed/app-target-only.
- `RawRadius` adopts a clean 3-role ladder (`cell=3/control=7/card=12`), which also resolves the app's existing internal disagreement between `Radius.panel` (8) and `SurfaceTokens.panelCornerRadius` (7) — this is a source-of-truth cleanup, not a new import.
- New `RawTokenInvariantTests` (`cardGap > cardPadding`, radius ladder ordering, motion duration ordering) plus a category-color completeness + WCAG-contrast test (pure hex math, no SwiftUI) that guards the dark-mode contrast fix `DESIGN.md` already documents.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` (full suite, not `--filter`) — 2690 passed, 0 failures
- [ ] Follow-up PRs (Epic 1 continued): rewrite `DesignTokens.swift`/`WindowMetrics.swift` as thin bridges over these raw values, collapse `SurfaceRank`/`GlassSurface` into the existing `NativePanelGlassSurface`/`SolidDataSurface` pair (fixes ~30 of 37 call sites currently sampling glass over real data), delete `HeroBalance`, fold `CategoryAccentTokens.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)