### PR TITLE
feat(dashboard): render period-comparison delta chips on hero metrics (AND-1052)

### DIFF
--- a/Sources/PlaidBar/Theme/DesignTokens.swift
+++ b/Sources/PlaidBar/Theme/DesignTokens.swift
@@ -107,6 +107,24 @@ extension Color {
     }
 }
 
+extension MetricDelta.Sentiment {
+    /// Bridges the SwiftUI-free Core delta sentiment to a concrete `Color` — the
+    /// only place `MetricDelta.Sentiment` meets SwiftUI (parity with the
+    /// `AppAccentColor → Color` bridge above), so the direction × polarity
+    /// resolution stays pure and unit-tested in Core. The tint is
+    /// **reinforcement only**: the chip's glyph and signed text carry the
+    /// meaning, never the color alone (ACCESSIBILITY.md). Negative sentiment
+    /// uses the caution `warning` orange rather than red — a spend uptick is a
+    /// nudge, not an error.
+    var tint: Color {
+        switch self {
+        case .positive: SemanticColors.positive
+        case .negative: SemanticColors.warning
+        case .neutral: Color.secondary
+        }
+    }
+}
+
 // MARK: - Spacing (8pt grid)
 
 enum Spacing {

--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -114,7 +114,8 @@ struct DashboardDestinationView: View {
                     detail: metric.detail,
                     accent: metric.accent,
                     reduceMotion: reduceMotion,
-                    provenance: metric.provenance
+                    provenance: metric.provenance,
+                    delta: metric.delta
                 )
             }
         }
@@ -259,6 +260,11 @@ struct DashboardDestinationView: View {
         /// Optional number-provenance for the figure (AND-641). Built masked when
         /// Privacy Mask is active, so the popover never leaks real values.
         var provenance: FigureProvenance?
+        /// Optional period-comparison chip (AND-1052). Built via
+        /// `MetricDeltaChip.make(isMasked:)`, which returns `nil` under Privacy
+        /// Mask — a delta is metadata derived from a private figure, so even the
+        /// bare arrow must vanish when values are hidden.
+        var delta: MetricDeltaChip?
     }
 
     /// The wealth summary the rail also computes — the single source for net worth,
@@ -285,14 +291,67 @@ struct DashboardDestinationView: View {
         )
     }
 
+    /// The dashboard's comparison window (AND-1052): trailing 30 days vs the 30
+    /// days before, matching the hero row's existing 30-day framing ("Last
+    /// 30-day spend", the 30-day cashflow). One constant so period choice and
+    /// chip copy stay in lockstep across the heroes.
+    private static let heroComparisonPeriod = ComparisonPeriod.trailingDays(30)
+
+    /// Period-comparison chip for the net-worth hero, from recorded balance
+    /// history via `PeriodComparison.netWorthDelta` (Core). Gated on the same
+    /// multi-currency resolution as the figure itself: a mixed-currency history
+    /// has no single net-worth number, so no delta is claimed (the same reason
+    /// the safe-to-spend hero falls back to "By currency"). Core additionally
+    /// returns `nil` when history doesn't reach the prior window (young
+    /// install) and when Privacy Mask is on.
+    private func netWorthDeltaChip(
+        aggregation: CurrencyAggregation,
+        asOf: Date,
+        isMasked: Bool
+    ) -> MetricDeltaChip? {
+        guard aggregation.singleCurrency != nil,
+              let delta = PeriodComparison.netWorthDelta(
+                  history: appState.balanceHistory,
+                  period: Self.heroComparisonPeriod,
+                  asOf: asOf
+              )
+        else { return nil }
+        return MetricDeltaChip.make(
+            delta: delta,
+            comparisonLabel: Self.heroComparisonPeriod.comparisonLabel,
+            isMasked: isMasked
+        )
+    }
+
+    /// Period-comparison chip for the last-30-day-spend hero, from
+    /// `PeriodComparison.totalSpendDelta` (Core) — the override-aware spend
+    /// kernel, fed the same live review metadata + rules the budget/category
+    /// surfaces pass, so recategorizing a transaction moves both windows of the
+    /// delta identically. `nil` under Privacy Mask (Core suppresses it).
+    private func spendDeltaChip(asOf: Date, isMasked: Bool) -> MetricDeltaChip? {
+        guard let delta = PeriodComparison.totalSpendDelta(
+            transactions: appState.transactions,
+            period: Self.heroComparisonPeriod,
+            asOf: asOf,
+            metadata: appState.transactionReviewMetadata,
+            rules: appState.transactionRules
+        ) else { return nil }
+        return MetricDeltaChip.make(
+            delta: delta,
+            comparisonLabel: Self.heroComparisonPeriod.comparisonLabel,
+            isMasked: isMasked
+        )
+    }
+
     private var heroMetrics: [HeroMetric] {
         let masked = appState.shouldMaskFinancialValues
         let summary = wealthSummary
+        let asOf = Date()
         let safeToSpend = SafeToSpendCalculator.compute(
             accounts: appState.accounts,
             recurringTransactions: appState.recurringTransactions,
             cashflow: summary.cashflow,
-            asOf: Date()
+            asOf: asOf
         )
         let freshness = appState.lastSyncDate
         let netWorthAggregation = MultiCurrencyBalancePresentation.netWorth(accounts: appState.accounts)
@@ -334,6 +393,11 @@ struct DashboardDestinationView: View {
                 accounts: appState.accounts,
                 freshness: freshness,
                 privacyMaskEnabled: masked
+            ),
+            delta: netWorthDeltaChip(
+                aggregation: netWorthAggregation,
+                asOf: asOf,
+                isMasked: masked
             )
         )
 
