### PR TITLE
feat(insights): fold Planning into Insights, deprecate-in-place (AND-979)

### DIFF
--- a/Sources/PlaidBar/App/NavigationModel.swift
+++ b/Sources/PlaidBar/App/NavigationModel.swift
@@ -340,10 +340,13 @@ final class NavigationModel {
         var restored = NavigationState()
         // Restore the last destination (AND-597). Absent ⇒ the default Dashboard,
         // so an upgrading user — and the flag-OFF popover, which only ever shows
-        // Dashboard — is unchanged.
+        // Dashboard — is unchanged. A persisted destination that has since been
+        // deprecated-in-place (Gate-0, AND-979 — e.g. `.planning`) redirects to
+        // its live target, so an upgrading user's old selection still decodes to
+        // somewhere real instead of a destination nothing renders.
         if let rawDestination = defaults.string(forKey: Keys.destination),
            let destination = RouteDestination(rawValue: rawDestination) {
-            restored.destination = destination
+            restored.destination = destination.canonicalRedirect ?? destination
         }
         if let raw = defaults.string(forKey: Keys.dashboardFilter),
            let filter = DashboardAccountFilterKind(rawValue: raw) {

--- a/Sources/PlaidBar/Views/AppShellView.swift
+++ b/Sources/PlaidBar/Views/AppShellView.swift
@@ -404,9 +404,12 @@ private struct SidebarView: View {
         }
     }
 
-    /// The destinations in a band, in `allCases` (sidebar) order.
+    /// The destinations in a band, in `allCases` (sidebar) order. Excludes
+    /// deprecated-in-place destinations (``RouteDestination/canonicalRedirect``,
+    /// e.g. `.planning`, folded into Insights 2026-07-02) — the case stays for
+    /// decode-safety, but it is no longer a selectable sidebar row.
     private func destinations(in band: RouteDestination.Band) -> [RouteDestination] {
-        RouteDestination.allCases.filter { $0.band == band }
+        RouteDestination.allCases.filter { $0.band == band && $0.canonicalRedirect == nil }
     }
 }
 

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -170,7 +170,9 @@ struct DashboardDestinationView: View {
         VStack(alignment: .leading, spacing: WindowMetrics.lg) {
             columnHeader("Money & insights", systemImage: "chart.pie")
 
-            DashboardRecurringCard(onOpen: { openRoute(.planning(section: .recurring)) })
+            // Planning folded into Insights 2026-07-02 (Gate-0, AND-979); the
+            // recurring detail now lives in Insights' Commitments column.
+            DashboardRecurringCard(onOpen: { openRoute(.insights()) })
 
             DashboardGoalsCard(onOpen: { openRoute(.goals()) })
 

--- a/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
+++ b/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
@@ -15,6 +15,13 @@ import SwiftUI
 /// `.settings` arm falls back to the shared placeholder defensively, but it is
 /// unreachable in practice.
 ///
+/// **`.planning` is deprecated-in-place** (Gate-0, AND-979 — folded into Insights
+/// 2026-07-02): `NavigationState.go(to:)`/`apply(_:)` and
+/// `NavigationModel.hydrate()` all redirect it to `.insights` before the
+/// selection ever reaches this router, so the `.planning` arm below is
+/// unreachable in practice, same as `.settings` — it renders Insights
+/// defensively rather than the retired `PlanningDestinationView`.
+///
 /// Window-first surface only: built solely behind `WindowFirstFeatureFlag`
 /// (default OFF), so with the flag off none of this is instantiated.
 struct DestinationContentView: View {
@@ -26,7 +33,9 @@ struct DestinationContentView: View {
         case .review: ReviewDestinationView()
         case .transactions: TransactionsDestinationView()
         case .budgets: BudgetsDestinationView()
-        case .planning: PlanningDestinationView()
+        case .planning:
+            // Unreachable — deprecated-in-place, redirected to .insights upstream.
+            InsightsDestinationView()
         case .goals: GoalsDestinationView()
         case .insights: InsightsDestinationView()
         case .alerts: AlertsDestinationView()

--- a/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsDestinationView.swift
@@ -5,10 +5,12 @@ import SwiftUI
 /// matching the Dashboard reference; `[⌘6]`), Epic 7 / AND-585.
 ///
 /// This re-*hosts* the Insights data — the on-device Foundation Models summary, the
-/// weekly review, and the trend charts — in a desk-distance desktop layout rather
-/// than re-using the popover's compact stack. It reads the *same* `AppState` +
-/// `PlaidBarCore` engines as the popover and the menu-bar surfaces, so the two can
-/// never diverge; **no model or chart logic lives here** (surface only).
+/// weekly review, the trend charts, and (since 2026-07-02, the Planning fold —
+/// Gate-0, AND-979) the forward-looking cashflow/commitments cards — in a
+/// desk-distance desktop layout rather than re-using the popover's compact stack.
+/// It reads the *same* `AppState` + `PlaidBarCore` engines as the popover and the
+/// menu-bar surfaces, so the two can never diverge; **no model or chart logic
+/// lives here** (surface only).
 ///
 /// Layout (desk-distance, ``WindowMetrics`` / ``WindowTypography`` — "comfortable
 /// density", a calm canvas of a few generous cards):
@@ -17,17 +19,27 @@ import SwiftUI
 ///    ``InsightsAIInsightView`` as a prominent full-width hero card. AI is **off by
 ///    default with a visible toggle** (AND-564); availability is detected with a
 ///    graceful NaturalLanguage / deterministic fallback (AND-563);
-/// 2. a **two-column card grid** below it, **at most three cards per column** under a
-///    `title2` column banner:
+/// 2. a **two-column card grid** below it under a `title2` column banner each:
 ///    - left **Trends** column — the net-worth trend, the spend donut, and the
 ///      activity heatmap, each its own ``WindowSection`` chart card
 ///      (``InsightsTrendsView``). Every chart ships its ``ChartAudioGraph`` audio
 ///      graph (AND-569) + a `reduceTransparency` / Privacy Mask text alternative;
 ///      **Liquid Glass never touches a chart** and no meaning rides on color alone
 ///      (ACCESSIBILITY.md);
-///    - right **Review** column — the existing ``WeeklyReviewCard`` re-hosted
-///      unchanged, so the window-first surface and the popover drive the same
-///      review state.
+///    - right **Planning & Review** column — the forward look, folded in from the
+///      retired Planning destination: the projected-balance forecast, the
+///      explainable Safe-to-Spend breakdown, upcoming recurring obligations, and
+///      the goals contribution overview — then the existing ``WeeklyReviewCard``
+///      re-hosted unchanged, so this surface and the popover drive the same
+///      review state. This column intentionally runs longer than the app's usual
+///      "≤3 cards" convention (5 cards) rather than introducing an unprecedented
+///      third content column — every card is still a self-contained
+///      ``WindowSection``, so the cost is a longer scroll, not new structure.
+///      Deliberately does **not** duplicate Dashboard's headline hero metrics
+///      (Net Worth / Safe-to-Spend / 30-day spend) or its Recurring/Goals glance
+///      cards — those already live there; this column's job is the *why* and the
+///      *forecast* behind them, not repeating the same figures a third time
+///      (the redundancy AND-727 flags).
 ///   On a narrow window the two columns stack.
 ///
 /// **Privacy Mask / App Lock:** the shell paints the full lock gate over the whole
@@ -41,6 +53,8 @@ import SwiftUI
 /// this file is never instantiated.
 struct InsightsDestinationView: View {
     @Environment(AppState.self) private var appState
+
+    private var isMasked: Bool { appState.shouldMaskFinancialValues }
 
     var body: some View {
         GeometryReader { proxy in
@@ -57,13 +71,13 @@ struct InsightsDestinationView: View {
                         HStack(alignment: .top, spacing: WindowMetrics.columnGap) {
                             trendsColumn
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
-                            reviewColumn
+                            planningAndReviewColumn
                                 .frame(maxWidth: .infinity, alignment: .topLeading)
                         }
                     } else {
                         VStack(alignment: .leading, spacing: WindowMetrics.xl) {
                             trendsColumn
-                            reviewColumn
+                            planningAndReviewColumn
                         }
                     }
                 }
@@ -74,7 +88,10 @@ struct InsightsDestinationView: View {
         }
         .navigationTitle(RouteDestination.insights.title)
         .accessibilityElement(children: .contain)
-        .task { await appState.loadInitialData() }
+        .task {
+            await appState.loadInitialData()
+            await appState.goalsStore.loadIfNeeded()
+        }
     }
 
     // MARK: - Columns
@@ -92,11 +109,17 @@ struct InsightsDestinationView: View {
         .accessibilityElement(children: .contain)
     }
 
-    /// The right/secondary **Review** column — the weekly review, re-hosted
-    /// unchanged so this surface and the popover drive the same review state.
-    private var reviewColumn: some View {
+    /// The right/secondary **Planning & Review** column — the forward look folded
+    /// in from Planning (projected balance, safe-to-spend breakdown, recurring,
+    /// goals), then the weekly review. See the type doc for why this column runs
+    /// longer than the app's usual card-count convention.
+    private var planningAndReviewColumn: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.lg) {
-            columnHeader("Review", systemImage: "calendar.badge.checkmark")
+            columnHeader("Planning & Review", systemImage: "calendar.badge.checkmark")
+            projectedBalanceCard
+            safeToSpendBreakdownCard
+            recurringCard
+            goalsCard
             WeeklyReviewCard()
         }
         .accessibilityElement(children: .contain)
@@ -114,6 +137,231 @@ struct InsightsDestinationView: View {
         }
         .labelStyle(.titleAndIcon)
         .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Projected balance card (folded from Planning)
+
+    /// The forward cashflow projection (AND-498), hosted as a card in the
+    /// Planning & Review column. Charts stay solid: the chart backs onto the
+    /// quiet ``WindowSection`` surface, never glass. While Privacy Mask is on the
+    /// forecast is withheld (it would otherwise reveal the balance trajectory);
+    /// while history is too thin it shows a quiet "building forecast" line so the
+    /// column keeps a uniform card rather than a hole.
+    @ViewBuilder
+    private var projectedBalanceCard: some View {
+        let projection = ProjectedBalancePresentation.evaluate(
+            history: appState.balanceHistory,
+            recurring: appState.recurringTransactions,
+            now: Date()
+        )
+        WindowSection("Projected balance", systemImage: "chart.xyaxis.line") {
+            if case let .available(balanceProjection) = projection, !isMasked {
+                Text(projectedLowDetail(balanceProjection))
+                    .windowSupportingText()
+                    .monospacedDigit()
+            }
+        } content: {
+            switch projection {
+            case let .available(balanceProjection):
+                if isMasked {
+                    maskedForecastNotice
+                } else {
+                    ProjectedBalanceChart(projection: balanceProjection)
+                        .frame(minHeight: WindowMetrics.heatmapHeroMinHeight)
+                }
+            case .insufficientHistory:
+                Label(
+                    "Building your forecast — a projected line appears once VaultPeek has recorded a little balance history.",
+                    systemImage: "hourglass"
+                )
+                .windowBodyText()
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: WindowMetrics.heatmapHeroMinHeight, alignment: .leading)
+            }
+        }
+        .loadingRedaction(appState.loadState(for: .summaryCards))
+    }
+
+    private var maskedForecastNotice: some View {
+        Label("Forecast hidden while VaultPeek is private", systemImage: "eye.slash")
+            .windowBodyText()
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: WindowMetrics.heatmapHeroMinHeight, alignment: .leading)
+    }
+
+    private func projectedLowDetail(_ projection: BalanceProjection) -> String {
+        "Projected low \(Formatters.currency(projection.projectedLow.balance, format: .compact)) on \(Formatters.displayDate(projection.projectedLow.date))"
+    }
+
+    // MARK: - Safe-to-spend breakdown card (folded from Planning)
+
+    /// The wealth summary supplies the cashflow window the safe-to-spend
+    /// breakdown needs; built from the same inputs the popover/Dashboard use so
+    /// the number matches everywhere.
+    private var wealthPresentation: WealthSummaryPresentation {
+        WealthSummaryPresentation.evaluate(
+            accounts: appState.accounts,
+            transactions: appState.transactions,
+            isDemoMode: appState.usesDemoConnectionPresentation,
+            serverConnected: appState.serverConnected,
+            credentialsConfigured: appState.serverCredentialsConfigured,
+            linkedItemCount: appState.statusItemCount,
+            syncedItemCount: appState.serverSyncedItemCount ?? 0,
+            itemStatuses: appState.itemStatuses,
+            isSyncStale: appState.isSyncStale,
+            lastSyncRelative: appState.lastSyncRelative,
+            statusSyncText: appState.statusSyncText,
+            errorMessage: appState.error,
+            creditUtilizationThreshold: appState.creditUtilizationThreshold,
+            lowCashThreshold: appState.lowBalanceThreshold,
+            largeTransactionThreshold: appState.largeTransactionThreshold,
+            balanceHistory: appState.balanceHistory
+        )
+    }
+
+    /// The safe-to-spend result — the exact Core computation behind Dashboard's
+    /// hero figure, computed once per body pass for the breakdown card below.
+    private var safeToSpendResult: SafeToSpendResult {
+        SafeToSpendCalculator.compute(
+            accounts: appState.accounts,
+            recurringTransactions: appState.recurringTransactions,
+            cashflow: wealthPresentation.cashflow,
+            asOf: Date()
+        )
+    }
+
+    /// The explainable, signed safe-to-spend reconciliation behind Dashboard's
+    /// hero figure — `SafeToSpendCard` re-hosted from the popover. It self-cards
+    /// (its own glass chrome at popover scale), so like the other re-hosted cards
+    /// it is mounted directly under the column banner rather than re-wrapped (no
+    /// card-in-card). Dashboard's hero tile carries the big figure; this card
+    /// adds the "why".
+    private var safeToSpendBreakdownCard: some View {
+        SafeToSpendCard(
+            result: safeToSpendResult,
+            lastUpdatedRelative: appState.lastSyncRelative,
+            privacyMaskEnabled: isMasked
+        )
+        .loadingRedaction(appState.loadState(for: .summaryCards))
+    }
+
+    // MARK: - Recurring obligations card (folded from Planning)
+
+    /// Upcoming recurring obligations (AND-400), read-only. Re-hosts the
+    /// popover's self-carding ``RecurringObligationsSection`` directly under the
+    /// column banner (no card-in-card), exactly as Planning did. The "open"
+    /// affordance is dropped (`onOpenSubscriptions: nil`) — this card, not a
+    /// separate destination, is now the recurring detail surface Dashboard's
+    /// "open" chevron lands on. When nothing is detected it shows the shared
+    /// contextual, actionable empty state in a uniform ``WindowSection`` card
+    /// rather than self-hiding, so the column keeps an even rhythm.
+    @ViewBuilder
+    private var recurringCard: some View {
+        let presentation = RecurringObligationsPresentation.make(
+            from: appState.recurringTransactions,
+            asOf: Date()
+        )
+        if presentation.isEmpty {
+            WindowSection("Recurring", systemImage: "repeat") {
+                EmptyView()
+            } content: {
+                SecondaryUnavailableView(presentation: appState.recurringUnavailableState) {
+                    appState.performRecurringUnavailableAction(appState.recurringUnavailableState.action)
+                }
+            }
+            .accessibilityElement(children: .contain)
+        } else {
+            RecurringObligationsSection(
+                presentation: presentation,
+                onOpenSubscriptions: nil,
+                privacyMaskEnabled: isMasked,
+                scale: .window
+            )
+            .loadingRedaction(appState.loadState(for: .recurring))
+        }
+    }
+
+    // MARK: - Goals contribution overview (folded from Planning, AND-606)
+
+    /// The read-only goals contribution overview, hosted in a window-scale
+    /// ``WindowSection`` with a `title3` header and an "Open Goals" accessory that
+    /// switches to the Goals workspace. Figures are window `.body`+ and tabular;
+    /// progress is carried by the percent text and counts, never color alone.
+    private var goalsCard: some View {
+        let summary = GoalsSummary.make(from: appState.goalsStore.goals)
+        return WindowSection("Goals", systemImage: RouteDestination.goals.systemImage) {
+            Button("Open Goals") {
+                appState.navigationModel.go(to: .goals)
+            }
+            .buttonStyle(.link)
+            .accessibilityHint("Switches to the Goals workspace.")
+        } content: {
+            if summary.isEmpty {
+                ContentUnavailableView {
+                    Label("No goals yet", systemImage: "flag.checkered")
+                } description: {
+                    Text("Set targets and track contributions in the Goals workspace.")
+                }
+                .frame(maxWidth: .infinity, minHeight: 140)
+            } else {
+                goalsOverview(summary)
+            }
+        }
+        .accessibilityLabel(goalsAccessibilityLabel(summary))
+    }
+
+    private func goalsOverview(_ summary: GoalsSummary) -> some View {
+        VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+            if isMasked {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .tint(.secondary)
+                    .accessibilityHidden(true)
+            } else {
+                ProgressView(value: summary.overallFraction)
+                    .progressViewStyle(.linear)
+                    .tint(SemanticColors.brand)
+                    .accessibilityHidden(true)
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                Text("\(goalsPercent(summary.overallPercent)) of total")
+                    .windowDataText()
+                Spacer(minLength: WindowMetrics.sm)
+                Text("\(goalsCurrency(summary.totalSaved)) of \(goalsCurrency(summary.totalTarget))")
+                    .windowSupportingText()
+                    .monospacedDigit()
+            }
+
+            HStack(spacing: WindowMetrics.md) {
+                Label(summary.goalCountLabel, systemImage: "flag")
+                    .windowSupportingText()
+                if summary.fundedCount > 0 {
+                    Label("\(summary.fundedCount) funded", systemImage: "checkmark.seal")
+                        .windowSupportingText()
+                }
+                if summary.behindCount > 0 {
+                    Label("\(summary.behindCount) behind", systemImage: "exclamationmark.triangle")
+                        .windowSupportingText()
+                }
+            }
+        }
+    }
+
+    private func goalsAccessibilityLabel(_ summary: GoalsSummary) -> String {
+        guard !summary.isEmpty else { return "Goals: no goals yet." }
+        var parts = ["Goals: \(goalsPercent(summary.overallPercent)) of total saved across \(summary.goalCountLabel)"]
+        if summary.fundedCount > 0 { parts.append("\(summary.fundedCount) funded") }
+        if summary.behindCount > 0 { parts.append("\(summary.behindCount) behind") }
+        return parts.joined(separator: ". ")
+    }
+
+    private func goalsCurrency(_ amount: Double) -> String {
+        PrivacyMaskPresentation.currency(amount, format: .full, isEnabled: isMasked, style: .compact)
+    }
+
+    private func goalsPercent(_ value: Int) -> String {
+        PrivacyMaskPresentation.percent(Double(value), decimals: 0, isEnabled: isMasked)
     }
 }
 

--- a/Sources/PlaidBarCore/Models/CommandRegistry.swift
+++ b/Sources/PlaidBarCore/Models/CommandRegistry.swift
@@ -127,7 +127,12 @@ public struct CommandRegistry: Sendable, Equatable {
         var commands: [Command] = []
 
         // 1. Navigate — one per destination, in sidebar order (navigate class).
-        for destination in RouteDestination.allCases {
+        // Deprecated-in-place destinations (``RouteDestination/canonicalRedirect``,
+        // e.g. `.planning`) are excluded here too, matching the sidebar — a "Go to
+        // Planning" result that lands on Insights would read as two destinations
+        // when it is really one. Its search keywords still find Insights, folded
+        // into `navigateKeywords(.insights)` below.
+        for destination in RouteDestination.allCases where destination.canonicalRedirect == nil {
             commands.append(
                 Command(
                     id: navigateID(destination),
@@ -217,16 +222,23 @@ public struct CommandRegistry: Sendable, Equatable {
     }
 
     /// Search synonyms so a destination is reachable by its job, not just its
-    /// label (e.g. "spending" → Budgets, "subscriptions" → Planning).
+    /// label (e.g. "spending" → Budgets, "subscriptions" → Insights). Insights'
+    /// list absorbs Planning's former keywords (folded 2026-07-02, Gate-0
+    /// AND-979) so muscle-memory searches for "forecast"/"cashflow"/etc. still
+    /// find the right destination even though `.planning` no longer has its own
+    /// navigate command.
     private static func navigateKeywords(_ destination: RouteDestination) -> [String] {
         switch destination {
         case .dashboard: ["home", "overview", "net worth", "summary"]
         case .review: ["inbox", "triage", "approve", "categorize", "unreviewed"]
         case .transactions: ["ledger", "history", "spending", "payments"]
         case .budgets: ["spending", "categories", "limits", "over budget"]
-        case .planning: ["forecast", "recurring", "subscriptions", "runway", "cashflow"]
+        case .planning: ["forecast", "recurring", "subscriptions", "runway", "cashflow"] // unreachable: no navigate command (deprecated-in-place)
         case .goals: ["savings", "payoff", "targets", "progress"]
-        case .insights: ["receipts", "weekly review", "trends", "ai"]
+        case .insights: [
+                "receipts", "weekly review", "trends", "ai",
+                "forecast", "recurring", "subscriptions", "runway", "cashflow", "planning",
+            ]
         case .alerts: ["notifications", "warnings", "watchlist"]
         case .accounts: ["banks", "institutions", "balances", "connections"]
         case .settings: ["preferences", "configuration", "options"]

--- a/Sources/PlaidBarCore/Models/NavigationState.swift
+++ b/Sources/PlaidBarCore/Models/NavigationState.swift
@@ -147,9 +147,11 @@ public struct NavigationState: Sendable, Equatable, Codable {
 
     /// Navigate to a bare destination, preserving the per-destination selection
     /// already held. (Selection within a destination is preserved across
-    /// destination switches — the selection-restoration contract.)
+    /// destination switches — the selection-restoration contract.) A deprecated
+    /// destination (``RouteDestination/canonicalRedirect``) redirects to its live
+    /// target instead — the deprecate-in-place mechanism (Gate-0, AND-979).
     public mutating func go(to destination: RouteDestination) {
-        self.destination = destination
+        self.destination = destination.canonicalRedirect ?? destination
     }
 
     /// Apply a typed ``Route``: select its destination and fold any carried
@@ -157,8 +159,13 @@ public struct NavigationState: Sendable, Equatable, Codable {
     /// owns (dashboard account selection) are written here; richer per-destination
     /// selection (transaction id, category, goal id) is added as those
     /// destinations land in later Epic 2 subs.
+    ///
+    /// A route targeting a deprecated destination lands on its redirect instead
+    /// (``RouteDestination/canonicalRedirect``) — the deprecate-in-place mechanism
+    /// (Gate-0, AND-979) — so an old `.planning(section:)` construction still
+    /// resolves somewhere live rather than a destination nothing renders.
     public mutating func apply(_ route: Route) {
-        destination = route.destination
+        destination = route.destination.canonicalRedirect ?? route.destination
         switch route {
         case .accounts(let itemID):
             // An account deep-link selects that account on the dashboard surface

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -142,6 +142,27 @@ public enum RouteDestination: String, CaseIterable, Sendable, Hashable, Codable 
         case .dashboard, .planning, .insights, .settings: nil
         }
     }
+
+    /// The destination a **deprecated** case redirects to, or `nil` for a live
+    /// destination. Deprecate-in-place (Gate-0, AND-979): a folded destination's
+    /// case stays in the enum so a persisted `lastSelectedDestination` value or an
+    /// already-indexed `vaultpeek://route/<destination>` deep link still decodes
+    /// and lands somewhere real, instead of failing to resolve. Applied at every
+    /// entry point that turns a `RouteDestination`/`Route` into the live selection
+    /// (`NavigationState.go(to:)`/`apply(_:)`, `NavigationModel.hydrate()`,
+    /// `Route.canonical(for:)`) — never route *to* a deprecated case directly.
+    ///
+    /// `.planning` folded into `.insights` 2026-07-02: its content (Safe-to-Spend
+    /// breakdown, projected-balance forecast, upcoming recurring, goals overview)
+    /// moved to Insights' Cashflow/Commitments columns. The case, `⌘4`, and
+    /// `Route.planning(section:)` all stay decode-safe; hard-deletion is a
+    /// separate, later cleanup issue after a release's confirmation window.
+    public var canonicalRedirect: RouteDestination? {
+        switch self {
+        case .planning: .insights
+        default: nil
+        }
+    }
 }
 
 // MARK: - Sub-section enums
@@ -245,13 +266,21 @@ public enum Route: Sendable, Hashable, Codable {
     /// The canonical route for a bare destination, using each case's default
     /// selection. Lets the sidebar (which selects a `RouteDestination`) produce a
     /// full `Route` without inventing selection.
+    ///
+    /// A deprecated destination (``RouteDestination/canonicalRedirect``) resolves
+    /// straight to its redirect target's canonical route — `.planning` never
+    /// constructs `.planning()` here, only `.insights()` — so a sidebar tap, a
+    /// `⌘K` result, or a resolved deep link always lands on the live destination.
     public static func canonical(for destination: RouteDestination) -> Route {
-        switch destination {
+        if let redirect = destination.canonicalRedirect {
+            return canonical(for: redirect)
+        }
+        return switch destination {
         case .dashboard: .dashboard
         case .review: .review()
         case .transactions: .transactions()
         case .budgets: .budgets()
-        case .planning: .planning()
+        case .planning: .planning() // unreachable: redirected above
         case .goals: .goals()
         case .insights: .insights()
         case .alerts: .alerts()
@@ -262,11 +291,14 @@ public enum Route: Sendable, Hashable, Codable {
 
     /// Maps a weekly-review navigation target onto a route, so the existing
     /// `WeeklyReviewNavigationTarget` deep-links land on the new destinations.
-    /// `.safeToSpend` lives on the Dashboard canvas.
+    /// `.safeToSpend` lives on the Dashboard canvas. `.recurring` used to land on
+    /// Planning's recurring section; Planning folded into Insights (2026-07-02),
+    /// so it now lands on Insights generally — Insights has no dedicated recurring
+    /// section to scroll to yet.
     public static func from(weeklyReview target: WeeklyReviewNavigationTarget) -> Route {
         switch target {
         case .reviewInbox: .review()
-        case .recurring: .planning(section: .recurring)
+        case .recurring: .insights()
         case .safeToSpend: .dashboard
         }
     }

--- a/Tests/PlaidBarCoreTests/CommandRegistryTests.swift
+++ b/Tests/PlaidBarCoreTests/CommandRegistryTests.swift
@@ -6,14 +6,24 @@ import Testing
 struct CommandRegistryDefaultTests {
     private let registry = CommandRegistry.makeDefault()
 
-    @Test("Has a navigate command for every destination, the 4 act verbs, and find")
+    /// The destinations a navigate command exists for — every `RouteDestination`
+    /// except deprecated-in-place ones (``RouteDestination/canonicalRedirect``,
+    /// e.g. `.planning`, folded into Insights 2026-07-02, Gate-0 AND-979). A
+    /// "Go to Planning" result would just duplicate "Go to Insights", so the
+    /// deprecated case has no navigate command of its own — it's still
+    /// findable by its old keywords, folded into Insights' keyword list.
+    private var liveDestinations: [RouteDestination] {
+        RouteDestination.allCases.filter { $0.canonicalRedirect == nil }
+    }
+
+    @Test("Has a navigate command for every live destination, the 4 act verbs, and find")
     func completeness() {
         let commands = registry.commands
 
-        // Navigate: one per RouteDestination.
+        // Navigate: one per live (non-deprecated) RouteDestination.
         let navigateDestinations = commands.compactMap { $0.kind.navigationDestination }
-        #expect(Set(navigateDestinations) == Set(RouteDestination.allCases))
-        #expect(navigateDestinations.count == RouteDestination.allCases.count)
+        #expect(Set(navigateDestinations) == Set(liveDestinations))
+        #expect(navigateDestinations.count == liveDestinations.count)
 
         // Act: exactly the four global verbs.
         let actions = commands.compactMap { command -> CommandRegistry.Action? in
@@ -27,8 +37,8 @@ struct CommandRegistryDefaultTests {
         let findCount = commands.filter { $0.kind == .find }.count
         #expect(findCount == 1)
 
-        // Total = 10 destinations + 4 acts + 1 find = 15.
-        #expect(commands.count == RouteDestination.allCases.count + 4 + 1)
+        // Total = 9 live destinations + 4 acts + 1 find = 14.
+        #expect(commands.count == liveDestinations.count + 4 + 1)
     }
 
     @Test("All command ids are unique and stable")
@@ -56,11 +66,12 @@ struct CommandRegistryDefaultTests {
     @Test("Display order is navigate (sidebar order) → act → find")
     func displayOrder() {
         let kinds = registry.commands.map(\.kind)
-        let navigateCount = RouteDestination.allCases.count
+        let navigateCount = liveDestinations.count
 
-        // First N are navigate, in sidebar (allCases) order.
+        // First N are navigate, in sidebar (allCases, minus deprecated-in-place
+        // destinations) order.
         let navigatePrefix = kinds.prefix(navigateCount).compactMap(\.navigationDestination)
-        #expect(navigatePrefix == RouteDestination.allCases)
+        #expect(navigatePrefix == liveDestinations)
 
         // Then the four acts, then find last.
         #expect(kinds[navigateCount] == .act(.refresh))
@@ -124,8 +135,11 @@ struct CommandRegistrySearchTests {
 
     @Test("Keyword-driven navigation: unique synonyms surface their destination")
     func keywordNavigation() {
-        // "subscriptions" is unique to Planning; "limits" is unique to Budgets.
-        #expect(registry.search("subscriptions").first?.kind == .navigate(.planning))
+        // "subscriptions" was unique to Planning; folded into Insights' keyword
+        // list when Planning was deprecated-in-place (2026-07-02, Gate-0
+        // AND-979), so it now surfaces "Go to Insights". "limits" is unique to
+        // Budgets.
+        #expect(registry.search("subscriptions").first?.kind == .navigate(.insights))
         #expect(registry.search("limits").first?.kind == .navigate(.budgets))
         // "banks" is unique to Accounts.
         #expect(registry.search("banks").first?.kind == .navigate(.accounts))

--- a/Tests/PlaidBarCoreTests/RouteDeepLinkTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteDeepLinkTests.swift
@@ -10,7 +10,11 @@ struct RouteDeepLinkTests {
             let urlString = RouteDeepLink.urlString(for: destination)
             let url = try #require(URL(string: urlString))
             let route = try #require(RouteDeepLink.route(from: url))
-            #expect(route.destination == destination)
+            // A deprecated-in-place destination's already-indexed deep link
+            // (e.g. an old vaultpeek://route/planning widget/Spotlight item)
+            // still resolves — to its live redirect target, not itself
+            // (Gate-0, AND-979 — decode-safety, not a dead link).
+            #expect(route.destination == destination.canonicalRedirect ?? destination)
             // The canonical route for the destination is what a bare deep link
             // resolves to (no per-row selection carried).
             #expect(route == Route.canonical(for: destination))

--- a/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
@@ -116,16 +116,21 @@ struct RouteTests {
     @Test("Canonical route for each destination uses default selection")
     func canonicalRoutes() {
         for d in RouteDestination.allCases {
-            #expect(Route.canonical(for: d).destination == d)
+            // A deprecated-in-place destination's canonical route resolves to
+            // its redirect target (Gate-0, AND-979), not itself.
+            #expect(Route.canonical(for: d).destination == d.canonicalRedirect ?? d)
         }
         #expect(Route.canonical(for: .review) == .review())
         #expect(Route.canonical(for: .settings) == .settings())
+        #expect(Route.canonical(for: .planning) == .insights())
     }
 
     @Test("Weekly-review navigation targets map onto routes")
     func weeklyReviewMapping() {
         #expect(Route.from(weeklyReview: .reviewInbox) == .review())
-        #expect(Route.from(weeklyReview: .recurring) == .planning(section: .recurring))
+        // Planning folded into Insights 2026-07-02 (Gate-0, AND-979); the
+        // recurring detail now lives in Insights' Planning & Review column.
+        #expect(Route.from(weeklyReview: .recurring) == .insights())
         #expect(Route.from(weeklyReview: .safeToSpend) == .dashboard)
     }
 
@@ -373,11 +378,12 @@ struct NavigationStateTransitionTests {
     func applySetsDestinationForEveryRoute() {
         // `apply` is the single in-window navigation entry point (palette, keymap,
         // glance chip, App Intents). Applying any route must land on its
-        // destination — the core deep-link guarantee.
+        // destination — the core deep-link guarantee. A deprecated-in-place
+        // destination (Gate-0, AND-979) lands on its redirect target instead.
         for destination in RouteDestination.allCases {
             var state = NavigationState()
             state.apply(.canonical(for: destination))
-            #expect(state.destination == destination)
+            #expect(state.destination == destination.canonicalRedirect ?? destination)
         }
     }
 
@@ -404,6 +410,17 @@ struct NavigationStateTransitionTests {
         // Per-destination selection persists across a destination switch.
         #expect(state.selectedAccountID == "demo_checking")
         #expect(state.dashboardFilter == .cash)
+    }
+
+    @Test("go(to: .planning) redirects to Insights (deprecate-in-place, Gate-0 AND-979)")
+    func goToPlanningRedirectsToInsights() {
+        // Planning folded into Insights 2026-07-02. The case stays in
+        // RouteDestination for decode-safety (a persisted UserDefaults value or
+        // an already-indexed vaultpeek://route/planning deep link must still
+        // land somewhere live), but any live navigation call redirects it.
+        var state = NavigationState()
+        state.go(to: .planning)
+        #expect(state.destination == .insights)
     }
 
     @Test("NavigationState round-trips through Codable")


### PR DESCRIPTION
## Summary
- First real IA fold of the redesign migration ("2. b — merge all of it into Insights as new cards, I design the layout").
- Planning's forward-looking content (projected-balance forecast, safe-to-spend breakdown, upcoming recurring, goals contribution overview) moves into a new **Planning & Review** column on `InsightsDestinationView`, alongside the existing Trends column and `WeeklyReviewCard`.
- Deliberately does **not** bring over Planning's hero metrics row or duplicate Dashboard's Recurring/Goals glance cards — Dashboard already owns those headline figures; this column's job is the *why*/*forecast* behind them (the redundancy AND-727 flags, not resolved here, just not made worse). The column runs to 5 cards rather than introducing an unprecedented third content column.
- **First implementation of the Gate-0 "deprecate-in-place" mechanism**: `RouteDestination.canonicalRedirect` (`.planning → .insights`), applied at every entry point that sets the live selection (`NavigationState.go(to:)`/`apply(_:)`, `Route.canonical(for:)`, `NavigationModel.hydrate()`'s persisted restore) — a persisted selection or an already-indexed `vaultpeek://route/planning` deep link still resolves, to Insights instead of nowhere.
- Sidebar and ⌘K command-palette both filter Planning out of the navigate list; its search keywords fold into Insights' so muscle-memory search still works.
- `PlanningDestinationView.swift` is left in the tree, unreferenced — hard-deletion is a later cleanup issue, same as the enum case itself.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` (full suite) — 2691 passed (2690 baseline + 1 new dedicated redirect test), 0 failures. Updated 7 existing Core tests that encoded the pre-fold routing behavior.
- [ ] Visual spot-check once merged: Insights should show two columns (Trends / Planning & Review with 5 cards), Planning should no longer appear in the sidebar, ⌘4 should land on Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)