### PR TITLE
refactor(surfaces): collapse SurfaceRank into solid/native data surfaces (AND-980)

### DIFF
--- a/Sources/PlaidBar/Settings/SettingsView.swift
+++ b/Sources/PlaidBar/Settings/SettingsView.swift
@@ -427,7 +427,7 @@ private struct AppearancePreviewCard: View {
                     .monospacedDigit()
             }
             .padding(Spacing.sm)
-            .glassSurface(.inset)
+            .solidDataSurface(cornerRadius: Radius.panel)
         }
         .padding(outerPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -524,8 +524,8 @@ private struct AccentSwatchPreviewRow: View {
 /// Privacy-safe live preview of the in-app text size (AND-570). Synthetic labels
 /// scaled by the caller's `.dynamicTypeSize` — never real account data — so the
 /// user sees the effect of the Text Size picker the instant it changes. Uses a
-/// semantic text style and the hero-balance modifier so the preview tracks the
-/// same scaling path as the real dashboard surfaces.
+/// semantic text style and the display-balance modifier so the preview tracks
+/// the same scaling path as the real dashboard surfaces.
 private struct TextSizePreviewRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.xxs) {
@@ -533,7 +533,7 @@ private struct TextSizePreviewRow: View {
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
             Text("$12,345.67")
-                .heroBalance()
+                .displayBalance()
             Text("Preview only — sample data")
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/Sources/PlaidBar/Theme/Typography.swift
+++ b/Sources/PlaidBar/Theme/Typography.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 // MARK: - Type Scale Notes (AND-515)
 //
-// Dynamic Type: the two display sizes (`DisplayBalance`, `HeroBalance`) scale
-// their fixed base point size (30pt / 28pt) with the user's text-size /
-// accessibility setting via `@ScaledMetric(relativeTo:)` — a plain
-// `.system(size:)` font does NOT scale, so the metric is what makes the hero
-// figure grow instead of staying pinned. They also opt into
+// Dynamic Type: the display size (`DisplayBalance`) scales its fixed base
+// point size (30pt) with the user's text-size / accessibility setting via
+// `@ScaledMetric(relativeTo:)` — a plain `.system(size:)` font does NOT
+// scale, so the metric is what makes the hero figure grow instead of staying
+// pinned. It also opts into
 // `.dynamicTypeSize(.xSmall ... .accessibility3)` to cap before the
 // layout-breaking AX4/AX5 steps. Every other modifier here is built on a semantic text style
 // (`.caption`, `.callout`, `.caption2`) and therefore scales with Dynamic Type
@@ -56,19 +56,6 @@ struct DisplayBalance: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(.system(size: size, weight: .semibold, design: .default).monospacedDigit())
-            .dynamicTypeSize(.xSmall ... .accessibility3)
-    }
-}
-
-/// Level 1 — Hero: legacy 28pt rounded balance header (detail surfaces).
-/// Dynamic Type (AND-515): `@ScaledMetric(relativeTo: .largeTitle)` scales the
-/// 28pt base with text-size; tabular digits preserved; same accessibility clamp.
-struct HeroBalance: ViewModifier {
-    @ScaledMetric(relativeTo: .largeTitle) private var size: CGFloat = 28
-
-    func body(content: Content) -> some View {
-        content
-            .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
             .dynamicTypeSize(.xSmall ... .accessibility3)
     }
 }
@@ -128,10 +115,6 @@ extension View {
     /// Reduce Motion). Pass the rendered string. See `RollingTabularNumber`.
     func rollingTabularNumber(_ value: String, reduceMotion: Bool) -> some View {
         modifier(RollingTabularNumber(value: value, reduceMotion: reduceMotion))
-    }
-
-    func heroBalance() -> some View {
-        modifier(HeroBalance())
     }
 
     func sectionTitle() -> some View {

--- a/Sources/PlaidBar/Views/AccountDetailFlyout.swift
+++ b/Sources/PlaidBar/Views/AccountDetailFlyout.swift
@@ -890,15 +890,21 @@ struct AccountDrillInActionBar: View {
                 Button {
                     onAction(action)
                 } label: {
-                    Label(action.title, systemImage: action.iconName)
+                    let labelContent = Label(action.title, systemImage: action.iconName)
                         .font(.caption.weight(.medium))
                         .foregroundStyle(action == .remove ? SemanticColors.negative : AppearanceTextColors.primary)
                         .padding(.horizontal, Spacing.sm)
                         .padding(.vertical, Spacing.chipVertical)
-                        .glassSurface(
-                            action == .remove ? .emphasized(SemanticColors.negative) : .inset,
-                            cornerRadius: Radius.control
-                        )
+
+                    // A ternary can't pick between `emphasizedDataSurface` and
+                    // `solidDataSurface` directly (different `ViewModifier` types
+                    // behind `some View`), so the destructive action branches the
+                    // surface call itself.
+                    if action == .remove {
+                        labelContent.emphasizedDataSurface(tint: SemanticColors.negative, cornerRadius: Radius.control)
+                    } else {
+                        labelContent.solidDataSurface(cornerRadius: Radius.control)
+                    }
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(action.accessibilityLabel(accountDisplayName: accountDisplayName))

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -490,7 +490,7 @@ private struct NotConnectedFooterButton: View {
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, Spacing.sm)
                 .padding(.vertical, Spacing.chipVertical)
-                .glassSurface(.inset)
+                .solidDataSurface(cornerRadius: Radius.panel)
         }
         .buttonStyle(.plain)
         .help("Open Settings to connect VaultPeek to your bank.")
@@ -526,7 +526,7 @@ private struct DataModeChip: View {
         }
         .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.chipVertical)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Data mode: \(mode)")
     }

--- a/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
+++ b/Sources/PlaidBar/Views/BalanceTimeMachineView.swift
@@ -146,7 +146,7 @@ struct BalanceTimeMachineView: View {
                 }
             }
             .padding(Spacing.sm)
-            .glassSurface(.inset)
+            .solidDataSurface(cornerRadius: Radius.panel)
         }
     }
 }

