### PR TITLE
fix(dashboard): tighten net-worth delta chip currency gate to USD

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardDestinationView.swift
@@ -298,18 +298,21 @@ struct DashboardDestinationView: View {
     private static let heroComparisonPeriod = ComparisonPeriod.trailingDays(30)
 
     /// Period-comparison chip for the net-worth hero, from recorded balance
-    /// history via `PeriodComparison.netWorthDelta` (Core). Gated on the same
-    /// multi-currency resolution as the figure itself: a mixed-currency history
-    /// has no single net-worth number, so no delta is claimed (the same reason
-    /// the safe-to-spend hero falls back to "By currency"). Core additionally
-    /// returns `nil` when history doesn't reach the prior window (young
-    /// install) and when Privacy Mask is on.
+    /// history via `PeriodComparison.netWorthDelta` (Core). Gated on the figure
+    /// resolving to **USD specifically**, not just any single currency: a
+    /// mixed-currency history has no single net-worth number (the same reason
+    /// the safe-to-spend hero falls back to "By currency"), and the chip's
+    /// vocabulary is USD-only — `MetricDeltaChip.make` formats the amount via
+    /// `Formatters.signedCurrency` (always `$`) and speaks "dollars" — so an
+    /// all-EUR figure ("€48.000") must never carry a "+$420" chip. Core
+    /// additionally returns `nil` when history doesn't reach the prior window
+    /// (young install) and when Privacy Mask is on.
     private func netWorthDeltaChip(
         aggregation: CurrencyAggregation,
         asOf: Date,
         isMasked: Bool
     ) -> MetricDeltaChip? {
-        guard aggregation.singleCurrency != nil,
+        guard aggregation.singleCurrency == .usd,
               let delta = PeriodComparison.netWorthDelta(
                   history: appState.balanceHistory,
                   period: Self.heroComparisonPeriod,

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1692,10 +1692,12 @@ struct PlaidBarTests {
         #expect(dashboard.contains("isMasked: masked"))
         #expect(dashboard.contains("spendDeltaChip(asOf: asOf, isMasked: masked)"))
 
-        // The net-worth chip is gated on single-currency resolution — a
-        // mixed-currency delta is meaningless (same gate as the "By currency"
-        // fallback).
-        #expect(dashboard.contains("aggregation.singleCurrency != nil"))
+        // The net-worth chip is gated on the figure resolving to USD
+        // specifically — a mixed-currency delta is meaningless (same reason as
+        // the "By currency" fallback), and the Core chip's text/spoken label
+        // are USD-only ("$", "dollars"), so a single non-USD figure must not
+        // carry a dollar-denominated chip either.
+        #expect(dashboard.contains("aggregation.singleCurrency == .usd"))
 
         // The tile folds the chip's spelled-out label into its one combined
         // VoiceOver element instead of exposing a separate glyph element.


### PR DESCRIPTION
Follow-up to #756: the review pass on the delta-chip wiring found that MetricDeltaChip's text/spoken vocabulary is USD-only (Formatters.signedCurrency always renders "$", the a11y label says "dollars"), while the net-worth figure formats in its own resolved currency — so a single-EUR (or unknown-currency) figure would have carried a dollar-denominated chip.

This tightens the gate from `singleCurrency != nil` to `singleCurrency == .usd`, updates the doc comment, and updates the source-invariant test pin to guard the stricter gate. Relax the gate once Core's MetricDeltaChip.make learns a currency parameter (tracked as a carry-forward).

Verification (from the review agent, commit d3c6e151): strict-concurrency build clean, full swift test 2745 green, headless demo re-render verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)