### PR TITLE
feat(core): PeriodComparison/MetricDelta foundation for the product-wide comparison layer

### DIFF
--- a/Sources/PlaidBarCore/Models/BalanceProjection.swift
+++ b/Sources/PlaidBarCore/Models/BalanceProjection.swift
@@ -8,6 +8,20 @@ import Foundation
 /// matching `SafeToSpendConfidence` semantics. Pure value type — produced by
 /// `BalanceProjector`, rendered by `ProjectedBalanceChart`.
 public struct BalanceProjection: Sendable, Equatable {
+    /// One day of the uncertainty band around the projected line:
+    /// `low <= projected balance <= high` on `date`.
+    public struct BandPoint: Sendable, Equatable {
+        public let date: Date
+        public let low: Double
+        public let high: Double
+
+        public init(date: Date, low: Double, high: Double) {
+            self.date = date
+            self.low = low
+            self.high = high
+        }
+    }
+
     /// Forward daily balance series, oldest (the anchor, today) first. Length is
     /// `horizonDays + 1` — index 0 is the anchor day, the rest are future days.
     public let series: [BalanceSnapshot]
@@ -18,17 +32,24 @@ public struct BalanceProjection: Sendable, Equatable {
     /// Pre-rendered VoiceOver summary so meaning never relies on the line's
     /// dash/color alone (ACCESSIBILITY.md).
     public let accessibilitySummary: String
+    /// Deterministic uncertainty band around `series`, one point per series
+    /// day, widening ~sqrt(days out) and scaled by `confidence` (higher
+    /// confidence → narrower). `nil` when there is no recurring signal to size
+    /// the band honestly (and for callers that never computed one).
+    public let band: [BandPoint]?
 
     public init(
         series: [BalanceSnapshot],
         projectedLow: BalanceSnapshot,
         confidence: SafeToSpendConfidence,
-        accessibilitySummary: String
+        accessibilitySummary: String,
+        band: [BandPoint]? = nil
     ) {
         self.series = series
         self.projectedLow = projectedLow
         self.confidence = confidence
         self.accessibilitySummary = accessibilitySummary
+        self.band = band
     }
 
     /// The anchor (today) balance the projection starts from.

--- a/Sources/PlaidBarCore/Models/ChartComparisonLayer.swift
+++ b/Sources/PlaidBarCore/Models/ChartComparisonLayer.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// A horizontal reference line for a chart: the value, a short label, the
+/// preformatted (mask-aware) value text, and a spoken description. Pure value
+/// type so the chart view does no math or formatting of its own.
+///
+/// The numeric `value` stays real even under Privacy Mask — a baseline is only
+/// ever drawn *inside* a chart whose own series is already governed by the
+/// same mask state, so the line's position leaks nothing the chart does not.
+/// Only the rendered *text* is masked.
+public struct ChartBaseline: Sendable, Equatable {
+    /// The y-value the line sits at.
+    public let value: Double
+    /// Short label, e.g. `"Daily average"`.
+    public let label: String
+    /// Preformatted value text, already mask-aware (`"$84"` or `"••••"`).
+    public let valueText: String
+    /// Spoken description with no glyphs, already mask-aware.
+    public let accessibilityText: String
+
+    public init(value: Double, label: String, valueText: String, accessibilityText: String) {
+        self.value = value
+        self.label = label
+        self.valueText = valueText
+        self.accessibilityText = accessibilityText
+    }
+}
+
+/// A prior-period series overlaid on the current period's axis: each prior
+/// point is date-shifted **forward by the window length**, so day 1 of the
+/// prior window lands on day 1 of the current window and the two lines
+/// compare visually day-for-day.
+public struct GhostSeries: Sendable, Equatable {
+    /// Prior-period balance points, dates shifted onto the current axis.
+    public let points: [BalanceSnapshot]
+    /// Legend label, e.g. `"Previous 90 days"`.
+    public let label: String
+    /// Spoken summary of what the ghost line shows (never color/dash alone —
+    /// ACCESSIBILITY.md).
+    public let accessibilitySummary: String
+
+    public init(points: [BalanceSnapshot], label: String, accessibilitySummary: String) {
+        self.points = points
+        self.label = label
+        self.accessibilitySummary = accessibilitySummary
+    }
+}
+
+/// Builds the prior-window ghost overlay for the net-worth trend chart by
+/// reusing `BalanceTrend.evaluate` on the window immediately before the
+/// current one — same windowing, same `requiredPointCount` honesty gate: when
+/// the prior window has too few recorded points for an honest line, there is
+/// no ghost at all rather than a misleading one.
+public enum BalanceTrendComparison {
+    /// The prior window's trend points shifted forward by `windowDays` so they
+    /// overlay the current window's axis, or `nil` when the prior window lacks
+    /// `BalanceTrend.requiredPointCount` points.
+    public static func evaluate(
+        history: [BalanceSnapshot],
+        now: Date,
+        windowDays: Int = 90,
+        calendar: Calendar = .current
+    ) -> GhostSeries? {
+        guard windowDays > 0,
+              let priorEnd = calendar.date(
+                  byAdding: .day, value: -windowDays, to: calendar.startOfDay(for: now)
+              ),
+              let priorTrend = BalanceTrend.evaluate(
+                  history: history,
+                  now: priorEnd,
+                  windowDays: windowDays,
+                  calendar: calendar
+              )
+        else { return nil }
+
+        var shifted: [BalanceSnapshot] = []
+        shifted.reserveCapacity(priorTrend.points.count)
+        for point in priorTrend.points {
+            guard let date = calendar.date(byAdding: .day, value: windowDays, to: point.date) else {
+                return nil
+            }
+            shifted.append(BalanceSnapshot(date: date, balance: point.balance))
+        }
+
+        let movement: String
+        switch priorTrend.direction {
+        case .up:
+            movement = "rose \(Formatters.currency(abs(priorTrend.delta), format: .full))"
+        case .down:
+            movement = "fell \(Formatters.currency(abs(priorTrend.delta), format: .full))"
+        case .flat:
+            movement = "held steady"
+        }
+
+        return GhostSeries(
+            points: shifted,
+            label: "Previous \(windowDays) days",
+            accessibilitySummary:
+            "Previous \(windowDays)-day period, overlaid for comparison: net worth \(movement) over that period."
+        )
+    }
+}
+
+public extension PeriodComparison {
+    /// Average of `values` as a chart baseline, or `nil` when there is nothing
+    /// to average. `valueText`/`accessibilityText` are mask-aware; the numeric
+    /// value stays real for drawing (see `ChartBaseline`).
+    static func averageBaseline(
+        values: [Double],
+        label: String,
+        isMasked: Bool
+    ) -> ChartBaseline? {
+        guard !values.isEmpty else { return nil }
+        let average = values.reduce(0, +) / Double(values.count)
+        let valueText = isMasked
+            ? PrivacyMaskPresentation.compactValue
+            : Formatters.currency(average, format: .compact)
+        let accessibilityText = isMasked
+            ? "\(label): hidden while Privacy Mask is on."
+            : "\(label): \(Formatters.currency(average, format: .full))."
+        return ChartBaseline(
+            value: average,
+            label: label,
+            valueText: valueText,
+            accessibilityText: accessibilityText
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/MetricDelta.swift
+++ b/Sources/PlaidBarCore/Models/MetricDelta.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// One period-over-period comparison of a single metric — the shared "so what?"
+/// vocabulary behind every delta chip and comparison baseline in the app.
+///
+/// `MetricDelta` deliberately classifies movement **more strictly** than
+/// `BalanceTrend`: the trend's ±0.005 gate answers "did the line move at all?"
+/// (raw movement, so a sparkline never draws a false flat), while this type
+/// answers "is the movement worth a chip?" — a `direction` here is `.flat`
+/// unless the change clears **both** the absolute and the relative
+/// `Threshold`, so a $2 wiggle on an $800 baseline never earns an arrow.
+/// `BalanceTrend` is intentionally left untouched; the two gates serve
+/// different questions.
+public struct MetricDelta: Sendable, Equatable {
+    /// How to read the metric's movement: is a rise good news or bad news?
+    public enum Polarity: Sendable, Equatable {
+        /// Rising is good (income, net worth, savings).
+        case higherIsBetter
+        /// Rising is bad (spend, debt, utilization).
+        case lowerIsBetter
+        /// Movement carries no judgement (counts, informational figures).
+        case neutral
+    }
+
+    /// Direction × polarity, resolved for presentation: which way should the
+    /// chip *feel*? Flat movement is always neutral.
+    public enum Sentiment: Sendable, Equatable {
+        case positive
+        case negative
+        case neutral
+    }
+
+    /// Significance gates a change must clear before it is classified as
+    /// movement. Both gates must pass: `minimumAbsolute` kills sub-dollar
+    /// noise, `minimumRelative` kills tiny wiggles on large baselines.
+    public struct Threshold: Sendable, Equatable {
+        /// Smallest absolute change (in the metric's own unit) that counts.
+        public let minimumAbsolute: Double
+        /// Smallest change relative to the previous magnitude that counts
+        /// (fraction, e.g. `0.01` = 1%). Waived when the previous magnitude is
+        /// itself below `minimumAbsolute` — there is no meaningful baseline to
+        /// be relative to.
+        public let minimumRelative: Double
+
+        public init(minimumAbsolute: Double = 1.0, minimumRelative: Double = 0.01) {
+            self.minimumAbsolute = minimumAbsolute
+            self.minimumRelative = minimumRelative
+        }
+
+        /// The default gate for currency metrics: at least $1 and at least 1%.
+        public static let currency = Threshold()
+    }
+
+    /// The metric's value in the current period.
+    public let current: Double
+    /// The metric's value in the comparison period.
+    public let previous: Double
+    /// Signed change, always `current - previous`.
+    public let delta: Double
+    /// Signed percent change (`+14.0` = up 14%), measured against the previous
+    /// magnitude. `nil` when the previous magnitude is below
+    /// `Threshold.minimumAbsolute` — a near-zero baseline would produce a fake
+    /// "+4,800%" style figure, so no percentage is claimed at all.
+    public let percentChange: Double?
+    /// Chip-worthy direction. `.flat` unless the change cleared **both**
+    /// threshold gates. Reuses `GlanceSnapshot.ChangeDirection` so the glyph
+    /// convention (▲/▼/■) is defined exactly once.
+    public let direction: GlanceSnapshot.ChangeDirection
+    /// How to read the movement (rise good vs rise bad vs no judgement).
+    public let polarity: Polarity
+
+    public init(
+        current: Double,
+        previous: Double,
+        delta: Double,
+        percentChange: Double?,
+        direction: GlanceSnapshot.ChangeDirection,
+        polarity: Polarity
+    ) {
+        self.current = current
+        self.previous = previous
+        self.delta = delta
+        self.percentChange = percentChange
+        self.direction = direction
+        self.polarity = polarity
+    }
+
+    /// Direction × polarity: `.up` on a `higherIsBetter` metric is positive,
+    /// `.up` on a `lowerIsBetter` metric (spend rising) is negative, and flat
+    /// or `neutral`-polarity movement is always neutral.
+    public var sentiment: Sentiment {
+        switch (direction, polarity) {
+        case (.flat, _), (_, .neutral):
+            return .neutral
+        case (.up, .higherIsBetter), (.down, .lowerIsBetter):
+            return .positive
+        case (.up, .lowerIsBetter), (.down, .higherIsBetter):
+            return .negative
+        }
+    }
+
+    /// The shared direction glyph (▲/▼/■) — same characters as
+    /// `GlanceSnapshot.ChangeDirection.glyph`, by construction.
+    public var glyph: String {
+        direction.glyph
+    }
+
+    /// Signed currency text for the delta, byte-identical to
+    /// `Formatters.signedCurrency` output (`+$420`, `-$63`, `$0`).
+    public func signedText(format: CurrencyFormat = .full) -> String {
+        Formatters.signedCurrency(delta, format: format)
+    }
+
+    /// Signed percent text (`+14%`, `-8%`) via the existing percent formatter,
+    /// or `nil` when no honest percentage exists (see `percentChange`).
+    public func percentText(decimals: Int = 0) -> String? {
+        percentChange.map { change in
+            change > 0
+                ? "+\(Formatters.percent(change, decimals: decimals))"
+                : Formatters.percent(change, decimals: decimals)
+        }
+    }
+
+    /// Classify a period-over-period change.
+    ///
+    /// The change registers as movement (`.up`/`.down`) only when it clears
+    /// **both** `threshold` gates; otherwise `direction` is `.flat`. The
+    /// relative gate is waived when the previous magnitude is below
+    /// `threshold.minimumAbsolute` (no meaningful baseline), which is also
+    /// exactly when `percentChange` is withheld.
+    public static func evaluate(
+        current: Double,
+        previous: Double,
+        polarity: Polarity,
+        threshold: Threshold = .currency
+    ) -> MetricDelta {
+        let delta = current - previous
+        let previousMagnitude = abs(previous)
+        let hasBaseline = previousMagnitude >= threshold.minimumAbsolute
+
+        let percentChange: Double? = hasBaseline
+            ? (delta / previousMagnitude) * 100
+            : nil
+
+        let clearsAbsolute = abs(delta) >= threshold.minimumAbsolute
+        let clearsRelative = !hasBaseline || abs(delta) >= threshold.minimumRelative * previousMagnitude
+        let direction: GlanceSnapshot.ChangeDirection = (clearsAbsolute && clearsRelative)
+            ? .evaluate(delta)
+            : .flat
+
+        return MetricDelta(
+            current: current,
+            previous: previous,
+            delta: delta,
+            percentChange: percentChange,
+            direction: direction,
+            polarity: polarity
+        )
+    }
+}

--- a/Sources/PlaidBarCore/Models/MetricDeltaChip.swift
+++ b/Sources/PlaidBarCore/Models/MetricDeltaChip.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Display-ready comparison chip: the glyph, text, sentiment, and VoiceOver
+/// label a view needs to render a "so what?" delta next to a hero number —
+/// with zero math left in the view layer.
+public struct MetricDeltaChip: Sendable, Equatable {
+    /// Which figures the chip text carries.
+    public enum Style: Sendable, Equatable {
+        /// Signed currency only: `+$420 vs last month`.
+        case currency
+        /// Signed percent only: `+14% vs last month`.
+        case percent
+        /// Both: `+$420 (+14%) vs last month`.
+        case currencyAndPercent
+    }
+
+    /// Direction glyph (▲/▼/■), same convention as `GlanceSnapshot.ChangeDirection`.
+    public let glyph: String
+    /// Chip body, e.g. `+$420 vs last month`.
+    public let text: String
+    /// Resolved direction × polarity feel for tinting (never color alone —
+    /// the glyph + signed text carry the meaning textually).
+    public let sentiment: MetricDelta.Sentiment
+    /// Fully spoken label with no glyphs or symbols, e.g.
+    /// `Up 420 dollars versus last month`.
+    public let accessibilityLabel: String
+
+    public init(
+        glyph: String,
+        text: String,
+        sentiment: MetricDelta.Sentiment,
+        accessibilityLabel: String
+    ) {
+        self.glyph = glyph
+        self.text = text
+        self.sentiment = sentiment
+        self.accessibilityLabel = accessibilityLabel
+    }
+
+    /// Build a chip from a delta, or `nil` when nothing should render.
+    ///
+    /// **Privacy Mask suppresses the chip entirely** (`isMasked` → `nil`).
+    /// A delta is metadata *derived from* a private figure, so it is dropped
+    /// under mask exactly like `DashboardGoalsCard` drops its pace label —
+    /// never rendered as `▲ ••••`: even a bare arrow leaks which way a hidden
+    /// number moved.
+    ///
+    /// A `.flat` delta also returns `nil` unless `showsFlat` is requested, so
+    /// insignificant movement stays silent by default.
+    ///
+    /// - Parameters:
+    ///   - delta: the classified comparison.
+    ///   - comparisonLabel: trailing context, e.g. `"vs last month"` (see
+    ///     `ComparisonPeriod.comparisonLabel`). A leading `"vs "` is spoken as
+    ///     `"versus "` in the accessibility label.
+    ///   - format: currency format for the signed amount.
+    ///   - style: which figures the text carries. Percent styles fall back to
+    ///     the signed currency amount when `percentChange` is `nil` (no honest
+    ///     percentage exists) rather than inventing one.
+    ///   - showsFlat: when `true`, a flat delta renders as `■` + "Unchanged".
+    ///   - isMasked: Privacy Mask state; `true` suppresses the chip.
+    public static func make(
+        delta: MetricDelta,
+        comparisonLabel: String,
+        format: CurrencyFormat = .compact,
+        style: Style = .currency,
+        showsFlat: Bool = false,
+        isMasked: Bool
+    ) -> MetricDeltaChip? {
+        guard !isMasked else { return nil }
+        if delta.direction == .flat, !showsFlat { return nil }
+
+        let text: String
+        let spokenBody: String
+        if delta.direction == .flat {
+            text = "Unchanged \(comparisonLabel)"
+            spokenBody = "Unchanged"
+        } else {
+            let amountText = delta.signedText(format: format)
+            let percentText = delta.percentText()
+            let figure: String
+            switch style {
+            case .currency:
+                figure = amountText
+            case .percent:
+                figure = percentText ?? amountText
+            case .currencyAndPercent:
+                figure = percentText.map { "\(amountText) (\($0))" } ?? amountText
+            }
+            text = "\(figure) \(comparisonLabel)"
+            spokenBody = "\(directionWord(delta.direction)) \(spokenFigure(delta: delta, style: style))"
+        }
+
+        return MetricDeltaChip(
+            glyph: delta.glyph,
+            text: text,
+            sentiment: delta.sentiment,
+            accessibilityLabel: "\(spokenBody) \(spokenComparison(comparisonLabel))"
+        )
+    }
+
+    // MARK: - Spoken composition
+
+    private static func directionWord(_ direction: GlanceSnapshot.ChangeDirection) -> String {
+        switch direction {
+        case .up: "Up"
+        case .down: "Down"
+        case .flat: "Unchanged"
+        }
+    }
+
+    /// The chip's figure in words: `420 dollars`, `14 percent`, or
+    /// `420 dollars, 14 percent` — no `$`/`%` symbols, no sign glyphs (the
+    /// direction word already carries the sign).
+    private static func spokenFigure(delta: MetricDelta, style: Style) -> String {
+        let dollars = spokenDollars(abs(delta.delta))
+        guard let percentChange = delta.percentChange else { return dollars }
+        let percent = "\(Int(abs(percentChange).rounded())) percent"
+        switch style {
+        case .currency: return dollars
+        case .percent: return percent
+        case .currencyAndPercent: return "\(dollars), \(percent)"
+        }
+    }
+
+    /// `420.5` → `"421 dollars"`, `1` → `"1 dollar"`. Whole-dollar precision
+    /// matches the chip's compact visual style.
+    private static func spokenDollars(_ magnitude: Double) -> String {
+        let rounded = Int(magnitude.rounded())
+        return rounded == 1 ? "1 dollar" : "\(rounded) dollars"
+    }
+
+    /// `"vs last month"` → `"versus last month"` so VoiceOver never reads a
+    /// bare "vs".
+    private static func spokenComparison(_ label: String) -> String {
+        label.hasPrefix("vs ") ? "versus \(label.dropFirst(3))" : label
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/AccountSparkline.swift
+++ b/Sources/PlaidBarCore/Utilities/AccountSparkline.swift
@@ -83,7 +83,10 @@ public enum AccountSparkline {
 
     /// Maps balances onto 0...1 by min/max. A zero-spread (flat) series maps to
     /// a constant mid-line so the chart draws a level stroke, not a NaN.
-    static func normalize(_ balances: [Double]) -> [Double] {
+    /// Public so every spark strip normalizes identically — this is also the
+    /// normalizer behind `GlanceSnapshot`'s sparkline and
+    /// `PeriodComparison.dailySpendSpark`.
+    public static func normalize(_ balances: [Double]) -> [Double] {
         guard let minimum = balances.min(), let maximum = balances.max() else {
             return []
         }

--- a/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
+++ b/Sources/PlaidBarCore/Utilities/BalanceProjector.swift
@@ -132,8 +132,55 @@ public enum BalanceProjector {
             series: series,
             projectedLow: projectedLow,
             confidence: confidence,
-            accessibilitySummary: summary
+            accessibilitySummary: summary,
+            band: uncertaintyBand(series: series, confidence: confidence)
         )
+    }
+
+    // MARK: - Uncertainty band
+
+    /// Half-width multiplier per confidence tier: higher confidence → narrower
+    /// band. Public so a chart legend can explain the band width honestly.
+    public static func bandHalfWidthScale(for confidence: SafeToSpendConfidence) -> Double {
+        switch confidence {
+        case .ok: 0.5
+        case .lowConfidence: 1.0
+        case .insufficientData: 1.5
+        }
+    }
+
+    /// Deterministic uncertainty band around a projected series.
+    ///
+    /// The band's unit is the series' own mean absolute day-over-day movement
+    /// (no randomness, no external state), scaled by the confidence tier; the
+    /// half-width then grows with the square root of days out — the standard
+    /// "uncertainty compounds like a random walk" shape. Day 0 (the anchor,
+    /// a real recorded balance) always has zero width. Returns `nil` when the
+    /// series never moves (no recurring signal): a band sized from zero
+    /// movement would be a fake-precision zero-width ribbon.
+    ///
+    /// Invariant: `low <= series balance <= high` on every day, and the width
+    /// is non-decreasing across the horizon.
+    static func uncertaintyBand(
+        series: [BalanceSnapshot],
+        confidence: SafeToSpendConfidence
+    ) -> [BalanceProjection.BandPoint]? {
+        guard series.count >= 2 else { return nil }
+        var totalMovement = 0.0
+        for index in 1..<series.count {
+            totalMovement += abs(series[index].balance - series[index - 1].balance)
+        }
+        guard totalMovement > 0 else { return nil }
+
+        let unit = bandHalfWidthScale(for: confidence) * (totalMovement / Double(series.count - 1))
+        return series.enumerated().map { dayIndex, point in
+            let halfWidth = unit * Double(dayIndex).squareRoot()
+            return BalanceProjection.BandPoint(
+                date: point.date,
+                low: point.balance - halfWidth,
+                high: point.balance + halfWidth
+            )
+        }
     }
 
     // MARK: - Classification

--- a/Sources/PlaidBarCore/Utilities/PeriodComparison.swift
+++ b/Sources/PlaidBarCore/Utilities/PeriodComparison.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// Which two periods a comparison spans. The label is the chip's trailing
+/// context ("vs last month"), so period choice and copy stay in lockstep.
+public enum ComparisonPeriod: Sendable, Equatable {
+    /// The trailing `n` days ending today vs the `n` days immediately before.
+    case trailingDays(Int)
+    /// Month so far vs the **prior month to the same day**. This is the honest
+    /// mid-month compare: the classic misleading delta compares a partial
+    /// current month against the *full* prior month, which reads as "spending
+    /// way down!" every 1st-through-20th. Truncating the prior window to the
+    /// same elapsed days removes that lie.
+    case monthToDate
+    /// The full current calendar month vs the full prior calendar month.
+    case fullMonthOverMonth
+
+    /// Trailing chip copy, e.g. `"vs last month"`. Pairs with
+    /// `MetricDeltaChip.make(delta:comparisonLabel:...)`.
+    public var comparisonLabel: String {
+        switch self {
+        case let .trailingDays(days):
+            "vs prior \(days) days"
+        case .monthToDate:
+            "vs last month to date"
+        case .fullMonthOverMonth:
+            "vs last month"
+        }
+    }
+}
+
+/// The Core period-comparison engine: derives the current/prior date windows
+/// for a `ComparisonPeriod` and builds `MetricDelta`s for the domain metrics —
+/// always by calling the **existing** aggregation kernels once per window
+/// (`CategoryBudgetPlanner.netSpendByCategory`, `IncomeCategoryFlow`,
+/// `SpendingSummary.expenseTransactions`), never a second aggregation path.
+/// That guarantee matters: a user override or rule that recategorizes a
+/// transaction moves the spend in *both* windows, so a delta can never be
+/// manufactured by two aggregators disagreeing.
+///
+/// Everything takes an injected `asOf: Date` and `Calendar` — no hidden
+/// `Date()` — matching `CategoryBudgetPlanner` / `BalanceProjector`.
+public enum PeriodComparison {
+    /// A half-open date window in canonical `yyyy-MM-dd` transaction keys:
+    /// `startKey` inclusive, `endKey` **exclusive**. Canonical keys sort
+    /// lexicographically, so windowing is a pair of string compares.
+    public struct Window: Sendable, Equatable {
+        public let startKey: String
+        public let endKey: String
+
+        public init(startKey: String, endKey: String) {
+            self.startKey = startKey
+            self.endKey = endKey
+        }
+    }
+
+    // MARK: - Windows
+
+    /// The current and prior windows for `period`, or `nil` when the calendar
+    /// math cannot produce them (e.g. non-positive trailing days).
+    ///
+    /// The two windows **never overlap**. For `.trailingDays` and
+    /// `.fullMonthOverMonth` they are exactly adjacent
+    /// (`prior.endKey == current.startKey`). For `.monthToDate` the prior
+    /// window is truncated to the same elapsed day count (clamped to the prior
+    /// month's own length), so on short-month boundaries a gap before the
+    /// current month start is deliberate — that truncation is the whole point
+    /// of the honest mid-month compare.
+    public static func windows(
+        for period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> (current: Window, prior: Window)? {
+        let today = calendar.startOfDay(for: date)
+        // Windows are end-exclusive, so "through today" means ending at the
+        // start of tomorrow.
+        guard let dayAfter = calendar.date(byAdding: .day, value: 1, to: today) else { return nil }
+
+        switch period {
+        case let .trailingDays(days):
+            guard days > 0,
+                  let currentStart = calendar.date(byAdding: .day, value: -days, to: dayAfter),
+                  let priorStart = calendar.date(byAdding: .day, value: -days, to: currentStart)
+            else { return nil }
+            return (
+                current: window(from: currentStart, to: dayAfter),
+                prior: window(from: priorStart, to: currentStart)
+            )
+
+        case .monthToDate:
+            guard let monthStart = CategoryBudgetPlanner.monthStartDate(asOf: today, calendar: calendar),
+                  let priorMonthStart = calendar.date(byAdding: .month, value: -1, to: monthStart),
+                  let elapsedDays = calendar.dateComponents([.day], from: monthStart, to: dayAfter).day,
+                  elapsedDays > 0,
+                  let priorEndUnclamped = calendar.date(byAdding: .day, value: elapsedDays, to: priorMonthStart)
+            else { return nil }
+            // Clamp: the prior window never spills past its own month (a
+            // March 31st compare covers all 28/29 days of February, no more).
+            let priorEnd = min(priorEndUnclamped, monthStart)
+            return (
+                current: window(from: monthStart, to: dayAfter),
+                prior: window(from: priorMonthStart, to: priorEnd)
+            )
+
+        case .fullMonthOverMonth:
+            guard let monthStart = CategoryBudgetPlanner.monthStartDate(asOf: today, calendar: calendar),
+                  let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: monthStart),
+                  let priorMonthStart = calendar.date(byAdding: .month, value: -1, to: monthStart)
+            else { return nil }
+            return (
+                current: window(from: monthStart, to: nextMonthStart),
+                prior: window(from: priorMonthStart, to: monthStart)
+            )
+        }
+    }
+
+    private static func window(from start: Date, to end: Date) -> Window {
+        Window(
+            startKey: Formatters.transactionDateString(start),
+            endKey: Formatters.transactionDateString(end)
+        )
+    }
+
+    // MARK: - Domain deltas
+
+    /// Total net spend delta (polarity: lower is better). Spend per window is
+    /// the sum of `CategoryBudgetPlanner.netSpendByCategory` — the one
+    /// override-aware spend kernel — so `metadata`/`rules`/`splits` move both
+    /// windows identically.
+    public static func totalSpendDelta(
+        transactions: [TransactionDTO],
+        period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current,
+        metadata: [TransactionReviewMetadata]? = nil,
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = [],
+        threshold: MetricDelta.Threshold = .currency
+    ) -> MetricDelta? {
+        guard let windows = windows(for: period, asOf: date, calendar: calendar) else { return nil }
+        let current = netSpend(
+            transactions: transactions, window: windows.current,
+            metadata: metadata, rules: rules, splits: splits
+        ).values.reduce(0, +)
+        let prior = netSpend(
+            transactions: transactions, window: windows.prior,
+            metadata: metadata, rules: rules, splits: splits
+        ).values.reduce(0, +)
+        return MetricDelta.evaluate(
+            current: current, previous: prior, polarity: .lowerIsBetter, threshold: threshold
+        )
+    }
+
+    /// Total income delta (polarity: higher is better). Income per window
+    /// reuses `IncomeCategoryFlow.incomeSources` — the existing inflow gate
+    /// (money in, own-account transfers excluded) — summed over its nodes.
+    public static func incomeDelta(
+        transactions: [TransactionDTO],
+        period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current,
+        threshold: MetricDelta.Threshold = .currency
+    ) -> MetricDelta? {
+        guard let windows = windows(for: period, asOf: date, calendar: calendar) else { return nil }
+        return MetricDelta.evaluate(
+            current: incomeTotal(transactions: transactions, window: windows.current),
+            previous: incomeTotal(transactions: transactions, window: windows.prior),
+            polarity: .higherIsBetter,
+            threshold: threshold
+        )
+    }
+
+    /// Per-category spend deltas (polarity: lower is better) across the union
+    /// of categories present in either window. `netSpendByCategory` is called
+    /// once per window, so an override or rule recategorizing a prior-window
+    /// transaction moves both sides of every delta.
+    public static func categorySpendDeltas(
+        transactions: [TransactionDTO],
+        period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current,
+        metadata: [TransactionReviewMetadata]? = nil,
+        rules: [TransactionRule]? = nil,
+        splits: [TransactionSplit] = [],
+        threshold: MetricDelta.Threshold = .currency
+    ) -> [SpendingCategory: MetricDelta] {
+        guard let windows = windows(for: period, asOf: date, calendar: calendar) else { return [:] }
+        let current = netSpend(
+            transactions: transactions, window: windows.current,
+            metadata: metadata, rules: rules, splits: splits
+        )
+        let prior = netSpend(
+            transactions: transactions, window: windows.prior,
+            metadata: metadata, rules: rules, splits: splits
+        )
+
+        var deltas: [SpendingCategory: MetricDelta] = [:]
+        for category in Set(current.keys).union(prior.keys) {
+            deltas[category] = MetricDelta.evaluate(
+                current: current[category] ?? 0,
+                previous: prior[category] ?? 0,
+                polarity: .lowerIsBetter,
+                threshold: threshold
+            )
+        }
+        return deltas
+    }
+
+    /// Net-worth delta (polarity: higher is better) from recorded balance
+    /// history: `current` is the latest snapshot, `previous` is the latest
+    /// snapshot **before** the prior window's exclusive end (the boundary
+    /// between the windows for adjacent periods).
+    ///
+    /// Returns `nil` when history does not reach back to the prior window —
+    /// a young install must never show a zero-baseline "+$48K since last
+    /// month" chip built from its own first sync.
+    public static func netWorthDelta(
+        history: [BalanceSnapshot],
+        period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current,
+        threshold: MetricDelta.Threshold = .currency
+    ) -> MetricDelta? {
+        guard let windows = windows(for: period, asOf: date, calendar: calendar),
+              let priorBoundary = Formatters.parseTransactionDate(windows.prior.endKey)
+        else { return nil }
+
+        let sorted = history.sorted { $0.date < $1.date }
+        guard let latest = sorted.last,
+              let previous = sorted.last(where: { $0.date < priorBoundary })
+        else { return nil }
+
+        return MetricDelta.evaluate(
+            current: latest.balance,
+            previous: previous.balance,
+            polarity: .higherIsBetter,
+            threshold: threshold
+        )
+    }
+
+    /// Normalized (0...1) daily expense buckets over the current window, for a
+    /// spark strip under a spend hero number. Windowing and expense
+    /// classification reuse `SpendingSummary.expenseTransactions`;
+    /// normalization reuses `AccountSparkline.normalize`.
+    ///
+    /// Returns `nil` when the window cannot be built or contains no expense
+    /// activity — an all-zero spark would draw a meaningless mid-line.
+    public static func dailySpendSpark(
+        transactions: [TransactionDTO],
+        period: ComparisonPeriod,
+        asOf date: Date,
+        calendar: Calendar = .current
+    ) -> [Double]? {
+        guard let windows = windows(for: period, asOf: date, calendar: calendar),
+              let start = Formatters.parseTransactionDate(windows.current.startKey),
+              let end = Formatters.parseTransactionDate(windows.current.endKey)
+        else { return nil }
+
+        let expenses = SpendingSummary.expenseTransactions(
+            from: transactions,
+            startingAt: windows.current.startKey,
+            endingBefore: windows.current.endKey
+        )
+        guard !expenses.isEmpty else { return nil }
+
+        var byDay: [String: Double] = [:]
+        for expense in expenses {
+            byDay[expense.date, default: 0] += expense.displayAmount
+        }
+
+        var series: [Double] = []
+        var day = start
+        while day < end {
+            series.append(byDay[Formatters.transactionDateString(day)] ?? 0)
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+            day = next
+        }
+        return AccountSparkline.normalize(series)
+    }
+
+    // MARK: - Kernel plumbing
+
+    /// Windowed, override-aware net spend per category — a direct pass-through
+    /// to `CategoryBudgetPlanner.netSpendByCategory` (the one spend kernel).
+    private static func netSpend(
+        transactions: [TransactionDTO],
+        window: Window,
+        metadata: [TransactionReviewMetadata]?,
+        rules: [TransactionRule]?,
+        splits: [TransactionSplit]
+    ) -> [SpendingCategory: Double] {
+        CategoryBudgetPlanner.netSpendByCategory(
+            from: transactions,
+            startKey: window.startKey,
+            endKey: window.endKey,
+            metadata: metadata,
+            rules: rules,
+            splits: splits
+        )
+    }
+
+    /// Windowed total income — the sum of `IncomeCategoryFlow.incomeSources`
+    /// nodes over the window's transactions (reusing its inflow gate).
+    private static func incomeTotal(
+        transactions: [TransactionDTO],
+        window: Window
+    ) -> Double {
+        let windowed = transactions.filter {
+            $0.date >= window.startKey && $0.date < window.endKey
+        }
+        return IncomeCategoryFlow.incomeSources(from: windowed).reduce(0) { $0 + $1.amount }
+    }
+}

--- a/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
+++ b/Sources/PlaidBarCore/Utilities/SpendingSummary.swift
@@ -1,21 +1,37 @@
 import Foundation
 
+/// Deprecated proto-version of the period-comparison vocabulary — prefer
+/// `PeriodComparison` + `MetricDelta` for any new comparison surface, so
+/// exactly one delta vocabulary exists. This shim now derives its delta
+/// fields from an embedded ``MetricDelta`` (absorbed rather than duplicated);
+/// the legacy field names are kept for existing call sites.
+///
+/// One deliberate tightening from the legacy math: `deltaPercent` is `0` when
+/// the previous total's magnitude is below `MetricDelta.Threshold.currency`'s
+/// absolute gate — the legacy formula exploded a sub-dollar baseline into a
+/// fake multi-thousand percent figure.
 public struct SpendingPeriodSummary: Sendable {
-    public let currentTotal: Double
-    public let previousTotal: Double
-    public let delta: Double
-    public let deltaPercent: Double
+    /// The canonical comparison (spend: lower is better).
+    public let metric: MetricDelta
     public let categories: [(SpendingCategory, Double)]
+
+    public var currentTotal: Double { metric.current }
+    public var previousTotal: Double { metric.previous }
+    public var delta: Double { metric.delta }
+    public var deltaPercent: Double {
+        previousTotal > 0 ? (metric.percentChange ?? 0) : 0
+    }
 
     public init(
         currentTotal: Double,
         previousTotal: Double,
         categories: [(SpendingCategory, Double)]
     ) {
-        self.currentTotal = currentTotal
-        self.previousTotal = previousTotal
-        self.delta = currentTotal - previousTotal
-        self.deltaPercent = previousTotal > 0 ? (delta / previousTotal) * 100 : 0
+        metric = MetricDelta.evaluate(
+            current: currentTotal,
+            previous: previousTotal,
+            polarity: .lowerIsBetter
+        )
         self.categories = categories
     }
 }

--- a/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceProjectorTests.swift
@@ -289,6 +289,101 @@ struct BalanceProjectorTests {
         #expect(balances.count > 1)
     }
 
+    // MARK: - Uncertainty band
+
+    @Test("Band is nil-safe: default init and no-signal projections carry no band")
+    func bandNilSafe() {
+        // A hand-built projection without a band keeps compiling and equating.
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let bare = BalanceProjection(
+            series: [anchor],
+            projectedLow: anchor,
+            confidence: .insufficientData,
+            accessibilitySummary: "x"
+        )
+        #expect(bare.band == nil)
+
+        // No recurring signal → flat series → no honest basis for a band.
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        #expect(projection.band == nil)
+    }
+
+    @Test("Band widens monotonically with days out and brackets the series")
+    func bandWidensAndBrackets() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let stream = Self.recurring("Rent", amount: 200, nextExpectedDate: "2026-06-11", category: .billsAndUtilities)
+        let projection = BalanceProjector.project(
+            anchor: anchor,
+            recurring: [stream],
+            asOf: Self.asOf,
+            horizonDays: 30,
+            calendar: Self.calendar
+        )!
+        let band = projection.band!
+        #expect(band.count == projection.series.count)
+        // Day 0 is a real recorded balance: zero width.
+        #expect(band[0].low == band[0].high)
+
+        var previousWidth = -1.0
+        for (index, point) in band.enumerated() {
+            let width = point.high - point.low
+            #expect(width >= previousWidth, "band narrowed at day \(index)")
+            previousWidth = width
+            // low <= series <= high on every day, dates aligned.
+            #expect(point.low <= projection.series[index].balance)
+            #expect(projection.series[index].balance <= point.high)
+            #expect(point.date == projection.series[index].date)
+        }
+        // It actually widens (not a degenerate zero ribbon).
+        #expect(band.last!.high - band.last!.low > 0)
+    }
+
+    @Test("Higher confidence produces a strictly narrower band")
+    func bandNarrowerAtHigherConfidence() {
+        // Scale ladder: ok < lowConfidence < insufficientData.
+        #expect(BalanceProjector.bandHalfWidthScale(for: .ok)
+            < BalanceProjector.bandHalfWidthScale(for: .lowConfidence))
+        #expect(BalanceProjector.bandHalfWidthScale(for: .lowConfidence)
+            < BalanceProjector.bandHalfWidthScale(for: .insufficientData))
+
+        // Same series, different confidence → proportionally narrower ribbon.
+        let series = [
+            BalanceSnapshot(date: Self.asOf, balance: 1_000),
+            BalanceSnapshot(date: Self.calendar.date(byAdding: .day, value: 1, to: Self.asOf)!, balance: 900),
+            BalanceSnapshot(date: Self.calendar.date(byAdding: .day, value: 2, to: Self.asOf)!, balance: 850),
+        ]
+        let confident = BalanceProjector.uncertaintyBand(series: series, confidence: .ok)!
+        let shaky = BalanceProjector.uncertaintyBand(series: series, confidence: .lowConfidence)!
+        for index in 1..<confident.count {
+            #expect(confident[index].high - confident[index].low
+                < shaky[index].high - shaky[index].low)
+        }
+    }
+
+    @Test("Band is byte-stable across runs with identical inputs")
+    func bandDeterministic() {
+        let anchor = BalanceSnapshot(date: Self.asOf, balance: 1_000)
+        let streams = [
+            Self.recurring("Rent", amount: 200, nextExpectedDate: "2026-06-11", category: .billsAndUtilities),
+            Self.recurring("Pay", amount: 400, nextExpectedDate: "2026-06-05", category: .income),
+        ]
+        let a = BalanceProjector.project(
+            anchor: anchor, recurring: streams, asOf: Self.asOf, horizonDays: 30, calendar: Self.calendar
+        )!
+        let b = BalanceProjector.project(
+            anchor: anchor, recurring: streams, asOf: Self.asOf, horizonDays: 30, calendar: Self.calendar
+        )!
+        #expect(a.band != nil)
+        #expect(a.band == b.band)
+        #expect(a == b)
+    }
+
     private static func recurring(
         _ merchant: String,
         amount: Double,

--- a/Tests/PlaidBarCoreTests/BalanceTrendComparisonTests.swift
+++ b/Tests/PlaidBarCoreTests/BalanceTrendComparisonTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("BalanceTrendComparison ghost overlay")
+struct BalanceTrendComparisonTests {
+    private static let calendar = Calendar(identifier: .gregorian)
+    private static var now: Date { Formatters.parseTransactionDate("2026-06-15")! }
+
+    private static func snapshot(_ key: String, _ balance: Double) -> BalanceSnapshot {
+        BalanceSnapshot(date: Formatters.parseTransactionDate(key)!, balance: balance)
+    }
+
+    @Test("Ghost points are the prior window's, date-shifted forward by exactly windowDays")
+    func ghostDatesShifted() {
+        let windowDays = 30
+        // Prior window (ending 30 days before now = May 16): points in early May.
+        let history = [
+            Self.snapshot("2026-05-01", 40_000),
+            Self.snapshot("2026-05-10", 41_000),
+            Self.snapshot("2026-05-16", 42_000),
+            // Current-window points must not appear in the ghost.
+            Self.snapshot("2026-06-01", 43_000),
+            Self.snapshot("2026-06-14", 44_000),
+        ]
+        let ghost = BalanceTrendComparison.evaluate(
+            history: history, now: Self.now, windowDays: windowDays, calendar: Self.calendar
+        )!
+        #expect(ghost.points.count == 3)
+        // Each prior date + 30 days, balances untouched.
+        #expect(ghost.points[0].date == Self.calendar.date(
+            byAdding: .day, value: windowDays, to: Formatters.parseTransactionDate("2026-05-01")!
+        ))
+        #expect(ghost.points[0].balance == 40_000)
+        #expect(ghost.points[2].date == Self.calendar.date(
+            byAdding: .day, value: windowDays, to: Formatters.parseTransactionDate("2026-05-16")!
+        ))
+        #expect(ghost.points[2].balance == 42_000)
+        #expect(ghost.label == "Previous 30 days")
+        // The spoken summary describes the prior movement in words, no glyphs.
+        #expect(ghost.accessibilitySummary.contains("Previous 30-day period"))
+        #expect(ghost.accessibilitySummary.contains("rose"))
+    }
+
+    @Test("Nil when the prior window lacks BalanceTrend's required point count")
+    func nilOnThinPriorWindow() {
+        // Only one prior-window point — under requiredPointCount (2), so the
+        // same honesty gate that blanks the sparkline blanks the ghost.
+        let history = [
+            Self.snapshot("2026-05-10", 41_000),
+            Self.snapshot("2026-06-01", 43_000),
+            Self.snapshot("2026-06-14", 44_000),
+        ]
+        #expect(BalanceTrendComparison.evaluate(
+            history: history, now: Self.now, windowDays: 30, calendar: Self.calendar
+        ) == nil)
+        #expect(BalanceTrendComparison.evaluate(
+            history: [], now: Self.now, windowDays: 30, calendar: Self.calendar
+        ) == nil)
+    }
+
+    @Test("Non-positive window is nil")
+    func nilOnInvalidWindow() {
+        let history = [
+            Self.snapshot("2026-05-01", 40_000),
+            Self.snapshot("2026-05-10", 41_000),
+        ]
+        #expect(BalanceTrendComparison.evaluate(
+            history: history, now: Self.now, windowDays: 0, calendar: Self.calendar
+        ) == nil)
+    }
+
+    @Test("Average baseline formats mask-aware text and keeps the numeric value")
+    func averageBaseline() {
+        let baseline = PeriodComparison.averageBaseline(
+            values: [100, 200, 300], label: "Daily average", isMasked: false
+        )!
+        #expect(baseline.value == 200)
+        #expect(baseline.valueText == Formatters.currency(200, format: .compact))
+        #expect(baseline.accessibilityText == "Daily average: \(Formatters.currency(200, format: .full)).")
+
+        let masked = PeriodComparison.averageBaseline(
+            values: [100, 200, 300], label: "Daily average", isMasked: true
+        )!
+        // The drawn value stays real (the chart itself is mask-governed);
+        // every rendered string is masked.
+        #expect(masked.value == 200)
+        #expect(masked.valueText == PrivacyMaskPresentation.compactValue)
+        #expect(!masked.accessibilityText.contains("$"))
+
+        #expect(PeriodComparison.averageBaseline(values: [], label: "x", isMasked: false) == nil)
+    }
+}