--- a/Sources/PlaidBar/Views/CategoryDashboardCard.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardCard.swift
@@ -82,7 +82,7 @@ struct CategoryDashboardCard: View {
         } else {
             content()
                 .padding(Spacing.sm)
-                .glassSurface(.raised)
+                .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
         }
     }
 

--- a/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
+++ b/Sources/PlaidBar/Views/CategoryDashboardWindow.swift
@@ -86,7 +86,7 @@ struct CategoryDashboardWindow: View {
             SpendDonutChart(model: donut, isPrivacyMasked: isMasked)
         }
         .padding(Spacing.md)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
     }
 
     // MARK: - Tree
@@ -103,7 +103,7 @@ struct CategoryDashboardWindow: View {
             )
         }
         .padding(Spacing.md)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
     }
 
     // MARK: - Flat table
@@ -189,7 +189,7 @@ struct CategoryDashboardWindow: View {
             tableFooter(totals)
         }
         .padding(Spacing.md)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
     }
 
     private func leftCell(_ row: CategoryDashboardTableRow) -> some View {
@@ -281,7 +281,7 @@ struct CategoryDashboardWindow: View {
         .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
         .multilineTextAlignment(.center)
         .padding(Spacing.lg)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
     }
 
     // MARK: - Helpers

--- a/Sources/PlaidBar/Views/CategoryTreeView.swift
+++ b/Sources/PlaidBar/Views/CategoryTreeView.swift
@@ -74,7 +74,7 @@ struct CategoryTreeView: View {
             }
         }
         .padding(Spacing.sm)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
     }
 
     private func groupHeader(

--- a/Sources/PlaidBar/Views/CommandPalette.swift
+++ b/Sources/PlaidBar/Views/CommandPalette.swift
@@ -43,7 +43,10 @@ struct CommandPalette: View {
         }
         .frame(width: 560)
         .frame(maxHeight: 420)
-        .glassSurface(.raised, cornerRadius: Radius.panel)
+        .solidDataSurface(
+            cornerRadius: Radius.panel,
+            fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity))
+        )
         .shadow(radius: 24, y: 8)
         .padding(.top, Spacing.xl)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
+++ b/Sources/PlaidBar/Views/ConnectionHealthStripView.swift
@@ -37,7 +37,7 @@ struct ConnectionHealthStripView: View {
                 Spacer(minLength: 0)
             }
             .padding(Spacing.sm)
-            .glassSurface(.inset)
+            .solidDataSurface(cornerRadius: Radius.panel)
         }
     }
 }

--- a/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardReadinessPanel.swift
@@ -25,6 +25,23 @@ struct DashboardReadinessPanel: View {
     }
 
     var body: some View {
+        Group {
+            // A ternary can't pick between `emphasizedDataSurface` and
+            // `solidDataSurface` directly (different `ViewModifier` types behind
+            // `some View`), so the attention state branches the surface call itself.
+            if needsAttention {
+                panelContent.emphasizedDataSurface(tint: tint)
+            } else {
+                panelContent.solidDataSurface(
+                    cornerRadius: Radius.panel,
+                    fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity))
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var panelContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 9) {
                 Image(systemName: icon)
@@ -62,8 +79,6 @@ struct DashboardReadinessPanel: View {
             }
         }
         .padding(Spacing.md)
-        .glassSurface(needsAttention ? .emphasized(tint) : .raised)
-        .accessibilityElement(children: .contain)
     }
 
     private var icon: String {

--- a/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
+++ b/Sources/PlaidBar/Views/FirstRunSnapshotView.swift
@@ -52,7 +52,7 @@ struct FirstRunSnapshotView: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.hero(SemanticColors.brand))
+        .heroAccentSurface()
         .accessibilityElement(children: .contain)
         .accessibilityLabel(snapshot.maskedAccessibilitySummary(isMasked: isMasked))
     }
