### PR TITLE
feat(ui): add shared design-elevation component kit

### DIFF
--- a/Sources/PlaidBar/Views/Shared/BudgetBarRow.swift
+++ b/Sources/PlaidBar/Views/Shared/BudgetBarRow.swift
@@ -105,14 +105,12 @@ struct BudgetBarRow: View {
         min(max(fillFraction, 0), 1)
     }
 
-    /// Verdict glyph — the non-color half of the verdict cue.
+    /// Verdict glyph — the non-color half of the verdict cue. Delegated to the
+    /// shared `CategoryBudgetStatus.iconName` vocabulary (with the same neutral
+    /// no-budget fallback as `statusIconName` elsewhere), so this row never
+    /// drifts from the glyphs the Budgets table and status bar use.
     private var statusGlyph: String {
-        switch status {
-        case .over: "exclamationmark.circle.fill"
-        case .nearing: "exclamationmark.triangle"
-        case .under: "checkmark.circle"
-        case nil: "minus.circle"
-        }
+        status?.iconName ?? "minus.circle"
     }
 
     /// Attention states (over/nearing) borrow the shared verdict tint so the

--- a/Sources/PlaidBar/Views/Shared/BudgetBarRow.swift
+++ b/Sources/PlaidBar/Views/Shared/BudgetBarRow.swift
@@ -1,0 +1,195 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Budget bar row (design-elevation shared kit)
+//
+// A single budget-vs-actual row: category label, capsule track filled to the
+// spent fraction with a visible tick at the budget position, and a trailing
+// preformatted verdict ("over by $86" / "$120 left"). It follows the
+// ``CategoryStatusBar`` philosophy: an over-budget row pins the fill full and
+// carries the magnitude in the tick + text, never by overflowing the bar; the
+// tick is a *shape* cue, not color-only. Verdict tinting is delegated to the
+// shared `CategoryBudgetStatus.verdictTint` — no second tint mapping.
+
+/// One budget-vs-actual row with a tick-marked capsule track.
+///
+/// Pure presentation: fractions and strings arrive precomputed and mask-aware.
+/// The row reads as one VoiceOver element ("Dining: $586 spent of $500 budget.
+/// Over by $86.") so track geometry never has to be interpreted by ear.
+struct BudgetBarRow: View {
+    let categoryLabel: String
+    /// Track fill as a fraction of the *track* (0…1, clamped here). For an
+    /// over-budget row pass 1 — the overage lives in `verdictText`, not in an
+    /// overflowing bar.
+    let fillFraction: Double
+    /// Where the budget sits on the track (0…1), or `nil` to hide the tick
+    /// (no budget set). Under budget this is 1 (budget at the track end);
+    /// over budget it is budget/spent, so the tick shows how far past it went.
+    var budgetTickFraction: Double?
+    /// Budget verdict driving glyph + tint (via the shared
+    /// `CategoryBudgetStatus.verdictTint`); `nil` means no budget set.
+    let status: CategoryBudgetStatus?
+    /// Preformatted, mask-aware verdict ("over by $86" / "$120 left" /
+    /// "No budget set").
+    let verdictText: String
+    /// Preformatted, mask-aware spent figure for VoiceOver.
+    let spentText: String
+    /// Preformatted, mask-aware budget figure for VoiceOver; `nil` when unbudgeted.
+    var limitText: String?
+    /// Fill accent for a healthy (under-budget) row — a redundant cue only.
+    var accent: Color = SemanticColors.brand
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Spacing.sm) {
+            Text(categoryLabel)
+                .font(.caption)
+                .lineLimit(1)
+                .frame(minWidth: 72, alignment: .leading)
+
+            track
+
+            // Glyph + text carry the verdict; tint is the redundant third cue.
+            Label {
+                Text(verdictText)
+                    .microText()
+                    .monospacedDigit()
+            } icon: {
+                Image(systemName: statusGlyph)
+                    .font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(status.verdictTint)
+            .lineLimit(1)
+            .layoutPriority(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private var track: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            ZStack(alignment: .leading) {
+                Capsule().fill(.quaternary.opacity(0.5))
+
+                if status != nil {
+                    Capsule()
+                        .fill(fillTint)
+                        .frame(width: max(width * clampedFill, 3))
+                        .animation(
+                            MotionTokens.animation(MotionTokens.content, reduceMotion: reduceMotion),
+                            value: clampedFill
+                        )
+                }
+
+                // Budget-position tick: a visible shape cue (mirrors the
+                // committed-recurring tick in ``CategoryStatusBar``), so the
+                // budget boundary never reads by color alone.
+                if let budgetTickFraction {
+                    let tickFraction = min(max(budgetTickFraction, 0), 1)
+                    Capsule()
+                        .fill(Color.primary.opacity(0.45))
+                        .frame(width: 2)
+                        .padding(.vertical, 1)
+                        .offset(x: min(max(width * tickFraction - 1, 0), width - 2))
+                }
+            }
+        }
+        .frame(height: 8)
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(true)
+    }
+
+    private var clampedFill: Double {
+        min(max(fillFraction, 0), 1)
+    }
+
+    /// Verdict glyph — the non-color half of the verdict cue.
+    private var statusGlyph: String {
+        switch status {
+        case .over: "exclamationmark.circle.fill"
+        case .nearing: "exclamationmark.triangle"
+        case .under: "checkmark.circle"
+        case nil: "minus.circle"
+        }
+    }
+
+    /// Attention states (over/nearing) borrow the shared verdict tint so the
+    /// bar agrees with the verdict text; a healthy fill uses the row accent
+    /// (the verdict tint for `.under` is deliberately quiet secondary text).
+    private var fillTint: Color {
+        switch status {
+        case .over, .nearing: status.verdictTint.opacity(0.85)
+        default: accent.opacity(0.82)
+        }
+    }
+
+    private var accessibilityText: String {
+        var sentence = "\(categoryLabel): \(spentText) spent"
+        if let limitText {
+            sentence += " of \(limitText) budget"
+        }
+        sentence += ". \(verdictText)."
+        return sentence
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Budget bar rows") {
+    VStack(spacing: Spacing.md) {
+        BudgetBarRow(
+            categoryLabel: "Dining",
+            fillFraction: 1,
+            budgetTickFraction: 500.0 / 586.0,
+            status: .over,
+            verdictText: "over by $86",
+            spentText: "$586",
+            limitText: "$500"
+        )
+        BudgetBarRow(
+            categoryLabel: "Groceries",
+            fillFraction: 0.86,
+            budgetTickFraction: 1,
+            status: .nearing,
+            verdictText: "$56 left",
+            spentText: "$344",
+            limitText: "$400"
+        )
+        BudgetBarRow(
+            categoryLabel: "Transport",
+            fillFraction: 0.31,
+            budgetTickFraction: 1,
+            status: .under,
+            verdictText: "$103 left",
+            spentText: "$47",
+            limitText: "$150"
+        )
+        BudgetBarRow(
+            categoryLabel: "Hobbies",
+            fillFraction: 0,
+            budgetTickFraction: nil,
+            status: nil,
+            verdictText: "No budget set",
+            spentText: "$62"
+        )
+    }
+    .padding(Spacing.lg)
+    .frame(width: 460)
+}
+
+#Preview("Budget bar rows — dark") {
+    BudgetBarRow(
+        categoryLabel: "Dining",
+        fillFraction: 1,
+        budgetTickFraction: 500.0 / 586.0,
+        status: .over,
+        verdictText: "over by $86",
+        spentText: "$586",
+        limitText: "$500"
+    )
+    .padding(Spacing.lg)
+    .frame(width: 460)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/ChartComparisonCaption.swift
+++ b/Sources/PlaidBar/Views/Shared/ChartComparisonCaption.swift
@@ -1,0 +1,64 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Chart comparison caption (design-elevation shared kit)
+//
+// The single quiet line under a chart that says what changed versus the
+// comparison period ("▲ 12% vs prior 30 days"). The text arrives preformatted
+// (and mask-aware) from the caller; direction is carried by the glyph/arrow
+// *in the text*, never by color (this caption is uniformly secondary).
+
+/// One secondary caption line for under a chart.
+///
+/// `spelledAccessibilityLabel` is the words-only reading ("up 12 percent
+/// versus the prior 30 days") so VoiceOver never has to guess at "▲".
+struct ChartComparisonCaption: View {
+    /// Optional leading SF Symbol (e.g. "chart.line.uptrend.xyaxis").
+    var glyph: String?
+    /// Preformatted caption text, direction included ("▲ 12% vs prior period").
+    let text: String
+    /// The same statement spelled in words for VoiceOver.
+    let spelledAccessibilityLabel: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+            if let glyph {
+                Image(systemName: glyph)
+                    .font(.caption2)
+            }
+            Text(text)
+                .font(.caption.monospacedDigit())
+                .lineLimit(1)
+        }
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(spelledAccessibilityLabel)
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Chart comparison captions") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        ChartComparisonCaption(
+            glyph: "calendar",
+            text: "▲ 12% vs prior 30 days",
+            spelledAccessibilityLabel: "Up 12 percent versus the prior 30 days"
+        )
+        ChartComparisonCaption(
+            text: "▼ $86 vs February",
+            spelledAccessibilityLabel: "Down 86 dollars versus February"
+        )
+    }
+    .padding(Spacing.lg)
+}
+
+#Preview("Chart comparison captions — dark") {
+    ChartComparisonCaption(
+        glyph: "calendar",
+        text: "▲ 12% vs prior 30 days",
+        spelledAccessibilityLabel: "Up 12 percent versus the prior 30 days"
+    )
+    .padding(Spacing.lg)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/ChartScrub.swift
+++ b/Sources/PlaidBar/Views/Shared/ChartScrub.swift
@@ -1,0 +1,174 @@
+import Charts
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Chart scrub (design-elevation shared kit)
+//
+// Hover/drag interactivity for Date-x Swift Charts: a thin vertical indicator
+// plus a small solid callout (date + value) that follows the pointer. The
+// chart supplies its own resolver closure — the modifier never touches series
+// data, so any chart (balance trend, spend trend, projections) can adopt it by
+// mapping a scrubbed `Date` to its preformatted, mask-aware value string.
+//
+// VoiceOver: the scrub is a pointer affordance, so it is a deliberate NO-OP
+// while VoiceOver runs — audio graphs (`ChartAudioGraphDescriptor`) remain the
+// accessibility path for series exploration, and the selection overlay would
+// only add noise. Reduce Motion: the indicator tracks the pointer with no
+// animated snapping (position updates are applied without animation).
+
+/// Wraps `chartXSelection(value:)` and renders the shared scrub indicator +
+/// callout. Apply to a `Chart` whose x dimension is `Date`.
+struct ChartScrub: ViewModifier {
+    /// Resolves a scrubbed date to its preformatted, mask-aware value string
+    /// ("$4,820.14" or "••••"); `nil` hides the callout (gap in the series).
+    let valueText: (Date) -> String?
+    /// Formats the callout's date line (defaults to an abbreviated date).
+    var dateText: (Date) -> String = { date in
+        date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+    @State private var selectedDate: Date?
+
+    func body(content: Content) -> some View {
+        if voiceOverEnabled {
+            // NO-OP under VoiceOver: audio graphs are the accessibility path.
+            content
+        } else {
+            content
+                .chartXSelection(value: $selectedDate)
+                .chartOverlay { proxy in
+                    GeometryReader { geometry in
+                        if let selectedDate,
+                           let plotAnchor = proxy.plotFrame,
+                           let xPosition = proxy.position(forX: selectedDate) {
+                            let plotFrame = geometry[plotAnchor]
+                            let x = plotFrame.minX + xPosition
+                            if plotFrame.minX ... plotFrame.maxX ~= x {
+                                indicator(x: x, plotFrame: plotFrame)
+                                callout(for: selectedDate, x: x, plotFrame: plotFrame)
+                            }
+                        }
+                    }
+                    // Presentation-only mirror of the pointer; the values are
+                    // already on-screen in the chart itself.
+                    .accessibilityHidden(true)
+                    // No animated snapping — the rule tracks the pointer 1:1
+                    // (also the Reduce Motion-correct behavior).
+                    .animation(nil, value: selectedDate)
+                }
+        }
+    }
+
+    /// The thin vertical rule at the scrubbed x position.
+    private func indicator(x: CGFloat, plotFrame: CGRect) -> some View {
+        Rectangle()
+            .fill(.secondary.opacity(0.55))
+            .frame(width: 1, height: plotFrame.height)
+            .position(x: x, y: plotFrame.midY)
+    }
+
+    /// The small solid callout (date + value) above the rule, clamped to stay
+    /// inside the plot horizontally. Solid background, never glass — a
+    /// financial figure must not sample translucency (R-08).
+    @ViewBuilder
+    private func callout(for date: Date, x: CGFloat, plotFrame: CGRect) -> some View {
+        if let value = valueText(date) {
+            VStack(alignment: .leading, spacing: Spacing.xxs) {
+                Text(dateText(date))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption.weight(.semibold).monospacedDigit())
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .background(.background, in: RoundedRectangle(cornerRadius: Radius.control))
+            .overlay {
+                RoundedRectangle(cornerRadius: Radius.control)
+                    .stroke(Color.primary.opacity(SurfaceTokens.panelStrokeOpacity), lineWidth: 1)
+            }
+            .fixedSize()
+            .modifier(CalloutPlacement(x: x, plotFrame: plotFrame))
+        }
+    }
+}
+
+/// Positions the callout above the scrub rule, clamped inside the plot frame.
+private struct CalloutPlacement: ViewModifier {
+    let x: CGFloat
+    let plotFrame: CGRect
+
+    @State private var size: CGSize = .zero
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGSize.self) { proxy in
+                proxy.size
+            } action: { newSize in
+                size = newSize
+            }
+            .position(
+                x: min(max(x, plotFrame.minX + size.width / 2), plotFrame.maxX - size.width / 2),
+                y: plotFrame.minY + size.height / 2
+            )
+    }
+}
+
+extension View {
+    /// Shared Date-x chart scrub: vertical rule + solid callout, resolver
+    /// supplied by the chart. No-op while VoiceOver runs (audio graphs are the
+    /// accessibility path); no animated snapping. See ``ChartScrub``.
+    func chartScrub(
+        valueText: @escaping (Date) -> String?,
+        dateText: @escaping (Date) -> String = { date in
+            date.formatted(date: .abbreviated, time: .omitted)
+        }
+    ) -> some View {
+        modifier(ChartScrub(valueText: valueText, dateText: dateText))
+    }
+}
+
+#if canImport(PreviewsMacros)
+private struct ChartScrubPreviewHost: View {
+    struct Point: Identifiable {
+        let id = UUID()
+        let date: Date
+        let balance: Double
+    }
+
+    let points: [Point] = {
+        let start = Date(timeIntervalSince1970: 1_760_000_000)
+        let balances: [Double] = [4820, 4770, 5010, 4950, 5240, 5180, 5420]
+        return balances.enumerated().map { index, balance in
+            Point(date: start.addingTimeInterval(Double(index) * 86_400), balance: balance)
+        }
+    }()
+
+    var body: some View {
+        Chart(points) { point in
+            LineMark(
+                x: .value("Date", point.date),
+                y: .value("Balance", point.balance)
+            )
+            .foregroundStyle(SemanticColors.sparkline)
+        }
+        .chartScrub { date in
+            points
+                .min { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }
+                .map { $0.balance.formatted(.currency(code: "USD")) }
+        }
+        .frame(width: 480, height: 200)
+        .padding(Spacing.lg)
+    }
+}
+
+#Preview("Chart scrub") {
+    ChartScrubPreviewHost()
+}
+
+#Preview("Chart scrub — dark") {
+    ChartScrubPreviewHost()
+        .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/DisclosureSection.swift
+++ b/Sources/PlaidBar/Views/Shared/DisclosureSection.swift
@@ -1,0 +1,117 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Disclosure section (design-elevation shared kit)
+//
+// The collapsible sibling of ``WindowSection``: same title style, padding, and
+// quiet solid card surface, with the header doubling as the expand/collapse
+// control. Collapsing hides the body but keeps the count in the header, so a
+// folded section still answers "how much is in here?".
+
+/// A collapsible titled card matching ``WindowSection``'s visual language.
+///
+/// The header is a real `Button` (keyboard- and VoiceOver-reachable) that stays
+/// a VoiceOver header; its accessibility value announces the count and the
+/// expanded/collapsed state ("4 items, collapsed"). The chevron rotation is
+/// disabled under Reduce Motion — state still reads from the disclosed content
+/// and the announced value, never from the chevron angle alone.
+struct DisclosureSection<Content: View>: View {
+    let title: String
+    /// Optional SF Symbol shown before the title (shape, not color, for meaning).
+    var systemImage: String?
+    /// Optional item count shown as a header accessory and voiced in the
+    /// header's accessibility value.
+    var count: Int?
+    @Binding var isExpanded: Bool
+    @ViewBuilder var content: () -> Content
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: isExpanded ? WindowMetrics.md : 0) {
+            Button {
+                withAnimation(MotionTokens.animation(MotionTokens.standard, reduceMotion: reduceMotion)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(alignment: .firstTextBaseline, spacing: WindowMetrics.xs) {
+                    Label {
+                        Text(title)
+                            .windowCardTitle()
+                    } icon: {
+                        if let systemImage {
+                            Image(systemName: systemImage)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .labelStyle(.titleAndIcon)
+
+                    Spacer(minLength: WindowMetrics.sm)
+
+                    if let count {
+                        Text("\(count)")
+                            .windowSupportingText()
+                            .monospacedDigit()
+                    }
+
+                    Image(systemName: "chevron.down")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityValue(accessibilityStateValue)
+
+            if isExpanded {
+                content()
+            }
+        }
+        .padding(WindowMetrics.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .windowCardSurface()
+        .accessibilityElement(children: .contain)
+    }
+
+    private var accessibilityStateValue: String {
+        let state = isExpanded ? "expanded" : "collapsed"
+        guard let count else { return state }
+        return "\(count) \(count == 1 ? "item" : "items"), \(state)"
+    }
+}
+
+#if canImport(PreviewsMacros)
+private struct DisclosureSectionPreviewHost: View {
+    @State private var expanded = true
+    @State private var collapsed = false
+
+    var body: some View {
+        VStack(spacing: WindowMetrics.lg) {
+            DisclosureSection(title: "Needs review", systemImage: "tray", count: 4, isExpanded: $expanded) {
+                VStack(alignment: .leading, spacing: WindowMetrics.sm) {
+                    Text("Whole Foods Market — $86.20")
+                    Text("City of Oakland Parking — $2.00")
+                }
+                .windowBodyText()
+            }
+            DisclosureSection(title: "Resolved this week", count: 12, isExpanded: $collapsed) {
+                Text("Resolved rows go here")
+                    .windowBodyText()
+            }
+        }
+        .padding(WindowMetrics.canvasMargin)
+        .frame(width: 520)
+    }
+}
+
+#Preview("Disclosure sections") {
+    DisclosureSectionPreviewHost()
+}
+
+#Preview("Disclosure sections — dark") {
+    DisclosureSectionPreviewHost()
+        .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/LedgerSummaryStrip.swift
+++ b/Sources/PlaidBar/Views/Shared/LedgerSummaryStrip.swift
@@ -1,0 +1,133 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Ledger summary strip (design-elevation shared kit)
+//
+// The aggregate line above a filtered ledger: what the visible rows *sum to*,
+// so a filter change answers "so what?" without scanning rows. Every figure
+// arrives as a preformatted, mask-aware string — the strip renders, it never
+// computes or formats money.
+
+/// Horizontal aggregate strip: emphasized Net, labeled In / Out, row count,
+/// and a trailing date-range caption, on a solid data surface (never glass —
+/// R-08).
+///
+/// The Net figure uses the tabular data role (semibold, monospaced digits),
+/// deliberately *not* the display-balance hero scale: this is a working
+/// summary, not the page's headline. An optional trailing slot is reserved for
+/// a future delta chip; it takes any view, so no Core delta type leaks in here.
+struct LedgerSummaryStrip<Trailing: View>: View {
+    /// Preformatted, mask-aware signed net ("−$1,204.18" or "••••").
+    let netText: String
+    /// Preformatted, mask-aware inflow total.
+    let inText: String
+    /// Preformatted, mask-aware outflow total.
+    let outText: String
+    /// How many rows the aggregates cover.
+    let count: Int
+    /// Preformatted range caption ("Mar 1 – Mar 31").
+    let dateRangeText: String
+    /// Reserved slot for a future delta chip; defaults to empty.
+    @ViewBuilder var trailing: () -> Trailing
+
+    init(
+        netText: String,
+        inText: String,
+        outText: String,
+        count: Int,
+        dateRangeText: String,
+        @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }
+    ) {
+        self.netText = netText
+        self.inText = inText
+        self.outText = outText
+        self.count = count
+        self.dateRangeText = dateRangeText
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.lg) {
+            figure(label: "Net", value: netText, emphasized: true)
+            figure(label: "In", value: inText)
+            figure(label: "Out", value: outText)
+
+            Text("\(count) \(count == 1 ? "transaction" : "transactions")")
+                .microText()
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: Spacing.sm)
+
+            trailing()
+
+            Text(dateRangeText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .solidDataSurface()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    @ViewBuilder
+    private func figure(label: String, value: String, emphasized: Bool = false) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+            Text(label)
+                .microText()
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+            if emphasized {
+                Text(value)
+                    .dataText()
+            } else {
+                Text(value)
+                    .font(.caption.monospacedDigit())
+            }
+        }
+        .lineLimit(1)
+    }
+
+    private var accessibilityText: String {
+        "Net \(netText). In \(inText). Out \(outText). "
+            + "\(count) \(count == 1 ? "transaction" : "transactions"). \(dateRangeText)."
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Ledger summary strip") {
+    VStack(spacing: Spacing.md) {
+        LedgerSummaryStrip(
+            netText: "−$1,204.18",
+            inText: "$4,820.00",
+            outText: "$6,024.18",
+            count: 47,
+            dateRangeText: "Mar 1 – Mar 31"
+        )
+        LedgerSummaryStrip(
+            netText: "••••",
+            inText: "••••",
+            outText: "••••",
+            count: 3,
+            dateRangeText: "This week"
+        )
+    }
+    .padding(Spacing.lg)
+    .frame(width: 560)
+}
+
+#Preview("Ledger summary strip — dark") {
+    LedgerSummaryStrip(
+        netText: "+$316.40",
+        inText: "$2,100.00",
+        outText: "$1,783.60",
+        count: 12,
+        dateRangeText: "Feb 1 – Feb 28"
+    )
+    .padding(Spacing.lg)
+    .frame(width: 560)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/LedgerSummaryStrip.swift
+++ b/Sources/PlaidBar/Views/Shared/LedgerSummaryStrip.swift
@@ -8,9 +8,9 @@ import SwiftUI
 // arrives as a preformatted, mask-aware string — the strip renders, it never
 // computes or formats money.
 
-/// Horizontal aggregate strip: emphasized Net, labeled In / Out, row count,
-/// and a trailing date-range caption, on a solid data surface (never glass —
-/// R-08).
+/// Horizontal aggregate strip: emphasized Net, labeled In / Out, a row-count
+/// caption, and a trailing date-range caption, on a solid data surface (never
+/// glass — R-08).
 ///
 /// The Net figure uses the tabular data role (semibold, monospaced digits),
 /// deliberately *not* the display-balance hero scale: this is a working
@@ -23,8 +23,10 @@ struct LedgerSummaryStrip<Trailing: View>: View {
     let inText: String
     /// Preformatted, mask-aware outflow total.
     let outText: String
-    /// How many rows the aggregates cover.
-    let count: Int
+    /// Preformatted, mask-aware row-count caption ("47 transactions" — or
+    /// "Count hidden" under Privacy Mask: counts are behavioral financial
+    /// metadata, withheld like the attention-queue and goals-fold counts).
+    let countText: String
     /// Preformatted range caption ("Mar 1 – Mar 31").
     let dateRangeText: String
     /// Reserved slot for a future delta chip; defaults to empty.
@@ -34,14 +36,14 @@ struct LedgerSummaryStrip<Trailing: View>: View {
         netText: String,
         inText: String,
         outText: String,
-        count: Int,
+        countText: String,
         dateRangeText: String,
         @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }
     ) {
         self.netText = netText
         self.inText = inText
         self.outText = outText
-        self.count = count
+        self.countText = countText
         self.dateRangeText = dateRangeText
         self.trailing = trailing
     }
@@ -52,7 +54,7 @@ struct LedgerSummaryStrip<Trailing: View>: View {
             figure(label: "In", value: inText)
             figure(label: "Out", value: outText)
 
-            Text("\(count) \(count == 1 ? "transaction" : "transactions")")
+            Text(countText)
                 .microText()
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
@@ -91,8 +93,7 @@ struct LedgerSummaryStrip<Trailing: View>: View {
     }
 
     private var accessibilityText: String {
-        "Net \(netText). In \(inText). Out \(outText). "
-            + "\(count) \(count == 1 ? "transaction" : "transactions"). \(dateRangeText)."
+        "Net \(netText). In \(inText). Out \(outText). \(countText). \(dateRangeText)."
     }
 }
 
@@ -103,14 +104,14 @@ struct LedgerSummaryStrip<Trailing: View>: View {
             netText: "−$1,204.18",
             inText: "$4,820.00",
             outText: "$6,024.18",
-            count: 47,
+            countText: "47 transactions",
             dateRangeText: "Mar 1 – Mar 31"
         )
         LedgerSummaryStrip(
             netText: "••••",
             inText: "••••",
             outText: "••••",
-            count: 3,
+            countText: "Count hidden",
             dateRangeText: "This week"
         )
     }
@@ -123,7 +124,7 @@ struct LedgerSummaryStrip<Trailing: View>: View {
         netText: "+$316.40",
         inText: "$2,100.00",
         outText: "$1,783.60",
-        count: 12,
+        countText: "12 transactions",
         dateRangeText: "Feb 1 – Feb 28"
     )
     .padding(Spacing.lg)

--- a/Sources/PlaidBar/Views/Shared/ReasonChipCluster.swift
+++ b/Sources/PlaidBar/Views/Shared/ReasonChipCluster.swift
@@ -1,0 +1,94 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Reason chip cluster (design-elevation shared kit)
+//
+// A dense row can carry many review reasons, but only the highest-priority one
+// earns pixels: one primary capsule (glyph + short label) plus, when more
+// reasons exist, a neutral "+N" overflow capsule. The full list lives in the
+// tooltip and the accessibility label, so nothing is lost — only deferred.
+
+/// One primary reason capsule + optional "+N" overflow capsule.
+///
+/// The primary chip's tint is a low-opacity capsule wash behind primary-color
+/// text (≥ 4.5:1 — the tint never carries the text); glyph + label carry the
+/// meaning (ACCESSIBILITY.md). The whole cluster is one VoiceOver element and
+/// one `.help()` tooltip, both voicing `allReasonsSummary`.
+struct ReasonChipCluster: View {
+    /// SF Symbol for the primary reason, usually `TransactionReviewReason.glyphName`.
+    let glyph: String
+    /// Short primary-reason label, usually `TransactionReviewReason.displayName`.
+    let label: String
+    /// Reinforcement wash behind the primary chip — never the only signal.
+    var tint: Color = SemanticColors.warning
+    /// How many further reasons the "+N" capsule stands in for. 0 hides it.
+    var overflowCount: Int = 0
+    /// Full "all reasons" sentence for the tooltip and VoiceOver.
+    let allReasonsSummary: String
+
+    var body: some View {
+        HStack(spacing: Spacing.xs) {
+            Label {
+                Text(label)
+                    .microText()
+                    .foregroundStyle(.primary)
+            } icon: {
+                Image(systemName: glyph)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(tint)
+            }
+            .labelStyle(.titleAndIcon)
+            .lineLimit(1)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.chipVertical)
+            .background(tint.opacity(0.12), in: Capsule())
+            .overlay(Capsule().stroke(tint.opacity(0.16), lineWidth: 1))
+
+            if overflowCount > 0 {
+                Text("+\(overflowCount)")
+                    .microText()
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, Spacing.sm)
+                    .padding(.vertical, Spacing.chipVertical)
+                    .background(.quaternary.opacity(0.5), in: Capsule())
+            }
+        }
+        .help(allReasonsSummary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(allReasonsSummary)
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Reason chips") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        ReasonChipCluster(
+            glyph: "arrow.triangle.2.circlepath",
+            label: "Duplicate?",
+            tint: SemanticColors.warning,
+            overflowCount: 2,
+            allReasonsSummary: "Possible duplicate, uncategorized, and unusual amount."
+        )
+        ReasonChipCluster(
+            glyph: "questionmark.circle",
+            label: "Uncategorized",
+            tint: SemanticColors.recurring,
+            allReasonsSummary: "Uncategorized."
+        )
+    }
+    .padding(Spacing.lg)
+    .frame(width: 360)
+}
+
+#Preview("Reason chips — dark") {
+    ReasonChipCluster(
+        glyph: "arrow.triangle.2.circlepath",
+        label: "Duplicate?",
+        overflowCount: 1,
+        allReasonsSummary: "Possible duplicate and pending."
+    )
+    .padding(Spacing.lg)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Sources/PlaidBar/Views/Shared/ReasonNextStepRow.swift
+++ b/Sources/PlaidBar/Views/Shared/ReasonNextStepRow.swift
@@ -1,0 +1,118 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Reason + next-step row (design-elevation shared kit)
+//
+// The standard "why + what next" grammar for attention/review surfaces:
+//
+//     [glyph] [reason] — [consequence]           [action]
+//
+// Pure presentation: the caller passes an already mask-aware reason/consequence
+// (typically built from the `TransactionReviewReason` taxonomy's
+// `displayName`/`glyphName`) and exactly one next step. There is deliberately
+// no action-less mode — a surfaced reason without a next step is a dead end,
+// and the kit refuses to render one.
+
+/// One reason line with a single trailing next-step action.
+///
+/// The glyph + reason text carry the meaning; `tint` is reinforcement only and
+/// never the sole signal (ACCESSIBILITY.md). The row reads as one VoiceOver
+/// element ("<reason>. <consequence>. Button: <actionTitle>") and activates the
+/// action directly, so assistive users get the grammar in one swipe.
+struct ReasonNextStepRow: View {
+    /// SF Symbol name, usually `TransactionReviewReason.glyphName`.
+    let glyph: String
+    /// Short reason text, usually `TransactionReviewReason.displayName`.
+    let reason: String
+    /// Optional one-sentence consequence ("This can double-count March.").
+    var consequence: String?
+    /// Reinforcement tint for the glyph only — meaning lives in glyph + text.
+    var tint: Color = SemanticColors.warning
+    /// The single next step. Required: no dead-end reasons.
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Image(systemName: glyph)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(minWidth: Sizing.iconInline)
+
+            // Reason (primary) and consequence (secondary) flow as one line and
+            // wrap together when the row is narrow.
+            reasonText
+                .font(.caption)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: Spacing.sm)
+
+            Button(actionTitle, action: action)
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .fixedSize()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { action() }
+    }
+
+    /// Reason (primary) + em-dash consequence (secondary) as one wrapping run
+    /// of text, via `Text` interpolation (the `+` concatenation API is
+    /// deprecated on macOS 26).
+    private var reasonText: Text {
+        guard let consequence else { return Text(reason) }
+        return Text("\(reason) — \(Text(consequence).foregroundStyle(.secondary))")
+    }
+
+    private var accessibilityText: String {
+        var parts = [reason]
+        if let consequence { parts.append(consequence) }
+        parts.append("Button: \(actionTitle)")
+        return parts.joined(separator: ". ")
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Reason rows") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        ReasonNextStepRow(
+            glyph: "arrow.triangle.2.circlepath",
+            reason: "Possible duplicate",
+            consequence: "Counting both inflates March dining by $42.",
+            tint: SemanticColors.warning,
+            actionTitle: "Compare"
+        ) {}
+        ReasonNextStepRow(
+            glyph: "questionmark.circle",
+            reason: "Uncategorized",
+            consequence: "Not counted in any budget yet.",
+            tint: SemanticColors.recurring,
+            actionTitle: "Categorize"
+        ) {}
+        ReasonNextStepRow(
+            glyph: "chart.line.uptrend.xyaxis",
+            reason: "Unusual amount",
+            tint: SemanticColors.negative,
+            actionTitle: "Review"
+        ) {}
+    }
+    .padding(Spacing.lg)
+    .frame(width: 420)
+}
+
+#Preview("Reason rows — dark") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        ReasonNextStepRow(
+            glyph: "arrow.triangle.2.circlepath",
+            reason: "Possible duplicate",
+            consequence: "Counting both inflates March dining by $42.",
+            actionTitle: "Compare"
+        ) {}
+    }
+    .padding(Spacing.lg)
+    .frame(width: 420)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Tests/PlaidBarTests/SharedComponentKitTests.swift
+++ b/Tests/PlaidBarTests/SharedComponentKitTests.swift
@@ -22,14 +22,19 @@ struct SharedComponentKitTests {
         #expect(scrub.contains(".chartXSelection(value: $selectedDate)"))
     }
 