--- a/Tests/PlaidBarCoreTests/MetricDeltaChipTests.swift
+++ b/Tests/PlaidBarCoreTests/MetricDeltaChipTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("MetricDeltaChip composition")
+struct MetricDeltaChipTests {
+    private static var spendUp: MetricDelta {
+        MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .lowerIsBetter)
+    }
+
+    private static var incomeDown: MetricDelta {
+        MetricDelta.evaluate(current: 4_500, previous: 5_000, polarity: .higherIsBetter)
+    }
+
+    private static var flat: MetricDelta {
+        MetricDelta.evaluate(current: 3_000, previous: 3_000, polarity: .lowerIsBetter)
+    }
+
+    // MARK: - Privacy Mask contract
+
+    @Test("isMasked suppresses the chip entirely — never a bare arrow")
+    func maskedReturnsNil() {
+        #expect(MetricDeltaChip.make(
+            delta: Self.spendUp, comparisonLabel: "vs last month", isMasked: true
+        ) == nil)
+        // Masking wins over every other knob, including showsFlat.
+        #expect(MetricDeltaChip.make(
+            delta: Self.flat, comparisonLabel: "vs last month", showsFlat: true, isMasked: true
+        ) == nil)
+    }
+
+    // MARK: - Flat handling
+
+    @Test("Flat deltas are hidden by default and shown only on request")
+    func flatHiddenUnlessRequested() {
+        #expect(MetricDeltaChip.make(
+            delta: Self.flat, comparisonLabel: "vs last month", isMasked: false
+        ) == nil)
+
+        let chip = MetricDeltaChip.make(
+            delta: Self.flat, comparisonLabel: "vs last month", showsFlat: true, isMasked: false
+        )!
+        #expect(chip.glyph == "■")
+        #expect(chip.text == "Unchanged vs last month")
+        #expect(chip.sentiment == .neutral)
+        #expect(chip.accessibilityLabel == "Unchanged versus last month")
+    }
+
+    // MARK: - Composition
+
+    @Test("Currency chip composes glyph, signed text, and comparison label")
+    func currencyComposition() {
+        let chip = MetricDeltaChip.make(
+            delta: Self.spendUp, comparisonLabel: "vs last month", isMasked: false
+        )!
+        #expect(chip.glyph == "▲")
+        #expect(chip.text == "+$420 vs last month")
+        // Spend rising reads negative even though the arrow points up.
+        #expect(chip.sentiment == .negative)
+        #expect(chip.accessibilityLabel == "Up 420 dollars versus last month")
+    }
+
+    @Test("Downward chip carries the minus sign and Down wording")
+    func downComposition() {
+        let chip = MetricDeltaChip.make(
+            delta: Self.incomeDown, comparisonLabel: "vs last month to date", isMasked: false
+        )!
+        #expect(chip.glyph == "▼")
+        #expect(chip.text == "-$500 vs last month to date")
+        #expect(chip.sentiment == .negative)
+        #expect(chip.accessibilityLabel == "Down 500 dollars versus last month to date")
+    }
+
+    @Test("Percent and combined styles render the honest percent")
+    func percentStyles() {
+        let percent = MetricDeltaChip.make(
+            delta: Self.spendUp, comparisonLabel: "vs last month", style: .percent, isMasked: false
+        )!
+        #expect(percent.text == "+14% vs last month")
+        #expect(percent.accessibilityLabel == "Up 14 percent versus last month")
+
+        let both = MetricDeltaChip.make(
+            delta: Self.spendUp, comparisonLabel: "vs last month", style: .currencyAndPercent, isMasked: false
+        )!
+        #expect(both.text == "+$420 (+14%) vs last month")
+        #expect(both.accessibilityLabel == "Up 420 dollars, 14 percent versus last month")
+    }
+
+    @Test("Percent styles fall back to currency when no honest percent exists")
+    func percentFallback() {
+        // Near-zero baseline: percentChange is nil, so no fake percent is shown.
+        let delta = MetricDelta.evaluate(current: 480, previous: 0, polarity: .higherIsBetter)
+        let chip = MetricDeltaChip.make(
+            delta: delta, comparisonLabel: "vs last month", style: .currencyAndPercent, isMasked: false
+        )!
+        #expect(chip.text == "+$480 vs last month")
+        #expect(chip.accessibilityLabel == "Up 480 dollars versus last month")
+    }
+
+    @Test("Chip text uses the requested currency format byte-for-byte")
+    func formatDelegation() {
+        let chip = MetricDeltaChip.make(
+            delta: Self.spendUp, comparisonLabel: "vs last month", format: .full, isMasked: false
+        )!
+        #expect(chip.text == "\(Formatters.signedCurrency(420, format: .full)) vs last month")
+    }
+}