@@ -250,7 +250,7 @@ private struct SnapshotMetricTile: View {
         }
         .padding(Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -375,7 +375,7 @@ struct MainPopover: View {
             // growing the whole popover past the screen-bounded height. In the
             // detached window the panel owns the height, so the rail fills it.
             .frame(maxHeight: columnMaxHeight)
-            .leftPanelSurface()
+            .nativePanelSurface()
             .transition(.move(edge: .leading).combined(with: .opacity))
     }
 
@@ -444,10 +444,10 @@ struct MainPopover: View {
             // morph id are applied by ONE modifier so `.glassEffectID` lands
             // immediately after the `.glassEffect` on the SAME view, inside the
             // columns' shared GlassEffectContainer (`.glassGroup()`). Applying
-            // `.glassEffectID` to the composed result of `leftPanelSurface()`
-            // (as before) bound it to a wrapper view, not to the glass-bearing
-            // view buried in the modifier, so the show/hide morph silently
-            // no-op'd. A stable id across content swaps lets the inspector's
+            // `.glassEffectID` to the composed result of a surface-modifier
+            // view (as before) bound it to a wrapper view, not to the
+            // glass-bearing view buried in the modifier, so the show/hide
+            // morph silently no-op'd. A stable id across content swaps lets the inspector's
             // glass fluidly morph as drill-ins open/close instead of hard-cutting.
             .modifier(InspectorGlassMorphSurface(
                 morphID: Self.inspectorMorphID,
@@ -696,15 +696,19 @@ struct MainPopover: View {
 /// The inspector column's left-panel glass surface, with the Liquid Glass morph
 /// id bound on the SAME view as the glass effect (AND-511).
 ///
-/// This mirrors the visual of `leftPanelSurface()` (the shared `.leftPanel`
-/// `SurfaceRank`: fill + `.glassEffect(.regular)` + stroke + shadow) but applies
+/// This mirrors the visual of `nativePanelSurface()` (chrome fill +
+/// `.glassEffect(.regular)` + stroke, using the left-panel depth constants
+/// below for the extra inner-stroke/shadow treatment) but applies
 /// `.glassEffectID` *immediately after* the `.glassEffect`, on the same `content`,
-/// so the morph identity actually binds. The previous code applied
-/// `.glassEffectID` to the composed output of `leftPanelSurface()`, which is a
+/// so the morph identity actually binds. Applying `.glassEffectID` to the
+/// composed output of a surface-modifier view (as before) bound it to a
 /// wrapper view — not the glass-bearing view inside the modifier — so the
 /// show/hide morph silently no-op'd. The merge radius of the enclosing
 /// `GlassEffectContainer` (`SurfaceTokens.glassMergeRadius`, small) keeps this
 /// panel's glass from fusing with the rail across the wide center column.
+/// The left-panel depth constants (fill/stroke/shadow) are inlined here
+/// rather than routed through a shared rank type, since this is the one
+/// surface that needs the morph-ID binding on the same view as `.glassEffect`.
 private struct InspectorGlassMorphSurface: ViewModifier {
     let morphID: String
     let namespace: Namespace.ID
@@ -712,15 +716,16 @@ private struct InspectorGlassMorphSurface: ViewModifier {
     @AppStorage(PopoverTransparencySetting.storageKey)
     private var popoverTransparency = PopoverTransparencySetting.defaultValue
 
-    private let rank = SurfaceRank.leftPanel
     private var cornerRadius: CGFloat { SurfaceTokens.panelCornerRadius }
+    private var fill: AnyShapeStyle { AnyShapeStyle(.quaternary.opacity(0.72)) }
+    private var depth: SurfaceTokens.SurfaceDepth { SurfaceTokens.leftPanelDepth }
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
         let multiplier = PopoverTransparencySetting(value: popoverTransparency).surfaceDepthMultiplier
 
         content
-            .background(rank.fill, in: shape)
+            .background(fill, in: shape)
             // `.glassEffect` and `.glassEffectID` are adjacent on this same view,
             // inside the columns' GlassEffectContainer — the binding the morph
             // requires (AND-511).
@@ -728,18 +733,18 @@ private struct InspectorGlassMorphSurface: ViewModifier {
             .glassEffectID(morphID, in: namespace)
             .overlay {
                 shape
-                    .stroke(rank.stroke(multiplier: multiplier), lineWidth: 1)
+                    .stroke(Color.primary.opacity(min(depth.strokeOpacity * multiplier, 0.16)), lineWidth: 1)
                     .overlay {
                         shape
                             .inset(by: 1)
-                            .stroke(rank.innerStroke(multiplier: multiplier), lineWidth: 0.5)
+                            .stroke(Color.white.opacity(min(depth.innerStrokeOpacity * multiplier, 0.10)), lineWidth: 0.5)
                     }
             }
             .shadow(
-                color: Color.black.opacity((rank.depth.shadow?.opacity ?? 0) * multiplier),
-                radius: rank.depth.shadow?.radius ?? 0,
-                x: rank.depth.shadow?.x ?? 0,
-                y: rank.depth.shadow?.y ?? 0
+                color: Color.black.opacity((depth.shadow?.opacity ?? 0) * multiplier),
+                radius: depth.shadow?.radius ?? 0,
+                x: depth.shadow?.x ?? 0,
+                y: depth.shadow?.y ?? 0
             )
     }
 }
@@ -1019,7 +1024,7 @@ private struct BalanceActivityHeatmap: View {
             }
         }
         .padding(Spacing.sm)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
         // Drop a selection that no longer maps to a day in the current range
         // (e.g. after a sync rolls the window forward), so the caption never
         // shows a stale date and the ring never points at a vanished cell.
@@ -1340,7 +1345,7 @@ private struct LocalInsightsCard: View {
             }
         }
         .padding(Spacing.sm)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(receipt.accessibilitySummary)
     }
@@ -1458,7 +1463,7 @@ private struct LocalInsightEvidenceChip: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.rowVertical)
-        .glassSurface(.inset, cornerRadius: Radius.control)
+        .solidDataSurface(cornerRadius: Radius.control)
         .help("\(chip.label): \(chip.value)")
     }
 
@@ -1478,6 +1483,23 @@ private struct DashboardStatusReadinessPanel: View {
     }
 
     var body: some View {
+        Group {
+            // A ternary can't pick between `emphasizedDataSurface` and
+            // `solidDataSurface` directly (different `ViewModifier` types behind
+            // `some View`), so the attention state branches the surface call itself.
+            if readinessNeedsAttention {
+                panelContent.emphasizedDataSurface(tint: tint)
+            } else {
+                panelContent.solidDataSurface(
+                    cornerRadius: Radius.panel,
+                    fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity))
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var panelContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 9) {
                 Image(systemName: icon)
@@ -1555,8 +1577,6 @@ private struct DashboardStatusReadinessPanel: View {
             }
         }
         .padding(Spacing.md)
-        .glassSurface(readinessNeedsAttention ? .emphasized(tint) : .raised)
-        .accessibilityElement(children: .contain)
     }
 
     private var icon: String {
@@ -1799,7 +1819,7 @@ private struct DashboardOverviewFallbackBanner: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.emphasized(SemanticColors.brandSecondary))
+        .emphasizedDataSurface(tint: SemanticColors.brandSecondary)
     }
 }
 