-    /// `BudgetBarRow` must delegate verdict tinting to the single shared
-    /// `CategoryBudgetStatus.verdictTint` mapping (AND-664 #4) rather than
-    /// re-declaring its own status → color switch for the verdict.
-    @Test func budgetBarRowDelegatesVerdictTint() throws {
+    /// `BudgetBarRow` must delegate the verdict's tint AND glyph to the single
+    /// shared mappings (`CategoryBudgetStatus.verdictTint` / `.iconName`,
+    /// AND-664 #4) rather than re-declaring its own status → color/symbol
+    /// switches — the glyph is the non-color half of the verdict cue, so a
+    /// forked vocabulary would contradict every other budget surface.
+    @Test func budgetBarRowDelegatesVerdictTintAndGlyph() throws {
         let row = try source(atRepoPath: "Sources/PlaidBar/Views/Shared/BudgetBarRow.swift")
 
         #expect(row.contains("status.verdictTint"))
         // The verdict Label's tint comes from the delegated mapping.
         #expect(row.contains(".foregroundStyle(status.verdictTint)"))
+        // The verdict glyph comes from the shared vocabulary, with the same
+        // neutral no-budget fallback as `statusIconName` elsewhere.
+        #expect(row.contains(#"status?.iconName ?? "minus.circle""#))
     }
 }

