### PR TITLE
fix(privacy): mask attention queue counts

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -36,10 +36,15 @@ struct AttentionQueueView: View {
 
                     Spacer()
 
-                    Text("\(rows.count)/\(AttentionQueue.maximumRowCount)")
-                        .microText()
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
+                    if let countText = AttentionQueue.countText(
+                        rowCount: rows.count,
+                        isMasked: appState.shouldMaskFinancialValues
+                    ) {
+                        Text(countText)
+                            .microText()
+                            .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
+                    }
                 }
 
                 VStack(spacing: Spacing.xs) {
@@ -51,7 +56,11 @@ struct AttentionQueueView: View {
                 }
             }
             .accessibilityElement(children: .contain)
-            .accessibilityLabel("\(title), \(rows.count) item\(rows.count == 1 ? "" : "s")")
+            .accessibilityLabel(AttentionQueue.containerAccessibilityLabel(
+                title: title,
+                rowCount: rows.count,
+                isMasked: appState.shouldMaskFinancialValues
+            ))
         }
     }
 

--- a/Sources/PlaidBarCore/Models/AttentionQueue.swift
+++ b/Sources/PlaidBarCore/Models/AttentionQueue.swift
@@ -109,6 +109,23 @@ public struct AttentionQueue: Equatable, Sendable {
     public static let maximumRowCount = 3
     private static let maxRenderedErrorLength = 160
 
+    /// Compact visible count for attention surfaces. Exact alert counts are
+    /// behavioral finance metadata, so Privacy Mask withholds the value instead
+    /// of rendering a numeric badge/count chip.
+    public static func countText(rowCount: Int, isMasked: Bool) -> String? {
+        guard !isMasked else { return nil }
+        return "\(max(0, rowCount))/\(maximumRowCount)"
+    }
+
+    /// VoiceOver label for the queue container. Mirrors the visible count privacy
+    /// contract so masked mode does not leak the exact number of active items.
+    public static func containerAccessibilityLabel(title: String, rowCount: Int, isMasked: Bool) -> String {
+        if isMasked {
+            return "\(title), private items"
+        }
+        return "\(title), \(rowCount) item\(rowCount == 1 ? "" : "s")"
+    }
+
     public let rows: [AttentionQueueRow]
 
     public init(rows: [AttentionQueueRow]) {

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -14,6 +14,28 @@ struct AttentionQueueTests {
         #expect(AttentionQueueSeverity.blocked.statusSymbolName == "xmark.octagon.fill")
     }
 
+    @Test("Visible count text is withheld under Privacy Mask")
+    func visibleCountTextWithheldWhenMasked() {
+        #expect(AttentionQueue.countText(rowCount: 2, isMasked: false) == "2/3")
+        #expect(AttentionQueue.countText(rowCount: 2, isMasked: true) == nil)
+    }
+
+    @Test("Container accessibility label withholds exact item counts under Privacy Mask")
+    func containerAccessibilityLabelWithholdsCountsWhenMasked() {
+        #expect(
+            AttentionQueue.containerAccessibilityLabel(title: "Attention", rowCount: 1, isMasked: false)
+                == "Attention, 1 item"
+        )
+        #expect(
+            AttentionQueue.containerAccessibilityLabel(title: "Attention", rowCount: 2, isMasked: false)
+                == "Attention, 2 items"
+        )
+        #expect(
+            AttentionQueue.containerAccessibilityLabel(title: "Attention", rowCount: 2, isMasked: true)
+                == "Attention, private items"
+        )
+    }
+
     @Test("Queue row accessibility labels include status text backup")
     func accessibilityLabelsIncludeStatusTextBackup() {
         let queue = AttentionQueue.evaluate(


### PR DESCRIPTION
## Summary
- Fixes #749 / AND-1035.
- Routes Attention Queue visible count and container VoiceOver label through Core helpers that withhold exact item counts while Privacy Mask is active.
- Preserves unmasked `N/3` visible copy and singular/plural accessibility behavior.
- Adds focused Core regression coverage for masked/unmasked count presentation.

## Test plan
- [x] `swift build --target PlaidBarCoreTests`
- [x] `git diff --check HEAD~1..HEAD`
- [x] Source invariant: confirmed `AttentionQueueView` uses `AttentionQueue.countText` / `containerAccessibilityLabel` with `appState.shouldMaskFinancialValues`, and tests cover masked visible + VoiceOver count withholding.

## Notes
- Full `swift test --filter ...` is blocked in this environment by unrelated FoundationModels macro plugin compilation errors in app-target files (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found), so verification is scoped to the pure Core test target plus source invariant.
