### PR TITLE
fix: mask Attention Queue counts

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -26,6 +26,15 @@ struct AttentionQueueView: View {
         return rows
     }
 
+    private var countPresentation: AttentionQueueCountPresentation.Result {
+        AttentionQueueCountPresentation.evaluate(
+            title: title,
+            rowCount: rows.count,
+            maximumRowCount: AttentionQueue.maximumRowCount,
+            isMasked: appState.shouldMaskFinancialValues
+        )
+    }
+
     var body: some View {
         if !rows.isEmpty {
             VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -36,7 +45,7 @@ struct AttentionQueueView: View {
 
                     Spacer()
 
-                    Text("\(rows.count)/\(AttentionQueue.maximumRowCount)")
+                    Text(countPresentation.visibleText)
                         .microText()
                         .foregroundStyle(.secondary)
                         .accessibilityHidden(true)
@@ -51,7 +60,7 @@ struct AttentionQueueView: View {
                 }
             }
             .accessibilityElement(children: .contain)
-            .accessibilityLabel("\(title), \(rows.count) item\(rows.count == 1 ? "" : "s")")
+            .accessibilityLabel(countPresentation.accessibilityLabel)
         }
     }
 

--- a/Sources/PlaidBarCore/Utilities/AttentionQueueCountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AttentionQueueCountPresentation.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Pure presenter for the Attention Queue's visible and spoken count copy.
+///
+/// The queue count is behavioral financial metadata: it can disclose how many
+/// accounts, alerts, or recovery states are active. When Privacy Mask / App Lock
+/// is engaged, preserve the qualitative state while withholding exact counts
+/// from both visible text and VoiceOver.
+public enum AttentionQueueCountPresentation {
+    public struct Result: Equatable, Sendable {
+        public let visibleText: String
+        public let accessibilityLabel: String
+
+        public init(visibleText: String, accessibilityLabel: String) {
+            self.visibleText = visibleText
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    public static func evaluate(
+        title: String,
+        rowCount: Int,
+        maximumRowCount: Int,
+        isMasked: Bool
+    ) -> Result {
+        if isMasked {
+            return Result(
+                visibleText: "Active",
+                accessibilityLabel: "\(title), active items hidden while Privacy Mask is on"
+            )
+        }
+
+        return Result(
+            visibleText: "\(rowCount)/\(maximumRowCount)",
+            accessibilityLabel: "\(title), \(rowCount) item\(rowCount == 1 ? "" : "s")"
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -4,6 +4,44 @@ import Testing
 
 @Suite("AttentionQueue Tests")
 struct AttentionQueueTests {
+    @Test("Count presentation masks visible and spoken queue counts")
+    func countPresentationMasksVisibleAndSpokenCounts() {
+        let presentation = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 2,
+            maximumRowCount: 3,
+            isMasked: true
+        )
+
+        #expect(presentation.visibleText == "Active")
+        #expect(presentation.accessibilityLabel == "Attention, active items hidden while Privacy Mask is on")
+        #expect(!presentation.visibleText.contains("2"))
+        #expect(!presentation.visibleText.contains("3"))
+        #expect(!presentation.accessibilityLabel.contains("2"))
+        #expect(!presentation.accessibilityLabel.contains("3"))
+    }
+
+    @Test("Count presentation preserves exact queue counts when unmasked")
+    func countPresentationPreservesExactCountsWhenUnmasked() {
+        let singular = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 1,
+            maximumRowCount: 3,
+            isMasked: false
+        )
+        let plural = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 2,
+            maximumRowCount: 3,
+            isMasked: false
+        )
+
+        #expect(singular.visibleText == "1/3")
+        #expect(singular.accessibilityLabel == "Attention, 1 item")
+        #expect(plural.visibleText == "2/3")
+        #expect(plural.accessibilityLabel == "Attention, 2 items")
+    }
+
     @Test("Severity exposes status text and shaped symbols")
     func severityExposesStatusTextAndSymbols() {
         #expect(AttentionQueueSeverity.healthy.statusLabel == "Healthy")


### PR DESCRIPTION
## Summary
- add a PlaidBarCore presenter for Attention Queue count copy
- preserve exact visible/VoiceOver counts when unmasked
- withhold exact queue counts from visible text and VoiceOver while Privacy Mask / App Lock is active

Fixes #749.

## Verification
- `swift build --target PlaidBarCoreTests` ✅
- `git diff --check` ✅
- ad-hoc helper assertion via `swiftc -I .build/arm64-apple-macosx/debug/Modules .tmp_attention_queue_count_check.swift .build/arm64-apple-macosx/debug/PlaidBarCore.build/AttentionQueueCountPresentation.swift.o -o .tmp_attention_queue_count_check && ./.tmp_attention_queue_count_check` ✅ (`attention queue count presentation checks passed`)
- `swift test --specifier 'PlaidBarCoreTests.AttentionQueueTests/countPresentationMasksVisibleAndSpokenCounts' --specifier 'PlaidBarCoreTests.AttentionQueueTests/countPresentationPreservesExactCountsWhenUnmasked'` blocked by existing app-target FoundationModels macro plugin failure before the selected tests run (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` plugin not found)

## Source invariant
- `AttentionQueueView` no longer interpolates `rows.count` directly into visible `Text` or its container `.accessibilityLabel`; both now flow through `AttentionQueueCountPresentation` with `appState.shouldMaskFinancialValues`.