--- a/Tests/PlaidBarTests/SharedComponentKitTests.swift
+++ b/Tests/PlaidBarTests/SharedComponentKitTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+/// Source-invariant guards for the shared design-elevation component kit
+/// (`Sources/PlaidBar/Views/Shared/`). These pin the accessibility contracts
+/// that a refactor could silently drop without breaking the build.
+@Suite("Shared component kit source invariants")
+struct SharedComponentKitTests {
+    private func source(atRepoPath path: String) throws -> String {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        return try String(contentsOf: root.appending(path: path), encoding: .utf8)
+    }
+
+    /// The chart scrub is a pointer affordance: it must stay a NO-OP while
+    /// VoiceOver runs, leaving audio graphs as the accessibility path.
+    @Test func chartScrubStaysNoOpUnderVoiceOver() throws {
+        let scrub = try source(atRepoPath: "Sources/PlaidBar/Views/Shared/ChartScrub.swift")
+
+        #expect(scrub.contains(#"@Environment(\.accessibilityVoiceOverEnabled)"#))
+        #expect(scrub.contains("if voiceOverEnabled {"))
+        // The selection binding must live on the non-VoiceOver branch only.
+        #expect(scrub.contains(".chartXSelection(value: $selectedDate)"))
+    }
+
+    /// `BudgetBarRow` must delegate verdict tinting to the single shared
+    /// `CategoryBudgetStatus.verdictTint` mapping (AND-664 #4) rather than
+    /// re-declaring its own status → color switch for the verdict.
+    @Test func budgetBarRowDelegatesVerdictTint() throws {
+        let row = try source(atRepoPath: "Sources/PlaidBar/Views/Shared/BudgetBarRow.swift")
+
+        #expect(row.contains("status.verdictTint"))
+        // The verdict Label's tint comes from the delegated mapping.
+        #expect(row.contains(".foregroundStyle(status.verdictTint)"))
+    }
+}


