### PR TITLE
refactor(design-tokens): bridge Sizing/Motion/window spacing to RawDesignTokens (AND-980)

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -137,12 +137,16 @@ enum Radius {
 // MARK: - Sizing
 
 /// Fixed-frame sizes for icons, chips, and rows so the same visual role
-/// always renders at the same size across surfaces.
+/// always renders at the same size across surfaces. The five roles shared
+/// with the window-scale token layer read from `RawSizing` (Gate-0, AND-980)
+/// so both surfaces stay numerically in sync from one source; the two
+/// popover-only glyph frames below have no window counterpart and stay
+/// literal.
 enum Sizing {
-    static let iconInline: CGFloat = 16
-    static let iconNav: CGFloat = 20
-    static let iconChip: CGFloat = 28
-    static let statusDot: CGFloat = 8
+    static let iconInline: CGFloat = CGFloat(RawSizing.iconInline)
+    static let iconNav: CGFloat = CGFloat(RawSizing.iconNav)
+    static let iconChip: CGFloat = CGFloat(RawSizing.iconChip)
+    static let statusDot: CGFloat = CGFloat(RawSizing.statusDot)
     /// Fixed glyph frame for inline row icons that need a tight bound (e.g.
     /// weekly-review checkbox/severity glyphs) without a backing tile.
     static let glyphSmall: CGFloat = 20
@@ -152,21 +156,27 @@ enum Sizing {
     /// Minimum clickable frame for borderless glyph controls. 28pt is the
     /// macOS pointer-target floor (compact control height); the 44pt HIG
     /// figure is a touch-input minimum and would break menu bar density.
-    static let hitTargetMin: CGFloat = 28
+    static let hitTargetMin: CGFloat = CGFloat(RawSizing.pointerTargetMin)
 }
 
 // MARK: - Motion
 
 /// The motion system: three durations, one reduce-motion gate. Every
 /// animation in the app flows through `animation(_:reduceMotion:)` so
-/// Reduce Motion disables movement in one place.
+/// Reduce Motion disables movement in one place. The four durations shared
+/// with the window-scale token layer read from `RawMotionDurations`
+/// (Gate-0, AND-980); the app-specific loop/decorative animations below have
+/// no window counterpart and stay literal.
 enum MotionTokens {
     /// Hover, press, chip toggles.
-    static let micro = Animation.easeOut(duration: 0.12)
+    static let micro = Animation.easeOut(duration: RawMotionDurations.micro)
     /// Selection, filter swaps, disclosure, banner entrances.
-    static let standard = Animation.easeInOut(duration: 0.2)
+    static let standard = Animation.easeInOut(duration: RawMotionDurations.standard)
     /// Drill-in/fly-out expansion and number transitions.
-    static let content = Animation.spring(response: 0.3, dampingFraction: 0.85)
+    static let content = Animation.spring(
+        response: RawMotionDurations.contentResponse,
+        dampingFraction: RawMotionDurations.contentDamping
+    )
     /// Refresh spinner movement. Always pass through `animation`.
     static let refreshSpin = Animation.linear(duration: 0.8).repeatForever(autoreverses: false)
     /// Refresh spinner settle when loading ends.
@@ -176,7 +186,7 @@ enum MotionTokens {
     /// Decorative background drift. Always pass through `animation`.
     static let backgroundDrift = Animation.easeInOut(duration: 18).repeatForever(autoreverses: true)
     /// Once-per-appearance left-to-right reveal for glance charts.
-    static let chartReveal = Animation.easeOut(duration: 0.55)
+    static let chartReveal = Animation.easeOut(duration: RawMotionDurations.chartReveal)
 
     static let staticLoadingOpacity = 0.62
     static let loadingPulseOpacity = 0.55

--- a/Sources/PlaidBar/Theme/WindowMetrics.swift
+++ b/Sources/PlaidBar/Theme/WindowMetrics.swift
@@ -1,3 +1,4 @@
+import PlaidBarCore
 import SwiftUI
 
 // MARK: - Window-Scale Design Foundation (AND-624)
@@ -50,11 +51,16 @@ enum WindowMetrics {
     static let sm: CGFloat = 12
     /// Card content padding and header↔body spacing. Kept strictly tighter than
     /// the inter-card gap (``lg``) so cards read as crisply separated, RepoBar-dense
-    /// surfaces rather than one soft run.
-    static let md: CGFloat = 16
+    /// surfaces rather than one soft run. Reads from `RawSpacing.cardPadding`
+    /// (Gate-0, AND-980) — this token IS the one intra-card padding role the
+    /// redesign's token doctrine names; the invariant below is asserted in
+    /// `RawTokenInvariantTests`, not just documented here.
+    static let md: CGFloat = CGFloat(RawSpacing.cardPadding)
     /// Between cards within a column, and section header↔content. Strictly greater
     /// than the card padding (``md``) so the grid reads as separated, not crammed.
-    static let lg: CGFloat = 20
+    /// Reads from `RawSpacing.cardGap` (Gate-0, AND-980) — the one inter-card
+    /// gap role; `cardGap > cardPadding` is a tested Core invariant.
+    static let lg: CGFloat = CGFloat(RawSpacing.cardGap)
     /// Between major sections of a canvas (hero row ↔ the column grid).
     static let xl: CGFloat = 24
     /// The gap between the two canvas columns. ≥ the inter-card gap so the two

--- a/Sources/PlaidBarCore/Models/RawDesignTokens.swift
+++ b/Sources/PlaidBarCore/Models/RawDesignTokens.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// MARK: - Raw design tokens (Gate-0 doctrine, AND-979)
+//
+// Pure, `Sendable`, SwiftUI-free numeric values shared by the popover-scale
+// (`Sources/PlaidBar/Theme/DesignTokens.swift`) and window-scale
+// (`Sources/PlaidBar/Theme/WindowMetrics.swift`) token layers, following the
+// same Core-owns-the-value / app-bridges-to-SwiftUI split already used by
+// `AppAccentColor`/`AppAccentSwatch` (`AppearancePreferences.swift`) for the
+// resolved accent color. Colors stay `Color`-typed and app-target-only —
+// they are dynamic system colors that must resolve per-appearance / Increase
+// Contrast at draw time, not frozen RGB values — so only numerics move here.
+//
+// This is the additive first step of the redesign token migration: nothing
+// in the app target consumes these yet (Epic 1, AND-980). The window-scale
+// `WindowMetrics.md`/`.lg` (16/20) already numerically match `cardPadding`/
+// `cardGap` below; `RawRadius` is the one genuine numeric change (adopts the
+// redesign's clean 3-role ladder, replacing the app's two disagreeing
+// "panel" radii — `Radius.panel = 8` vs `SurfaceTokens.panelCornerRadius = 7`).
+
+/// The 8pt-grid spacing scale shared across popover and window surfaces.
+/// `cardGap` is strictly greater than `cardPadding` by design — separation
+/// between sibling cards comes from spacing, not from strokes or nested
+/// chrome, so a dense grid still reads as distinct surfaces.
+public enum RawSpacing: Sendable {
+    public static let xxs: Double = 2
+    public static let xs: Double = 4
+    public static let sm: Double = 8
+    public static let md: Double = 12
+    /// The one intra-card content inset. Matches `WindowMetrics.md` today.
+    public static let cardPadding: Double = 16
+    /// The one inter-card gap. Matches `WindowMetrics.lg` today. Always
+    /// greater than `cardPadding` — see `RawTokenInvariantTests`.
+    public static let cardGap: Double = 20
+    public static let xxl: Double = 32
+}
+
+/// The corner-radius ladder: three roles, no more. Adopts the redesign's
+/// scale, which also resolves the app's existing internal disagreement
+/// between `Radius.panel` (8) and `SurfaceTokens.panelCornerRadius` (7).
+public enum RawRadius: Sendable {
+    /// Heatmap cells, tiny chips.
+    public static let cell: Double = 3
+    /// Rows, buttons, hover washes, segmented filters, badges.
+    public static let control: Double = 7
+    /// Cards, panels, popover content, sheets.
+    public static let card: Double = 12
+}
+
+/// Fixed-frame sizes so a visual role renders at the same size everywhere.
+/// Values already match the app's existing `Sizing` enum — centralized here
+/// so both token layers read one source instead of two independently-tuned
+/// copies.
+public enum RawSizing: Sendable {
+    public static let iconInline: Double = 16
+    public static let iconNav: Double = 20
+    public static let iconChip: Double = 28
+    public static let statusDot: Double = 8
+    /// The macOS pointer-target floor for borderless glyph controls — not
+    /// the 44pt touch-input minimum, which would wreck desktop density.
+    public static let pointerTargetMin: Double = 28
+    public static let rowMinHeight: Double = 44
+}
+
+/// Raw animation durations/response values. `Animation` itself is a SwiftUI
+/// type and stays app-target-only (`MotionTokens.animation(_:reduceMotion:)`
+/// wraps these); only the numeric curve parameters live in Core so they can
+/// be asserted here without an app-target test dependency.
+public enum RawMotionDurations: Sendable {
+    /// Hover, press, chip toggles.
+    public static let micro: Double = 0.12
+    /// Selection, filter swaps, disclosure, banner entrances.
+    public static let standard: Double = 0.2
+    /// Spring response for drill-in/fly-out expansion.
+    public static let contentResponse: Double = 0.3
+    /// Spring damping fraction for drill-in/fly-out expansion.
+    public static let contentDamping: Double = 0.85
+    /// Once-per-appearance chart reveal.
+    public static let chartReveal: Double = 0.55
+}

--- a/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
+++ b/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
@@ -1,0 +1,107 @@
+import PlaidBarCore
+import Testing
+
+@Suite("Raw design token invariants (Gate-0 doctrine, AND-979)")
+struct RawDesignTokensTests {
+    // MARK: Spacing
+
+    @Test("Card gap exceeds card padding — separation comes from spacing, not chrome")
+    func cardGapExceedsCardPadding() {
+        #expect(RawSpacing.cardGap > RawSpacing.cardPadding)
+    }
+
+    @Test("Spacing scale is strictly ordered")
+    func spacingScaleOrdered() {
+        #expect(RawSpacing.xxs < RawSpacing.xs)
+        #expect(RawSpacing.xs < RawSpacing.sm)
+        #expect(RawSpacing.sm < RawSpacing.md)
+        #expect(RawSpacing.md < RawSpacing.cardPadding)
+        #expect(RawSpacing.cardPadding < RawSpacing.cardGap)
+        #expect(RawSpacing.cardGap < RawSpacing.xxl)
+    }
+
+    // MARK: Radius
+
+    @Test("Radius ladder is strictly ordered: cell < control < card")
+    func radiusLadderOrdered() {
+        #expect(RawRadius.cell < RawRadius.control)
+        #expect(RawRadius.control < RawRadius.card)
+    }
+
+    // MARK: Sizing
+
+    @Test("Pointer-target floor is the 28pt desktop minimum, not the 44pt touch minimum")
+    func pointerTargetIsDesktopFloor() {
+        #expect(RawSizing.pointerTargetMin == 28)
+        #expect(RawSizing.pointerTargetMin < RawSizing.rowMinHeight)
+    }
+
+    // MARK: Motion
+
+    @Test("Motion durations are non-negative and ordered micro < standard < chartReveal")
+    func motionDurationOrdering() {
+        #expect(RawMotionDurations.micro > 0)
+        #expect(RawMotionDurations.micro < RawMotionDurations.standard)
+        #expect(RawMotionDurations.standard < RawMotionDurations.chartReveal)
+        #expect(RawMotionDurations.contentDamping > 0 && RawMotionDurations.contentDamping < 1)
+    }
+}
+
+@Suite("Category color completeness + contrast (Gate-0 doctrine, AND-979)")
+struct CategoryColorContrastTests {
+    /// Every `SpendingCategory` case must define both a light- and dark-mode
+    /// hex, and no two categories may share the exact same light-mode hex
+    /// (they'd be visually indistinguishable in the donut/legend).
+    @Test("Every category has a light and dark hex, and light hexes are unique")
+    func categoryHexCompleteness() {
+        var seenLight: Set<String> = []
+        for category in SpendingCategory.allCases {
+            #expect(!category.colorHex.isEmpty)
+            #expect(!category.colorHexDark.isEmpty)
+            let (inserted, _) = seenLight.insert(category.colorHex)
+            #expect(inserted, "Duplicate light-mode hex for \(category): \(category.colorHex)")
+        }
+    }
+
+    /// WCAG 2.x contrast ratio between a category's dark-mode hex and the
+    /// app's dark content background (#1E1E1E, matching the documented dark
+    /// chart-palette fix). Guards the specific 5-category contrast bug
+    /// DESIGN.md documents as already fixed — regresses loudly if a future
+    /// edit reintroduces a low-contrast dark value instead of adding a hex
+    /// patch.
+    @Test("Category dark-mode hex clears 3:1 contrast against the dark chart background", arguments: SpendingCategory.allCases)
+    func categoryDarkContrast(category: SpendingCategory) {
+        let ratio = contrastRatio(category.colorHexDark, against: "#1E1E1E")
+        #expect(ratio >= 3.0, "\(category) colorHexDark contrast \(ratio) < 3:1 against dark background")
+    }
+
+    // MARK: - WCAG contrast math (pure, no SwiftUI)
+
+    private func contrastRatio(_ hexA: String, against hexB: String) -> Double {
+        let lumA = relativeLuminance(hexA)
+        let lumB = relativeLuminance(hexB)
+        let lighter = max(lumA, lumB)
+        let darker = min(lumA, lumB)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ hex: String) -> Double {
+        let (r, g, b) = rgbComponents(hex)
+        func channel(_ c: Double) -> Double {
+            c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+    }
+
+    private func rgbComponents(_ hex: String) -> (Double, Double, Double) {
+        var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        sanitized.removeAll { $0 == "#" }
+        guard sanitized.count == 6, let value = UInt32(sanitized, radix: 16) else {
+            return (0, 0, 0)
+        }
+        let r = Double((value >> 16) & 0xFF) / 255
+        let g = Double((value >> 8) & 0xFF) / 255
+        let b = Double(value & 0xFF) / 255
+        return (r, g, b)
+    }
+}


### PR DESCRIPTION
## Summary
- Second increment of the token foundation (Gate-0 [AND-979](https://linear.app/andeslab/issue/AND-979), Epic 1 [AND-980](https://linear.app/andeslab/issue/AND-980)). Stacked on #739 (not yet merged) — diff will shrink once that lands.
- Pure refactor, zero visual diff. `DesignTokens.Sizing`'s five window-shared roles and `MotionTokens`' four window-shared durations now read from `RawSizing`/`RawMotionDurations` instead of independent literals.
- `WindowMetrics.md`/`.lg` — the two tokens the file's own comments already tie to the "gap > padding" invariant — now read from `RawSpacing.cardPadding`/`cardGap`, so that invariant is a tested Core fact (`RawTokenInvariantTests`) instead of just a doc comment.
- Deliberately **not** touched: Radius (popover or window). The redesign's radius ladder is a visible ~40-call-site pixel change that needs its own screenshot/design sign-off — tracked as an open Gate-0 decision, not bundled here.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` (full suite) — 2690 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)