@@ -1995,6 +2015,20 @@ private struct DashboardEmptyAccountState: View {
     }
 
     var body: some View {
+        // A ternary/`.map` can't pick between `emphasizedDataSurface` and
+        // `solidDataSurface` directly (different `ViewModifier` types behind
+        // `some View`), so the emphasis tint branches the surface call itself.
+        if let emphasizedTint {
+            emptyStateContent.emphasizedDataSurface(tint: emphasizedTint)
+        } else {
+            emptyStateContent.solidDataSurface(
+                cornerRadius: Radius.panel,
+                fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity))
+            )
+        }
+    }
+
+    private var emptyStateContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 9) {
                 Image(systemName: icon)
@@ -2036,7 +2070,6 @@ private struct DashboardEmptyAccountState: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(emphasizedTint.map { SurfaceRank.emphasized($0) } ?? .raised)
     }
 
     private var title: String {

--- a/Sources/PlaidBar/Views/ManagedPlanShell.swift
+++ b/Sources/PlaidBar/Views/ManagedPlanShell.swift
@@ -54,7 +54,7 @@ struct PlanSelectionShell: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
     }
 }
 
@@ -133,7 +133,7 @@ struct InstitutionUsageWidget: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
         .alert("Managed plans are coming soon", isPresented: $showUpgradeNote) {
             Button("OK", role: .cancel) {}
             if let docsURL = URL(string: PlaidBarConstants.repositoryFileURL("docs/privacy.md")) {

--- a/Sources/PlaidBar/Views/RecurringObligationsSection.swift
+++ b/Sources/PlaidBar/Views/RecurringObligationsSection.swift
@@ -47,7 +47,7 @@ struct RecurringObligationsSection: View {
                 }
             }
             .padding(Spacing.sm)
-            .glassSurface(.raised)
+            .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
             .accessibilityElement(children: .contain)
             .accessibilityLabel(accessibilitySummary)
         }

--- a/Sources/PlaidBar/Views/RecurringPaymentsView.swift
+++ b/Sources/PlaidBar/Views/RecurringPaymentsView.swift
@@ -102,7 +102,7 @@ struct RecurringPaymentsView: View {
         }
         .padding(Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
     }
 
     private var emptyState: some View {
@@ -151,6 +151,24 @@ private struct RecurringPaymentRow: View {
     let row: RecurringPaymentsSurfacePresentation.Row
 
     var body: some View {
+        Group {
+            // A ternary can't pick between `emphasizedDataSurface` and
+            // `solidDataSurface` directly (different `ViewModifier` types behind
+            // `some View`), so the attention state branches the surface call itself.
+            if row.needsAttention {
+                rowContent.emphasizedDataSurface(tint: SemanticColors.warning)
+            } else {
+                rowContent.solidDataSurface(
+                    cornerRadius: Radius.panel,
+                    fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity))
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(row.accessibilityLabel)
+    }
+
+    private var rowContent: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
                 Text(row.merchantName)
@@ -207,9 +225,6 @@ private struct RecurringPaymentRow: View {
         }
         .padding(Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(row.needsAttention ? .emphasized(SemanticColors.warning) : .raised)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(row.accessibilityLabel)
     }
 }
 

--- a/Sources/PlaidBar/Views/ReviewInboxView.swift
+++ b/Sources/PlaidBar/Views/ReviewInboxView.swift
@@ -646,7 +646,7 @@ private struct ConditionalRaisedSurface: ViewModifier {
         if embedded {
             content
         } else {
-            content.glassSurface(.raised)
+            content.solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
         }
     }
 }

--- a/Sources/PlaidBar/Views/SafeToSpendCard.swift
+++ b/Sources/PlaidBar/Views/SafeToSpendCard.swift
@@ -29,7 +29,7 @@ struct SafeToSpendCard: View {
             breakdownDisclosure
         }
         .padding(Spacing.sm)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilitySummary)
     }

--- a/Sources/PlaidBar/Views/SetupView.swift
+++ b/Sources/PlaidBar/Views/SetupView.swift
@@ -197,7 +197,7 @@ struct SetupView: View {
             }
             .padding(Spacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .glassSurface(.inset)
+            .solidDataSurface(cornerRadius: Radius.panel)
 
             // Plan preview + usage shell. Production shows the managed-plan
             // *preview* picker, but today's production path is still BYO Plaid
@@ -411,7 +411,7 @@ private struct FirstRunCompletionPanel: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
     }
 
     private var icon: String {
@@ -467,7 +467,7 @@ private struct SetupRecoveryCallout: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.emphasized(color))
+        .emphasizedDataSurface(tint: color)
         .accessibilityElement(children: .combine)
     }
 }