--- a/Tests/PlaidBarCoreTests/MetricDeltaTests.swift
+++ b/Tests/PlaidBarCoreTests/MetricDeltaTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+@Suite("MetricDelta classification")
+struct MetricDeltaTests {
+    // MARK: - Threshold matrix
+
+    @Test("+$2 on an $800 baseline is flat via the relative gate")
+    func smallRelativeChangeIsFlat() {
+        let delta = MetricDelta.evaluate(current: 802, previous: 800, polarity: .lowerIsBetter)
+        // Clears the $1 absolute gate but not the 1% relative gate (needs $8).
+        #expect(delta.direction == .flat)
+        #expect(delta.delta == 2)
+        #expect(delta.sentiment == .neutral)
+    }
+
+    @Test("+$0.60 is flat via the absolute gate even when relatively large")
+    func smallAbsoluteChangeIsFlat() {
+        // On a $10 baseline, $0.60 is 6% (clears relative) but under the $1
+        // absolute gate.
+        let delta = MetricDelta.evaluate(current: 10.6, previous: 10, polarity: .lowerIsBetter)
+        #expect(delta.direction == .flat)
+    }
+
+    @Test("+$420 on a $3,000 baseline clears both gates and reads up")
+    func significantChangeIsUp() {
+        let delta = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .lowerIsBetter)
+        #expect(delta.direction == .up)
+        #expect(delta.delta == 420)
+        #expect(abs((delta.percentChange ?? 0) - 14) < 0.000_1)
+    }
+
+    @Test("Down movement clears the gates symmetrically")
+    func significantDropIsDown() {
+        let delta = MetricDelta.evaluate(current: 2_580, previous: 3_000, polarity: .lowerIsBetter)
+        #expect(delta.direction == .down)
+        #expect(delta.delta == -420)
+        #expect(abs((delta.percentChange ?? 0) + 14) < 0.000_1)
+    }
+
+    @Test("Both thresholds must clear — stricter than BalanceTrend's ±0.005")
+    func stricterThanBalanceTrend() {
+        // A one-cent move would be `.up` under BalanceTrend's raw-movement
+        // gate; MetricDelta calls it flat because it is not chip-worthy.
+        let delta = MetricDelta.evaluate(current: 800.01, previous: 800, polarity: .neutral)
+        #expect(delta.direction == .flat)
+    }
+
+    // MARK: - Percent honesty
+
+    @Test("percentChange is nil when the previous magnitude is near zero")
+    func percentNilOnTinyBaseline() {
+        let delta = MetricDelta.evaluate(current: 480, previous: 0.4, polarity: .higherIsBetter)
+        // No fake "+119,900%" — the baseline is below the absolute gate.
+        #expect(delta.percentChange == nil)
+        #expect(delta.percentText() == nil)
+        // The movement itself still registers (relative gate is waived).
+        #expect(delta.direction == .up)
+    }
+
+    @Test("percentChange is nil on an exactly-zero baseline")
+    func percentNilOnZeroBaseline() {
+        let delta = MetricDelta.evaluate(current: 100, previous: 0, polarity: .higherIsBetter)
+        #expect(delta.percentChange == nil)
+        #expect(delta.direction == .up)
+    }
+
+    @Test("percentText carries an explicit sign in both directions")
+    func percentTextSigned() {
+        let up = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .neutral)
+        #expect(up.percentText() == "+14%")
+        let down = MetricDelta.evaluate(current: 2_580, previous: 3_000, polarity: .neutral)
+        #expect(down.percentText() == "-14%")
+    }
+
+    // MARK: - Sentiment = direction × polarity
+
+    @Test("Spend rising is negative; spend falling is positive")
+    func lowerIsBetterSentiment() {
+        let up = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .lowerIsBetter)
+        #expect(up.sentiment == .negative)
+        let down = MetricDelta.evaluate(current: 2_580, previous: 3_000, polarity: .lowerIsBetter)
+        #expect(down.sentiment == .positive)
+    }
+
+    @Test("Income rising is positive; income falling is negative")
+    func higherIsBetterSentiment() {
+        let up = MetricDelta.evaluate(current: 5_500, previous: 5_000, polarity: .higherIsBetter)
+        #expect(up.sentiment == .positive)
+        let down = MetricDelta.evaluate(current: 4_500, previous: 5_000, polarity: .higherIsBetter)
+        #expect(down.sentiment == .negative)
+    }
+
+    @Test("Neutral polarity and flat direction are always neutral")
+    func neutralSentiment() {
+        let neutral = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .neutral)
+        #expect(neutral.sentiment == .neutral)
+        let flat = MetricDelta.evaluate(current: 3_000, previous: 3_000, polarity: .lowerIsBetter)
+        #expect(flat.direction == .flat)
+        #expect(flat.sentiment == .neutral)
+    }
+
+    // MARK: - Text delegation
+
+    @Test("signedText byte-matches Formatters.signedCurrency")
+    func signedTextMatchesFormatter() {
+        let up = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .neutral)
+        #expect(up.signedText(format: .compact) == Formatters.signedCurrency(420, format: .compact))
+        #expect(up.signedText(format: .full) == Formatters.signedCurrency(420, format: .full))
+        let down = MetricDelta.evaluate(current: 2_580, previous: 3_000, polarity: .neutral)
+        #expect(down.signedText(format: .compact) == Formatters.signedCurrency(-420, format: .compact))
+    }
+
+    @Test("Glyphs match the GlanceSnapshot.ChangeDirection convention")
+    func glyphConvention() {
+        let up = MetricDelta.evaluate(current: 3_420, previous: 3_000, polarity: .neutral)
+        #expect(up.glyph == GlanceSnapshot.ChangeDirection.up.glyph)
+        let flat = MetricDelta.evaluate(current: 3_000, previous: 3_000, polarity: .neutral)
+        #expect(flat.glyph == GlanceSnapshot.ChangeDirection.flat.glyph)
+    }
+}