@@ -357,7 +421,8 @@ struct DashboardDestinationView: View {
             value: PrivacyMaskPresentation.currency(summary.cashflow.spending, format: .compact, isEnabled: masked),
             systemImage: "creditcard",
             detail: "Across \(summary.cashflow.transactionCount) transaction\(summary.cashflow.transactionCount == 1 ? "" : "s")",
-            accent: .secondary
+            accent: .secondary,
+            delta: spendDeltaChip(asOf: asOf, isMasked: masked)
         )
 
         return [netWorth, safe, spend]

--- a/Sources/PlaidBar/Views/Destinations/WindowSection.swift
+++ b/Sources/PlaidBar/Views/Destinations/WindowSection.swift
@@ -144,6 +144,12 @@ struct WindowHeroMetricTile: View {
     /// explains the number's sources, freshness, and exclusions. Already
     /// privacy-mask-aware (built masked when values are hidden).
     var provenance: FigureProvenance?
+    /// Optional period-comparison chip under the figure (AND-1052) — "▲ +$420 vs
+    /// last month". Built by `MetricDeltaChip.make` in Core, which already
+    /// suppresses it under Privacy Mask (returns `nil`) and for insignificant
+    /// movement. Declared last so the memberwise init keeps every existing
+    /// call site compiling unchanged.
+    var delta: MetricDeltaChip?
 
     var body: some View {
         VStack(alignment: .leading, spacing: WindowMetrics.xs) {
@@ -189,6 +195,10 @@ struct WindowHeroMetricTile: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
 
+            if let delta {
+                DeltaChip(chip: delta)
+            }
+
             if let detail {
                 Text(detail)
                     .windowSupportingText()
@@ -201,6 +211,10 @@ struct WindowHeroMetricTile: View {
 
     private var accessibilityLabel: String {
         var parts = ["\(label): \(value)"]
+        // Spoken in visual order (value → delta → detail); the chip contributes
+        // its spelled-out Core label ("Up 420 dollars versus last month") so the
+        // tile stays one combined VoiceOver element with no glyphs to guess at.
+        if let delta { parts.append(delta.accessibilityLabel) }
         if let detail { parts.append(detail) }
         return parts.joined(separator: ". ")
     }
@@ -286,7 +300,13 @@ extension View {
                 systemImage: "chart.line.uptrend.xyaxis",
                 detail: "across 6 accounts",
                 accent: SemanticColors.brand,
-                reduceMotion: false
+                reduceMotion: false,
+                delta: MetricDeltaChip(
+                    glyph: "▲",
+                    text: "+$1,240 vs last month",
+                    sentiment: .positive,
+                    accessibilityLabel: "Up 1240 dollars versus last month"
+                )
             )
             WindowHeroMetricTile(
                 label: "Safe to spend",

--- a/Sources/PlaidBar/Views/Shared/DeltaChip.swift
+++ b/Sources/PlaidBar/Views/Shared/DeltaChip.swift
@@ -1,0 +1,84 @@
+import PlaidBarCore
+import SwiftUI
+
+// MARK: - Delta chip (design-elevation shared kit)
+//
+// The one-line "so what?" comparison next to a hero number: a direction glyph
+// plus the preformatted delta text from `MetricDeltaChip` (PlaidBarCore), e.g.
+// "▲ +$420 vs last month". All math, thresholds, and Privacy Mask suppression
+// live in Core (`MetricDeltaChip.make` returns `nil` when masked or
+// insignificant) — this view only renders a chip it is handed.
+//
+// Meaning is carried by the glyph *and* the signed text; the sentiment tint on
+// the glyph is reinforcement only, never the sole signal (ACCESSIBILITY.md).
+
+/// Renders a Core ``MetricDeltaChip`` as a quiet supporting line.
+///
+/// Reads as one VoiceOver element speaking the chip's spelled-out
+/// `accessibilityLabel` ("Up 420 dollars versus last month"); the glyph text is
+/// hidden so VoiceOver never guesses at "▲". Hosts that fold the chip into a
+/// larger combined element (e.g. ``WindowHeroMetricTile``) append
+/// `chip.accessibilityLabel` themselves.
+struct DeltaChip: View {
+    let chip: MetricDeltaChip
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+            Text(chip.glyph)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(chip.sentiment.tint)
+                .accessibilityHidden(true)
+            Text(chip.text)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(chip.accessibilityLabel)
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview("Delta chips") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        DeltaChip(chip: MetricDeltaChip(
+            glyph: "▲",
+            text: "+$420 vs last month",
+            sentiment: .positive,
+            accessibilityLabel: "Up 420 dollars versus last month"
+        ))
+        DeltaChip(chip: MetricDeltaChip(
+            glyph: "▲",
+            text: "+$96 vs prior 30 days",
+            sentiment: .negative,
+            accessibilityLabel: "Up 96 dollars versus prior 30 days"
+        ))
+        DeltaChip(chip: MetricDeltaChip(
+            glyph: "■",
+            text: "Unchanged vs last month",
+            sentiment: .neutral,
+            accessibilityLabel: "Unchanged versus last month"
+        ))
+    }
+    .padding(Spacing.lg)
+}
+
+#Preview("Delta chips — dark") {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        DeltaChip(chip: MetricDeltaChip(
+            glyph: "▼",
+            text: "-$63 (-8%) vs last month",
+            sentiment: .positive,
+            accessibilityLabel: "Down 63 dollars, 8 percent versus last month"
+        ))
+        DeltaChip(chip: MetricDeltaChip(
+            glyph: "▼",
+            text: "-$1,180 vs prior 30 days",
+            sentiment: .negative,
+            accessibilityLabel: "Down 1180 dollars versus prior 30 days"
+        ))
+    }
+    .padding(Spacing.lg)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1658,6 +1658,51 @@ struct PlaidBarTests {
         #expect(card.contains("Open Goals"))
     }
 
+    /// Source-invariant guard for AND-1052: the Dashboard hero delta chips are
+    /// built exclusively through the mask-aware Core factory
+    /// (`MetricDeltaChip.make(isMasked:)`, which returns `nil` under Privacy
+    /// Mask) and are fed the same masking source the hero values use — so a
+    /// masked figure can never leak even a bare direction arrow. The app target
+    /// is an `@main` executable that can't be `@testable import`ed, so this pins
+    /// the wiring (the mask-suppression *math* is unit-tested in
+    /// PlaidBarCoreTests).
+    @Test("Dashboard hero delta chips route through mask-aware Core construction (AND-1052)")
+    func dashboardHeroDeltaChipsAreMaskAware() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let dashboard = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift"),
+            encoding: .utf8
+        )
+        let tile = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/WindowSection.swift"),
+            encoding: .utf8
+        )
+
+        // The chips come only from the Core factory — never the raw memberwise
+        // init, which would bypass the Privacy Mask suppression.
+        #expect(dashboard.contains("MetricDeltaChip.make("))
+        #expect(!dashboard.contains("MetricDeltaChip(glyph:"))
+
+        // Both chip builders thread the mask through to Core, and both call
+        // sites pass the same `shouldMaskFinancialValues`-derived flag the hero
+        // values themselves run through.
+        #expect(dashboard.contains("let masked = appState.shouldMaskFinancialValues"))
+        #expect(dashboard.contains("isMasked: isMasked"))
+        #expect(dashboard.contains("delta: netWorthDeltaChip("))
+        #expect(dashboard.contains("isMasked: masked"))
+        #expect(dashboard.contains("spendDeltaChip(asOf: asOf, isMasked: masked)"))
+
+        // The net-worth chip is gated on single-currency resolution — a
+        // mixed-currency delta is meaningless (same gate as the "By currency"
+        // fallback).
+        #expect(dashboard.contains("aggregation.singleCurrency != nil"))
+
+        // The tile folds the chip's spelled-out label into its one combined
+        // VoiceOver element instead of exposing a separate glyph element.
+        #expect(tile.contains("if let delta { parts.append(delta.accessibilityLabel) }"))
+        #expect(tile.contains("DeltaChip(chip: delta)"))
+    }
+
     @Test("Demo goals never persist over real local-first goals")
     func demoGoalsStayInMemoryOnlyAndRestoreOnExit() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)