@@ -552,7 +552,7 @@ private struct OnboardingChoiceButton: View {
         .buttonStyle(.plain)
         .focusable(true)
         .hoverHighlight(cornerRadius: Radius.panel)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
     }
 }
 
@@ -603,7 +603,7 @@ private struct OnboardingPreflightPanel: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
     }
 
     private func preflightRow(_ row: OnboardingPreflightRow) -> some View {

--- a/Sources/PlaidBar/Views/SharedModifiers.swift
+++ b/Sources/PlaidBar/Views/SharedModifiers.swift
@@ -1,37 +1,16 @@
 import PlaidBarCore
 import SwiftUI
 
-// MARK: - Glass Surface Ranks
+// MARK: - Hero Accent + Emphasized Data Surfaces
 
-/// The popover's three-rank surface system. Ranks use *hierarchical* shape
-/// styles (not flat `Color` fills) so surfaces participate in macOS vibrancy
-/// over the `.regularMaterial` popover root, and respond to Reduce
-/// Transparency / Increase Contrast for free. Default surfaces draw no
-/// stroke — separation comes from spacing; hairlines are reserved for
-/// emphasized (attention) states.
-enum SurfaceRank {
-    /// Persistent left fly-out panel.
-    case leftPanel
-    /// Primary content panels: account list, fly-out, heatmap.
-    case raised
-    /// Quiet secondary surfaces: metric strips, legends, chips.
-    case inset
-    /// Decorative hero emphasis. Never carries finance meaning by itself.
-    case hero(Color)
-    /// Attention states only: tinted fill plus hairline.
-    case emphasized(Color)
-
-    var fill: AnyShapeStyle {
-        // Fills sit over the popover's `.ultraThinMaterial` root: the thinner
-        // material lets the desktop through, so panels need a little more body
-        // than over `.regularMaterial` to keep separation and keep `.secondary`
-        // text legible over a busy wallpaper.
-        switch self {
-        case .leftPanel: AnyShapeStyle(.quaternary.opacity(0.72))
-        case .raised: AnyShapeStyle(.quaternary)
-        case .inset: AnyShapeStyle(.quaternary.opacity(0.55))
-        case let .hero(tint):
-            AnyShapeStyle(
+extension View {
+    /// Decorative hero-accent solid surface: a tinted gradient wash, never
+    /// glass (R-08 — a financial figure must never sample translucency).
+    /// Never carries financial/status meaning by itself.
+    func heroAccentSurface(tint: Color = SemanticColors.brand) -> some View {
+        solidDataSurface(
+            cornerRadius: Radius.panel,
+            fill: AnyShapeStyle(
                 LinearGradient(
                     colors: [
                         tint.opacity(SurfaceTokens.heroGlowOpacity),
@@ -41,94 +20,23 @@ enum SurfaceRank {
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
-            )
-        case let .emphasized(tint): AnyShapeStyle(tint.opacity(0.12))
-        }
+            ),
+            stroke: tint.opacity(0.10)
+        )
     }
 
-    var depth: SurfaceTokens.SurfaceDepth {
-        switch self {
-        case .leftPanel:
-            SurfaceTokens.leftPanelDepth
-        case .raised:
-            SurfaceTokens.raisedDepth
-        case .inset:
-            SurfaceTokens.insetDepth
-        case .hero:
-            SurfaceTokens.heroDepth
-        case .emphasized:
-            SurfaceTokens.emphasizedDepth
-        }
-    }
-
-    func stroke(multiplier: Double) -> Color {
-        switch self {
-        case let .emphasized(tint):
-            tint.opacity(min(depth.strokeOpacity * multiplier, 0.22))
-        case let .hero(tint):
-            tint.opacity(min(depth.strokeOpacity * multiplier, 0.16))
-        case .leftPanel, .raised, .inset:
-            Color.primary.opacity(min(depth.strokeOpacity * multiplier, 0.16))
-        }
-    }
-
-    func innerStroke(multiplier: Double) -> Color {
-        Color.white.opacity(min(depth.innerStrokeOpacity * multiplier, 0.10))
-    }
-}
-
-private struct GlassSurface: ViewModifier {
-    let rank: SurfaceRank
-    let cornerRadius: CGFloat
-    @AppStorage(PopoverTransparencySetting.storageKey) private var popoverTransparency = PopoverTransparencySetting.defaultValue
-
-    func body(content: Content) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius)
-        let multiplier = PopoverTransparencySetting(value: popoverTransparency).surfaceDepthMultiplier
-
-        // Raised/inset ranks carry no underlay fill so the Liquid Glass material
-        // reads clean, but the emphasized rank keeps its tinted wash — attention
-        // states must survive the glass path.
-        content
-            .background(liquidGlassFill, in: shape)
-            .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
-            .overlay { surfaceStroke(shape: shape, multiplier: multiplier) }
-            .surfaceShadow(rank.depth.shadow, multiplier: multiplier)
-    }
-
-    private var liquidGlassFill: AnyShapeStyle {
-        switch rank {
-        case .raised, .inset:
-            AnyShapeStyle(.clear)
-        case .leftPanel, .hero, .emphasized:
-            rank.fill
-        }
-    }
-
-    private func surfaceStroke(shape: RoundedRectangle, multiplier: Double) -> some View {
-        shape.stroke(rank.stroke(multiplier: multiplier), lineWidth: 1)
-            .overlay {
-                shape
-                    .inset(by: 1)
-                    .stroke(rank.innerStroke(multiplier: multiplier), lineWidth: 0.5)
-            }
-    }
-}
-
-extension View {
-    func glassSurface(
-        _ rank: SurfaceRank = .raised,
-        cornerRadius: CGFloat = Radius.panel
-    ) -> some View {
-        modifier(GlassSurface(rank: rank, cornerRadius: cornerRadius))
-    }
-
-    func leftPanelSurface() -> some View {
-        glassSurface(.leftPanel, cornerRadius: SurfaceTokens.panelCornerRadius)
-    }
-
-    func heroAccentSurface(tint: Color = SemanticColors.brand) -> some View {
-        glassSurface(.hero(tint), cornerRadius: Radius.panel)
+    /// Solid attention-state data surface: tinted fill + tinted hairline
+    /// stroke. The emphasized-state counterpart to `solidDataSurface()` for
+    /// attention rows/cards that need a color wash while staying non-glass
+    /// (R-08). Attention states are the one place a tinted wash is
+    /// appropriate on a data surface — the tint plus an accompanying
+    /// icon/text label carries the meaning, never color alone.
+    func emphasizedDataSurface(tint: Color, cornerRadius: CGFloat = Radius.panel) -> some View {
+        solidDataSurface(
+            cornerRadius: cornerRadius,
+            fill: AnyShapeStyle(tint.opacity(0.12)),
+            stroke: tint.opacity(0.16)
+        )
     }
 
     /// Subtle scroll-edge depth (AND-383): a scrolling row fades as it approaches the
@@ -142,17 +50,6 @@ extension View {
             content
                 .opacity(reduceMotion || phase.isIdentity ? 1 : MotionTokens.scrollEdgeFadeOpacity)
         }
-    }
-}
-
-private extension View {
-    func surfaceShadow(_ shadow: SurfaceTokens.SurfaceShadow?, multiplier: Double) -> some View {
-        self.shadow(
-            color: Color.black.opacity((shadow?.opacity ?? 0) * multiplier),
-            radius: shadow?.radius ?? 0,
-            x: shadow?.x ?? 0,
-            y: shadow?.y ?? 0
-        )
     }
 }
 
@@ -202,10 +99,8 @@ struct SolidDataSurface: ViewModifier {
 }
 
 extension View {
-    /// Chrome-rank fill+stroke surface under native Liquid Glass. New surfaces
-    /// should prefer the rank-based `glassSurface(_:cornerRadius:)` vibrancy
-    /// system above; this remains for setup/attention chrome not yet migrated.
-    /// Chrome only — route data surfaces through ``solidDataSurface`` /
+    /// Chrome-rank fill+stroke surface under native Liquid Glass. Chrome
+    /// only — route data surfaces through ``solidDataSurface`` /
     /// ``nativeInsetSurface``.
     func nativePanelSurface(
         cornerRadius: CGFloat = SurfaceTokens.panelCornerRadius,

--- a/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
+++ b/Sources/PlaidBar/Views/WealthSummaryFlyout.swift
@@ -375,7 +375,7 @@ private struct WealthMetricTile: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(Spacing.sm)
-        .glassSurface(.inset, cornerRadius: Radius.control)
+        .solidDataSurface(cornerRadius: Radius.control)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(title): \(value). \(detail)")
     }

--- a/Sources/PlaidBar/Views/WeeklyReviewCard.swift
+++ b/Sources/PlaidBar/Views/WeeklyReviewCard.swift
@@ -23,7 +23,7 @@ struct WeeklyReviewCard: View {
             }
         }
         .padding(Spacing.sm)
-        .glassSurface(.raised)
+        .solidDataSurface(cornerRadius: Radius.panel, fill: AnyShapeStyle(Color.primary.opacity(SurfaceTokens.controlFillOpacity)))
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilitySummary(presentation))
     }

--- a/Sources/PlaidBar/Views/WindowFirstOrientationView.swift
+++ b/Sources/PlaidBar/Views/WindowFirstOrientationView.swift
@@ -126,7 +126,7 @@ private struct OrientationPointRow: View {
         }
         .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .glassSurface(.inset)
+        .solidDataSurface(cornerRadius: Radius.panel)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(point.accessibilityLabel)
     }

--- a/Sources/PlaidBarCore/Models/RawDesignTokens.swift
+++ b/Sources/PlaidBarCore/Models/RawDesignTokens.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// MARK: - Raw design tokens (Gate-0 doctrine, AND-979)
+//
+// Pure, `Sendable`, SwiftUI-free numeric values shared by the popover-scale
+// (`Sources/PlaidBar/Theme/DesignTokens.swift`) and window-scale
+// (`Sources/PlaidBar/Theme/WindowMetrics.swift`) token layers, following the
+// same Core-owns-the-value / app-bridges-to-SwiftUI split already used by
+// `AppAccentColor`/`AppAccentSwatch` (`AppearancePreferences.swift`) for the
+// resolved accent color. Colors stay `Color`-typed and app-target-only —
+// they are dynamic system colors that must resolve per-appearance / Increase
+// Contrast at draw time, not frozen RGB values — so only numerics move here.
+//
+// This is the additive first step of the redesign token migration: nothing
+// in the app target consumes these yet (Epic 1, AND-980). The window-scale
+// `WindowMetrics.md`/`.lg` (16/20) already numerically match `cardPadding`/
+// `cardGap` below; `RawRadius` is the one genuine numeric change (adopts the
+// redesign's clean 3-role ladder, replacing the app's two disagreeing
+// "panel" radii — `Radius.panel = 8` vs `SurfaceTokens.panelCornerRadius = 7`).
+
+/// The 8pt-grid spacing scale shared across popover and window surfaces.
+/// `cardGap` is strictly greater than `cardPadding` by design — separation
+/// between sibling cards comes from spacing, not from strokes or nested
+/// chrome, so a dense grid still reads as distinct surfaces.
+public enum RawSpacing: Sendable {
+    public static let xxs: Double = 2
+    public static let xs: Double = 4
+    public static let sm: Double = 8
+    public static let md: Double = 12
+    /// The one intra-card content inset. Matches `WindowMetrics.md` today.
+    public static let cardPadding: Double = 16
+    /// The one inter-card gap. Matches `WindowMetrics.lg` today. Always
+    /// greater than `cardPadding` — see `RawTokenInvariantTests`.
+    public static let cardGap: Double = 20
+    public static let xxl: Double = 32
+}
+
+/// The corner-radius ladder: three roles, no more. Adopts the redesign's
+/// scale, which also resolves the app's existing internal disagreement
+/// between `Radius.panel` (8) and `SurfaceTokens.panelCornerRadius` (7).
+public enum RawRadius: Sendable {
+    /// Heatmap cells, tiny chips.
+    public static let cell: Double = 3
+    /// Rows, buttons, hover washes, segmented filters, badges.
+    public static let control: Double = 7
+    /// Cards, panels, popover content, sheets.
+    public static let card: Double = 12
+}
+
+/// Fixed-frame sizes so a visual role renders at the same size everywhere.
+/// Values already match the app's existing `Sizing` enum — centralized here
+/// so both token layers read one source instead of two independently-tuned
+/// copies.
+public enum RawSizing: Sendable {
+    public static let iconInline: Double = 16
+    public static let iconNav: Double = 20
+    public static let iconChip: Double = 28
+    public static let statusDot: Double = 8
+    /// The macOS pointer-target floor for borderless glyph controls — not
+    /// the 44pt touch-input minimum, which would wreck desktop density.
+    public static let pointerTargetMin: Double = 28
+    public static let rowMinHeight: Double = 44
+}
+
+/// Raw animation durations/response values. `Animation` itself is a SwiftUI
+/// type and stays app-target-only (`MotionTokens.animation(_:reduceMotion:)`
+/// wraps these); only the numeric curve parameters live in Core so they can
+/// be asserted here without an app-target test dependency.
+public enum RawMotionDurations: Sendable {
+    /// Hover, press, chip toggles.
+    public static let micro: Double = 0.12
+    /// Selection, filter swaps, disclosure, banner entrances.
+    public static let standard: Double = 0.2
+    /// Spring response for drill-in/fly-out expansion.
+    public static let contentResponse: Double = 0.3
+    /// Spring damping fraction for drill-in/fly-out expansion.
+    public static let contentDamping: Double = 0.85
+    /// Once-per-appearance chart reveal.
+    public static let chartReveal: Double = 0.55
+}

--- a/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
+++ b/Tests/PlaidBarCoreTests/RawDesignTokensTests.swift
@@ -1,0 +1,107 @@
+import PlaidBarCore
+import Testing
+
+@Suite("Raw design token invariants (Gate-0 doctrine, AND-979)")
+struct RawDesignTokensTests {
+    // MARK: Spacing
+
+    @Test("Card gap exceeds card padding — separation comes from spacing, not chrome")
+    func cardGapExceedsCardPadding() {
+        #expect(RawSpacing.cardGap > RawSpacing.cardPadding)
+    }
+
+    @Test("Spacing scale is strictly ordered")
+    func spacingScaleOrdered() {
+        #expect(RawSpacing.xxs < RawSpacing.xs)
+        #expect(RawSpacing.xs < RawSpacing.sm)
+        #expect(RawSpacing.sm < RawSpacing.md)
+        #expect(RawSpacing.md < RawSpacing.cardPadding)
+        #expect(RawSpacing.cardPadding < RawSpacing.cardGap)
+        #expect(RawSpacing.cardGap < RawSpacing.xxl)
+    }
+
+    // MARK: Radius
+
+    @Test("Radius ladder is strictly ordered: cell < control < card")
+    func radiusLadderOrdered() {
+        #expect(RawRadius.cell < RawRadius.control)
+        #expect(RawRadius.control < RawRadius.card)
+    }
+
+    // MARK: Sizing
+
+    @Test("Pointer-target floor is the 28pt desktop minimum, not the 44pt touch minimum")
+    func pointerTargetIsDesktopFloor() {
+        #expect(RawSizing.pointerTargetMin == 28)
+        #expect(RawSizing.pointerTargetMin < RawSizing.rowMinHeight)
+    }
+
+    // MARK: Motion
+
+    @Test("Motion durations are non-negative and ordered micro < standard < chartReveal")
+    func motionDurationOrdering() {
+        #expect(RawMotionDurations.micro > 0)
+        #expect(RawMotionDurations.micro < RawMotionDurations.standard)
+        #expect(RawMotionDurations.standard < RawMotionDurations.chartReveal)
+        #expect(RawMotionDurations.contentDamping > 0 && RawMotionDurations.contentDamping < 1)
+    }
+}
+
+@Suite("Category color completeness + contrast (Gate-0 doctrine, AND-979)")
+struct CategoryColorContrastTests {
+    /// Every `SpendingCategory` case must define both a light- and dark-mode
+    /// hex, and no two categories may share the exact same light-mode hex
+    /// (they'd be visually indistinguishable in the donut/legend).
+    @Test("Every category has a light and dark hex, and light hexes are unique")
+    func categoryHexCompleteness() {
+        var seenLight: Set<String> = []
+        for category in SpendingCategory.allCases {
+            #expect(!category.colorHex.isEmpty)
+            #expect(!category.colorHexDark.isEmpty)
+            let (inserted, _) = seenLight.insert(category.colorHex)
+            #expect(inserted, "Duplicate light-mode hex for \(category): \(category.colorHex)")
+        }
+    }
+
+    /// WCAG 2.x contrast ratio between a category's dark-mode hex and the
+    /// app's dark content background (#1E1E1E, matching the documented dark
+    /// chart-palette fix). Guards the specific 5-category contrast bug
+    /// DESIGN.md documents as already fixed — regresses loudly if a future
+    /// edit reintroduces a low-contrast dark value instead of adding a hex
+    /// patch.
+    @Test("Category dark-mode hex clears 3:1 contrast against the dark chart background", arguments: SpendingCategory.allCases)
+    func categoryDarkContrast(category: SpendingCategory) {
+        let ratio = contrastRatio(category.colorHexDark, against: "#1E1E1E")
+        #expect(ratio >= 3.0, "\(category) colorHexDark contrast \(ratio) < 3:1 against dark background")
+    }
+
+    // MARK: - WCAG contrast math (pure, no SwiftUI)
+
+    private func contrastRatio(_ hexA: String, against hexB: String) -> Double {
+        let lumA = relativeLuminance(hexA)
+        let lumB = relativeLuminance(hexB)
+        let lighter = max(lumA, lumB)
+        let darker = min(lumA, lumB)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ hex: String) -> Double {
+        let (r, g, b) = rgbComponents(hex)
+        func channel(_ c: Double) -> Double {
+            c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+    }
+
+    private func rgbComponents(_ hex: String) -> (Double, Double, Double) {
+        var sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        sanitized.removeAll { $0 == "#" }
+        guard sanitized.count == 6, let value = UInt32(sanitized, radix: 16) else {
+            return (0, 0, 0)
+        }
+        let r = Double((value >> 16) & 0xFF) / 255
+        let g = Double((value >> 8) & 0xFF) / 255
+        let b = Double(value & 0xFF) / 255
+        return (r, g, b)
+    }
+}


### PR DESCRIPTION
## Summary
- Third increment of the token foundation (Gate-0 [AND-979](https://linear.app/andeslab/issue/AND-979), Epic 1 [AND-980](https://linear.app/andeslab/issue/AND-980)). Stacked on #739 (not yet merged) — diff will shrink once that lands.
- **Fixes a real bug**: the legacy `SurfaceRank`/`GlassSurface` system applied `.glassEffect(.regular)` unconditionally to every rank, including `.raised`/`.inset` over real financial data (~30 of 37 call sites) — directly violating the "Liquid Glass on chrome, not data" doctrine (R-08) the app's own `SharedModifiers.swift` already named but never finished applying.
- `SharedModifiers.swift`: deleted `SurfaceRank`/`GlassSurface`/`glassSurface(_:cornerRadius:)`/`leftPanelSurface()`. `heroAccentSurface(tint:)` now builds on `solidDataSurface` (was glass). New `emphasizedDataSurface(tint:cornerRadius:)` covers the 6 real attention-state call sites, also solid.
- 22 call-site files updated: `.raised`/`.inset` → `solidDataSurface` (fill differentiated to preserve the old visual-weight distinction); `.leftPanel` → `nativePanelSurface()` (correctly stays glass — genuine chrome); `.emphasized(tint)` → `emphasizedDataSurface(tint:)`; `.hero(tint)` → `heroAccentSurface()`. 5 conditional/ternary call sites restructured as `if/else` (a ternary can't unify two different `ViewModifier` types under `some View`).
- `MainPopover.swift`'s `InspectorGlassMorphSurface` referenced `SurfaceRank.leftPanel` directly (not via `glassSurface`/`leftPanelSurface`) for its `.glassEffectID`-binding requirement — inlined the same left-panel fill/stroke/shadow constants rather than routing through `nativePanelSurface`, since it needs `.glassEffectID` on the same view as `.glassEffect`. Legitimate chrome glass, visual behavior unchanged.
- Deleted the dead `HeroBalance` (SF Pro Rounded) typography role — one call site, now uses `.displayBalance()`.
- **Corner radii preserved exactly** at every call site — this PR fixes the glass-vs-solid material only. The radius ladder change is a separate, later PR needing its own visual sign-off (open Gate-0 decision).

## Note for reviewer
`CommandPalette.swift` was mapped `.raised` → `solidDataSurface`, same as other former-`.raised` sites — worth a second look on whether the ⌘K command palette (a floating command/search overlay, not a literal balance display) should instead stay chrome/glass like a sheet. Flagged, not blocking.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` (full suite) — 2690 passed, 0 failures (matches pre-change baseline)
- [ ] Visual spot-check once merged: account list / metric strips / attention rows should look solid (not translucent) against the desktop; left rail + inspector column should still show genuine glass

🤖 Generated with [Claude Code](https://claude.com/claude-code)