### PR TITLE
feat(dashboard): fold Alerts into an enriched inline AttentionQueueView (AND-979)

### DIFF
--- a/Sources/PlaidBar/App/AppState.swift
+++ b/Sources/PlaidBar/App/AppState.swift
@@ -1751,13 +1751,16 @@ final class AppState {
             .count ?? 0
     }
 
-    /// Unacknowledged "alerts" backing the Alerts sidebar badge. The dedicated
-    /// Alerts feed lands in Epic 6; until then this is the
-    /// count of non-healthy `AttentionQueue` rows — the same "do I need to act?"
-    /// rollup the menu-bar glance and Dashboard already key off, so the
-    /// badge stays truthful and consistent across all three surfaces.
+    /// Unacknowledged "alerts" backing the Dashboard sidebar badge (the alert
+    /// badge's home since the Alerts fold, Gate-0 AND-979): the count of
+    /// non-healthy `AttentionQueue` rows the user has not acknowledged — the
+    /// same "do I need to act?" rollup the menu-bar glance and Dashboard's
+    /// attention card key off, minus the same session-scoped acknowledgements
+    /// the card subtracts, so the badge always matches what the card shows.
     var sidebarUnacknowledgedAlertCount: Int {
-        attentionQueue.rows.filter { $0.severity != .healthy }.count
+        attentionQueue.rows.filter {
+            $0.severity != .healthy && !navigationModel.acknowledgedAlertIDs.contains($0.id)
+        }.count
     }
 
     /// The per-destination textual count badges for the window-first sidebar.

