### PR TITLE
fix(privacy): mask folded attention queue counts

### DIFF
--- a/Sources/PlaidBar/Views/AttentionQueueView.swift
+++ b/Sources/PlaidBar/Views/AttentionQueueView.swift
@@ -46,6 +46,15 @@ struct AttentionQueueView: View {
         return rows
     }
 
+    private var countPresentation: AttentionQueueCountPresentation.Result {
+        AttentionQueueCountPresentation.evaluate(
+            title: title,
+            rowCount: rows.count,
+            maximumRowCount: AttentionQueue.maximumRowCount,
+            isMasked: appState.shouldMaskFinancialValues
+        )
+    }
+
     var body: some View {
         // A `Group` (always present, even when `rows` is momentarily empty —
         // e.g. everything visible got acknowledged) so the self-heal below
@@ -62,7 +71,7 @@ struct AttentionQueueView: View {
 
                         Spacer()
 
-                        Text("\(rows.count)/\(AttentionQueue.maximumRowCount)")
+                        Text(countPresentation.visibleText)
                             .microText()
                             .foregroundStyle(.secondary)
                             .accessibilityHidden(true)
@@ -86,7 +95,7 @@ struct AttentionQueueView: View {
                     }
                 }
                 .accessibilityElement(children: .contain)
-                .accessibilityLabel("\(title), \(rows.count) item\(rows.count == 1 ? "" : "s")")
+                .accessibilityLabel(countPresentation.accessibilityLabel)
             }
         }
         // Self-heal: an acknowledged id whose row is no longer live (the

--- a/Sources/PlaidBarCore/Utilities/AttentionQueueCountPresentation.swift
+++ b/Sources/PlaidBarCore/Utilities/AttentionQueueCountPresentation.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure presenter for the Attention Queue's visible and spoken count copy.
+///
+/// The queue count is behavioral financial metadata: it can disclose how many
+/// accounts, alerts, or recovery states are active. When Privacy Mask / App Lock
+/// is engaged, preserve the qualitative state while withholding exact counts
+/// from both visible text and VoiceOver.
+public enum AttentionQueueCountPresentation {
+    public struct Result: Equatable, Sendable {
+        public let visibleText: String
+        public let accessibilityLabel: String
+
+        public init(visibleText: String, accessibilityLabel: String) {
+            self.visibleText = visibleText
+            self.accessibilityLabel = accessibilityLabel
+        }
+    }
+
+    public static func evaluate(
+        title: String,
+        rowCount: Int,
+        maximumRowCount: Int,
+        isMasked: Bool
+    ) -> Result {
+        if isMasked {
+            // Only the *count* is withheld — the rows themselves stay visible
+            // and VoiceOver-readable, so the copy must not claim the items are
+            // hidden.
+            return Result(
+                visibleText: "Active",
+                accessibilityLabel: "\(title), item count hidden while Privacy Mask is on"
+            )
+        }
+
+        return Result(
+            visibleText: "\(rowCount)/\(maximumRowCount)",
+            accessibilityLabel: "\(title), \(rowCount) item\(rowCount == 1 ? "" : "s")"
+        )
+    }
+}

--- a/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
+++ b/Tests/PlaidBarCoreTests/AttentionQueueTests.swift
@@ -4,6 +4,44 @@ import Testing
 
 @Suite("AttentionQueue Tests")
 struct AttentionQueueTests {
+    @Test("Count presentation masks visible and spoken queue counts")
+    func countPresentationMasksVisibleAndSpokenCounts() {
+        let presentation = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 2,
+            maximumRowCount: 3,
+            isMasked: true
+        )
+
+        #expect(presentation.visibleText == "Active")
+        #expect(presentation.accessibilityLabel == "Attention, item count hidden while Privacy Mask is on")
+        #expect(!presentation.visibleText.contains("2"))
+        #expect(!presentation.visibleText.contains("3"))
+        #expect(!presentation.accessibilityLabel.contains("2"))
+        #expect(!presentation.accessibilityLabel.contains("3"))
+    }
+
+    @Test("Count presentation preserves exact queue counts when unmasked")
+    func countPresentationPreservesExactCountsWhenUnmasked() {
+        let singular = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 1,
+            maximumRowCount: 3,
+            isMasked: false
+        )
+        let plural = AttentionQueueCountPresentation.evaluate(
+            title: "Attention",
+            rowCount: 2,
+            maximumRowCount: 3,
+            isMasked: false
+        )
+
+        #expect(singular.visibleText == "1/3")
+        #expect(singular.accessibilityLabel == "Attention, 1 item")
+        #expect(plural.visibleText == "2/3")
+        #expect(plural.accessibilityLabel == "Attention, 2 items")
+    }
+
     @Test("Severity exposes status text and shaped symbols")
     func severityExposesStatusTextAndSymbols() {
         #expect(AttentionQueueSeverity.healthy.statusLabel == "Healthy")


### PR DESCRIPTION
## Summary
- Masks the Attention Queue's visible count chip and VoiceOver count copy when Privacy Mask/App Lock is active on the folded Alerts feature branch.
- Adds a pure Core presenter plus regression coverage for masked/unmasked count presentation.
- Stacked on `feature/redesign-alerts-fold` so PR #744 does not reintroduce the already-tracked #749 / AND-1035 leak while the main-branch fix PRs remain open.

## Verification
- `git diff --check origin/feature/redesign-alerts-fold...HEAD`
- `swift test --filter AttentionQueueTests/countPresentation -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — blocked before focused test execution by unrelated FoundationModels macro/plugin errors (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found in app-target services).
- `swift build --target PlaidBarCore -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed.
- `/tmp/hermes-verify-pr744-attentionqueue.py` source invariant — passed and removed.

## Privacy/security
No Plaid credentials, provider tokens, raw IDs, transaction payloads, balances, prompts, response bodies, local SQLite data, logs, or screenshots were moved. This is a local presentation-only Privacy Mask fix for count-bearing behavioral metadata.

Fixes #749