### PR DESCRIPTION
## What

Wires the merged Core delta engine (`PeriodComparison` / `MetricDeltaChip`, #755) into the hero-metric surface — the exemplar the downstream screen PRs copy.

- **`Views/Shared/DeltaChip.swift`** (new): renders a Core `MetricDeltaChip` — semibold sentiment-tinted glyph (`.accessibilityHidden`) + caption `.monospacedDigit()` text. Tint is reinforcement only; glyph + signed words carry the meaning. Light/dark previews with up/down/flat chips.
- **`Theme/DesignTokens.swift`**: the single `MetricDelta.Sentiment → Color` bridge (`.positive → SemanticColors.positive`, `.negative → SemanticColors.warning`, `.neutral → .secondary`), parity with the existing `AppAccentColor → Color` bridge.
- **`WindowHeroMetricTile`**: optional `delta: MetricDeltaChip?` declared **last** (all existing call sites compile unchanged), rendered between value and detail; the chip's spelled-out label is appended to the tile's one combined VoiceOver element.
- **`DashboardDestinationView`** (exemplar wiring): net-worth chip from `PeriodComparison.netWorthDelta(.trailingDays(30))`, gated on `singleCurrency` resolution (same gate as the "By currency" fallback — a mixed-currency delta is meaningless); spend chip from `totalSpendDelta(.trailingDays(30))` fed the live review metadata + rules (override-aware kernel). `asOf: Date()` injected at the call site per the existing `SafeToSpendCalculator`/`CategoryDashboardBuilder` pattern — no `Date()` in Core.

## Privacy

Both chips pass the tiles' own `shouldMaskFinancialValues` flag through `MetricDeltaChip.make(isMasked:)`, which returns `nil` under Privacy Mask — a masked figure never leaks even a bare arrow. A source-invariant test pins the mask-aware construction (no raw `MetricDeltaChip(glyph:)` init in the dashboard, `isMasked: masked` at both call sites, single-currency gate, combined-a11y fold).

## Gates

- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — clean
- Full `swift test` — **2745 passed, 0 failed** (12 skips are the known Keychain-sandbox skips); includes the new AND-1052 regression guard
- `git diff --check` clean; secret scan on changed files clean

## Renders

Headless `--demo --render-window-first`, light appearance: the Last 30-day spend hero shows "▲ +$1,810 vs prior 30 days" (orange caution glyph, secondary text) between value and detail with the tile layout intact. The net-worth hero correctly shows **no** chip in demo — its balance history is one fresh snapshot, so Core's young-install guard returns `nil` (never a zero-baseline "+$60K" chip). Other window screens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)