--- a/Tests/PlaidBarCoreTests/PeriodComparisonTests.swift
+++ b/Tests/PlaidBarCoreTests/PeriodComparisonTests.swift
@@ -1,0 +1,338 @@
+import Foundation
+import Testing
+@testable import PlaidBarCore
+
+// MARK: - Window derivation
+
+@Suite("PeriodComparison windows")
+struct PeriodComparisonWindowTests {
+    private static let calendar = Calendar(identifier: .gregorian)
+
+    private static func day(_ key: String) -> Date {
+        Formatters.parseTransactionDate(key)!
+    }
+
+    @Test("Trailing-30 windows are adjacent with no gap or overlap")
+    func trailingThirtyAdjacency() {
+        let windows = PeriodComparison.windows(
+            for: .trailingDays(30), asOf: Self.day("2026-06-15"), calendar: Self.calendar
+        )!
+        // Current: the 30 days ending today (end exclusive = tomorrow).
+        #expect(windows.current.startKey == "2026-05-17")
+        #expect(windows.current.endKey == "2026-06-16")
+        // Prior: the 30 days immediately before, sharing the boundary key.
+        #expect(windows.prior.startKey == "2026-04-17")
+        #expect(windows.prior.endKey == windows.current.startKey)
+    }
+
+    @Test("Full month-over-month windows are adjacent calendar months")
+    func fullMonthAdjacency() {
+        let windows = PeriodComparison.windows(
+            for: .fullMonthOverMonth, asOf: Self.day("2026-06-15"), calendar: Self.calendar
+        )!
+        #expect(windows.current.startKey == "2026-06-01")
+        #expect(windows.current.endKey == "2026-07-01")
+        #expect(windows.prior.startKey == "2026-05-01")
+        #expect(windows.prior.endKey == windows.current.startKey)
+    }
+
+    @Test("Month-to-date compares against the prior month to the same day")
+    func monthToDateSameDay() {
+        let windows = PeriodComparison.windows(
+            for: .monthToDate, asOf: Self.day("2026-06-15"), calendar: Self.calendar
+        )!
+        // Current: June 1 through end of June 15 (15 elapsed days).
+        #expect(windows.current.startKey == "2026-06-01")
+        #expect(windows.current.endKey == "2026-06-16")
+        // Prior: May 1 through the same 15 elapsed days — NOT the full month.
+        #expect(windows.prior.startKey == "2026-05-01")
+        #expect(windows.prior.endKey == "2026-05-16")
+    }
+
+    @Test("Month-to-date on Mar 31 clamps the prior window to February's length")
+    func monthToDateClampsShortMonth() {
+        // 2026: February has 28 days.
+        let windows = PeriodComparison.windows(
+            for: .monthToDate, asOf: Self.day("2026-03-31"), calendar: Self.calendar
+        )!
+        #expect(windows.prior.startKey == "2026-02-01")
+        #expect(windows.prior.endKey == "2026-03-01") // all 28 days, no spill
+    }
+
+    @Test("Month-to-date clamp honors a leap-year February")
+    func monthToDateLeapClamp() {
+        // 2024: February has 29 days.
+        let windows = PeriodComparison.windows(
+            for: .monthToDate, asOf: Self.day("2024-03-31"), calendar: Self.calendar
+        )!
+        #expect(windows.prior.startKey == "2024-02-01")
+        #expect(windows.prior.endKey == "2024-03-01") // all 29 days
+        // A mid-leap-February same-day compare stays unclamped.
+        let midMonth = PeriodComparison.windows(
+            for: .monthToDate, asOf: Self.day("2024-03-15"), calendar: Self.calendar
+        )!
+        #expect(midMonth.prior.endKey == "2024-02-16")
+    }
+
+    @Test("January month-to-date wraps to December of the prior year")
+    func januaryYearWrap() {
+        let windows = PeriodComparison.windows(
+            for: .monthToDate, asOf: Self.day("2026-01-10"), calendar: Self.calendar
+        )!
+        #expect(windows.current.startKey == "2026-01-01")
+        #expect(windows.prior.startKey == "2025-12-01")
+        #expect(windows.prior.endKey == "2025-12-11")
+
+        let fullMonth = PeriodComparison.windows(
+            for: .fullMonthOverMonth, asOf: Self.day("2026-01-10"), calendar: Self.calendar
+        )!
+        #expect(fullMonth.prior.startKey == "2025-12-01")
+        #expect(fullMonth.prior.endKey == "2026-01-01")
+    }
+
+    @Test("All window keys are canonical yyyy-MM-dd transaction keys")
+    func allKeysCanonical() {
+        let periods: [ComparisonPeriod] = [.trailingDays(7), .trailingDays(30), .monthToDate, .fullMonthOverMonth]
+        for period in periods {
+            let windows = PeriodComparison.windows(
+                for: period, asOf: Self.day("2026-01-03"), calendar: Self.calendar
+            )!
+            for key in [
+                windows.current.startKey, windows.current.endKey,
+                windows.prior.startKey, windows.prior.endKey,
+            ] {
+                #expect(Formatters.isCanonicalTransactionDateKey(key), "non-canonical key \(key) for \(period)")
+            }
+        }
+    }
+
+    @Test("Non-positive trailing day counts produce no windows")
+    func invalidTrailingDays() {
+        #expect(PeriodComparison.windows(for: .trailingDays(0), asOf: Self.day("2026-06-15"), calendar: Self.calendar) == nil)
+        #expect(PeriodComparison.windows(for: .trailingDays(-5), asOf: Self.day("2026-06-15"), calendar: Self.calendar) == nil)
+    }
+
+    @Test("Comparison labels pair with the period semantics")
+    func comparisonLabels() {
+        #expect(ComparisonPeriod.trailingDays(30).comparisonLabel == "vs prior 30 days")
+        #expect(ComparisonPeriod.monthToDate.comparisonLabel == "vs last month to date")
+        #expect(ComparisonPeriod.fullMonthOverMonth.comparisonLabel == "vs last month")
+    }
+}
+
+// MARK: - Domain builders
+
+@Suite("PeriodComparison engine")
+struct PeriodComparisonEngineTests {
+    private static let calendar = Calendar(identifier: .gregorian)
+    /// June 15, 2026 — month-to-date windows: current [Jun 1, Jun 16),
+    /// prior [May 1, May 16).
+    private static var asOf: Date { Formatters.parseTransactionDate("2026-06-15")! }
+
+    private static func tx(
+        id: String,
+        amount: Double,
+        date: String,
+        category: SpendingCategory?
+    ) -> TransactionDTO {
+        TransactionDTO(id: id, accountId: "acc", amount: amount, date: date, name: id, category: category)
+    }
+
+    /// Transactions straddling both month-to-date windows, plus rows that must
+    /// never count as spend (income, transfer) and rows outside both windows.
+    private static var fixture: [TransactionDTO] {
+        [
+            // Current window (June 1–15).
+            tx(id: "cur-food", amount: 120, date: "2026-06-03", category: .foodAndDrink),
+            tx(id: "cur-shop", amount: 80, date: "2026-06-10", category: .shopping),
+            tx(id: "cur-income", amount: -3_000, date: "2026-06-01", category: .income),
+            tx(id: "cur-transfer", amount: 500, date: "2026-06-05", category: .transferOut),
+            // Prior window (May 1–15).
+            tx(id: "pri-food", amount: 200, date: "2026-05-04", category: .foodAndDrink),
+            tx(id: "pri-shop", amount: 50, date: "2026-05-12", category: .shopping),
+            tx(id: "pri-income", amount: -2_800, date: "2026-05-01", category: .income),
+            // Outside both windows: late May (after the same-day cut) and April.
+            tx(id: "gap-food", amount: 999, date: "2026-05-20", category: .foodAndDrink),
+            tx(id: "old-shop", amount: 999, date: "2026-04-10", category: .shopping),
+        ]
+    }
+
+    @Test("Fixture rows split into the correct windows; transfers and income excluded")
+    func totalSpendSplitsWindows() {
+        let delta = PeriodComparison.totalSpendDelta(
+            transactions: Self.fixture,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )!
+        // Current spend 120 + 80 = 200; prior spend 200 + 50 = 250. The
+        // transfer, both paychecks, the post-cut May row, and April never count.
+        #expect(delta.current == 200)
+        #expect(delta.previous == 250)
+        #expect(delta.delta == -50)
+        #expect(delta.direction == .down)
+        // Spend falling is good news.
+        #expect(delta.sentiment == .positive)
+    }
+
+    @Test("Income delta uses the inflow gate and higher-is-better polarity")
+    func incomeDeltaBuilds() {
+        let delta = PeriodComparison.incomeDelta(
+            transactions: Self.fixture,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )!
+        #expect(delta.current == 3_000)
+        #expect(delta.previous == 2_800)
+        #expect(delta.direction == .up)
+        #expect(delta.sentiment == .positive)
+    }
+
+    @Test("Category deltas cover the union of both windows' categories")
+    func categoryDeltasUnion() {
+        let onlyPrior = Self.fixture + [
+            Self.tx(id: "pri-travel", amount: 300, date: "2026-05-08", category: .travel),
+        ]
+        let deltas = PeriodComparison.categorySpendDeltas(
+            transactions: onlyPrior,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )
+        #expect(deltas[.foodAndDrink]?.delta == -80) // 120 vs 200
+        #expect(deltas[.shopping]?.delta == 30) // 80 vs 50
+        // Travel exists only in the prior window but still gets a delta.
+        #expect(deltas[.travel]?.current == 0)
+        #expect(deltas[.travel]?.previous == 300)
+        #expect(deltas[.travel]?.direction == .down)
+        // Income/transfers never appear as spend categories.
+        #expect(deltas[.income] == nil)
+        #expect(deltas[.transferOut] == nil)
+    }
+
+    @Test("An override recategorizing a PRIOR-window transaction moves both windows")
+    func overridesMoveBothWindows() {
+        // Recategorize the prior-window shopping row to food. Because both
+        // windows run through the same kernel with the same metadata, food's
+        // prior total gains 50 and shopping's prior total loses 50 — the delta
+        // can never be manufactured by one window ignoring the override.
+        let metadata = [TransactionReviewMetadata(id: "pri-shop", userCategory: .foodAndDrink)]
+        let deltas = PeriodComparison.categorySpendDeltas(
+            transactions: Self.fixture,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar,
+            metadata: metadata
+        )
+        #expect(deltas[.foodAndDrink]?.previous == 250) // 200 + moved 50
+        #expect(deltas[.foodAndDrink]?.delta == -130) // 120 vs 250
+        #expect(deltas[.shopping]?.previous == 0)
+        #expect(deltas[.shopping]?.current == 80)
+
+        // The total is invariant under recategorization (it only moves buckets).
+        let total = PeriodComparison.totalSpendDelta(
+            transactions: Self.fixture,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar,
+            metadata: metadata
+        )!
+        #expect(total.current == 200)
+        #expect(total.previous == 250)
+    }
+
+    // MARK: - Net worth
+
+    @Test("Net-worth delta picks the boundary snapshot for the previous value")
+    func netWorthBoundarySelection() {
+        // Trailing-30 asOf Jun 15: prior window ends (exclusively) Jun 16-30 =
+        // May 17. The previous value must be the latest snapshot strictly
+        // before that boundary — May 16, not the boundary-day May 17 snapshot
+        // (which belongs to the current window).
+        let history = [
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-05-10")!, balance: 40_000),
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-05-16")!, balance: 41_000),
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-05-17")!, balance: 45_000),
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-06-14")!, balance: 43_500),
+        ]
+        let delta = PeriodComparison.netWorthDelta(
+            history: history,
+            period: .trailingDays(30),
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )!
+        #expect(delta.current == 43_500)
+        #expect(delta.previous == 41_000)
+        #expect(delta.direction == .up)
+        #expect(delta.sentiment == .positive)
+    }
+
+    @Test("Young history that misses the prior window yields nil, never a zero baseline")
+    func youngHistoryYieldsNil() {
+        // All snapshots inside the current window: a fresh install. A naive
+        // implementation would compare against 0 and show "+$48K this month".
+        let history = [
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-06-10")!, balance: 48_000),
+            BalanceSnapshot(date: Formatters.parseTransactionDate("2026-06-14")!, balance: 48_200),
+        ]
+        let delta = PeriodComparison.netWorthDelta(
+            history: history,
+            period: .trailingDays(30),
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )
+        #expect(delta == nil)
+        #expect(PeriodComparison.netWorthDelta(
+            history: [],
+            period: .trailingDays(30),
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        ) == nil)
+    }
+
+    // MARK: - Daily spend spark
+
+    @Test("Daily spend spark buckets by day over the current window and normalizes")
+    func dailySpendSpark() {
+        let spark = PeriodComparison.dailySpendSpark(
+            transactions: Self.fixture,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )!
+        // June 1–15 inclusive = 15 daily buckets.
+        #expect(spark.count == 15)
+        // Normalized to 0...1: the heaviest day (June 3, $120) is 1, quiet days 0.
+        #expect(spark[2] == 1)
+        #expect(spark[9] == 80.0 / 120.0)
+        #expect(spark[0] == 0)
+        #expect(spark.allSatisfy { $0 >= 0 && $0 <= 1 })
+    }
+
+    @Test("Daily spend spark is nil with no expense activity in the window")
+    func dailySpendSparkNilWhenQuiet() {
+        let quiet = [
+            Self.tx(id: "inc", amount: -3_000, date: "2026-06-01", category: .income),
+            Self.tx(id: "move", amount: 500, date: "2026-06-05", category: .transferOut),
+        ]
+        let spark = PeriodComparison.dailySpendSpark(
+            transactions: quiet,
+            period: .monthToDate,
+            asOf: Self.asOf,
+            calendar: Self.calendar
+        )
+        #expect(spark == nil)
+    }
+
+    @Test("Deterministic across repeated calls with identical inputs")
+    func deterministic() {
+        let a = PeriodComparison.totalSpendDelta(
+            transactions: Self.fixture, period: .monthToDate, asOf: Self.asOf, calendar: Self.calendar
+        )
+        let b = PeriodComparison.totalSpendDelta(
+            transactions: Self.fixture, period: .monthToDate, asOf: Self.asOf, calendar: Self.calendar
+        )
+        #expect(a == b)
+    }
+}


