### PR TITLE
fix(privacy): mask heatmap activity counts

### DIFF
--- a/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
+++ b/Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift
@@ -59,7 +59,7 @@ struct DashboardActivityHeatmapCard: View {
             ? PrivacyMaskPresentation.compactValue
             : Formatters.currency(layout.totalValue, format: .compact)
         return VStack(alignment: .leading, spacing: WindowMetrics.xs) {
-            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
+            Label(masked ? "Activity summary hidden" : "\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
                 .windowBodyText()
             Text(masked
                 ? "Activity totals are hidden while VaultPeek is private."
@@ -499,7 +499,7 @@ struct DashboardYearHeatmapGrid: View {
             "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
         )
         // VoiceOver audio graph over the active days (AND-569) — same Core source.
-        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
+        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: isPrivacyMasked))
     }
 
     /// Resolve the cell size **and** inter-cell gap so the full 53-week year fits the

--- a/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
+++ b/Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift
@@ -134,7 +134,7 @@ struct InsightsTrendsView: View {
             ? PrivacyMaskPresentation.compactValue
             : Formatters.currency(layout.totalValue, format: .compact)
         return VStack(alignment: .leading, spacing: WindowMetrics.xs) {
-            Label("\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
+            Label(isMasked ? "Activity summary hidden" : "\(layout.activeDayCount) active days in the last year", systemImage: "calendar")
                 .windowBodyText()
             Text(isMasked
                 ? "Activity totals are hidden while VaultPeek is private."
@@ -211,7 +211,7 @@ struct InsightsActivityHeatmapGrid: View {
             "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription)."
         )
         // VoiceOver audio graph over the active days (AND-569).
-        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: false))
+        .audioGraph(ChartAudioGraph.heatmap(layout, isPrivacyMasked: isPrivacyMasked))
     }
 
     @ViewBuilder

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1018,7 +1018,7 @@ private struct BalanceActivityHeatmap: View {
 
                 Spacer()
 
-                Text(isInitialLoad ? "Loading activity" : "\(layout.activeDayCount) active days")
+                Text(activityCountLabel(isInitialLoad: isInitialLoad, layout: layout))
                     .microText()
                     .foregroundStyle(.secondary)
             }
@@ -1047,7 +1047,7 @@ private struct BalanceActivityHeatmap: View {
         .accessibilityLabel(
             isInitialLoad
                 ? (loadState?.loadingAccessibilityLabel ?? "Loading activity heatmap.")
-                : "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription). Select a day to see its detail."
+                : activityAccessibilityLabel(layout: layout)
         )
         // VoiceOver audio graph over the active days. Suppressed during the first
         // sync (placeholder grid) and honors Privacy Mask (AND-569).
@@ -1064,6 +1064,19 @@ private struct BalanceActivityHeatmap: View {
                 )
                 : ChartAudioGraph.heatmap(layout, isPrivacyMasked: appState.shouldMaskFinancialValues)
         )
+    }
+
+    private func activityCountLabel(isInitialLoad: Bool, layout: SpendingHeatmapLayout) -> String {
+        if isInitialLoad { return "Loading activity" }
+        if appState.shouldMaskFinancialValues { return "Activity hidden" }
+        return "\(layout.activeDayCount) active days"
+    }
+
+    private func activityAccessibilityLabel(layout: SpendingHeatmapLayout) -> String {
+        if appState.shouldMaskFinancialValues {
+            return "\(layout.mode.summaryTitle) heatmap details are hidden while VaultPeek is private."
+        }
+        return "\(layout.mode.summaryTitle) heatmap for the last 365 days with \(layout.activeDayCount) active days. \(layout.mode.semanticDescription). Select a day to see its detail."
     }
 
     @ViewBuilder

--- a/Sources/PlaidBar/Views/MainPopover.swift
+++ b/Sources/PlaidBar/Views/MainPopover.swift
@@ -1081,7 +1081,14 @@ private struct BalanceActivityHeatmap: View {
 
     @ViewBuilder
     private func focusedDayCaption(for layout: SpendingHeatmapLayout) -> some View {
-        if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues), !isInitialLoad {
+        if selectedDay != nil, appState.shouldMaskFinancialValues, !isInitialLoad {
+            Text(maskedHeatmapDayDetailLabel(for: layout.mode))
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(AppearanceTextColors.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+                .accessibilityLabel(maskedHeatmapDayDetailLabel(for: layout.mode))
+        } else if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues), !isInitialLoad {
             HStack(spacing: 4) {
                 Image(systemName: "calendar")
                     .font(.system(size: 9, weight: .semibold))
@@ -1100,6 +1107,10 @@ private struct BalanceActivityHeatmap: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
+    }
+
+    private func maskedHeatmapDayDetailLabel(for mode: SpendingHeatmapMode) -> String {
+        "\(mode.summaryTitle) day details are hidden while VaultPeek is private."
     }
 
     private func toggleSelection(_ day: String) {
@@ -1244,7 +1255,10 @@ private struct BalanceHeatmapCell: View {
     }
 
     private var helpText: String {
-        SpendingHeatmap.cellLabel(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)
+        if isPrivacyMasked {
+            return "\(mode.summaryTitle) day details are hidden while VaultPeek is private."
+        }
+        return SpendingHeatmap.cellLabel(for: day, mode: mode)
     }
 
     static func fillColor(intensity: Double, value: Double, mode: SpendingHeatmapMode) -> Color {

--- a/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
+++ b/Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift
@@ -318,13 +318,30 @@ public enum ChartAudioGraph {
     /// zero-pitch noise). x is a day index across the active days (each labeled
     /// with its date), y is the day's signed value in the active mode. Discrete.
     ///
-    /// When Privacy Mask is on, the per-point spoken label drops the exact amount
-    /// but keeps the date + transaction count, mirroring the heatmap's masked
-    /// header total. Returns no points when there is no activity.
+    /// When Privacy Mask is on, the heatmap's spoken surface withholds active-day
+    /// counts, per-day dates, and transaction counts as behavioral finance
+    /// metadata. Returns no points when there is no activity or masking is active.
     public static func heatmap(
         _ layout: SpendingHeatmapLayout,
         isPrivacyMasked: Bool = false
     ) -> Descriptor {
+        if isPrivacyMasked {
+            return Descriptor(
+                title: layout.mode.summaryTitle,
+                summary: "Activity heatmap details are hidden while VaultPeek is private.",
+                xAxis: NumericAxis(title: "Active day", lowerBound: 0, upperBound: 0),
+                yAxis: NumericAxis(
+                    title: layout.mode == .spending ? "Spend" : "Net cashflow",
+                    lowerBound: 0,
+                    upperBound: 0
+                ),
+                seriesName: layout.mode.shortLabel,
+                isContinuous: false,
+                isPrivacyMasked: true,
+                points: []
+            )
+        }
+
         let activeDays = layout.days.filter { $0.transactionCount > 0 }
 
         let points = activeDays.enumerated().map { index, day -> Point in

--- a/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
+++ b/Tests/PlaidBarCoreTests/ChartAudioGraphTests.swift
@@ -191,7 +191,7 @@ struct ChartAudioGraphTests {
         #expect(descriptor.yAxis.title == "Spend")
     }
 
-    @Test("heatmap point labels carry the amount when unmasked and hide it when masked")
+    @Test("heatmap point labels carry the amount when unmasked and withhold points when masked")
     func heatmapLabelMasking() {
         let calendar = Calendar.current
         let end = calendar.startOfDay(for: Date())
@@ -202,9 +202,8 @@ struct ChartAudioGraphTests {
         #expect(try! #require(unmasked.points.first).label.contains("$75"))
 
         let masked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: true)
-        let maskedPoint = try! #require(masked.points.first)
-        #expect(!maskedPoint.label.contains("$"))
-        #expect(maskedPoint.label.contains("transaction"))
+        #expect(masked.points.isEmpty)
+        #expect(masked.summary == "Activity heatmap details are hidden while VaultPeek is private.")
     }
 
     @Test("empty heatmap yields an empty descriptor")
@@ -269,7 +268,7 @@ struct ChartAudioGraphTests {
 
         let masked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: true)
         #expect(masked.isPrivacyMasked)
-        #expect(!ChartAudioGraph.yAxisValueDescription(masked.points[0].yValue, isMasked: masked.isPrivacyMasked).contains("$"))
+        #expect(masked.points.isEmpty)
     }
 
     @Test("trend descriptor is unmasked (trend chart is not privacy-masked)")
@@ -343,7 +342,7 @@ struct ChartAudioGraphTests {
         #expect(leaked.isEmpty)
     }
 
-    @Test("masked heatmap's full spoken surface leaks no amount")
+    @Test("masked heatmap's full spoken surface leaks no amount or activity counts")
     func heatmapAxSpokenStringsFullyMasked() {
         let calendar = Calendar.current
         let end = calendar.startOfDay(for: Date())
@@ -351,9 +350,12 @@ struct ChartAudioGraphTests {
         let layout = heatmapLayout([transaction(day, amount: 75)])
 
         let masked = ChartAudioGraph.heatmap(layout, isPrivacyMasked: true)
+        #expect(masked.points.isEmpty)
         for line in masked.axSpokenStrings() {
             #expect(!line.contains("$"))
             #expect(!line.contains("75"))
+            #expect(!line.localizedCaseInsensitiveContains("active day"))
+            #expect(!line.localizedCaseInsensitiveContains("transaction"))
         }
     }
 

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1535,13 +1535,13 @@ struct PlaidBarTests {
     }
 
     /// Source-invariant guard for the AND-671 follow-up: the popover heatmap
-    /// (`MainPopover.swift`) renders its interactive cells AND the focused-day
-    /// caption *while Privacy Mask is on*, so both must source their text from the
-    /// mask-aware Core helpers with the live `appState.shouldMaskFinancialValues`
-    /// threaded in — otherwise the per-cell hover/VoiceOver label or the selected
-    /// day's caption would leak the real value. The `@main` app target isn't
-    /// unit-testable, so this string-matches the wiring so it can't be dropped.
-    @Test("Popover heatmap cell help and focused-day caption thread the live Privacy Mask state (AND-671)")
+    /// (`MainPopover.swift`) renders interactive cells and a focused-day caption
+    /// while Privacy Mask is on. Unlike the larger window grids, this compact
+    /// popover surface claims details are hidden, so per-cell hover/VoiceOver and
+    /// selected-day caption copy must collapse to generic masked text instead of
+    /// exposing date/count metadata. The `@main` app target isn't unit-testable, so
+    /// this string-matches the wiring so it can't be dropped.
+    @Test("Popover heatmap hides per-cell and focused-day details under Privacy Mask (AND-671)")
     func popoverHeatmapMasksCellHelpAndFocusedCaption() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let popover = try String(
@@ -1549,17 +1549,22 @@ struct PlaidBarTests {
             encoding: .utf8
         )
 
-        // Per-cell hover/VoiceOver label is sourced from the mask-aware Core label,
-        // and the cell is constructed with the live Privacy Mask state.
-        #expect(popover.contains("SpendingHeatmap.cellLabel(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)"))
+        // Per-cell hover/VoiceOver label receives the live mask state, but the
+        // masked branch must use generic copy instead of Core's date/count label.
         #expect(popover.contains("var isPrivacyMasked: Bool = false"))
         #expect(popover.contains("isPrivacyMasked: appState.shouldMaskFinancialValues"))
+        #expect(popover.contains("if isPrivacyMasked {\n            return \"\\(mode.summaryTitle) day details are hidden while VaultPeek is private.\""))
+        #expect(popover.contains("return SpendingHeatmap.cellLabel(for: day, mode: mode)"))
+        #expect(!popover.contains("SpendingHeatmap.cellLabel(for: day, mode: mode, isPrivacyMasked: isPrivacyMasked)"))
 
-        // Focused-day caption: the summary (whose captionText drives the visual
-        // Text and whose accessibilityLabel drives the VoiceOver label) is built
-        // with the live mask flag, so a selected cell never leaks its value.
+        // Focused-day caption: when Privacy Mask is active, the selected cell also
+        // renders value-free/date-free/count-free masked copy before building the
+        // summary whose captionText/accessibilityLabel include date/count detail.
+        #expect(popover.contains("if selectedDay != nil, appState.shouldMaskFinancialValues, !isInitialLoad {"))
+        #expect(popover.contains("Text(maskedHeatmapDayDetailLabel(for: layout.mode))"))
+        #expect(popover.contains(".accessibilityLabel(maskedHeatmapDayDetailLabel(for: layout.mode))"))
         #expect(popover.contains(
-            "SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues)"
+            "} else if let summary = SpendingHeatmap.focusedDaySummary(for: selectedDay, in: layout, isPrivacyMasked: appState.shouldMaskFinancialValues), !isInitialLoad {"
         ))
         #expect(popover.contains("Text(summary.captionText)"))
         #expect(popover.contains(".accessibilityLabel(summary.accessibilityLabel)"))

--- a/Tests/PlaidBarTests/PlaidBarTests.swift
+++ b/Tests/PlaidBarTests/PlaidBarTests.swift
@@ -1705,6 +1705,37 @@ struct PlaidBarTests {
         #expect(tile.contains("DeltaChip(chip: delta)"))
     }
 
+    @Test("Activity heatmap privacy mask withholds active-day counts from text and audio surfaces")
+    func activityHeatmapPrivacyMaskWithholdsActiveDayCounts() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let dashboard = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/DashboardOverviewColumn.swift"),
+            encoding: .utf8
+        )
+        let insights = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/Destinations/InsightsTrendsView.swift"),
+            encoding: .utf8
+        )
+        let popover = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBar/Views/MainPopover.swift"),
+            encoding: .utf8
+        )
+        let audioGraph = try String(
+            contentsOf: root.appending(path: "Sources/PlaidBarCore/Utilities/ChartAudioGraph.swift"),
+            encoding: .utf8
+        )
+
+        #expect(dashboard.contains("Label(masked ? \"Activity summary hidden\" : \"\\(layout.activeDayCount) active days in the last year\""))
+        #expect(insights.contains("Label(isMasked ? \"Activity summary hidden\" : \"\\(layout.activeDayCount) active days in the last year\""))
+        #expect(popover.contains("if appState.shouldMaskFinancialValues { return \"Activity hidden\" }"))
+        #expect(popover.contains("heatmap details are hidden while VaultPeek is private"))
+        #expect(dashboard.contains("ChartAudioGraph.heatmap(layout, isPrivacyMasked: isPrivacyMasked)"))
+        #expect(insights.contains("ChartAudioGraph.heatmap(layout, isPrivacyMasked: isPrivacyMasked)"))
+        #expect(audioGraph.contains("if isPrivacyMasked"))
+        #expect(audioGraph.contains("points: []"))
+        #expect(audioGraph.contains("Activity heatmap details are hidden while VaultPeek is private."))
+    }
+
     @Test("Demo goals never persist over real local-first goals")
     func demoGoalsStayInMemoryOnlyAndRestoreOnExit() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)


### PR DESCRIPTION
## Summary
- masks Dashboard/Insights heatmap text alternatives so Privacy Mask/App Lock no longer shows exact active-day counts
- masks the menu-bar heatmap visible footer and VoiceOver label while private
- changes masked heatmap audio descriptors to withhold active-day/date/transaction-count metadata instead of preserving per-day points

Fixes #758
Linear: AND-1146
Kanban: t_94ad38f7

## Verification
- `git diff --check`
- `swift build --target PlaidBarCoreTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` — passed (`Build of target: 'PlaidBarCoreTests' complete!`)
- ad-hoc source invariant `/tmp/vaultpeek-heatmap-privacy-invariant.py` — passed `AD_HOC_VERIFICATION_OK`; temp script removed

## Known blocker
- `swift test --filter ChartAudioGraphTests -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors` is blocked before test execution by unrelated app-target FoundationModels macro/plugin resolution errors in `Sources/PlaidBar/Services/FoundationModels*` (`FoundationModelsMacros.GenerableMacro` / `GuideMacro` not found). This matches the existing app-target filtered-test blocker for VaultPeek.