### PR DESCRIPTION
## What

New `Sources/PlaidBar/Views/Shared/` — the additive shared UI kit for the product-wide design elevation (PR-1 of the elevation stack). Seven pure-presentation components; **no existing view was modified** (zero risk to source-invariant tests). All data/strings are passed in preformatted and mask-aware.

- **ReasonNextStepRow** — the standard "why + what next" grammar: taxonomy glyph + reason — consequence + one required trailing action (no dead-end mode). Reads as one VoiceOver element and activates the action.
- **ReasonChipCluster** — one primary reason capsule (low-opacity tint wash, primary-color text) + neutral "+N" overflow; full reasons summary in `.help()` and the accessibility label.
- **DisclosureSection** — collapsible sibling of `WindowSection` (same title style/padding/surface); header is a Button that stays a VoiceOver header and announces "N items, collapsed"; chevron rotation gated by Reduce Motion.
- **LedgerSummaryStrip** — Net / In / Out / count / date-range aggregate strip on `solidDataSurface` (never glass); generic trailing slot reserved for the future delta chip (no Core delta types).
- **ChartComparisonCaption** — single secondary, monospaced-digit caption for under charts with a spelled-in-words VoiceOver label.
- **chartScrub()** — Date-x Swift Charts scrub: `chartXSelection` + thin vertical rule + small solid callout, value resolved by a caller-supplied `(Date) -> String?`. **NO-OP while VoiceOver runs** (audio graphs remain the a11y path); no animated snapping.
- **BudgetBarRow** — budget-vs-actual capsule row: fill to spent, visible shape tick at the budget position, preformatted "over by $X" / "$X left" verdict. Over-budget pins the fill full (CategoryStatusBar philosophy); verdict tint **delegated** to the shared `CategoryBudgetStatus.verdictTint` — no second tint mapping.

DeltaChip is deliberately not in this PR (depends on a Core type landing in a sibling PR). All components ship with light + dark `#Preview` blocks on synthetic data.

## Why

The elevation screen PRs (Transactions, Review, Budgets, Dashboard, Insights…) all need the same reason/next-step grammar, disclosure sections, ledger aggregates, and chart interactivity. Landing the kit first keeps those PRs thin and visually consistent.

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- Full `swift test` — **2698 tests passed** (includes 2 new source-invariant tests pinning the chartScrub VoiceOver no-op and the BudgetBarRow verdict-tint delegation)
- `git diff --check` clean; secret scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)