### PR DESCRIPTION
## What

Pure `PlaidBarCore` period-comparison engine — the foundation for delta chips on every hero number and comparison baselines on every chart. No app-target (`Sources/PlaidBar/`) changes.

- **`MetricDelta`** — threshold-gated delta classification: `.flat` unless BOTH the absolute ($1) and relative (1%) gates clear (deliberately stricter than `BalanceTrend`'s ±0.005 raw-movement gate, which is left untouched and documented as answering a different question). `percentChange` is nil on a near-zero baseline (no fake infinite %), direction reuses `GlanceSnapshot.ChangeDirection` glyphs (▲/▼/■), sentiment = direction × polarity, `signedText` delegates to `Formatters.signedCurrency` byte-for-byte.
- **`MetricDeltaChip`** — display-ready chip (glyph, "+\$420 vs last month" text, sentiment, glyph-free spoken label). **Returns nil under Privacy Mask**: deltas are derived metadata, suppressed entirely (repo precedent: `DashboardGoalsCard` pace label) — never "▲ ••••".
- **`PeriodComparison`** — canonical `yyyy-MM-dd` end-exclusive windows for `.trailingDays` / `.monthToDate` (prior month truncated to the same elapsed days — avoids the classic partial-month-vs-full-month misleading delta) / `.fullMonthOverMonth`. Domain builders all reuse existing kernels, never a second aggregation path: `totalSpendDelta`/`categorySpendDeltas` via `CategoryBudgetPlanner.netSpendByCategory` once per window (overrides/rules move BOTH windows), `incomeDelta` via `IncomeCategoryFlow.incomeSources`, `dailySpendSpark` via `SpendingSummary.expenseTransactions` + `AccountSparkline.normalize` (promoted internal → public). `netWorthDelta` returns nil when history doesn't reach the prior window — no zero-baseline "+\$48K" on a young install.
- **`ChartComparisonLayer`** — `ChartBaseline` (mask-aware value text), `GhostSeries` (prior-period points date-shifted forward by the window length to overlay the current axis), `BalanceTrendComparison` gated on `BalanceTrend.requiredPointCount`, `PeriodComparison.averageBaseline`.
- **`BalanceProjection.band`** — defaulted-nil `[BandPoint]` uncertainty band; `BalanceProjector` computes it deterministically (half-width ∝ √daysOut × confidence scale, low ≤ series ≤ high, nil when there's no recurring signal to size it honestly).
- **`SpendingPeriodSummary` absorbed** onto `MetricDelta` (doc-deprecated toward `PeriodComparison`) so exactly one delta vocabulary exists; legacy field names kept for its test-only consumers.

## Verification

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- Full `swift test` — **2742 tests, all passing** (adds 5 new suites: threshold matrix, window adjacency/leap-clamp/year-wrap, kernel-reuse override guarantee, mask/flat chip contracts, ghost shift + band invariants)
- `git diff --check` clean; secret scan on changed files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)