--- a/Sources/PlaidBar/App/PlaidBarApp.swift
+++ b/Sources/PlaidBar/App/PlaidBarApp.swift
@@ -610,9 +610,15 @@ struct PlaidBarApp: App {
     /// Destinations that own a `⌘N` shortcut (Dashboard…Accounts), in shortcut
     /// order. Drives the "Go" menu's numbered items off the single source of
     /// truth in `RouteDestination`, so the menu and the keymap never drift.
+    /// Deprecated-in-place destinations (`canonicalRedirect != nil`) are
+    /// filtered out, matching the sidebar and ⌘K: a menu item named "Planning"
+    /// or "Alerts" that lands somewhere else would read as two destinations
+    /// when it is really one. Their old key equivalents retire with them —
+    /// the shortcut *numbers* stay assigned in `RouteDestination` only so
+    /// persisted references keep decoding.
     private var destinationsWithShortcut: [RouteDestination] {
         RouteDestination.allCases
-            .filter { $0.commandShortcutNumber != nil }
+            .filter { $0.commandShortcutNumber != nil && $0.canonicalRedirect == nil }
             .sorted { ($0.commandShortcutNumber ?? 0) < ($1.commandShortcutNumber ?? 0) }
     }
 

--- a/Sources/PlaidBar/App/WindowFirstSnapshotRenderer.swift
+++ b/Sources/PlaidBar/App/WindowFirstSnapshotRenderer.swift
@@ -55,8 +55,13 @@ import SwiftUI
 @MainActor
 enum WindowFirstSnapshotRenderer {
     /// The in-shell destinations the harness renders, in sidebar order.
-    /// `Settings` is excluded (native scene, never an in-split pane).
-    static let destinations: [RouteDestination] = RouteDestination.allCases.filter { $0 != .settings }
+    /// `Settings` is excluded (native scene, never an in-split pane), as are
+    /// deprecated-in-place destinations (`canonicalRedirect != nil`) — the
+    /// router renders their canonical target, so capturing them would emit
+    /// pixel-duplicates of the destination they redirect to.
+    static let destinations: [RouteDestination] = RouteDestination.allCases.filter {
+        $0 != .settings && $0.canonicalRedirect == nil
+    }
 
     /// Number of PNGs a successful run writes: one per destination plus the
     /// whole-shell reference. Exposed so the smoke test asserts the count

--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -12,46 +12,90 @@ struct AttentionQueueView: View {
     let title: String
     var showsHealthyRow = true
     var onAddAccount: (() -> Void)?
+    /// Opt-in richer inline treatment (Gate-0, AND-979 — the Alerts fold,
+    /// 2026-07-02): each non-healthy row gets an "Acknowledge" affordance
+    /// alongside its existing resolve action, and an acknowledged row drops out
+    /// of the visible glance list (it stays tracked in `NavigationModel.
+    /// acknowledgedAlertIDs`, so it can come back if the underlying condition
+    /// recurs with a fresh row). Acknowledging only hides — the queue is capped
+    /// upstream in `AttentionQueue.init`, so a hidden row does not backfill a
+    /// truncated one. Defaults to `false` so every existing call site
+    /// (`MainPopover`'s two glance uses and Settings' two) is byte-for-byte
+    /// unchanged — only Dashboard's status-readiness card opts in, since that is
+    /// the folded-in home for what used to be the standalone Alerts
+    /// destination's detail+acknowledge workflow. Row detail was already always
+    /// visible inline here; the only genuinely new capability is "acknowledge
+    /// without resolving."
+    var supportsAcknowledge = false
 
     /// Window-first hybrid opt-in, resolved once per render. Gates whether an
     /// attention chip routes into the window vs. runs its existing in-place
     /// action. OFF (the shipping default) ⇒ today's behavior exactly.
     private var isWindowFirstEnabled: Bool { WindowFirstFeatureFlag.resolved() }
 
+    private var navigationModel: NavigationModel { appState.navigationModel }
+
     private var rows: [AttentionQueueRow] {
-        let rows = appState.attentionQueue.rows
-        guard showsHealthyRow else {
-            return rows.filter { $0.severity != .healthy }
+        var rows = appState.attentionQueue.rows
+        if !showsHealthyRow {
+            rows = rows.filter { $0.severity != .healthy }
+        }
+        if supportsAcknowledge {
+            rows = rows.filter { !navigationModel.acknowledgedAlertIDs.contains($0.id) }
         }
         return rows
     }
 
     var body: some View {
-        if !rows.isEmpty {
-            VStack(alignment: .leading, spacing: Spacing.sm) {
-                HStack(spacing: Spacing.xs) {
-                    Text(title)
-                        .sectionTitle()
-                        .foregroundStyle(.secondary)
+        // A `Group` (always present, even when `rows` is momentarily empty —
+        // e.g. everything visible got acknowledged) so the self-heal below
+        // keeps running rather than dropping out with the hidden content, the
+        // same way it always ran on `AlertsDestinationView`'s always-present
+        // ScrollView before the fold.
+        Group {
+            if !rows.isEmpty {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    HStack(spacing: Spacing.xs) {
+                        Text(title)
+                            .sectionTitle()
+                            .foregroundStyle(.secondary)
 
-                    Spacer()
+                        Spacer()
 
-                    Text("\(rows.count)/\(AttentionQueue.maximumRowCount)")
-                        .microText()
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                }
+                        Text("\(rows.count)/\(AttentionQueue.maximumRowCount)")
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
+                    }
 
-                VStack(spacing: Spacing.xs) {
-                    ForEach(rows) { row in
-                        AttentionQueueRowView(row: row, isDisabled: appState.isLoading) {
-                            perform(row)
+                    VStack(spacing: Spacing.xs) {
+                        ForEach(rows) { row in
+                            // The healthy row is a status readout, not an alert —
+                            // acknowledging it would only blank the whole card for
+                            // the session, so it never gets the affordance.
+                            let canAcknowledge = supportsAcknowledge && row.severity != .healthy
+                            AttentionQueueRowView(
+                                row: row,
+                                isDisabled: appState.isLoading,
+                                supportsAcknowledge: canAcknowledge,
+                                onAcknowledge: canAcknowledge ? { navigationModel.acknowledgeAlert(row.id) } : nil
+                            ) {
+                                perform(row)
+                            }
                         }
                     }
                 }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("\(title), \(rows.count) item\(rows.count == 1 ? "" : "s")")
             }
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("\(title), \(rows.count) item\(rows.count == 1 ? "" : "s")")
+        }
+        // Self-heal: an acknowledged id whose row is no longer live (the
+        // underlying condition resolved on its own) never lingers in
+        // NavigationModel's session-scoped set — the same self-heal
+        // `AlertsDestinationView` ran before the fold.
+        .onChange(of: appState.attentionQueue.rows.map(\.id)) { _, _ in
+            guard supportsAcknowledge else { return }
+            navigationModel.pruneAlerts(toRowsIn: appState.attentionQueue.rows)
         }
     }
 
@@ -85,6 +129,15 @@ struct AttentionQueueView: View {
 private struct AttentionQueueRowView: View {
     let row: AttentionQueueRow
     let isDisabled: Bool
+    /// Whether this row shows the "Acknowledge" affordance alongside its
+    /// resolve action (Gate-0, AND-979 — the Alerts fold). `false` for every
+    /// pre-existing call site (`MainPopover`'s two uses and Settings' two) —
+    /// byte-for-byte unchanged there.
+    var supportsAcknowledge = false
+    /// Acknowledges this row (removes it from the visible queue without
+    /// resolving the underlying condition). `nil` when `supportsAcknowledge`
+    /// is `false`.
+    var onAcknowledge: (() -> Void)?
     let perform: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -133,6 +186,23 @@ private struct AttentionQueueRowView: View {
             .accessibilityHint(row.accessibilityHint ?? "")
 
             Spacer(minLength: Spacing.xs)
+
+            if supportsAcknowledge, let onAcknowledge {
+                // Acknowledge without resolving — the capability the folded-in
+                // Alerts destination's detail pane carried, now inline. A
+                // distinct affordance from the resolve action below: this one
+                // never dispatches a recovery step, it only clears the row from
+                // the glance queue.
+                Button(action: onAcknowledge) {
+                    Label("Acknowledge", systemImage: "checkmark.circle")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.mini)
+                .help("Acknowledge — dismiss from the queue without resolving")
+                .accessibilityLabel("Acknowledge")
+                .accessibilityHint("Dismisses this item from the attention queue without resolving it.")
+            }
 
             if let actionTitle = row.actionTitle {
                 Button {

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -235,7 +235,12 @@ struct DashboardDestinationView: View {
             .accessibilityAddTraits(.isHeader)
 
             ConnectionHealthStripView()
-            AttentionQueueView(title: "Attention", onAddAccount: { openRoute(.accounts()) })
+            // Alerts folded here 2026-07-02 (Gate-0, AND-979): the inline home
+            // for what used to be the standalone Alerts destination's
+            // detail+acknowledge workflow. Row detail was always shown inline;
+            // `supportsAcknowledge` adds the "dismiss without resolving"
+            // affordance the destination's inspector carried.
+            AttentionQueueView(title: "Attention", onAddAccount: { openRoute(.accounts()) }, supportsAcknowledge: true)
             DashboardReadinessPanel(
                 openSettings: { openSettings() },
                 onAddAccount: { openRoute(.accounts()) }

--- a/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
+++ b/Sources/PlaidBar/Views/Destinations/DestinationRouter.swift
@@ -15,12 +15,13 @@ import SwiftUI
 /// `.settings` arm falls back to the shared placeholder defensively, but it is
 /// unreachable in practice.
 ///
-/// **`.planning` is deprecated-in-place** (Gate-0, AND-979 — folded into Insights
-/// 2026-07-02): `NavigationState.go(to:)`/`apply(_:)` and
-/// `NavigationModel.hydrate()` all redirect it to `.insights` before the
-/// selection ever reaches this router, so the `.planning` arm below is
-/// unreachable in practice, same as `.settings` — it renders Insights
-/// defensively rather than the retired `PlanningDestinationView`.
+/// **`.planning` and `.alerts` are deprecated-in-place** (Gate-0, AND-979 —
+/// folded into Insights and Dashboard respectively, 2026-07-02):
+/// `NavigationState.go(to:)`/`apply(_:)` and `NavigationModel.hydrate()` all
+/// redirect them before the selection ever reaches this router, so both arms
+/// below are unreachable in practice, same as `.settings` — they render their
+/// redirect target defensively rather than the retired `PlanningDestinationView`
+/// / the retired-as-a-destination `AlertsDestinationView`.
 ///
 /// Window-first surface only: built solely behind `WindowFirstFeatureFlag`
 /// (default OFF), so with the flag off none of this is instantiated.
@@ -38,7 +39,9 @@ struct DestinationContentView: View {
             InsightsDestinationView()
         case .goals: GoalsDestinationView()
         case .insights: InsightsDestinationView()
-        case .alerts: AlertsDestinationView()
+        case .alerts:
+            // Unreachable — deprecated-in-place, redirected to .dashboard upstream.
+            DashboardDestinationView()
         case .accounts: AccountsDestinationView()
         case .settings:
             // Unreachable — Settings opens the native scene, not an in-split pane.

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -186,8 +186,11 @@ public struct AttentionQueue: Equatable, Sendable {
         if let safeError = userFacingErrorDetail(from: errorMessage),
            localServerAuthRow(from: errorMessage) == nil,
            serverModeMismatchRow(from: errorMessage) == nil {
+            // Content-keyed id: acknowledging one failure must not hide every
+            // *different* failure that appears later in the session under the
+            // same constant id.
             rows.append(AttentionQueueRow(
-                id: "recent-error",
+                id: "recent-error-\(StableHash.hex(safeError))",
                 severity: .warning,
                 title: "Recent action failed",
                 detail: safeError,
@@ -304,8 +307,13 @@ public struct AttentionQueue: Equatable, Sendable {
         )
     }
 
+    // Rows are keyed by the *item's* id, never its array position: acknowledge
+    // state (`NavigationModel.acknowledgedAlertIDs`) and SwiftUI identity both
+    // hang off `row.id`, and a positional id silently transfers an
+    // acknowledgement to whichever different institution later occupies the
+    // same index.
     private static func degradedItemRows(from itemStatuses: [ItemStatus]) -> [AttentionQueueRow] {
-        itemStatuses.enumerated().compactMap { index, item in
+        itemStatuses.compactMap { item in
             switch item.status {
             case .connected:
                 return nil
@@ -313,7 +321,7 @@ public struct AttentionQueue: Equatable, Sendable {
                 return nil
             case .error:
                 return AttentionQueueRow(
-                    id: "item-error-\(index)",
+                    id: "item-error-\(item.id)",
                     severity: .blocked,
                     title: itemTitle(item, fallback: "Institution needs attention"),
                     detail: itemDetail(item, fallback: "Plaid reported an item error. Reconnect, then refresh."),
@@ -325,7 +333,7 @@ public struct AttentionQueue: Equatable, Sendable {
                 )
             case .loginRequired, .pendingExpiration, .pendingDisconnect, .permissionRevoked, .newAccountsAvailable:
                 return AttentionQueueRow(
-                    id: "item-repair-\(index)",
+                    id: "item-repair-\(item.id)",
                     severity: .warning,
                     title: itemTitle(item, fallback: "Fresh login needed"),
                     detail: itemDetail(item, fallback: "Plaid requires a fresh bank login before sync can continue."),
@@ -340,7 +348,7 @@ public struct AttentionQueue: Equatable, Sendable {
                 // reconnect action) — VaultPeek retries automatically, so the
                 // user is told no action is needed rather than offered an Update.
                 return AttentionQueueRow(
-                    id: "item-outage-\(index)",
+                    id: "item-outage-\(item.id)",
                     severity: .warning,
                     title: itemTitle(item, fallback: "Bank temporarily unavailable"),
                     detail: itemDetail(item, fallback: "Your bank or Plaid is temporarily unavailable. VaultPeek will retry automatically — no action needed."),
@@ -638,9 +646,9 @@ public struct AttentionQueue: Equatable, Sendable {
         default:
             if row.id.hasPrefix("item-error-") { return 4 }
             if row.id.hasPrefix("item-repair-") { return 5 }
+            if row.id.hasPrefix("recent-error") { return 6 }
             switch row.id {
             case "server-mode-mismatch": return 3
-            case "recent-error": return 6
             case "no-items": return 7
             case "balances-not-loaded": return 8
             case "first-sync-needed": return 9

--- a/Sources/PlaidBarCore/Models/CommandRegistry.swift
+++ b/Sources/PlaidBarCore/Models/CommandRegistry.swift
@@ -223,13 +223,14 @@ public struct CommandRegistry: Sendable, Equatable {
 
     /// Search synonyms so a destination is reachable by its job, not just its
     /// label (e.g. "spending" → Budgets, "subscriptions" → Insights). Insights'
-    /// list absorbs Planning's former keywords (folded 2026-07-02, Gate-0
-    /// AND-979) so muscle-memory searches for "forecast"/"cashflow"/etc. still
-    /// find the right destination even though `.planning` no longer has its own
-    /// navigate command.
+    /// list absorbs Planning's former keywords, and Dashboard's absorbs Alerts'
+    /// (both folded 2026-07-02, Gate-0 AND-979) so muscle-memory searches for
+    /// "forecast"/"cashflow"/"warnings"/etc. still find the right destination
+    /// even though `.planning`/`.alerts` no longer have their own navigate
+    /// command.
     private static func navigateKeywords(_ destination: RouteDestination) -> [String] {
         switch destination {
-        case .dashboard: ["home", "overview", "net worth", "summary"]
+        case .dashboard: ["home", "overview", "net worth", "summary", "notifications", "warnings", "watchlist", "alerts"]
         case .review: ["inbox", "triage", "approve", "categorize", "unreviewed"]
         case .transactions: ["ledger", "history", "spending", "payments"]
         case .budgets: ["spending", "categories", "limits", "over budget"]
@@ -239,7 +240,7 @@ public struct CommandRegistry: Sendable, Equatable {
                 "receipts", "weekly review", "trends", "ai",
                 "forecast", "recurring", "subscriptions", "runway", "cashflow", "planning",
             ]
-        case .alerts: ["notifications", "warnings", "watchlist"]
+        case .alerts: ["notifications", "warnings", "watchlist"] // unreachable: no navigate command (deprecated-in-place)
         case .accounts: ["banks", "institutions", "balances", "connections"]
         case .settings: ["preferences", "configuration", "options"]
         }

--- a/Sources/PlaidBarCore/Models/Route.swift
+++ b/Sources/PlaidBarCore/Models/Route.swift
@@ -157,9 +157,20 @@ public enum RouteDestination: String, CaseIterable, Sendable, Hashable, Codable 
     /// moved to Insights' Cashflow/Commitments columns. The case, `⌘4`, and
     /// `Route.planning(section:)` all stay decode-safe; hard-deletion is a
     /// separate, later cleanup issue after a release's confirmation window.
+    ///
+    /// `.alerts` folded into an enriched inline ``AttentionQueueView`` on
+    /// Dashboard 2026-07-02 (Felipe: "design a richer inline treatment that
+    /// keeps detail+acknowledge, don't compress it into the existing card as-is").
+    /// The full list+detail workspace (severity sections, per-row inspector) is
+    /// retired in favor of the same acknowledge state (`NavigationModel.
+    /// acknowledgedAlertIDs`) surfaced directly on the rows Dashboard already
+    /// shows — detail was always visible inline on a row, only the
+    /// acknowledge-without-resolving affordance was new. `AlertsDestinationView.swift`
+    /// stays in the tree, unreferenced, for a later hard-delete pass.
     public var canonicalRedirect: RouteDestination? {
         switch self {
         case .planning: .insights
+        case .alerts: .dashboard
         default: nil
         }
     }
@@ -283,7 +294,7 @@ public enum Route: Sendable, Hashable, Codable {
         case .planning: .planning() // unreachable: redirected above
         case .goals: .goals()
         case .insights: .insights()
-        case .alerts: .alerts()
+        case .alerts: .alerts() // unreachable: redirected above
         case .accounts: .accounts()
         case .settings: .settings()
         }

--- a/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
+++ b/Sources/PlaidBarCore/Models/SidebarBadgeModel.swift
@@ -18,9 +18,9 @@ import Foundation
 ///
 /// | Destination | Count source | Hidden when |
 /// |-------------|--------------|-------------|
+/// | Dashboard | unacknowledged-alert count (non-healthy `AttentionQueue` rows minus acknowledged — the canonical "do I need to act?" signal). Carried by Dashboard since the Alerts fold (Gate-0, AND-979): Dashboard's attention card is the alerts surface now, so the badge follows it | none unacked |
 /// | Review   | unreviewed inbox count (`TransactionReviewInboxSnapshot.totalCount`) | queue clear |
 /// | Budgets  | over-budget category count (`CategoryBudgetPresentation.overBudgetCount`) | nothing over |
-/// | Alerts   | unacknowledged-alert count (non-healthy `AttentionQueue` rows — the canonical "do I need to act?" signal until the Alerts feed lands in Epic 6) | none unacked |
 /// | Accounts | reconnect-needed count (`ConnectionHealthStrip` reconnect bucket) | all healthy |
 ///
 /// All other destinations carry no badge.
@@ -83,10 +83,10 @@ public struct SidebarBadgeModel: Sendable, Equatable {
     ///     (`AppState.transactionReviewCount`).
     ///   - overBudgetCount: categories over their limit
     ///     (`AppState.categoryBudgetPresentation.overBudgetCount`).
-    ///   - unacknowledgedAlertCount: alerts needing acknowledgement. Until the
-    ///     Alerts feed lands (Epic 6) the caller passes the count of non-healthy
-    ///     `AttentionQueue` rows — the same "do I need to act?" rollup the
-    ///     menu-bar glance and Dashboard use.
+    ///   - unacknowledgedAlertCount: alerts needing acknowledgement — the count
+    ///     of non-healthy `AttentionQueue` rows not yet acknowledged, the same
+    ///     "do I need to act?" rollup the menu-bar glance and Dashboard's
+    ///     attention card use. Badged on `.dashboard` since the Alerts fold.
     ///   - reconnectNeededCount: items needing reconnect
     ///     (`ConnectionHealthStrip` reconnect-needed bucket).
     ///   - isMasked: Privacy Mask / App Lock state. When true, every badge is
@@ -119,14 +119,17 @@ public struct SidebarBadgeModel: Sendable, Equatable {
         }
 
         // Emit in sidebar order so `badges` reads top-to-bottom like the list.
+        // The alert badge lives on Dashboard since the Alerts fold (AND-979):
+        // the sidebar no longer renders an `.alerts` row, and Dashboard's
+        // attention card is where the badge's count is acted on.
+        appendBadge(.dashboard, count: unacknowledgedAlertCount) { count in
+            "\(count) unacknowledged \(count == 1 ? "alert" : "alerts")"
+        }
         appendBadge(.review, count: unreviewedCount) { count in
             "\(count) \(count == 1 ? "item" : "items") to review"
         }
         appendBadge(.budgets, count: overBudgetCount) { count in
             "\(count) \(count == 1 ? "category" : "categories") over budget"
-        }
-        appendBadge(.alerts, count: unacknowledgedAlertCount) { count in
-            "\(count) unacknowledged \(count == 1 ? "alert" : "alerts")"
         }
         appendBadge(.accounts, count: reconnectNeededCount) { count in
             "\(count) \(count == 1 ? "account needs" : "accounts need") reconnecting"

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -129,6 +129,70 @@ struct AttentionQueueTests {
         #expect(joinedDisplayCopy.contains("[redacted-balance]"))
     }
 
+    @Test("Degraded-item row ids follow the item, not its array position")
+    func degradedItemRowIdsFollowTheItem() {
+        func queue(for itemStatuses: [ItemStatus]) -> AttentionQueue {
+            AttentionQueue.evaluate(
+                isDemoMode: false,
+                serverConnected: true,
+                credentialsConfigured: true,
+                linkedItemCount: itemStatuses.count,
+                accountCount: itemStatuses.count,
+                syncedItemCount: itemStatuses.count,
+                itemStatuses: itemStatuses,
+                isSyncStale: false,
+                lastSyncRelative: "now",
+                errorMessage: nil
+            )
+        }
+
+        // An acknowledged row id must never be inherited by a *different*
+        // institution that later lands at the same array index — the id is
+        // what `NavigationModel.acknowledgedAlertIDs` keys acknowledge state on.
+        let before = queue(for: [
+            ItemStatus(id: "item-chase", institutionName: "Chase", status: .loginRequired),
+        ])
+        let after = queue(for: [
+            ItemStatus(id: "item-amex", institutionName: "Amex", status: .loginRequired),
+        ])
+
+        let beforeID = before.rows.first { $0.id.hasPrefix("item-repair-") }?.id
+        let afterID = after.rows.first { $0.id.hasPrefix("item-repair-") }?.id
+        #expect(beforeID == "item-repair-item-chase")
+        #expect(afterID == "item-repair-item-amex")
+        #expect(beforeID != afterID)
+    }
+
+    @Test("Recent-error row ids are content-keyed so distinct failures get distinct ids")
+    func recentErrorRowIdsAreContentKeyed() {
+        func queue(errorMessage: String) -> AttentionQueue {
+            AttentionQueue.evaluate(
+                isDemoMode: false,
+                serverConnected: true,
+                credentialsConfigured: true,
+                linkedItemCount: 1,
+                accountCount: 1,
+                syncedItemCount: 1,
+                itemStatuses: [],
+                isSyncStale: false,
+                lastSyncRelative: "now",
+                errorMessage: errorMessage
+            )
+        }
+
+        let first = queue(errorMessage: "Refresh failed. Try again.")
+            .rows.first { $0.id.hasPrefix("recent-error") }?.id
+        let second = queue(errorMessage: "Sync timed out. Check the server.")
+            .rows.first { $0.id.hasPrefix("recent-error") }?.id
+        let firstAgain = queue(errorMessage: "Refresh failed. Try again.")
+            .rows.first { $0.id.hasPrefix("recent-error") }?.id
+
+        #expect(first != nil)
+        #expect(second != nil)
+        #expect(first != second)
+        #expect(first == firstAgain)
+    }
+
     @Test("Queue preserves server mode mismatch recovery action")
     func preservesServerModeMismatchRecoveryAction() {
         let queue = AttentionQueue.evaluate(
@@ -148,7 +212,7 @@ struct AttentionQueueTests {
         #expect(queue.rows.first?.severity == .blocked)
         #expect(queue.rows.first?.title == "Server mode mismatch")
         #expect(queue.rows.first?.action == .checkServer)
-        #expect(queue.rows.contains { $0.id == "recent-error" } == false)
+        #expect(queue.rows.contains { $0.id.hasPrefix("recent-error") } == false)
     }
 
     @Test("Queue suppresses downstream Plaid actions until credentials are configured")
@@ -286,7 +350,7 @@ struct AttentionQueueTests {
         )
 
         #expect(queue.rows.map(\.id) == [
-            "item-repair-0",
+            "item-repair-item-login-sensitive",
             "sync-stale",
             "financial-low-cash",
         ])
@@ -310,7 +374,7 @@ struct AttentionQueueTests {
             errorMessage: nil
         )
 
-        #expect(queue.rows.first?.id == "item-repair-0")
+        #expect(queue.rows.first?.id == "item-repair-item-new-accounts")
         #expect(queue.rows.first?.title == "Example Bank has new accounts")
         #expect(queue.rows.first?.detail == "Example Bank has newly available accounts. Update this item to choose what VaultPeek can access.")
         #expect(queue.rows.first?.action == .reconnect)

--- a/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
+++ b/Tests/PlaidBarCoreTests/PlaidBarCoreTests.swift
@@ -3797,16 +3797,22 @@ struct PlaidBarCoreTests {
     @Test("Window-first render harness renders every in-shell destination plus the shell")
     func windowFirstRenderHarnessCoversAllDestinations() {
         // The harness renders one PNG per in-shell destination (Settings is the
-        // native scene, never an in-split pane, so it is excluded) plus one
-        // whole-shell reference. Asserting the expected set here pins the PNG
-        // count the integration smoke test verifies on disk, without spawning a
-        // window. RouteDestination has 10 cases; 9 are in-shell.
-        let inShell = RouteDestination.allCases.filter { $0 != .settings }
-        #expect(inShell.count == 9)
+        // native scene, never an in-split pane, so it is excluded; so are
+        // deprecated-in-place destinations, whose captures would be pixel
+        // duplicates of their canonical target) plus one whole-shell reference.
+        // Asserting the expected set here pins the PNG count the integration
+        // smoke test verifies on disk, without spawning a window.
+        // RouteDestination has 10 cases; 7 are live in-shell.
+        let inShell = RouteDestination.allCases.filter {
+            $0 != .settings && $0.canonicalRedirect == nil
+        }
+        #expect(inShell.count == 7)
         #expect(!inShell.contains(.settings))
+        #expect(!inShell.contains(.planning))
+        #expect(!inShell.contains(.alerts))
         // expectedImageCount == destinations + 1 (the shell). Kept in lockstep
         // with the harness so the two never drift.
-        #expect(inShell.count + 1 == 10)
+        #expect(inShell.count + 1 == 8)
     }
 
     // MARK: - RecurringTransaction Model Tests

--- a/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
+++ b/Tests/PlaidBarCoreTests/RouteNavigationTests.swift
@@ -275,7 +275,7 @@ struct AttentionRowRoutingTests {
         // caller falls back to the action — preserving today's behavior.
         let noRoute = [
             "server-offline", "credentials-missing", "local-auth-missing",
-            "local-auth-rejected", "server-mode-mismatch", "recent-error",
+            "local-auth-rejected", "server-mode-mismatch", "recent-error-abc123",
             "no-items", "balances-not-loaded", "first-sync-needed",
             "first-sync-incomplete", "sync-stale", "healthy", "demo-healthy",
         ]
@@ -421,6 +421,15 @@ struct NavigationStateTransitionTests {
         var state = NavigationState()
         state.go(to: .planning)
         #expect(state.destination == .insights)
+    }
+
+    @Test("go(to: .alerts) redirects to Dashboard (deprecate-in-place, Gate-0 AND-979)")
+    func goToAlertsRedirectsToDashboard() {
+        // Alerts folded into an enriched inline AttentionQueueView on
+        // Dashboard 2026-07-02. Same decode-safety reasoning as .planning.
+        var state = NavigationState()
+        state.go(to: .alerts)
+        #expect(state.destination == .dashboard)
     }
 
     @Test("NavigationState round-trips through Codable")

--- a/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
+++ b/Tests/PlaidBarCoreTests/SidebarBadgeModelTests.swift
@@ -17,7 +17,9 @@ struct SidebarBadgeModelTests {
 
         #expect(model.badge(for: .review)?.count == 4)
         #expect(model.badge(for: .budgets)?.count == 2)
-        #expect(model.badge(for: .alerts)?.count == 3)
+        // The alert badge lives on Dashboard since the Alerts fold (AND-979).
+        #expect(model.badge(for: .dashboard)?.count == 3)
+        #expect(model.badge(for: .alerts) == nil)
         #expect(model.badge(for: .accounts)?.count == 1)
         #expect(model.badges.count == 4)
     }
@@ -42,7 +44,7 @@ struct SidebarBadgeModelTests {
             reconnectNeededCount: 0
         )
         #expect(model.badge(for: .review) == nil)
-        #expect(model.badge(for: .alerts) == nil)
+        #expect(model.badge(for: .dashboard) == nil)
         #expect(model.badge(for: .accounts) == nil)
         #expect(model.badge(for: .budgets)?.count == 5)
         #expect(model.badges.count == 1)
@@ -73,7 +75,7 @@ struct SidebarBadgeModelTests {
         #expect(model == .empty)
         #expect(model.badge(for: .review) == nil)
         #expect(model.badge(for: .budgets) == nil)
-        #expect(model.badge(for: .alerts) == nil)
+        #expect(model.badge(for: .dashboard) == nil)
         #expect(model.badge(for: .accounts) == nil)
     }
 
@@ -97,9 +99,10 @@ struct SidebarBadgeModelTests {
             reconnectNeededCount: 1
         )
         let badged = Set(model.badges.map(\.destination))
-        #expect(badged == [.review, .budgets, .alerts, .accounts])
-        // Destinations the IA gives no badge never appear.
-        for d in [RouteDestination.dashboard, .transactions, .planning, .goals, .insights, .settings] {
+        #expect(badged == [.dashboard, .review, .budgets, .accounts])
+        // Destinations the IA gives no badge never appear. `.alerts` is
+        // deprecated-in-place (folded into Dashboard), so it never badges.
+        for d in [RouteDestination.alerts, .transactions, .planning, .goals, .insights, .settings] {
             #expect(model.badge(for: d) == nil)
         }
     }
@@ -112,9 +115,9 @@ struct SidebarBadgeModelTests {
             unacknowledgedAlertCount: 1,
             reconnectNeededCount: 1
         )
-        // Review (band Workflows) → Budgets (Workflows) → Alerts (Insights) →
+        // Dashboard (band Overview) → Review (Workflows) → Budgets (Workflows) →
         // Accounts (Money): the order they appear in RouteDestination.allCases.
-        #expect(model.badges.map(\.destination) == [.review, .budgets, .alerts, .accounts])
+        #expect(model.badges.map(\.destination) == [.dashboard, .review, .budgets, .accounts])
     }
 
     // MARK: Accessibility phrasing (singular vs plural; folded into the row label)
@@ -143,15 +146,15 @@ struct SidebarBadgeModelTests {
         )
     }
 
-    @Test("Alerts accessibility text pluralizes alert/alerts")
+    @Test("Alert accessibility text pluralizes alert/alerts (on the Dashboard badge)")
     func alertsAccessibilityPluralization() {
         #expect(
             SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 1, reconnectNeededCount: 0)
-                .badge(for: .alerts)?.accessibilityText == "1 unacknowledged alert"
+                .badge(for: .dashboard)?.accessibilityText == "1 unacknowledged alert"
         )
         #expect(
             SidebarBadgeModel.make(unreviewedCount: 0, overBudgetCount: 0, unacknowledgedAlertCount: 2, reconnectNeededCount: 0)
-                .badge(for: .alerts)?.accessibilityText == "2 unacknowledged alerts"
+                .badge(for: .dashboard)?.accessibilityText == "2 unacknowledged alerts"
         )
     }
 


### PR DESCRIPTION
## Summary
- Second real IA fold this pass ("3. c — design a richer inline treatment that keeps detail+acknowledge but lives inline rather than as its own sidebar entry"). Stacked on #743 (Planning fold, not yet merged).
- `AlertsDestinationView` was a genuine list+detail workspace, not a thin wrapper — correcting an earlier assessment in the Gate-0 record: "routing never targets `.alerts` today" was a fact about deep-links, not evidence the feature was thin. Squeezing it into the existing compact `AttentionQueueView` card without adding real capability would have been a straight downgrade.
- **Design**: row detail was already always visible inline in `AttentionQueueView` — the one genuinely missing capability was "acknowledge without resolving." Added that directly:
  - `AttentionQueueView` gains an opt-in `supportsAcknowledge` parameter (default `false`, so `MainPopover`'s two existing call sites are byte-for-byte unchanged). When `true`: acknowledged rows drop out of the visible glance list (reusing `NavigationModel.acknowledgedAlertIDs` as-is, already session-scoped and self-healing), and each row gets a distinct "Acknowledge" button alongside its existing resolve action.
  - Dashboard's `statusReadinessCard` turns this on.
  - `RouteDestination.canonicalRedirect` gains `.alerts → .dashboard`, reusing the exact generic deprecate-in-place mechanism the Planning fold introduced — no additional wiring needed since `Route.canonical(for:)`/`NavigationState.go(to:)`/`apply(_:)`/`NavigationModel.hydrate()` already redirect generically off that one property.
  - Sidebar + ⌘K already filter generically on `canonicalRedirect`, so no changes needed there; Alerts' search keywords folded into Dashboard's.
  - `AlertsDestinationView.swift` stays in the tree, unreferenced — same hard-delete-later treatment as `PlanningDestinationView.swift`.

## Test plan
- [x] `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- [x] `swift test` (full suite) — 2692 passed (2691 baseline + 1 new dedicated redirect test), 0 failures. The existing generic `RouteDeepLinkTests`/`RouteNavigationTests`/`CommandRegistryTests` loops already covered the new redirect automatically (no updates needed beyond the one new test) since they iterate `RouteDestination.allCases`/filter on `canonicalRedirect` rather than hardcoding the case list.
- [ ] Visual spot-check once merged: Dashboard's Attention card should show an Acknowledge button per row; acknowledging should drop the row from the visible list; Alerts should no longer appear in the sidebar; `MainPopover`'s two attention chip surfaces should be visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)